### PR TITLE
fix: leader-mongodb 6-Tier 코드리뷰 반영 (daily review 2026-05-02)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -31,7 +31,7 @@ graph TD
     ExposedCore["leader-exposed-core\n(예정)"]
     ExposedJdbc["leader-exposed-jdbc\n(예정)"]
     ExposedR2dbc["leader-exposed-r2dbc\n(예정)"]
-    Mongo["leader-mongodb\n(예정)"]
+    Mongo["leader-mongodb\n(MongoDB)"]
     SBCommon["leader-spring-boot-common\n(Boot 버전 독립)"]
     SB3["leader-spring-boot3\n(예정)"]
     SB4["leader-spring-boot4\n(예정)"]
@@ -61,7 +61,7 @@ graph TD
 | `leader-exposed-core` | 예정 | Exposed 공통 스키마 (JDBC/R2DBC 드라이버 미포함) |
 | `leader-exposed-jdbc` | 예정 | Exposed JDBC 백엔드 |
 | `leader-exposed-r2dbc` | 예정 | Exposed R2DBC 백엔드 |
-| `leader-mongodb` | 예정 | MongoDB 백엔드 |
+| `leader-mongodb` | 안정 | MongoDB 백엔드 (`findOneAndUpdate` + TTL 인덱스) |
 | `leader-micrometer` | 예정 | Micrometer 메트릭 연동 |
 | `leader-spring-boot-common` | 안정 | Boot 버전 독립 속성 + 자동 구성 지원 클래스 |
 | `leader-spring-boot3` | 예정 | Spring Boot 3 자동 구성 |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ graph TD
     ExposedCore["leader-exposed-core\n(planned)"]
     ExposedJdbc["leader-exposed-jdbc\n(planned)"]
     ExposedR2dbc["leader-exposed-r2dbc\n(planned)"]
-    Mongo["leader-mongodb\n(planned)"]
+    Mongo["leader-mongodb\n(MongoDB)"]
     SBCommon["leader-spring-boot-common\n(Boot version-independent)"]
     SB3["leader-spring-boot3\n(planned)"]
     SB4["leader-spring-boot4\n(planned)"]
@@ -61,7 +61,7 @@ graph TD
 | `leader-exposed-core` | Planned | Common Exposed schema (no JDBC/R2DBC driver) |
 | `leader-exposed-jdbc` | Planned | Exposed JDBC backend |
 | `leader-exposed-r2dbc` | Planned | Exposed R2DBC backend |
-| `leader-mongodb` | Planned | MongoDB backend |
+| `leader-mongodb` | Stable | MongoDB backend (`findOneAndUpdate` + TTL index) |
 | `leader-micrometer` | Planned | Micrometer metrics integration |
 | `leader-spring-boot-common` | Stable | Boot version-independent properties + auto-config support |
 | `leader-spring-boot3` | Planned | Spring Boot 3 auto-configuration |

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElectionOptions.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElectionOptions.kt
@@ -21,22 +21,19 @@ import java.time.Duration
  * ```
  *
  * @property leaderOptions 단일 리더 선출 옵션 (waitTime, leaseTime)
- * @property retryDelay 락 획득 재시도 대기 기본 시간 (jitter 적용 전). 기본값 50ms
- * @property releaseTimeout suspend 코드에서 락 해제 시 적용할 타임아웃. 기본값 5초
+ * @property retryDelay 락 획득 재시도 시 적용할 full jitter 상한 (`[1ms, retryDelay)` 균등 분포). 기본값 50ms
  */
 data class MongoLeaderElectionOptions(
     val leaderOptions: LeaderElectionOptions = LeaderElectionOptions.Default,
     val retryDelay: Duration = Duration.ofMillis(50),
-    val releaseTimeout: Duration = Duration.ofSeconds(5),
 ) : Serializable {
     init {
         require(retryDelay > Duration.ZERO) { "retryDelay must be positive: $retryDelay" }
-        require(releaseTimeout > Duration.ZERO) { "releaseTimeout must be positive: $releaseTimeout" }
     }
 
     companion object {
         /**
-         * 기본 옵션 인스턴스 (`waitTime=5s`, `leaseTime=60s`, `retryDelay=50ms`, `releaseTimeout=5s`).
+         * 기본 옵션 인스턴스 (`waitTime=5s`, `leaseTime=60s`, `retryDelay=50ms`).
          */
         @JvmField
         val Default = MongoLeaderElectionOptions()

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderGroupElection.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderGroupElection.kt
@@ -63,10 +63,10 @@ class MongoLeaderGroupElection private constructor(
      * **주의:** 이 값은 근사치입니다. TTL 만료 주기(최대 60초) 동안 만료 문서가 잔류할 수 있습니다.
      */
     override fun activeCount(lockName: String): Int {
-        val pattern = Regex.escape(lockName) + ":slot:\\d+$"
+        val ids = (0 until maxLeaders).map { slotKey(lockName, it) }
         return groupCollection.countDocuments(
             Filters.and(
-                Filters.regex("_id", "^$pattern"),
+                Filters.`in`("_id", ids),
                 Filters.gt("expireAt", Date())
             )
         ).toInt()

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderGroupElectionOptions.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderGroupElectionOptions.kt
@@ -18,13 +18,11 @@ import java.time.Duration
  * ```
  *
  * @property leaderGroupOptions 그룹 리더 선출 옵션 (maxLeaders, waitTime, leaseTime)
- * @property retryDelay 락 획득 재시도 대기 기본 시간 (jitter 적용 전). 기본값 50ms
- * @property releaseTimeout suspend 코드에서 락 해제 시 적용할 타임아웃. 기본값 5초
+ * @property retryDelay 락 획득 재시도 시 적용할 full jitter 상한 (`[1ms, retryDelay)` 균등 분포). 기본값 50ms
  */
 data class MongoLeaderGroupElectionOptions(
     val leaderGroupOptions: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
     val retryDelay: Duration = Duration.ofMillis(50),
-    val releaseTimeout: Duration = Duration.ofSeconds(5),
 ) : Serializable {
 
     /** 허용하는 최대 동시 리더 수 ([LeaderGroupElectionOptions.maxLeaders] 위임). */
@@ -33,7 +31,6 @@ data class MongoLeaderGroupElectionOptions(
     init {
         require(maxLeaders > 0) { "maxLeaders must be positive: $maxLeaders" }
         require(retryDelay > Duration.ZERO) { "retryDelay must be positive: $retryDelay" }
-        require(releaseTimeout > Duration.ZERO) { "releaseTimeout must be positive: $releaseTimeout" }
     }
 
     companion object {

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderGroupElection.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderGroupElection.kt
@@ -5,7 +5,6 @@ import com.mongodb.client.model.Filters
 import com.mongodb.kotlin.client.coroutine.MongoCollection as CoroutineMongoCollection
 import io.bluetape4k.leader.LeaderGroupState
 import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElection
-import io.bluetape4k.leader.mongodb.lock.MongoLock
 import io.bluetape4k.leader.mongodb.lock.MongoSuspendLock
 import io.bluetape4k.leader.mongodb.lock.validateLockName
 import io.bluetape4k.logging.coroutines.KLoggingChannel
@@ -62,7 +61,7 @@ class MongoSuspendLeaderGroupElection private constructor(
             coroutineGroupCollection: CoroutineMongoCollection<Document>,
             options: MongoLeaderGroupElectionOptions = MongoLeaderGroupElectionOptions.Default,
         ): MongoSuspendLeaderGroupElection {
-            MongoLock.ensureIndexes(groupCollection)
+            // 두 컬렉션은 동일 namespace이므로 coroutine 드라이버에서 한 번만 인덱스 생성하면 충분
             MongoSuspendLock.ensureIndexes(coroutineGroupCollection)
             return MongoSuspendLeaderGroupElection(groupCollection, coroutineGroupCollection, options)
         }
@@ -78,10 +77,10 @@ class MongoSuspendLeaderGroupElection private constructor(
      * **주의:** 이 값은 근사치입니다. TTL 만료 주기(최대 60초) 동안 만료 문서가 잔류할 수 있습니다.
      */
     override fun activeCount(lockName: String): Int {
-        val pattern = Regex.escape(lockName) + ":slot:\\d+$"
+        val ids = (0 until maxLeaders).map { slotKey(lockName, it) }
         return groupCollection.countDocuments(
             Filters.and(
-                Filters.regex("_id", "^$pattern"),
+                Filters.`in`("_id", ids),
                 Filters.gt("expireAt", Date())
             )
         ).toInt()
@@ -144,13 +143,12 @@ class MongoSuspendLeaderGroupElection private constructor(
 /**
  * MongoDB 분산 세마포어(슬롯 기반)를 이용하여 최대 [options.maxLeaders]개의 리더로 선출된 경우에만 suspend [action]을 실행합니다.
  *
- * state 조회용 동기 [syncGroupCollection]과 락 획득/해제용 코루틴 [coroutineGroupCollection]을 모두 전달해야 합니다.
+ * 수신자는 state 조회용 동기 컬렉션이고, 락 획득/해제용 [coroutineGroupCollection]을 함께 전달해야 합니다.
  * 이는 [MongoSuspendLeaderGroupElection]의 이중 컬렉션 설계 때문입니다.
  */
-suspend fun <T> suspendRunIfLeaderGroup(
-    syncGroupCollection: MongoCollection<Document>,
+suspend fun <T> MongoCollection<Document>.suspendRunIfLeaderGroup(
     coroutineGroupCollection: CoroutineMongoCollection<Document>,
     lockName: String,
     options: MongoLeaderGroupElectionOptions = MongoLeaderGroupElectionOptions.Default,
     action: suspend () -> T,
-): T? = MongoSuspendLeaderGroupElection(syncGroupCollection, coroutineGroupCollection, options).runIfLeader(lockName, action)
+): T? = MongoSuspendLeaderGroupElection(this, coroutineGroupCollection, options).runIfLeader(lockName, action)

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/lock/MongoLock.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/lock/MongoLock.kt
@@ -156,8 +156,9 @@ class MongoLock private constructor(
 
             val remaining = deadline - System.currentTimeMillis()
             if (remaining > 0L) {
-                val jitter = Random.nextLong(retryDelay.toMillis() / 2 + 1)
-                Thread.sleep(minOf(retryDelay.toMillis() + jitter, remaining))
+                // AWS full jitter: sleep ∈ [1ms, retryDelay) — 동일 retry 윈도우에 인스턴스가 몰리는 것을 방지
+                val jitter = Random.nextLong(1, retryDelay.toMillis().coerceAtLeast(2))
+                Thread.sleep(minOf(jitter, remaining))
             }
         } while (System.currentTimeMillis() < deadline)
 

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/lock/MongoSuspendLock.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/lock/MongoSuspendLock.kt
@@ -159,8 +159,9 @@ class MongoSuspendLock private constructor(
 
             val remaining = deadline - System.currentTimeMillis()
             if (remaining > 0L) {
-                val jitter = Random.nextLong(retryDelay.toMillis() / 2 + 1)
-                delay(minOf(retryDelay.toMillis() + jitter, remaining).milliseconds)
+                // AWS full jitter: delay ∈ [1ms, retryDelay) — 동일 retry 윈도우에 인스턴스가 몰리는 것을 방지
+                val jitter = Random.nextLong(1, retryDelay.toMillis().coerceAtLeast(2))
+                delay(minOf(jitter, remaining).milliseconds)
             }
         } while (System.currentTimeMillis() < deadline)
 

--- a/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElectionTest.kt
+++ b/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElectionTest.kt
@@ -11,6 +11,7 @@ import io.bluetape4k.logging.debug
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterOrEqualTo
 import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.Duration
@@ -209,5 +210,36 @@ class MongoLeaderElectionTest : AbstractMongoLeaderTest() {
     fun `ensureIndexes - 연속 호출 시 멱등하게 동작한다`() {
         MongoLock.ensureIndexes(lockCollection)
         MongoLock.ensureIndexes(lockCollection)
+    }
+
+    @Test
+    fun `unlock - takeover 후 원소유자가 unlock 시도해도 신규 소유자의 락 문서는 유지된다`() {
+        val lockName = randomLockName()
+        val oldLock = MongoLock(lockCollection, lockName)
+        oldLock.tryLock(Duration.ofSeconds(1), Duration.ofMillis(200)).shouldBeTrue()
+
+        Thread.sleep(350)
+
+        val newLock = MongoLock(lockCollection, lockName)
+        newLock.tryLock(Duration.ofSeconds(2), Duration.ofSeconds(10)).shouldBeTrue()
+
+        oldLock.unlock()
+
+        newLock.isHeldByCurrentInstance().shouldBeTrue()
+        lockCollection.countDocuments(Filters.eq("_id", lockName)) shouldBeEqualTo 1L
+
+        newLock.unlock()
+    }
+
+    @Test
+    fun `runAsyncIfLeader - 정상 완료 후 락 문서가 삭제된다`() {
+        val lockName = randomLockName()
+        val election = MongoLeaderElection(lockCollection)
+
+        election.runAsyncIfLeader(lockName, VirtualThreadExecutor) {
+            futureOf { "ok" }
+        }.get(5, TimeUnit.SECONDS) shouldBeEqualTo "ok"
+
+        lockCollection.countDocuments(Filters.eq("_id", lockName)) shouldBeEqualTo 0L
     }
 }

--- a/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderGroupElectionTest.kt
+++ b/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderGroupElectionTest.kt
@@ -219,4 +219,20 @@ class MongoLeaderGroupElectionTest : AbstractMongoLeaderTest() {
         }.get(5, TimeUnit.SECONDS)
         result shouldBeEqualTo "복구 성공"
     }
+
+    @Test
+    fun `runAsyncIfLeader - action 동기 throw 후 슬롯 락 문서가 즉시 삭제된다`() {
+        val lockName = randomLockName()
+
+        assertThrows<CompletionException> {
+            election.runAsyncIfLeader<Int>(lockName, VirtualThreadExecutor) {
+                throw IllegalStateException("action 동기 예외")
+            }.join()
+        }
+
+        val ids = (0 until options.maxLeaders).map { "$lockName:slot:$it" }
+        groupLockCollection.countDocuments(
+            com.mongodb.client.model.Filters.`in`("_id", ids)
+        ) shouldBeEqualTo 0L
+    }
 }

--- a/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderElectionTest.kt
+++ b/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderElectionTest.kt
@@ -170,4 +170,12 @@ class MongoSuspendLeaderElectionTest : AbstractMongoLeaderTest() {
             result shouldBeEqualTo "round-$i"
         }
     }
+
+    @Test
+    fun `ensureIndexes - resetEnsuredFor 후 재호출 시 에러 없이 완료된다 (suspend)`() = runSuspendIO {
+        val namespace = coroutineLockCollection.namespace.fullName
+        io.bluetape4k.leader.mongodb.lock.MongoSuspendLock.resetEnsuredFor(namespace)
+
+        io.bluetape4k.leader.mongodb.lock.MongoSuspendLock.ensureIndexes(coroutineLockCollection)
+    }
 }

--- a/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderGroupElectionTest.kt
+++ b/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderGroupElectionTest.kt
@@ -163,4 +163,42 @@ class MongoSuspendLeaderGroupElectionTest : AbstractMongoLeaderTest() {
         release.complete(Unit)
         holder.join()
     }
+
+    @Test
+    fun `runIfLeader - 슬롯 획득 중 코루틴 취소 시 부분 획득된 슬롯이 없다`() = runSuspendIO {
+        val lockName = randomLockName()
+        val maxLeaders = 1
+        val holder = makeElection(maxLeaders = maxLeaders, waitTime = Duration.ofSeconds(30))
+        // 모든 슬롯 점유 중인 election
+        val acquired = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+
+        val holderJob = launch {
+            holder.runIfLeader(lockName) {
+                acquired.complete(Unit)
+                release.await()
+            }
+        }
+        acquired.await()
+
+        // 점유된 슬롯에 진입 시도하다가 취소되는 contender
+        val contender = makeElection(maxLeaders = maxLeaders, waitTime = Duration.ofSeconds(30))
+        val contenderJob = launch {
+            contender.runIfLeader(lockName) { "never" }
+        }
+
+        delay(100)
+        contenderJob.cancel()
+        contenderJob.join()
+
+        // 취소된 contender가 슬롯을 점유하지 않았음을 검증 (holder만 보유)
+        val ids = (0 until maxLeaders).map { "$lockName:slot:$it" }
+        val activeCount = groupLockCollection.countDocuments(
+            com.mongodb.client.model.Filters.`in`("_id", ids)
+        )
+        activeCount shouldBeEqualTo 1L
+
+        release.complete(Unit)
+        holderJob.join()
+    }
 }


### PR DESCRIPTION
## Summary

PR #47의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: leader-mongodb 6-Tier 코드리뷰 반영 (daily review 2026-05-02)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 개요

bluetape4k-design Step 6-R 6-Tier 코드 리뷰 결과를 반영합니다. 지난 24시간 내 신규 추가된 leader-mongodb 모듈 (#46 merged) 대상 5개 전문 리뷰어 (security, performance, design, kotlin idiom, test coverage) 동시 진행.

리뷰 결과: CRITICAL 0건, HIGH 9건 → 본 PR에서 7건 반영, 2건 (Java 호환 invoke / NonCancellable 내부 catch dead code) 은 의도적/정책적으로 보류.

## 변경 사항

### 성능 (HIGH x 2)
- **Full jitter 적용** (`MongoLock.kt`, `MongoSuspendLock.kt`)
  - Before: `sleep ∈ [retryDelay, 1.5×retryDelay]` 단방향 jitter — N개 인스턴스가 25ms 윈도우에 몰림
  - After: `sleep ∈ [1ms, retryDelay)` AWS full jitter 균등 분포
- **`activeCount` regex → `$in`** (`MongoLeaderGroupElection`, `MongoSuspendLeaderGroupElection`)
  - Before: `Filters.regex("_id", "^pattern")` — `\\d+` 메타문자로 IXSCAN 포기 가능성
  - After: `Filters.in("_id", listOf(slotKey(0)…slotKey(N-1)))` — \_id 인덱스 포인트룩업

### 설계 (HIGH x 2 + 정리 x 1)
- **`releaseTimeout` dead config 제거** (`MongoLeaderElectionOptions`, `MongoLeaderGroupElectionOptions`)
  - 필드/검증/KDoc 모두 존재하나 `withTimeout` 등 사용처 0건. 0.1.0-SNAPSHOT 미배포 단계 cleanup.
- **`suspendRunIfLeaderGroup` 확장 함수화** (`MongoSuspendLeaderGroupElection`)
  - 다른 5개 helper는 `MongoCollection.runIfLeader…` 형태인데 이것만 top-level 위치 — `MongoCollection<Document>` 확장으로 변경.
- **이중 `ensureIndexes` 호출 정리** (`MongoSuspendLeaderGroupElection.invoke`)
  - `MongoLock.ensureIndexes` + `MongoSuspendLock.ensureIndexes` 동일 namespace 두 번 호출 → `MongoSuspendLock` 한 번만.

### 테스트 (HIGH x 4 + CRITICAL x 1)
- `MongoLeaderElectionTest`:
  - takeover 후 원소유자 `unlock` 시도 → 신규 소유자 락 보존
  - `runAsyncIfLeader` 정상 완료 후 락 문서 삭제 확인
- `MongoLeaderGroupElectionTest`:
  - `runAsyncIfLeader` action 동기 throw 후 슬롯 락 즉시 삭제
- `MongoSuspendLeaderElectionTest`:
  - `MongoSuspendLock.ensureIndexes` resetEnsuredFor 후 재호출
- `MongoSuspendLeaderGroupElectionTest`:
  - 슬롯 획득 중 코루틴 취소 시 부분 획득 없음

### 문서
- `README.md` / `README.ko.md`: `leader-mongodb` 상태 Planned → Stable (다이어그램 + 모듈 표 모두 반영)

## 검증
- ✅ `./gradlew :leader-mongodb:test` 47/47 통과 (기존 42 + 신규 5)
- ✅ `./gradlew :leader-mongodb:detekt` (root detekt) green
- ✅ 컴파일 + 캐시된 단위 테스트 모두 통과

## 보류한 리뷰 항목
- **suspend companion invoke Java 호환성** — 라이브러리는 Kotlin 코루틴 API 의도, 변경 시 ensureIndexes 호출 시점 트레이드오프 발생.
- **NonCancellable 안의 `catch (CancellationException) { throw e }`** — auto-memory `feedback_cancellation_exception` 규칙으로 디펜시브 코드 유지.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #47, head `9a1d39be7f572e73b2a7e264bb5de36573331b83`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
