### PR TITLE
fix: leader-exposed-jdbc 5-Tier 코드 리뷰 반영 (daily review 2026-05-03)

### DIFF
--- a/docs/lessons/2026-05-03-exposed-jdbc-daily-review.md
+++ b/docs/lessons/2026-05-03-exposed-jdbc-daily-review.md
@@ -1,0 +1,47 @@
+# 2026-05-03 leader-exposed-jdbc Daily Review (5-Tier)
+
+## 배경
+
+`leader-exposed-jdbc` 모듈이 직전 24시간 내에 신규 도입됨. 5개 코드 리뷰 에이전트(코드 일반/silent failure/타입 설계/KDoc/테스트 커버리지)를 병렬 실행하여 수정 사항 도출.
+
+## 적용된 수정
+
+### CRITICAL
+
+1. **`Thread.sleep` `InterruptedException` 누수** — `ExposedJdbcLock.tryLock` / `ExposedJdbcGroupLock.tryLock`의 retry 루프에서 `Thread.sleep`이 `runCatching` 외부에 위치 → `runIfLeader`의 "never-throws" 계약 위반 가능. `try/catch (InterruptedException)`으로 보호하고 interrupt flag 복원 후 false 반환.
+2. **`runCatching`의 `CancellationException` 흡수** — `tryAcquireOnce`를 `runCatching`으로 감싸 `CancellationException`까지 흡수. `try/catch(CancellationException) { throw }` 명시적 재전파로 변경.
+3. **`RetryStrategy` 변형의 검증 부재** — `Jitter(baseDelayMs=0)`, `Exponential(maxDelayMs<baseDelayMs)`, `Fixed(0)` 모두 무검증으로 생성 가능. 각 변형에 `init { require(...) }` 추가, `delayMs(remaining<=0)` 동작을 명시 (0 반환).
+
+### HIGH
+
+4. **Async `whenCompleteAsync` `CancellationException` 미처리** — `CompletableFuture` cancel 시 `j.u.c.CancellationException`이 throwable로 전달되어 FAILED 이력 기록됨. 동기 path와 일관되게 cancel은 history skip 처리.
+5. **`ExposedJdbcGroupLock.slot` 검증 부재** — 음수 slot 허용. `init { require(slot >= 0) }` 추가.
+6. **Magic 255** — `lockOwner` 길이 검증의 magic literal을 `ExposedLeaderConstants.LOCK_OWNER_LENGTH`로 통일 (스키마 컬럼 폭과 단일 진실 원천).
+7. **`sanitizeUrl` `jdbc:` 접두사 미처리** — `URI("jdbc:postgresql://user:pw@host/db")`는 opaque URI로 파싱되어 `rawUserInfo == null` → 패스워드 그대로 로그 노출 (보안 결함). `jdbc:` 접두사 분리 후 hierarchical URI로 재파싱하도록 수정.
+8. **`ensureSchema` 실패 로깅 부재** — 스키마 초기화 실패가 raw 예외로만 전파. `try/catch`로 감싸 컨텍스트 로그 후 재전파.
+9. **공개 API KDoc/예제 보강** — `runIfLeader` / `runAsyncIfLeader` / `activeCount` / `availableSlots` / `state` 등 override 메서드 KDoc 부재 또는 단순. 예제 + `@throws` + 계약(null 반환, CancellationException 재전파) 명시. `Database` 확장함수 5개 모두 사용 예제 추가.
+
+## 추가된 테스트
+
+- `ExposedJdbcOptionsValidationTest` (10) — 옵션 init validation: lockOwner 255자 경계, maxLeaders 0/음수, RetryStrategy 변형 invariants
+- `ExposedJdbcSchemaInitializerTest` (6) — sanitizeUrl 마스킹 (Postgres/MySQL/userinfo 없음/잘못된 URL/빈 userinfo) + ensureSchema 다중 스레드 동시성
+- `ExposedJdbcLockTest`에 `isHeldByCurrentInstance` 4종 시나리오 추가 (보유/해제/만료/takeover)
+- `ExposedJdbcGroupLockTest`에 slot 음수 init 검증 추가
+- `ExposedJdbcLeaderElectionTest`에 async `failedFuture` 경로 (FAILED 이력 + 락 해제 + 재획득 가능)
+- `ExposedJdbcLeaderGroupElectionTest`에 group async failedFuture + maxLeaders=1 경계 시맨틱 추가
+- `RetryStrategyTest`에 baseDelayMs<2 거부 + 정상 생성 케이스로 갱신
+
+## 테스트 결과
+
+H2 / PostgreSQL / MySQL_V8 3DB 통과: 187 tests passing (ParameterizedTest로 DB별 실행).
+
+## 변경 요약
+
+- main: 12 file, +211 / -45
+- test: 6 file (3 추가 + 3 수정), +306 / -20
+- README.md / README.ko.md: VirtualThread 예제 정정 + 그룹 상태 조회 섹션 + RetryStrategy invariants 표 추가
+
+## 후속 항목 (out-of-scope)
+
+- `ExposedLeaderSchema` 캐시 키를 URL이 아닌 Database identity 기반으로 변경 가능성 (동일 URL/다른 schema/credentials 시나리오)
+- `SchemaUtils.createMissingTablesAndColumns` deprecation 대응 (Exposed migration 권고)

--- a/leader-exposed-jdbc/README.ko.md
+++ b/leader-exposed-jdbc/README.ko.md
@@ -111,14 +111,29 @@ val result = election.runIfLeader("parallel-batch") {
 // 최대 3개 노드가 동시 실행; 나머지는 null 반환
 ```
 
+### 그룹 상태 조회
+
+```kotlin
+val state = election.state("parallel-batch")
+println("active=${state.activeCount} max=${state.maxLeaders} full=${state.isFull}")
+println("사용 가능 슬롯: ${election.availableSlots("parallel-batch")}")
+```
+
 ### 가상 스레드 단일 리더
 
 ```kotlin
-val election = ExposedJdbcVirtualThreadLeaderElection(db)
+// 기존 ExposedJdbcLeaderElection을 래핑
+val election = ExposedJdbcLeaderElection(db)
+val vtElection = ExposedJdbcVirtualThreadLeaderElection(election)
 
-val result = election.runInVirtualThread("nightly-sync") {
+val future: VirtualFuture<Result?> = vtElection.runAsyncIfLeader("nightly-sync") {
     syncData()
 }
+val result = future.get(5, TimeUnit.SECONDS)
+
+// 또는 Database 확장함수로 간편하게
+val result2 = db.runVirtualIfLeader("nightly-sync") { syncData() }
+    .get(5, TimeUnit.SECONDS)
 ```
 
 ### 옵션 커스터마이징
@@ -162,6 +177,14 @@ sealed class RetryStrategy {
 ```
 
 기본값은 `Jitter(50ms)` — 대부분의 OLTP 워크로드에 적합합니다.
+
+각 전략은 생성 시점에 파라미터를 검증합니다:
+
+| 변형 | 제약 |
+|---|---|
+| `Jitter` | `baseDelayMs >= 2` |
+| `Exponential` | `baseDelayMs >= 1`, `maxDelayMs >= baseDelayMs` |
+| `Fixed` | `fixedMs >= 1` |
 
 ## 이력 기록
 

--- a/leader-exposed-jdbc/README.md
+++ b/leader-exposed-jdbc/README.md
@@ -111,14 +111,29 @@ val result = election.runIfLeader("parallel-batch") {
 // Up to 3 nodes run concurrently; others return null
 ```
 
+### Inspecting group state
+
+```kotlin
+val state = election.state("parallel-batch")
+println("active=${state.activeCount} max=${state.maxLeaders} full=${state.isFull}")
+println("available slots: ${election.availableSlots("parallel-batch")}")
+```
+
 ### Virtual-thread single-leader
 
 ```kotlin
-val election = ExposedJdbcVirtualThreadLeaderElection(db)
+// Wrap an existing ExposedJdbcLeaderElection
+val election = ExposedJdbcLeaderElection(db)
+val vtElection = ExposedJdbcVirtualThreadLeaderElection(election)
 
-val result = election.runInVirtualThread("nightly-sync") {
+val future: VirtualFuture<Result?> = vtElection.runAsyncIfLeader("nightly-sync") {
     syncData()
 }
+val result = future.get(5, TimeUnit.SECONDS)
+
+// Or use the Database extension shortcut
+val result2 = db.runVirtualIfLeader("nightly-sync") { syncData() }
+    .get(5, TimeUnit.SECONDS)
 ```
 
 ### Custom options
@@ -162,6 +177,14 @@ sealed class RetryStrategy {
 ```
 
 Default is `Jitter(50ms)` — suitable for most OLTP workloads.
+
+Each variant validates its parameters at construction:
+
+| Variant | Constraint |
+|---|---|
+| `Jitter` | `baseDelayMs >= 2` |
+| `Exponential` | `baseDelayMs >= 1`, `maxDelayMs >= baseDelayMs` |
+| `Fixed` | `fixedMs >= 1` |
 
 ## History Recording
 

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElection.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElection.kt
@@ -25,15 +25,27 @@ import java.util.concurrent.Executor
  * Exposed JDBC 기반 단일 리더 선출 구현체.
  *
  * `UPDATE + INSERT + SELECT` 패턴으로 DB 행 수준 락을 구현합니다.
- * H2, PostgreSQL, MySQL 8 호환.
+ * 지원 DB는 모듈 README의 호환성 매트릭스를 참조하세요.
  *
+ * ### 기본 사용
  * ```kotlin
  * val election = ExposedJdbcLeaderElection(db)
  * val result = election.runIfLeader("daily-job") { processData() }
  * // result == processData() 반환값 (리더 획득 성공) 또는 null (획득 실패)
  * ```
  *
- * **private constructor** — [invoke]를 통해서만 생성하세요. 생성 시 [ensureSchema]를 보장합니다.
+ * ### 경합 시 skip
+ * ```kotlin
+ * // 다른 노드가 이미 리더면 즉시 null 반환 (예외 없음)
+ * val report = election.runIfLeader("nightly-report") { generateReport() }
+ *     ?: run {
+ *         logger.info("리더가 아니므로 작업 건너뜀")
+ *         return
+ *     }
+ * ```
+ *
+ * **private constructor** — [invoke] 팩터리를 통해서만 생성하세요.
+ * 첫 호출 시 [ExposedJdbcSchemaInitializer.ensureSchema]가 실행되어 스키마가 자동으로 생성됩니다.
  *
  * @param db Exposed [Database] 인스턴스
  * @param options 단일 리더 선출 옵션
@@ -60,6 +72,19 @@ class ExposedJdbcLeaderElection private constructor(
         }
     }
 
+    /**
+     * [lockName]에 대해 리더로 승격되면 [action]을 실행하고 결과를 반환합니다.
+     *
+     * - 리더 획득에 성공하면 [action] 결과를 반환합니다.
+     * - 리더 획득에 실패하면 `null`을 반환합니다 (**예외 없음** — ShedLock 호환 skip-on-contention 계약).
+     * - [action]이 던지는 예외는 그대로 전파되며, 락은 항상 해제됩니다.
+     * - [CancellationException]은 재전파되며 FAILED 이력에 기록되지 않습니다.
+     *
+     * @param lockName 락 식별자 (영숫자/하이픈/언더스코어/콜론, 1-255자)
+     * @param action 리더 획득 성공 시 실행할 작업
+     * @return [action] 결과 또는 `null`
+     * @throws IllegalArgumentException [lockName]이 유효하지 않은 경우
+     */
     override fun <T> runIfLeader(lockName: String, action: () -> T): T? {
         validateExposedLockName(lockName)
 
@@ -100,6 +125,25 @@ class ExposedJdbcLeaderElection private constructor(
         }
     }
 
+    /**
+     * [lockName]에 대해 리더로 승격되면 비동기로 [action]을 실행합니다.
+     *
+     * 비동기 실행 성공/실패는 반환된 [CompletableFuture]에 반영되며, [action]이 동기적으로
+     * 던지는 예외는 [CompletableFuture.failedFuture]로 래핑되어 전파됩니다.
+     *
+     * ```kotlin
+     * val future: CompletableFuture<Report?> = election.runAsyncIfLeader(
+     *     lockName = "report-job",
+     *     executor = VirtualThreadExecutor,
+     *     action = { generateReportAsync() }, // CompletableFuture<Report> 반환
+     * )
+     * ```
+     *
+     * @param lockName 락 식별자
+     * @param executor 비동기 실행자
+     * @param action 리더 획득 성공 시 실행할 비동기 작업
+     * @return 작업 결과를 담은 [CompletableFuture] (리더 획득 실패 시 `null`로 완료)
+     */
     override fun <T> runAsyncIfLeader(
         lockName: String,
         executor: Executor,
@@ -129,10 +173,12 @@ class ExposedJdbcLeaderElection private constructor(
                         }
 
                     actionFuture.whenCompleteAsync({ _, throwable ->
-                        if (throwable != null) {
-                            recordFailed(historyId, lock.token, startedAt)
-                        } else {
-                            recordCompleted(historyId, lock.token, startedAt)
+                        when {
+                            throwable == null -> recordCompleted(historyId, lock.token, startedAt)
+                            // CompletableFuture.cancel 또는 코루틴 취소: FAILED 미기록 (취소이므로)
+                            throwable is java.util.concurrent.CancellationException -> { /* skip */ }
+                            throwable is CancellationException -> { /* skip */ }
+                            else -> recordFailed(historyId, lock.token, startedAt)
                         }
                         runCatching { lock.unlock() }
                             .onSuccess { log.debug { "비동기 리더 권한을 반납했습니다. lockName=$lockName" } }

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElectionExtensions.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElectionExtensions.kt
@@ -12,6 +12,11 @@ import java.util.concurrent.Executor
  * `ExposedJdbcLeaderElection(this, options).runIfLeader(lockName, action)`의 편의 함수입니다.
  * [ExposedJdbcLeaderElection.invoke]를 통해 ensureSchema가 보장됩니다.
  *
+ * ```kotlin
+ * val report = db.runIfLeader("daily-report") { generateReport() }
+ *     ?: return // 리더가 아니면 건너뜀
+ * ```
+ *
  * @param lockName 리더 선출에 사용할 락 이름
  * @param options 선출 옵션. 기본값 [ExposedJdbcLeaderElectionOptions.Default]
  * @param action 리더 획득 성공 시 실행할 작업
@@ -25,6 +30,12 @@ fun <T> Database.runIfLeader(
 
 /**
  * 이 [Database]에 대한 단일 리더 선출을 비동기로 실행합니다.
+ *
+ * ```kotlin
+ * val future: CompletableFuture<Report?> = db.runAsyncIfLeader("nightly-sync") {
+ *     CompletableFuture.supplyAsync { syncData() }
+ * }
+ * ```
  *
  * @param lockName 리더 선출에 사용할 락 이름
  * @param executor 비동기 실행 [Executor]. 기본값 [VirtualThreadExecutor]
@@ -41,6 +52,11 @@ fun <T> Database.runAsyncIfLeader(
 
 /**
  * 이 [Database]에 대한 단일 리더 선출을 Virtual Thread에서 비동기로 실행합니다.
+ *
+ * ```kotlin
+ * val result: String? = db.runVirtualIfLeader("vt-job") { computeHeavy() }
+ *     .get(5, TimeUnit.SECONDS)
+ * ```
  *
  * @param lockName 리더 선출에 사용할 락 이름
  * @param options 선출 옵션. 기본값 [ExposedJdbcLeaderElectionOptions.Default]
@@ -59,6 +75,14 @@ fun <T> Database.runVirtualIfLeader(
 /**
  * 이 [Database]에 대한 그룹 리더 선출을 실행합니다.
  *
+ * ```kotlin
+ * val opts = ExposedJdbcLeaderGroupElectionOptions(
+ *     leaderGroupOptions = LeaderGroupElectionOptions(maxLeaders = 4),
+ * )
+ * val result = db.runIfLeaderGroup("worker-pool", opts) { processChunk() }
+ * // 최대 4개 노드 동시 실행, 슬롯 만석 시 null
+ * ```
+ *
  * @param lockName 리더 그룹 선출에 사용할 락 이름
  * @param options 그룹 선출 옵션. 기본값 [ExposedJdbcLeaderGroupElectionOptions.Default]
  * @param action 리더 획득 성공 시 실행할 작업
@@ -72,6 +96,17 @@ fun <T> Database.runIfLeaderGroup(
 
 /**
  * 이 [Database]에 대한 그룹 리더 선출을 비동기로 실행합니다.
+ *
+ * ```kotlin
+ * val future = db.runAsyncIfLeaderGroup(
+ *     lockName = "parallel-batch",
+ *     options = ExposedJdbcLeaderGroupElectionOptions(
+ *         leaderGroupOptions = LeaderGroupElectionOptions(maxLeaders = 3),
+ *     ),
+ * ) {
+ *     CompletableFuture.supplyAsync { processChunk() }
+ * }
+ * ```
  *
  * @param lockName 리더 그룹 선출에 사용할 락 이름
  * @param executor 비동기 실행 [Executor]. 기본값 [VirtualThreadExecutor]

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElectionOptions.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElectionOptions.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.exposed.jdbc
 
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.exposed.ExposedLeaderConstants
 import java.io.Serializable
 
 /**
@@ -8,7 +9,10 @@ import java.io.Serializable
  *
  * ```kotlin
  * val options = ExposedJdbcLeaderElectionOptions(
- *     leaderOptions = LeaderElectionOptions(waitTime = 3.seconds, leaseTime = 30.seconds),
+ *     leaderOptions = LeaderElectionOptions(
+ *         waitTime = Duration.ofSeconds(3),
+ *         leaseTime = Duration.ofSeconds(30),
+ *     ),
  *     retryStrategy = RetryStrategy.Jitter(baseDelayMs = 100L),
  *     recordHistory = true,
  *     lockOwner = "worker-1",
@@ -19,7 +23,7 @@ import java.io.Serializable
  * @property leaderOptions 단일 리더 선출 옵션 (waitTime, leaseTime)
  * @property retryStrategy 락 획득 재시도 전략. 기본값 [RetryStrategy.Jitter]
  * @property recordHistory `true`이면 획득/완료/실패 이력을 [io.bluetape4k.leader.exposed.tables.LeaderLockHistoryTable]에 기록
- * @property lockOwner 락 보유자 식별자. `null`이면 미기록
+ * @property lockOwner 락 보유자 식별자. 컬럼 폭 [ExposedLeaderConstants.LOCK_OWNER_LENGTH]자 이내. `null`이면 미기록
  */
 data class ExposedJdbcLeaderElectionOptions(
     val leaderOptions: LeaderElectionOptions = LeaderElectionOptions.Default,
@@ -30,12 +34,21 @@ data class ExposedJdbcLeaderElectionOptions(
 
     init {
         lockOwner?.let {
-            require(it.length <= 255) { "lockOwner must be <= 255 chars, but was ${it.length}" }
+            require(it.length <= ExposedLeaderConstants.LOCK_OWNER_LENGTH) {
+                "lockOwner must be <= ${ExposedLeaderConstants.LOCK_OWNER_LENGTH} chars, but was ${it.length}"
+            }
         }
     }
 
     companion object {
-        /** 기본 옵션 인스턴스. */
+        /**
+         * 기본 옵션 인스턴스.
+         *
+         * - leaderOptions = [LeaderElectionOptions.Default] (waitTime/leaseTime은 leader-core 기본값)
+         * - retryStrategy = [RetryStrategy.Jitter] (baseDelayMs = 50ms)
+         * - recordHistory = `false`
+         * - lockOwner = `null`
+         */
         @JvmField
         val Default = ExposedJdbcLeaderElectionOptions()
     }

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElection.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElection.kt
@@ -29,17 +29,30 @@ import kotlin.random.Random
 /**
  * Exposed JDBC 기반 복수 리더 그룹 선출 구현체.
  *
- * `(lockName, slot)` 복합 PK 기반 슬롯 순회로 최대 [options.maxLeaders]개의 동시 리더를 허용합니다.
+ * `(lockName, slot)` 복합 PK 기반 슬롯 순회로 최대
+ * [ExposedJdbcLeaderGroupElectionOptions.maxLeaders]개의 동시 리더를 허용합니다.
  * 슬롯 시작 위치를 랜덤화하여 핫스팟을 방지합니다.
  *
+ * ### 기본 사용
  * ```kotlin
- * val election = ExposedJdbcLeaderGroupElection(db, ExposedJdbcLeaderGroupElectionOptions(
- *     leaderGroupOptions = LeaderGroupElectionOptions(maxLeaders = 3)
- * ))
+ * val election = ExposedJdbcLeaderGroupElection(
+ *     db,
+ *     ExposedJdbcLeaderGroupElectionOptions(
+ *         leaderGroupOptions = LeaderGroupElectionOptions(maxLeaders = 3),
+ *     ),
+ * )
  * val result = election.runIfLeader("batch-job") { processChunk() }
+ * // 최대 3개 노드 동시 실행, 나머지는 null 반환
  * ```
  *
- * **private constructor** — [invoke]를 통해서만 생성하세요.
+ * ### 그룹 상태 조회
+ * ```kotlin
+ * val state = election.state("batch-job")
+ * println("active=${state.activeCount} / max=${state.maxLeaders}")
+ * println("available=${election.availableSlots("batch-job")}")
+ * ```
+ *
+ * **private constructor** — [invoke] 팩터리를 사용하세요. 첫 호출 시 스키마가 자동으로 생성됩니다.
  *
  * @param db Exposed [Database] 인스턴스
  * @param options 그룹 리더 선출 옵션
@@ -66,8 +79,14 @@ class ExposedJdbcLeaderGroupElection private constructor(
         }
     }
 
+    /** 동시 허용 리더 수 ([ExposedJdbcLeaderGroupElectionOptions.maxLeaders] 위임). */
     override val maxLeaders: Int get() = options.maxLeaders
 
+    /**
+     * [lockName]의 현재 활성 슬롯 수(만료되지 않은 lease 보유 행)를 반환합니다.
+     *
+     * DB 오류 발생 시 best-effort로 `0`을 반환합니다 (호출자에게 예외를 전파하지 않음).
+     */
     override fun activeCount(lockName: String): Int = runCatching {
         transaction(db) {
             val now = Instant.now()
@@ -85,11 +104,22 @@ class ExposedJdbcLeaderGroupElection private constructor(
         0
     }
 
+    /** [lockName]에서 즉시 획득 가능한 슬롯 수. */
     override fun availableSlots(lockName: String): Int = maxLeaders - activeCount(lockName)
 
+    /** [lockName]에 대한 [LeaderGroupState] 스냅샷을 반환합니다. */
     override fun state(lockName: String): LeaderGroupState =
         LeaderGroupState(lockName, maxLeaders, activeCount(lockName))
 
+    /**
+     * [lockName] 그룹의 빈 슬롯을 하나 획득하면 [action]을 실행합니다.
+     *
+     * - 모든 슬롯이 사용 중이면 `null`을 반환합니다 (예외 없음).
+     * - [action] 예외는 그대로 전파되며, 슬롯은 항상 반납됩니다.
+     * - [CancellationException]은 재전파되며 FAILED 이력에 기록되지 않습니다.
+     *
+     * @throws IllegalArgumentException [lockName]이 유효하지 않은 경우
+     */
     override fun <T> runIfLeader(lockName: String, action: () -> T): T? {
         validateExposedLockName(lockName)
 
@@ -138,6 +168,18 @@ class ExposedJdbcLeaderGroupElection private constructor(
         return null
     }
 
+    /**
+     * [lockName] 그룹의 슬롯을 비동기로 획득하여 [action]을 실행합니다.
+     *
+     * 슬롯 획득 실패 시 `null`로 완료된 [CompletableFuture]를 반환합니다.
+     * action이 동기적으로 던지는 예외는 [CompletableFuture.failedFuture]로 래핑됩니다.
+     *
+     * ```kotlin
+     * val future = election.runAsyncIfLeader("batch", VirtualThreadExecutor) {
+     *     processChunkAsync()  // CompletableFuture<Result>
+     * }
+     * ```
+     */
     override fun <T> runAsyncIfLeader(
         lockName: String,
         executor: Executor,
@@ -179,10 +221,12 @@ class ExposedJdbcLeaderGroupElection private constructor(
                     }
 
                 actionFuture.whenCompleteAsync({ _, throwable ->
-                    if (throwable != null) {
-                        recordFailed(historyId, lock.token, startedAt, slot)
-                    } else {
-                        recordCompleted(historyId, lock.token, startedAt, slot)
+                    when {
+                        throwable == null -> recordCompleted(historyId, lock.token, startedAt, slot)
+                        // 취소(코루틴/CompletableFuture)는 FAILED로 기록하지 않음
+                        throwable is java.util.concurrent.CancellationException -> { /* skip */ }
+                        throwable is CancellationException -> { /* skip */ }
+                        else -> recordFailed(historyId, lock.token, startedAt, slot)
                     }
                     runCatching { lock.unlock() }
                         .onSuccess { log.debug { "비동기 그룹 슬롯 반납. lockName=$lockName, slot=$slot" } }

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElectionOptions.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElectionOptions.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.exposed.jdbc
 
 import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.exposed.ExposedLeaderConstants
 import java.io.Serializable
 
 /**
@@ -11,14 +12,15 @@ import java.io.Serializable
  *     leaderGroupOptions = LeaderGroupElectionOptions(maxLeaders = 3),
  *     retryStrategy = RetryStrategy.Exponential(),
  *     recordHistory = true,
+ *     lockOwner = "worker-1",
  * )
  * val election = ExposedJdbcLeaderGroupElection(db, options)
  * ```
  *
- * @property leaderGroupOptions 그룹 리더 선출 옵션 (maxLeaders, waitTime, leaseTime)
+ * @property leaderGroupOptions 그룹 리더 선출 옵션 (maxLeaders, waitTime, leaseTime). `maxLeaders`는 양수여야 함
  * @property retryStrategy 락 획득 재시도 전략. 기본값 [RetryStrategy.Jitter]
  * @property recordHistory `true`이면 획득/완료/실패 이력을 기록
- * @property lockOwner 락 보유자 식별자. `null`이면 미기록
+ * @property lockOwner 락 보유자 식별자. 컬럼 폭 [ExposedLeaderConstants.LOCK_OWNER_LENGTH]자 이내. `null`이면 미기록
  */
 data class ExposedJdbcLeaderGroupElectionOptions(
     val leaderGroupOptions: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
@@ -33,12 +35,21 @@ data class ExposedJdbcLeaderGroupElectionOptions(
     init {
         require(maxLeaders > 0) { "maxLeaders must be positive: $maxLeaders" }
         lockOwner?.let {
-            require(it.length <= 255) { "lockOwner must be <= 255 chars, but was ${it.length}" }
+            require(it.length <= ExposedLeaderConstants.LOCK_OWNER_LENGTH) {
+                "lockOwner must be <= ${ExposedLeaderConstants.LOCK_OWNER_LENGTH} chars, but was ${it.length}"
+            }
         }
     }
 
     companion object {
-        /** 기본 옵션 인스턴스. */
+        /**
+         * 기본 옵션 인스턴스.
+         *
+         * - leaderGroupOptions = [LeaderGroupElectionOptions.Default]
+         * - retryStrategy = [RetryStrategy.Jitter]
+         * - recordHistory = `false`
+         * - lockOwner = `null`
+         */
         @JvmField
         val Default = ExposedJdbcLeaderGroupElectionOptions()
     }

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcVirtualThreadLeaderElection.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcVirtualThreadLeaderElection.kt
@@ -7,17 +7,19 @@ import io.bluetape4k.leader.VirtualThreadLeaderElection
 /**
  * Virtual Thread 기반 Exposed JDBC 리더 선출 구현체.
  *
- * [ExposedJdbcLeaderElection]을 delegate로 사용하며, [virtualFuture]로 래핑합니다.
- * delegate가 이미 [ExposedJdbcLeaderElection.invoke]로 ensureSchema를 보장하므로
- * 이 클래스는 직접 생성이 가능합니다 (private constructor 없음).
+ * [ExposedJdbcLeaderElection]을 delegate로 사용하며 [virtualFuture]로 래핑합니다.
+ * 스키마 초기화는 delegate에서 보장됩니다.
  *
  * ```kotlin
  * val election = ExposedJdbcLeaderElection(db)
  * val vtElection = ExposedJdbcVirtualThreadLeaderElection(election)
- * val result = vtElection.runAsyncIfLeader("job-lock") { processData() }.await()
+ * val result: String? = vtElection.runAsyncIfLeader("job-lock") { processData() }
+ *     .get(5, TimeUnit.SECONDS)
  * ```
  *
- * @param delegate 기반 [ExposedJdbcLeaderElection] 인스턴스
+ * 편의 함수 [Database.runVirtualIfLeader]도 제공됩니다.
+ *
+ * @property delegate 기반 [ExposedJdbcLeaderElection] 인스턴스
  */
 class ExposedJdbcVirtualThreadLeaderElection(
     private val delegate: ExposedJdbcLeaderElection,
@@ -26,8 +28,8 @@ class ExposedJdbcVirtualThreadLeaderElection(
     /**
      * [lockName]에 대한 리더 선출을 Virtual Thread에서 비동기로 실행합니다.
      *
-     * delegate의 [ExposedJdbcLeaderElection.runIfLeader]를 Virtual Thread에서 실행합니다.
-     *
+     * @param lockName 락 식별자
+     * @param action 리더 획득 성공 시 실행할 작업
      * @return [action] 실행 결과를 담은 [VirtualFuture]. 리더 획득 실패 시 `null`로 완료됨
      */
     override fun <T> runAsyncIfLeader(lockName: String, action: () -> T): VirtualFuture<T?> =

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/RetryStrategy.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/RetryStrategy.kt
@@ -1,27 +1,35 @@
 package io.bluetape4k.leader.exposed.jdbc
 
+import java.io.Serializable
 import java.util.concurrent.ThreadLocalRandom
 
 /**
  * 락 획득 재시도 대기 전략을 정의하는 sealed class.
  *
- * 각 전략의 [delayMs] 반환값은 항상 `0 < result <= remaining` 범위를 보장합니다.
- * `remaining` 파라미터로 deadline 초과를 방지합니다.
+ * 락 구현체(`ExposedJdbcLock`, `ExposedJdbcGroupLock`)가 내부적으로 사용하는 재시도 전략입니다.
+ * 일반 사용자는 [ExposedJdbcLeaderElectionOptions.retryStrategy]를 통해 전략을 선택하기만 하면 됩니다.
  *
+ * ### 예시
  * ```kotlin
- * val strategy = RetryStrategy.Jitter(baseDelayMs = 50L)
- * val delay = strategy.delayMs(attempt = 0, remaining = 1000L)
- * Thread.sleep(delay)
+ * val options = ExposedJdbcLeaderElectionOptions(
+ *     retryStrategy = RetryStrategy.Exponential(baseDelayMs = 50L, maxDelayMs = 1_000L),
+ * )
+ * val election = ExposedJdbcLeaderElection(db, options)
  * ```
+ *
+ * ### 계약 (모든 변형 공통)
+ * - `remaining > 0`일 때: `1 <= delayMs(attempt, remaining) <= remaining`.
+ * - `remaining <= 0`일 때: `delayMs`는 `0`을 반환할 수 있으나, 호출자가 `remaining > 0`을
+ *   먼저 검증하므로 실제로 사용되지 않습니다.
  */
-sealed class RetryStrategy {
+sealed class RetryStrategy : Serializable {
 
     /**
      * 시도 횟수와 남은 시간을 기반으로 대기 시간(밀리초)을 계산합니다.
      *
      * @param attempt 현재 재시도 횟수 (0-based)
      * @param remaining deadline까지 남은 밀리초. 반환값이 이 값을 초과하지 않음을 보장
-     * @return 대기 시간 (밀리초). 항상 `1 <= result <= remaining`
+     * @return 대기 시간 (밀리초). `remaining > 0`이면 `1..remaining` 범위, 그 외 `0`
      */
     abstract fun delayMs(attempt: Int, remaining: Long): Long
 
@@ -31,12 +39,18 @@ sealed class RetryStrategy {
      * `[1ms, baseDelayMs)` 균등 분포에서 랜덤 값을 선택합니다.
      * 동일 재시도 윈도우에 인스턴스가 집중되는 것을 방지합니다.
      *
-     * @property baseDelayMs jitter 상한 (기본값 50ms)
+     * `baseDelayMs`가 1 이하인 경우 [IllegalArgumentException]을 발생시킵니다 (충분한 jitter 폭 확보).
+     *
+     * @property baseDelayMs jitter 상한 (기본값 50ms, 최소 2)
      */
     data class Jitter(val baseDelayMs: Long = 50L) : RetryStrategy() {
+        init {
+            require(baseDelayMs >= 2L) { "baseDelayMs must be >= 2: $baseDelayMs" }
+        }
+
         override fun delayMs(attempt: Int, remaining: Long): Long {
-            val upper = baseDelayMs.coerceAtLeast(2L)
-            return ThreadLocalRandom.current().nextLong(1L, upper).coerceAtMost(remaining)
+            if (remaining <= 0L) return 0L
+            return ThreadLocalRandom.current().nextLong(1L, baseDelayMs).coerceAtMost(remaining)
         }
     }
 
@@ -46,12 +60,18 @@ sealed class RetryStrategy {
      * `baseDelayMs * 2^attempt` 를 최대 `maxDelayMs`까지 증가시킵니다.
      * `attempt`는 내부적으로 10으로 클램프하여 오버플로를 방지합니다.
      *
-     * @property baseDelayMs 기본 대기 시간 (기본값 50ms)
-     * @property maxDelayMs 최대 대기 시간 (기본값 5000ms)
+     * @property baseDelayMs 기본 대기 시간 (기본값 50ms, 최소 1)
+     * @property maxDelayMs 최대 대기 시간 (기본값 5000ms, `baseDelayMs` 이상)
      */
     data class Exponential(val baseDelayMs: Long = 50L, val maxDelayMs: Long = 5_000L) : RetryStrategy() {
+        init {
+            require(baseDelayMs >= 1L) { "baseDelayMs must be >= 1: $baseDelayMs" }
+            require(maxDelayMs >= baseDelayMs) { "maxDelayMs ($maxDelayMs) must be >= baseDelayMs ($baseDelayMs)" }
+        }
+
         override fun delayMs(attempt: Int, remaining: Long): Long {
-            val capped = attempt.coerceAtMost(10)
+            if (remaining <= 0L) return 0L
+            val capped = attempt.coerceAtLeast(0).coerceAtMost(10)
             val delay = (baseDelayMs * (1L shl capped)).coerceAtMost(maxDelayMs)
             return delay.coerceAtMost(remaining).coerceAtLeast(1L)
         }
@@ -62,10 +82,16 @@ sealed class RetryStrategy {
      *
      * 매 재시도마다 동일한 대기 시간을 사용합니다.
      *
-     * @property fixedMs 고정 대기 시간 (기본값 50ms)
+     * @property fixedMs 고정 대기 시간 (기본값 50ms, 최소 1)
      */
     data class Fixed(val fixedMs: Long = 50L) : RetryStrategy() {
-        override fun delayMs(attempt: Int, remaining: Long): Long =
-            fixedMs.coerceAtMost(remaining).coerceAtLeast(1L)
+        init {
+            require(fixedMs >= 1L) { "fixedMs must be >= 1: $fixedMs" }
+        }
+
+        override fun delayMs(attempt: Int, remaining: Long): Long {
+            if (remaining <= 0L) return 0L
+            return fixedMs.coerceAtMost(remaining).coerceAtLeast(1L)
+        }
     }
 }

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLock.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLock.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.leader.exposed.tables.LeaderGroupLockTable
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
+import kotlinx.coroutines.CancellationException
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.less
@@ -41,6 +42,10 @@ internal class ExposedJdbcGroupLock internal constructor(
     private val retryStrategy: RetryStrategy,
     private val lockOwner: String? = null,
 ) {
+    init {
+        require(slot >= 0) { "slot must be >= 0: $slot" }
+    }
+
     companion object : KLogging()
 
     /** 인스턴스별 고유 fencing token. */
@@ -56,9 +61,11 @@ internal class ExposedJdbcGroupLock internal constructor(
         var attempt = 0
 
         do {
-            val acquired = runCatching {
+            val acquired = try {
                 tryAcquireOnce(leaseTime)
-            }.getOrElse { e ->
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
                 log.warn(e) { "DB 오류 (재시도 유지): lockName=$lockName, slot=$slot, attempt=$attempt" }
                 false
             }
@@ -70,7 +77,13 @@ internal class ExposedJdbcGroupLock internal constructor(
 
             val remaining = deadline - System.currentTimeMillis()
             if (remaining > 0L) {
-                Thread.sleep(retryStrategy.delayMs(attempt++, remaining))
+                try {
+                    Thread.sleep(retryStrategy.delayMs(attempt++, remaining))
+                } catch (e: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    log.debug { "sleep interrupted; 재시도 중단: lockName=$lockName, slot=$slot" }
+                    return false
+                }
             }
         } while (System.currentTimeMillis() < deadline)
 

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcLock.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcLock.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.leader.exposed.tables.LeaderLockTable
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
+import kotlinx.coroutines.CancellationException
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greater
@@ -61,9 +62,11 @@ internal class ExposedJdbcLock internal constructor(
         var attempt = 0
 
         do {
-            val acquired = runCatching {
+            val acquired = try {
                 tryAcquireOnce(leaseTime)
-            }.getOrElse { e ->
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
                 log.warn(e) { "DB 오류 (재시도 유지): lockName=$lockName, attempt=$attempt" }
                 false
             }
@@ -76,7 +79,14 @@ internal class ExposedJdbcLock internal constructor(
             val remaining = deadline - System.currentTimeMillis()
             if (remaining > 0L) {
                 // sleep은 transaction 바깥에서만 호출 (HikariCP 풀 고갈 방지)
-                Thread.sleep(retryStrategy.delayMs(attempt++, remaining))
+                // InterruptedException 발생 시 interrupt flag 복원 후 false 반환 (never-throws 계약)
+                try {
+                    Thread.sleep(retryStrategy.delayMs(attempt++, remaining))
+                } catch (e: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    log.debug { "sleep interrupted; 재시도 중단: lockName=$lockName" }
+                    return false
+                }
             }
         } while (System.currentTimeMillis() < deadline)
 

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcSchemaInitializer.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcSchemaInitializer.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.leader.exposed.ExposedLeaderSchema
 import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -27,6 +28,9 @@ internal object ExposedJdbcSchemaInitializer : KLogging() {
     /**
      * [db]에 리더 선출 테이블이 없으면 생성합니다. 동일 DB URL에 대해 최초 1회만 실행됩니다.
      *
+     * 스키마 생성 실패 시 guard key를 설정하지 않으므로 다음 호출 시 재시도됩니다.
+     * 실패 시 컨텍스트 로그를 남기고 원본 예외를 그대로 전파합니다.
+     *
      * @throws Exception 스키마 생성 중 DB 오류 발생 시 (재시도 허용)
      */
     fun ensureSchema(db: Database) {
@@ -34,21 +38,39 @@ internal object ExposedJdbcSchemaInitializer : KLogging() {
         if (initializedDbs.containsKey(dbKey)) return
         initLock.withLock {
             if (initializedDbs.containsKey(dbKey)) return
-            transaction(db) {
-                SchemaUtils.createMissingTablesAndColumns(*ExposedLeaderSchema.allTables)
+            try {
+                transaction(db) {
+                    SchemaUtils.createMissingTablesAndColumns(*ExposedLeaderSchema.allTables)
+                }
+            } catch (e: Throwable) {
+                log.warn(e) { "리더 선출 스키마 초기화 실패 (다음 호출 시 재시도): ${sanitizeUrl(dbKey)}" }
+                throw e
             }
             initializedDbs[dbKey] = true
             log.debug { "리더 선출 스키마 초기화 완료: ${sanitizeUrl(dbKey)}" }
         }
     }
 
-    private fun sanitizeUrl(url: String): String {
+    /**
+     * JDBC URL 내 userinfo(특히 password)를 `***`로 마스킹합니다.
+     *
+     * `jdbc:` 접두사를 제거한 후 [URI]로 파싱하여 userinfo 부분만 치환합니다.
+     * 파싱 실패 시 원본 URL을 반환합니다 (best-effort).
+     */
+    internal fun sanitizeUrl(url: String): String {
+        // "jdbc:postgresql://user:pw@host/db" → URI는 opaque로 파싱하므로 rawUserInfo == null.
+        // 접두사 제거 후 hierarchical URI로 재파싱하여 userinfo 추출.
+        val (prefix, rest) = if (url.startsWith("jdbc:", ignoreCase = true)) {
+            "jdbc:" to url.substring(5)
+        } else {
+            "" to url
+        }
         return try {
-            val uri = URI(url)
-            val rawUserInfo = uri.rawUserInfo ?: return url
-            if (rawUserInfo.isEmpty()) return url
+            val uri = URI(rest)
+            val rawUserInfo = uri.rawUserInfo
+            if (rawUserInfo.isNullOrEmpty()) return url
 
-            URI(
+            val sanitized = URI(
                 uri.scheme,
                 "***",
                 uri.host,
@@ -57,6 +79,7 @@ internal object ExposedJdbcSchemaInitializer : KLogging() {
                 uri.query,
                 uri.fragment
             ).toString()
+            prefix + sanitized
         } catch (_: URISyntaxException) {
             url
         } catch (_: IllegalArgumentException) {

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElectionTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElectionTest.kt
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.time.Duration
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -301,6 +302,43 @@ class ExposedJdbcLeaderElectionTest : AbstractExposedJdbcLeaderTest() {
 
         val result = election.runIfLeader(lockName) { "복구 성공" }
         result shouldBeEqualTo "복구 성공"
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - action이 failedFuture 반환 시 FAILED 이력 기록 후 락 해제된다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val options = ExposedJdbcLeaderElectionOptions(
+            recordHistory = true,
+            leaderOptions = LeaderElectionOptions(
+                waitTime = Duration.ofSeconds(2),
+                leaseTime = Duration.ofSeconds(10),
+            ),
+        )
+        val election = ExposedJdbcLeaderElection(db, options)
+
+        assertThrows<CompletionException> {
+            election.runAsyncIfLeader<Int>(lockName, VirtualThreadExecutor) {
+                CompletableFuture.failedFuture(IllegalStateException("async 실패"))
+            }.join()
+        }
+
+        // 다음 호출이 성공해야 함 (락 해제됨)
+        val result = election.runIfLeader(lockName) { "복구 성공" }
+        result shouldBeEqualTo "복구 성공"
+
+        // FAILED 이력 1건 + 복구 시도의 ACQUIRED+COMPLETED 1건 (총 history 2건 중 FAILED 1건)
+        val failedCount = transaction(db) {
+            LeaderLockHistoryTable.selectAll()
+                .where {
+                    (LeaderLockHistoryTable.lockName eq lockName) and
+                        (LeaderLockHistoryTable.status eq HistoryStatus.FAILED.name)
+                }
+                .count()
+        }
+        failedCount shouldBeEqualTo 1L
     }
 
     @ParameterizedTest

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElectionTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElectionTest.kt
@@ -298,6 +298,67 @@ class ExposedJdbcLeaderGroupElectionTest : AbstractExposedJdbcLeaderTest() {
 
     @ParameterizedTest
     @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - action이 failedFuture 반환 시 슬롯이 반환되어 다음 호출 성공한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val election = ExposedJdbcLeaderGroupElection(db, makeOptions(maxLeaders = 1))
+
+        assertThrows<CompletionException> {
+            election.runAsyncIfLeader<Int>(lockName, VirtualThreadExecutor) {
+                java.util.concurrent.CompletableFuture.failedFuture(IllegalStateException("async 실패"))
+            }.join()
+        }
+
+        val result = election.runIfLeader(lockName) { "복구 성공" }
+        result shouldBeEqualTo "복구 성공"
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runIfLeader - maxLeaders=1 일 때 단일 리더 시맨틱과 동일하게 동작한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val options = makeOptions(maxLeaders = 1)
+        val election = ExposedJdbcLeaderGroupElection(db, options)
+
+        // 첫 획득 → 정상
+        val result = election.runIfLeader(lockName) { "ok" }
+        result shouldBeEqualTo "ok"
+
+        // 보유자가 잡고 있는 동안 다른 획득 시도 → null
+        val acquiredLatch = CountDownLatch(1)
+        val holdLatch = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+        executor.submit {
+            election.runIfLeader(lockName) {
+                acquiredLatch.countDown()
+                holdLatch.await()
+            }
+        }
+        try {
+            acquiredLatch.await(5, TimeUnit.SECONDS)
+            val shortElection = ExposedJdbcLeaderGroupElection(
+                db,
+                ExposedJdbcLeaderGroupElectionOptions(
+                    leaderGroupOptions = LeaderGroupElectionOptions(
+                        maxLeaders = 1,
+                        waitTime = Duration.ofMillis(100),
+                        leaseTime = Duration.ofSeconds(5),
+                    ),
+                ),
+            )
+            shortElection.runIfLeader(lockName) { "should-not-run" }.shouldBeNull()
+        } finally {
+            holdLatch.countDown()
+            executor.shutdown()
+            executor.awaitTermination(5, TimeUnit.SECONDS)
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
     fun `Database 확장함수 runIfLeaderGroup - 정상 동작한다`(testDB: TestDB) {
         val db = connectDb(testDB)
         cleanTables(db)

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcOptionsValidationTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcOptionsValidationTest.kt
@@ -1,0 +1,85 @@
+package io.bluetape4k.leader.exposed.jdbc
+
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Options data class 의 init 검증 동작 확인.
+ *
+ * DB 의존이 없으므로 testcontainers를 사용하지 않습니다.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExposedJdbcOptionsValidationTest {
+
+    @Test
+    fun `ExposedJdbcLeaderElectionOptions - lockOwner 256자는 IllegalArgumentException 발생`() {
+        assertThrows<IllegalArgumentException> {
+            ExposedJdbcLeaderElectionOptions(lockOwner = "x".repeat(256))
+        }
+    }
+
+    @Test
+    fun `ExposedJdbcLeaderElectionOptions - lockOwner 정확히 255자는 허용`() {
+        ExposedJdbcLeaderElectionOptions(lockOwner = "x".repeat(255))
+    }
+
+    @Test
+    fun `ExposedJdbcLeaderElectionOptions - lockOwner null은 허용`() {
+        ExposedJdbcLeaderElectionOptions(lockOwner = null)
+    }
+
+    @Test
+    fun `ExposedJdbcLeaderGroupElectionOptions - maxLeaders 0은 IllegalArgumentException 발생`() {
+        assertThrows<IllegalArgumentException> {
+            ExposedJdbcLeaderGroupElectionOptions(
+                leaderGroupOptions = LeaderGroupElectionOptions(maxLeaders = 0),
+            )
+        }
+    }
+
+    @Test
+    fun `ExposedJdbcLeaderGroupElectionOptions - maxLeaders 음수는 IllegalArgumentException 발생`() {
+        assertThrows<IllegalArgumentException> {
+            ExposedJdbcLeaderGroupElectionOptions(
+                leaderGroupOptions = LeaderGroupElectionOptions(maxLeaders = -1),
+            )
+        }
+    }
+
+    @Test
+    fun `ExposedJdbcLeaderGroupElectionOptions - lockOwner 256자는 IllegalArgumentException 발생`() {
+        assertThrows<IllegalArgumentException> {
+            ExposedJdbcLeaderGroupElectionOptions(lockOwner = "y".repeat(256))
+        }
+    }
+
+    @Test
+    fun `RetryStrategy_Jitter - baseDelayMs 1은 IllegalArgumentException 발생`() {
+        assertThrows<IllegalArgumentException> {
+            RetryStrategy.Jitter(baseDelayMs = 1L)
+        }
+    }
+
+    @Test
+    fun `RetryStrategy_Exponential - baseDelayMs 0은 IllegalArgumentException 발생`() {
+        assertThrows<IllegalArgumentException> {
+            RetryStrategy.Exponential(baseDelayMs = 0L)
+        }
+    }
+
+    @Test
+    fun `RetryStrategy_Exponential - maxDelayMs가 baseDelayMs보다 작으면 IllegalArgumentException 발생`() {
+        assertThrows<IllegalArgumentException> {
+            RetryStrategy.Exponential(baseDelayMs = 100L, maxDelayMs = 50L)
+        }
+    }
+
+    @Test
+    fun `RetryStrategy_Fixed - fixedMs 0은 IllegalArgumentException 발생`() {
+        assertThrows<IllegalArgumentException> {
+            RetryStrategy.Fixed(fixedMs = 0L)
+        }
+    }
+}

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/RetryStrategyTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/RetryStrategyTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.leader.exposed.jdbc
 import org.amshove.kluent.shouldBeInRange
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.assertThrows
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RetryStrategyTest {
@@ -15,8 +16,14 @@ class RetryStrategyTest {
     }
 
     @Test
-    fun `Jitter - baseDelayMs가 1일 때 IllegalArgumentException이 발생하지 않는다`() {
-        val strategy = RetryStrategy.Jitter(baseDelayMs = 1L)
+    fun `Jitter - baseDelayMs가 1 이하면 IllegalArgumentException 발생`() {
+        assertThrows<IllegalArgumentException> { RetryStrategy.Jitter(baseDelayMs = 1L) }
+        assertThrows<IllegalArgumentException> { RetryStrategy.Jitter(baseDelayMs = 0L) }
+    }
+
+    @Test
+    fun `Jitter - baseDelayMs 2 이상은 정상 생성된다`() {
+        val strategy = RetryStrategy.Jitter(baseDelayMs = 2L)
         val delay = strategy.delayMs(attempt = 0, remaining = 100L)
         delay shouldBeInRange 1L..100L
     }

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLockTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLockTest.kt
@@ -6,6 +6,8 @@ import io.bluetape4k.leader.exposed.jdbc.RetryStrategy
 import io.bluetape4k.logging.KLogging
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.time.Duration
@@ -110,5 +112,18 @@ class ExposedJdbcGroupLockTest : AbstractExposedJdbcLeaderTest() {
         lock.unlock()
 
         lock.unlock()
+    }
+
+    @Test
+    fun `생성자 - slot 음수는 IllegalArgumentException 발생`() {
+        // DB 연결 없이 init 검증만 확인 — connectDb 불필요
+        assertThrows<IllegalArgumentException> {
+            ExposedJdbcGroupLock(
+                org.jetbrains.exposed.v1.jdbc.Database.connect("jdbc:h2:mem:slot-validate;DB_CLOSE_DELAY=-1"),
+                lockName = "slot-validate",
+                slot = -1,
+                retryStrategy = RetryStrategy.Jitter(),
+            )
+        }
     }
 }

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcLockTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcLockTest.kt
@@ -105,6 +105,68 @@ class ExposedJdbcLockTest : AbstractExposedJdbcLeaderTest() {
 
     @ParameterizedTest
     @MethodSource("enableDialects")
+    fun `isHeldByCurrentInstance - 락 획득 후 true 반환`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lock = ExposedJdbcLock(db, randomName(), RetryStrategy.Jitter())
+        lock.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(10)).shouldBeTrue()
+
+        lock.isHeldByCurrentInstance().shouldBeTrue()
+
+        lock.unlock()
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `isHeldByCurrentInstance - unlock 이후 false 반환`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lock = ExposedJdbcLock(db, randomName(), RetryStrategy.Jitter())
+        lock.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(10))
+        lock.unlock()
+
+        lock.isHeldByCurrentInstance().shouldBeFalse()
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `isHeldByCurrentInstance - leaseTime 만료 시 false 반환`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lock = ExposedJdbcLock(db, randomName(), RetryStrategy.Jitter())
+        val leaseTime = Duration.ofMillis(150)
+        lock.tryLock(Duration.ofSeconds(1), leaseTime)
+
+        Thread.sleep(leaseTime.toMillis() * 2)
+
+        lock.isHeldByCurrentInstance().shouldBeFalse()
+        lock.unlock()
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `isHeldByCurrentInstance - 만료 후 다른 인스턴스 takeover 시 원본 인스턴스는 false 반환`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+
+        val original = ExposedJdbcLock(db, lockName, RetryStrategy.Jitter())
+        original.tryLock(Duration.ofSeconds(1), Duration.ofMillis(150))
+        Thread.sleep(250)
+
+        val takeover = ExposedJdbcLock(db, lockName, RetryStrategy.Jitter())
+        takeover.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(10)).shouldBeTrue()
+
+        // 원본 인스턴스 token은 더 이상 유효하지 않음
+        original.isHeldByCurrentInstance().shouldBeFalse()
+        // 새 인스턴스는 자신 token으로 보유 중
+        takeover.isHeldByCurrentInstance().shouldBeTrue()
+
+        takeover.unlock()
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
     fun `tryLock - 멀티스레드 경합 시 단 하나만 락 획득에 성공한다`(testDB: TestDB) {
         val db = connectDb(testDB)
         cleanTables(db)

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcSchemaInitializerTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcSchemaInitializerTest.kt
@@ -1,0 +1,105 @@
+package io.bluetape4k.leader.exposed.jdbc.lock
+
+import io.bluetape4k.exposed.tests.TestDB
+import io.bluetape4k.leader.exposed.jdbc.AbstractExposedJdbcLeaderTest
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldContain
+import org.amshove.kluent.shouldNotContain
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class ExposedJdbcSchemaInitializerTest : AbstractExposedJdbcLeaderTest() {
+
+    companion object : KLogging()
+
+    // --- sanitizeUrl ---
+
+    @Test
+    fun `sanitizeUrl - jdbc postgres URL 의 password가 마스킹된다`() {
+        val url = "jdbc:postgresql://alice:s3cret@db.example.com:5432/leader"
+        val sanitized = ExposedJdbcSchemaInitializer.sanitizeUrl(url)
+
+        sanitized shouldNotContain "s3cret"
+        sanitized shouldContain "***"
+        sanitized shouldContain "jdbc:"
+        sanitized shouldContain "db.example.com"
+        sanitized shouldContain "leader"
+    }
+
+    @Test
+    fun `sanitizeUrl - jdbc mysql URL 의 password가 마스킹된다`() {
+        val url = "jdbc:mysql://root:topsecret@mysql.host:3306/leader?useSSL=false"
+        val sanitized = ExposedJdbcSchemaInitializer.sanitizeUrl(url)
+
+        sanitized shouldNotContain "topsecret"
+        sanitized shouldContain "***"
+    }
+
+    @Test
+    fun `sanitizeUrl - userinfo 없는 URL은 그대로 반환된다`() {
+        val url = "jdbc:postgresql://db.example.com:5432/leader"
+        val sanitized = ExposedJdbcSchemaInitializer.sanitizeUrl(url)
+
+        sanitized shouldBeEqualTo url
+    }
+
+    @Test
+    fun `sanitizeUrl - 잘못된 형식의 URL은 원본 그대로 반환된다`() {
+        val url = "not::a::valid::url"
+        val sanitized = ExposedJdbcSchemaInitializer.sanitizeUrl(url)
+
+        sanitized shouldBeEqualTo url
+    }
+
+    @Test
+    fun `sanitizeUrl - 빈 userinfo 는 원본 그대로 반환된다`() {
+        val url = "jdbc:postgresql://@db.example.com:5432/leader"
+        val sanitized = ExposedJdbcSchemaInitializer.sanitizeUrl(url)
+
+        sanitized shouldBeEqualTo url
+    }
+
+    // --- ensureSchema 동시성 ---
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `ensureSchema - 다중 스레드 동시 호출에도 예외 없이 1회만 초기화된다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        ExposedJdbcSchemaInitializer.resetFor(db)
+
+        val threadCount = 16
+        val readyLatch = CountDownLatch(threadCount)
+        val startLatch = CountDownLatch(1)
+        val errorCount = AtomicInteger(0)
+        val executor = Executors.newFixedThreadPool(threadCount)
+
+        try {
+            repeat(threadCount) {
+                executor.submit {
+                    readyLatch.countDown()
+                    startLatch.await()
+                    try {
+                        ExposedJdbcSchemaInitializer.ensureSchema(db)
+                    } catch (e: Throwable) {
+                        log.warn(e) { "ensureSchema 예외 발생" }
+                        errorCount.incrementAndGet()
+                    }
+                }
+            }
+            readyLatch.await(5, TimeUnit.SECONDS)
+            startLatch.countDown()
+        } finally {
+            executor.shutdown()
+            executor.awaitTermination(10, TimeUnit.SECONDS)
+        }
+
+        errorCount.get() shouldBeEqualTo 0
+    }
+}


### PR DESCRIPTION
## Summary

PR #58의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: leader-exposed-jdbc 5-Tier 코드 리뷰 반영 (daily review 2026-05-03)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 배경

`leader-exposed-jdbc` 모듈이 직전 24시간 내 신규 도입됨. 5개 코드 리뷰 에이전트(코드 일반 / silent failure / 타입 설계 / KDoc / 테스트 커버리지)를 병렬 실행하여 발견된 이슈를 수정.

## CRITICAL 수정

| 이슈 | 파일 |
|---|---|
| `Thread.sleep` `InterruptedException`이 `runCatching` 외부 → never-throws 계약 위반 가능 | `ExposedJdbcLock.kt`, `ExposedJdbcGroupLock.kt` |
| `runCatching`의 `CancellationException` 흡수 → 명시적 `try/catch` 재전파 | 동상 |
| `RetryStrategy` 변형별 `init { require(...) }` 부재 (`Jitter(0)`, `Exponential(maxDelayMs<base)`, `Fixed(0)` 무검증 통과) | `RetryStrategy.kt` |

## HIGH 수정

- async `whenCompleteAsync`에서 `j.u.c.CancellationException` FAILED로 기록되는 동기 path와의 비대칭 → cancel은 history skip
- `ExposedJdbcGroupLock.slot` `>= 0` 검증 추가
- **보안**: `ExposedJdbcSchemaInitializer.sanitizeUrl`이 `jdbc:` 접두사 미처리로 password 마스킹 실패. 접두사 분리 후 hierarchical URI 재파싱
- `ensureSchema` 실패 컨텍스트 로깅 + 재전파
- magic literal 255 → `ExposedLeaderConstants.LOCK_OWNER_LENGTH` 일원화

## KDoc / README

- 공개 override(`runIfLeader` / `runAsyncIfLeader` / `activeCount` / `availableSlots` / `state`) KDoc + 예제 보강. CancellationException 재전파 + null 반환 계약 명시
- `Database` 확장함수 5종 사용 예제 추가
- README VirtualThread 예제 오류 정정 (`delegate` 패턴) + 그룹 상태 조회 섹션 + RetryStrategy invariants 표

## 테스트 (3DB 파라미터화 — H2 / PostgreSQL / MySQL_V8)

- `ExposedJdbcOptionsValidationTest` 신규 (10): 옵션 invariants
- `ExposedJdbcSchemaInitializerTest` 신규 (6): sanitizeUrl 보안 + 동시 `ensureSchema`
- `isHeldByCurrentInstance` 4 시나리오 (보유/해제/만료/takeover)
- async `failedFuture` 경로 (단일 + 그룹) + `maxLeaders=1` 경계
- `RetryStrategyTest`: 신규 invariants 반영

**결과**: 187 tests passing (3DB × 파라미터화).

## 후속 (out-of-scope)

- 스키마 캐시 키를 URL 대신 Database identity 기반으로 검토 (동일 URL/다른 schema 충돌 가능성)
- Exposed `SchemaUtils.createMissingTablesAndColumns` deprecation → `MigrationUtils` 마이그레이션

## Test Plan

- [x] `./gradlew clean :leader-exposed-jdbc:build -x test` 성공
- [x] `./gradlew :leader-exposed-jdbc:test` 187 passing (H2 + PostgreSQL + MySQL_V8)
- [x] `./gradlew detekt` 통과
- [x] CI 3DB 매트릭스 통과 확인
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #58, head `ad6e24b30ae4c4bc50745bc25e47e6736376485b`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
