### PR TITLE
feat: leader-hazelcast 구현 (IMap 토큰 락 기반)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -26,18 +26,18 @@ graph TD
     Core["leader-core\n(인터페이스 + 로컬 구현)"]
     Lettuce["leader-redis-lettuce\n(Lettuce Redis)"]
     Redisson["leader-redis-redisson\n(Redisson Redis)"]
+    Hazelcast["leader-hazelcast\n(Hazelcast)"]
     Exposed["leader-exposed\n(예정)"]
     Mongo["leader-mongodb\n(예정)"]
-    Hazelcast["leader-hazelcast\n(예정)"]
     SB3["leader-spring-boot3\n(예정)"]
     SB4["leader-spring-boot4\n(예정)"]
     Metrics["leader-micrometer\n(예정)"]
 
     Lettuce --> Core
     Redisson --> Core
+    Hazelcast --> Core
     Exposed --> Core
     Mongo --> Core
-    Hazelcast --> Core
     SB3 --> Core
     SB4 --> Core
     Metrics --> Core
@@ -50,9 +50,9 @@ graph TD
 | `leader-core` | 안정 | 인터페이스 + 로컬 인메모리 구현체 |
 | `leader-redis-lettuce` | 안정 | Lettuce 기반 Redis 백엔드 |
 | `leader-redis-redisson` | 안정 | Redisson 기반 Redis 백엔드 |
+| `leader-hazelcast` | 안정 | Hazelcast 백엔드 (IMap 기반, CP Subsystem 불필요) |
 | `leader-exposed` | 예정 | Exposed/JDBC 백엔드 |
 | `leader-mongodb` | 예정 | MongoDB 백엔드 |
-| `leader-hazelcast` | 예정 | Hazelcast 백엔드 |
 | `leader-micrometer` | 예정 | Micrometer 메트릭 연동 |
 | `leader-spring-boot3` | 예정 | Spring Boot 3 자동 구성 |
 | `leader-spring-boot4` | 예정 | Spring Boot 4 자동 구성 |
@@ -121,6 +121,58 @@ val election = LocalLeaderElection()
 val result = election.runIfLeader("job") { "done" }
 ```
 
+## `runIfLeader` 동작 원리
+
+여러 노드가 동시에 `runIfLeader`를 호출하면 하나만 락을 획득하고 action을 실행하며, 나머지는 `null`을 반환합니다.
+
+```mermaid
+sequenceDiagram
+    participant NodeA
+    participant NodeB
+    participant LockStore
+
+    par NodeA 시도
+        NodeA->>LockStore: tryLock("job", waitTime, leaseTime)
+    and NodeB 시도
+        NodeB->>LockStore: tryLock("job", waitTime, leaseTime)
+    end
+
+    LockStore-->>NodeA: 획득 성공 (true)
+    LockStore-->>NodeB: 획득 실패 → waitTime까지 재시도
+
+    NodeA->>NodeA: action()
+    NodeA->>LockStore: unlock("job")
+    NodeA-->>NodeA: action() 결과 반환
+
+    LockStore-->>NodeB: 타임아웃 (false)
+    NodeB-->>NodeB: null 반환
+```
+
+### 복수 리더 그룹: 슬롯 기반 세마포어
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant GroupElection
+    participant LockStore
+
+    Caller->>GroupElection: runIfLeader(lockName, action)
+    loop slot = 0..maxLeaders-1
+        GroupElection->>LockStore: tryLock(lockName:slot:i, ...)
+        alt 슬롯 획득 성공
+            LockStore-->>GroupElection: true
+            GroupElection->>Caller: action()
+            Caller-->>GroupElection: result
+            GroupElection->>LockStore: unlock(lockName:slot:i)
+            GroupElection-->>Caller: result
+        else 슬롯 사용 중
+            LockStore-->>GroupElection: false
+            Note over GroupElection: 다음 슬롯 시도
+        end
+    end
+    Note over GroupElection: 모든 슬롯 사용 중 → null 반환
+```
+
 ## API 개요
 
 ### 핵심 인터페이스
@@ -166,7 +218,7 @@ LeaderGroupElectionOptions(
 | Spring 연동 | 예정 | 지원 (핵심 기능) |
 | JDBC/SQL | 예정 | 지원 |
 | MongoDB | 예정 | 지원 |
-| Hazelcast | 예정 | 지원 |
+| Hazelcast | 지원 | 지원 |
 
 ## 요구사항
 

--- a/README.md
+++ b/README.md
@@ -26,18 +26,18 @@ graph TD
     Core["leader-core\n(Interfaces + Local impls)"]
     Lettuce["leader-redis-lettuce\n(Lettuce Redis)"]
     Redisson["leader-redis-redisson\n(Redisson Redis)"]
+    Hazelcast["leader-hazelcast\n(Hazelcast)"]
     Exposed["leader-exposed\n(planned)"]
     Mongo["leader-mongodb\n(planned)"]
-    Hazelcast["leader-hazelcast\n(planned)"]
     SB3["leader-spring-boot3\n(planned)"]
     SB4["leader-spring-boot4\n(planned)"]
     Metrics["leader-micrometer\n(planned)"]
 
     Lettuce --> Core
     Redisson --> Core
+    Hazelcast --> Core
     Exposed --> Core
     Mongo --> Core
-    Hazelcast --> Core
     SB3 --> Core
     SB4 --> Core
     Metrics --> Core
@@ -50,9 +50,9 @@ graph TD
 | `leader-core` | Stable | Interfaces + local in-process implementations |
 | `leader-redis-lettuce` | Stable | Lettuce-based Redis backend |
 | `leader-redis-redisson` | Stable | Redisson-based Redis backend |
+| `leader-hazelcast` | Stable | Hazelcast backend (IMap-based, no CP Subsystem) |
 | `leader-exposed` | Planned | Exposed/JDBC backend |
 | `leader-mongodb` | Planned | MongoDB backend |
-| `leader-hazelcast` | Planned | Hazelcast backend |
 | `leader-micrometer` | Planned | Micrometer metrics integration |
 | `leader-spring-boot3` | Planned | Spring Boot 3 auto-configuration |
 | `leader-spring-boot4` | Planned | Spring Boot 4 auto-configuration |
@@ -121,6 +121,58 @@ val election = LocalLeaderElection()
 val result = election.runIfLeader("job") { "done" }
 ```
 
+## How `runIfLeader` Works
+
+Multiple nodes call `runIfLeader` concurrently — only one acquires the lock and runs the action; the rest return `null`.
+
+```mermaid
+sequenceDiagram
+    participant NodeA
+    participant NodeB
+    participant LockStore
+
+    par NodeA attempts
+        NodeA->>LockStore: tryLock("job", waitTime, leaseTime)
+    and NodeB attempts
+        NodeB->>LockStore: tryLock("job", waitTime, leaseTime)
+    end
+
+    LockStore-->>NodeA: acquired (true)
+    LockStore-->>NodeB: not acquired → wait/retry until timeout
+
+    NodeA->>NodeA: action()
+    NodeA->>LockStore: unlock("job")
+    NodeA-->>NodeA: return action() result
+
+    LockStore-->>NodeB: timeout (false)
+    NodeB-->>NodeB: return null
+```
+
+### Multi-leader group: slot-based semaphore
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant GroupElection
+    participant LockStore
+
+    Caller->>GroupElection: runIfLeader(lockName, action)
+    loop slot = 0..maxLeaders-1
+        GroupElection->>LockStore: tryLock(lockName:slot:i, ...)
+        alt slot acquired
+            LockStore-->>GroupElection: true
+            GroupElection->>Caller: action()
+            Caller-->>GroupElection: result
+            GroupElection->>LockStore: unlock(lockName:slot:i)
+            GroupElection-->>Caller: result
+        else slot busy
+            LockStore-->>GroupElection: false
+            Note over GroupElection: try next slot
+        end
+    end
+    Note over GroupElection: all slots busy → return null
+```
+
 ## API Overview
 
 ### Core interfaces
@@ -164,7 +216,7 @@ LeaderGroupElectionOptions(
 | Spring integration | Planned | Yes (core feature) |
 | JDBC/SQL | Planned | Yes |
 | MongoDB | Planned | Yes |
-| Hazelcast | Planned | Yes |
+| Hazelcast | Yes | Yes |
 
 ## Requirements
 

--- a/leader-core/README.ko.md
+++ b/leader-core/README.ko.md
@@ -77,6 +77,57 @@ LeaderGroupElectionOptions(
 )
 ```
 
+## 시퀀스 다이어그램
+
+### 단일 리더: 락 획득/해제
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant LeaderElection
+    participant LockStore
+
+    Caller->>LeaderElection: runIfLeader(lockName, action)
+    LeaderElection->>LockStore: tryLock(lockName, waitTime, leaseTime)
+
+    alt 락 획득 성공
+        LockStore-->>LeaderElection: true
+        LeaderElection->>Caller: action()
+        Caller-->>LeaderElection: result
+        LeaderElection->>LockStore: unlock(lockName)
+        LeaderElection-->>Caller: result (T)
+    else waitTime 내 획득 실패
+        LockStore-->>LeaderElection: false
+        LeaderElection-->>Caller: null
+    end
+```
+
+### 복수 리더 그룹: 슬롯 기반 세마포어 (maxLeaders = N)
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant GroupElection
+    participant LockStore
+
+    Caller->>GroupElection: runIfLeader(lockName, action)
+    loop slot = 0..N-1
+        GroupElection->>LockStore: tryLock(lockName:slot:i, ...)
+        alt 슬롯 획득 성공
+            LockStore-->>GroupElection: true
+            Note over GroupElection: 슬롯 i 확보
+            GroupElection->>Caller: action()
+            Caller-->>GroupElection: result
+            GroupElection->>LockStore: unlock(lockName:slot:i)
+            GroupElection-->>Caller: result (T)
+        else 슬롯 사용 중
+            LockStore-->>GroupElection: false
+            Note over GroupElection: 다음 슬롯 시도
+        end
+    end
+    Note over GroupElection: 모든 슬롯 사용 중 → null 반환
+```
+
 ## 로컬 구현체 목록
 
 모든 로컬 구현체는 JVM 기본 동기화 프리미티브(`ReentrantLock`, `Semaphore`)를 사용합니다. 외부 의존 없음.

--- a/leader-core/README.md
+++ b/leader-core/README.md
@@ -77,6 +77,57 @@ LeaderGroupElectionOptions(
 )
 ```
 
+## Sequence Diagrams
+
+### Single-leader: lock acquire/release
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant LeaderElection
+    participant LockStore
+
+    Caller->>LeaderElection: runIfLeader(lockName, action)
+    LeaderElection->>LockStore: tryLock(lockName, waitTime, leaseTime)
+
+    alt lock acquired
+        LockStore-->>LeaderElection: true
+        LeaderElection->>Caller: action()
+        Caller-->>LeaderElection: result
+        LeaderElection->>LockStore: unlock(lockName)
+        LeaderElection-->>Caller: result (T)
+    else not acquired within waitTime
+        LockStore-->>LeaderElection: false
+        LeaderElection-->>Caller: null
+    end
+```
+
+### Multi-leader group: slot-based semaphore (maxLeaders = N)
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant GroupElection
+    participant LockStore
+
+    Caller->>GroupElection: runIfLeader(lockName, action)
+    loop slot = 0..N-1
+        GroupElection->>LockStore: tryLock(lockName:slot:i, ...)
+        alt slot acquired
+            LockStore-->>GroupElection: true
+            Note over GroupElection: acquired slot i
+            GroupElection->>Caller: action()
+            Caller-->>GroupElection: result
+            GroupElection->>LockStore: unlock(lockName:slot:i)
+            GroupElection-->>Caller: result (T)
+        else slot busy
+            LockStore-->>GroupElection: false
+            Note over GroupElection: try next slot
+        end
+    end
+    Note over GroupElection: all slots busy → return null
+```
+
 ## Local Implementations
 
 All local implementations use JVM primitives (`ReentrantLock`, `Semaphore`) — no external dependencies.

--- a/leader-hazelcast/README.ko.md
+++ b/leader-hazelcast/README.ko.md
@@ -161,6 +161,71 @@ val election = HazelcastLeaderElection(hazelcast, options)
 확인: IMap.get(lockKey) == token
 ```
 
+### 락 획득/해제 시퀀스
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant HazelcastLock
+    participant IMap
+
+    Caller->>HazelcastLock: tryLock(waitTime, leaseTime)
+    loop deadline 까지 반복
+        HazelcastLock->>IMap: putIfAbsent(lockKey, token, leaseTimeMs)
+        alt 키 없음 (null 반환)
+            IMap-->>HazelcastLock: null
+            HazelcastLock-->>Caller: true (획득 성공)
+        else 키 존재
+            IMap-->>HazelcastLock: 기존 토큰
+            HazelcastLock->>HazelcastLock: sleep min(50ms, remaining)
+        end
+    end
+    HazelcastLock-->>Caller: false (timeout)
+
+    Note over Caller,IMap: action() 실행 중 (TTL 카운트다운)
+
+    Caller->>HazelcastLock: isHeldByCurrentInstance()
+    HazelcastLock->>IMap: get(lockKey)
+    IMap-->>HazelcastLock: 저장된 토큰
+    HazelcastLock-->>Caller: 저장된 토큰 == token
+
+    Caller->>HazelcastLock: unlock()
+    HazelcastLock->>IMap: remove(lockKey, token)
+    alt 토큰 일치
+        IMap-->>HazelcastLock: true
+        Note over HazelcastLock: 락 해제 완료
+    else 토큰 불일치 (TTL 만료, 다른 노드가 재획득)
+        IMap-->>HazelcastLock: false
+        Note over HazelcastLock: 경고 — 스플릿 브레인 가능성
+    end
+```
+
+### 그룹 선출 슬롯 시퀀스 (maxLeaders = N)
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant GroupElection
+    participant IMap
+
+    Caller->>GroupElection: runIfLeader(lockName)
+    loop slot = 0..N-1
+        GroupElection->>IMap: putIfAbsent(lockName:slot:i, token, leaseTimeMs)
+        alt 슬롯 획득 성공
+            IMap-->>GroupElection: null
+            Note over GroupElection: acquiredLock = slot i
+            GroupElection->>Caller: action()
+            Caller-->>GroupElection: result
+            GroupElection->>IMap: remove(lockName:slot:i, token)
+            GroupElection-->>Caller: result
+        else 슬롯 사용 중
+            IMap-->>GroupElection: 기존 토큰
+            Note over GroupElection: 다음 슬롯 시도
+        end
+    end
+    Note over GroupElection: 모든 슬롯 사용 중 → null 반환
+```
+
 그룹 선출은 N개의 슬롯 키(`lockName:slot:0` … `lockName:slot:N-1`)로 세마포어를 시뮬레이션합니다. 각 호출자는 슬롯을 순서대로 시도하고, 처음 획득한 슬롯을 사용합니다.
 
 락 맵 이름:

--- a/leader-hazelcast/README.ko.md
+++ b/leader-hazelcast/README.ko.md
@@ -1,0 +1,178 @@
+# leader-hazelcast
+
+[English](README.md)
+
+Hazelcast 기반 분산 리더 선출 — 블로킹, 비동기, Virtual Thread, 코루틴 API 제공.
+
+---
+
+## 개요
+
+`leader-hazelcast`는 Hazelcast `IMap`을 분산 락 저장소로 사용하여 `leader-core` 인터페이스를 구현합니다. CP Subsystem 없이 동작하며, `putIfAbsent + TTL` + 토큰 기반 조건부 해제 방식으로 락을 구현합니다.
+
+락 전략: `IMap.putIfAbsent(key, token, leaseTimeMs, MILLISECONDS)`로 원자적 획득, `IMap.remove(key, token)`으로 보유자만 해제. 스레드 ID에 의존하지 않는 토큰 모델 — Virtual Thread 및 코루틴 스레드 전환에서도 안전합니다.
+
+> **주의:** `leaseTime`은 action의 최대 실행 시간보다 충분히 커야 합니다.
+> TTL이 만료되면 락이 자동 해제되며, 갱신(watchdog)은 수행되지 않습니다.
+>
+> **주의:** 락 맵에는 near-cache를 절대 활성화하지 마십시오.
+> 오래된 near-cache 값이 `isHeldByCurrentInstance()` 오판을 유발할 수 있습니다.
+
+## 아키텍처
+
+```mermaid
+classDiagram
+    class LeaderElection { <<interface>> }
+    class LeaderGroupElection { <<interface>> }
+    class SuspendLeaderElection { <<interface>> }
+    class SuspendLeaderGroupElection { <<interface>> }
+
+    class HazelcastLock {
+        +tryLock(waitTime, leaseTime) Boolean
+        +isHeldByCurrentInstance() Boolean
+        +unlock()
+    }
+    class HazelcastSuspendLock {
+        +tryLock(waitTime, leaseTime) Boolean
+        +isHeldByCurrentInstance() Boolean
+        +unlock()
+    }
+
+    HazelcastLeaderElection ..|> LeaderElection
+    HazelcastLeaderGroupElection ..|> LeaderGroupElection
+    HazelcastSuspendLeaderElection ..|> SuspendLeaderElection
+    HazelcastSuspendLeaderGroupElection ..|> SuspendLeaderGroupElection
+
+    HazelcastLeaderElection --> HazelcastLock
+    HazelcastLeaderGroupElection --> HazelcastLock
+    HazelcastSuspendLeaderElection --> HazelcastSuspendLock
+    HazelcastSuspendLeaderGroupElection --> HazelcastSuspendLock
+```
+
+## 구현체
+
+| 클래스 | 인터페이스 | 설명 |
+|--------|-----------|------|
+| `HazelcastLeaderElection` | `LeaderElection` | 블로킹 + 비동기 단일 리더 |
+| `HazelcastLeaderGroupElection` | `LeaderGroupElection` | 블로킹 + 비동기 복수 리더 (슬롯 기반) |
+| `HazelcastSuspendLeaderElection` | `SuspendLeaderElection` | 코루틴 단일 리더 |
+| `HazelcastSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` | 코루틴 복수 리더 (슬롯 기반) |
+
+## 사용법
+
+### 설정
+
+```kotlin
+val config = ClientConfig().apply {
+    networkConfig.addAddress("localhost:5701")
+}
+val hazelcast = HazelcastClient.newHazelcastClient(config)
+```
+
+### 블로킹 단일 리더
+
+```kotlin
+val election = HazelcastLeaderElection(hazelcast)
+
+val result = election.runIfLeader("daily-report") {
+    generateReport()
+}
+// 리더 노드: generateReport() 반환값, 나머지: null
+```
+
+### 블로킹 복수 리더 그룹
+
+```kotlin
+val options = LeaderGroupElectionOptions(maxLeaders = 3)
+val election = HazelcastLeaderGroupElection(hazelcast, options)
+
+val result = election.runIfLeader("parallel-batch") {
+    processChunk()
+}
+// 최대 3개 노드가 동시에 실행, 나머지는 null 반환
+```
+
+### 비동기 단일 리더
+
+```kotlin
+val election = HazelcastLeaderElection(hazelcast)
+
+val future: CompletableFuture<Report?> = election.runAsyncIfLeader("daily-report") {
+    CompletableFuture.supplyAsync { generateReport() }
+}
+```
+
+### 코루틴 단일 리더
+
+```kotlin
+val election = HazelcastSuspendLeaderElection(hazelcast)
+
+val result = election.runIfLeader("nightly-sync") {
+    delay(100)
+    syncData()
+}
+```
+
+### 코루틴 복수 리더 그룹
+
+```kotlin
+val options = LeaderGroupElectionOptions(maxLeaders = 2)
+val election = HazelcastSuspendLeaderGroupElection(hazelcast, options)
+
+coroutineScope {
+    val jobs = (1..5).map {
+        async { election.runIfLeader("task-group") { processTask(it) } }
+    }
+    jobs.awaitAll()  // 2개 동시 실행, 3개는 null 반환
+}
+```
+
+### 확장 함수
+
+```kotlin
+// 블로킹
+hazelcast.runIfLeader("job") { doWork() }
+hazelcast.runIfLeaderGroup("job", options) { doWork() }
+
+// 코루틴
+hazelcast.suspendRunIfLeader("job") { doWork() }
+hazelcast.suspendRunIfLeaderGroup("job", options) { doWork() }
+```
+
+### 커스텀 옵션
+
+```kotlin
+val options = LeaderElectionOptions(
+    waitTime = Duration.ofSeconds(3),
+    leaseTime = Duration.ofSeconds(60)
+)
+val election = HazelcastLeaderElection(hazelcast, options)
+```
+
+## 락 내부 구현
+
+`HazelcastLock`은 CP Subsystem 없이 `IMap` 연산으로 분산 락을 구현합니다:
+
+```
+획득: IMap.putIfAbsent(lockKey, token, leaseTimeMs, MILLISECONDS)
+     → null 반환 = 획득 성공 (키 없음), 기존 토큰 반환 = 실패
+해제: IMap.remove(lockKey, token)
+     → 원자적 조건부 삭제 — 값이 토큰과 일치할 때만 삭제
+확인: IMap.get(lockKey) == token
+```
+
+그룹 선출은 N개의 슬롯 키(`lockName:slot:0` … `lockName:slot:N-1`)로 세마포어를 시뮬레이션합니다. 각 호출자는 슬롯을 순서대로 시도하고, 처음 획득한 슬롯을 사용합니다.
+
+락 맵 이름:
+- 단일 리더: `bluetape4k:leader:locks`
+- 그룹: `bluetape4k:leader:group:locks`
+
+## 의존성
+
+```kotlin
+// build.gradle.kts
+implementation("io.github.bluetape4k.leader:leader-hazelcast:0.1.0-SNAPSHOT")
+
+// Hazelcast 클라이언트가 클래스패스에 있어야 합니다
+implementation("com.hazelcast:hazelcast:5.x.x")
+```

--- a/leader-hazelcast/README.md
+++ b/leader-hazelcast/README.md
@@ -159,6 +159,71 @@ Release: IMap.remove(lockKey, token)
 Check:   IMap.get(lockKey) == token
 ```
 
+### Lock acquire/release sequence
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant HazelcastLock
+    participant IMap
+
+    Caller->>HazelcastLock: tryLock(waitTime, leaseTime)
+    loop until deadline
+        HazelcastLock->>IMap: putIfAbsent(lockKey, token, leaseTimeMs)
+        alt key absent (null returned)
+            IMap-->>HazelcastLock: null
+            HazelcastLock-->>Caller: true (acquired)
+        else key exists
+            IMap-->>HazelcastLock: existingToken
+            HazelcastLock->>HazelcastLock: sleep min(50ms, remaining)
+        end
+    end
+    HazelcastLock-->>Caller: false (timeout)
+
+    Note over Caller,IMap: action() executes while lock is held (TTL counts down)
+
+    Caller->>HazelcastLock: isHeldByCurrentInstance()
+    HazelcastLock->>IMap: get(lockKey)
+    IMap-->>HazelcastLock: storedToken
+    HazelcastLock-->>Caller: storedToken == token
+
+    Caller->>HazelcastLock: unlock()
+    HazelcastLock->>IMap: remove(lockKey, token)
+    alt token matches
+        IMap-->>HazelcastLock: true
+        Note over HazelcastLock: lock released
+    else token mismatch (TTL expired, another holder)
+        IMap-->>HazelcastLock: false
+        Note over HazelcastLock: warn — split-leader possible
+    end
+```
+
+### Group election slot sequence (maxLeaders = N)
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant GroupElection
+    participant IMap
+
+    Caller->>GroupElection: runIfLeader(lockName)
+    loop slot = 0..N-1
+        GroupElection->>IMap: putIfAbsent(lockName:slot:i, token, leaseTimeMs)
+        alt slot acquired
+            IMap-->>GroupElection: null
+            Note over GroupElection: acquiredLock = slot i
+            GroupElection->>Caller: action()
+            Caller-->>GroupElection: result
+            GroupElection->>IMap: remove(lockName:slot:i, token)
+            GroupElection-->>Caller: result
+        else slot busy
+            IMap-->>GroupElection: existingToken
+            Note over GroupElection: try next slot
+        end
+    end
+    Note over GroupElection: all slots busy → return null
+```
+
 Group election simulates a semaphore with N slot keys (`lockName:slot:0` … `lockName:slot:N-1`). Each caller tries slots in sequence; first acquired slot wins.
 
 Lock map names:

--- a/leader-hazelcast/README.md
+++ b/leader-hazelcast/README.md
@@ -1,0 +1,176 @@
+# leader-hazelcast
+
+[한국어](README.ko.md)
+
+Hazelcast-backed leader election — blocking, async, virtual-thread, and coroutine APIs.
+
+---
+
+## Overview
+
+`leader-hazelcast` implements `leader-core` interfaces using Hazelcast `IMap` as a distributed lock store. No CP Subsystem required — lock primitives use `putIfAbsent + TTL` and token-based conditional release.
+
+Lock strategy: `IMap.putIfAbsent(key, token, leaseTimeMs, MILLISECONDS)` for atomic acquire, `IMap.remove(key, token)` for owner-only release. Thread-unbound token model — safe for Virtual Threads and coroutine thread switches.
+
+> **Note:** `leaseTime` must be longer than the expected action duration. TTL expiry automatically releases the lock; no watchdog renewal is performed.
+>
+> **Note:** Never enable near-cache on the lock map. Stale near-cache reads can cause `isHeldByCurrentInstance()` to misidentify the lock holder.
+
+## Architecture
+
+```mermaid
+classDiagram
+    class LeaderElection { <<interface>> }
+    class LeaderGroupElection { <<interface>> }
+    class SuspendLeaderElection { <<interface>> }
+    class SuspendLeaderGroupElection { <<interface>> }
+
+    class HazelcastLock {
+        +tryLock(waitTime, leaseTime) Boolean
+        +isHeldByCurrentInstance() Boolean
+        +unlock()
+    }
+    class HazelcastSuspendLock {
+        +tryLock(waitTime, leaseTime) Boolean
+        +isHeldByCurrentInstance() Boolean
+        +unlock()
+    }
+
+    HazelcastLeaderElection ..|> LeaderElection
+    HazelcastLeaderGroupElection ..|> LeaderGroupElection
+    HazelcastSuspendLeaderElection ..|> SuspendLeaderElection
+    HazelcastSuspendLeaderGroupElection ..|> SuspendLeaderGroupElection
+
+    HazelcastLeaderElection --> HazelcastLock
+    HazelcastLeaderGroupElection --> HazelcastLock
+    HazelcastSuspendLeaderElection --> HazelcastSuspendLock
+    HazelcastSuspendLeaderGroupElection --> HazelcastSuspendLock
+```
+
+## Implementations
+
+| Class | Interface | Description |
+|-------|-----------|-------------|
+| `HazelcastLeaderElection` | `LeaderElection` | Blocking + async single-leader |
+| `HazelcastLeaderGroupElection` | `LeaderGroupElection` | Blocking + async multi-leader (slot-based) |
+| `HazelcastSuspendLeaderElection` | `SuspendLeaderElection` | Coroutine single-leader |
+| `HazelcastSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` | Coroutine multi-leader (slot-based) |
+
+## Usage
+
+### Setup
+
+```kotlin
+val config = ClientConfig().apply {
+    networkConfig.addAddress("localhost:5701")
+}
+val hazelcast = HazelcastClient.newHazelcastClient(config)
+```
+
+### Blocking single-leader
+
+```kotlin
+val election = HazelcastLeaderElection(hazelcast)
+
+val result = election.runIfLeader("daily-report") {
+    generateReport()
+}
+// result == generateReport() return value on leader, null on others
+```
+
+### Blocking multi-leader group
+
+```kotlin
+val options = LeaderGroupElectionOptions(maxLeaders = 3)
+val election = HazelcastLeaderGroupElection(hazelcast, options)
+
+val result = election.runIfLeader("parallel-batch") {
+    processChunk()
+}
+// up to 3 nodes run concurrently, rest return null
+```
+
+### Async single-leader
+
+```kotlin
+val election = HazelcastLeaderElection(hazelcast)
+
+val future: CompletableFuture<Report?> = election.runAsyncIfLeader("daily-report") {
+    CompletableFuture.supplyAsync { generateReport() }
+}
+```
+
+### Coroutine single-leader
+
+```kotlin
+val election = HazelcastSuspendLeaderElection(hazelcast)
+
+val result = election.runIfLeader("nightly-sync") {
+    delay(100)
+    syncData()
+}
+```
+
+### Coroutine multi-leader group
+
+```kotlin
+val options = LeaderGroupElectionOptions(maxLeaders = 2)
+val election = HazelcastSuspendLeaderGroupElection(hazelcast, options)
+
+coroutineScope {
+    val jobs = (1..5).map {
+        async { election.runIfLeader("task-group") { processTask(it) } }
+    }
+    jobs.awaitAll()  // 2 run concurrently, 3 return null
+}
+```
+
+### Extension functions
+
+```kotlin
+// Blocking
+hazelcast.runIfLeader("job") { doWork() }
+hazelcast.runIfLeaderGroup("job", options) { doWork() }
+
+// Coroutine
+hazelcast.suspendRunIfLeader("job") { doWork() }
+hazelcast.suspendRunIfLeaderGroup("job", options) { doWork() }
+```
+
+### Custom options
+
+```kotlin
+val options = LeaderElectionOptions(
+    waitTime = Duration.ofSeconds(3),
+    leaseTime = Duration.ofSeconds(60)
+)
+val election = HazelcastLeaderElection(hazelcast, options)
+```
+
+## Lock Internals
+
+`HazelcastLock` uses `IMap` operations for CP-Subsystem-free distributed locking:
+
+```
+Acquire: IMap.putIfAbsent(lockKey, token, leaseTimeMs, MILLISECONDS)
+         → returns null on success (key was absent), existing token on failure
+Release: IMap.remove(lockKey, token)
+         → atomic conditional delete — only removes if value matches token
+Check:   IMap.get(lockKey) == token
+```
+
+Group election simulates a semaphore with N slot keys (`lockName:slot:0` … `lockName:slot:N-1`). Each caller tries slots in sequence; first acquired slot wins.
+
+Lock map names:
+- Single-leader: `bluetape4k:leader:locks`
+- Group: `bluetape4k:leader:group:locks`
+
+## Dependency
+
+```kotlin
+// build.gradle.kts
+implementation("io.github.bluetape4k.leader:leader-hazelcast:0.1.0-SNAPSHOT")
+
+// Hazelcast must be on the classpath
+implementation("com.hazelcast:hazelcast:5.x.x")
+```

--- a/leader-hazelcast/build.gradle.kts
+++ b/leader-hazelcast/build.gradle.kts
@@ -7,8 +7,8 @@ dependencies {
     api(Libs.hazelcast)
 
     testImplementation(Libs.bluetape4k_junit5)
+    testImplementation(Libs.bluetape4k_testcontainers)
     testImplementation(Libs.kotlinx_coroutines_test)
     testImplementation(Libs.testcontainers)
     testImplementation(Libs.testcontainers_junit_jupiter)
-    testImplementation(Libs.testcontainers_hazelcast)
 }

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElection.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElection.kt
@@ -1,0 +1,133 @@
+package io.bluetape4k.leader.hazelcast
+
+import com.hazelcast.core.HazelcastInstance
+import com.hazelcast.map.IMap
+import io.bluetape4k.leader.LeaderElection
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.hazelcast.lock.HazelcastLock
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.error
+import io.bluetape4k.support.requireNotBlank
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+
+/**
+ * [HazelcastInstance]의 [IMap] 분산 락을 이용하여 리더 선출을 수행합니다.
+ *
+ * `putIfAbsent` + TTL 방식의 토큰 기반 락이므로 스레드에 귀속되지 않으며
+ * Virtual Thread, ThreadPool 환경에서 모두 안전하게 동작합니다.
+ *
+ * ```kotlin
+ * val election = HazelcastLeaderElection(hazelcastInstance)
+ * val result = election.runIfLeader("daily-job") { processData() }
+ * // result == processData() 반환값 (리더 획득 성공) 또는 null (획득 실패)
+ * ```
+ *
+ * @param hazelcast Hazelcast 클라이언트 인스턴스
+ * @param options 리더 선출 옵션 (waitTime, leaseTime)
+ */
+class HazelcastLeaderElection private constructor(
+    private val hazelcast: HazelcastInstance,
+    private val options: LeaderElectionOptions,
+): LeaderElection {
+
+    companion object: KLogging() {
+        const val LOCK_MAP_NAME = "bluetape4k:leader:locks"
+
+        @JvmStatic
+        operator fun invoke(
+            hazelcast: HazelcastInstance,
+            options: LeaderElectionOptions = LeaderElectionOptions.Default,
+        ): HazelcastLeaderElection = HazelcastLeaderElection(hazelcast, options)
+    }
+
+    private val lockMap: IMap<String, String> = hazelcast.getMap(LOCK_MAP_NAME)
+
+    override fun <T> runIfLeader(lockName: String, action: () -> T): T? {
+        lockName.requireNotBlank("lockName")
+
+        val lock = HazelcastLock(lockMap, lockName)
+        log.debug { "Leader 승격을 요청합니다 ... lockName=$lockName" }
+
+        val acquired = lock.tryLock(options.waitTime, options.leaseTime)
+        if (!acquired) {
+            log.debug { "Leader 승격 실패 (슬롯 없음). lockName=$lockName" }
+            return null
+        }
+
+        log.debug { "Leader로 승격하여 작업을 수행합니다. lockName=$lockName" }
+        try {
+            return action()
+        } finally {
+            if (lock.isHeldByCurrentInstance()) {
+                runCatching { lock.unlock() }
+                    .onSuccess { log.debug { "Leader 권한을 반납했습니다. lockName=$lockName" } }
+                    .onFailure { e -> log.error(e) { "Fail to release lock. lockName=$lockName" } }
+            }
+        }
+    }
+
+    /**
+     * 락 획득과 action 실행을 [executor] 스레드에서 수행합니다.
+     *
+     * [IMap] 기반 토큰 락은 스레드 귀속이 없으므로 완료 콜백 스레드에서 안전하게 해제합니다.
+     */
+    override fun <T> runAsyncIfLeader(
+        lockName: String,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> {
+        lockName.requireNotBlank("lockName")
+
+        val lock = HazelcastLock(lockMap, lockName)
+
+        return CompletableFuture
+            .supplyAsync({ lock.tryLock(options.waitTime, options.leaseTime) }, executor)
+            .thenComposeAsync({ acquired ->
+                if (!acquired) {
+                    log.debug { "Leader 승격 실패 (슬롯 없음, 비동기). lockName=$lockName" }
+                    CompletableFuture.completedFuture(null)
+                } else {
+                    log.debug { "Leader로 승격하여 비동기 작업을 수행합니다. lockName=$lockName" }
+                    val actionFuture = runCatching { action() }
+                        .getOrElse { error ->
+                            runCatching { lock.unlock() }
+                            return@thenComposeAsync CompletableFuture.failedFuture(error)
+                        }
+                    actionFuture.whenCompleteAsync({ _, _ ->
+                        if (lock.isHeldByCurrentInstance()) {
+                            runCatching { lock.unlock() }
+                                .onSuccess { log.debug { "비동기 Leader 권한을 반납했습니다. lockName=$lockName" } }
+                                .onFailure { e -> log.error(e) { "Fail to release lock (async). lockName=$lockName" } }
+                        }
+                    }, executor)
+                }
+            }, executor)
+    }
+}
+
+/**
+ * Hazelcast 분산 락을 이용하여 리더로 선출된 경우에만 [action]을 실행합니다.
+ */
+inline fun <T> HazelcastInstance.runIfLeader(
+    jobName: String,
+    options: LeaderElectionOptions = LeaderElectionOptions.Default,
+    crossinline action: () -> T,
+): T? {
+    jobName.requireNotBlank("jobName")
+    return HazelcastLeaderElection(this, options).runIfLeader(jobName) { action() }
+}
+
+/**
+ * Hazelcast 분산 락을 이용하여 리더로 선출된 경우에만 비동기 [action]을 실행합니다.
+ */
+inline fun <T> HazelcastInstance.runAsyncIfLeader(
+    jobName: String,
+    executor: Executor = java.util.concurrent.ForkJoinPool.commonPool(),
+    options: LeaderElectionOptions = LeaderElectionOptions.Default,
+    crossinline action: () -> CompletableFuture<T>,
+): CompletableFuture<T?> {
+    jobName.requireNotBlank("jobName")
+    return HazelcastLeaderElection(this, options).runAsyncIfLeader(jobName, executor) { action() }
+}

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElection.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElection.kt
@@ -93,6 +93,7 @@ class HazelcastLeaderElection private constructor(
                     val actionFuture = runCatching { action() }
                         .getOrElse { error ->
                             runCatching { lock.unlock() }
+                                .onFailure { e -> log.error(e) { "Fail to release lock on action error (async). lockName=$lockName" } }
                             return@thenComposeAsync CompletableFuture.failedFuture(error)
                         }
                     actionFuture.whenCompleteAsync({ _, _ ->

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElection.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElection.kt
@@ -1,0 +1,138 @@
+package io.bluetape4k.leader.hazelcast
+
+import com.hazelcast.core.HazelcastInstance
+import com.hazelcast.map.IMap
+import io.bluetape4k.leader.LeaderGroupElection
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.hazelcast.lock.HazelcastLock
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.error
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+
+/**
+ * [IMap] 슬롯 기반 분산 세마포어를 이용한 복수 리더 선출 구현체입니다.
+ *
+ * `${lockName}:slot:N` 키를 사용하는 [HazelcastLock] N개로 `maxLeaders` 슬롯을 시뮬레이션합니다.
+ * CP Subsystem 없이 동작하며 토큰 기반이므로 스레드에 귀속되지 않습니다.
+ *
+ * ```kotlin
+ * val election = HazelcastLeaderGroupElection(hazelcastInstance, LeaderGroupElectionOptions(maxLeaders = 3))
+ * val result = election.runIfLeader("batch-job") { processChunk() }
+ * ```
+ *
+ * @param hazelcast Hazelcast 클라이언트 인스턴스
+ * @param options 리더 그룹 선출 옵션 (maxLeaders, waitTime, leaseTime)
+ */
+class HazelcastLeaderGroupElection private constructor(
+    private val hazelcast: HazelcastInstance,
+    options: LeaderGroupElectionOptions,
+): LeaderGroupElection {
+
+    companion object: KLogging() {
+        const val LOCK_MAP_NAME = "bluetape4k:leader:group:locks"
+
+        @JvmStatic
+        operator fun invoke(
+            hazelcast: HazelcastInstance,
+            options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
+        ): HazelcastLeaderGroupElection {
+            options.maxLeaders.requirePositiveNumber("maxLeaders")
+            return HazelcastLeaderGroupElection(hazelcast, options)
+        }
+    }
+
+    override val maxLeaders: Int = options.maxLeaders
+    private val waitTime = options.waitTime
+    private val leaseTime = options.leaseTime
+
+    private val lockMap: IMap<String, String> = hazelcast.getMap(LOCK_MAP_NAME)
+
+    private fun slotKey(lockName: String, slot: Int) = "$lockName:slot:$slot"
+
+    override fun activeCount(lockName: String): Int =
+        (0 until maxLeaders).count { slot -> lockMap.containsKey(slotKey(lockName, slot)) }
+
+    override fun availableSlots(lockName: String): Int = maxLeaders - activeCount(lockName)
+
+    override fun state(lockName: String): LeaderGroupState =
+        LeaderGroupState(lockName, maxLeaders, activeCount(lockName))
+
+    override fun <T> runIfLeader(lockName: String, action: () -> T): T? {
+        lockName.requireNotBlank("lockName")
+
+        val slotWaitTime = waitTime.dividedBy(maxLeaders.toLong())
+        log.debug { "리더 그룹 슬롯 획득을 요청합니다. lockName=$lockName, maxLeaders=$maxLeaders" }
+
+        val acquiredLock = (0 until maxLeaders)
+            .map { slot -> HazelcastLock(lockMap, slotKey(lockName, slot)) }
+            .firstOrNull { lock -> lock.tryLock(slotWaitTime, leaseTime) }
+
+        if (acquiredLock == null) {
+            log.debug { "리더 그룹 슬롯 획득 실패 (슬롯 없음). lockName=$lockName" }
+            return null
+        }
+
+        log.debug { "리더 그룹 슬롯을 획득하여 작업을 수행합니다. lockName=$lockName" }
+        try {
+            return action()
+        } finally {
+            if (acquiredLock.isHeldByCurrentInstance()) {
+                runCatching { acquiredLock.unlock() }
+                    .onSuccess { log.debug { "리더 그룹 슬롯을 반납했습니다. lockName=$lockName" } }
+                    .onFailure { e -> log.error(e) { "Fail to release group slot. lockName=$lockName" } }
+            }
+        }
+    }
+
+    override fun <T> runAsyncIfLeader(
+        lockName: String,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> {
+        lockName.requireNotBlank("lockName")
+
+        val slotWaitTime = waitTime.dividedBy(maxLeaders.toLong())
+
+        return CompletableFuture.supplyAsync({
+            (0 until maxLeaders)
+                .map { slot -> HazelcastLock(lockMap, slotKey(lockName, slot)) }
+                .firstOrNull { lock -> lock.tryLock(slotWaitTime, leaseTime) }
+        }, executor).thenComposeAsync({ acquiredLock ->
+            if (acquiredLock == null) {
+                log.debug { "리더 그룹 슬롯 획득 실패 (비동기). lockName=$lockName" }
+                CompletableFuture.completedFuture(null)
+            } else {
+                log.debug { "리더 그룹 슬롯을 획득하여 비동기 작업을 수행합니다. lockName=$lockName" }
+                val actionFuture = runCatching { action() }
+                    .getOrElse { error ->
+                        runCatching { acquiredLock.unlock() }
+                        return@thenComposeAsync CompletableFuture.failedFuture(error)
+                    }
+                actionFuture.whenCompleteAsync({ _, _ ->
+                    if (acquiredLock.isHeldByCurrentInstance()) {
+                        runCatching { acquiredLock.unlock() }
+                            .onSuccess { log.debug { "비동기 리더 그룹 슬롯을 반납했습니다. lockName=$lockName" } }
+                            .onFailure { e -> log.error(e) { "Fail to release group slot (async). lockName=$lockName" } }
+                    }
+                }, executor)
+            }
+        }, executor)
+    }
+}
+
+/**
+ * Hazelcast 분산 세마포어(슬롯 기반)를 이용하여 최대 [options.maxLeaders]개의 리더로 선출된 경우에만 [action]을 실행합니다.
+ */
+inline fun <T> HazelcastInstance.runIfLeaderGroup(
+    lockName: String,
+    options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
+    crossinline action: () -> T,
+): T? {
+    lockName.requireNotBlank("lockName")
+    return HazelcastLeaderGroupElection(this, options).runIfLeader(lockName) { action() }
+}

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElection.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElection.kt
@@ -69,6 +69,7 @@ class HazelcastLeaderGroupElection private constructor(
         log.debug { "리더 그룹 슬롯 획득을 요청합니다. lockName=$lockName, maxLeaders=$maxLeaders" }
 
         val acquiredLock = (0 until maxLeaders)
+            .asSequence()
             .map { slot -> HazelcastLock(lockMap, slotKey(lockName, slot)) }
             .firstOrNull { lock -> lock.tryLock(slotWaitTime, leaseTime) }
 
@@ -100,6 +101,7 @@ class HazelcastLeaderGroupElection private constructor(
 
         return CompletableFuture.supplyAsync({
             (0 until maxLeaders)
+                .asSequence()
                 .map { slot -> HazelcastLock(lockMap, slotKey(lockName, slot)) }
                 .firstOrNull { lock -> lock.tryLock(slotWaitTime, leaseTime) }
         }, executor).thenComposeAsync({ acquiredLock ->
@@ -111,6 +113,7 @@ class HazelcastLeaderGroupElection private constructor(
                 val actionFuture = runCatching { action() }
                     .getOrElse { error ->
                         runCatching { acquiredLock.unlock() }
+                            .onFailure { e -> log.error(e) { "Fail to release group slot on action error (async). lockName=$lockName" } }
                         return@thenComposeAsync CompletableFuture.failedFuture(error)
                     }
                 actionFuture.whenCompleteAsync({ _, _ ->

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderElection.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderElection.kt
@@ -9,7 +9,6 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 
@@ -66,8 +65,6 @@ class HazelcastSuspendLeaderElection private constructor(
                     try {
                         lock.unlock()
                         log.debug { "Leader 권한을 반납했습니다 (suspend). lockName=$lockName" }
-                    } catch (e: CancellationException) {
-                        throw e
                     } catch (e: Exception) {
                         log.warn(e) { "Fail to release lock (suspend). lockName=$lockName" }
                     }

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderElection.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderElection.kt
@@ -63,12 +63,14 @@ class HazelcastSuspendLeaderElection private constructor(
             // NonCancellable: 코루틴 취소 시에도 락 해제가 중단되지 않도록 보호
             withContext(NonCancellable) {
                 if (lock.isHeldByCurrentInstance()) {
-                    runCatching { lock.unlock() }
-                        .onSuccess { log.debug { "Leader 권한을 반납했습니다 (suspend). lockName=$lockName" } }
-                        .onFailure { e ->
-                            if (e is CancellationException) throw e
-                            log.warn(e) { "Fail to release lock (suspend). lockName=$lockName" }
-                        }
+                    try {
+                        lock.unlock()
+                        log.debug { "Leader 권한을 반납했습니다 (suspend). lockName=$lockName" }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log.warn(e) { "Fail to release lock (suspend). lockName=$lockName" }
+                    }
                 }
             }
         }

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderElection.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderElection.kt
@@ -1,0 +1,88 @@
+package io.bluetape4k.leader.hazelcast
+
+import com.hazelcast.core.HazelcastInstance
+import com.hazelcast.map.IMap
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderElection
+import io.bluetape4k.leader.hazelcast.lock.HazelcastSuspendLock
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
+import io.bluetape4k.support.requireNotBlank
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+
+/**
+ * [HazelcastInstance]의 [IMap] 분산 락을 이용한 코루틴 기반 리더 선출 구현체입니다.
+ *
+ * 토큰 기반 락(`putIfAbsent` + TTL)으로 코루틴 스레드 전환과 무관하게 안전하게 동작합니다.
+ *
+ * ```kotlin
+ * val election = HazelcastSuspendLeaderElection(hazelcastInstance)
+ * val result = election.runIfLeader("daily-job") {
+ *     delay(100)
+ *     processData()
+ * }
+ * ```
+ *
+ * @param hazelcast Hazelcast 클라이언트 인스턴스
+ * @param options 리더 선출 옵션 (waitTime, leaseTime)
+ */
+class HazelcastSuspendLeaderElection private constructor(
+    private val hazelcast: HazelcastInstance,
+    private val options: LeaderElectionOptions,
+): SuspendLeaderElection {
+
+    companion object: KLoggingChannel() {
+        @JvmStatic
+        operator fun invoke(
+            hazelcast: HazelcastInstance,
+            options: LeaderElectionOptions = LeaderElectionOptions.Default,
+        ): HazelcastSuspendLeaderElection = HazelcastSuspendLeaderElection(hazelcast, options)
+    }
+
+    private val lockMap: IMap<String, String> = hazelcast.getMap(HazelcastLeaderElection.LOCK_MAP_NAME)
+
+    override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? {
+        lockName.requireNotBlank("lockName")
+
+        val lock = HazelcastSuspendLock(lockMap, lockName)
+        log.debug { "Leader 승격을 요청합니다 (suspend) ... lockName=$lockName" }
+
+        val acquired = lock.tryLock(options.waitTime, options.leaseTime)
+        if (!acquired) {
+            log.debug { "Leader 승격 실패 (슬롯 없음, suspend). lockName=$lockName" }
+            return null
+        }
+
+        log.debug { "Leader로 승격하여 suspend 작업을 수행합니다. lockName=$lockName" }
+        try {
+            return action()
+        } finally {
+            // NonCancellable: 코루틴 취소 시에도 락 해제가 중단되지 않도록 보호
+            withContext(NonCancellable) {
+                if (lock.isHeldByCurrentInstance()) {
+                    runCatching { lock.unlock() }
+                        .onSuccess { log.debug { "Leader 권한을 반납했습니다 (suspend). lockName=$lockName" } }
+                        .onFailure { e ->
+                            if (e is CancellationException) throw e
+                            log.warn(e) { "Fail to release lock (suspend). lockName=$lockName" }
+                        }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Hazelcast 분산 락을 이용하여 리더로 선출된 경우에만 suspend [action]을 실행합니다.
+ */
+suspend inline fun <T> HazelcastInstance.suspendRunIfLeader(
+    jobName: String,
+    options: LeaderElectionOptions = LeaderElectionOptions.Default,
+    crossinline action: suspend () -> T,
+): T? {
+    jobName.requireNotBlank("jobName")
+    return HazelcastSuspendLeaderElection(this, options).runIfLeader(jobName) { action() }
+}

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderGroupElection.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderGroupElection.kt
@@ -11,8 +11,9 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requirePositiveNumber
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 
 /**
@@ -64,11 +65,12 @@ class HazelcastSuspendLeaderGroupElection private constructor(
     override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? {
         lockName.requireNotBlank("lockName")
 
-        val slotWaitTime = if (maxLeaders > 0) waitTime.dividedBy(maxLeaders.toLong()) else waitTime
+        val slotWaitTime = waitTime.dividedBy(maxLeaders.toLong())
         log.debug { "리더 그룹 슬롯 획득을 요청합니다 (suspend). lockName=$lockName, maxLeaders=$maxLeaders" }
 
         var acquiredLock: HazelcastSuspendLock? = null
         for (slot in 0 until maxLeaders) {
+            currentCoroutineContext().ensureActive()
             val lock = HazelcastSuspendLock(lockMap, slotKey(lockName, slot))
             if (lock.tryLock(slotWaitTime, leaseTime)) {
                 acquiredLock = lock
@@ -90,8 +92,6 @@ class HazelcastSuspendLeaderGroupElection private constructor(
                     try {
                         acquiredLock.unlock()
                         log.debug { "리더 그룹 슬롯을 반납했습니다 (suspend). lockName=$lockName" }
-                    } catch (e: CancellationException) {
-                        throw e
                     } catch (e: Exception) {
                         log.warn(e) { "Fail to release group slot (suspend). lockName=$lockName" }
                     }
@@ -104,7 +104,7 @@ class HazelcastSuspendLeaderGroupElection private constructor(
 /**
  * Hazelcast 분산 세마포어(슬롯 기반)를 이용하여 최대 [options.maxLeaders]개의 리더로 선출된 경우에만 suspend [action]을 실행합니다.
  */
-suspend inline fun <T> HazelcastInstance.runSuspendIfLeaderGroup(
+suspend inline fun <T> HazelcastInstance.suspendRunIfLeaderGroup(
     lockName: String,
     options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
     crossinline action: suspend () -> T,

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderGroupElection.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderGroupElection.kt
@@ -67,9 +67,14 @@ class HazelcastSuspendLeaderGroupElection private constructor(
         val slotWaitTime = if (maxLeaders > 0) waitTime.dividedBy(maxLeaders.toLong()) else waitTime
         log.debug { "리더 그룹 슬롯 획득을 요청합니다 (suspend). lockName=$lockName, maxLeaders=$maxLeaders" }
 
-        val acquiredLock = (0 until maxLeaders)
-            .map { slot -> HazelcastSuspendLock(lockMap, slotKey(lockName, slot)) }
-            .firstOrNull { lock -> lock.tryLock(slotWaitTime, leaseTime) }
+        var acquiredLock: HazelcastSuspendLock? = null
+        for (slot in 0 until maxLeaders) {
+            val lock = HazelcastSuspendLock(lockMap, slotKey(lockName, slot))
+            if (lock.tryLock(slotWaitTime, leaseTime)) {
+                acquiredLock = lock
+                break
+            }
+        }
 
         if (acquiredLock == null) {
             log.debug { "리더 그룹 슬롯 획득 실패 (슬롯 없음, suspend). lockName=$lockName" }
@@ -82,12 +87,14 @@ class HazelcastSuspendLeaderGroupElection private constructor(
         } finally {
             withContext(NonCancellable) {
                 if (acquiredLock.isHeldByCurrentInstance()) {
-                    runCatching { acquiredLock.unlock() }
-                        .onSuccess { log.debug { "리더 그룹 슬롯을 반납했습니다 (suspend). lockName=$lockName" } }
-                        .onFailure { e ->
-                            if (e is CancellationException) throw e
-                            log.warn(e) { "Fail to release group slot (suspend). lockName=$lockName" }
-                        }
+                    try {
+                        acquiredLock.unlock()
+                        log.debug { "리더 그룹 슬롯을 반납했습니다 (suspend). lockName=$lockName" }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log.warn(e) { "Fail to release group slot (suspend). lockName=$lockName" }
+                    }
                 }
             }
         }

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderGroupElection.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderGroupElection.kt
@@ -1,0 +1,107 @@
+package io.bluetape4k.leader.hazelcast
+
+import com.hazelcast.core.HazelcastInstance
+import com.hazelcast.map.IMap
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElection
+import io.bluetape4k.leader.hazelcast.lock.HazelcastSuspendLock
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.withContext
+
+/**
+ * [IMap] 슬롯 기반 분산 세마포어를 이용한 코루틴 기반 복수 리더 선출 구현체입니다.
+ *
+ * ```kotlin
+ * val election = HazelcastSuspendLeaderGroupElection(hazelcastInstance, LeaderGroupElectionOptions(maxLeaders = 3))
+ * val result = election.runIfLeader("batch-job") {
+ *     delay(100)
+ *     processChunk()
+ * }
+ * ```
+ *
+ * @param hazelcast Hazelcast 클라이언트 인스턴스
+ * @param options 리더 그룹 선출 옵션 (maxLeaders, waitTime, leaseTime)
+ */
+class HazelcastSuspendLeaderGroupElection private constructor(
+    private val hazelcast: HazelcastInstance,
+    options: LeaderGroupElectionOptions,
+): SuspendLeaderGroupElection {
+
+    companion object: KLoggingChannel() {
+        @JvmStatic
+        operator fun invoke(
+            hazelcast: HazelcastInstance,
+            options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
+        ): HazelcastSuspendLeaderGroupElection {
+            options.maxLeaders.requirePositiveNumber("maxLeaders")
+            return HazelcastSuspendLeaderGroupElection(hazelcast, options)
+        }
+    }
+
+    override val maxLeaders: Int = options.maxLeaders
+    private val waitTime = options.waitTime
+    private val leaseTime = options.leaseTime
+
+    private val lockMap: IMap<String, String> = hazelcast.getMap(HazelcastLeaderGroupElection.LOCK_MAP_NAME)
+
+    private fun slotKey(lockName: String, slot: Int) = "$lockName:slot:$slot"
+
+    override fun activeCount(lockName: String): Int =
+        (0 until maxLeaders).count { slot -> lockMap.containsKey(slotKey(lockName, slot)) }
+
+    override fun availableSlots(lockName: String): Int = maxLeaders - activeCount(lockName)
+
+    override fun state(lockName: String): LeaderGroupState =
+        LeaderGroupState(lockName, maxLeaders, activeCount(lockName))
+
+    override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? {
+        lockName.requireNotBlank("lockName")
+
+        val slotWaitTime = if (maxLeaders > 0) waitTime.dividedBy(maxLeaders.toLong()) else waitTime
+        log.debug { "리더 그룹 슬롯 획득을 요청합니다 (suspend). lockName=$lockName, maxLeaders=$maxLeaders" }
+
+        val acquiredLock = (0 until maxLeaders)
+            .map { slot -> HazelcastSuspendLock(lockMap, slotKey(lockName, slot)) }
+            .firstOrNull { lock -> lock.tryLock(slotWaitTime, leaseTime) }
+
+        if (acquiredLock == null) {
+            log.debug { "리더 그룹 슬롯 획득 실패 (슬롯 없음, suspend). lockName=$lockName" }
+            return null
+        }
+
+        log.debug { "리더 그룹 슬롯을 획득하여 suspend 작업을 수행합니다. lockName=$lockName" }
+        try {
+            return action()
+        } finally {
+            withContext(NonCancellable) {
+                if (acquiredLock.isHeldByCurrentInstance()) {
+                    runCatching { acquiredLock.unlock() }
+                        .onSuccess { log.debug { "리더 그룹 슬롯을 반납했습니다 (suspend). lockName=$lockName" } }
+                        .onFailure { e ->
+                            if (e is CancellationException) throw e
+                            log.warn(e) { "Fail to release group slot (suspend). lockName=$lockName" }
+                        }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Hazelcast 분산 세마포어(슬롯 기반)를 이용하여 최대 [options.maxLeaders]개의 리더로 선출된 경우에만 suspend [action]을 실행합니다.
+ */
+suspend inline fun <T> HazelcastInstance.runSuspendIfLeaderGroup(
+    lockName: String,
+    options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
+    crossinline action: suspend () -> T,
+): T? {
+    lockName.requireNotBlank("lockName")
+    return HazelcastSuspendLeaderGroupElection(this, options).runIfLeader(lockName) { action() }
+}

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/lock/HazelcastLock.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/lock/HazelcastLock.kt
@@ -1,0 +1,59 @@
+package io.bluetape4k.leader.hazelcast.lock
+
+import com.hazelcast.map.IMap
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+/**
+ * [IMap] 기반 분산 락 구현체입니다.
+ *
+ * `putIfAbsent(key, token, ttl)` 으로 원자적 획득, `remove(key, token)` 으로 토큰 일치 시에만 해제합니다.
+ * 스레드 ID 에 의존하지 않으므로 Virtual Thread, ThreadPool 등 어느 실행 모델에서도 안전합니다.
+ *
+ * @param lockMap 락 상태를 저장하는 [IMap]
+ * @param lockKey 락 식별 키
+ */
+class HazelcastLock(
+    private val lockMap: IMap<String, String>,
+    val lockKey: String,
+) {
+    companion object: KLogging() {
+        private const val RETRY_DELAY_MS = 50L
+    }
+
+    private val token: String = UUID.randomUUID().toString()
+
+    /**
+     * [waitTime] 내에 락 획득을 시도합니다. 성공하면 `true`, 타임아웃이면 `false`를 반환합니다.
+     */
+    fun tryLock(waitTime: Duration, leaseTime: Duration): Boolean {
+        val deadline = System.currentTimeMillis() + waitTime.toMillis()
+        val leaseMs = leaseTime.toMillis()
+
+        do {
+            val previous = lockMap.putIfAbsent(lockKey, token, leaseMs, TimeUnit.MILLISECONDS)
+            if (previous == null) {
+                log.debug { "Lock 획득 성공: lockKey=$lockKey" }
+                return true
+            }
+            if (System.currentTimeMillis() < deadline) {
+                Thread.sleep(RETRY_DELAY_MS)
+            }
+        } while (System.currentTimeMillis() < deadline)
+
+        log.debug { "Lock 획득 실패 (timeout): lockKey=$lockKey" }
+        return false
+    }
+
+    fun isHeldByCurrentInstance(): Boolean = lockMap[lockKey] == token
+
+    fun unlock() {
+        val removed = lockMap.remove(lockKey, token)
+        if (removed) {
+            log.debug { "Lock 해제 성공: lockKey=$lockKey" }
+        }
+    }
+}

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/lock/HazelcastLock.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/lock/HazelcastLock.kt
@@ -1,8 +1,10 @@
 package io.bluetape4k.leader.hazelcast.lock
 
+import com.hazelcast.core.HazelcastException
 import com.hazelcast.map.IMap
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
 import java.time.Duration
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -12,6 +14,12 @@ import java.util.concurrent.TimeUnit
  *
  * `putIfAbsent(key, token, ttl)` 으로 원자적 획득, `remove(key, token)` 으로 토큰 일치 시에만 해제합니다.
  * 스레드 ID 에 의존하지 않으므로 Virtual Thread, ThreadPool 등 어느 실행 모델에서도 안전합니다.
+ *
+ * **주의:** [leaseTime]은 action의 최대 실행 시간보다 충분히 커야 합니다.
+ * TTL이 만료되면 락이 자동 해제되어 다른 노드가 동시에 리더가 될 수 있습니다.
+ *
+ * **주의:** [lockMap]에는 near-cache를 절대 활성화하지 마십시오.
+ * near-cache의 stale 값이 [isHeldByCurrentInstance] 오판을 유발할 수 있습니다.
  *
  * @param lockMap 락 상태를 저장하는 [IMap]
  * @param lockKey 락 식별 키
@@ -27,20 +35,30 @@ class HazelcastLock(
     private val token: String = UUID.randomUUID().toString()
 
     /**
-     * [waitTime] 내에 락 획득을 시도합니다. 성공하면 `true`, 타임아웃이면 `false`를 반환합니다.
+     * [waitTime] 내에 락 획득을 시도합니다. 성공하면 `true`, 타임아웃이거나 클러스터 오류이면 `false`를 반환합니다.
+     *
+     * Hazelcast 클러스터 이벤트(파티션 마이그레이션, 멤버 이탈 등)로 인한 [HazelcastException]은
+     * 예외를 전파하지 않고 `false`로 처리합니다. 이로써 `runIfLeader()` 가 절대 throws하지 않는
+     * 계약을 보장합니다.
      */
     fun tryLock(waitTime: Duration, leaseTime: Duration): Boolean {
         val deadline = System.currentTimeMillis() + waitTime.toMillis()
         val leaseMs = leaseTime.toMillis()
 
         do {
-            val previous = lockMap.putIfAbsent(lockKey, token, leaseMs, TimeUnit.MILLISECONDS)
+            val previous = try {
+                lockMap.putIfAbsent(lockKey, token, leaseMs, TimeUnit.MILLISECONDS)
+            } catch (e: HazelcastException) {
+                log.warn(e) { "Hazelcast 클러스터 오류로 락 획득 실패: lockKey=$lockKey" }
+                return false
+            }
             if (previous == null) {
                 log.debug { "Lock 획득 성공: lockKey=$lockKey" }
                 return true
             }
-            if (System.currentTimeMillis() < deadline) {
-                Thread.sleep(RETRY_DELAY_MS)
+            val remaining = deadline - System.currentTimeMillis()
+            if (remaining > 0) {
+                Thread.sleep(minOf(RETRY_DELAY_MS, remaining))
             }
         } while (System.currentTimeMillis() < deadline)
 
@@ -48,12 +66,25 @@ class HazelcastLock(
         return false
     }
 
+    /**
+     * 현재 인스턴스(토큰)가 락을 보유하고 있는지 확인합니다.
+     *
+     * [IMap]에 저장된 값이 이 인스턴스의 토큰과 일치하는 경우에만 `true`를 반환합니다.
+     */
     fun isHeldByCurrentInstance(): Boolean = lockMap[lockKey] == token
 
+    /**
+     * 현재 인스턴스가 보유한 락을 해제합니다.
+     *
+     * 토큰 일치 여부를 검증한 후 원자적으로 제거합니다.
+     * 토큰 불일치(리스 만료로 인한 타 노드 재획득 등)인 경우 경고 로그를 남깁니다.
+     */
     fun unlock() {
         val removed = lockMap.remove(lockKey, token)
         if (removed) {
             log.debug { "Lock 해제 성공: lockKey=$lockKey" }
+        } else {
+            log.warn { "Lock 해제 실패 — 토큰 불일치 (리스 만료 가능성). lockKey=$lockKey" }
         }
     }
 }

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/lock/HazelcastSuspendLock.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/lock/HazelcastSuspendLock.kt
@@ -1,8 +1,10 @@
 package io.bluetape4k.leader.hazelcast.lock
 
+import com.hazelcast.core.HazelcastException
 import com.hazelcast.map.IMap
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -16,6 +18,12 @@ import kotlin.time.Duration.Companion.milliseconds
  *
  * `putIfAbsent(key, token, ttl)` / `remove(key, token)` 을 `withContext(Dispatchers.IO)` 로 감싸
  * suspend 함수로 제공합니다. 토큰 기반이므로 코루틴 스레드 전환과 무관하게 안전합니다.
+ *
+ * **주의:** [leaseTime]은 action의 최대 실행 시간보다 충분히 커야 합니다.
+ * TTL이 만료되면 락이 자동 해제되어 다른 노드가 동시에 리더가 될 수 있습니다.
+ *
+ * **주의:** [lockMap]에는 near-cache를 절대 활성화하지 마십시오.
+ * near-cache의 stale 값이 [isHeldByCurrentInstance] 오판을 유발할 수 있습니다.
  *
  * @param lockMap 락 상태를 저장하는 [IMap]
  * @param lockKey 락 식별 키
@@ -31,24 +39,32 @@ class HazelcastSuspendLock(
     private val token: String = UUID.randomUUID().toString()
 
     /**
-     * [waitTime] 내에 락 획득을 시도합니다. 성공하면 `true`, 타임아웃이면 `false`를 반환합니다.
+     * [waitTime] 내에 락 획득을 시도합니다. 성공하면 `true`, 타임아웃이거나 클러스터 오류이면 `false`를 반환합니다.
      *
      * 블로킹 `putIfAbsent` 를 `Dispatchers.IO` 에서 실행하고, 재시도 대기는 `delay` 로 suspend 합니다.
+     * Hazelcast 클러스터 이벤트로 인한 [HazelcastException]은 `false`로 처리하여
+     * `runIfLeader()` 가 절대 throws하지 않는 계약을 보장합니다.
      */
     suspend fun tryLock(waitTime: Duration, leaseTime: Duration): Boolean {
         val deadline = System.currentTimeMillis() + waitTime.toMillis()
         val leaseMs = leaseTime.toMillis()
 
         do {
-            val previous = withContext(Dispatchers.IO) {
-                lockMap.putIfAbsent(lockKey, token, leaseMs, TimeUnit.MILLISECONDS)
+            val previous = try {
+                withContext(Dispatchers.IO) {
+                    lockMap.putIfAbsent(lockKey, token, leaseMs, TimeUnit.MILLISECONDS)
+                }
+            } catch (e: HazelcastException) {
+                log.warn(e) { "Hazelcast 클러스터 오류로 락 획득 실패 (suspend): lockKey=$lockKey" }
+                return false
             }
             if (previous == null) {
                 log.debug { "Lock 획득 성공 (suspend): lockKey=$lockKey" }
                 return true
             }
-            if (System.currentTimeMillis() < deadline) {
-                delay(RETRY_DELAY_MS.milliseconds)
+            val remaining = deadline - System.currentTimeMillis()
+            if (remaining > 0) {
+                delay(minOf(RETRY_DELAY_MS, remaining).milliseconds)
             }
         } while (System.currentTimeMillis() < deadline)
 
@@ -56,14 +72,27 @@ class HazelcastSuspendLock(
         return false
     }
 
+    /**
+     * 현재 인스턴스(토큰)가 락을 보유하고 있는지 확인합니다.
+     *
+     * [IMap]에 저장된 값이 이 인스턴스의 토큰과 일치하는 경우에만 `true`를 반환합니다.
+     */
     suspend fun isHeldByCurrentInstance(): Boolean = withContext(Dispatchers.IO) {
         lockMap[lockKey] == token
     }
 
+    /**
+     * 현재 인스턴스가 보유한 락을 해제합니다.
+     *
+     * 토큰 일치 여부를 검증한 후 원자적으로 제거합니다.
+     * 토큰 불일치(리스 만료로 인한 타 노드 재획득 등)인 경우 경고 로그를 남깁니다.
+     */
     suspend fun unlock() = withContext(Dispatchers.IO) {
         val removed = lockMap.remove(lockKey, token)
         if (removed) {
             log.debug { "Lock 해제 성공 (suspend): lockKey=$lockKey" }
+        } else {
+            log.warn { "Lock 해제 실패 — 토큰 불일치 (리스 만료 가능성, suspend). lockKey=$lockKey" }
         }
     }
 }

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/lock/HazelcastSuspendLock.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/lock/HazelcastSuspendLock.kt
@@ -3,7 +3,9 @@ package io.bluetape4k.leader.hazelcast.lock
 import com.hazelcast.map.IMap
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import java.time.Duration
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -12,8 +14,8 @@ import kotlin.time.Duration.Companion.milliseconds
 /**
  * [IMap] 기반 분산 락의 코루틴 구현체입니다.
  *
- * `putIfAbsent(key, token, ttl)` / `remove(key, token)` 을 사용하며,
- * 재시도 대기는 `delay` 로 suspend 합니다. 토큰 기반이므로 코루틴 스레드 전환과 무관하게 안전합니다.
+ * `putIfAbsent(key, token, ttl)` / `remove(key, token)` 을 `withContext(Dispatchers.IO)` 로 감싸
+ * suspend 함수로 제공합니다. 토큰 기반이므로 코루틴 스레드 전환과 무관하게 안전합니다.
  *
  * @param lockMap 락 상태를 저장하는 [IMap]
  * @param lockKey 락 식별 키
@@ -30,13 +32,17 @@ class HazelcastSuspendLock(
 
     /**
      * [waitTime] 내에 락 획득을 시도합니다. 성공하면 `true`, 타임아웃이면 `false`를 반환합니다.
+     *
+     * 블로킹 `putIfAbsent` 를 `Dispatchers.IO` 에서 실행하고, 재시도 대기는 `delay` 로 suspend 합니다.
      */
     suspend fun tryLock(waitTime: Duration, leaseTime: Duration): Boolean {
         val deadline = System.currentTimeMillis() + waitTime.toMillis()
         val leaseMs = leaseTime.toMillis()
 
         do {
-            val previous = lockMap.putIfAbsent(lockKey, token, leaseMs, TimeUnit.MILLISECONDS)
+            val previous = withContext(Dispatchers.IO) {
+                lockMap.putIfAbsent(lockKey, token, leaseMs, TimeUnit.MILLISECONDS)
+            }
             if (previous == null) {
                 log.debug { "Lock 획득 성공 (suspend): lockKey=$lockKey" }
                 return true
@@ -50,9 +56,11 @@ class HazelcastSuspendLock(
         return false
     }
 
-    fun isHeldByCurrentInstance(): Boolean = lockMap[lockKey] == token
+    suspend fun isHeldByCurrentInstance(): Boolean = withContext(Dispatchers.IO) {
+        lockMap[lockKey] == token
+    }
 
-    fun unlock() {
+    suspend fun unlock() = withContext(Dispatchers.IO) {
         val removed = lockMap.remove(lockKey, token)
         if (removed) {
             log.debug { "Lock 해제 성공 (suspend): lockKey=$lockKey" }

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/lock/HazelcastSuspendLock.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/lock/HazelcastSuspendLock.kt
@@ -1,0 +1,61 @@
+package io.bluetape4k.leader.hazelcast.lock
+
+import com.hazelcast.map.IMap
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import kotlinx.coroutines.delay
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * [IMap] 기반 분산 락의 코루틴 구현체입니다.
+ *
+ * `putIfAbsent(key, token, ttl)` / `remove(key, token)` 을 사용하며,
+ * 재시도 대기는 `delay` 로 suspend 합니다. 토큰 기반이므로 코루틴 스레드 전환과 무관하게 안전합니다.
+ *
+ * @param lockMap 락 상태를 저장하는 [IMap]
+ * @param lockKey 락 식별 키
+ */
+class HazelcastSuspendLock(
+    private val lockMap: IMap<String, String>,
+    val lockKey: String,
+) {
+    companion object: KLoggingChannel() {
+        private const val RETRY_DELAY_MS = 50L
+    }
+
+    private val token: String = UUID.randomUUID().toString()
+
+    /**
+     * [waitTime] 내에 락 획득을 시도합니다. 성공하면 `true`, 타임아웃이면 `false`를 반환합니다.
+     */
+    suspend fun tryLock(waitTime: Duration, leaseTime: Duration): Boolean {
+        val deadline = System.currentTimeMillis() + waitTime.toMillis()
+        val leaseMs = leaseTime.toMillis()
+
+        do {
+            val previous = lockMap.putIfAbsent(lockKey, token, leaseMs, TimeUnit.MILLISECONDS)
+            if (previous == null) {
+                log.debug { "Lock 획득 성공 (suspend): lockKey=$lockKey" }
+                return true
+            }
+            if (System.currentTimeMillis() < deadline) {
+                delay(RETRY_DELAY_MS.milliseconds)
+            }
+        } while (System.currentTimeMillis() < deadline)
+
+        log.debug { "Lock 획득 실패 (timeout, suspend): lockKey=$lockKey" }
+        return false
+    }
+
+    fun isHeldByCurrentInstance(): Boolean = lockMap[lockKey] == token
+
+    fun unlock() {
+        val removed = lockMap.remove(lockKey, token)
+        if (removed) {
+            log.debug { "Lock 해제 성공 (suspend): lockKey=$lockKey" }
+        }
+    }
+}

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/AbstractHazelcastLeaderTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/AbstractHazelcastLeaderTest.kt
@@ -1,0 +1,29 @@
+package io.bluetape4k.leader.hazelcast
+
+import com.hazelcast.client.HazelcastClient
+import com.hazelcast.client.config.ClientConfig
+import com.hazelcast.core.HazelcastInstance
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.storage.HazelcastServer
+import io.bluetape4k.utils.ShutdownQueue
+import org.junit.jupiter.api.TestInstance
+import java.util.UUID
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractHazelcastLeaderTest {
+
+    companion object: KLogging() {
+        val hazelcastServer: HazelcastServer = HazelcastServer.Launcher.hazelcast
+
+        val hazelcastClient: HazelcastInstance by lazy {
+            val config = ClientConfig().apply {
+                networkConfig.addAddress(hazelcastServer.url)
+            }
+            HazelcastClient.newHazelcastClient(config).also {
+                ShutdownQueue.register { it.shutdown() }
+            }
+        }
+
+        fun randomName(): String = "leader-test:${UUID.randomUUID().toString().take(8)}"
+    }
+}

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElectionTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElectionTest.kt
@@ -1,0 +1,239 @@
+package io.bluetape4k.leader.hazelcast
+
+import io.bluetape4k.concurrent.futureOf
+import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledForJreRange
+import org.junit.jupiter.api.condition.JRE
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.random.Random
+
+class HazelcastLeaderElectionTest: AbstractHazelcastLeaderTest() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `runIfLeader - 리더로 선출되어 action 을 실행하고 결과를 반환한다`() {
+        val election = HazelcastLeaderElection(hazelcastClient)
+        val result = election.runIfLeader(randomName()) { "hello" }
+        result shouldBeEqualTo "hello"
+    }
+
+    @Test
+    fun `runIfLeader - lock 이 이미 보유된 경우 waitTime 초과 시 null 을 반환한다`() {
+        val lockName = randomName()
+        val shortWaitOptions = LeaderElectionOptions(
+            waitTime = Duration.ofMillis(100),
+            leaseTime = Duration.ofSeconds(5),
+        )
+        val election = HazelcastLeaderElection(hazelcastClient, shortWaitOptions)
+        val lockAcquired = CountDownLatch(1)
+        val releaseLock = CountDownLatch(1)
+        val holder = Executors.newSingleThreadExecutor()
+
+        holder.submit {
+            election.runIfLeader(lockName) {
+                lockAcquired.countDown()
+                releaseLock.await(3, TimeUnit.SECONDS)
+            }
+        }
+
+        try {
+            lockAcquired.await(2, TimeUnit.SECONDS)
+            val result = election.runIfLeader(lockName) { 1 }
+            result.shouldBeNull()
+        } finally {
+            releaseLock.countDown()
+            holder.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `runIfLeader - 멀티스레드 환경에서 순차적으로 leader 작업이 실행된다`() {
+        val lockName = randomName()
+        val election = HazelcastLeaderElection(hazelcastClient)
+        val task1 = AtomicInteger(0)
+        val task2 = AtomicInteger(0)
+        val numThreads = 8
+        val roundsPerThread = 4
+
+        MultithreadingTester()
+            .workers(numThreads)
+            .rounds(roundsPerThread)
+            .add {
+                election.runIfLeader(lockName) {
+                    log.debug { "작업 1. task1=${task1.get()}" }
+                    task1.incrementAndGet()
+                    Thread.sleep(Random.nextLong(5, 10))
+                }
+            }
+            .add {
+                election.runIfLeader(lockName) {
+                    log.debug { "작업 2. task2=${task2.get()}" }
+                    task2.incrementAndGet()
+                    Thread.sleep(Random.nextLong(5, 10))
+                }
+            }
+            .run()
+
+        task1.get() shouldBeGreaterThan 0
+        task2.get() shouldBeGreaterThan 0
+    }
+
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @Test
+    fun `runIfLeader - Virtual Thread 환경에서 순차적으로 leader 작업이 실행된다`() {
+        val lockName = randomName()
+        val election = HazelcastLeaderElection(hazelcastClient)
+        val task1 = AtomicInteger(0)
+        val task2 = AtomicInteger(0)
+
+        StructuredTaskScopeTester()
+            .rounds(16)
+            .add {
+                election.runIfLeader(lockName) {
+                    log.debug { "작업 1. task1=${task1.get()}" }
+                    task1.incrementAndGet()
+                    Thread.sleep(Random.nextLong(5, 10))
+                }
+            }
+            .add {
+                election.runIfLeader(lockName) {
+                    log.debug { "작업 2. task2=${task2.get()}" }
+                    task2.incrementAndGet()
+                    Thread.sleep(Random.nextLong(5, 10))
+                }
+            }
+            .run()
+
+        task1.get() shouldBeGreaterThan 0
+        task2.get() shouldBeGreaterThan 0
+    }
+
+    @Test
+    fun `runAsyncIfLeader - 리더로 선출되어 비동기 action 을 실행하고 결과를 반환한다`() {
+        val lockName = randomName()
+        val election = HazelcastLeaderElection(hazelcastClient)
+        val latch = CountDownLatch(2)
+
+        val future1 = futureOf {
+            election.runAsyncIfLeader(lockName) {
+                futureOf {
+                    log.debug { "비동기 작업 1 시작" }
+                    Thread.sleep(50)
+                    latch.countDown()
+                    42
+                }
+            }.join()
+        }
+        val future2 = futureOf {
+            election.runAsyncIfLeader(lockName) {
+                futureOf {
+                    log.debug { "비동기 작업 2 시작" }
+                    Thread.sleep(50)
+                    latch.countDown()
+                    43
+                }
+            }.join()
+        }
+        latch.await(5, TimeUnit.SECONDS)
+        future1.get() shouldBeEqualTo 42
+        future2.get() shouldBeEqualTo 43
+    }
+
+    @Test
+    fun `runAsyncIfLeader - action 실패 후에도 lock 이 해제되어 다음 호출이 성공한다`() {
+        val lockName = randomName()
+        val options = LeaderElectionOptions(waitTime = Duration.ofSeconds(2), leaseTime = Duration.ofSeconds(10))
+        val election = HazelcastLeaderElection(hazelcastClient, options)
+
+        runCatching {
+            election.runAsyncIfLeader(lockName) {
+                CompletableFuture.failedFuture<Int>(IllegalStateException("boom"))
+            }.join()
+        }
+
+        val result = election.runAsyncIfLeader(lockName) { futureOf { 99 } }
+            .get(3, TimeUnit.SECONDS)
+        result shouldBeEqualTo 99
+    }
+
+    @Test
+    fun `runAsyncIfLeader - 멀티스레드 환경에서 순차적으로 비동기 leader 작업이 실행된다`() {
+        val lockName = randomName()
+        val election = HazelcastLeaderElection(hazelcastClient)
+        val task1 = AtomicInteger(0)
+        val task2 = AtomicInteger(0)
+        val numThreads = 8
+        val roundsPerThread = 4
+
+        MultithreadingTester()
+            .workers(numThreads)
+            .rounds(roundsPerThread)
+            .add {
+                election.runAsyncIfLeader(lockName) {
+                    futureOf {
+                        task1.incrementAndGet()
+                        Thread.sleep(Random.nextLong(5, 10))
+                    }
+                }.join()
+            }
+            .add {
+                election.runAsyncIfLeader(lockName) {
+                    futureOf {
+                        task2.incrementAndGet()
+                        Thread.sleep(Random.nextLong(5, 10))
+                    }
+                }.join()
+            }
+            .run()
+
+        task1.get() shouldBeGreaterThan 0
+        task2.get() shouldBeGreaterThan 0
+    }
+
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @Test
+    fun `runAsyncIfLeader - Virtual Thread 환경에서 순차적으로 비동기 leader 작업이 실행된다`() {
+        val lockName = randomName()
+        val election = HazelcastLeaderElection(hazelcastClient)
+        val task1 = AtomicInteger(0)
+        val task2 = AtomicInteger(0)
+
+        StructuredTaskScopeTester()
+            .rounds(16)
+            .add {
+                election.runAsyncIfLeader(lockName, VirtualThreadExecutor) {
+                    futureOf {
+                        task1.incrementAndGet()
+                        Thread.sleep(Random.nextLong(5, 10))
+                    }
+                }.join()
+            }
+            .add {
+                election.runAsyncIfLeader(lockName, VirtualThreadExecutor) {
+                    futureOf {
+                        task2.incrementAndGet()
+                        Thread.sleep(Random.nextLong(5, 10))
+                    }
+                }.join()
+            }
+            .run()
+
+        task1.get() shouldBeGreaterThan 0
+        task2.get() shouldBeGreaterThan 0
+    }
+}

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElectionTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElectionTest.kt
@@ -68,7 +68,7 @@ class HazelcastLeaderGroupElectionTest: AbstractHazelcastLeaderTest() {
         executor.submit {
             singleElection.runIfLeader(lockName) {
                 acquiredLatch.countDown()
-                holdLatch.await()
+                holdLatch.await(5, TimeUnit.SECONDS)
             }
         }
 

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElectionTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElectionTest.kt
@@ -1,0 +1,209 @@
+package io.bluetape4k.leader.hazelcast
+
+import io.bluetape4k.concurrent.futureOf
+import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeFalse
+import org.amshove.kluent.shouldBeLessOrEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledForJreRange
+import org.junit.jupiter.api.condition.JRE
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.max
+import kotlin.random.Random
+
+class HazelcastLeaderGroupElectionTest: AbstractHazelcastLeaderTest() {
+
+    companion object: KLogging()
+
+    private val options = LeaderGroupElectionOptions(
+        maxLeaders = 3,
+        waitTime = Duration.ofSeconds(10),
+        leaseTime = Duration.ofSeconds(60),
+    )
+    private val election by lazy { HazelcastLeaderGroupElection(hazelcastClient, options) }
+
+    @Test
+    fun `runIfLeader - 리더로 선출되어 action 을 실행하고 결과를 반환한다`() {
+        val result = election.runIfLeader(randomName()) { "hello" }
+        result shouldBeEqualTo "hello"
+    }
+
+    @Test
+    fun `runIfLeader - 서로 다른 lockName 은 독립적인 슬롯 풀을 가진다`() {
+        val result1 = election.runIfLeader(randomName()) { "a" }
+        val result2 = election.runIfLeader(randomName()) { "b" }
+        result1 shouldBeEqualTo "a"
+        result2 shouldBeEqualTo "b"
+    }
+
+    @Test
+    fun `runIfLeader - action 예외 발생 후에도 슬롯이 반환되어 다음 호출이 성공한다`() {
+        val lockName = randomName()
+        runCatching { election.runIfLeader(lockName) { throw RuntimeException("실패") } }
+        val result = election.runIfLeader(lockName) { "복구 성공" }
+        result shouldBeEqualTo "복구 성공"
+    }
+
+    @Test
+    fun `runIfLeader - 모든 슬롯이 사용 중이면 waitTime 초과 시 null 을 반환한다`() {
+        val shortWaitOptions = LeaderGroupElectionOptions(maxLeaders = 1, waitTime = Duration.ofMillis(100))
+        val singleElection = HazelcastLeaderGroupElection(hazelcastClient, shortWaitOptions)
+        val lockName = randomName()
+        val acquiredLatch = CountDownLatch(1)
+        val holdLatch = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+
+        executor.submit {
+            singleElection.runIfLeader(lockName) {
+                acquiredLatch.countDown()
+                holdLatch.await()
+            }
+        }
+
+        try {
+            acquiredLatch.await(2, TimeUnit.SECONDS)
+            val result = singleElection.runIfLeader(lockName) { }
+            result.shouldBeNull()
+        } finally {
+            holdLatch.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `state - 초기 상태는 activeCount=0, isEmpty=true 이다`() {
+        val lockName = randomName()
+        val state = election.state(lockName)
+        state.lockName shouldBeEqualTo lockName
+        state.maxLeaders shouldBeEqualTo options.maxLeaders
+        state.activeCount shouldBeEqualTo 0
+        state.isEmpty.shouldBeTrue()
+        state.isFull.shouldBeFalse()
+    }
+
+    @Test
+    fun `동시 실행 중인 리더 수가 maxLeaders 를 초과하지 않는다`() {
+        val lockName = randomName()
+        val currentConcurrent = AtomicInteger(0)
+        val peakConcurrent = AtomicInteger(0)
+
+        MultithreadingTester()
+            .workers(options.maxLeaders * 4)
+            .rounds(2)
+            .add {
+                election.runIfLeader(lockName) {
+                    val current = currentConcurrent.incrementAndGet()
+                    peakConcurrent.updateAndGet { max(it, current) }
+                    Thread.sleep(Random.nextLong(5, 15))
+                    currentConcurrent.decrementAndGet()
+                }
+            }
+            .run()
+
+        log.debug { "최대 동시 실행 수: ${peakConcurrent.get()} / maxLeaders=${options.maxLeaders}" }
+        peakConcurrent.get() shouldBeLessOrEqualTo options.maxLeaders
+    }
+
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @Test
+    fun `Virtual Thread 환경에서 동시 실행 중인 리더 수가 maxLeaders 를 초과하지 않는다`() {
+        val lockName = randomName()
+        val currentConcurrent = AtomicInteger(0)
+        val peakConcurrent = AtomicInteger(0)
+
+        StructuredTaskScopeTester()
+            .rounds(options.maxLeaders * 8)
+            .add {
+                election.runIfLeader(lockName) {
+                    val current = currentConcurrent.incrementAndGet()
+                    peakConcurrent.updateAndGet { max(it, current) }
+                    Thread.sleep(Random.nextLong(5, 15))
+                    currentConcurrent.decrementAndGet()
+                }
+            }
+            .run()
+
+        log.debug { "최대 동시 실행 수: ${peakConcurrent.get()} / maxLeaders=${options.maxLeaders}" }
+        peakConcurrent.get() shouldBeLessOrEqualTo options.maxLeaders
+    }
+
+    @Test
+    fun `runAsyncIfLeader - 리더로 선출되어 비동기 action 을 실행하고 결과를 반환한다`() {
+        val result = election.runAsyncIfLeader(randomName()) { futureOf { "hello" } }.join()
+        result shouldBeEqualTo "hello"
+    }
+
+    @Test
+    fun `runAsyncIfLeader - action 예외 발생 후에도 슬롯이 반환되어 다음 호출이 성공한다`() {
+        val lockName = randomName()
+        runCatching {
+            election.runAsyncIfLeader(lockName) {
+                futureOf<Int> { throw RuntimeException("실패") }
+            }.join()
+        }
+        val result = election.runAsyncIfLeader(lockName) { futureOf { "복구 성공" } }.join()
+        result shouldBeEqualTo "복구 성공"
+    }
+
+    @Test
+    fun `runAsyncIfLeader - 동시 실행 중인 리더 수가 maxLeaders 를 초과하지 않는다`() {
+        val lockName = randomName()
+        val currentConcurrent = AtomicInteger(0)
+        val peakConcurrent = AtomicInteger(0)
+
+        MultithreadingTester()
+            .workers(options.maxLeaders * 4)
+            .rounds(2)
+            .add {
+                election.runAsyncIfLeader(lockName) {
+                    futureOf {
+                        val current = currentConcurrent.incrementAndGet()
+                        peakConcurrent.updateAndGet { max(it, current) }
+                        Thread.sleep(Random.nextLong(5, 15))
+                        currentConcurrent.decrementAndGet()
+                    }
+                }.join()
+            }
+            .run()
+
+        log.debug { "최대 동시 실행 수: ${peakConcurrent.get()} / maxLeaders=${options.maxLeaders}" }
+        peakConcurrent.get() shouldBeLessOrEqualTo options.maxLeaders
+    }
+
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @Test
+    fun `runAsyncIfLeader - Virtual Thread 에서 동시 실행 중인 리더 수가 maxLeaders 를 초과하지 않는다`() {
+        val lockName = randomName()
+        val currentConcurrent = AtomicInteger(0)
+        val peakConcurrent = AtomicInteger(0)
+
+        StructuredTaskScopeTester()
+            .rounds(options.maxLeaders * 8)
+            .add {
+                election.runAsyncIfLeader(lockName, VirtualThreadExecutor) {
+                    futureOf {
+                        val current = currentConcurrent.incrementAndGet()
+                        peakConcurrent.updateAndGet { max(it, current) }
+                        Thread.sleep(Random.nextLong(5, 15))
+                        currentConcurrent.decrementAndGet()
+                    }
+                }.join()
+            }
+            .run()
+
+        log.debug { "최대 동시 실행 수: ${peakConcurrent.get()} / maxLeaders=${options.maxLeaders}" }
+        peakConcurrent.get() shouldBeLessOrEqualTo options.maxLeaders
+    }
+}

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderElectionTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderElectionTest.kt
@@ -1,0 +1,152 @@
+package io.bluetape4k.leader.hazelcast
+
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
+import org.amshove.kluent.shouldBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledForJreRange
+import org.junit.jupiter.api.condition.JRE
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.random.Random
+
+class HazelcastSuspendLeaderElectionTest: AbstractHazelcastLeaderTest() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `runIfLeader - 리더로 선출되어 suspend action 을 실행하고 결과를 반환한다`() = runTest {
+        val election = HazelcastSuspendLeaderElection(hazelcastClient)
+        val result = election.runIfLeader(randomName()) {
+            delay(10)
+            "hello"
+        }
+        result shouldBeEqualTo "hello"
+    }
+
+    @Test
+    fun `runIfLeader - lock 이 이미 보유된 경우 waitTime 초과 시 null 을 반환한다`() = runTest {
+        val lockName = randomName()
+        val shortWaitOptions = LeaderElectionOptions(
+            waitTime = Duration.ofMillis(100),
+            leaseTime = Duration.ofSeconds(5),
+        )
+        val election = HazelcastSuspendLeaderElection(hazelcastClient, shortWaitOptions)
+        val lockAcquired = CountDownLatch(1)
+        val releaseLock = CountDownLatch(1)
+        val holder = Executors.newSingleThreadExecutor()
+
+        holder.submit {
+            val blockingElection = HazelcastLeaderElection(hazelcastClient, shortWaitOptions)
+            blockingElection.runIfLeader(lockName) {
+                lockAcquired.countDown()
+                releaseLock.await(3, TimeUnit.SECONDS)
+            }
+        }
+
+        try {
+            lockAcquired.await(2, TimeUnit.SECONDS)
+            val result = election.runIfLeader(lockName) { 1 }
+            result.shouldBeNull()
+        } finally {
+            releaseLock.countDown()
+            holder.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `runIfLeader - 코루틴 내 스레드 전환이 발생해도 lock 이 올바르게 해제된다`() = runTest {
+        val lockName = randomName()
+        val election = HazelcastSuspendLeaderElection(hazelcastClient)
+
+        // 여러 번 실행하여 lock 해제 확인
+        repeat(5) {
+            election.runIfLeader(lockName) {
+                delay(10)
+                "done-$it"
+            }
+        }
+
+        // 마지막 결과가 정상 반환되어야 함
+        val result = election.runIfLeader(lockName) { "final" }
+        result shouldBeEqualTo "final"
+    }
+
+    @Test
+    fun `runIfLeader - 멀티스레드 환경에서 순차적으로 leader suspend 작업이 실행된다`() {
+        val lockName = randomName()
+        val election = HazelcastSuspendLeaderElection(hazelcastClient)
+        val task1 = AtomicInteger(0)
+        val task2 = AtomicInteger(0)
+        val numThreads = 8
+        val roundsPerThread = 4
+
+        MultithreadingTester()
+            .workers(numThreads)
+            .rounds(roundsPerThread)
+            .add {
+                kotlinx.coroutines.runBlocking {
+                    election.runIfLeader(lockName) {
+                        log.debug { "suspend 작업 1. task1=${task1.get()}" }
+                        task1.incrementAndGet()
+                        delay(Random.nextLong(5, 10))
+                    }
+                }
+            }
+            .add {
+                kotlinx.coroutines.runBlocking {
+                    election.runIfLeader(lockName) {
+                        log.debug { "suspend 작업 2. task2=${task2.get()}" }
+                        task2.incrementAndGet()
+                        delay(Random.nextLong(5, 10))
+                    }
+                }
+            }
+            .run()
+
+        task1.get() shouldBeGreaterThan 0
+        task2.get() shouldBeGreaterThan 0
+    }
+
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @Test
+    fun `runIfLeader - Virtual Thread 환경에서 순차적으로 leader suspend 작업이 실행된다`() {
+        val lockName = randomName()
+        val election = HazelcastSuspendLeaderElection(hazelcastClient)
+        val task1 = AtomicInteger(0)
+        val task2 = AtomicInteger(0)
+
+        StructuredTaskScopeTester()
+            .rounds(16)
+            .add {
+                kotlinx.coroutines.runBlocking {
+                    election.runIfLeader(lockName) {
+                        task1.incrementAndGet()
+                        delay(Random.nextLong(5, 10))
+                    }
+                }
+            }
+            .add {
+                kotlinx.coroutines.runBlocking {
+                    election.runIfLeader(lockName) {
+                        task2.incrementAndGet()
+                        delay(Random.nextLong(5, 10))
+                    }
+                }
+            }
+            .run()
+
+        task1.get() shouldBeGreaterThan 0
+        task2.get() shouldBeGreaterThan 0
+    }
+}

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderGroupElectionTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderGroupElectionTest.kt
@@ -74,7 +74,7 @@ class HazelcastSuspendLeaderGroupElectionTest: AbstractHazelcastLeaderTest() {
             )
             blockingElection.runIfLeader(lockName) {
                 acquiredLatch.countDown()
-                holdLatch.await()
+                holdLatch.await(5, TimeUnit.SECONDS)
             }
         }
 

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderGroupElectionTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderGroupElectionTest.kt
@@ -1,0 +1,140 @@
+package io.bluetape4k.leader.hazelcast
+
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeLessOrEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledForJreRange
+import org.junit.jupiter.api.condition.JRE
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.max
+import kotlin.random.Random
+
+class HazelcastSuspendLeaderGroupElectionTest: AbstractHazelcastLeaderTest() {
+
+    companion object: KLogging()
+
+    private val options = LeaderGroupElectionOptions(
+        maxLeaders = 3,
+        waitTime = Duration.ofSeconds(10),
+        leaseTime = Duration.ofSeconds(60),
+    )
+    private val election by lazy { HazelcastSuspendLeaderGroupElection(hazelcastClient, options) }
+
+    @Test
+    fun `runIfLeader - 리더로 선출되어 suspend action 을 실행하고 결과를 반환한다`() = runTest {
+        val result = election.runIfLeader(randomName()) {
+            delay(10)
+            "hello"
+        }
+        result shouldBeEqualTo "hello"
+    }
+
+    @Test
+    fun `runIfLeader - 서로 다른 lockName 은 독립적인 슬롯 풀을 가진다`() = runTest {
+        val result1 = election.runIfLeader(randomName()) { "a" }
+        val result2 = election.runIfLeader(randomName()) { "b" }
+        result1 shouldBeEqualTo "a"
+        result2 shouldBeEqualTo "b"
+    }
+
+    @Test
+    fun `runIfLeader - action 예외 발생 후에도 슬롯이 반환되어 다음 호출이 성공한다`() = runTest {
+        val lockName = randomName()
+        runCatching { election.runIfLeader(lockName) { throw RuntimeException("실패") } }
+        val result = election.runIfLeader(lockName) { "복구 성공" }
+        result shouldBeEqualTo "복구 성공"
+    }
+
+    @Test
+    fun `runIfLeader - 모든 슬롯이 사용 중이면 waitTime 초과 시 null 을 반환한다`() = runTest {
+        val shortWaitOptions = LeaderGroupElectionOptions(maxLeaders = 1, waitTime = Duration.ofMillis(100))
+        val singleElection = HazelcastSuspendLeaderGroupElection(hazelcastClient, shortWaitOptions)
+        val lockName = randomName()
+        val acquiredLatch = CountDownLatch(1)
+        val holdLatch = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+
+        executor.submit {
+            val blockingElection = HazelcastLeaderGroupElection(
+                hazelcastClient,
+                shortWaitOptions.copy(waitTime = Duration.ofSeconds(5))
+            )
+            blockingElection.runIfLeader(lockName) {
+                acquiredLatch.countDown()
+                holdLatch.await()
+            }
+        }
+
+        try {
+            acquiredLatch.await(2, TimeUnit.SECONDS)
+            val result = singleElection.runIfLeader(lockName) { }
+            result.shouldBeNull()
+        } finally {
+            holdLatch.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `runIfLeader - 멀티스레드 환경에서 동시 실행 중인 리더 수가 maxLeaders 를 초과하지 않는다`() {
+        val lockName = randomName()
+        val currentConcurrent = AtomicInteger(0)
+        val peakConcurrent = AtomicInteger(0)
+
+        MultithreadingTester()
+            .workers(options.maxLeaders * 4)
+            .rounds(2)
+            .add {
+                runBlocking {
+                    election.runIfLeader(lockName) {
+                        val current = currentConcurrent.incrementAndGet()
+                        peakConcurrent.updateAndGet { max(it, current) }
+                        delay(Random.nextLong(5, 15))
+                        currentConcurrent.decrementAndGet()
+                    }
+                }
+            }
+            .run()
+
+        log.debug { "최대 동시 실행 수: ${peakConcurrent.get()} / maxLeaders=${options.maxLeaders}" }
+        peakConcurrent.get() shouldBeLessOrEqualTo options.maxLeaders
+    }
+
+    @EnabledForJreRange(min = JRE.JAVA_21)
+    @Test
+    fun `runIfLeader - Virtual Thread 환경에서 동시 실행 중인 리더 수가 maxLeaders 를 초과하지 않는다`() {
+        val lockName = randomName()
+        val currentConcurrent = AtomicInteger(0)
+        val peakConcurrent = AtomicInteger(0)
+
+        StructuredTaskScopeTester()
+            .rounds(options.maxLeaders * 8)
+            .add {
+                runBlocking {
+                    election.runIfLeader(lockName) {
+                        val current = currentConcurrent.incrementAndGet()
+                        peakConcurrent.updateAndGet { max(it, current) }
+                        delay(Random.nextLong(5, 15))
+                        currentConcurrent.decrementAndGet()
+                    }
+                }
+            }
+            .run()
+
+        log.debug { "최대 동시 실행 수: ${peakConcurrent.get()} / maxLeaders=${options.maxLeaders}" }
+        peakConcurrent.get() shouldBeLessOrEqualTo options.maxLeaders
+    }
+}

--- a/leader-hazelcast/src/test/resources/junit-platform.properties
+++ b/leader-hazelcast/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/leader-hazelcast/src/test/resources/logback-test.xml
+++ b/leader-hazelcast/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%32.32t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.leader" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## Summary

Closes #9

PR #26의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: leader-hazelcast 구현 (IMap 토큰 락 기반)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Closes #9 — leader-hazelcast 구현

Hazelcast CP Subsystem 없이 `IMap.putIfAbsent + TTL` + 토큰 기반 조건부 해제로 분산 리더 선출을 구현합니다.
스레드 ID에 의존하지 않는 토큰 모델로 Virtual Thread, 코루틴 스레드 전환 환경에서 모두 안전합니다.

---

## Work Done

- **`HazelcastLock`** / **`HazelcastSuspendLock`**: `IMap.putIfAbsent + TTL` 원자적 획득, `IMap.remove(key, token)` 소유자 전용 해제. `HazelcastException` 캐치 → `false` 반환으로 `runIfLeader()` never-throws 계약 보장
- **`HazelcastLeaderElection`**: `LeaderElection` + `AsyncLeaderElection` 구현 (블로킹·CompletableFuture 비동기)
- **`HazelcastSuspendLeaderElection`**: `SuspendLeaderElection` 구현, `NonCancellable` 락 해제 보호
- **`HazelcastLeaderGroupElection`**: N슬롯 IMap 키(`lockName:slot:0..N-1`)로 CP Subsystem 없이 세마포어 시뮬레이션
- **`HazelcastSuspendLeaderGroupElection`**: 코루틴 그룹 선출, 슬롯 루프 `ensureActive()` 취소 협조
- **확장 함수**: `runIfLeader`, `runAsyncIfLeader`, `runIfLeaderGroup`, `suspendRunIfLeader`, `suspendRunIfLeaderGroup`
- **테스트**: `HazelcastServer.Launcher.hazelcast` JVM 단위 싱글톤, 30개 테스트 통과
- **README.md + README.ko.md** 작성

---

## Spec DoD (Issue #9)

| 항목 | 상태 |
|------|------|
| sync 구현체 + 테스트 | ✅ |
| suspend 구현체 + 테스트 | ✅ |
| Group Election + 테스트 | ✅ |

## Test Results

```
Module : :leader-hazelcast
Tests  : 30 passing, 0 failed, 0 skipped
Time   : ~20s
Date   : 2026-04-30
```

## Pre-PR Checklist (CLAUDE.md)

| 항목 | 상태 |
|------|------|
| 로컬 테스트 전부 통과 | ✅ |
| Tier 1 autoresearch:security | ⏭️ N/A — 인증/SQL/외부API 없음 |
| Tier 2 Ops/SRE (CRITICAL 1 포함 → 전부 수정) | ✅ |
| Tier 3 code-review-graph (모듈 외부 영향 없음) | ✅ |
| Tier 4 Kotlin 품질 | ✅ HIGH 2 수정 |
| Tier 5 pr-review-toolkit | ✅ HIGH 4 수정 |
| Tier 6 Performance/stability | ✅ HIGH 2 수정 |
| README.md + README.ko.md | ✅ |
| 한국어 KDoc (모든 public API) | ✅ |

## Commits (4 total)

```
ce93b48 docs: leader-hazelcast README.md + README.ko.md 추가
88e324b fix: 6-R 코드 리뷰 반영 — CRITICAL/HIGH/MEDIUM 수정
30f190a fix: HazelcastSuspendLock 블로킹 IMap 호출에 withContext(Dispatchers.IO) 적용
32d798f feat: leader-hazelcast 구현 (IMap 토큰 락 기반)
```

**Final status: DONE** — PR awaiting merge.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #9, milestone `0.1.0`, assignee `debop`
- PR: #26, head `198f1a264f440ad51d0607010aa870dbe44a2011`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
