### PR TITLE
fix: 코루틴 취소 안전성 + 옵션/상태 검증 강화 (daily review 2026-04-30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,20 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **leader-redis-lettuce coroutine cancellation safety**: `LettuceSuspendLeaderElection` and `LettuceSuspendLeaderGroupElection` now wrap unlock/release in `withContext(NonCancellable)` so the Redis key/permit is reliably released when the calling coroutine is cancelled mid-`action`. Previously, cancellation between `action()` and the `finally` block could leak the Redis lock until lease expiry. (daily review)
+- **Lettuce backend observability**: `runCatching { unlock/release }` blocks in Lettuce single- and group-leader implementations now surface failures via `.onFailure { log.warn }`. Token mismatch / Redis errors during release were previously dropped silently. (daily review)
+
+### Changed
+
+- **Argument validation pushed into option/state types**: `LeaderElectionOptions`, `LeaderGroupElectionOptions`, and `LeaderGroupState` now reject invalid arguments in their `init {}` blocks (`waitTime` ≥ 0, `leaseTime` > 0, `maxLeaders` ≥ 1, `activeCount ∈ 0..maxLeaders`, `lockName` non-blank). Previously these only blew up later inside semaphore/lock code. (daily review)
+- **Redisson KDoc accuracy**: removed stale "throws RedisException on contention" claims and replaced with the actual ShedLock-style `null` return contract; `@throws RedisException` now only documents the interrupt path. (daily review)
+- **Suspend interface contract** (`SuspendLeaderElection`, `SuspendLeaderGroupElection`): added explicit cancellation contract to KDoc — implementations must release the lock/slot and rethrow `CancellationException`. (daily review)
+
 ### Planned
 
-- `leader-exposed` — Exposed/JDBC backend (issue #7)
+- `leader-exposed-core`/`leader-exposed-jdbc`/`leader-exposed-r2dbc` — Exposed backends (issue #7, refactor #24)
 - `leader-mongodb` — MongoDB backend (issue #8)
 - `leader-hazelcast` — Hazelcast backend (issue #9)
 - `leader-micrometer` — Micrometer metrics integration (issue #10)

--- a/README.ko.md
+++ b/README.ko.md
@@ -26,7 +26,9 @@ graph TD
     Core["leader-core\n(인터페이스 + 로컬 구현)"]
     Lettuce["leader-redis-lettuce\n(Lettuce Redis)"]
     Redisson["leader-redis-redisson\n(Redisson Redis)"]
-    Exposed["leader-exposed\n(예정)"]
+    ExposedCore["leader-exposed-core\n(예정)"]
+    ExposedJdbc["leader-exposed-jdbc\n(예정)"]
+    ExposedR2dbc["leader-exposed-r2dbc\n(예정)"]
     Mongo["leader-mongodb\n(예정)"]
     Hazelcast["leader-hazelcast\n(예정)"]
     SB3["leader-spring-boot3\n(예정)"]
@@ -35,7 +37,9 @@ graph TD
 
     Lettuce --> Core
     Redisson --> Core
-    Exposed --> Core
+    ExposedCore --> Core
+    ExposedJdbc --> ExposedCore
+    ExposedR2dbc --> ExposedCore
     Mongo --> Core
     Hazelcast --> Core
     SB3 --> Core
@@ -50,7 +54,9 @@ graph TD
 | `leader-core` | 안정 | 인터페이스 + 로컬 인메모리 구현체 |
 | `leader-redis-lettuce` | 안정 | Lettuce 기반 Redis 백엔드 |
 | `leader-redis-redisson` | 안정 | Redisson 기반 Redis 백엔드 |
-| `leader-exposed` | 예정 | Exposed/JDBC 백엔드 |
+| `leader-exposed-core` | 예정 | Exposed 공통 스키마 (JDBC/R2DBC 드라이버 미포함) |
+| `leader-exposed-jdbc` | 예정 | Exposed JDBC 백엔드 |
+| `leader-exposed-r2dbc` | 예정 | Exposed R2DBC 백엔드 |
 | `leader-mongodb` | 예정 | MongoDB 백엔드 |
 | `leader-hazelcast` | 예정 | Hazelcast 백엔드 |
 | `leader-micrometer` | 예정 | Micrometer 메트릭 연동 |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ graph TD
     Core["leader-core\n(Interfaces + Local impls)"]
     Lettuce["leader-redis-lettuce\n(Lettuce Redis)"]
     Redisson["leader-redis-redisson\n(Redisson Redis)"]
-    Exposed["leader-exposed\n(planned)"]
+    ExposedCore["leader-exposed-core\n(planned)"]
+    ExposedJdbc["leader-exposed-jdbc\n(planned)"]
+    ExposedR2dbc["leader-exposed-r2dbc\n(planned)"]
     Mongo["leader-mongodb\n(planned)"]
     Hazelcast["leader-hazelcast\n(planned)"]
     SB3["leader-spring-boot3\n(planned)"]
@@ -35,7 +37,9 @@ graph TD
 
     Lettuce --> Core
     Redisson --> Core
-    Exposed --> Core
+    ExposedCore --> Core
+    ExposedJdbc --> ExposedCore
+    ExposedR2dbc --> ExposedCore
     Mongo --> Core
     Hazelcast --> Core
     SB3 --> Core
@@ -50,7 +54,9 @@ graph TD
 | `leader-core` | Stable | Interfaces + local in-process implementations |
 | `leader-redis-lettuce` | Stable | Lettuce-based Redis backend |
 | `leader-redis-redisson` | Stable | Redisson-based Redis backend |
-| `leader-exposed` | Planned | Exposed/JDBC backend |
+| `leader-exposed-core` | Planned | Common Exposed schema (no JDBC/R2DBC driver) |
+| `leader-exposed-jdbc` | Planned | Exposed JDBC backend |
+| `leader-exposed-r2dbc` | Planned | Exposed R2DBC backend |
 | `leader-mongodb` | Planned | MongoDB backend |
 | `leader-hazelcast` | Planned | Hazelcast backend |
 | `leader-micrometer` | Planned | Micrometer metrics integration |

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderGroupElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderGroupElection.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.Executor
  * - 상태 조회 메서드([state], [activeCount], [availableSlots])는 [LeaderGroupElectionState]에서 상속합니다.
  *
  * ```kotlin
- * val election: AsyncLeaderGroupElection = LocalAsyncLeaderGroupElection(maxLeaders = 3)
+ * val election: AsyncLeaderGroupElection = LocalAsyncLeaderGroupElection(LeaderGroupElectionOptions(maxLeaders = 3))
  * val result = election.runAsyncIfLeader("batch-job") {
  *     CompletableFuture.completedFuture(processChunk())
  * }.join()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionOptions.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionOptions.kt
@@ -23,6 +23,11 @@ data class LeaderElectionOptions(
     val waitTime: Duration = Duration.ofSeconds(5),
     val leaseTime: Duration = Duration.ofSeconds(60),
 ): Serializable {
+    init {
+        require(!waitTime.isNegative) { "waitTime must not be negative: $waitTime" }
+        require(!leaseTime.isNegative && !leaseTime.isZero) { "leaseTime must be positive: $leaseTime" }
+    }
+
     companion object {
         /**
          * 기본 옵션 인스턴스 (`waitTime=5s`, `leaseTime=60s`).

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupElection.kt
@@ -19,7 +19,7 @@ package io.bluetape4k.leader
  * - 상태 조회 메서드([state], [activeCount], [availableSlots])는 근사값을 반환할 수 있습니다.
  *
  * ```kotlin
- * val election = LocalLeaderGroupElection(maxLeaders = 3)
+ * val election = LocalLeaderGroupElection(LeaderGroupElectionOptions(maxLeaders = 3))
  * val result = election.runIfLeader("batch-job") { processChunk() }
  *
  * println(election.state("batch-job"))  // LeaderGroupState(activeCount=2, ...)

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupElectionOptions.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupElectionOptions.kt
@@ -26,6 +26,12 @@ data class LeaderGroupElectionOptions(
     val waitTime: Duration = Duration.ofSeconds(5),
     val leaseTime: Duration = Duration.ofSeconds(60),
 ): Serializable {
+    init {
+        require(maxLeaders >= 1) { "maxLeaders must be >= 1: $maxLeaders" }
+        require(!waitTime.isNegative) { "waitTime must not be negative: $waitTime" }
+        require(!leaseTime.isNegative && !leaseTime.isZero) { "leaseTime must be positive: $leaseTime" }
+    }
+
     companion object {
         /**
          * 기본 옵션 인스턴스 (`maxLeaders=2`, `waitTime=5s`, `leaseTime=60s`).

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupElectionState.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupElectionState.kt
@@ -7,7 +7,7 @@ package io.bluetape4k.leader
  * 모든 리더 그룹 선출 인터페이스가 이 인터페이스를 상속하여 상태 조회 메서드를 공유합니다.
  *
  * ```kotlin
- * val election: LeaderGroupElectionState = LocalLeaderGroupElection(maxLeaders = 3)
+ * val election: LeaderGroupElectionState = LocalLeaderGroupElection(LeaderGroupElectionOptions(maxLeaders = 3))
  * val state = election.state("batch-job")  // LeaderGroupState
  * ```
  */
@@ -20,7 +20,7 @@ interface LeaderGroupElectionState {
      * [lockName]에 대해 현재 활성(실행 중인) 리더 수를 반환합니다.
      *
      * ```kotlin
-     * val election = LocalLeaderGroupElection(maxLeaders = 3)
+     * val election = LocalLeaderGroupElection(LeaderGroupElectionOptions(maxLeaders = 3))
      * val count = election.activeCount("batch-job")
      * // count == 0  (아무도 실행 중이 아닐 때)
      * ```
@@ -34,7 +34,7 @@ interface LeaderGroupElectionState {
      * [lockName]에 대해 새 리더를 수용할 수 있는 남은 슬롯 수를 반환합니다.
      *
      * ```kotlin
-     * val election = LocalLeaderGroupElection(maxLeaders = 3)
+     * val election = LocalLeaderGroupElection(LeaderGroupElectionOptions(maxLeaders = 3))
      * val slots = election.availableSlots("batch-job")
      * // slots == 3  (아무도 실행 중이 아닐 때)
      * ```
@@ -48,7 +48,7 @@ interface LeaderGroupElectionState {
      * [lockName]에 대한 현재 [LeaderGroupState]를 반환합니다.
      *
      * ```kotlin
-     * val election = LocalLeaderGroupElection(maxLeaders = 3)
+     * val election = LocalLeaderGroupElection(LeaderGroupElectionOptions(maxLeaders = 3))
      * val state = election.state("batch-job")
      * // state.maxLeaders == 3
      * // state.activeCount == 0

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupState.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupState.kt
@@ -20,6 +20,14 @@ data class LeaderGroupState(
     val maxLeaders: Int,
     val activeCount: Int,
 ) {
+    init {
+        require(lockName.isNotBlank()) { "lockName must not be blank" }
+        require(maxLeaders >= 1) { "maxLeaders must be >= 1: $maxLeaders" }
+        require(activeCount in 0..maxLeaders) {
+            "activeCount must be in 0..$maxLeaders: $activeCount"
+        }
+    }
+
     /**
      * 새 리더를 수용할 수 있는 남은 슬롯 수.
      *

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/VirtualThreadLeaderGroupElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/VirtualThreadLeaderGroupElection.kt
@@ -21,7 +21,7 @@ import io.bluetape4k.concurrent.virtualthread.VirtualFuture
  * - 상태 조회 메서드([state], [activeCount], [availableSlots])는 [LeaderGroupElectionState]에서 상속합니다.
  *
  * ```kotlin
- * val election = LocalVirtualThreadLeaderGroupElection(maxLeaders = 3)
+ * val election = LocalVirtualThreadLeaderGroupElection(LeaderGroupElectionOptions(maxLeaders = 3))
  * val result = election.runAsyncIfLeader("batch-job") { processChunk() }.await()
  * ```
  */

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElection.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentHashMap
  * - 이 구현체는 `kotlinx.coroutines.sync.Semaphore`(코루틴 suspend)를 사용합니다.
  *
  * ```kotlin
- * val election = LocalSuspendLeaderGroupElection(maxLeaders = 3)
+ * val election = LocalSuspendLeaderGroupElection(LeaderGroupElectionOptions(maxLeaders = 3))
  *
  * // 최대 3개 코루틴이 동시에 실행
  * val result = election.runIfLeader("batch-job") { processChunkSuspend() }
@@ -33,7 +33,7 @@ import java.util.concurrent.ConcurrentHashMap
  * println(election.state("batch-job"))
  * ```
  *
- * @param maxLeaders 허용하는 최대 동시 리더 수. 기본값 2
+ * @param options 리더 그룹 선출 옵션. 기본값은 [LeaderGroupElectionOptions.Default]
  */
 class LocalSuspendLeaderGroupElection private constructor(
     private val options: LeaderGroupElectionOptions,

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderElection.kt
@@ -6,7 +6,9 @@ package io.bluetape4k.leader.coroutines
  * ## 동작/계약
  * - 구현체는 동일 [lockName]에 대해 리더 획득 성공 호출만 [action]을 실행합니다.
  * - [action]은 suspend 함수이며 호출 컨텍스트/디스패처는 구현체 정책을 따릅니다.
- * - 리더 선출 실패/취소/예외 전파 규칙은 구현체에 위임됩니다.
+ * - 리더 획득 실패 시 `null`을 반환합니다 (ShedLock skip 방식).
+ * - [action] 실행 중 코루틴 취소 시 락/슬롯은 반드시 반환되어야 하며,
+ *   `CancellationException`은 반환 작업 후 호출자에게 재전파해야 합니다.
  *
  * ```kotlin
  * val result = election.runIfLeader("sync-job") { "ok" }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderGroupElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderGroupElection.kt
@@ -15,12 +15,13 @@ import io.bluetape4k.leader.LeaderGroupElectionState
  *
  * ## 동작/계약
  * - 구현체는 `lockName` 기준으로 최대 [maxLeaders]개의 `action`을 동시에 실행합니다.
- * - 슬롯이 가득 찬 경우, 빈 슬롯이 생길 때까지 호출 코루틴이 suspend됩니다.
+ * - 슬롯이 가득 찬 경우 [waitTime] 내 슬롯을 획득하지 못하면 `null`을 반환합니다 (ShedLock skip 방식).
  * - `action` 예외 발생 시에도 슬롯이 반드시 반환됩니다.
+ * - 코루틴 취소 시 슬롯은 반드시 반환되어야 하며, `CancellationException`은 반환 작업 후 재전파해야 합니다.
  * - 상태 조회 메서드([state], [activeCount], [availableSlots])는 근사값을 반환할 수 있습니다.
  *
  * ```kotlin
- * val election = LocalSuspendLeaderGroupElection(maxLeaders = 3)
+ * val election = LocalSuspendLeaderGroupElection(LeaderGroupElectionOptions(maxLeaders = 3))
  * val result = election.runIfLeader("batch-job") { processChunkSuspend() }
  *
  * println(election.state("batch-job"))  // LeaderGroupState(activeCount=2, ...)

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderGroupElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderGroupElection.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
  * - [LocalAsyncLeaderGroupElection]: 비동기([java.util.concurrent.CompletableFuture]) 실행만
  * - [LocalVirtualThreadLeaderGroupElection]: [io.bluetape4k.concurrent.virtualthread.VirtualFuture] 실행
  *
- * @param maxLeaders 허용하는 최대 동시 리더 수
+ * @param options 리더 그룹 선출 옵션 (maxLeaders, waitTime, leaseTime). 기본값은 [LeaderGroupElectionOptions.Default]
  */
 abstract class AbstractLocalLeaderGroupElection(
     protected val options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalAsyncLeaderGroupElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalAsyncLeaderGroupElection.kt
@@ -18,7 +18,7 @@ import java.util.concurrent.Executor
  * - 분산 환경이 아닌 단일 JVM 프로세스 내 동시 실행 제한에 적합합니다.
  *
  * ```kotlin
- * val election = LocalAsyncLeaderGroupElection(maxLeaders = 3)
+ * val election = LocalAsyncLeaderGroupElection(LeaderGroupElectionOptions(maxLeaders = 3))
  *
  * // 최대 3개 Virtual Thread 가 동시에 실행
  * val result = election.runAsyncIfLeader("batch-job") {
@@ -26,7 +26,7 @@ import java.util.concurrent.Executor
  * }.join()
  * ```
  *
- * @param maxLeaders 허용하는 최대 동시 리더 수. 기본값 2
+ * @param options 리더 그룹 선출 옵션. 기본값은 [LeaderGroupElectionOptions.Default]
  */
 class LocalAsyncLeaderGroupElection private constructor(
     options: LeaderGroupElectionOptions,

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderGroupElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderGroupElection.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.Executor
  * - 분산 환경이 아닌 단일 JVM 프로세스 내 동시 실행 제한에 적합합니다.
  *
  * ```kotlin
- * val election = LocalLeaderGroupElection(maxLeaders = 3)
+ * val election = LocalLeaderGroupElection(LeaderGroupElectionOptions(maxLeaders = 3))
  *
  * // 동기 실행 (최대 3개 스레드 동시)
  * val result = election.runIfLeader("batch-job") { processChunk() }
@@ -26,7 +26,7 @@ import java.util.concurrent.Executor
  * val future = election.runAsyncIfLeader("batch-job") { CompletableFuture.completedFuture(42) }
  * ```
  *
- * @param maxLeaders 허용하는 최대 동시 리더 수. 기본값 2
+ * @param options 리더 그룹 선출 옵션. 기본값은 [LeaderGroupElectionOptions.Default]
  */
 class LocalLeaderGroupElection private constructor(options: LeaderGroupElectionOptions):
     AbstractLocalLeaderGroupElection(options), LeaderGroupElection {

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalVirtualThreadLeaderGroupElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalVirtualThreadLeaderGroupElection.kt
@@ -21,13 +21,13 @@ import io.bluetape4k.support.requirePositiveNumber
  * - 반환이 [VirtualFuture]로 `await()` API가 명시적입니다.
  *
  * ```kotlin
- * val election = LocalVirtualThreadLeaderGroupElection(maxLeaders = 3)
+ * val election = LocalVirtualThreadLeaderGroupElection(LeaderGroupElectionOptions(maxLeaders = 3))
  *
  * // 최대 3개 Virtual Thread 가 동시에 실행
  * val result = election.runAsyncIfLeader("batch-job") { processChunk() }.await()
  * ```
  *
- * @param maxLeaders 허용하는 최대 동시 리더 수. 기본값 2
+ * @param options 리더 그룹 선출 옵션. 기본값은 [LeaderGroupElectionOptions.Default]
  */
 class LocalVirtualThreadLeaderGroupElection private constructor(
     options: LeaderGroupElectionOptions,

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionOptionsTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionOptionsTest.kt
@@ -38,14 +38,34 @@ class LeaderElectionOptionsTest {
     @Test
     fun `LeaderGroupElectionOptions maxLeaders 가 0 이하면 예외가 발생한다`() {
         assertThrows<IllegalArgumentException> {
-            io.bluetape4k.leader.local.LocalLeaderGroupElection(
-                LeaderGroupElectionOptions(maxLeaders = 0)
-            )
+            LeaderGroupElectionOptions(maxLeaders = 0)
         }
         assertThrows<IllegalArgumentException> {
-            io.bluetape4k.leader.local.LocalLeaderGroupElection(
-                LeaderGroupElectionOptions(maxLeaders = -1)
-            )
+            LeaderGroupElectionOptions(maxLeaders = -1)
+        }
+    }
+
+    @Test
+    fun `LeaderElectionOptions leaseTime 이 0 이하면 예외가 발생한다`() {
+        assertThrows<IllegalArgumentException> {
+            LeaderElectionOptions(leaseTime = Duration.ZERO)
+        }
+        assertThrows<IllegalArgumentException> {
+            LeaderElectionOptions(leaseTime = Duration.ofSeconds(-1))
+        }
+    }
+
+    @Test
+    fun `LeaderElectionOptions waitTime 이 음수면 예외가 발생한다`() {
+        assertThrows<IllegalArgumentException> {
+            LeaderElectionOptions(waitTime = Duration.ofMillis(-1))
+        }
+    }
+
+    @Test
+    fun `LeaderGroupElectionOptions leaseTime 이 0 이하면 예외가 발생한다`() {
+        assertThrows<IllegalArgumentException> {
+            LeaderGroupElectionOptions(leaseTime = Duration.ZERO)
         }
     }
 

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderGroupStateTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderGroupStateTest.kt
@@ -5,6 +5,7 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class LeaderGroupStateTest {
 
@@ -48,5 +49,35 @@ class LeaderGroupStateTest {
         state.availableSlots shouldBeEqualTo 10
         state.isEmpty.shouldBeTrue()
         state.isFull.shouldBeFalse()
+    }
+
+    @Test
+    fun `blank lockName 으로 생성 시 예외가 발생한다`() {
+        assertThrows<IllegalArgumentException> {
+            LeaderGroupState(lockName = "", maxLeaders = 3, activeCount = 0)
+        }
+        assertThrows<IllegalArgumentException> {
+            LeaderGroupState(lockName = "   ", maxLeaders = 3, activeCount = 0)
+        }
+    }
+
+    @Test
+    fun `maxLeaders 가 0 이하이면 예외가 발생한다`() {
+        assertThrows<IllegalArgumentException> {
+            LeaderGroupState(lockName = "job", maxLeaders = 0, activeCount = 0)
+        }
+        assertThrows<IllegalArgumentException> {
+            LeaderGroupState(lockName = "job", maxLeaders = -1, activeCount = 0)
+        }
+    }
+
+    @Test
+    fun `activeCount 가 범위를 벗어나면 예외가 발생한다`() {
+        assertThrows<IllegalArgumentException> {
+            LeaderGroupState(lockName = "job", maxLeaders = 3, activeCount = -1)
+        }
+        assertThrows<IllegalArgumentException> {
+            LeaderGroupState(lockName = "job", maxLeaders = 3, activeCount = 4)
+        }
     }
 }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElection.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElection.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.leader.LeaderElection
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
 import io.bluetape4k.leader.lettuce.lock.LettuceLock
 import io.bluetape4k.support.requireNotBlank
 import io.lettuce.core.api.StatefulRedisConnection
@@ -60,9 +61,8 @@ class LettuceLeaderElection(
         try {
             return action()
         } finally {
-            if (lock.isHeldByCurrentInstance()) {
-                runCatching { lock.unlock() }
-            }
+            runCatching { if (lock.isHeldByCurrentInstance()) lock.unlock() }
+                .onFailure { log.warn(it) { "Fail to release lock. lockName=$lockName" } }
         }
     }
 
@@ -87,14 +87,12 @@ class LettuceLeaderElection(
                 log.debug { "리더 선출 성공 (async): lockName=$lockName" }
                 try {
                     action().whenComplete { _, _ ->
-                        if (lock.isHeldByCurrentInstance()) {
-                            runCatching { lock.unlock() }
-                        }
+                        runCatching { if (lock.isHeldByCurrentInstance()) lock.unlock() }
+                            .onFailure { log.warn(it) { "Fail to release lock. lockName=$lockName" } }
                     }
                 } catch (e: Throwable) {
-                    if (lock.isHeldByCurrentInstance()) {
-                        runCatching { lock.unlock() }
-                    }
+                    runCatching { if (lock.isHeldByCurrentInstance()) lock.unlock() }
+                        .onFailure { log.warn(it) { "Fail to release lock. lockName=$lockName" } }
                     CompletableFuture.failedFuture(e)
                 }
             }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElection.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElection.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderGroupState
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
 import io.bluetape4k.leader.lettuce.semaphore.LettuceSemaphore
 import io.bluetape4k.support.requireNotBlank
 import io.lettuce.core.api.StatefulRedisConnection
@@ -21,7 +22,7 @@ import java.util.concurrent.Executor
  * val result = election.runIfLeader("batch-job") { processChunk() }
  * ```
  *
- * @param options    리더 선출 옵션 (기본값: [LeaderElectionOptions.Default])
+ * @param options    리더 선출 옵션 (기본값: [LeaderGroupElectionOptions.Default])
  * @return [LettuceLeaderGroupElection] 인스턴스
  */
 fun StatefulRedisConnection<String, String>.leaderGroupElection(
@@ -99,6 +100,7 @@ class LettuceLeaderGroupElection(
             return action()
         } finally {
             runCatching { semaphore.release() }
+                .onFailure { log.warn(it) { "Fail to release semaphore slot. lockName=$lockName" } }
         }
     }
 
@@ -125,9 +127,11 @@ class LettuceLeaderGroupElection(
                 try {
                     action().whenComplete { _, _ ->
                         runCatching { semaphore.release() }
+                .onFailure { log.warn(it) { "Fail to release semaphore slot. lockName=$lockName" } }
                     }
                 } catch (e: Throwable) {
                     runCatching { semaphore.release() }
+                .onFailure { log.warn(it) { "Fail to release semaphore slot. lockName=$lockName" } }
                     CompletableFuture.failedFuture(e)
                 }
             }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElection.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElection.kt
@@ -4,9 +4,13 @@ import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.coroutines.SuspendLeaderElection
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
 import io.bluetape4k.leader.lettuce.lock.LettuceSuspendLock
 import io.bluetape4k.support.requireNotBlank
 import io.lettuce.core.api.StatefulRedisConnection
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
 
 /**
  * [StatefulRedisConnection]에서 [LettuceSuspendLeaderElection] 인스턴스를 생성합니다.
@@ -58,8 +62,13 @@ class LettuceSuspendLeaderElection(
         try {
             return action()
         } finally {
-            if (lock.isHeldByCurrentInstance()) {
-                runCatching { lock.unlock() }
+            // NonCancellable: 코루틴 취소 시에도 락 해제가 중단되지 않도록 보호
+            withContext(NonCancellable) {
+                runCatching { if (lock.isHeldByCurrentInstance()) lock.unlock() }
+                    .onFailure { error ->
+                        if (error is CancellationException) throw error
+                        log.warn(error) { "Fail to release lock. lockName=$lockName" }
+                    }
             }
         }
     }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElection.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElection.kt
@@ -5,17 +5,21 @@ import io.bluetape4k.leader.LeaderGroupState
 import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElection
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
 import io.bluetape4k.leader.lettuce.semaphore.LettuceSemaphore
 import io.bluetape4k.support.requireNotBlank
 import io.lettuce.core.api.StatefulRedisConnection
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.future.await
+import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
 
 /**
  * [StatefulRedisConnection]에서 [LettuceSuspendLeaderGroupElection] 인스턴스를 생성합니다.
  *
  * ```kotlin
- * val election = connection.suspendLeaderGroupElection(maxLeaders = 3)
+ * val election = connection.suspendLeaderGroupElection(LeaderGroupElectionOptions(maxLeaders = 3))
  * val result = election.runIfLeader("batch-job") { processChunkSuspend() }
  * ```
  *
@@ -93,7 +97,14 @@ class LettuceSuspendLeaderGroupElection(
         try {
             return action()
         } finally {
-            runCatching { semaphore.releaseAsync().await() }
+            // NonCancellable: 코루틴 취소 시에도 슬롯 반납이 중단되지 않도록 보호
+            withContext(NonCancellable) {
+                runCatching { semaphore.releaseAsync().await() }
+                    .onFailure { error ->
+                        if (error is CancellationException) throw error
+                        log.warn(error) { "Fail to release semaphore slot. lockName=$lockName" }
+                    }
+            }
         }
     }
 }

--- a/leader-redis-redisson/README.ko.md
+++ b/leader-redis-redisson/README.ko.md
@@ -158,25 +158,14 @@ val election = RedissonLeaderElection(client, options)
 
 ## 테스트 인프라
 
-테스트는 Testcontainers `GenericContainer("redis:7-alpine")`을 직접 사용합니다. 외부 테스트 유틸 클래스에 대한 의존이 없습니다:
+테스트는 `bluetape4k-testcontainers` 의 `RedisServer.Launcher.redis` (JVM 전역 싱글톤 Redis 컨테이너) 를 사용합니다:
 
 ```kotlin
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractRedissonLeaderTest {
     companion object : KLogging() {
-        private val redisContainer =
-            GenericContainer("redis:7-alpine").withExposedPorts(6379)
-
-        init { redisContainer.start() }
-
-        val redisUrl: String
-            get() = "redis://${redisContainer.host}:${redisContainer.getMappedPort(6379)}"
-
-        val redissonClient: RedissonClient by lazy {
-            val config = Config().apply {
-                useSingleServer().setAddress(redisUrl)
-            }
-            Redisson.create(config)
-        }
+        val redis = RedisServer.Launcher.redis
+        val redisUrl: String get() = redis.url
     }
 }
 ```

--- a/leader-redis-redisson/README.md
+++ b/leader-redis-redisson/README.md
@@ -164,25 +164,14 @@ val election = RedissonSuspendLeaderElection(client, LeaderElectionOptions.Defau
 
 ## Test Infrastructure
 
-Tests use Testcontainers `GenericContainer("redis:7-alpine")` — self-contained, no dependency on external test utilities:
+Tests use `bluetape4k-testcontainers` `RedisServer.Launcher.redis`, a JVM-wide singleton Redis container:
 
 ```kotlin
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractRedissonLeaderTest {
     companion object : KLogging() {
-        private val redisContainer =
-            GenericContainer("redis:7-alpine").withExposedPorts(6379)
-
-        init { redisContainer.start() }
-
-        val redisUrl: String
-            get() = "redis://${redisContainer.host}:${redisContainer.getMappedPort(6379)}"
-
-        val redissonClient: RedissonClient by lazy {
-            val config = Config().apply {
-                useSingleServer().setAddress(redisUrl)
-            }
-            Redisson.create(config)
-        }
+        val redis = RedisServer.Launcher.redis
+        val redisUrl: String get() = redis.url
     }
 }
 ```

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElection.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElection.kt
@@ -21,7 +21,8 @@ import java.util.concurrent.TimeUnit
  * ## 동작
  * - [runIfLeader]: 동기 방식으로 락을 획득한 뒤 [LeaderElection.runIfLeader]를 실행하고, 완료 후 락을 해제합니다.
  * - [runAsyncIfLeader]: `tryLockAsync`로 비동기 락을 획득하고, `CompletableFuture` 완료 시 [RLock.unlockAsync]로 락을 해제합니다.
- * - 락 획득 실패 시 [org.redisson.client.RedisException]을 던집니다.
+ * - [LeaderElectionOptions.waitTime] 내 락 획득에 실패하면 `null`을 반환합니다 (ShedLock skip 방식).
+ * - 락 대기 중 인터럽트가 발생하면 [org.redisson.client.RedisException]으로 래핑되어 전파됩니다.
  *
  * ```kotlin
  * val election = RedissonLeaderElection(redissonClient)
@@ -58,7 +59,8 @@ class RedissonLeaderElection private constructor(
      *
      * @param lockName lock name - lock 획득에 성공하면 leader로 승격되는 것이다.
      * @param action leader 로 승격되면 수행할 코드 블럭
-     * @return 작업 결과
+     * @return [action] 실행 결과, 리더 획득 실패 시 `null`
+     * @throws org.redisson.client.RedisException 락 대기 중 인터럽트가 발생한 경우
      */
     override fun <T> runIfLeader(lockName: String, action: () -> T): T? {
         lockName.requireNotBlank("lockName")
@@ -98,7 +100,7 @@ class RedissonLeaderElection private constructor(
      * @param lockName lock name - lock 획득에 성공하면 leader로 승격되는 것이다.
      * @param executor 작업이 수행될 executor
      * @param action leader 로 승격되면 수행할 코드 블럭
-     * @return 작업 결과
+     * @return [action] 실행 결과를 담은 [CompletableFuture]. 리더 획득 실패 시 `null`로 완료됨
      */
     override fun <T> runAsyncIfLeader(
         lockName: String,
@@ -233,7 +235,7 @@ inline fun <T> RedissonClient.runIfLeader(
  * @param executor 작업을 수행할 Executor
  * @param options 리더 선출 옵션
  * @param action 리더로 선출되었을 때 수행할 비동기 작업
- * @return 작업 결과를 담은 []CompletableFuture] 인스턴스
+ * @return 작업 결과를 담은 [CompletableFuture] 인스턴스. 리더 획득 실패 시 `null`로 완료됨
  */
 inline fun <T> RedissonClient.runAsyncIfLeader(
     jobName: String,

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElection.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElection.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
  *
  * ```kotlin
  * val client: RedissonClient = ...
- * val options = RedissonLeaderGroupElectionOptions(maxLeaders = 3)
+ * val options = LeaderGroupElectionOptions(maxLeaders = 3)
  * val result: Int = client.runIfLeaderGroup("batch-job", options) {
  *     // 최대 3개 프로세스가 동시에 실행
  *     42
@@ -48,8 +48,8 @@ inline fun <T> RedissonClient.runIfLeaderGroup(
  *
  * ## 동작
  * - `lockName`별로 Redis 분산 `RSemaphore(maxLeaders)`를 생성하여 동시 실행 수를 제한합니다.
- * - 슬롯이 가득 찬 경우 [LeaderGroupElectionOptions.waitTime] 내에 슬롯을 획득하지 못하면
- *   [RedisException]을 던집니다.
+ * - 슬롯이 가득 찬 경우 [LeaderGroupElectionOptions.waitTime] 내에 슬롯을 획득하지 못하면 `null`을 반환합니다 (ShedLock skip 방식).
+ * - 슬롯 대기 중 인터럽트가 발생하면 [RedisException]으로 래핑되어 전파됩니다.
  * - 슬롯 획득 성공 시 `action`을 실행하고, 완료(또는 예외) 후 반드시 슬롯을 반납합니다.
  * - 여러 JVM 프로세스에 걸친 분산 동시 실행 제한에 적합합니다.
  *
@@ -58,7 +58,7 @@ inline fun <T> RedissonClient.runIfLeaderGroup(
  * - 이 구현체는 Redis 기반 `RSemaphore`를 사용하므로 여러 프로세스에서 동작합니다.
  *
  * ```kotlin
- * val options = RedissonLeaderGroupElectionOptions(maxLeaders = 3)
+ * val options = LeaderGroupElectionOptions(maxLeaders = 3)
  * val election = RedissonLeaderGroupElection(redissonClient, options)
  *
  * // 최대 3개 스레드/프로세스가 동시에 실행
@@ -139,8 +139,8 @@ class RedissonLeaderGroupElection private constructor(
      *
      * @param lockName 리더 그룹 선출에 사용할 락 이름
      * @param action 슬롯 획득 성공 시 실행할 동기 작업
-     * @return [action] 실행 결과
-     * @throws RedisException 슬롯 획득 실패 또는 인터럽트 발생 시
+     * @return [action] 실행 결과, 슬롯 획득 실패 시 `null`
+     * @throws RedisException 슬롯 대기 중 인터럽트가 발생한 경우
      */
     override fun <T> runIfLeader(
         lockName: String,
@@ -177,14 +177,13 @@ class RedissonLeaderGroupElection private constructor(
     /**
      * [lockName]의 분산 [RSemaphore] 슬롯을 [executor]에서 획득하고 비동기 [action]을 실행합니다.
      *
-     * - 슬롯이 가득 찬 경우 [waitTime] 내 슬롯을 획득하지 못하면 [RedisException]을 던집니다.
+     * - 슬롯이 가득 찬 경우 [waitTime] 내 슬롯을 획득하지 못하면 `null`로 완료된 [CompletableFuture]를 반환합니다.
      * - [action] 예외 발생 시에도 슬롯은 반드시 반환됩니다.
      *
      * @param lockName 리더 그룹 선출에 사용할 락 이름
      * @param executor 비동기 실행에 사용할 [Executor]
      * @param action 슬롯 획득 성공 시 실행할 비동기 작업
-     * @return [action] 실행 결과를 담은 [CompletableFuture]
-     * @throws RedisException 슬롯 획득 실패 또는 인터럽트 발생 시
+     * @return [action] 실행 결과를 담은 [CompletableFuture]. 슬롯 획득 실패 시 `null`로 완료됨
      */
     override fun <T> runAsyncIfLeader(
         lockName: String,

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElection.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElection.kt
@@ -20,7 +20,8 @@ import java.util.concurrent.TimeUnit
  * Redisson 분산 락을 이용하여 리더 선출을 통한 suspend 작업을 실행합니다.
  *
  * 락 획득에 성공하면 [action]을 실행하고, 완료 후 락을 해제합니다.
- * 락 획득 실패 시 [org.redisson.client.RedisException]을 던집니다.
+ * [LeaderElectionOptions.waitTime] 내 락 획득에 실패하면 `null`을 반환합니다 (ShedLock skip 방식).
+ * 락 대기 중 인터럽트가 발생하면 [org.redisson.client.RedisException]으로 래핑되어 전파됩니다.
  *
  * ```kotlin
  * val result = redissonClient.suspendRunIfLeader("my-job") {
@@ -109,13 +110,13 @@ class RedissonSuspendLeaderElection private constructor(
      * Redisson Lock을 이용하여, 리더로 선출되면 [action]을 수행하고, 그렇지 않다면 수행하지 않습니다.
      *
      * Coroutine 환경에서 스레드 전환으로 인한 락 소유자 불일치를 방지하기 위해,
-     * `Thread.currentThread().threadId()` 대신 Redis `RAtomicLong` 기반의
-     * [io.bluetape4k.redis.redisson.coroutines.getLockId]로 발급한 고유 ID를 락 식별자로 사용합니다.
+     * `Thread.currentThread().threadId()` 대신 PID-seeded Snowflake-like ID
+     * (`timestamp | pid%(2^10) | seq`, 동반자 객체의 `nextLockId()` 참고)를 락 식별자로 사용합니다.
      *
      * @param lockName 락 이름 — 락 획득에 성공하면 리더로 승격됩니다.
      * @param action 리더로 승격되었을 때 수행할 suspend 코드 블록
-     * @return [action] 실행 결과
-     * @throws org.redisson.client.RedisException 락 획득 실패 또는 인터럽트 발생 시
+     * @return [action] 실행 결과, 리더 획득 실패 시 `null`
+     * @throws org.redisson.client.RedisException 락 대기 중 인터럽트가 발생한 경우
      */
     override suspend fun <T> runIfLeader(
         lockName: String,

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElection.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElection.kt
@@ -22,7 +22,7 @@ import java.time.Duration
  *
  * ```kotlin
  * val client: RedissonClient = ...
- * val options = RedissonLeaderGroupElectionOptions(maxLeaders = 3)
+ * val options = LeaderGroupElectionOptions(maxLeaders = 3)
  * val result: Int = client.runSuspendIfLeaderGroup("batch-job", options) {
  *     // 최대 3개 프로세스가 동시에 실행
  *     delay(100)
@@ -51,18 +51,18 @@ suspend fun <T> RedissonClient.runSuspendIfLeaderGroup(
  *
  * ## 동작
  * - `lockName`별로 Redis 분산 `RSemaphore(maxLeaders)`를 생성하여 동시 실행 수를 제한합니다.
- * - 슬롯이 가득 찬 경우 [LeaderGroupElectionOptions.waitTime] 내에 슬롯을 획득하지 못하면
- *   [RedisException]을 던집니다.
+ * - 슬롯이 가득 찬 경우 [LeaderGroupElectionOptions.waitTime] 내에 슬롯을 획득하지 못하면 `null`을 반환합니다 (ShedLock skip 방식).
+ * - 슬롯 대기 중 인터럽트가 발생하면 [RedisException]으로 래핑되어 전파됩니다.
  * - `tryAcquireAsync`/`releaseAsync`를 사용하여 호출 코루틴을 블로킹하지 않습니다.
  * - `action` 예외 발생 시에도 슬롯은 반드시 반환됩니다.
  * - 여러 JVM 프로세스에 걸친 분산 동시 실행 제한에 적합합니다.
  *
  * ## [RedissonLeaderGroupElection] 과의 차이
  * - [RedissonLeaderGroupElection]은 스레드를 블로킹합니다.
- * - 이 구현체는 `awit()`으로 코루틴을 suspend합니다.
+ * - 이 구현체는 `await()`으로 코루틴을 suspend합니다.
  *
  * ```kotlin
- * val options = RedissonLeaderGroupElectionOptions(maxLeaders = 3)
+ * val options = LeaderGroupElectionOptions(maxLeaders = 3)
  * val election = RedissonSuspendLeaderGroupElection(redissonClient, options)
  *
  * // 최대 3개 코루틴/프로세스가 동시에 실행
@@ -136,13 +136,13 @@ class RedissonSuspendLeaderGroupElection private constructor(
     /**
      * [lockName]의 분산 [RSemaphore] 슬롯을 비동기로 획득하고 suspend [action]을 실행합니다.
      *
-     * - 슬롯이 가득 찬 경우 [waitTime] 내 슬롯을 획득하지 못하면 [RedisException]을 던집니다.
+     * - 슬롯이 가득 찬 경우 [waitTime] 내 슬롯을 획득하지 못하면 `null`을 반환합니다 (ShedLock skip 방식).
      * - [action] 예외 발생 시에도 슬롯은 반드시 반환됩니다.
      *
      * @param lockName 리더 그룹 선출에 사용할 락 이름
      * @param action 슬롯 획득 성공 시 실행할 suspend 작업
-     * @return [action] 실행 결과
-     * @throws RedisException 슬롯 획득 실패 또는 인터럽트 발생 시
+     * @return [action] 실행 결과, 슬롯 획득 실패 시 `null`
+     * @throws RedisException 슬롯 대기 중 인터럽트가 발생한 경우
      */
     override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? {
         lockName.requireNotBlank("lockName")


### PR DESCRIPTION
## Summary

PR #25의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: 코루틴 취소 안전성 + 옵션/상태 검증 강화 (daily review 2026-04-30)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

자동 일일 리뷰 작업 결과로, 지난 24h 내 추가된 모든 소스(`leader-core`, `leader-redis-lettuce`, `leader-redis-redisson`)를 5개의 code review agent(`code-reviewer`, `silent-failure-hunter`, `type-design-analyzer`, `comment-analyzer`, `pr-test-analyzer`)에 병렬로 회부하고, **CRITICAL/HIGH** 등급의 문제만 선별하여 수정했습니다.

## Highlights

### CRITICAL 수정 — 코루틴 취소 시 Redis 자원 누설
- `LettuceSuspendLeaderElection.runIfLeader`, `LettuceSuspendLeaderGroupElection.runIfLeader`
- `action()` 실행 중 호출 코루틴이 취소되면 `finally` 안의 `await()` 가 즉시 `CancellationException` 으로 다시 던져지면서 **Redis lock/permit 이 lease 만료까지 누설**되었습니다.
- `withContext(NonCancellable) { runCatching { … }.onFailure { …; rethrow CancellationException } }` 패턴으로 보호 (Redisson 측에서 이미 사용 중인 패턴과 일치).

### HIGH — 무음 실패 가시화
- Lettuce 단일/그룹 리더의 `runCatching { unlock() / release() }` 가 토큰 불일치·Lua 스크립트 오류 등을 통째로 삼키고 있었습니다. `.onFailure { log.warn }` 추가.

### 옵션/상태 타입의 invariant 강화
- `LeaderElectionOptions` (`waitTime ≥ 0`, `leaseTime > 0`)
- `LeaderGroupElectionOptions` (`maxLeaders ≥ 1` + 위 두 조건)
- `LeaderGroupState` (`lockName` 비공백, `maxLeaders ≥ 1`, `activeCount ∈ 0..maxLeaders`)
- 잘못된 값을 받았을 때 semaphore/lock 깊숙이서 터지지 않고, **타입 생성 시점**에 IllegalArgumentException 으로 즉시 거부.

### KDoc 정확도
- Redisson 4종 (`RedissonLeaderElection`, `RedissonLeaderGroupElection`, `RedissonSuspendLeaderElection`, `RedissonSuspendLeaderGroupElection`) 의 "락/슬롯 획득 실패 시 RedisException" 기재를 **실제 동작인 `null` 반환**으로 정정. `@throws RedisException` 는 인터럽트 경로만 명시.
- `SuspendLeaderElection` / `SuspendLeaderGroupElection` KDoc 에 **코루틴 취소 시 락/슬롯 반환 + CancellationException 재전파** 계약을 명시 (구현체 위임 → 인터페이스 계약).
- 컴파일 안 되던 KDoc 예시(`LocalLeaderGroupElection(maxLeaders = 3)` 등) 7군데 정정.

### 테스트 추가
- `LeaderElectionOptionsTest`: `maxLeaders ≤ 0`, `leaseTime ≤ 0`, `waitTime < 0` 검증 4 케이스.
- `LeaderGroupStateTest`: blank `lockName`, `maxLeaders ≤ 0`, `activeCount` 범위 검증 3 케이스.

### 문서 동기화
- 루트 `README.md` / `README.ko.md`: `leader-exposed` → `leader-exposed-{core,jdbc,r2dbc}` 3 모듈 분리 반영.
- `leader-redis-redisson/README.{md,ko.md}`: 테스트 인프라 설명을 `GenericContainer` 직사용에서 `bluetape4k-testcontainers` `RedisServer.Launcher` 로 동기화.
- `CHANGELOG.md`: Unreleased 섹션에 본 PR 의 Fixed/Changed 항목 추가.

## Out of scope (의도적 미수정)

리뷰에서 제기되었지만 **별도 PR이 적절하다고 판단하여 보류**한 항목들 (CHANGELOG 에는 기재하지 않음):

- **인터페이스 상속 관계 분리** (`LeaderElection: AsyncLeaderElection` → 형제 capability 로 분리). 구조 변경이라 1.0 후보로 별도 검토 권장.
- **`LockName` value class 도입**으로 blank 검증 통일.
- **인터럽트를 RedisException 으로 래핑**하는 4 곳의 동작 자체. 명백한 위반이라기보다 설계 선택이라 별도 논의 필요.
- **Lettuce 의 `IllegalStateException` catch** 로 timeout 신호로 사용하는 패턴 — `LettuceSemaphore.acquire` 에 dedicated sentinel 도입이 필요.
- 누락된 cancellation/contention 테스트의 **풀 매트릭스** (backend × variant × scenario) — 별도 issue 로 트래킹 권장.

## Test plan

- [x] `:leader-core:test` (단위 테스트 + 신규 검증 테스트)
- [x] `:leader-redis-lettuce:test` (Testcontainers Redis)
- [x] `:leader-redis-redisson:test` (Testcontainers Redis)
- [x] 컴파일 (3 모듈 모두 클린)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #25, head `19c965432eba5681d65207274a8caaefb64722bb`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
