### PR TITLE
test: StrategicLeaderElection 엣지 케이스 테스트 추가 및 버그 수정

### DIFF
--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElection.kt
@@ -9,6 +9,7 @@ import io.bluetape4k.leader.strategy.ElectionStrategy
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
+import kotlinx.coroutines.CancellationException
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantLock
@@ -82,6 +83,8 @@ class LocalStrategicLeaderElection(
             val value = action()
             updateResult(lockName, nodeId, CandidateResult.SUCCESS)
             value
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Throwable) {
             updateResult(lockName, nodeId, CandidateResult.FAILURE)
             throw e

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElectionTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElectionTest.kt
@@ -3,6 +3,8 @@ package io.bluetape4k.leader.local
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.scorers.IdleTimeScorer
+import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
+import io.bluetape4k.leader.strategy.scorers.WeightedScorer
 import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
 import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
 import org.amshove.kluent.shouldBeEqualTo
@@ -142,5 +144,136 @@ class LocalStrategicLeaderElectionTest {
         node1.unregisterCandidate(lockName, "node-1")
 
         node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun `단일 후보는 항상 자신이 선출됨`() {
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+
+        val result = node1.runIfLeader(lockName, FifoElectionStrategy) { "executed" }
+        result shouldBeEqualTo "executed"
+    }
+
+    @Test
+    fun `동일 nodeId 재등록 시 CandidateInfo 갱신됨`() {
+        node1.registerCandidate(lockName, CandidateInfo("node-1", successCount = 3))
+        node1.registerCandidate(lockName, CandidateInfo("node-1", successCount = 10))
+
+        val candidates = node1.listCandidates(lockName)
+        candidates.size shouldBeEqualTo 1
+        candidates.first().successCount shouldBeEqualTo 10L
+    }
+
+    @Test
+    fun `서로 다른 lockName 은 독립적인 후보 풀`() {
+        val lock1 = "lock-alpha"
+        val lock2 = "lock-beta"
+        node1.registerCandidate(lock1, CandidateInfo("node-1"))
+        node1.registerCandidate(lock1, CandidateInfo("node-2"))
+        node1.registerCandidate(lock2, CandidateInfo("node-3"))
+
+        node1.listCandidates(lock1).size shouldBeEqualTo 2
+        node1.listCandidates(lock2).size shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `updateResult - 존재하지 않는 nodeId 는 무시됨`() {
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+
+        node1.updateResult(lockName, "ghost-node", CandidateResult.SUCCESS)
+
+        node1.listCandidates(lockName).size shouldBeEqualTo 1
+        node1.listCandidates(lockName).first().successCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `IdleTime - updateResult 후 winner 변경됨`() {
+        val now = Instant.now()
+        val c1 = CandidateInfo("node-1", lastCompletionTime = now.minusSeconds(100))
+        val c2 = CandidateInfo("node-2", lastCompletionTime = now.minusSeconds(10))
+
+        node1.registerCandidate(lockName, c1)
+        node1.registerCandidate(lockName, c2)
+
+        val strategy = ScoredElectionStrategy(IdleTimeScorer)
+
+        // 초기: node-1 이 더 오래 쉬었음 → winner
+        strategy.elect(node1.listCandidates(lockName)).winner?.nodeId shouldBeEqualTo "node-1"
+
+        // node-1 작업 후 lastCompletionTime = now → idle≈0
+        node1.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+
+        // 다음 라운드: node-2 가 더 오래 쉬었음 → winner 변경
+        strategy.elect(node1.listCandidates(lockName)).winner?.nodeId shouldBeEqualTo "node-2"
+    }
+
+    @Test
+    fun `FIFO - 동일 registeredAt 시 nodeId 사전순 선출`() {
+        val t0 = Instant.now()
+        node1.registerCandidate(lockName, CandidateInfo("node-c", registeredAt = t0))
+        node1.registerCandidate(lockName, CandidateInfo("node-a", registeredAt = t0))
+        node1.registerCandidate(lockName, CandidateInfo("node-b", registeredAt = t0))
+
+        val winner = FifoElectionStrategy.elect(node1.listCandidates(lockName)).winner
+        winner?.nodeId shouldBeEqualTo "node-a"
+    }
+
+    @Test
+    fun `runIfLeader - winner 아닌 노드는 action 실행 안 함`() {
+        val t0 = Instant.now()
+        // node2 가 나중에 등록 → FIFO 에서 탈락
+        node2.registerCandidate(lockName, CandidateInfo("node-1", registeredAt = t0))
+        node2.registerCandidate(lockName, CandidateInfo("node-2", registeredAt = t0.plusMillis(10)))
+
+        val result = node2.runIfLeader(lockName, FifoElectionStrategy) { "should-not-run" }
+        result.shouldBeNull()
+        node2.listCandidates(lockName).first { it.nodeId == "node-2" }.successCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `SuccessRate - 성공률 높은 노드 선출`() {
+        val candidates = listOf(
+            CandidateInfo("node-1", successCount = 1, failureCount = 9),  // 10%
+            CandidateInfo("node-2", successCount = 9, failureCount = 1),  // 90%
+            CandidateInfo("node-3", successCount = 5, failureCount = 5),  // 50%
+        )
+        candidates.forEach { node1.registerCandidate(lockName, it) }
+        candidates.forEach { node2.registerCandidate(lockName, it) }
+        candidates.forEach { node3.registerCandidate(lockName, it) }
+
+        val strategy = ScoredElectionStrategy(SuccessRateScorer)
+        val winner = strategy.elect(node1.listCandidates(lockName)).winner
+        winner?.nodeId shouldBeEqualTo "node-2"
+
+        val counter = AtomicInteger(0)
+        node1.runIfLeader(lockName, strategy) { counter.incrementAndGet() }
+        node2.runIfLeader(lockName, strategy) { counter.incrementAndGet() }
+        node3.runIfLeader(lockName, strategy) { counter.incrementAndGet() }
+
+        counter.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `Weighted scorer - 성공률 우선 winner 선출`() {
+        val candidates = listOf(
+            CandidateInfo("node-1", successCount = 10, failureCount = 0),  // 100%
+            CandidateInfo("node-2", successCount = 0, failureCount = 10),  // 0%
+            CandidateInfo("node-3", successCount = 5, failureCount = 5),   // 50%
+        )
+        candidates.forEach { node1.registerCandidate(lockName, it) }
+        candidates.forEach { node2.registerCandidate(lockName, it) }
+        candidates.forEach { node3.registerCandidate(lockName, it) }
+
+        val scorer = WeightedScorer(IdleTimeScorer to 0.1, SuccessRateScorer to 0.9)
+        val strategy = ScoredElectionStrategy(scorer)
+        val winner = strategy.elect(node1.listCandidates(lockName)).winner
+        winner?.nodeId shouldBeEqualTo "node-1"
+
+        val counter = AtomicInteger(0)
+        node1.runIfLeader(lockName, strategy) { counter.incrementAndGet() }
+        node2.runIfLeader(lockName, strategy) { counter.incrementAndGet() }
+        node3.runIfLeader(lockName, strategy) { counter.incrementAndGet() }
+
+        counter.get() shouldBeEqualTo 1
     }
 }

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
@@ -46,6 +46,13 @@ class RedissonCandidateRegistry(private val redissonClient: RedissonClient) {
     fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
         val cache = mapCacheFor(lockName)
         val current = cache[nodeId] ?: return
-        cache.put(nodeId, current.withResult(result))
+        val updated = current.withResult(result)
+        // remainTimeToLive: -1 = no TTL, -2 = absent
+        val remainMs = cache.remainTimeToLive(nodeId)
+        if (remainMs > 0) {
+            cache.put(nodeId, updated, remainMs, TimeUnit.MILLISECONDS)
+        } else {
+            cache.put(nodeId, updated)
+        }
     }
 }

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
@@ -1,0 +1,51 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import org.redisson.api.RedissonClient
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+/**
+ * Redisson [RMapCache][org.redisson.api.RMapCache] 를 이용한 후보 레지스트리입니다.
+ *
+ * ## 저장 구조
+ * - Key: `leader:strategy:candidates:{lockName}`
+ * - Field: `nodeId`, Value: [CandidateInfo]
+ * - 항목별 TTL: [registerCandidate] 호출 시 설정 (heartbeat 역할)
+ *
+ * ## 분산 일관성 주의
+ * [updateResult] 는 read-modify-write 이므로 완전한 원자성을 보장하지 않습니다.
+ * winner 노드만 자신의 항목을 갱신하므로 실제 충돌 가능성은 낮습니다.
+ *
+ * @param redissonClient Redisson 클라이언트
+ */
+class RedissonCandidateRegistry(private val redissonClient: RedissonClient) {
+
+    private fun cacheKey(lockName: String) = "leader:strategy:candidates:$lockName"
+
+    private fun mapCacheFor(lockName: String) =
+        redissonClient.getMapCache<String, CandidateInfo>(cacheKey(lockName))
+
+    fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+        val cache = mapCacheFor(lockName)
+        if (ttl == Duration.ZERO) {
+            cache.put(info.nodeId, info)
+        } else {
+            cache.put(info.nodeId, info, ttl.toMillis(), TimeUnit.MILLISECONDS)
+        }
+    }
+
+    fun unregisterCandidate(lockName: String, nodeId: String) {
+        mapCacheFor(lockName).remove(nodeId)
+    }
+
+    fun listCandidates(lockName: String): List<CandidateInfo> =
+        mapCacheFor(lockName).readAllValues().toList()
+
+    fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
+        val cache = mapCacheFor(lockName)
+        val current = cache[nodeId] ?: return
+        cache.put(nodeId, current.withResult(result))
+    }
+}

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElection.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElection.kt
@@ -9,6 +9,7 @@ import io.bluetape4k.leader.strategy.ElectionStrategy
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
+import kotlinx.coroutines.CancellationException
 import org.redisson.api.RedissonClient
 import java.time.Duration
 
@@ -75,6 +76,8 @@ class RedissonStrategicLeaderElection(
             val value = action()
             updateResult(lockName, nodeId, CandidateResult.SUCCESS)
             value
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Throwable) {
             updateResult(lockName, nodeId, CandidateResult.FAILURE)
             throw e

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElection.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElection.kt
@@ -1,0 +1,83 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.idgenerators.uuid.Uuid
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.StrategicLeaderElection
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.ElectionStrategy
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import org.redisson.api.RedissonClient
+import java.time.Duration
+
+/**
+ * Redisson 백엔드 기반 [StrategicLeaderElection] 구현체입니다.
+ *
+ * ## 선출 방식
+ * 분산 락 없이 결정론적 전략을 사용합니다.
+ * 모든 노드가 동일한 후보 목록에 동일한 전략을 적용하면 동일한 winner를 계산합니다.
+ * winner 인 노드만 action 을 실행합니다.
+ *
+ * ## 주의
+ * 후보 등록/만료 타이밍 차이로 노드마다 다른 후보 목록을 볼 수 있습니다.
+ * 엄격한 상호 배제가 필요한 경우 [RedissonLeaderElection] (락 기반)을 사용하세요.
+ *
+ * @param redissonClient Redisson 클라이언트
+ * @param nodeId 이 인스턴스의 노드 식별자. 미지정 시 UUID v7 자동 생성.
+ */
+class RedissonStrategicLeaderElection(
+    redissonClient: RedissonClient,
+    override val nodeId: String = Uuid.V7.nextBase62(),
+) : StrategicLeaderElection {
+
+    companion object : KLogging()
+
+    private val registry = RedissonCandidateRegistry(redissonClient)
+
+    override fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
+        registry.registerCandidate(lockName, info, ttl)
+
+    override fun unregisterCandidate(lockName: String, nodeId: String) =
+        registry.unregisterCandidate(lockName, nodeId)
+
+    override fun listCandidates(lockName: String): List<CandidateInfo> =
+        registry.listCandidates(lockName)
+
+    override fun updateResult(lockName: String, nodeId: String, result: CandidateResult) =
+        registry.updateResult(lockName, nodeId, result)
+
+    override fun <T> runIfLeader(
+        lockName: String,
+        strategy: ElectionStrategy,
+        options: LeaderElectionOptions,
+        action: () -> T,
+    ): T? {
+        val result = strategy.elect(listCandidates(lockName))
+        val winner = result.winner ?: return null
+
+        val total = result.eliminations.size + 1
+        log.info { "[$lockName] 선출: ${winner.nodeId} (전략: ${strategy::class.simpleName}, 후보: ${total}명)" }
+        if (result.scores.isNotEmpty()) {
+            val scoreText = result.scores.entries
+                .sortedByDescending { it.value }
+                .joinToString(", ") { (id, s) -> "$id=%.2f".format(s) }
+            log.debug { "[$lockName] 점수: $scoreText" }
+        }
+        result.eliminations.forEach { e ->
+            log.debug { "[$lockName] 탈락: ${e.candidate.nodeId} — ${e.reason}" }
+        }
+
+        if (winner.nodeId != nodeId) return null
+
+        return try {
+            val value = action()
+            updateResult(lockName, nodeId, CandidateResult.SUCCESS)
+            value
+        } catch (e: Throwable) {
+            updateResult(lockName, nodeId, CandidateResult.FAILURE)
+            throw e
+        }
+    }
+}

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElection.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElection.kt
@@ -1,0 +1,82 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.idgenerators.uuid.Uuid
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.coroutines.StrategicSuspendLeaderElection
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.ElectionStrategy
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.redisson.api.RedissonClient
+import java.time.Duration
+
+/**
+ * Redisson 백엔드 기반 [StrategicSuspendLeaderElection] 구현체입니다.
+ *
+ * Redisson 블로킹 호출은 [Dispatchers.IO] 에서 실행합니다.
+ * [CancellationException] 은 작업 실패가 아니므로 failureCount 를 증가시키지 않고 재전파합니다.
+ *
+ * @param redissonClient Redisson 클라이언트
+ * @param nodeId 이 인스턴스의 노드 식별자. 미지정 시 UUID v7 자동 생성.
+ */
+class RedissonStrategicSuspendLeaderElection(
+    redissonClient: RedissonClient,
+    override val nodeId: String = Uuid.V7.nextBase62(),
+) : StrategicSuspendLeaderElection {
+
+    companion object : KLogging()
+
+    private val registry = RedissonCandidateRegistry(redissonClient)
+
+    override suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
+        withContext(Dispatchers.IO) { registry.registerCandidate(lockName, info, ttl) }
+
+    override suspend fun unregisterCandidate(lockName: String, nodeId: String) =
+        withContext(Dispatchers.IO) { registry.unregisterCandidate(lockName, nodeId) }
+
+    override suspend fun listCandidates(lockName: String): List<CandidateInfo> =
+        withContext(Dispatchers.IO) { registry.listCandidates(lockName) }
+
+    override suspend fun updateResult(lockName: String, nodeId: String, result: CandidateResult) =
+        withContext(Dispatchers.IO) { registry.updateResult(lockName, nodeId, result) }
+
+    override suspend fun <T> runIfLeader(
+        lockName: String,
+        strategy: ElectionStrategy,
+        options: LeaderElectionOptions,
+        action: suspend () -> T,
+    ): T? {
+        val result = strategy.elect(listCandidates(lockName))
+        val winner = result.winner ?: return null
+
+        val total = result.eliminations.size + 1
+        log.info { "[$lockName] 선출: ${winner.nodeId} (전략: ${strategy::class.simpleName}, 후보: ${total}명)" }
+        if (result.scores.isNotEmpty()) {
+            val scoreText = result.scores.entries
+                .sortedByDescending { it.value }
+                .joinToString(", ") { (id, s) -> "$id=%.2f".format(s) }
+            log.debug { "[$lockName] 점수: $scoreText" }
+        }
+        result.eliminations.forEach { e ->
+            log.debug { "[$lockName] 탈락: ${e.candidate.nodeId} — ${e.reason}" }
+        }
+
+        if (winner.nodeId != nodeId) return null
+
+        return try {
+            val value = action()
+            updateResult(lockName, nodeId, CandidateResult.SUCCESS)
+            value
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            updateResult(lockName, nodeId, CandidateResult.FAILURE)
+            throw e
+        }
+    }
+}

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElectionTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElectionTest.kt
@@ -8,9 +8,11 @@ import io.bluetape4k.leader.strategy.scorers.WeightedScorer
 import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
 import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -72,6 +74,20 @@ class RedissonStrategicLeaderElectionTest : AbstractRedissonLeaderTest() {
         node1.listCandidates(lockName).size shouldBeEqualTo 1
 
         Thread.sleep(500)
+        node1.listCandidates(lockName).size shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `updateResult 후 TTL 보존 - 항목이 여전히 만료됨`() {
+        val lockName = randomName()
+        val ttl = Duration.ofMillis(500)
+
+        node1.registerCandidate(lockName, CandidateInfo("node-1"), ttl)
+        node1.runIfLeader(lockName, FifoElectionStrategy) { "ok" }  // updateResult(SUCCESS) 내부 호출
+
+        // updateResult 후에도 TTL 유지되어야 함
+        node1.listCandidates(lockName).size shouldBeEqualTo 1
+        Thread.sleep(700)
         node1.listCandidates(lockName).size shouldBeEqualTo 0
     }
 
@@ -189,5 +205,165 @@ class RedissonStrategicLeaderElectionTest : AbstractRedissonLeaderTest() {
         node3.runIfLeader(lockName, strategy) { counter.incrementAndGet() }
 
         counter.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `단일 후보는 항상 자신이 선출됨`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+
+        val result = node1.runIfLeader(lockName, FifoElectionStrategy) { "executed" }
+        result.shouldNotBeNull()
+        result shouldBeEqualTo "executed"
+    }
+
+    @Test
+    fun `action 예외 시 failureCount 증가 및 예외 전파`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+
+        assertThrows(RuntimeException::class.java) {
+            node1.runIfLeader(lockName, FifoElectionStrategy) {
+                throw RuntimeException("intentional error")
+            }
+        }
+
+        val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        updated.failureCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `동일 nodeId 재등록 시 CandidateInfo 갱신됨`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1", successCount = 3))
+        node1.registerCandidate(lockName, CandidateInfo("node-1", successCount = 10))
+
+        val candidates = node1.listCandidates(lockName)
+        candidates.size shouldBeEqualTo 1
+        candidates.first().successCount shouldBeEqualTo 10L
+    }
+
+    @Test
+    fun `서로 다른 lockName은 독립적인 후보 풀`() {
+        val lock1 = randomName()
+        val lock2 = randomName()
+
+        node1.registerCandidate(lock1, CandidateInfo("node-1"))
+        node1.registerCandidate(lock1, CandidateInfo("node-2"))
+        node1.registerCandidate(lock2, CandidateInfo("node-3"))
+
+        node1.listCandidates(lock1).size shouldBeEqualTo 2
+        node1.listCandidates(lock2).size shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `updateResult - 존재하지 않는 nodeId는 무시됨`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+
+        // 존재하지 않는 nodeId — 예외 없이 무시
+        node1.updateResult(lockName, "ghost-node", CandidateResult.SUCCESS)
+
+        val candidates = node1.listCandidates(lockName)
+        candidates.size shouldBeEqualTo 1
+        candidates.first().successCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `IdleTime - updateResult 후 winner 변경됨`() {
+        val lockName = randomName()
+        val now = Instant.now()
+        val candidates = listOf(
+            CandidateInfo("node-1", lastCompletionTime = now.minusSeconds(100)),
+            CandidateInfo("node-2", lastCompletionTime = now.minusSeconds(10)),
+        )
+        candidates.forEach { node1.registerCandidate(lockName, it) }
+        candidates.forEach { node2.registerCandidate(lockName, it) }
+
+        val strategy = ScoredElectionStrategy(IdleTimeScorer)
+
+        // 초기: node-1 이 가장 오래 쉬었음 → winner
+        val firstWinner = strategy.elect(node1.listCandidates(lockName)).winner
+        firstWinner?.nodeId shouldBeEqualTo "node-1"
+
+        // node-1 이 작업 후 lastCompletionTime = now → idle≈0
+        node1.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+
+        // 다음 라운드: node-2 가 더 오래 쉬었음 → winner 변경
+        val secondWinner = strategy.elect(node1.listCandidates(lockName)).winner
+        secondWinner?.nodeId shouldBeEqualTo "node-2"
+    }
+
+    @Test
+    fun `FIFO - 동일 registeredAt 시 nodeId 사전순 선출`() {
+        val lockName = randomName()
+        val t0 = Instant.now()
+        // "node-a" < "node-b" < "node-c" 사전순
+        val candidates = listOf(
+            CandidateInfo("node-c", registeredAt = t0),
+            CandidateInfo("node-a", registeredAt = t0),
+            CandidateInfo("node-b", registeredAt = t0),
+        )
+        candidates.forEach { node1.registerCandidate(lockName, it) }
+
+        val winner = FifoElectionStrategy.elect(node1.listCandidates(lockName)).winner
+        winner?.nodeId shouldBeEqualTo "node-a"
+    }
+
+    @Test
+    fun `CandidateInfo - Instant 필드 직렬화 라운드트립`() {
+        val lockName = randomName()
+        val t0 = Instant.now()
+        val original = CandidateInfo(
+            nodeId = "node-1",
+            registeredAt = t0,
+            lastStartTime = t0.plusMillis(100),
+            lastCompletionTime = t0.plusMillis(200),
+            successCount = 7L,
+            failureCount = 3L,
+        )
+        node1.registerCandidate(lockName, original)
+
+        val retrieved = node1.listCandidates(lockName).first()
+        retrieved.nodeId shouldBeEqualTo original.nodeId
+        retrieved.successCount shouldBeEqualTo original.successCount
+        retrieved.failureCount shouldBeEqualTo original.failureCount
+        // Instant 직렬화: 나노초 精度 손실 허용 (밀리초 단위 비교)
+        retrieved.registeredAt.toEpochMilli() shouldBeEqualTo original.registeredAt.toEpochMilli()
+        retrieved.lastCompletionTime?.toEpochMilli() shouldBeEqualTo original.lastCompletionTime?.toEpochMilli()
+    }
+
+    @Test
+    fun `updateResult FAILURE - failureCount 증가`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.updateResult(lockName, "node-1", CandidateResult.FAILURE)
+        node1.updateResult(lockName, "node-1", CandidateResult.FAILURE)
+
+        val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        updated.failureCount shouldBeEqualTo 2L
+        updated.successCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `runIfLeader - winner 아닌 노드는 action 실행 안 함`() {
+        val lockName = randomName()
+        val t0 = Instant.now()
+        node1.registerCandidate(lockName, CandidateInfo("node-1", registeredAt = t0))
+        node2.registerCandidate(lockName, CandidateInfo("node-2", registeredAt = t0.plusMillis(10)))
+
+        // node2 는 winner 가 아님 → null
+        val result = node2.runIfLeader(lockName, FifoElectionStrategy) { "should-not-run" }
+        result.shouldBeNull()
+
+        // node2 의 successCount 변화 없음
+        val node2Info = node2.listCandidates(lockName).first { it.nodeId == "node-2" }
+        node2Info.successCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `listCandidates - 빈 lockName 은 빈 목록 반환`() {
+        val lockName = randomName()
+        node1.listCandidates(lockName).size shouldBeEqualTo 0
     }
 }

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElectionTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElectionTest.kt
@@ -1,0 +1,193 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.scorers.IdleTimeScorer
+import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
+import io.bluetape4k.leader.strategy.scorers.WeightedScorer
+import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
+import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RedissonStrategicLeaderElectionTest : AbstractRedissonLeaderTest() {
+
+    private lateinit var node1: RedissonStrategicLeaderElection
+    private lateinit var node2: RedissonStrategicLeaderElection
+    private lateinit var node3: RedissonStrategicLeaderElection
+
+    @BeforeEach
+    fun setup() {
+        node1 = RedissonStrategicLeaderElection(redissonClient, "node-1")
+        node2 = RedissonStrategicLeaderElection(redissonClient, "node-2")
+        node3 = RedissonStrategicLeaderElection(redissonClient, "node-3")
+    }
+
+    @Test
+    fun `FIFO - 가장 먼저 등록된 노드가 action 실행`() {
+        val lockName = randomName()
+        val t0 = Instant.now()
+        val candidates = listOf(
+            CandidateInfo("node-1", registeredAt = t0),
+            CandidateInfo("node-2", registeredAt = t0.plusMillis(10)),
+            CandidateInfo("node-3", registeredAt = t0.plusMillis(20)),
+        )
+        candidates.forEach { node1.registerCandidate(lockName, it) }
+        candidates.forEach { node2.registerCandidate(lockName, it) }
+        candidates.forEach { node3.registerCandidate(lockName, it) }
+
+        val counter = AtomicInteger(0)
+        val r1 = node1.runIfLeader(lockName, FifoElectionStrategy) { counter.incrementAndGet() }
+        val r2 = node2.runIfLeader(lockName, FifoElectionStrategy) { counter.incrementAndGet() }
+        val r3 = node3.runIfLeader(lockName, FifoElectionStrategy) { counter.incrementAndGet() }
+
+        r1.shouldNotBeNull()
+        r2.shouldBeNull()
+        r3.shouldBeNull()
+        counter.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `후보 없으면 null 반환`() {
+        val lockName = randomName()
+        val result = node1.runIfLeader(lockName, FifoElectionStrategy) { "should-not-run" }
+        result.shouldBeNull()
+    }
+
+    @Test
+    fun `TTL 만료 후 후보 자동 제거`() {
+        val lockName = randomName()
+        val ttl = Duration.ofMillis(300)
+
+        node1.registerCandidate(lockName, CandidateInfo("node-1"), ttl)
+        node1.listCandidates(lockName).size shouldBeEqualTo 1
+
+        Thread.sleep(500)
+        node1.listCandidates(lockName).size shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `unregisterCandidate - 등록 해제 후 목록에서 제거`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.registerCandidate(lockName, CandidateInfo("node-2"))
+        node1.unregisterCandidate(lockName, "node-1")
+
+        val candidates = node1.listCandidates(lockName)
+        candidates.size shouldBeEqualTo 1
+        candidates.first().nodeId shouldBeEqualTo "node-2"
+    }
+
+    @Test
+    fun `updateResult - SUCCESS 후 successCount 증가`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+
+        val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        updated.successCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `runIfLeader SUCCESS 후 successCount 자동 증가`() {
+        val lockName = randomName()
+        val t0 = Instant.now()
+        node1.registerCandidate(lockName, CandidateInfo("node-1", registeredAt = t0))
+
+        node1.runIfLeader(lockName, FifoElectionStrategy) { "ok" }
+
+        val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        updated.successCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `Scored IdleTime - 가장 오래 쉰 노드가 winner로 선출`() {
+        val lockName = randomName()
+        val now = Instant.now()
+        val candidates = listOf(
+            CandidateInfo("node-1", lastCompletionTime = now.minusSeconds(10)),
+            CandidateInfo("node-2", lastCompletionTime = now.minusSeconds(100)),
+            CandidateInfo("node-3", lastCompletionTime = now.minusSeconds(50)),
+        )
+        candidates.forEach { node1.registerCandidate(lockName, it) }
+        candidates.forEach { node2.registerCandidate(lockName, it) }
+        candidates.forEach { node3.registerCandidate(lockName, it) }
+
+        val strategy = ScoredElectionStrategy(IdleTimeScorer)
+
+        // 모든 노드가 동일한 후보 목록에서 동일한 winner 계산 (결정론적)
+        val winner = strategy.elect(node1.listCandidates(lockName)).winner
+        winner?.nodeId shouldBeEqualTo "node-2"
+
+        // winner 노드만 action 실행
+        val r2 = node2.runIfLeader(lockName, strategy) { "node-2 ran" }
+        r2.shouldNotBeNull()
+
+        // updateResult 후 node-2 lastCompletionTime = now → 다음 라운드에서 node-2는 idle=0
+        // node-1(idle≈10s)은 여전히 winner가 아님 (node-3 idle≈50s가 다음 winner)
+        val r1 = node1.runIfLeader(lockName, strategy) { "node-1 ran" }
+        r1.shouldBeNull()
+    }
+
+    @Test
+    fun `Scored SuccessRate - 성공률 높은 노드 선출`() {
+        val lockName = randomName()
+        val candidates = listOf(
+            CandidateInfo("node-1", successCount = 1, failureCount = 9),   // 10%
+            CandidateInfo("node-2", successCount = 9, failureCount = 1),   // 90%
+            CandidateInfo("node-3", successCount = 5, failureCount = 5),   // 50%
+        )
+        candidates.forEach { node1.registerCandidate(lockName, it) }
+        candidates.forEach { node2.registerCandidate(lockName, it) }
+        candidates.forEach { node3.registerCandidate(lockName, it) }
+
+        val strategy = ScoredElectionStrategy(SuccessRateScorer)
+
+        // 결정론적 선출 검증
+        val winner = strategy.elect(node1.listCandidates(lockName)).winner
+        winner?.nodeId shouldBeEqualTo "node-2"
+
+        val counter = AtomicInteger(0)
+        node1.runIfLeader(lockName, strategy) { counter.incrementAndGet() }
+        node2.runIfLeader(lockName, strategy) { counter.incrementAndGet() }
+        node3.runIfLeader(lockName, strategy) { counter.incrementAndGet() }
+
+        counter.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `Weighted scorer - 성공률 우선 winner 선출`() {
+        val lockName = randomName()
+        val candidates = listOf(
+            CandidateInfo("node-1", successCount = 10, failureCount = 0),  // 100%
+            CandidateInfo("node-2", successCount = 0, failureCount = 10),  // 0%
+            CandidateInfo("node-3", successCount = 5, failureCount = 5),   // 50%
+        )
+        candidates.forEach { node1.registerCandidate(lockName, it) }
+        candidates.forEach { node2.registerCandidate(lockName, it) }
+        candidates.forEach { node3.registerCandidate(lockName, it) }
+
+        // 성공률 weight 높게 → node-1 선출
+        val scorer = WeightedScorer(IdleTimeScorer to 0.1, SuccessRateScorer to 0.9)
+        val strategy = ScoredElectionStrategy(scorer)
+
+        val winner = strategy.elect(node1.listCandidates(lockName)).winner
+        winner?.nodeId shouldBeEqualTo "node-1"
+
+        val counter = AtomicInteger(0)
+        node1.runIfLeader(lockName, strategy) { counter.incrementAndGet() }
+        node2.runIfLeader(lockName, strategy) { counter.incrementAndGet() }
+        node3.runIfLeader(lockName, strategy) { counter.incrementAndGet() }
+
+        counter.get() shouldBeEqualTo 1
+    }
+}

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElectionTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElectionTest.kt
@@ -1,155 +1,126 @@
-package io.bluetape4k.leader.local
+package io.bluetape4k.leader.redisson
 
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
 import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
 import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class LocalStrategicSuspendLeaderElectionTest {
+class RedissonStrategicSuspendLeaderElectionTest : AbstractRedissonLeaderTest() {
 
-    private val lockName = "test-suspend-lock"
-
-    private lateinit var node1: LocalStrategicSuspendLeaderElection
-    private lateinit var node2: LocalStrategicSuspendLeaderElection
-    private lateinit var node3: LocalStrategicSuspendLeaderElection
+    private lateinit var node1: RedissonStrategicSuspendLeaderElection
+    private lateinit var node2: RedissonStrategicSuspendLeaderElection
+    private lateinit var node3: RedissonStrategicSuspendLeaderElection
 
     @BeforeEach
     fun setup() {
-        node1 = LocalStrategicSuspendLeaderElection("node-1")
-        node2 = LocalStrategicSuspendLeaderElection("node-2")
-        node3 = LocalStrategicSuspendLeaderElection("node-3")
+        node1 = RedissonStrategicSuspendLeaderElection(redissonClient, "node-1")
+        node2 = RedissonStrategicSuspendLeaderElection(redissonClient, "node-2")
+        node3 = RedissonStrategicSuspendLeaderElection(redissonClient, "node-3")
     }
 
     @Test
-    fun `FIFO - node1 먼저 등록하면 node1 만 action 실행`() = runTest {
+    fun `FIFO - 가장 먼저 등록된 노드가 action 실행`() = runSuspendIO {
+        val lockName = randomName()
         val t0 = Instant.now()
-        node1.registerCandidate(lockName, CandidateInfo("node-1", registeredAt = t0))
-        node1.registerCandidate(lockName, CandidateInfo("node-2", registeredAt = t0.plusMillis(10)))
-        node2.registerCandidate(lockName, CandidateInfo("node-1", registeredAt = t0))
-        node2.registerCandidate(lockName, CandidateInfo("node-2", registeredAt = t0.plusMillis(10)))
+        val candidates = listOf(
+            CandidateInfo("node-1", registeredAt = t0),
+            CandidateInfo("node-2", registeredAt = t0.plusMillis(10)),
+            CandidateInfo("node-3", registeredAt = t0.plusMillis(20)),
+        )
+        candidates.forEach { node1.registerCandidate(lockName, it) }
+        candidates.forEach { node2.registerCandidate(lockName, it) }
+        candidates.forEach { node3.registerCandidate(lockName, it) }
 
         val counter = AtomicInteger(0)
         val r1 = node1.runIfLeader(lockName, FifoElectionStrategy) { counter.incrementAndGet() }
         val r2 = node2.runIfLeader(lockName, FifoElectionStrategy) { counter.incrementAndGet() }
+        val r3 = node3.runIfLeader(lockName, FifoElectionStrategy) { counter.incrementAndGet() }
 
         r1.shouldNotBeNull()
         r2.shouldBeNull()
+        r3.shouldBeNull()
         counter.get() shouldBeEqualTo 1
     }
 
     @Test
-    fun `updateResult - SUCCESS 후 successCount 증가`() = runTest {
-        node1.registerCandidate(lockName, CandidateInfo("node-1"))
-        node1.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
-
-        val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
-        updated.successCount shouldBeEqualTo 1L
-    }
-
-    @Test
-    fun `후보 0명이면 runIfLeader null 반환`() = runTest {
+    fun `후보 없으면 null 반환`() = runSuspendIO {
+        val lockName = randomName()
         val result = node1.runIfLeader(lockName, FifoElectionStrategy) { "should-not-run" }
         result.shouldBeNull()
     }
 
     @Test
-    fun `unregisterCandidate - 등록 해제 후 목록에서 제거`() = runTest {
-        node1.registerCandidate(lockName, CandidateInfo("node-1"))
-        node1.unregisterCandidate(lockName, "node-1")
-        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+    fun `TTL 만료 후 후보 자동 제거`() = runSuspendIO {
+        val lockName = randomName()
+        val ttl = Duration.ofMillis(300)
+
+        node1.registerCandidate(lockName, CandidateInfo("node-1"), ttl)
+        node1.listCandidates(lockName).size shouldBeEqualTo 1
+
+        Thread.sleep(500)
+        node1.listCandidates(lockName).size shouldBeEqualTo 0
     }
 
     @Test
-    fun `CancellationException - 코루틴 취소 시 failureCount 증가 없음`() = runTest {
+    fun `CancellationException - failureCount 증가 없음`() = runSuspendIO {
+        val lockName = randomName()
         node1.registerCandidate(lockName, CandidateInfo("node-1"))
+
         var caughtCancellation = false
         try {
             withTimeout(50L) {
                 node1.runIfLeader(lockName, FifoElectionStrategy) {
-                    delay(10_000L) // 타임아웃보다 훨씬 긴 지연
+                    delay(10_000L)
                 }
             }
         } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
             caughtCancellation = true
         }
         caughtCancellation.shouldBeTrue()
-        val candidate = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+
+        val candidate = node1.listCandidates(lockName).firstOrNull { it.nodeId == "node-1" }
+        candidate.shouldNotBeNull()
         candidate.failureCount shouldBeEqualTo 0L
     }
 
     @Test
-    fun `action 예외 시 failureCount 증가 및 예외 재전파`() = runTest {
+    fun `action 예외 시 failureCount 증가 및 예외 전파`() = runSuspendIO {
+        val lockName = randomName()
         node1.registerCandidate(lockName, CandidateInfo("node-1"))
 
         runCatching {
             node1.runIfLeader(lockName, FifoElectionStrategy) {
                 throw RuntimeException("intentional error")
             }
-        }.isFailure.shouldBeTrue()
+        }
 
-        val info = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
-        info.failureCount shouldBeEqualTo 1L
+        val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        updated.failureCount shouldBeEqualTo 1L
     }
 
     @Test
-    fun `동일 nodeId 재등록 시 CandidateInfo 갱신됨`() = runTest {
-        node1.registerCandidate(lockName, CandidateInfo("node-1", successCount = 3))
-        node1.registerCandidate(lockName, CandidateInfo("node-1", successCount = 10))
-
-        val candidates = node1.listCandidates(lockName)
-        candidates.size shouldBeEqualTo 1
-        candidates.first().successCount shouldBeEqualTo 10L
-    }
-
-    @Test
-    fun `서로 다른 lockName 은 독립적인 후보 풀`() = runTest {
-        val lock1 = "lock-alpha"
-        val lock2 = "lock-beta"
-        node1.registerCandidate(lock1, CandidateInfo("node-1"))
-        node1.registerCandidate(lock1, CandidateInfo("node-2"))
-        node1.registerCandidate(lock2, CandidateInfo("node-3"))
-
-        node1.listCandidates(lock1).size shouldBeEqualTo 2
-        node1.listCandidates(lock2).size shouldBeEqualTo 1
-    }
-
-    @Test
-    fun `단일 후보는 항상 자신이 선출됨`() = runTest {
-        node1.registerCandidate(lockName, CandidateInfo("node-1"))
-        val result = node1.runIfLeader(lockName, FifoElectionStrategy) { "executed" }
-        result shouldBeEqualTo "executed"
-    }
-
-    @Test
-    fun `FIFO - 동일 registeredAt 시 nodeId 사전순 선출`() = runTest {
-        val t0 = Instant.now()
-        node1.registerCandidate(lockName, CandidateInfo("node-c", registeredAt = t0))
-        node1.registerCandidate(lockName, CandidateInfo("node-a", registeredAt = t0))
-        node1.registerCandidate(lockName, CandidateInfo("node-b", registeredAt = t0))
-
-        val winner = FifoElectionStrategy.elect(node1.listCandidates(lockName)).winner
-        winner?.nodeId shouldBeEqualTo "node-a"
-    }
-
-    @Test
-    fun `SuccessRate - 성공률 높은 노드 선출`() = runTest {
+    fun `Scored SuccessRate - 성공률 높은 노드 선출`() = runSuspendIO {
+        val lockName = randomName()
         val candidates = listOf(
             CandidateInfo("node-1", successCount = 1, failureCount = 9),  // 10%
             CandidateInfo("node-2", successCount = 9, failureCount = 1),  // 90%
@@ -172,7 +143,8 @@ class LocalStrategicSuspendLeaderElectionTest {
     }
 
     @Test
-    fun `동시 coroutine 실행 - 정확히 1개 노드만 실행`() = runTest {
+    fun `동시 coroutine 실행 - 정확히 1개 노드만 실행`() = runSuspendIO {
+        val lockName = randomName()
         val t0 = Instant.now()
         val candidates = listOf(
             CandidateInfo("node-1", registeredAt = t0),
@@ -193,5 +165,28 @@ class LocalStrategicSuspendLeaderElectionTest {
             jobs.awaitAll()
         }
         counter.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `unregisterCandidate - 등록 해제 후 목록에서 제거`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.registerCandidate(lockName, CandidateInfo("node-2"))
+        node1.unregisterCandidate(lockName, "node-1")
+
+        val candidates = node1.listCandidates(lockName)
+        candidates.size shouldBeEqualTo 1
+        candidates.first().nodeId shouldBeEqualTo "node-2"
+    }
+
+    @Test
+    fun `runIfLeader SUCCESS 후 successCount 자동 증가`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+
+        node1.runIfLeader(lockName, FifoElectionStrategy) { "ok" }
+
+        val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        updated.successCount shouldBeEqualTo 1L
     }
 }


### PR DESCRIPTION
## Summary

PR #32의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `test: StrategicLeaderElection 엣지 케이스 테스트 추가 및 버그 수정`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 변경 사항

### 버그 수정

#### C1 — `RedissonCandidateRegistry.updateResult` TTL 유실 버그
`RMapCache.put(K, V)` 호출 시 TTL 파라미터 미전달 → 항목이 영구화되어 heartbeat 모델 붕괴.
`remainTimeToLive(nodeId)` 로 잔여 TTL 을 읽어 재설정하도록 수정.

```kotlin
// 수정 전
cache.put(nodeId, current.withResult(result))  // TTL 유실

// 수정 후
val remainMs = cache.remainTimeToLive(nodeId)
if (remainMs > 0) cache.put(nodeId, updated, remainMs, TimeUnit.MILLISECONDS)
else cache.put(nodeId, updated)
```

#### H1 — 블로킹 구현 `CancellationException` 처리 누락
`LocalStrategicLeaderElection`, `RedissonStrategicLeaderElection` 의 `catch (Throwable)` 블록이
`CancellationException` 도 `FAILURE` 로 처리하는 문제. suspend 구현체와 동일하게 CE 재전파 추가.

---

### 테스트 추가

| 파일 | 추가 테스트 수 |
|---|---|
| `LocalStrategicLeaderElectionTest` | +11 |
| `LocalStrategicSuspendLeaderElectionTest` | +7 |
| `RedissonStrategicLeaderElectionTest` | +12 (TTL 보존 회귀 포함) |
| `RedissonStrategicSuspendLeaderElectionTest` | 신규 파일 (8개) |

**주요 엣지 케이스:**
- 단일 후보 항상 선출
- 동일 nodeId 재등록 시 CandidateInfo 갱신
- lockName 독립 후보 풀 격리
- ghost nodeId `updateResult` 무시
- `IdleTime` — `updateResult` 후 winner 변경
- `FIFO` tiebreaker — 동일 `registeredAt` 시 nodeId 사전순
- `SuccessRate` / `WeightedScorer` 선출 검증
- `CancellationException` — `withTimeout` 패턴으로 전파 검증
- 동시 coroutine 3개 → counter=1
- **TTL 보존 회귀**: `runIfLeader` 후에도 항목이 TTL 만료됨을 검증

## 테스트 결과

```
leader-core:test      193 passing
leader-redis-redisson:test  30 passing
```
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #32, head `1aab88830c475fc37cdce883c4bcf0544b2810bd`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
