### PR TITLE
test: leader-redis-redisson 테스트 인프라 자립화 (Issue #3)

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -102,6 +102,7 @@ object Libs {
     const val bluetape4k_bom = "io.github.bluetape4k:bluetape4k-bom:1.8.0-SNAPSHOT"
     const val bluetape4k_core = "io.github.bluetape4k:bluetape4k-core"
     const val bluetape4k_coroutines = "io.github.bluetape4k:bluetape4k-coroutines"
+    const val bluetape4k_idgenerators = "io.github.bluetape4k:bluetape4k-idgenerators"
     const val bluetape4k_logging = "io.github.bluetape4k:bluetape4k-logging"
     const val bluetape4k_junit5 = "io.github.bluetape4k:bluetape4k-junit5"
     const val bluetape4k_lettuce = "io.github.bluetape4k:bluetape4k-lettuce"

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElection.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElection.kt
@@ -5,8 +5,8 @@ import io.bluetape4k.leader.coroutines.SuspendLeaderElection
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
-import io.bluetape4k.redis.redisson.coroutines.getLockId
 import io.bluetape4k.support.requireNotBlank
+import java.util.concurrent.ThreadLocalRandom
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.future.await
@@ -119,12 +119,9 @@ class RedissonSuspendLeaderElection private constructor(
         try {
             log.debug { "Leader 승격을 요청합니다 ..." }
 
-            // Thread Id 기반으로 Lock 을 걸게 되므로, Coroutines 환경에서는 사용할 수 없다.
-            // 고유의 Id 값을 제공해야 하므로 [RAtomicLong] 을 사용한다.
-            val lockId = redissonClient.getLockId(lockName)
-
-            // Redis IO 를 줄이기 위해 Default Snowflake 를 사용합니다.
-            // val lockId = Snowflakers.Default.nextId()
+            // Coroutine 환경에서 Thread ID 대신 랜덤 ID를 사용하여 락 소유자를 식별합니다.
+            // Thread ID는 코루틴이 여러 스레드 사이를 이동하기 때문에 사용할 수 없습니다.
+            val lockId = ThreadLocalRandom.current().nextLong()
 
             val acquired = lock
                 .tryLockAsync(

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElection.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElection.kt
@@ -6,7 +6,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
-import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.future.await
@@ -52,13 +52,13 @@ suspend inline fun <T> RedissonClient.suspendRunIfLeader(
  * Redisson 분산 락을 이용하여 여러 프로세스/스레드 중 단 하나만 작업을 수행하도록 리더를 선출합니다.
  * Coroutine 환경에서 사용할 수 있는 suspend 버전입니다.
  *
- * ## threadId 대신 getLockId()를 사용하는 이유
+ * ## threadId 대신 PID-seeded Snowflake ID를 사용하는 이유
  * Redisson의 [RLock]은 락 소유자를 스레드 ID로 식별합니다.
  * 그러나 Coroutine은 여러 스레드를 오가며 실행되므로, 락 획득 시점의 스레드와
  * 락 해제 시점의 스레드가 달라질 수 있습니다.
- * 이를 해결하기 위해 [io.bluetape4k.redis.redisson.coroutines.getLockId]를 사용하여
- * Snowflake 알고리즘으로 Coroutine 세션마다 고유한 ID를 발급하고 (Redis 왕복 없음),
- * 이 ID를 락 획득/해제 양쪽에 동일하게 사용합니다.
+ * 이를 해결하기 위해 `timestamp | pid%(2^10) | seq` 형태의 ID를 생성하여
+ * 같은 머신의 다른 프로세스, 같은 프로세스의 다른 코루틴 사이에서 충돌 없이
+ * 락 소유자를 식별합니다. (Redis 왕복 없음)
  *
  * ```kotlin
  * val election = RedissonSuspendLeaderElection(redissonClient)
@@ -79,12 +79,21 @@ class RedissonSuspendLeaderElection private constructor(
 ): SuspendLeaderElection {
 
     companion object: KLoggingChannel() {
-        /**
-         * [RedissonSuspendLeaderElection] 인스턴스를 생성합니다.
-         *
-         * @param redissonClient RedissonClient 인스턴스
-         * @param options 리더 선출 옵션
-         */
+        // PID-seeded Snowflake-like ID 생성기
+        // timestamp(42bit) | pid%(2^10)(10bit) | seq(12bit)
+        // - 단일 JVM: seq 단조 증가로 충돌 없음
+        // - HA (동일 머신 다중 프로세스): pid % 1024 가 달라 충돌 없음
+        // - HA (다중 머신): 같은 pid % 1024 가 같은 ms 에 같은 seq 를 가질 경우만 충돌 (무시할 확률)
+        private val machineId = ProcessHandle.current().pid() and 0x3FFL  // 10비트
+        private val lockIdSeq = AtomicLong(0L)
+
+        private fun nextLockId(): Long {
+            val ts = System.currentTimeMillis() shl 22
+            val mid = machineId shl 12
+            val seq = lockIdSeq.getAndIncrement() and 0xFFFL  // 12비트
+            return ts or mid or seq
+        }
+
         operator fun invoke(
             redissonClient: RedissonClient,
             options: LeaderElectionOptions = LeaderElectionOptions.Default,
@@ -119,9 +128,7 @@ class RedissonSuspendLeaderElection private constructor(
         try {
             log.debug { "Leader 승격을 요청합니다 ..." }
 
-            // Coroutine 환경에서 Thread ID 대신 랜덤 ID를 사용하여 락 소유자를 식별합니다.
-            // Thread ID는 코루틴이 여러 스레드 사이를 이동하기 때문에 사용할 수 없습니다.
-            val lockId = ThreadLocalRandom.current().nextLong()
+            val lockId = nextLockId()
 
             val acquired = lock
                 .tryLockAsync(

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/AbstractRedissonLeaderTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/AbstractRedissonLeaderTest.kt
@@ -1,0 +1,49 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+import org.testcontainers.containers.GenericContainer
+import java.util.UUID
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractRedissonLeaderTest {
+
+    companion object: KLogging() {
+        private val redisContainer: GenericContainer<*> =
+            GenericContainer("redis:7-alpine").withExposedPorts(6379)
+
+        init {
+            redisContainer.start()
+        }
+
+        val redisUrl: String
+            get() = "redis://${redisContainer.host}:${redisContainer.getMappedPort(6379)}"
+
+        val redissonClient: RedissonClient by lazy {
+            val config = Config().apply {
+                useSingleServer()
+                    .setAddress(redisUrl)
+                    .setConnectionPoolSize(8)
+                    .setConnectionMinimumIdleSize(2)
+            }
+            Redisson.create(config)
+        }
+
+        fun randomName(): String = "leader-test:${UUID.randomUUID().toString().take(8)}"
+    }
+
+    @BeforeAll
+    fun setupRedisson() {
+        redissonClient.getAtomicLong("_init").get()
+    }
+
+    @AfterAll
+    fun teardownRedisson() {
+        // 컨테이너는 JVM 종료 시 자동 정리됨 (companion object lazy)
+    }
+}

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElectionSupportTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElectionSupportTest.kt
@@ -7,9 +7,6 @@ import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.redis.redisson.AbstractRedissonTest
-import io.bluetape4k.redis.redisson.RedissonTestUtils.randomName
-import io.bluetape4k.redis.redisson.RedissonTestUtils.redissonClient
 import io.bluetape4k.utils.Runtimex
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
@@ -21,7 +18,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.random.Random
 
-class RedissonLeaderElectionSupportTest: AbstractRedissonTest() {
+class RedissonLeaderElectionSupportTest: AbstractRedissonLeaderTest() {
 
     companion object: KLogging()
 

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElectionTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElectionTest.kt
@@ -7,9 +7,6 @@ import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.redis.redisson.AbstractRedissonTest
-import io.bluetape4k.redis.redisson.RedissonTestUtils.randomName
-import io.bluetape4k.redis.redisson.RedissonTestUtils.redissonClient
 import io.bluetape4k.utils.Runtimex
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterThan
@@ -17,7 +14,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
-import org.redisson.client.RedisException
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
@@ -27,7 +23,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.random.Random
 
-class RedissonLeaderElectionTest: AbstractRedissonTest() {
+class RedissonLeaderElectionTest: AbstractRedissonLeaderTest() {
 
     companion object: KLogging()
 
@@ -119,7 +115,7 @@ class RedissonLeaderElectionTest: AbstractRedissonTest() {
     }
 
     @Test
-    fun `run action should throw when lock is not acquired`() {
+    fun `run action should return null when lock is not acquired`() {
         val lockName = randomName()
         val options = LeaderElectionOptions(
             waitTime = Duration.ofMillis(100),
@@ -142,9 +138,8 @@ class RedissonLeaderElectionTest: AbstractRedissonTest() {
 
         try {
             lockAcquired.await(1, TimeUnit.SECONDS)
-            assertThrows<RedisException> {
-                leaderElection.runIfLeader(lockName) { 1 }
-            }
+            val result = leaderElection.runIfLeader(lockName) { 1 }
+            result shouldBeEqualTo null
         } finally {
             releaseLock.countDown()
             lockHolder.shutdownNow()

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElectionTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElectionTest.kt
@@ -7,9 +7,6 @@ import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.redis.redisson.AbstractRedissonTest
-import io.bluetape4k.redis.redisson.RedissonTestUtils.randomName
-import io.bluetape4k.redis.redisson.RedissonTestUtils.redissonClient
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeLessOrEqualTo
@@ -18,7 +15,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
-import org.redisson.client.RedisException
 import java.time.Duration
 import java.util.concurrent.CompletionException
 import java.util.concurrent.CountDownLatch
@@ -28,7 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.max
 import kotlin.random.Random
 
-class RedissonLeaderGroupElectionTest: AbstractRedissonTest() {
+class RedissonLeaderGroupElectionTest: AbstractRedissonLeaderTest() {
 
     companion object: KLogging()
 
@@ -74,7 +70,7 @@ class RedissonLeaderGroupElectionTest: AbstractRedissonTest() {
     }
 
     @Test
-    fun `runIfLeader - maxLeaders 슬롯이 모두 사용 중이면 waitTime 초과 시 RedisException 이 발생한다`() {
+    fun `runIfLeader - maxLeaders 슬롯이 모두 사용 중이면 waitTime 초과 시 null 을 반환한다`() {
         val shortWaitOptions = LeaderGroupElectionOptions(maxLeaders = 1, waitTime = Duration.ofMillis(100))
         val singleElection = RedissonLeaderGroupElection(redissonClient, shortWaitOptions)
         val lockName = randomName()
@@ -91,9 +87,8 @@ class RedissonLeaderGroupElectionTest: AbstractRedissonTest() {
 
         try {
             acquiredLatch.await(2, TimeUnit.SECONDS)
-            assertThrows<RedisException> {
-                singleElection.runIfLeader(lockName) { }
-            }
+            val result = singleElection.runIfLeader(lockName) { }
+            result shouldBeEqualTo null
         } finally {
             holdLatch.countDown()
             executor.shutdownNow()

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElectionSupportTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElectionSupportTest.kt
@@ -1,12 +1,8 @@
 package io.bluetape4k.leader.redisson
 
-import io.bluetape4k.coroutines.support.log
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
-import io.bluetape4k.redis.redisson.AbstractRedissonTest
-import io.bluetape4k.redis.redisson.RedissonTestUtils.randomName
-import io.bluetape4k.redis.redisson.RedissonTestUtils.redissonClient
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
@@ -14,7 +10,7 @@ import org.junit.jupiter.api.Test
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
 
-class RedissonSuspendLeaderElectionSupportTest: AbstractRedissonTest() {
+class RedissonSuspendLeaderElectionSupportTest: AbstractRedissonLeaderTest() {
 
     companion object: KLoggingChannel()
 
@@ -29,15 +25,14 @@ class RedissonSuspendLeaderElectionSupportTest: AbstractRedissonTest() {
                     randomDelay(50, 100)
                     log.debug { "작업 1 을 종료합니다." }
                 }
-            }.log("job1"),
-
+            },
             launch {
                 redissonClient.suspendRunIfLeader(jobName) {
                     log.debug { "작업 2 을 시작합니다." }
                     randomDelay(50, 100)
                     log.debug { "작업 2 을 종료합니다." }
                 }
-            }.log("job2")
+            }
         )
         jobs.joinAll()
     }

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElectionTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElectionTest.kt
@@ -1,28 +1,22 @@
 package io.bluetape4k.leader.redisson
 
-import io.bluetape4k.coroutines.support.log
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
-import io.bluetape4k.redis.redisson.AbstractRedissonTest
-import io.bluetape4k.redis.redisson.RedissonTestUtils.randomName
-import io.bluetape4k.redis.redisson.RedissonTestUtils.redissonClient
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Test
-import org.redisson.client.RedisException
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
 
-class RedissonSuspendLeaderElectionTest: AbstractRedissonTest() {
+class RedissonSuspendLeaderElectionTest: AbstractRedissonLeaderTest() {
 
     companion object: KLoggingChannel()
 
@@ -38,7 +32,7 @@ class RedissonSuspendLeaderElectionTest: AbstractRedissonTest() {
                     randomDelay()
                     log.debug { "작업 1 을 종료합니다." }
                 }
-            }.log("job1")
+            }
 
             launch {
                 leaderElection.runIfLeader(lockName) {
@@ -46,7 +40,7 @@ class RedissonSuspendLeaderElectionTest: AbstractRedissonTest() {
                     randomDelay()
                     log.debug { "작업 2 을 종료합니다." }
                 }
-            }.log("job2")
+            }
         }
     }
 
@@ -86,7 +80,7 @@ class RedissonSuspendLeaderElectionTest: AbstractRedissonTest() {
     }
 
     @Test
-    fun `run action should throw when lock is not acquired`() = runSuspendIO {
+    fun `run action should return null when lock is not acquired`() = runSuspendIO {
         val lockName = randomName()
         val options = LeaderElectionOptions(
             waitTime = Duration.ofMillis(100),
@@ -97,11 +91,8 @@ class RedissonSuspendLeaderElectionTest: AbstractRedissonTest() {
 
         lock.lock(3, TimeUnit.SECONDS)
         try {
-            val result = runCatching {
-                leaderElection.runIfLeader(lockName) { 1 }
-            }
-            result.isFailure.shouldBeTrue()
-            (result.exceptionOrNull() is RedisException).shouldBeTrue()
+            val result = leaderElection.runIfLeader(lockName) { 1 }
+            result shouldBeEqualTo null
         } finally {
             if (lock.isHeldByCurrentThread) {
                 lock.unlock()

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElectionTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElectionTest.kt
@@ -5,9 +5,6 @@ import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
-import io.bluetape4k.redis.redisson.AbstractRedissonTest
-import io.bluetape4k.redis.redisson.RedissonTestUtils.randomName
-import io.bluetape4k.redis.redisson.RedissonTestUtils.redissonClient
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -24,7 +21,7 @@ import kotlin.math.max
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
 
-class RedissonSuspendLeaderGroupElectionTest: AbstractRedissonTest() {
+class RedissonSuspendLeaderGroupElectionTest: AbstractRedissonLeaderTest() {
 
     companion object: KLoggingChannel()
 


### PR DESCRIPTION
## Summary

Closes #3

PR #17의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `test: leader-redis-redisson 테스트 인프라 자립화 (Issue #3)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 변경 요약

Issue #3: `leader-redis-redisson` 테스트를 `bluetape4k-redisson` 테스트 클래스 의존 없이 자립화

## 주요 변경사항

### 신규
- `AbstractRedissonLeaderTest`: Testcontainers `GenericContainer` 직접 사용한 자립형 Redis 테스트 기반 클래스

### 테스트 6개 수정
- `AbstractRedissonTest` → `AbstractRedissonLeaderTest` 교체
- `RedissonTestUtils.{redissonClient,randomName}` 정적 임포트 제거

### 동작 수정 (PR #15 반영)
- `runIfLeader()`가 락 획득 실패 시 예외를 던지는 대신 `null` 반환하도록 변경
- 영향 파일: `RedissonLeaderElectionTest`, `RedissonLeaderGroupElectionTest`, `RedissonSuspendLeaderElectionTest`

### 버그 수정
- `RedissonSuspendLeaderElection`: `getLockId()` (bluetape4k-idgenerators `compileOnly` → ClassNotFoundException) → `ThreadLocalRandom.current().nextLong()` 대체

## 테스트 결과

```
49 tests completed, 0 failed
```

Closes #3
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #3, milestone `0.1.0`, assignee `debop`
- PR: #17, head `45efebefa03a04190ce7909d987fe954b7616da7`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
