### PR TITLE
ci: publish-snapshot을 Nightly 성공 시에만 실행

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,8 +1,10 @@
 name: Publish Snapshot
 
 on:
-  schedule:
-    - cron: '0 18 * * *'  # 매일 03:00 KST (18:00 UTC)
+  workflow_run:
+    workflows: ["Nightly"]
+    types: [completed]
+    branches: [develop]
   workflow_dispatch:
 
 concurrency:
@@ -15,34 +17,13 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
-  check-activity:
-    name: Check Recent Commits
-    runs-on: ubuntu-latest
-    outputs:
-      has_commits: ${{ steps.check.outputs.has_commits }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: develop
-      - name: Check commits in last 24 hours
-        id: check
-        run: |
-          COUNT=$(git log --oneline --since="24 hours ago" origin/develop | wc -l)
-          echo "Recent commit count: $COUNT"
-          if [ "$COUNT" -gt 0 ]; then
-            echo "has_commits=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_commits=false" >> "$GITHUB_OUTPUT"
-          fi
-
   publish:
     name: Publish SNAPSHOT to Maven Central
     runs-on: ubuntu-latest
-    needs: check-activity
+    # workflow_run: Nightly 성공 시에만 실행. 수동 dispatch는 항상 실행.
     if: |
-      needs.check-activity.outputs.has_commits == 'true' ||
-      github.event_name == 'workflow_dispatch'
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

PR #20의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `ci: publish-snapshot을 Nightly 성공 시에만 실행`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 변경 내용

- `publish-snapshot.yml` 트리거를 `schedule` cron → `workflow_run` (Nightly 완료 시)으로 교체
- `github.event.workflow_run.conclusion == 'success'` 조건으로 Nightly 실패 시 배포 차단
- 수동 `workflow_dispatch`는 유지
- `check-activity` 잡(24h 커밋 체크) 제거 — Nightly 자체가 실행 여부를 이미 보장

## 실행 순서

```
Nightly (매일 04:00 KST, develop)
  └─ 성공 → Publish Snapshot 자동 실행
  └─ 실패 → 배포 건너뜀
```
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #20, head `da5ee7d22a1bf06e3a3dfa5879044f293ff75f76`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
