### PR TITLE
fix: daily review 2026-05-01 — 6-Tier 코드 리뷰 결과 반영

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -32,6 +32,7 @@ graph TD
     ExposedJdbc["leader-exposed-jdbc\n(예정)"]
     ExposedR2dbc["leader-exposed-r2dbc\n(예정)"]
     Mongo["leader-mongodb\n(예정)"]
+    SBCommon["leader-spring-boot-common\n(Boot 버전 독립)"]
     SB3["leader-spring-boot3\n(예정)"]
     SB4["leader-spring-boot4\n(예정)"]
     Metrics["leader-micrometer\n(예정)"]
@@ -43,8 +44,9 @@ graph TD
     ExposedJdbc --> ExposedCore
     ExposedR2dbc --> ExposedCore
     Mongo --> Core
-    SB3 --> Core
-    SB4 --> Core
+    SBCommon --> Core
+    SB3 --> SBCommon
+    SB4 --> SBCommon
     Metrics --> Core
 ```
 
@@ -61,6 +63,7 @@ graph TD
 | `leader-exposed-r2dbc` | 예정 | Exposed R2DBC 백엔드 |
 | `leader-mongodb` | 예정 | MongoDB 백엔드 |
 | `leader-micrometer` | 예정 | Micrometer 메트릭 연동 |
+| `leader-spring-boot-common` | 안정 | Boot 버전 독립 속성 + 자동 구성 지원 클래스 |
 | `leader-spring-boot3` | 예정 | Spring Boot 3 자동 구성 |
 | `leader-spring-boot4` | 예정 | Spring Boot 4 자동 구성 |
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ graph TD
     ExposedJdbc["leader-exposed-jdbc\n(planned)"]
     ExposedR2dbc["leader-exposed-r2dbc\n(planned)"]
     Mongo["leader-mongodb\n(planned)"]
+    SBCommon["leader-spring-boot-common\n(Boot version-independent)"]
     SB3["leader-spring-boot3\n(planned)"]
     SB4["leader-spring-boot4\n(planned)"]
     Metrics["leader-micrometer\n(planned)"]
@@ -43,8 +44,9 @@ graph TD
     ExposedJdbc --> ExposedCore
     ExposedR2dbc --> ExposedCore
     Mongo --> Core
-    SB3 --> Core
-    SB4 --> Core
+    SBCommon --> Core
+    SB3 --> SBCommon
+    SB4 --> SBCommon
     Metrics --> Core
 ```
 
@@ -61,6 +63,7 @@ graph TD
 | `leader-exposed-r2dbc` | Planned | Exposed R2DBC backend |
 | `leader-mongodb` | Planned | MongoDB backend |
 | `leader-micrometer` | Planned | Micrometer metrics integration |
+| `leader-spring-boot-common` | Stable | Boot version-independent properties + auto-config support |
 | `leader-spring-boot3` | Planned | Spring Boot 3 auto-configuration |
 | `leader-spring-boot4` | Planned | Spring Boot 4 auto-configuration |
 

--- a/leader-core/README.ko.md
+++ b/leader-core/README.ko.md
@@ -150,7 +150,7 @@ sequenceDiagram
 전략 기반 선출은 **후보 등록 단계**와 **전략 적용 단계**를 분리하여 유연한 리더 선출 정책을 가능하게 합니다.
 
 ```
-registerCandidate() → selectLeader(strategy) → 1명 선출, 나머지 skip
+registerCandidate() → elect(strategy) → 1명 선출, 나머지 skip
 ```
 
 ### 내장 전략

--- a/leader-core/README.md
+++ b/leader-core/README.md
@@ -150,7 +150,7 @@ All local implementations use JVM primitives (`ReentrantLock`, `Semaphore`) — 
 Strategic election separates the **nomination phase** (candidate registration) from the **decision phase** (strategy application), enabling flexible leader selection policies.
 
 ```
-registerCandidate() → selectLeader(strategy) → 1 winner, rest skipped
+registerCandidate() → elect(strategy) → 1 winner, rest skipped
 ```
 
 ### Built-in Strategies

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderElection.kt
@@ -13,12 +13,29 @@ import java.time.Duration
  * ## 선출 흐름
  * 1. [registerCandidate] 로 후보 등록
  * 2. [listCandidates] 로 현재 후보 목록 조회
- * 3. [ElectionStrategy.selectLeader] 로 winner 결정
+ * 3. [ElectionStrategy.elect] 로 winner 결정
  * 4. winner 이면 action 실행, 아니면 null 반환
  *
  * ## 분산 일관성 주의
  * 모든 노드가 동일한 후보 목록에 결정론적 전략을 적용하면 동일 winner 를 계산합니다.
  * 단, 후보 등록/조회 시점 차이로 인한 불일치는 백엔드 구현에서 처리해야 합니다.
+ *
+ * ## 사용 예제
+ *
+ * ```kotlin
+ * val election = LocalStrategicLeaderElection("node-1")
+ *
+ * // 1. 후보 등록 — 분산 환경에서는 heartbeat 주기로 갱신
+ * election.registerCandidate("nightly-job", CandidateInfo(election.nodeId))
+ *
+ * // 2. ScoredElectionStrategy + IdleTimeScorer — 가장 오래 쉰 노드 선출
+ * val strategy = ScoredElectionStrategy(IdleTimeScorer)
+ *
+ * // 3. 선출되면 action 실행, 아니면 null
+ * val result: Report? = election.runIfLeader("nightly-job", strategy) {
+ *     generateNightlyReport()
+ * }
+ * ```
  */
 interface StrategicLeaderElection {
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElection.kt
@@ -35,10 +35,10 @@ class LocalStrategicLeaderElection(
     private val locks = ConcurrentHashMap<String, ReentrantLock>()
 
     private fun candidatesFor(lockName: String): ConcurrentHashMap<String, CandidateInfo> =
-        registry.getOrPut(lockName) { ConcurrentHashMap() }
+        registry.computeIfAbsent(lockName) { ConcurrentHashMap() }
 
     private fun lockFor(lockName: String): ReentrantLock =
-        locks.getOrPut(lockName) { ReentrantLock() }
+        locks.computeIfAbsent(lockName) { ReentrantLock() }
 
     override fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
         candidatesFor(lockName)[info.nodeId] = info

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElection.kt
@@ -35,10 +35,10 @@ class LocalStrategicSuspendLeaderElection(
     private val mutexes = ConcurrentHashMap<String, Mutex>()
 
     private fun candidatesFor(lockName: String): ConcurrentHashMap<String, CandidateInfo> =
-        registry.getOrPut(lockName) { ConcurrentHashMap() }
+        registry.computeIfAbsent(lockName) { ConcurrentHashMap() }
 
     private fun mutexFor(lockName: String): Mutex =
-        mutexes.getOrPut(lockName) { Mutex() }
+        mutexes.computeIfAbsent(lockName) { Mutex() }
 
     override suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
         candidatesFor(lockName)[info.nodeId] = info

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/ElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/ElectionStrategy.kt
@@ -7,6 +7,26 @@ package io.bluetape4k.leader.strategy
  * 이를 통해 분산 환경에서 각 노드가 독립적으로 동일한 winner를 계산할 수 있습니다.
  *
  * 동점 발생 시 기본 tie-breaker: `registeredAt` 오름차순 → `nodeId` 사전순.
+ *
+ * ## 내장 전략
+ * - [io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy] — 가장 먼저 등록된 후보
+ * - [io.bluetape4k.leader.strategy.strategies.RandomElectionStrategy] — 결정론적 랜덤 (seed 필요)
+ * - [io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy] — 점수 최대 후보
+ *
+ * ## 커스텀 전략 예제
+ *
+ * ```kotlin
+ * // 짝수 nodeId 만 winner 후보로 인정하는 전략
+ * object EvenNodeStrategy : ElectionStrategy {
+ *     override fun elect(candidates: List<CandidateInfo>): ElectionResult {
+ *         val even = candidates.filter { it.nodeId.last().digitToIntOrNull()?.rem(2) == 0 }
+ *         val winner = even.minByOrNull { it.registeredAt } ?: return ElectionResult.EMPTY
+ *         val eliminations = candidates.filter { it.nodeId != winner.nodeId }
+ *             .map { Elimination(it, "홀수 nodeId") }
+ *         return ElectionResult(winner, eliminations)
+ *     }
+ * }
+ * ```
  */
 interface ElectionStrategy {
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/IdleTimeScorer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/IdleTimeScorer.kt
@@ -11,6 +11,13 @@ import io.bluetape4k.leader.strategy.CandidateScorer
  *
  * 점수는 후보 풀 내 최대 idle 시간을 기준으로 0.0 ~ 100.0 범위로 정규화됩니다.
  * [WeightedScorer] 와 다른 scorer 를 함께 사용할 때 단위 통일을 위함입니다.
+ *
+ * ```kotlin
+ * val strategy = ScoredElectionStrategy(IdleTimeScorer)
+ * election.runIfLeader("rotating-batch", strategy) {
+ *     processBatch()
+ * }
+ * ```
  */
 object IdleTimeScorer : CandidateScorer {
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/RecentSuccessScorer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/RecentSuccessScorer.kt
@@ -11,6 +11,15 @@ import io.bluetape4k.leader.strategy.CandidateScorer
  * - 마지막 실행이 실패 또는 이력 없음: 0.0
  *
  * 직전 작업이 성공한 노드를 재선출하여 연속 성공 가능성을 높입니다.
+ *
+ * ```kotlin
+ * // sticky leader: 성공한 노드 우선 + 일부 부하 분산
+ * val scorer = WeightedScorer(
+ *     RecentSuccessScorer to 0.7,
+ *     IdleTimeScorer to 0.3,
+ * )
+ * val strategy = ScoredElectionStrategy(scorer)
+ * ```
  */
 object RecentSuccessScorer : CandidateScorer {
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/SuccessRateScorer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/SuccessRateScorer.kt
@@ -8,6 +8,12 @@ import io.bluetape4k.leader.strategy.CandidateScorer
  *
  * 실행 이력이 없는 노드는 성공률 0.0으로 처리됩니다.
  * 복원력(Resilience) 목적으로 안정적인 노드를 선호합니다.
+ *
+ * ```kotlin
+ * // 안정성 우선: 성공률이 가장 높은 노드 선출
+ * val strategy = ScoredElectionStrategy(SuccessRateScorer)
+ * election.runIfLeader("payment-job", strategy) { processPayments() }
+ * ```
  */
 object SuccessRateScorer : CandidateScorer {
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/WeightedScorer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/WeightedScorer.kt
@@ -19,6 +19,13 @@ class WeightedScorer(
     val scorers: List<Pair<CandidateScorer, Double>>,
 ) : CandidateScorer {
 
+    init {
+        require(scorers.isNotEmpty()) { "WeightedScorer requires at least one scorer" }
+        require(scorers.all { (_, w) -> w > 0.0 }) {
+            "All scorer weights must be positive: ${scorers.map { it.second }}"
+        }
+    }
+
     constructor(vararg scorers: Pair<CandidateScorer, Double>) : this(scorers.toList())
 
     override fun score(candidate: CandidateInfo, all: List<CandidateInfo>): Double =

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/ScoredElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/ScoredElectionStrategy.kt
@@ -18,8 +18,9 @@ class ScoredElectionStrategy(val scorer: CandidateScorer) : ElectionStrategy {
     override fun elect(candidates: List<CandidateInfo>): ElectionResult {
         if (candidates.isEmpty()) return ElectionResult.EMPTY
         val scores = candidates.associateWith { scorer.score(it, candidates) }
-        val maxScore = scores.values.max()
+        val maxScore = scores.values.maxOrNull() ?: return ElectionResult.EMPTY
         val topCandidates = candidates.filter { scores[it] == maxScore }
+        if (topCandidates.isEmpty()) return ElectionResult.EMPTY
         val winner = topCandidates.minWith(
             compareBy(CandidateInfo::registeredAt).thenBy(CandidateInfo::nodeId)
         )

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElectionTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElectionTest.kt
@@ -7,10 +7,13 @@ import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
 import io.bluetape4k.leader.strategy.scorers.WeightedScorer
 import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
 import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
+import kotlinx.coroutines.CancellationException
+import org.amshove.kluent.invoking
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.shouldThrow
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -275,5 +278,34 @@ class LocalStrategicLeaderElectionTest {
         node3.runIfLeader(lockName, strategy) { counter.incrementAndGet() }
 
         counter.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `CancellationException은 failureCount를 증가시키지 않고 전파된다`() {
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        invoking {
+            node1.runIfLeader(lockName, FifoElectionStrategy) {
+                throw CancellationException("작업 취소됨")
+            }
+        } shouldThrow CancellationException::class
+
+        val info = node1.listCandidates(lockName).first { it.nodeId == node1.nodeId }
+        info.failureCount shouldBeEqualTo 0L
+        info.successCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `일반 예외는 failureCount 증가 후 전파된다`() {
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        invoking {
+            node1.runIfLeader(lockName, FifoElectionStrategy) {
+                error("boom")
+            }
+        } shouldThrow IllegalStateException::class
+
+        val info = node1.listCandidates(lockName).first { it.nodeId == node1.nodeId }
+        info.failureCount shouldBeEqualTo 1L
     }
 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/strategy/ElectionStrategyTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/strategy/ElectionStrategyTest.kt
@@ -1,8 +1,12 @@
 package io.bluetape4k.leader.strategy
 
 import io.bluetape4k.leader.strategy.scorers.IdleTimeScorer
+import io.bluetape4k.leader.strategy.scorers.RecentSuccessScorer
 import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
 import io.bluetape4k.leader.strategy.scorers.WeightedScorer
+import org.amshove.kluent.invoking
+import org.amshove.kluent.shouldBeIn
+import org.amshove.kluent.shouldThrow
 import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
 import io.bluetape4k.leader.strategy.strategies.RandomElectionStrategy
 import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
@@ -172,5 +176,122 @@ class ElectionStrategyTest {
     @Test
     fun `Scored - 후보 없으면 null 반환`() {
         ScoredElectionStrategy(IdleTimeScorer).elect(emptyList()).winner.shouldBeNull()
+    }
+
+    @Test
+    fun `Scored - 모든 후보 점수 0 (이력 없음) tie-breaker로 선출`() {
+        val candidates = listOf(
+            candidate("z", registeredAt = t1),
+            candidate("a", registeredAt = t0),
+            candidate("m", registeredAt = t0),
+        )
+        val winner = ScoredElectionStrategy(SuccessRateScorer).elect(candidates).winner
+        winner.shouldNotBeNull()
+        winner.nodeId shouldBeEqualTo "a"
+    }
+
+    // ── RecentSuccessScorer ──────────────────────────────────────────────────
+
+    @Test
+    fun `RecentSuccess - successCount 0 이면 점수 0`() {
+        val now = Instant.now()
+        val c = candidate("x", successCount = 0, lastCompletionTime = now)
+        RecentSuccessScorer.score(c, listOf(c)) shouldBeEqualTo 0.0
+    }
+
+    @Test
+    fun `RecentSuccess - lastCompletionTime null 이면 점수 0`() {
+        val c = candidate("x", successCount = 5, lastCompletionTime = null)
+        RecentSuccessScorer.score(c, listOf(c)) shouldBeEqualTo 0.0
+    }
+
+    @Test
+    fun `RecentSuccess - lastCompletion이 lastStart보다 이전이면 점수 0 (실행 중)`() {
+        val now = Instant.now()
+        val c = CandidateInfo(
+            nodeId = "x",
+            registeredAt = t0,
+            lastStartTime = now,
+            lastCompletionTime = now.minusSeconds(10),
+            successCount = 5,
+        )
+        RecentSuccessScorer.score(c, listOf(c)) shouldBeEqualTo 0.0
+    }
+
+    @Test
+    fun `RecentSuccess - 단일 성공 후보는 100점`() {
+        val now = Instant.now()
+        val c = candidate("only", successCount = 1, lastCompletionTime = now)
+        RecentSuccessScorer.score(c, listOf(c)) shouldBeEqualTo 100.0
+    }
+
+    @Test
+    fun `RecentSuccess - 동일 시각 다수 후보 모두 100점`() {
+        val now = Instant.now()
+        val a = candidate("a", successCount = 1, lastCompletionTime = now)
+        val b = candidate("b", successCount = 1, lastCompletionTime = now)
+        val all = listOf(a, b)
+        RecentSuccessScorer.score(a, all) shouldBeEqualTo 100.0
+        RecentSuccessScorer.score(b, all) shouldBeEqualTo 100.0
+    }
+
+    @Test
+    fun `RecentSuccess - 가장 최근 완료 후보가 가장 높은 점수`() {
+        val now = Instant.now()
+        val recent = candidate("recent", successCount = 1, lastCompletionTime = now)
+        val older = candidate("older", successCount = 1, lastCompletionTime = now.minusSeconds(100))
+        val candidates = listOf(older, recent)
+        val recentScore = RecentSuccessScorer.score(recent, candidates)
+        val olderScore = RecentSuccessScorer.score(older, candidates)
+        recentScore shouldBeEqualTo 100.0
+        olderScore shouldBeEqualTo 0.0
+    }
+
+    @Test
+    fun `RecentSuccess - 모든 후보가 successCount 0 이면 모두 0점`() {
+        val a = candidate("a", successCount = 0, failureCount = 3)
+        val b = candidate("b", successCount = 0, failureCount = 5)
+        val all = listOf(a, b)
+        RecentSuccessScorer.score(a, all) shouldBeEqualTo 0.0
+        RecentSuccessScorer.score(b, all) shouldBeEqualTo 0.0
+    }
+
+    // ── RandomElectionStrategy (null seed) ─────────────────────────────────
+
+    @Test
+    fun `Random null seed - 단일 후보면 항상 자기 자신 선출`() {
+        val only = candidate("solo")
+        repeat(20) {
+            RandomElectionStrategy().elect(listOf(only)).winner?.nodeId shouldBeEqualTo "solo"
+        }
+    }
+
+    @Test
+    fun `Random null seed - winner는 항상 입력 리스트의 멤버`() {
+        val candidates = (1..5).map { candidate("n$it") }
+        val ids = candidates.map { it.nodeId }
+        val strategy = RandomElectionStrategy()
+        repeat(50) {
+            val w = strategy.elect(candidates).winner
+            w.shouldNotBeNull()
+            w.nodeId shouldBeIn ids
+        }
+    }
+
+    // ── WeightedScorer validation ─────────────────────────────────────────
+
+    @Test
+    fun `WeightedScorer - 빈 scorer 목록은 require 실패`() {
+        invoking { WeightedScorer(emptyList()) } shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `WeightedScorer - 음수 weight 는 require 실패`() {
+        invoking { WeightedScorer(IdleTimeScorer to -0.5) } shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `WeightedScorer - 0 weight 는 require 실패`() {
+        invoking { WeightedScorer(IdleTimeScorer to 0.0) } shouldThrow IllegalArgumentException::class
     }
 }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateInfoCodec.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateInfoCodec.kt
@@ -39,11 +39,41 @@ internal object LettuceCandidateInfoCodec {
         if (s.isEmpty()) return emptyMap()
         return s.split(",").associate { kv ->
             val idx = kv.indexOf("=")
-            if (idx < 0) kv.unesc() to ""
-            else kv.substring(0, idx).unesc() to kv.substring(idx + 1).unesc()
+            require(idx >= 0) { "metadata 항목에 '=' 가 없습니다: $kv" }
+            kv.substring(0, idx).unesc() to kv.substring(idx + 1).unesc()
         }
     }
 
     private fun String.esc() = replace("%", "%25").replace("|", "%7C").replace(",", "%2C").replace("=", "%3D")
-    private fun String.unesc() = replace("%7C", "|").replace("%2C", ",").replace("%3D", "=").replace("%25", "%")
+
+    /**
+     * 단일 패스 percent-decoder. 체이닝 [String.replace] 는 nested 토큰
+     * (예: 인코딩된 `%7C` = `%257C`) 에서 잘못된 결과를 낳으므로 직접 스캔합니다.
+     */
+    private fun String.unesc(): String {
+        if (isEmpty() || !contains('%')) return this
+        val sb = StringBuilder(length)
+        var i = 0
+        while (i < length) {
+            val c = this[i]
+            if (c == '%' && i + 2 < length) {
+                val token = substring(i + 1, i + 3)
+                val replaced = when (token) {
+                    "25" -> '%'
+                    "7C" -> '|'
+                    "2C" -> ','
+                    "3D" -> '='
+                    else -> null
+                }
+                if (replaced != null) {
+                    sb.append(replaced)
+                    i += 3
+                    continue
+                }
+            }
+            sb.append(c)
+            i++
+        }
+        return sb.toString()
+    }
 }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt
@@ -2,6 +2,8 @@ package io.bluetape4k.leader.lettuce
 
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
 import io.lettuce.core.ScanArgs
 import io.lettuce.core.ScanCursor
 import io.lettuce.core.SetArgs
@@ -25,6 +27,11 @@ import java.time.Duration
 internal class LettuceCandidateRegistry(
     private val connection: StatefulRedisConnection<String, String>,
 ) {
+    companion object: KLogging() {
+        /** Redis SCAN 페이지 크기 힌트. 상한이 아니라 페이지당 반환 키 개수 가이드입니다. */
+        private const val SCAN_PAGE_SIZE = 1000L
+    }
+
     private val sync = connection.sync()
 
     private fun candidateKey(lockName: String, nodeId: String) =
@@ -58,13 +65,23 @@ internal class LettuceCandidateRegistry(
         sync.del(candidateKey(lockName, nodeId))
     }
 
-    /** [lockName] 에 등록된 현재 후보 목록을 반환합니다. */
+    /**
+     * [lockName] 에 등록된 현재 후보 목록을 반환합니다.
+     *
+     * 손상된 단일 항목(잘못된 인코딩, 숫자 파싱 실패 등)은 경고 로그를 남기고 skip 합니다.
+     * 한 항목 때문에 전체 선출 라운드가 중단되지 않도록 보호합니다.
+     */
     fun listCandidates(lockName: String): List<CandidateInfo> {
         validateLockName(lockName)
         val keys = scanKeys(lockName)
         if (keys.isEmpty()) return emptyList()
         return sync.mget(*keys.toTypedArray())
-            .mapNotNull { kv -> kv.value?.let { LettuceCandidateInfoCodec.decode(it) } }
+            .mapNotNull { kv ->
+                val raw = kv.value ?: return@mapNotNull null
+                runCatching { LettuceCandidateInfoCodec.decode(raw) }
+                    .onFailure { log.warn(it) { "[$lockName] CandidateInfo 디코딩 실패 — 항목 skip: key=${kv.key}" } }
+                    .getOrNull()
+            }
     }
 
     /**
@@ -82,7 +99,7 @@ internal class LettuceCandidateRegistry(
     }
 
     private fun scanKeys(lockName: String): List<String> {
-        val args = ScanArgs.Builder.matches(keyPattern(lockName)).limit(1000)
+        val args = ScanArgs.Builder.matches(keyPattern(lockName)).limit(SCAN_PAGE_SIZE)
         val keys = mutableListOf<String>()
         var cursor: ScanCursor = ScanCursor.INITIAL
         do {

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElection.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElection.kt
@@ -66,7 +66,10 @@ class LettuceStrategicLeaderElection(
         options: LeaderElectionOptions,
         action: () -> T,
     ): T? {
-        val result = strategy.elect(listCandidates(lockName))
+        val candidates = runCatching { listCandidates(lockName) }
+            .onFailure { log.warn(it) { "[$lockName] 후보 목록 조회 실패 — 선출 skip" } }
+            .getOrElse { return null }
+        val result = strategy.elect(candidates)
         val winner = result.winner ?: return null
 
         val total = result.eliminations.size + 1

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElection.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElection.kt
@@ -65,7 +65,15 @@ class LettuceStrategicSuspendLeaderElection(
         options: LeaderElectionOptions,
         action: suspend () -> T,
     ): T? {
-        val result = strategy.elect(listCandidates(lockName))
+        val candidates = try {
+            listCandidates(lockName)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            log.warn(e) { "[$lockName] 후보 목록 조회 실패 — 선출 skip" }
+            return null
+        }
+        val result = strategy.elect(candidates)
         val winner = result.winner ?: return null
 
         val total = result.eliminations.size + 1

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt
@@ -4,6 +4,8 @@ package io.bluetape4k.leader.lettuce
 
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.ScanArgs
 import io.lettuce.core.ScanCursor
@@ -26,6 +28,11 @@ import java.time.Duration
 internal class LettuceSuspendCandidateRegistry(
     connection: StatefulRedisConnection<String, String>,
 ) {
+    companion object: KLogging() {
+        /** Redis SCAN 페이지 크기 힌트. 상한이 아니라 페이지당 반환 키 개수 가이드입니다. */
+        private const val SCAN_PAGE_SIZE = 1000L
+    }
+
     private val cmds: RedisCoroutinesCommands<String, String> = connection.coroutines()
 
     private fun candidateKey(lockName: String, nodeId: String) =
@@ -58,13 +65,22 @@ internal class LettuceSuspendCandidateRegistry(
         cmds.del(candidateKey(lockName, nodeId))
     }
 
-    /** [lockName] 에 등록된 현재 후보 목록을 반환합니다. */
+    /**
+     * [lockName] 에 등록된 현재 후보 목록을 반환합니다.
+     *
+     * 손상된 단일 항목(잘못된 인코딩, 숫자 파싱 실패 등)은 경고 로그를 남기고 skip 합니다.
+     */
     suspend fun listCandidates(lockName: String): List<CandidateInfo> {
         validateLockName(lockName)
         val keys = scanKeys(lockName)
         if (keys.isEmpty()) return emptyList()
         return cmds.mget(*keys.toTypedArray())
-            .mapNotNull { kv -> if (kv.hasValue()) LettuceCandidateInfoCodec.decode(kv.getValue()) else null }
+            .mapNotNull { kv ->
+                if (!kv.hasValue()) return@mapNotNull null
+                runCatching { LettuceCandidateInfoCodec.decode(kv.getValue()) }
+                    .onFailure { log.warn(it) { "[$lockName] CandidateInfo 디코딩 실패 — 항목 skip: key=${kv.key}" } }
+                    .getOrNull()
+            }
             .toList()
     }
 
@@ -82,7 +98,7 @@ internal class LettuceSuspendCandidateRegistry(
     }
 
     private suspend fun scanKeys(lockName: String): List<String> {
-        val args = ScanArgs.Builder.matches(keyPattern(lockName)).limit(1000)
+        val args = ScanArgs.Builder.matches(keyPattern(lockName)).limit(SCAN_PAGE_SIZE)
         val keys = mutableListOf<String>()
         var cursor: ScanCursor = ScanCursor.INITIAL
         do {

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateInfoCodecTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateInfoCodecTest.kt
@@ -1,0 +1,108 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.leader.strategy.CandidateInfo
+import org.amshove.kluent.invoking
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldThrow
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LettuceCandidateInfoCodecTest {
+
+    @Test
+    fun `roundtrip - 기본 필드 보존`() {
+        val original = CandidateInfo(
+            nodeId = "node-1",
+            registeredAt = Instant.parse("2026-04-30T10:00:00Z"),
+            lastStartTime = Instant.parse("2026-04-30T10:01:00Z"),
+            lastCompletionTime = Instant.parse("2026-04-30T10:02:00Z"),
+            successCount = 7,
+            failureCount = 3,
+            metadata = mapOf("region" to "ap-northeast-2", "version" to "1.0.0"),
+        )
+
+        val encoded = LettuceCandidateInfoCodec.encode(original)
+        val decoded = LettuceCandidateInfoCodec.decode(encoded)
+
+        decoded shouldBeEqualTo original
+    }
+
+    @Test
+    fun `roundtrip - null 시각 필드 보존`() {
+        val original = CandidateInfo(nodeId = "n1", registeredAt = Instant.now())
+        val encoded = LettuceCandidateInfoCodec.encode(original)
+        val decoded = LettuceCandidateInfoCodec.decode(encoded)
+        decoded.lastStartTime shouldBeEqualTo null
+        decoded.lastCompletionTime shouldBeEqualTo null
+        decoded.metadata shouldBeEqualTo emptyMap()
+    }
+
+    @Test
+    fun `roundtrip - metadata 값에 percent encoded 토큰 리터럴 포함 (CRITICAL 회귀 테스트)`() {
+        // 인코딩된 `%7C` (즉, 사용자 입력이 `%7C` 문자열) 처리: 잘못된 unesc 순서면 깨짐
+        val original = CandidateInfo(
+            nodeId = "node",
+            registeredAt = Instant.now(),
+            metadata = mapOf(
+                "literal-7C" to "%7C",
+                "literal-2C" to "%2C",
+                "literal-25" to "%25",
+                "literal-3D" to "%3D",
+            ),
+        )
+
+        val encoded = LettuceCandidateInfoCodec.encode(original)
+        val decoded = LettuceCandidateInfoCodec.decode(encoded)
+
+        decoded.metadata["literal-7C"] shouldBeEqualTo "%7C"
+        decoded.metadata["literal-2C"] shouldBeEqualTo "%2C"
+        decoded.metadata["literal-25"] shouldBeEqualTo "%25"
+        decoded.metadata["literal-3D"] shouldBeEqualTo "%3D"
+    }
+
+    @Test
+    fun `roundtrip - 구분자 문자(특수문자) metadata 값 안전 처리`() {
+        val original = CandidateInfo(
+            nodeId = "node",
+            registeredAt = Instant.now(),
+            metadata = mapOf(
+                "delim-pipe" to "a|b|c",
+                "delim-comma" to "a,b,c",
+                "delim-equal" to "a=b=c",
+                "delim-percent" to "100%",
+                "all" to "a|b,c=d%e",
+            ),
+        )
+
+        val encoded = LettuceCandidateInfoCodec.encode(original)
+        val decoded = LettuceCandidateInfoCodec.decode(encoded)
+
+        decoded.metadata shouldBeEqualTo original.metadata
+    }
+
+    @Test
+    fun `roundtrip - nodeId 에 모든 구분자 포함`() {
+        val original = CandidateInfo(
+            nodeId = "weird|node,id=1%v",
+            registeredAt = Instant.parse("2026-04-30T10:00:00Z"),
+        )
+        val encoded = LettuceCandidateInfoCodec.encode(original)
+        val decoded = LettuceCandidateInfoCodec.decode(encoded)
+        decoded.nodeId shouldBeEqualTo "weird|node,id=1%v"
+    }
+
+    @Test
+    fun `decode - 잘못된 포맷이면 IllegalArgumentException`() {
+        invoking { LettuceCandidateInfoCodec.decode("only|three|fields") } shouldThrow IllegalArgumentException::class
+    }
+
+    @Test
+    fun `decode - 손상된 metadata 항목(=없음) IllegalArgumentException`() {
+        // 7개 필드 형식은 맞지만 metadata 마지막 필드의 한 항목에 = 가 없음
+        val now = Instant.now().toEpochMilli()
+        val malformed = "node|$now|||0|0|key1=val1,brokenpair"
+        invoking { LettuceCandidateInfoCodec.decode(malformed) } shouldThrow IllegalArgumentException::class
+    }
+}

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.redisson
 
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.logging.KLogging
 import org.redisson.api.RedissonClient
 import java.time.Duration
 import java.util.concurrent.TimeUnit
@@ -21,6 +22,8 @@ import java.util.concurrent.TimeUnit
  * @param redissonClient Redisson 클라이언트
  */
 internal class RedissonCandidateRegistry(private val redissonClient: RedissonClient) {
+
+    companion object: KLogging()
 
     private fun cacheKey(lockName: String) = "leader:strategy:candidates:$lockName"
 

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElection.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElection.kt
@@ -56,7 +56,10 @@ class RedissonStrategicLeaderElection(
         options: LeaderElectionOptions,
         action: () -> T,
     ): T? {
-        val result = strategy.elect(listCandidates(lockName))
+        val candidates = runCatching { listCandidates(lockName) }
+            .onFailure { log.warn(it) { "[$lockName] 후보 목록 조회 실패 — 선출 skip" } }
+            .getOrElse { return null }
+        val result = strategy.elect(candidates)
         val winner = result.winner ?: return null
 
         val total = result.eliminations.size + 1

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElection.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElection.kt
@@ -52,7 +52,15 @@ class RedissonStrategicSuspendLeaderElection(
         options: LeaderElectionOptions,
         action: suspend () -> T,
     ): T? {
-        val result = strategy.elect(listCandidates(lockName))
+        val candidates = try {
+            listCandidates(lockName)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            log.warn(e) { "[$lockName] 후보 목록 조회 실패 — 선출 skip" }
+            return null
+        }
+        val result = strategy.elect(candidates)
         val winner = result.winner ?: return null
 
         val total = result.eliminations.size + 1

--- a/leader-spring-boot-common/src/test/kotlin/io/bluetape4k/leader/spring/config/LeaderElectionConfigSupportTest.kt
+++ b/leader-spring-boot-common/src/test/kotlin/io/bluetape4k/leader/spring/config/LeaderElectionConfigSupportTest.kt
@@ -1,0 +1,48 @@
+package io.bluetape4k.leader.spring.config
+
+import io.bluetape4k.leader.spring.properties.LeaderElectionProperties
+import io.bluetape4k.leader.spring.properties.LeaderGroupProperties
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderElectionConfigSupportTest {
+
+    private class TestSupport(private val props: LeaderElectionProperties) : LeaderElectionConfigSupport() {
+        override fun properties(): LeaderElectionProperties = props
+        fun exposedElectionOptions() = electionOptions()
+        fun exposedGroupElectionOptions() = groupElectionOptions()
+    }
+
+    @Test
+    fun `electionOptions 가 properties로 부터 LeaderElectionOptions 생성`() {
+        val support = TestSupport(
+            LeaderElectionProperties(
+                waitTime = Duration.ofSeconds(7),
+                leaseTime = Duration.ofMinutes(1),
+            ),
+        )
+        val options = support.exposedElectionOptions()
+        options.waitTime shouldBeEqualTo Duration.ofSeconds(7)
+        options.leaseTime shouldBeEqualTo Duration.ofMinutes(1)
+    }
+
+    @Test
+    fun `groupElectionOptions 가 group 속성으로부터 옵션 생성`() {
+        val support = TestSupport(
+            LeaderElectionProperties(
+                group = LeaderGroupProperties(
+                    maxLeaders = 4,
+                    waitTime = Duration.ofSeconds(1),
+                    leaseTime = Duration.ofSeconds(30),
+                ),
+            ),
+        )
+        val options = support.exposedGroupElectionOptions()
+        options.maxLeaders shouldBeEqualTo 4
+        options.waitTime shouldBeEqualTo Duration.ofSeconds(1)
+        options.leaseTime shouldBeEqualTo Duration.ofSeconds(30)
+    }
+}

--- a/leader-spring-boot-common/src/test/kotlin/io/bluetape4k/leader/spring/properties/LeaderElectionPropertiesTest.kt
+++ b/leader-spring-boot-common/src/test/kotlin/io/bluetape4k/leader/spring/properties/LeaderElectionPropertiesTest.kt
@@ -1,0 +1,39 @@
+package io.bluetape4k.leader.spring.properties
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderElectionPropertiesTest {
+
+    @Test
+    fun `기본값으로 LeaderElectionOptions 생성`() {
+        val props = LeaderElectionProperties()
+        val options = props.toOptions()
+
+        options.waitTime shouldBeEqualTo Duration.ofSeconds(5)
+        options.leaseTime shouldBeEqualTo Duration.ofSeconds(60)
+    }
+
+    @Test
+    fun `사용자 지정 값 매핑`() {
+        val props = LeaderElectionProperties(
+            waitTime = Duration.ofSeconds(3),
+            leaseTime = Duration.ofSeconds(120),
+        )
+        val options = props.toOptions()
+
+        options.waitTime shouldBeEqualTo Duration.ofSeconds(3)
+        options.leaseTime shouldBeEqualTo Duration.ofSeconds(120)
+    }
+
+    @Test
+    fun `group 속성 기본값`() {
+        val props = LeaderElectionProperties()
+        props.group.maxLeaders shouldBeEqualTo 2
+        props.group.waitTime shouldBeEqualTo Duration.ofSeconds(5)
+        props.group.leaseTime shouldBeEqualTo Duration.ofSeconds(60)
+    }
+}

--- a/leader-spring-boot-common/src/test/kotlin/io/bluetape4k/leader/spring/properties/LeaderGroupPropertiesTest.kt
+++ b/leader-spring-boot-common/src/test/kotlin/io/bluetape4k/leader/spring/properties/LeaderGroupPropertiesTest.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.leader.spring.properties
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderGroupPropertiesTest {
+
+    @Test
+    fun `기본값으로 LeaderGroupElectionOptions 생성`() {
+        val props = LeaderGroupProperties()
+        val options = props.toOptions()
+
+        options.maxLeaders shouldBeEqualTo 2
+        options.waitTime shouldBeEqualTo Duration.ofSeconds(5)
+        options.leaseTime shouldBeEqualTo Duration.ofSeconds(60)
+    }
+
+    @Test
+    fun `사용자 지정 값 매핑`() {
+        val props = LeaderGroupProperties(
+            maxLeaders = 5,
+            waitTime = Duration.ofSeconds(2),
+            leaseTime = Duration.ofMinutes(2),
+        )
+        val options = props.toOptions()
+
+        options.maxLeaders shouldBeEqualTo 5
+        options.waitTime shouldBeEqualTo Duration.ofSeconds(2)
+        options.leaseTime shouldBeEqualTo Duration.ofMinutes(2)
+    }
+}


### PR DESCRIPTION
## Summary

PR #45의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: daily review 2026-05-01 — 6-Tier 코드 리뷰 결과 반영`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

지난 24시간 변경된 코드 (StrategicLeaderElection / leader-hazelcast / leader-spring-boot-common 등)에 대해 bluetape4k-design Step 6-R 6-Tier 코드 리뷰 중 5개 리뷰 에이전트 (security / ops-reliability / kotlin-quality / test+silent-failure / perf+stability) 를 병렬 실행하고 그 결과를 반영했습니다.

## CRITICAL — 수정 1건

- **`LettuceCandidateInfoCodec.unesc()` percent-decode 버그**: chained `String.replace` 가 nested percent 토큰(예: 인코딩된 `%7C` = `%257C`) 을 올바르게 복원하지 못해 metadata 가 손상되던 버그. 단일패스 디코더로 재작성하고 회귀 테스트를 추가했습니다.

## HIGH — 수정 5건

- `LocalStrategicLeaderElection` / `LocalStrategicSuspendLeaderElection`: `ConcurrentHashMap.getOrPut` 은 비원자적이라 동시 진입 시 중복 `ReentrantLock`/`Mutex` 가 생성될 수 있는 점을 `computeIfAbsent` 로 수정.
- `StrategicLeaderElection` KDoc: stale `selectLeader` 참조 → `elect`.
- Lettuce/Redisson `runIfLeader`: `listCandidates()` Redis 예외 시 `runCatching + warn 로그 + null 반환` — "never throws on contention" 계약 준수.
- `LettuceCandidateRegistry`/`LettuceSuspendCandidateRegistry.listCandidates`: 단일 항목 디코딩 실패가 전체 선출 라운드를 중단시키지 않도록 항목별 `runCatching` + skip + warn.
- `LettuceCandidateInfoCodec.decodeMeta`: '=' 없는 metadata 항목은 silent drop 대신 `require` 로 실패하도록 변경.

## MEDIUM — 수정 4건

- `ScoredElectionStrategy.elect`: `maxOrNull` + `topCandidates.isEmpty()` 가드.
- `WeightedScorer`: 빈 scorer 목록 / 비양수 weight `init` 검증 추가.
- `LettuceCandidate(Suspend)Registry`: 매직 넘버 1000 → `SCAN_PAGE_SIZE` 명명 상수.
- `RedissonCandidateRegistry`: `companion object: KLogging()` 추가.

## 누락 테스트 추가

| 파일 | 추가 케이스 |
|------|-------|
| `LettuceCandidateInfoCodecTest` (신규) | roundtrip 기본/null/특수문자/구분자, percent-decode CRITICAL 회귀, 잘못된 포맷, 손상된 metadata 항목 (총 7개) |
| `ElectionStrategyTest` | `RecentSuccessScorer` 7 시나리오 + `RandomElectionStrategy(null)` 2 + `WeightedScorer` 검증 3 + `ScoredElectionStrategy` tie-breaker (총 13) |
| `LocalStrategicLeaderElectionTest` | `CancellationException` 미실패 처리 + 일반 예외 `failureCount` 증가 (2) |
| `leader-spring-boot-common` 신설 | `LeaderElectionPropertiesTest`, `LeaderGroupPropertiesTest`, `LeaderElectionConfigSupportTest` (총 7) |

## KDoc 예제 강화

`StrategicLeaderElection`, `ElectionStrategy`, `IdleTimeScorer`, `RecentSuccessScorer`, `SuccessRateScorer` 에 실사용 예제 코드블록을 추가했습니다.

## README 동기화

- 루트 `README.md` / `README.ko.md`: `leader-spring-boot-common` 모듈을 모듈 표/의존 그래프에 추가.
- `leader-core/README.md` / `README.ko.md`: stale `selectLeader` → `elect`.

## Test plan

- [x] `./gradlew :leader-core:test :leader-spring-boot-common:test` — 215 passing
- [x] `./gradlew :leader-redis-lettuce:test --tests "...LettuceCandidateInfoCodecTest"` — 7 passing (Redis 불필요)
- [x] 전 모듈 `compileKotlin` / `compileTestKotlin` 통과
- [x] CI 에서 `leader-redis-lettuce` / `leader-redis-redisson` / `leader-hazelcast` Testcontainers 통합 테스트 — CI 잡에 위임

## 리뷰 보고서 출처

5개 리뷰 에이전트 (Sonnet) 병렬 실행 — 자세한 내용은 커밋 메시지 참조.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #45, head `6437eb704f16d4c5f2698f3c81f38ed4b1c18e05`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
