### PR TITLE
feat: 플러그형 선출 전략(StrategicLeaderElection) 추가 — leader-core pilot 구현 (#29)

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -12,10 +12,26 @@
 | #2 | LettuceLock/Semaphore 이식 및 bluetape4k-lettuce 의존성 제거 | ✅ 완료 | merged |
 | #3 | leader-redis-redisson 테스트 자립화 (AbstractRedissonLeaderTest) | ✅ 완료 | #17 merged |
 | #15 | runIfLeader() 반환 타입 T?로 변경 (skip 동작) | ✅ 완료 | merged |
+| #27 | leader-spring-boot-common — Boot 버전 독립 공통 모듈 | ✅ 완료 | #28 merged |
+| #29 | 플러그형 선출 전략 (StrategicLeaderElection) — leader-core pilot | 🔄 진행 중 | feat/strategic-leader-election |
 
 ---
 
 ## 예정 작업
+
+### #29 — 플러그형 선출 전략 (StrategicLeaderElection) 🔄 진행 중
+
+> Spec: [docs/spec/strategic-leader-election.md](docs/spec/strategic-leader-election.md)
+> Plan: [docs/plan/strategic-leader-election.md](docs/plan/strategic-leader-election.md)
+
+- ✅ leader-core pilot 구현: CandidateInfo, ElectionStrategy, CandidateScorer, Local 구현체
+- ✅ 내장 전략: FifoElectionStrategy, RandomElectionStrategy, ScoredElectionStrategy
+- ✅ 내장 Scorer: IdleTimeScorer, SuccessRateScorer, RecentSuccessScorer, WeightedScorer
+- [ ] Redis(Redisson/Lettuce) 백엔드 구현 (CandidateRegistry — sorted set/hash + TTL)
+- [ ] Exposed/MongoDB 백엔드 구현
+- [ ] 분산 epoch seed 공유 (RandomElectionStrategy 분산 결정론)
+
+---
 
 ### #4 — 테스트 커버리지 확대
 

--- a/WIP.md
+++ b/WIP.md
@@ -13,7 +13,7 @@
 | #3 | leader-redis-redisson 테스트 자립화 (AbstractRedissonLeaderTest) | ✅ 완료 | #17 merged |
 | #15 | runIfLeader() 반환 타입 T?로 변경 (skip 동작) | ✅ 완료 | merged |
 | #27 | leader-spring-boot-common — Boot 버전 독립 공통 모듈 | ✅ 완료 | #28 merged |
-| #29 | 플러그형 선출 전략 (StrategicLeaderElection) — leader-core pilot | 🔄 진행 중 | feat/strategic-leader-election |
+| #29 | 플러그형 선출 전략 (StrategicLeaderElection) — leader-core pilot | 🔄 진행 중 | #30 review |
 
 ---
 

--- a/docs/plan/strategic-leader-election.md
+++ b/docs/plan/strategic-leader-election.md
@@ -1,0 +1,107 @@
+# Plan — Strategic Leader Election
+
+> 작성: 2026-04-30
+> 참조 Spec: docs/spec/strategic-leader-election.md
+
+---
+
+## 구현 순서
+
+의존 관계 순서로 bottom-up 구현.
+
+| # | 파일 | 의존 |
+|---|------|------|
+| 1 | `CandidateResult.kt` | 없음 |
+| 2 | `CandidateInfo.kt` | `CandidateResult` |
+| 3 | `CandidateScorer.kt` | `CandidateInfo` |
+| 4 | `ElectionStrategy.kt` | `CandidateInfo` |
+| 5 | `IdleTimeScorer.kt` | `CandidateScorer` |
+| 6 | `SuccessRateScorer.kt` | `CandidateScorer` |
+| 7 | `RecentSuccessScorer.kt` | `CandidateScorer` |
+| 8 | `WeightedScorer.kt` | `CandidateScorer` |
+| 9 | `FifoElectionStrategy.kt` | `ElectionStrategy` |
+| 10 | `RandomElectionStrategy.kt` | `ElectionStrategy` |
+| 11 | `ScoredElectionStrategy.kt` | `ElectionStrategy`, `CandidateScorer` |
+| 12 | `StrategicLeaderElection.kt` | `CandidateInfo`, `ElectionStrategy`, `CandidateResult`, `LeaderElectionOptions` |
+| 13 | `StrategicSuspendLeaderElection.kt` | 위와 동일 (suspend 버전) |
+| 14 | `LocalStrategicLeaderElection.kt` | `StrategicLeaderElection` |
+| 15 | `LocalStrategicSuspendLeaderElection.kt` | `StrategicSuspendLeaderElection` |
+| T1 | `ElectionStrategyTest.kt` | 전략 3종 단위 테스트 |
+| T2 | `CandidateScorerTest.kt` | Scorer 4종 단위 테스트 |
+| T3 | `LocalStrategicLeaderElectionTest.kt` | Local 구현 통합 테스트 |
+| T4 | `LocalStrategicSuspendLeaderElectionTest.kt` | suspend 버전 통합 테스트 |
+
+---
+
+## 설계 결정 사항
+
+### 1. `StrategicLeaderElection` — 기존 인터페이스와 독립 계층
+
+`LeaderElection`을 extend하지 않는다. 선출 방식이 근본적으로 다르므로(락 경쟁 vs 후보 목록 기반) 별도 계층으로 분리.
+
+### 2. `LocalStrategicLeaderElection` — 동기화 전략
+
+- 후보 맵: `ConcurrentHashMap<String, ConcurrentHashMap<String, CandidateInfo>>`
+  - 외부 키: `lockName`, 내부 키: `nodeId`
+- `runIfLeader()` 내부: `reentrantLock()` 으로 전체 시퀀스(listCandidates → selectLeader → run) atomic 보장
+
+### 3. `updateResult()` — 불변 CandidateInfo 업데이트
+
+`CandidateInfo`는 data class(불변). `updateResult()` 는 기존 `CandidateInfo`를 `copy()`로 업데이트 후 맵 교체.
+
+### 4. `RandomElectionStrategy` — 결정론적 처리
+
+로컬 pilot 구현에서는 seed 파라미터 제공. 분산 환경에서의 shared seed는 백엔드 구현 시 처리.
+
+### 5. Tie-breaking
+
+동점 후보 발생 시 `registeredAt` 오름차순(먼저 등록한 쪽) 으로 결정. 모든 전략에 공통 적용.
+
+---
+
+## 파일 트리
+
+```
+leader-core/src/main/kotlin/io/bluetape4k/leader/
+├── strategy/
+│   ├── CandidateInfo.kt
+│   ├── CandidateResult.kt
+│   ├── ElectionStrategy.kt
+│   ├── CandidateScorer.kt
+│   ├── strategies/
+│   │   ├── FifoElectionStrategy.kt
+│   │   ├── RandomElectionStrategy.kt
+│   │   └── ScoredElectionStrategy.kt
+│   └── scorers/
+│       ├── IdleTimeScorer.kt
+│       ├── SuccessRateScorer.kt
+│       ├── RecentSuccessScorer.kt
+│       └── WeightedScorer.kt
+├── StrategicLeaderElection.kt
+├── coroutines/
+│   └── StrategicSuspendLeaderElection.kt
+└── local/
+    ├── LocalStrategicLeaderElection.kt
+    └── LocalStrategicSuspendLeaderElection.kt
+```
+
+---
+
+## 테스트 시나리오 (주요)
+
+### ElectionStrategyTest
+
+- `FifoElectionStrategy`: 3명 후보 중 가장 먼저 등록된 후보 선출
+- `RandomElectionStrategy`: 동일 seed → 동일 결과
+- `ScoredElectionStrategy(IdleTimeScorer)`: idle 시간 가장 긴 후보 선출
+- `ScoredElectionStrategy(WeightedScorer)`: weight 조합 최고점 선출
+- 후보 0명: `null` 반환
+- 후보 1명: 해당 후보 반환
+
+### LocalStrategicLeaderElectionTest
+
+- 3개 노드 동시 `runIfLeader()`: 정확히 1개만 action 실행
+- `updateResult(SUCCESS)` 후 `successCount` 증가 확인
+- `updateResult(FAILURE)` 후 `failureCount` 증가 확인
+- `FifoElectionStrategy` 적용: 가장 먼저 등록된 노드가 winner
+- `ScoredElectionStrategy(IdleTimeScorer)` 적용: idle 가장 긴 노드 winner

--- a/docs/spec/strategic-leader-election.md
+++ b/docs/spec/strategic-leader-election.md
@@ -1,0 +1,234 @@
+# Spec — Strategic Leader Election
+
+> 작성: 2026-04-30
+> 이슈: #29 (예정)
+> 상태: Draft
+
+---
+
+## 1. 배경 및 목적
+
+현재 `LeaderElection` 구현체들은 분산 락(FIFO) 방식으로 리더를 선출한다. 이 방식은 단순하지만 다음 시나리오에서 한계가 있다.
+
+- **부하 분산**: 항상 동일 노드가 리더가 되면 특정 노드에 부하 집중
+- **복원력(Resilience)**: 최근 실패한 노드보다 성공한 노드를 리더로 선호해야 하는 경우
+- **공정성**: 오래 쉰 노드에게 우선권을 주어 작업 기회 균등 분배
+
+이 기능은 **플러그형 선출 전략(Pluggable Election Strategy)** 을 leader-core 에 추가하여 다양한 선출 기준을 지원한다.
+
+---
+
+## 2. 범위
+
+### In-scope
+
+- `CandidateInfo` — 후보 노드 메타데이터 (leader-core)
+- `ElectionStrategy` — 선출 전략 인터페이스 (leader-core)
+- `CandidateScorer` — 점수화 인터페이스 (leader-core)
+- 내장 Scorer 구현체 4종 (leader-core)
+- `ScoredElectionStrategy`, `FifoElectionStrategy`, `RandomElectionStrategy` (leader-core)
+- `StrategicLeaderElection` / `StrategicSuspendLeaderElection` — 새 인터페이스 (leader-core)
+- `LocalStrategicLeaderElection` / `LocalStrategicSuspendLeaderElection` — 인메모리 pilot 구현체 (leader-core)
+- 단위 테스트 (leader-core)
+
+### Out-of-scope (별도 이슈)
+
+- Redis/Exposed/MongoDB 백엔드의 `StrategicLeaderElection` 구현
+- 분산 CandidateRegistry (백엔드별 저장소)
+- Heartbeat 데몬 관리 유틸리티
+- `AsyncStrategicLeaderElection` / `VirtualThreadStrategicLeaderElection` 변형 (후순위)
+
+---
+
+## 3. 선출 흐름
+
+```
+runIfLeader() 호출
+  ↓
+ensureRegistered(lockName, candidateInfo)   ← 후보 등록 (없으면 신규, 있으면 TTL 갱신)
+  ↓
+listCandidates(lockName)                    ← 현재 후보 목록 조회
+  ↓
+strategy.selectLeader(candidates)          ← 전략 적용 → 1명 선출
+  ↓
+winner.nodeId == myNodeId ?
+  YES → run action() → updateResult()     ← 작업 실행 + 결과 기록
+  NO  → return null                        ← drop (skip)
+```
+
+> **Local pilot scope**: 단일 프로세스 내 `reentrantLock()` 으로 listCandidates→selectLeader→run 시퀀스 atomic 보장.  
+> 분산 환경에서는 노드별 등록/조회 시점 차이로 후보 목록이 달라져 winner 불일치 가능.  
+> **분산 일관성 보장(epoch/coordinator 패턴)은 백엔드 구현 시 처리한다.**
+
+단, `RandomElectionStrategy` 사용 시 분산 환경에서 shared seed 필요 (백엔드 구현 시 처리).
+
+---
+
+## 4. 데이터 모델
+
+### CandidateInfo
+
+```kotlin
+data class CandidateInfo(
+    val nodeId: String,                          // 후보 노드 식별자 (UUID 권장)
+    val registeredAt: Instant = Instant.now(),   // 후보 등록 시각
+    val lastStartTime: Instant? = null,          // 마지막 작업 시작 시각
+    val lastCompletionTime: Instant? = null,     // 마지막 작업 완료 시각
+    val successCount: Long = 0,                  // 누적 성공 횟수
+    val failureCount: Long = 0,                  // 누적 실패 횟수
+    val metadata: Map<String, String> = emptyMap(), // 확장 메타데이터
+) {
+    /** 마지막 완료 이후 경과 시간. 완료 이력 없으면 등록 시각부터 계산 (null 없음). */
+    val idleDuration: Duration
+        get() = lastCompletionTime?.let { Duration.between(it, Instant.now()) }
+                ?: Duration.between(registeredAt, Instant.now())
+    val successRate: Double
+        get() = if (successCount + failureCount == 0L) 0.0
+                else successCount.toDouble() / (successCount + failureCount)
+    val totalCount: Long get() = successCount + failureCount
+}
+```
+
+### CandidateResult
+
+```kotlin
+enum class CandidateResult { SUCCESS, FAILURE }
+```
+
+---
+
+## 5. 인터페이스 설계
+
+### ElectionStrategy
+
+```kotlin
+interface ElectionStrategy {
+    fun selectLeader(candidates: List<CandidateInfo>): CandidateInfo?
+}
+```
+
+### CandidateScorer
+
+```kotlin
+interface CandidateScorer {
+    fun score(candidate: CandidateInfo, all: List<CandidateInfo>): Double
+}
+```
+
+### StrategicLeaderElection
+
+```kotlin
+interface StrategicLeaderElection {
+    val nodeId: String
+
+    /**
+     * 후보 등록 (없으면 신규 등록, 있으면 정보 갱신).
+     * [ttl] = `Duration.ZERO` 이면 TTL 없음 (Local 구현은 무시).
+     * 분산 백엔드 구현 시 heartbeat 주기의 2배 이상으로 설정 권장.
+     */
+    fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO)
+
+    /** 등록 해제 */
+    fun unregisterCandidate(lockName: String, nodeId: String)
+
+    /** 현재 후보 목록 조회 */
+    fun listCandidates(lockName: String): List<CandidateInfo>
+
+    /** 선출 후 결과 갱신 */
+    fun updateResult(lockName: String, nodeId: String, result: CandidateResult)
+
+    /**
+     * 전략으로 리더 선출 후 winner 만 action 실행.
+     * 선출 실패(후보 없음) 또는 다른 노드가 winner 이면 null 반환.
+     */
+    fun <T> runIfLeader(
+        lockName: String,
+        strategy: ElectionStrategy,
+        options: LeaderElectionOptions,
+        action: () -> T,
+    ): T?
+}
+```
+
+### StrategicSuspendLeaderElection
+
+`StrategicLeaderElection` 의 suspend 버전 — 동일 구조, 모든 메서드 suspend.
+
+---
+
+## 6. 내장 전략 목록
+
+| 클래스 | 설명 | 동작 |
+|--------|------|------|
+| `FifoElectionStrategy` | 가장 먼저 등록한 후보 선출 | `registeredAt` 오름차순 첫 번째 |
+| `RandomElectionStrategy` | 랜덤 선출 | 주어진 seed 또는 시스템 랜덤 |
+| `ScoredElectionStrategy` | 점수 기반 선출 | `scorer.score()` 최고점 후보 |
+
+---
+
+## 7. 내장 Scorer 목록
+
+| 클래스 | 선호 후보 | 점수 산식 |
+|--------|----------|---------|
+| `IdleTimeScorer` | 가장 오래 쉰 노드 | `idleDuration.toMillis()` (미실행 노드 = 등록 이후 전체 경과 시간) |
+| `SuccessRateScorer` | 성공률 높은 노드 | `successRate * 100` |
+| `RecentSuccessScorer` | 최근 성공한 노드 | 성공한 경우 최근 완료시각 점수 |
+| `WeightedScorer` | 복합 기준 | `Σ(scorer.score * weight)` |
+
+---
+
+## 8. 파일 배치
+
+```
+leader-core/src/main/kotlin/io/bluetape4k/leader/
+  strategy/
+    CandidateInfo.kt
+    CandidateResult.kt
+    ElectionStrategy.kt
+    CandidateScorer.kt
+    strategies/
+      FifoElectionStrategy.kt
+      RandomElectionStrategy.kt
+      ScoredElectionStrategy.kt
+    scorers/
+      IdleTimeScorer.kt
+      SuccessRateScorer.kt
+      RecentSuccessScorer.kt
+      WeightedScorer.kt
+  StrategicLeaderElection.kt
+  coroutines/
+    StrategicSuspendLeaderElection.kt
+  local/
+    LocalStrategicLeaderElection.kt          ← pilot 구현 (in-memory)
+    LocalStrategicSuspendLeaderElection.kt   ← pilot suspend 구현
+
+leader-core/src/test/kotlin/io/bluetape4k/leader/
+  strategy/
+    ElectionStrategyTest.kt
+    CandidateScorerTest.kt
+  local/
+    LocalStrategicLeaderElectionTest.kt
+    LocalStrategicSuspendLeaderElectionTest.kt
+```
+
+---
+
+## 9. 제약 / 비기능 요구사항
+
+- 모든 타입: Kotlin 2.3+, JVM 21 타겟
+- `CandidateInfo`: `Serializable` 구현 (Redis 직렬화 호환)
+- 스레드 안전: `LocalStrategicLeaderElection` 은 `ConcurrentHashMap` + `reentrantLock()` 사용
+- `CancellationException` 재전파 보장 (suspend 구현체)
+- 모든 공개 API: 한국어 KDoc
+
+---
+
+## 10. 수용 기준 (Acceptance Criteria)
+
+- [ ] `FifoElectionStrategy` — 가장 먼저 등록한 후보가 선출됨
+- [ ] `ScoredElectionStrategy(IdleTimeScorer)` — 가장 오래 쉰 후보가 선출됨
+- [ ] `ScoredElectionStrategy(WeightedScorer)` — 복합 점수 최고 후보 선출됨
+- [ ] `LocalStrategicLeaderElection.runIfLeader()` — winner 만 action 실행, 나머지 null 반환
+- [ ] `updateResult()` 후 `successCount`/`failureCount` 반영됨
+- [ ] 후보 0명인 경우 `selectLeader()` → null 반환
+- [ ] 모든 테스트 통과

--- a/leader-core/README.ko.md
+++ b/leader-core/README.ko.md
@@ -140,8 +140,72 @@ sequenceDiagram
 | `LocalSuspendLeaderElection` | `SuspendLeaderElection` | 코루틴 `Mutex` 기반 |
 | `LocalLeaderGroupElection` | `LeaderGroupElection` | `Semaphore` 기반 복수 리더 |
 | `LocalSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` | 코루틴 `Semaphore` 기반 |
+| `LocalStrategicLeaderElection` | `StrategicLeaderElection` | 전략 기반 블로킹 선출 |
+| `LocalStrategicSuspendLeaderElection` | `StrategicSuspendLeaderElection` | 전략 기반 코루틴 선출 |
+
+## 전략 기반 선출 (Strategic Election)
+
+### 개요
+
+전략 기반 선출은 **후보 등록 단계**와 **전략 적용 단계**를 분리하여 유연한 리더 선출 정책을 가능하게 합니다.
+
+```
+registerCandidate() → selectLeader(strategy) → 1명 선출, 나머지 skip
+```
+
+### 내장 전략
+
+| 전략 | 설명 |
+|------|------|
+| `FifoElectionStrategy` | 등록 시각이 가장 이른 후보 선출 |
+| `RandomElectionStrategy(seed)` | seed 기반 결정론적 무작위 선출 (분산 환경: 공유 seed 필수) |
+| `ScoredElectionStrategy(scorer)` | 점수 최고 후보 선출 |
+
+### 내장 Scorer (0–100 정규화)
+
+| Scorer | 설명 |
+|--------|------|
+| `IdleTimeScorer` | 마지막 완료 후 가장 오래 쉰 노드 우선 |
+| `SuccessRateScorer` | 성공률 높은 노드 우선 |
+| `RecentSuccessScorer` | 가장 최근에 성공 완료한 노드 우선 |
+| `WeightedScorer` | 복수 Scorer 가중 합산 |
+
+### 핵심 인터페이스
+
+```kotlin
+interface StrategicLeaderElection {
+    val nodeId: String
+    fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO)
+    fun unregisterCandidate(lockName: String, nodeId: String)
+    fun listCandidates(lockName: String): List<CandidateInfo>
+    fun <T> runIfLeader(lockName: String, strategy: ElectionStrategy, options: LeaderElectionOptions, action: () -> T): T?
+}
+```
 
 ## 사용 예시
+
+### 전략 기반 선출 — IdleTime Scorer
+
+```kotlin
+val election = LocalStrategicLeaderElection("node-1")
+
+election.registerCandidate("batch-job", CandidateInfo("node-1"))
+election.registerCandidate("batch-job", CandidateInfo("node-2"))
+
+val result = election.runIfLeader("batch-job", ScoredElectionStrategy(IdleTimeScorer)) {
+    processBatch()
+}
+// 가장 오래 쉰 노드만 processBatch() 실행, 나머지는 null 반환
+```
+
+### 전략 기반 선출 — 가중 Scorer
+
+```kotlin
+val scorer = WeightedScorer(IdleTimeScorer to 0.4, SuccessRateScorer to 0.6)
+val strategy = ScoredElectionStrategy(scorer)
+
+val result = election.runIfLeader("weighted-job", strategy) { work() }
+```
 
 ### 블로킹 단일 리더
 

--- a/leader-core/README.md
+++ b/leader-core/README.md
@@ -140,8 +140,72 @@ All local implementations use JVM primitives (`ReentrantLock`, `Semaphore`) — 
 | `LocalSuspendLeaderElection` | `SuspendLeaderElection` | Coroutine with `Mutex` |
 | `LocalLeaderGroupElection` | `LeaderGroupElection` | `Semaphore`-based multi-leader |
 | `LocalSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` | Coroutine `Semaphore` |
+| `LocalStrategicLeaderElection` | `StrategicLeaderElection` | Strategy-based blocking election |
+| `LocalStrategicSuspendLeaderElection` | `StrategicSuspendLeaderElection` | Strategy-based coroutine election |
+
+## Strategic Election
+
+### Overview
+
+Strategic election separates the **nomination phase** (candidate registration) from the **decision phase** (strategy application), enabling flexible leader selection policies.
+
+```
+registerCandidate() → selectLeader(strategy) → 1 winner, rest skipped
+```
+
+### Built-in Strategies
+
+| Strategy | Description |
+|----------|-------------|
+| `FifoElectionStrategy` | Earliest registered candidate wins |
+| `RandomElectionStrategy(seed)` | Deterministic random selection (seed required for distributed use) |
+| `ScoredElectionStrategy(scorer)` | Highest-scoring candidate wins |
+
+### Built-in Scorers (0–100 normalized)
+
+| Scorer | Description |
+|--------|-------------|
+| `IdleTimeScorer` | Node idle longest since last completion |
+| `SuccessRateScorer` | Highest success-rate node |
+| `RecentSuccessScorer` | Most recently succeeded node |
+| `WeightedScorer` | Weighted sum of multiple scorers |
+
+### Key Interfaces
+
+```kotlin
+interface StrategicLeaderElection {
+    val nodeId: String
+    fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO)
+    fun unregisterCandidate(lockName: String, nodeId: String)
+    fun listCandidates(lockName: String): List<CandidateInfo>
+    fun <T> runIfLeader(lockName: String, strategy: ElectionStrategy, options: LeaderElectionOptions, action: () -> T): T?
+}
+```
 
 ## Usage Examples
+
+### Strategic election — scored idle-time
+
+```kotlin
+val election = LocalStrategicLeaderElection("node-1")
+
+election.registerCandidate("batch-job", CandidateInfo("node-1"))
+election.registerCandidate("batch-job", CandidateInfo("node-2"))
+
+val result = election.runIfLeader("batch-job", ScoredElectionStrategy(IdleTimeScorer)) {
+    processBatch()
+}
+// Only the node idle longest runs processBatch(); others return null
+```
+
+### Strategic election — weighted scorer
+
+```kotlin
+val scorer = WeightedScorer(IdleTimeScorer to 0.4, SuccessRateScorer to 0.6)
+val strategy = ScoredElectionStrategy(scorer)
+
+val result = election.runIfLeader("weighted-job", strategy) { work() }
+```
 
 ### Blocking single-leader
 

--- a/leader-core/build.gradle.kts
+++ b/leader-core/build.gradle.kts
@@ -4,6 +4,7 @@ configurations {
 
 dependencies {
     api(Libs.bluetape4k_core)
+    api(Libs.bluetape4k_idgenerators)
     api(Libs.bluetape4k_logging)
 
     implementation(Libs.kotlinx_coroutines_core)

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderElection.kt
@@ -1,0 +1,63 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.ElectionStrategy
+import java.time.Duration
+
+/**
+ * 플러그형 선출 전략을 지원하는 리더 선출 인터페이스입니다.
+ *
+ * 기존 [LeaderElection] 과 달리 분산 락 경쟁 대신 후보 목록 기반 선출 방식을 사용합니다.
+ *
+ * ## 선출 흐름
+ * 1. [registerCandidate] 로 후보 등록
+ * 2. [listCandidates] 로 현재 후보 목록 조회
+ * 3. [ElectionStrategy.selectLeader] 로 winner 결정
+ * 4. winner 이면 action 실행, 아니면 null 반환
+ *
+ * ## 분산 일관성 주의
+ * 모든 노드가 동일한 후보 목록에 결정론적 전략을 적용하면 동일 winner 를 계산합니다.
+ * 단, 후보 등록/조회 시점 차이로 인한 불일치는 백엔드 구현에서 처리해야 합니다.
+ */
+interface StrategicLeaderElection {
+
+    /** 이 인스턴스가 나타내는 노드 식별자 */
+    val nodeId: String
+
+    /**
+     * 후보 등록 또는 갱신.
+     *
+     * [ttl] = [Duration.ZERO] 이면 TTL 없음 (Local 구현은 무시).
+     * 분산 백엔드에서는 heartbeat 주기의 2배 이상으로 설정 권장.
+     */
+    fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO)
+
+    /** 후보 등록 해제 */
+    fun unregisterCandidate(lockName: String, nodeId: String)
+
+    /** [lockName] 에 등록된 현재 후보 목록 조회 */
+    fun listCandidates(lockName: String): List<CandidateInfo>
+
+    /**
+     * 작업 결과를 후보 정보에 반영합니다.
+     * [result] 에 따라 [CandidateInfo.successCount] 또는 [CandidateInfo.failureCount] 가 증가합니다.
+     */
+    fun updateResult(lockName: String, nodeId: String, result: CandidateResult)
+
+    /**
+     * 전략으로 리더를 선출하고 winner 인 경우에만 [action] 을 실행합니다.
+     *
+     * @param lockName 선출 식별자
+     * @param strategy 선출 전략
+     * @param options 선출 옵션 (waitTime, leaseTime)
+     * @param action 리더 획득 성공 시 실행할 작업
+     * @return [action] 실행 결과, 선출 실패 또는 다른 노드가 winner 이면 `null`
+     */
+    fun <T> runIfLeader(
+        lockName: String,
+        strategy: ElectionStrategy,
+        options: LeaderElectionOptions = LeaderElectionOptions.Default,
+        action: () -> T,
+    ): T?
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderElection.kt
@@ -1,0 +1,54 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.ElectionStrategy
+import java.time.Duration
+
+/**
+ * 코루틴 기반 플러그형 선출 전략을 지원하는 리더 선출 인터페이스입니다.
+ *
+ * [io.bluetape4k.leader.StrategicLeaderElection] 의 suspend 버전입니다.
+ *
+ * [action] 실행 중 코루틴 취소 시 `CancellationException` 은 반드시 호출자에게 재전파해야 합니다.
+ */
+interface StrategicSuspendLeaderElection {
+
+    /** 이 인스턴스가 나타내는 노드 식별자 */
+    val nodeId: String
+
+    /**
+     * 후보 등록 또는 갱신.
+     *
+     * [ttl] = [Duration.ZERO] 이면 TTL 없음 (Local 구현은 무시).
+     */
+    suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO)
+
+    /** 후보 등록 해제 */
+    suspend fun unregisterCandidate(lockName: String, nodeId: String)
+
+    /** [lockName] 에 등록된 현재 후보 목록 조회 */
+    suspend fun listCandidates(lockName: String): List<CandidateInfo>
+
+    /**
+     * 작업 결과를 후보 정보에 반영합니다.
+     */
+    suspend fun updateResult(lockName: String, nodeId: String, result: CandidateResult)
+
+    /**
+     * 전략으로 리더를 선출하고 winner 인 경우에만 suspend [action] 을 실행합니다.
+     *
+     * @param lockName 선출 식별자
+     * @param strategy 선출 전략
+     * @param options 선출 옵션
+     * @param action 리더 획득 성공 시 실행할 suspend 작업
+     * @return [action] 실행 결과, 선출 실패 또는 다른 노드가 winner 이면 `null`
+     */
+    suspend fun <T> runIfLeader(
+        lockName: String,
+        strategy: ElectionStrategy,
+        options: LeaderElectionOptions = LeaderElectionOptions.Default,
+        action: suspend () -> T,
+    ): T?
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElection.kt
@@ -64,7 +64,14 @@ class LocalStrategicLeaderElection(
             strategy.elect(listCandidates(lockName))
         }
         val winner = result.winner ?: return null
-        log.info { "[$lockName] 선출: ${winner.nodeId} (전략: ${strategy::class.simpleName}, 후보: ${result.eliminations.size + 1}명)" }
+        val total = result.eliminations.size + 1
+        log.info { "[$lockName] 선출: ${winner.nodeId} (전략: ${strategy::class.simpleName}, 후보: ${total}명)" }
+        if (result.scores.isNotEmpty()) {
+            val scoreText = result.scores.entries
+                .sortedByDescending { it.value }
+                .joinToString(", ") { (id, s) -> "$id=%.2f".format(s) }
+            log.debug { "[$lockName] 점수: $scoreText" }
+        }
         result.eliminations.forEach { e ->
             log.debug { "[$lockName] 탈락: ${e.candidate.nodeId} — ${e.reason}" }
         }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElection.kt
@@ -6,6 +6,8 @@ import io.bluetape4k.leader.StrategicLeaderElection
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.ElectionStrategy
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantLock
@@ -23,6 +25,8 @@ import kotlin.concurrent.withLock
 class LocalStrategicLeaderElection(
     override val nodeId: String = TimebasedUuid.Epoch.nextIdAsString(),
 ) : StrategicLeaderElection {
+
+    companion object : KLogging()
 
     private val registry = ConcurrentHashMap<String, ConcurrentHashMap<String, CandidateInfo>>()
     private val locks = ConcurrentHashMap<String, ReentrantLock>()
@@ -55,9 +59,13 @@ class LocalStrategicLeaderElection(
         action: () -> T,
     ): T? {
         // 선출 단계만 lockName 단위 락으로 보호
-        val winner = lockFor(lockName).withLock {
-            strategy.selectLeader(listCandidates(lockName))
-        } ?: return null
+        val result = lockFor(lockName).withLock {
+            strategy.elect(listCandidates(lockName))
+        }
+        result.eliminations.forEach { e ->
+            log.debug { "[$lockName] 탈락: ${e.candidate.nodeId} — ${e.reason}" }
+        }
+        val winner = result.winner ?: return null
         if (winner.nodeId != nodeId) return null
 
         // action 은 락 외부에서 실행

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElection.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.ElectionStrategy
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantLock
@@ -62,10 +63,11 @@ class LocalStrategicLeaderElection(
         val result = lockFor(lockName).withLock {
             strategy.elect(listCandidates(lockName))
         }
+        val winner = result.winner ?: return null
+        log.info { "[$lockName] 선출: ${winner.nodeId} (전략: ${strategy::class.simpleName}, 후보: ${result.eliminations.size + 1}명)" }
         result.eliminations.forEach { e ->
             log.debug { "[$lockName] 탈락: ${e.candidate.nodeId} — ${e.reason}" }
         }
-        val winner = result.winner ?: return null
         if (winner.nodeId != nodeId) return null
 
         // action 은 락 외부에서 실행

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElection.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.leader.local
 
+import io.bluetape4k.idgenerators.uuid.TimebasedUuid
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.StrategicLeaderElection
 import io.bluetape4k.leader.strategy.CandidateInfo
@@ -17,9 +18,11 @@ import kotlin.concurrent.withLock
  * lockName 단위 [ReentrantLock] 으로 선출 단계의 스레드 안전성을 보장합니다.
  * action 실행은 락 외부에서 수행하여 무관한 lockName 간 간섭을 방지합니다.
  *
- * @property nodeId 이 인스턴스가 나타내는 노드 식별자
+ * @property nodeId 이 인스턴스가 나타내는 노드 식별자. 미지정 시 UUID v7([TimebasedUuid.Epoch])로 자동 생성됩니다.
  */
-class LocalStrategicLeaderElection(override val nodeId: String) : StrategicLeaderElection {
+class LocalStrategicLeaderElection(
+    override val nodeId: String = TimebasedUuid.Epoch.nextIdAsString(),
+) : StrategicLeaderElection {
 
     private val registry = ConcurrentHashMap<String, ConcurrentHashMap<String, CandidateInfo>>()
     private val locks = ConcurrentHashMap<String, ReentrantLock>()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElection.kt
@@ -1,0 +1,70 @@
+package io.bluetape4k.leader.local
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.StrategicLeaderElection
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.ElectionStrategy
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/**
+ * 인메모리(단일 프로세스) [StrategicLeaderElection] 구현체입니다.
+ *
+ * 단일 프로세스 내 pilot 테스트 및 단위 테스트 용도로 사용합니다.
+ * lockName 단위 [ReentrantLock] 으로 선출 단계의 스레드 안전성을 보장합니다.
+ * action 실행은 락 외부에서 수행하여 무관한 lockName 간 간섭을 방지합니다.
+ *
+ * @property nodeId 이 인스턴스가 나타내는 노드 식별자
+ */
+class LocalStrategicLeaderElection(override val nodeId: String) : StrategicLeaderElection {
+
+    private val registry = ConcurrentHashMap<String, ConcurrentHashMap<String, CandidateInfo>>()
+    private val locks = ConcurrentHashMap<String, ReentrantLock>()
+
+    private fun candidatesFor(lockName: String): ConcurrentHashMap<String, CandidateInfo> =
+        registry.getOrPut(lockName) { ConcurrentHashMap() }
+
+    private fun lockFor(lockName: String): ReentrantLock =
+        locks.getOrPut(lockName) { ReentrantLock() }
+
+    override fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+        candidatesFor(lockName)[info.nodeId] = info
+    }
+
+    override fun unregisterCandidate(lockName: String, nodeId: String) {
+        candidatesFor(lockName).remove(nodeId)
+    }
+
+    override fun listCandidates(lockName: String): List<CandidateInfo> =
+        candidatesFor(lockName).values.toList()
+
+    override fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
+        candidatesFor(lockName).computeIfPresent(nodeId) { _, current -> current.withResult(result) }
+    }
+
+    override fun <T> runIfLeader(
+        lockName: String,
+        strategy: ElectionStrategy,
+        options: LeaderElectionOptions,
+        action: () -> T,
+    ): T? {
+        // 선출 단계만 lockName 단위 락으로 보호
+        val winner = lockFor(lockName).withLock {
+            strategy.selectLeader(listCandidates(lockName))
+        } ?: return null
+        if (winner.nodeId != nodeId) return null
+
+        // action 은 락 외부에서 실행
+        return try {
+            val value = action()
+            updateResult(lockName, nodeId, CandidateResult.SUCCESS)
+            value
+        } catch (e: Throwable) {
+            updateResult(lockName, nodeId, CandidateResult.FAILURE)
+            throw e
+        }
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElection.kt
@@ -1,0 +1,74 @@
+package io.bluetape4k.leader.local
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.coroutines.StrategicSuspendLeaderElection
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.ElectionStrategy
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * 인메모리(단일 프로세스) [StrategicSuspendLeaderElection] 구현체입니다.
+ *
+ * [LocalStrategicLeaderElection] 의 suspend 버전으로, lockName 단위 [Mutex] 로 코루틴 안전성을 보장합니다.
+ * action 실행은 뮤텍스 외부에서 수행하여 무관한 lockName 간 간섭을 방지합니다.
+ * [CancellationException] 은 작업 실패로 간주하지 않으며, failureCount 를 증가시키지 않고 즉시 재전파합니다.
+ *
+ * @property nodeId 이 인스턴스가 나타내는 노드 식별자
+ */
+class LocalStrategicSuspendLeaderElection(override val nodeId: String) : StrategicSuspendLeaderElection {
+
+    private val registry = ConcurrentHashMap<String, ConcurrentHashMap<String, CandidateInfo>>()
+    private val mutexes = ConcurrentHashMap<String, Mutex>()
+
+    private fun candidatesFor(lockName: String): ConcurrentHashMap<String, CandidateInfo> =
+        registry.getOrPut(lockName) { ConcurrentHashMap() }
+
+    private fun mutexFor(lockName: String): Mutex =
+        mutexes.getOrPut(lockName) { Mutex() }
+
+    override suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+        candidatesFor(lockName)[info.nodeId] = info
+    }
+
+    override suspend fun unregisterCandidate(lockName: String, nodeId: String) {
+        candidatesFor(lockName).remove(nodeId)
+    }
+
+    override suspend fun listCandidates(lockName: String): List<CandidateInfo> =
+        candidatesFor(lockName).values.toList()
+
+    override suspend fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
+        candidatesFor(lockName).computeIfPresent(nodeId) { _, current -> current.withResult(result) }
+    }
+
+    override suspend fun <T> runIfLeader(
+        lockName: String,
+        strategy: ElectionStrategy,
+        options: LeaderElectionOptions,
+        action: suspend () -> T,
+    ): T? {
+        // 선출 단계만 lockName 단위 뮤텍스로 보호
+        val winner = mutexFor(lockName).withLock {
+            strategy.selectLeader(listCandidates(lockName))
+        } ?: return null
+        if (winner.nodeId != nodeId) return null
+
+        // action 은 뮤텍스 외부에서 실행
+        return try {
+            val value = action()
+            updateResult(lockName, nodeId, CandidateResult.SUCCESS)
+            value
+        } catch (e: CancellationException) {
+            // 코루틴 취소는 작업 실패가 아님 — failureCount 증가 없이 재전파
+            throw e
+        } catch (e: Throwable) {
+            updateResult(lockName, nodeId, CandidateResult.FAILURE)
+            throw e
+        }
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElection.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.ElectionStrategy
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -63,10 +64,11 @@ class LocalStrategicSuspendLeaderElection(
         val result = mutexFor(lockName).withLock {
             strategy.elect(listCandidates(lockName))
         }
+        val winner = result.winner ?: return null
+        log.info { "[$lockName] 선출: ${winner.nodeId} (전략: ${strategy::class.simpleName}, 후보: ${result.eliminations.size + 1}명)" }
         result.eliminations.forEach { e ->
             log.debug { "[$lockName] 탈락: ${e.candidate.nodeId} — ${e.reason}" }
         }
-        val winner = result.winner ?: return null
         if (winner.nodeId != nodeId) return null
 
         // action 은 뮤텍스 외부에서 실행

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElection.kt
@@ -6,6 +6,8 @@ import io.bluetape4k.leader.coroutines.StrategicSuspendLeaderElection
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.ElectionStrategy
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -24,6 +26,8 @@ import java.util.concurrent.ConcurrentHashMap
 class LocalStrategicSuspendLeaderElection(
     override val nodeId: String = TimebasedUuid.Epoch.nextIdAsString(),
 ) : StrategicSuspendLeaderElection {
+
+    companion object : KLogging()
 
     private val registry = ConcurrentHashMap<String, ConcurrentHashMap<String, CandidateInfo>>()
     private val mutexes = ConcurrentHashMap<String, Mutex>()
@@ -56,9 +60,13 @@ class LocalStrategicSuspendLeaderElection(
         action: suspend () -> T,
     ): T? {
         // 선출 단계만 lockName 단위 뮤텍스로 보호
-        val winner = mutexFor(lockName).withLock {
-            strategy.selectLeader(listCandidates(lockName))
-        } ?: return null
+        val result = mutexFor(lockName).withLock {
+            strategy.elect(listCandidates(lockName))
+        }
+        result.eliminations.forEach { e ->
+            log.debug { "[$lockName] 탈락: ${e.candidate.nodeId} — ${e.reason}" }
+        }
+        val winner = result.winner ?: return null
         if (winner.nodeId != nodeId) return null
 
         // action 은 뮤텍스 외부에서 실행

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElection.kt
@@ -65,7 +65,14 @@ class LocalStrategicSuspendLeaderElection(
             strategy.elect(listCandidates(lockName))
         }
         val winner = result.winner ?: return null
-        log.info { "[$lockName] 선출: ${winner.nodeId} (전략: ${strategy::class.simpleName}, 후보: ${result.eliminations.size + 1}명)" }
+        val total = result.eliminations.size + 1
+        log.info { "[$lockName] 선출: ${winner.nodeId} (전략: ${strategy::class.simpleName}, 후보: ${total}명)" }
+        if (result.scores.isNotEmpty()) {
+            val scoreText = result.scores.entries
+                .sortedByDescending { it.value }
+                .joinToString(", ") { (id, s) -> "$id=%.2f".format(s) }
+            log.debug { "[$lockName] 점수: $scoreText" }
+        }
         result.eliminations.forEach { e ->
             log.debug { "[$lockName] 탈락: ${e.candidate.nodeId} — ${e.reason}" }
         }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElection.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.leader.local
 
+import io.bluetape4k.idgenerators.uuid.TimebasedUuid
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.coroutines.StrategicSuspendLeaderElection
 import io.bluetape4k.leader.strategy.CandidateInfo
@@ -18,9 +19,11 @@ import java.util.concurrent.ConcurrentHashMap
  * action 실행은 뮤텍스 외부에서 수행하여 무관한 lockName 간 간섭을 방지합니다.
  * [CancellationException] 은 작업 실패로 간주하지 않으며, failureCount 를 증가시키지 않고 즉시 재전파합니다.
  *
- * @property nodeId 이 인스턴스가 나타내는 노드 식별자
+ * @property nodeId 이 인스턴스가 나타내는 노드 식별자. 미지정 시 UUID v7([TimebasedUuid.Epoch])로 자동 생성됩니다.
  */
-class LocalStrategicSuspendLeaderElection(override val nodeId: String) : StrategicSuspendLeaderElection {
+class LocalStrategicSuspendLeaderElection(
+    override val nodeId: String = TimebasedUuid.Epoch.nextIdAsString(),
+) : StrategicSuspendLeaderElection {
 
     private val registry = ConcurrentHashMap<String, ConcurrentHashMap<String, CandidateInfo>>()
     private val mutexes = ConcurrentHashMap<String, Mutex>()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/CandidateInfo.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/CandidateInfo.kt
@@ -1,0 +1,60 @@
+package io.bluetape4k.leader.strategy
+
+import java.io.Serializable
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * 리더 선출 후보 노드의 메타데이터를 담는 데이터 클래스입니다.
+ *
+ * [idleDuration] 은 마지막 완료 이후 경과 시간을 나타내며, 실행 이력이 없으면 [registeredAt] 부터 계산합니다.
+ *
+ * @property nodeId 노드 식별자 (UUID 권장)
+ * @property registeredAt 후보 등록 시각
+ * @property lastStartTime 마지막 작업 시작 시각
+ * @property lastCompletionTime 마지막 작업 완료 시각
+ * @property successCount 누적 성공 횟수
+ * @property failureCount 누적 실패 횟수
+ * @property metadata 확장 메타데이터
+ */
+data class CandidateInfo(
+    val nodeId: String,
+    val registeredAt: Instant = Instant.now(),
+    val lastStartTime: Instant? = null,
+    val lastCompletionTime: Instant? = null,
+    val successCount: Long = 0L,
+    val failureCount: Long = 0L,
+    val metadata: Map<String, String> = emptyMap(),
+) : Serializable {
+
+    /**
+     * 마지막 완료 이후 경과 시간.
+     * 완료 이력이 없으면 [registeredAt] 부터 계산합니다 (미실행 노드 = 등록 이후 전체 경과 시간).
+     */
+    val idleDuration: Duration
+        get() = lastCompletionTime?.let { Duration.between(it, Instant.now()) }
+            ?: Duration.between(registeredAt, Instant.now())
+
+    /** 성공률 (0.0 ~ 1.0). 이력 없으면 0.0. */
+    val successRate: Double
+        get() = if (successCount + failureCount == 0L) 0.0
+                else successCount.toDouble() / (successCount + failureCount)
+
+    /** 총 실행 횟수 */
+    val totalCount: Long get() = successCount + failureCount
+
+    /**
+     * 작업 결과를 반영한 새 [CandidateInfo] 를 반환합니다.
+     */
+    fun withResult(result: CandidateResult, completionTime: Instant = Instant.now()): CandidateInfo =
+        when (result) {
+            CandidateResult.SUCCESS -> copy(
+                lastCompletionTime = completionTime,
+                successCount = successCount + 1,
+            )
+            CandidateResult.FAILURE -> copy(
+                lastCompletionTime = completionTime,
+                failureCount = failureCount + 1,
+            )
+        }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/CandidateInfo.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/CandidateInfo.kt
@@ -1,6 +1,5 @@
 package io.bluetape4k.leader.strategy
 
-import io.bluetape4k.idgenerators.uuid.TimebasedUuid
 import java.io.Serializable
 import java.time.Duration
 import java.time.Instant
@@ -10,7 +9,7 @@ import java.time.Instant
  *
  * [idleDuration] 은 마지막 완료 이후 경과 시간을 나타내며, 실행 이력이 없으면 [registeredAt] 부터 계산합니다.
  *
- * @property nodeId 노드 식별자. 미지정 시 UUID v7([TimebasedUuid.Epoch])로 자동 생성됩니다.
+ * @property nodeId 노드 식별자. 노드 인스턴스 생성 시 UUID v7으로 할당하고 재사용해야 합니다.
  * @property registeredAt 후보 등록 시각
  * @property lastStartTime 마지막 작업 시작 시각
  * @property lastCompletionTime 마지막 작업 완료 시각
@@ -19,7 +18,7 @@ import java.time.Instant
  * @property metadata 확장 메타데이터
  */
 data class CandidateInfo(
-    val nodeId: String = TimebasedUuid.Epoch.nextIdAsString(),
+    val nodeId: String,
     val registeredAt: Instant = Instant.now(),
     val lastStartTime: Instant? = null,
     val lastCompletionTime: Instant? = null,

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/CandidateInfo.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/CandidateInfo.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.leader.strategy
 
+import io.bluetape4k.idgenerators.uuid.TimebasedUuid
 import java.io.Serializable
 import java.time.Duration
 import java.time.Instant
@@ -9,7 +10,7 @@ import java.time.Instant
  *
  * [idleDuration] 은 마지막 완료 이후 경과 시간을 나타내며, 실행 이력이 없으면 [registeredAt] 부터 계산합니다.
  *
- * @property nodeId 노드 식별자 (UUID 권장)
+ * @property nodeId 노드 식별자. 미지정 시 UUID v7([TimebasedUuid.Epoch])로 자동 생성됩니다.
  * @property registeredAt 후보 등록 시각
  * @property lastStartTime 마지막 작업 시작 시각
  * @property lastCompletionTime 마지막 작업 완료 시각
@@ -18,7 +19,7 @@ import java.time.Instant
  * @property metadata 확장 메타데이터
  */
 data class CandidateInfo(
-    val nodeId: String,
+    val nodeId: String = TimebasedUuid.Epoch.nextIdAsString(),
     val registeredAt: Instant = Instant.now(),
     val lastStartTime: Instant? = null,
     val lastCompletionTime: Instant? = null,

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/CandidateResult.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/CandidateResult.kt
@@ -1,0 +1,12 @@
+package io.bluetape4k.leader.strategy
+
+/**
+ * 리더로 선출된 노드의 작업 실행 결과를 나타냅니다.
+ */
+enum class CandidateResult {
+    /** 작업 성공 */
+    SUCCESS,
+
+    /** 작업 실패 (예외 발생 포함) */
+    FAILURE,
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/CandidateScorer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/CandidateScorer.kt
@@ -1,0 +1,19 @@
+package io.bluetape4k.leader.strategy
+
+/**
+ * 후보 노드에 대해 선출 우선순위 점수를 계산하는 인터페이스입니다.
+ *
+ * 점수가 높을수록 리더로 선출될 가능성이 높습니다.
+ * [ScoredElectionStrategy] 에서 사용됩니다.
+ */
+fun interface CandidateScorer {
+
+    /**
+     * 후보 [candidate] 의 점수를 계산합니다.
+     *
+     * @param candidate 점수를 계산할 후보
+     * @param all 현재 선출에 참여 중인 전체 후보 목록 (상대 비교에 활용 가능)
+     * @return 점수 (높을수록 우선)
+     */
+    fun score(candidate: CandidateInfo, all: List<CandidateInfo>): Double
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/ElectionResult.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/ElectionResult.kt
@@ -5,10 +5,12 @@ package io.bluetape4k.leader.strategy
  *
  * @property winner 선출된 리더. 후보가 없으면 `null`.
  * @property eliminations 탈락 후보 목록과 각 탈락 사유.
+ * @property scores 후보별 점수 (nodeId → score). 점수 기반 전략에서만 채워집니다.
  */
 data class ElectionResult(
     val winner: CandidateInfo?,
     val eliminations: List<Elimination>,
+    val scores: Map<String, Double> = emptyMap(),
 ) {
     companion object {
         /** 후보 없음 — winner도 탈락자도 없는 빈 결과. */

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/ElectionResult.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/ElectionResult.kt
@@ -1,0 +1,17 @@
+package io.bluetape4k.leader.strategy
+
+/**
+ * 선출 결과입니다.
+ *
+ * @property winner 선출된 리더. 후보가 없으면 `null`.
+ * @property eliminations 탈락 후보 목록과 각 탈락 사유.
+ */
+data class ElectionResult(
+    val winner: CandidateInfo?,
+    val eliminations: List<Elimination>,
+) {
+    companion object {
+        /** 후보 없음 — winner도 탈락자도 없는 빈 결과. */
+        val EMPTY = ElectionResult(winner = null, eliminations = emptyList())
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/ElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/ElectionStrategy.kt
@@ -1,0 +1,20 @@
+package io.bluetape4k.leader.strategy
+
+/**
+ * 후보 목록에서 리더를 선출하는 전략 인터페이스입니다.
+ *
+ * 모든 구현체는 동일한 [candidates] 입력에 대해 결정론적으로 동일한 결과를 반환해야 합니다.
+ * 이를 통해 분산 환경에서 각 노드가 독립적으로 동일한 winner를 계산할 수 있습니다.
+ *
+ * 동점 발생 시 기본 tie-breaker: `registeredAt` 오름차순 → `nodeId` 사전순.
+ */
+fun interface ElectionStrategy {
+
+    /**
+     * [candidates] 중 리더를 선출합니다.
+     *
+     * @param candidates 선출에 참여할 후보 목록
+     * @return 선출된 리더, 후보가 없으면 `null`
+     */
+    fun selectLeader(candidates: List<CandidateInfo>): CandidateInfo?
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/ElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/ElectionStrategy.kt
@@ -8,13 +8,13 @@ package io.bluetape4k.leader.strategy
  *
  * 동점 발생 시 기본 tie-breaker: `registeredAt` 오름차순 → `nodeId` 사전순.
  */
-fun interface ElectionStrategy {
+interface ElectionStrategy {
 
     /**
-     * [candidates] 중 리더를 선출합니다.
+     * [candidates] 중 리더를 선출하고, 탈락 후보별 사유를 포함한 [ElectionResult]를 반환합니다.
      *
      * @param candidates 선출에 참여할 후보 목록
-     * @return 선출된 리더, 후보가 없으면 `null`
+     * @return 선출 결과 (winner + 탈락자 목록)
      */
-    fun selectLeader(candidates: List<CandidateInfo>): CandidateInfo?
+    fun elect(candidates: List<CandidateInfo>): ElectionResult
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/Elimination.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/Elimination.kt
@@ -1,0 +1,12 @@
+package io.bluetape4k.leader.strategy
+
+/**
+ * 선출에서 탈락한 후보와 그 사유를 담습니다.
+ *
+ * @property candidate 탈락 후보
+ * @property reason 탈락 사유 (사람이 읽을 수 있는 설명)
+ */
+data class Elimination(
+    val candidate: CandidateInfo,
+    val reason: String,
+)

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/IdleTimeScorer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/IdleTimeScorer.kt
@@ -1,0 +1,23 @@
+package io.bluetape4k.leader.strategy.scorers
+
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateScorer
+
+/**
+ * 마지막 작업 완료 이후 가장 오래 쉰 노드에 높은 점수를 부여하는 [CandidateScorer] 입니다.
+ *
+ * 실행 이력이 없는 노드는 [CandidateInfo.registeredAt] 기준 경과 시간으로 계산됩니다.
+ * 부하 분산 목적으로 특정 노드의 작업 독점을 방지합니다.
+ *
+ * 점수는 후보 풀 내 최대 idle 시간을 기준으로 0.0 ~ 100.0 범위로 정규화됩니다.
+ * [WeightedScorer] 와 다른 scorer 를 함께 사용할 때 단위 통일을 위함입니다.
+ */
+object IdleTimeScorer : CandidateScorer {
+
+    override fun score(candidate: CandidateInfo, all: List<CandidateInfo>): Double {
+        if (all.isEmpty()) return 0.0
+        val maxIdleMillis = all.maxOf { it.idleDuration.toMillis() }
+        if (maxIdleMillis == 0L) return 0.0
+        return candidate.idleDuration.toMillis().toDouble() / maxIdleMillis * 100.0
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/RecentSuccessScorer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/RecentSuccessScorer.kt
@@ -1,0 +1,32 @@
+package io.bluetape4k.leader.strategy.scorers
+
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateScorer
+
+/**
+ * 가장 최근에 성공 완료한 노드에 높은 점수를 부여하는 [CandidateScorer] 입니다.
+ *
+ * 점수 계산:
+ * - 마지막 실행이 성공: 후보 풀 내 최신 완료 시각 기준으로 0.0 ~ 100.0 정규화
+ * - 마지막 실행이 실패 또는 이력 없음: 0.0
+ *
+ * 직전 작업이 성공한 노드를 재선출하여 연속 성공 가능성을 높입니다.
+ */
+object RecentSuccessScorer : CandidateScorer {
+
+    override fun score(candidate: CandidateInfo, all: List<CandidateInfo>): Double {
+        if (candidate.successCount == 0L) return 0.0
+        val lastCompletion = candidate.lastCompletionTime ?: return 0.0
+        val lastStart = candidate.lastStartTime
+        if (lastStart != null && lastCompletion.isBefore(lastStart)) return 0.0
+
+        val successfulCompletions = all.mapNotNull { c ->
+            if (c.successCount > 0) c.lastCompletionTime?.toEpochMilli() else null
+        }
+        if (successfulCompletions.isEmpty()) return 0.0
+        val minEpoch = successfulCompletions.min()
+        val maxEpoch = successfulCompletions.max()
+        if (maxEpoch == minEpoch) return 100.0
+        return (lastCompletion.toEpochMilli() - minEpoch).toDouble() / (maxEpoch - minEpoch) * 100.0
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/SuccessRateScorer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/SuccessRateScorer.kt
@@ -1,0 +1,16 @@
+package io.bluetape4k.leader.strategy.scorers
+
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateScorer
+
+/**
+ * 성공률이 높은 노드에 높은 점수를 부여하는 [CandidateScorer] 입니다.
+ *
+ * 실행 이력이 없는 노드는 성공률 0.0으로 처리됩니다.
+ * 복원력(Resilience) 목적으로 안정적인 노드를 선호합니다.
+ */
+object SuccessRateScorer : CandidateScorer {
+
+    override fun score(candidate: CandidateInfo, all: List<CandidateInfo>): Double =
+        candidate.successRate * 100.0
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/WeightedScorer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/WeightedScorer.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.leader.strategy.scorers
+
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateScorer
+
+/**
+ * 복수의 [CandidateScorer] 에 가중치를 적용해 합산하는 복합 scorer 입니다.
+ *
+ * ```kotlin
+ * val scorer = WeightedScorer(
+ *     IdleTimeScorer to 0.6,
+ *     SuccessRateScorer to 0.4,
+ * )
+ * ```
+ *
+ * @property scorers (scorer, weight) 쌍 목록. weight 합계가 1.0일 필요는 없음.
+ */
+class WeightedScorer(
+    val scorers: List<Pair<CandidateScorer, Double>>,
+) : CandidateScorer {
+
+    constructor(vararg scorers: Pair<CandidateScorer, Double>) : this(scorers.toList())
+
+    override fun score(candidate: CandidateInfo, all: List<CandidateInfo>): Double =
+        scorers.sumOf { (scorer, weight) -> scorer.score(candidate, all) * weight }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/FifoElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/FifoElectionStrategy.kt
@@ -1,7 +1,9 @@
 package io.bluetape4k.leader.strategy.strategies
 
 import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.ElectionResult
 import io.bluetape4k.leader.strategy.ElectionStrategy
+import io.bluetape4k.leader.strategy.Elimination
 
 /**
  * 가장 먼저 등록된 후보를 리더로 선출하는 FIFO 전략입니다.
@@ -10,8 +12,21 @@ import io.bluetape4k.leader.strategy.ElectionStrategy
  */
 object FifoElectionStrategy : ElectionStrategy {
 
-    override fun selectLeader(candidates: List<CandidateInfo>): CandidateInfo? =
-        candidates.minWithOrNull(
+    override fun elect(candidates: List<CandidateInfo>): ElectionResult {
+        if (candidates.isEmpty()) return ElectionResult.EMPTY
+        val winner = candidates.minWith(
             compareBy(CandidateInfo::registeredAt).thenBy(CandidateInfo::nodeId)
         )
+        val eliminations = candidates
+            .filter { it.nodeId != winner.nodeId }
+            .map { c ->
+                val reason = if (c.registeredAt > winner.registeredAt) {
+                    "등록 시각 늦음 (${c.registeredAt} > ${winner.registeredAt})"
+                } else {
+                    "nodeId 사전순 뒤 (${c.nodeId} > ${winner.nodeId})"
+                }
+                Elimination(c, reason)
+            }
+        return ElectionResult(winner, eliminations)
+    }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/FifoElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/FifoElectionStrategy.kt
@@ -1,0 +1,17 @@
+package io.bluetape4k.leader.strategy.strategies
+
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.ElectionStrategy
+
+/**
+ * 가장 먼저 등록된 후보를 리더로 선출하는 FIFO 전략입니다.
+ *
+ * 동점(registeredAt 동일) 시 [CandidateInfo.nodeId] 사전순으로 결정합니다.
+ */
+object FifoElectionStrategy : ElectionStrategy {
+
+    override fun selectLeader(candidates: List<CandidateInfo>): CandidateInfo? =
+        candidates.minWithOrNull(
+            compareBy(CandidateInfo::registeredAt).thenBy(CandidateInfo::nodeId)
+        )
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/RandomElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/RandomElectionStrategy.kt
@@ -1,0 +1,29 @@
+package io.bluetape4k.leader.strategy.strategies
+
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.ElectionStrategy
+import kotlin.random.Random
+
+/**
+ * 후보 중 무작위로 리더를 선출하는 전략입니다.
+ *
+ * [seed] 를 지정하면 동일 후보 목록에 대해 결정론적 결과를 보장합니다.
+ *
+ * **분산 환경 주의**: [seed] 가 `null` 이면 각 노드가 서로 다른 winner 를 계산할 수 있습니다 (split-brain 위험).
+ * 분산 환경에서는 모든 노드가 동일한 [seed] 를 사용해야 합니다. seed 는 공유 백엔드(Redis 등)에서 epoch 단위로
+ * 생성하여 배포하는 것을 권장합니다.
+ * `seed=null` 은 단일 프로세스 테스트 또는 결과 분포가 중요하지 않은 경우에만 사용하세요.
+ *
+ * 무작위 선출 전 후보 목록을 [CandidateInfo.nodeId] 사전순으로 정렬하여 입력 순서 의존성을 제거합니다.
+ *
+ * @property seed 난수 seed. `null` 이면 시스템 랜덤 사용 (비결정론적 — 분산 환경 비권장).
+ */
+class RandomElectionStrategy(val seed: Long? = null) : ElectionStrategy {
+
+    override fun selectLeader(candidates: List<CandidateInfo>): CandidateInfo? {
+        if (candidates.isEmpty()) return null
+        val sorted = candidates.sortedBy(CandidateInfo::nodeId)
+        val random = if (seed != null) Random(seed) else Random.Default
+        return sorted[random.nextInt(sorted.size)]
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/RandomElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/RandomElectionStrategy.kt
@@ -1,7 +1,9 @@
 package io.bluetape4k.leader.strategy.strategies
 
 import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.ElectionResult
 import io.bluetape4k.leader.strategy.ElectionStrategy
+import io.bluetape4k.leader.strategy.Elimination
 import kotlin.random.Random
 
 /**
@@ -20,10 +22,14 @@ import kotlin.random.Random
  */
 class RandomElectionStrategy(val seed: Long? = null) : ElectionStrategy {
 
-    override fun selectLeader(candidates: List<CandidateInfo>): CandidateInfo? {
-        if (candidates.isEmpty()) return null
+    override fun elect(candidates: List<CandidateInfo>): ElectionResult {
+        if (candidates.isEmpty()) return ElectionResult.EMPTY
         val sorted = candidates.sortedBy(CandidateInfo::nodeId)
         val random = if (seed != null) Random(seed) else Random.Default
-        return sorted[random.nextInt(sorted.size)]
+        val winner = sorted[random.nextInt(sorted.size)]
+        val eliminations = candidates
+            .filter { it.nodeId != winner.nodeId }
+            .map { c -> Elimination(c, "랜덤 선출 탈락 (winner: ${winner.nodeId})") }
+        return ElectionResult(winner, eliminations)
     }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/ScoredElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/ScoredElectionStrategy.kt
@@ -35,6 +35,6 @@ class ScoredElectionStrategy(val scorer: CandidateScorer) : ElectionStrategy {
                 }
                 Elimination(c, reason)
             }
-        return ElectionResult(winner, eliminations)
+        return ElectionResult(winner, eliminations, scores.mapKeys { it.key.nodeId })
     }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/ScoredElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/ScoredElectionStrategy.kt
@@ -2,7 +2,9 @@ package io.bluetape4k.leader.strategy.strategies
 
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateScorer
+import io.bluetape4k.leader.strategy.ElectionResult
 import io.bluetape4k.leader.strategy.ElectionStrategy
+import io.bluetape4k.leader.strategy.Elimination
 
 /**
  * [CandidateScorer] 로 계산한 점수가 가장 높은 후보를 선출하는 전략입니다.
@@ -13,13 +15,26 @@ import io.bluetape4k.leader.strategy.ElectionStrategy
  */
 class ScoredElectionStrategy(val scorer: CandidateScorer) : ElectionStrategy {
 
-    override fun selectLeader(candidates: List<CandidateInfo>): CandidateInfo? {
-        if (candidates.isEmpty()) return null
+    override fun elect(candidates: List<CandidateInfo>): ElectionResult {
+        if (candidates.isEmpty()) return ElectionResult.EMPTY
         val scores = candidates.associateWith { scorer.score(it, candidates) }
         val maxScore = scores.values.max()
         val topCandidates = candidates.filter { scores[it] == maxScore }
-        return topCandidates.minWithOrNull(
+        val winner = topCandidates.minWith(
             compareBy(CandidateInfo::registeredAt).thenBy(CandidateInfo::nodeId)
         )
+        val winnerScore = scores.getValue(winner)
+        val eliminations = candidates
+            .filter { it.nodeId != winner.nodeId }
+            .map { c ->
+                val score = scores.getValue(c)
+                val reason = if (score < winnerScore) {
+                    "점수 미달 (%.2f < %.2f)".format(score, winnerScore)
+                } else {
+                    "점수 동점 — 등록 시각/nodeId 우선순위 낮음 (score: %.2f)".format(score)
+                }
+                Elimination(c, reason)
+            }
+        return ElectionResult(winner, eliminations)
     }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/ScoredElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/ScoredElectionStrategy.kt
@@ -1,0 +1,25 @@
+package io.bluetape4k.leader.strategy.strategies
+
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateScorer
+import io.bluetape4k.leader.strategy.ElectionStrategy
+
+/**
+ * [CandidateScorer] 로 계산한 점수가 가장 높은 후보를 선출하는 전략입니다.
+ *
+ * 동점 시 [CandidateInfo.registeredAt] 오름차순 → [CandidateInfo.nodeId] 사전순으로 결정합니다.
+ *
+ * @property scorer 후보 점수 계산에 사용할 [CandidateScorer]
+ */
+class ScoredElectionStrategy(val scorer: CandidateScorer) : ElectionStrategy {
+
+    override fun selectLeader(candidates: List<CandidateInfo>): CandidateInfo? {
+        if (candidates.isEmpty()) return null
+        val scores = candidates.associateWith { scorer.score(it, candidates) }
+        val maxScore = scores.values.max()
+        val topCandidates = candidates.filter { scores[it] == maxScore }
+        return topCandidates.minWithOrNull(
+            compareBy(CandidateInfo::registeredAt).thenBy(CandidateInfo::nodeId)
+        )
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElectionTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElectionTest.kt
@@ -1,0 +1,146 @@
+package io.bluetape4k.leader.local
+
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.scorers.IdleTimeScorer
+import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
+import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LocalStrategicLeaderElectionTest {
+
+    private val lockName = "test-lock"
+
+    private lateinit var node1: LocalStrategicLeaderElection
+    private lateinit var node2: LocalStrategicLeaderElection
+    private lateinit var node3: LocalStrategicLeaderElection
+
+    @BeforeEach
+    fun setup() {
+        node1 = LocalStrategicLeaderElection("node-1")
+        node2 = LocalStrategicLeaderElection("node-2")
+        node3 = LocalStrategicLeaderElection("node-3")
+    }
+
+    private fun registerAll(vararg nodes: LocalStrategicLeaderElection, registeredAt: Instant = Instant.now()) {
+        nodes.forEachIndexed { i, node ->
+            node.registerCandidate(lockName, CandidateInfo(
+                nodeId = node.nodeId,
+                registeredAt = registeredAt.plusMillis(i.toLong() * 10),
+            ))
+        }
+    }
+
+    @Test
+    fun `FIFO - node1 이 가장 먼저 등록하면 node1 만 action 실행`() {
+        val t0 = Instant.now()
+        node1.registerCandidate(lockName, CandidateInfo("node-1", registeredAt = t0))
+        node2.registerCandidate(lockName, CandidateInfo("node-2", registeredAt = t0.plusMillis(10)))
+        node3.registerCandidate(lockName, CandidateInfo("node-3", registeredAt = t0.plusMillis(20)))
+
+        // 3개 노드 모두 같은 후보 목록 공유 (in-memory 싱글 registry 아님 → 각 노드의 registry 에 등록 필요)
+        // node2, node3 에도 전체 후보 등록
+        node2.registerCandidate(lockName, CandidateInfo("node-1", registeredAt = t0))
+        node2.registerCandidate(lockName, CandidateInfo("node-3", registeredAt = t0.plusMillis(20)))
+        node3.registerCandidate(lockName, CandidateInfo("node-1", registeredAt = t0))
+        node3.registerCandidate(lockName, CandidateInfo("node-2", registeredAt = t0.plusMillis(10)))
+
+        val counter = AtomicInteger(0)
+        val r1 = node1.runIfLeader(lockName, FifoElectionStrategy) { counter.incrementAndGet() }
+        val r2 = node2.runIfLeader(lockName, FifoElectionStrategy) { counter.incrementAndGet() }
+        val r3 = node3.runIfLeader(lockName, FifoElectionStrategy) { counter.incrementAndGet() }
+
+        r1.shouldNotBeNull()
+        r2.shouldBeNull()
+        r3.shouldBeNull()
+        counter.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `updateResult - SUCCESS 후 successCount 증가`() {
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+
+        val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        updated.successCount shouldBeEqualTo 1L
+        updated.failureCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `updateResult - FAILURE 후 failureCount 증가`() {
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.updateResult(lockName, "node-1", CandidateResult.FAILURE)
+
+        val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        updated.successCount shouldBeEqualTo 0L
+        updated.failureCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `runIfLeader - action 성공 시 successCount 자동 증가`() {
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+
+        node1.runIfLeader(lockName, FifoElectionStrategy) { "ok" }
+
+        val info = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        info.successCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `runIfLeader - action 예외 시 failureCount 자동 증가 후 예외 재전파`() {
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+
+        runCatching {
+            node1.runIfLeader(lockName, FifoElectionStrategy) {
+                throw IllegalStateException("oops")
+            }
+        }.isFailure.shouldBeTrue()
+
+        val info = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        info.failureCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `ScoredIdleTime - 가장 오래 쉰 노드가 선출`() {
+        val now = Instant.now()
+        val longIdle = CandidateInfo("node-1", lastCompletionTime = now.minusSeconds(300))
+        val shortIdle = CandidateInfo("node-2", lastCompletionTime = now.minusSeconds(10))
+
+        // node1 이 오래 쉬었음
+        node1.registerCandidate(lockName, longIdle)
+        node1.registerCandidate(lockName, shortIdle)
+        node2.registerCandidate(lockName, longIdle)
+        node2.registerCandidate(lockName, shortIdle)
+
+        val counter = AtomicInteger(0)
+        val r1 = node1.runIfLeader(lockName, ScoredElectionStrategy(IdleTimeScorer)) { counter.incrementAndGet() }
+        val r2 = node2.runIfLeader(lockName, ScoredElectionStrategy(IdleTimeScorer)) { counter.incrementAndGet() }
+
+        r1.shouldNotBeNull()
+        r2.shouldBeNull()
+        counter.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `후보 0명이면 runIfLeader null 반환`() {
+        val result = node1.runIfLeader(lockName, FifoElectionStrategy) { "should-not-run" }
+        result.shouldBeNull()
+    }
+
+    @Test
+    fun `unregisterCandidate - 등록 해제 후 후보 목록에서 제거`() {
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.unregisterCandidate(lockName, "node-1")
+
+        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElectionTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElectionTest.kt
@@ -1,0 +1,69 @@
+package io.bluetape4k.leader.local
+
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LocalStrategicSuspendLeaderElectionTest {
+
+    private val lockName = "test-suspend-lock"
+
+    private lateinit var node1: LocalStrategicSuspendLeaderElection
+    private lateinit var node2: LocalStrategicSuspendLeaderElection
+
+    @BeforeEach
+    fun setup() {
+        node1 = LocalStrategicSuspendLeaderElection("node-1")
+        node2 = LocalStrategicSuspendLeaderElection("node-2")
+    }
+
+    @Test
+    fun `FIFO - node1 먼저 등록하면 node1 만 action 실행`() = runTest {
+        val t0 = Instant.now()
+        node1.registerCandidate(lockName, CandidateInfo("node-1", registeredAt = t0))
+        node1.registerCandidate(lockName, CandidateInfo("node-2", registeredAt = t0.plusMillis(10)))
+        node2.registerCandidate(lockName, CandidateInfo("node-1", registeredAt = t0))
+        node2.registerCandidate(lockName, CandidateInfo("node-2", registeredAt = t0.plusMillis(10)))
+
+        val counter = AtomicInteger(0)
+        val r1 = node1.runIfLeader(lockName, FifoElectionStrategy) { counter.incrementAndGet() }
+        val r2 = node2.runIfLeader(lockName, FifoElectionStrategy) { counter.incrementAndGet() }
+
+        r1.shouldNotBeNull()
+        r2.shouldBeNull()
+        counter.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `updateResult - SUCCESS 후 successCount 증가`() = runTest {
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+
+        val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        updated.successCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `후보 0명이면 runIfLeader null 반환`() = runTest {
+        val result = node1.runIfLeader(lockName, FifoElectionStrategy) { "should-not-run" }
+        result.shouldBeNull()
+    }
+
+    @Test
+    fun `unregisterCandidate - 등록 해제 후 목록에서 제거`() = runTest {
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.unregisterCandidate(lockName, "node-1")
+        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElectionTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElectionTest.kt
@@ -3,7 +3,9 @@ package io.bluetape4k.leader.local
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldBeTrue
@@ -65,5 +67,23 @@ class LocalStrategicSuspendLeaderElectionTest {
         node1.registerCandidate(lockName, CandidateInfo("node-1"))
         node1.unregisterCandidate(lockName, "node-1")
         node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun `CancellationException - 코루틴 취소 시 failureCount 증가 없음`() = runTest {
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        var caughtCancellation = false
+        try {
+            withTimeout(50L) {
+                node1.runIfLeader(lockName, FifoElectionStrategy) {
+                    delay(10_000L) // 타임아웃보다 훨씬 긴 지연
+                }
+            }
+        } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
+            caughtCancellation = true
+        }
+        caughtCancellation.shouldBeTrue()
+        val candidate = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        candidate.failureCount shouldBeEqualTo 0L
     }
 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/strategy/ElectionStrategyTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/strategy/ElectionStrategyTest.kt
@@ -1,0 +1,146 @@
+package io.bluetape4k.leader.strategy
+
+import io.bluetape4k.leader.strategy.scorers.IdleTimeScorer
+import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
+import io.bluetape4k.leader.strategy.scorers.WeightedScorer
+import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
+import io.bluetape4k.leader.strategy.strategies.RandomElectionStrategy
+import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ElectionStrategyTest {
+
+    private val t0 = Instant.parse("2026-01-01T00:00:00Z")
+    private val t1 = t0.plusSeconds(10)
+    private val t2 = t0.plusSeconds(20)
+
+    private fun candidate(
+        id: String,
+        registeredAt: Instant = t0,
+        lastCompletionTime: Instant? = null,
+        successCount: Long = 0,
+        failureCount: Long = 0,
+    ) = CandidateInfo(
+        nodeId = id,
+        registeredAt = registeredAt,
+        lastCompletionTime = lastCompletionTime,
+        successCount = successCount,
+        failureCount = failureCount,
+    )
+
+    // ── FifoElectionStrategy ──────────────────────────────────────────────────
+
+    @Test
+    fun `FIFO - 가장 먼저 등록된 후보 선출`() {
+        val candidates = listOf(
+            candidate("c", registeredAt = t2),
+            candidate("a", registeredAt = t0),
+            candidate("b", registeredAt = t1),
+        )
+        FifoElectionStrategy.selectLeader(candidates)?.nodeId shouldBeEqualTo "a"
+    }
+
+    @Test
+    fun `FIFO - registeredAt 동일 시 nodeId 사전순 선출`() {
+        val candidates = listOf(
+            candidate("z", registeredAt = t0),
+            candidate("a", registeredAt = t0),
+        )
+        FifoElectionStrategy.selectLeader(candidates)?.nodeId shouldBeEqualTo "a"
+    }
+
+    @Test
+    fun `FIFO - 후보 1명이면 해당 후보 반환`() {
+        val candidates = listOf(candidate("solo"))
+        FifoElectionStrategy.selectLeader(candidates)?.nodeId shouldBeEqualTo "solo"
+    }
+
+    @Test
+    fun `FIFO - 후보 없으면 null 반환`() {
+        FifoElectionStrategy.selectLeader(emptyList()).shouldBeNull()
+    }
+
+    // ── RandomElectionStrategy ────────────────────────────────────────────────
+
+    @Test
+    fun `Random - 동일 seed 동일 결과`() {
+        val candidates = listOf(candidate("a"), candidate("b"), candidate("c"))
+        val strategy = RandomElectionStrategy(seed = 42L)
+        val r1 = strategy.selectLeader(candidates)
+        val r2 = strategy.selectLeader(candidates)
+        r1.shouldNotBeNull()
+        r1.nodeId shouldBeEqualTo r2!!.nodeId
+    }
+
+    @Test
+    fun `Random - 후보 없으면 null 반환`() {
+        RandomElectionStrategy().selectLeader(emptyList()).shouldBeNull()
+    }
+
+    // ── ScoredElectionStrategy (IdleTimeScorer) ───────────────────────────────
+
+    @Test
+    fun `Scored IdleTime - 가장 오래 쉰 후보 선출`() {
+        val now = Instant.now()
+        val candidates = listOf(
+            candidate("recent", lastCompletionTime = now.minusSeconds(10)),
+            candidate("idle", lastCompletionTime = now.minusSeconds(100)),
+            candidate("medium", lastCompletionTime = now.minusSeconds(50)),
+        )
+        ScoredElectionStrategy(IdleTimeScorer)
+            .selectLeader(candidates)?.nodeId shouldBeEqualTo "idle"
+    }
+
+    @Test
+    fun `Scored IdleTime - 미실행 노드는 registeredAt 기준 경과 시간 적용`() {
+        val now = Instant.now()
+        val candidates = listOf(
+            // 미실행 노드: registeredAt이 오래됐으면 idle 시간 길다
+            candidate("never-ran", registeredAt = now.minusSeconds(200)),
+            candidate("ran-recently", lastCompletionTime = now.minusSeconds(10)),
+        )
+        ScoredElectionStrategy(IdleTimeScorer)
+            .selectLeader(candidates)?.nodeId shouldBeEqualTo "never-ran"
+    }
+
+    // ── ScoredElectionStrategy (SuccessRateScorer) ────────────────────────────
+
+    @Test
+    fun `Scored SuccessRate - 성공률 높은 후보 선출`() {
+        val candidates = listOf(
+            candidate("low", successCount = 1, failureCount = 9),   // 10%
+            candidate("high", successCount = 9, failureCount = 1),  // 90%
+            candidate("mid", successCount = 5, failureCount = 5),   // 50%
+        )
+        ScoredElectionStrategy(SuccessRateScorer)
+            .selectLeader(candidates)?.nodeId shouldBeEqualTo "high"
+    }
+
+    // ── ScoredElectionStrategy (WeightedScorer) ───────────────────────────────
+
+    @Test
+    fun `Scored Weighted - 복합 점수 최고 후보 선출`() {
+        val now = Instant.now()
+        val candidates = listOf(
+            // idle 짧지만 성공률 100%
+            candidate("success-focused", lastCompletionTime = now.minusSeconds(5), successCount = 10),
+            // idle 길지만 성공률 0%
+            candidate("idle-focused", lastCompletionTime = now.minusSeconds(500), successCount = 0, failureCount = 10),
+        )
+        // 성공률 weight 높게 → success-focused 선출
+        val scorer = WeightedScorer(IdleTimeScorer to 0.1, SuccessRateScorer to 0.9)
+        val winner = ScoredElectionStrategy(scorer).selectLeader(candidates)
+        winner?.nodeId shouldBeEqualTo "success-focused"
+    }
+
+    @Test
+    fun `Scored - 후보 없으면 null 반환`() {
+        ScoredElectionStrategy(IdleTimeScorer).selectLeader(emptyList()).shouldBeNull()
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/strategy/ElectionStrategyTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/strategy/ElectionStrategyTest.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.leader.strategy.strategies.RandomElectionStrategy
 import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -43,7 +44,7 @@ class ElectionStrategyTest {
             candidate("a", registeredAt = t0),
             candidate("b", registeredAt = t1),
         )
-        FifoElectionStrategy.selectLeader(candidates)?.nodeId shouldBeEqualTo "a"
+        FifoElectionStrategy.elect(candidates).winner?.nodeId shouldBeEqualTo "a"
     }
 
     @Test
@@ -52,18 +53,31 @@ class ElectionStrategyTest {
             candidate("z", registeredAt = t0),
             candidate("a", registeredAt = t0),
         )
-        FifoElectionStrategy.selectLeader(candidates)?.nodeId shouldBeEqualTo "a"
+        FifoElectionStrategy.elect(candidates).winner?.nodeId shouldBeEqualTo "a"
     }
 
     @Test
     fun `FIFO - 후보 1명이면 해당 후보 반환`() {
         val candidates = listOf(candidate("solo"))
-        FifoElectionStrategy.selectLeader(candidates)?.nodeId shouldBeEqualTo "solo"
+        FifoElectionStrategy.elect(candidates).winner?.nodeId shouldBeEqualTo "solo"
     }
 
     @Test
     fun `FIFO - 후보 없으면 null 반환`() {
-        FifoElectionStrategy.selectLeader(emptyList()).shouldBeNull()
+        FifoElectionStrategy.elect(emptyList()).winner.shouldBeNull()
+    }
+
+    @Test
+    fun `FIFO - 탈락자에 등록 시각 늦음 사유 포함`() {
+        val candidates = listOf(
+            candidate("a", registeredAt = t0),
+            candidate("b", registeredAt = t1),
+            candidate("c", registeredAt = t2),
+        )
+        val result = FifoElectionStrategy.elect(candidates)
+        result.winner?.nodeId shouldBeEqualTo "a"
+        result.eliminations.size shouldBeEqualTo 2
+        result.eliminations.all { it.reason.contains("등록 시각 늦음") }.shouldBeTrue()
     }
 
     // ── RandomElectionStrategy ────────────────────────────────────────────────
@@ -72,15 +86,24 @@ class ElectionStrategyTest {
     fun `Random - 동일 seed 동일 결과`() {
         val candidates = listOf(candidate("a"), candidate("b"), candidate("c"))
         val strategy = RandomElectionStrategy(seed = 42L)
-        val r1 = strategy.selectLeader(candidates)
-        val r2 = strategy.selectLeader(candidates)
+        val r1 = strategy.elect(candidates).winner
+        val r2 = strategy.elect(candidates).winner
         r1.shouldNotBeNull()
         r1.nodeId shouldBeEqualTo r2!!.nodeId
     }
 
     @Test
     fun `Random - 후보 없으면 null 반환`() {
-        RandomElectionStrategy().selectLeader(emptyList()).shouldBeNull()
+        RandomElectionStrategy().elect(emptyList()).winner.shouldBeNull()
+    }
+
+    @Test
+    fun `Random - 탈락자에 랜덤 선출 탈락 사유 포함`() {
+        val candidates = listOf(candidate("a"), candidate("b"), candidate("c"))
+        val result = RandomElectionStrategy(seed = 42L).elect(candidates)
+        result.winner.shouldNotBeNull()
+        result.eliminations.size shouldBeEqualTo 2
+        result.eliminations.all { it.reason.contains("랜덤 선출 탈락") }.shouldBeTrue()
     }
 
     // ── ScoredElectionStrategy (IdleTimeScorer) ───────────────────────────────
@@ -94,19 +117,18 @@ class ElectionStrategyTest {
             candidate("medium", lastCompletionTime = now.minusSeconds(50)),
         )
         ScoredElectionStrategy(IdleTimeScorer)
-            .selectLeader(candidates)?.nodeId shouldBeEqualTo "idle"
+            .elect(candidates).winner?.nodeId shouldBeEqualTo "idle"
     }
 
     @Test
     fun `Scored IdleTime - 미실행 노드는 registeredAt 기준 경과 시간 적용`() {
         val now = Instant.now()
         val candidates = listOf(
-            // 미실행 노드: registeredAt이 오래됐으면 idle 시간 길다
             candidate("never-ran", registeredAt = now.minusSeconds(200)),
             candidate("ran-recently", lastCompletionTime = now.minusSeconds(10)),
         )
         ScoredElectionStrategy(IdleTimeScorer)
-            .selectLeader(candidates)?.nodeId shouldBeEqualTo "never-ran"
+            .elect(candidates).winner?.nodeId shouldBeEqualTo "never-ran"
     }
 
     // ── ScoredElectionStrategy (SuccessRateScorer) ────────────────────────────
@@ -119,7 +141,19 @@ class ElectionStrategyTest {
             candidate("mid", successCount = 5, failureCount = 5),   // 50%
         )
         ScoredElectionStrategy(SuccessRateScorer)
-            .selectLeader(candidates)?.nodeId shouldBeEqualTo "high"
+            .elect(candidates).winner?.nodeId shouldBeEqualTo "high"
+    }
+
+    @Test
+    fun `Scored SuccessRate - 탈락자에 점수 미달 사유 포함`() {
+        val candidates = listOf(
+            candidate("low", successCount = 1, failureCount = 9),
+            candidate("high", successCount = 9, failureCount = 1),
+        )
+        val result = ScoredElectionStrategy(SuccessRateScorer).elect(candidates)
+        result.winner?.nodeId shouldBeEqualTo "high"
+        result.eliminations.size shouldBeEqualTo 1
+        result.eliminations.first().reason.contains("점수 미달").shouldBeTrue()
     }
 
     // ── ScoredElectionStrategy (WeightedScorer) ───────────────────────────────
@@ -128,19 +162,15 @@ class ElectionStrategyTest {
     fun `Scored Weighted - 복합 점수 최고 후보 선출`() {
         val now = Instant.now()
         val candidates = listOf(
-            // idle 짧지만 성공률 100%
             candidate("success-focused", lastCompletionTime = now.minusSeconds(5), successCount = 10),
-            // idle 길지만 성공률 0%
             candidate("idle-focused", lastCompletionTime = now.minusSeconds(500), successCount = 0, failureCount = 10),
         )
-        // 성공률 weight 높게 → success-focused 선출
         val scorer = WeightedScorer(IdleTimeScorer to 0.1, SuccessRateScorer to 0.9)
-        val winner = ScoredElectionStrategy(scorer).selectLeader(candidates)
-        winner?.nodeId shouldBeEqualTo "success-focused"
+        ScoredElectionStrategy(scorer).elect(candidates).winner?.nodeId shouldBeEqualTo "success-focused"
     }
 
     @Test
     fun `Scored - 후보 없으면 null 반환`() {
-        ScoredElectionStrategy(IdleTimeScorer).selectLeader(emptyList()).shouldBeNull()
+        ScoredElectionStrategy(IdleTimeScorer).elect(emptyList()).winner.shouldBeNull()
     }
 }


### PR DESCRIPTION
## Summary

Closes #29

PR #30의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: 플러그형 선출 전략(StrategicLeaderElection) 추가 — leader-core pilot 구현 (#29)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Closes #29

기존 FIFO/락 기반 리더 선출 방식 외에 **플러그형 선출 전략**을 leader-core에 추가합니다.

---

## Changes

### 신규 데이터 모델

- `CandidateInfo` — 후보 메타데이터 (nodeId, registeredAt, successCount, failureCount, lastStartTime, lastCompletionTime)
- `CandidateResult` — SUCCESS / FAILURE enum
- `ElectionStrategy` — 후보 목록 → winner 결정 인터페이스
- `CandidateScorer` — 단일 후보 0-100 정규화 점수 인터페이스

### 내장 전략 3종

| 전략 | 설명 |
|------|------|
| `FifoElectionStrategy` | 등록 시각 오름차순 선출 |
| `RandomElectionStrategy(seed)` | seed 기반 결정론적 무작위 선출 |
| `ScoredElectionStrategy(scorer)` | 점수 최고 후보 선출 |

### 내장 Scorer 4종 (0-100 pool 내 정규화)

| Scorer | 설명 |
|--------|------|
| `IdleTimeScorer` | 가장 오래 쉰 노드 우선 |
| `SuccessRateScorer` | 성공률 높은 노드 우선 |
| `RecentSuccessScorer` | 최근 성공 완료 노드 우선 |
| `WeightedScorer` | 복수 Scorer 가중 합산 |

### Local Pilot 구현체

- `LocalStrategicLeaderElection` — 블로킹, per-lockName `ReentrantLock`
- `LocalStrategicSuspendLeaderElection` — 코루틴 suspend, per-lockName `Mutex`

### 인터페이스

- `StrategicLeaderElection` — 블로킹 API
- `StrategicSuspendLeaderElection` — 코루틴 API

### 문서

- `docs/spec/strategic-leader-election.md` — 설계 스펙
- `docs/plan/strategic-leader-election.md` — 구현 계획
- `leader-core/README.md` + `README.ko.md` — 전략 선출 섹션 추가

---

## Test Results

```
174 tests passing (4.8s)
```

- `ElectionStrategyTest` — FIFO / Random / Scored 전략 11종
- `LocalStrategicLeaderElectionTest` — 블로킹 구현 8종
- `LocalStrategicSuspendLeaderElectionTest` — 코루틴 구현 5종 (CancellationException 회귀 포함)

---

## Design Decisions

- **결정론적 선출**: 동일 후보 목록 + 동일 전략 → 모든 노드 동일 winner → 분산 합의 불필요
- **per-lockName 락**: `ConcurrentHashMap<String, ReentrantLock>` → 무관한 lockName 간 직렬화 방지
- **CancellationException 분리**: `catch (e: CancellationException) { throw e }` 먼저 → 취소 ≠ 작업 실패
- **0-100 정규화**: 모든 Scorer pool 내 상대값 정규화 → `WeightedScorer` weight 직관적 동작

---

## Out of Scope (별도 이슈)

- Redis(Redisson/Lettuce) 백엔드 CandidateRegistry
- Exposed/MongoDB 백엔드
- 분산 epoch seed 공유

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #29, milestone `0.1.0`, assignee `debop`
- PR: #30, head `72ecb09f585d25f5d7549160d81c55cca5c73260`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
