### PR TITLE
fix: ExposedJdbcGroupLock isHeldByCurrentInstance() 추가 및 DB 오류 처리 개선 (#59, #60, #61)

### DIFF
--- a/docs/lessons/2026-05-03-issue-59-60-61-exposed-jdbc-grouplock.md
+++ b/docs/lessons/2026-05-03-issue-59-60-61-exposed-jdbc-grouplock.md
@@ -1,0 +1,41 @@
+# Lessons Learned — ExposedJdbcGroupLock 개선 (2026-05-03)
+
+**관련 PR**: #63
+**영향 모듈**: leader-exposed-jdbc
+
+## L1: internal class의 반환 타입 변경은 테스트 API까지 전파된다
+
+### 문제
+`ExposedJdbcGroupLock.tryLock()` 반환 타입을 `Boolean → Boolean?`으로 변경했을 때,
+테스트 파일에서 `.shouldBeTrue()` / `.shouldBeFalse()` (Kluent `Boolean` extension)가
+`Boolean?`에 직접 적용되지 않아 컴파일 오류 발생.
+
+### 교훈
+`internal class`라도 테스트에서 직접 사용하는 경우 반환 타입 변경 시 테스트 파일 확인 필수.
+Kluent의 `shouldBeTrue()` / `shouldBeFalse()`는 non-nullable `Boolean`에만 정의됨.
+`Boolean?` 결과는 `shouldBe(true)` / `shouldBe(false)` (infix, nullable 허용)로 대체.
+
+---
+
+## L2: tryLock() "never-throws" 계약과 DB 오류 구별의 트레이드오프
+
+### 문제
+`ExposedJdbcLock.tryLock()`은 "DB 오류 → false 반환" never-throws 계약을 가짐.
+그러나 그룹 락에서 `false`만으로는 "경합 실패"와 "DB 오류"를 구별할 수 없어
+maxLeaders번 반복 후 잘못된 "모든 슬롯 채움" 결론 도출 가능.
+
+### 교훈
+그룹 순회처럼 "실패의 원인"이 다음 동작을 결정하는 경우, Boolean 대신 tri-state를 사용.
+`Boolean?` (null=오류)은 기존 API 호환성을 유지하면서 오류 구별 가능한 최소 변경.
+
+---
+
+## L3: runCatching 내 CancellationException 재throw — 블로킹 코드도 예외 아님
+
+### 문제
+`tryAcquireOnce()` 내 INSERT `runCatching { }.onFailure`에서 `CancellationException`을
+재throw하지 않음. JDBC 블로킹 코드이지만 미래 coroutine context 실행 가능성 존재.
+
+### 교훈
+JDBC 블로킹 코드라도 `runCatching` 사용 시 `CancellationException` 재throw 패턴 적용.
+"never catch CancellationException without rethrowing" 규칙은 blocking/suspend 무관하게 적용.

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElection.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElection.kt
@@ -135,7 +135,14 @@ class ExposedJdbcLeaderGroupElection private constructor(
             val slot = (start + i) % maxLeaders
             val lock = ExposedJdbcGroupLock(db, lockName, slot, options.retryStrategy, options.lockOwner)
 
-            if (!lock.tryLock(perSlotWait, leaseTime)) continue
+            when (lock.tryLock(perSlotWait, leaseTime)) {
+                true -> { /* 획득 성공 — 아래 로직 계속 */ }
+                false -> continue
+                null -> {
+                    log.warn { "DB 오류로 슬롯 순회 중단: lockName=$lockName" }
+                    return null
+                }
+            }
 
             log.debug { "그룹 슬롯을 획득하여 작업을 수행합니다. lockName=$lockName, slot=$slot" }
 
@@ -194,13 +201,20 @@ class ExposedJdbcLeaderGroupElection private constructor(
         val start = Random.nextInt(maxLeaders)
 
         return CompletableFuture.supplyAsync({
-            (0 until maxLeaders)
-                .asSequence()
-                .map { i ->
-                    val slot = (start + i) % maxLeaders
-                    ExposedJdbcGroupLock(db, lockName, slot, options.retryStrategy, options.lockOwner) to slot
+            var acquired: Pair<ExposedJdbcGroupLock, Int>? = null
+            for (i in 0 until maxLeaders) {
+                val slot = (start + i) % maxLeaders
+                val lock = ExposedJdbcGroupLock(db, lockName, slot, options.retryStrategy, options.lockOwner)
+                when (lock.tryLock(perSlotWait, leaseTime)) {
+                    true -> { acquired = lock to slot; break }
+                    false -> continue
+                    null -> {
+                        log.warn { "DB 오류로 비동기 슬롯 순회 중단: lockName=$lockName, slot=$slot" }
+                        return@supplyAsync null
+                    }
                 }
-                .firstOrNull { (lock, _) -> lock.tryLock(perSlotWait, leaseTime) }
+            }
+            acquired
         }, executor).thenComposeAsync({ acquired ->
             if (acquired == null) {
                 log.debug { "그룹 슬롯 획득 실패 (비동기). lockName=$lockName" }

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLock.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLock.kt
@@ -2,12 +2,13 @@ package io.bluetape4k.leader.exposed.jdbc.lock
 
 import io.bluetape4k.leader.exposed.retry.RetryStrategy
 import io.bluetape4k.leader.exposed.tables.LeaderGroupLockTable
-import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.CancellationException
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greater
 import org.jetbrains.exposed.v1.core.less
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
@@ -46,7 +47,7 @@ internal class ExposedJdbcGroupLock internal constructor(
         require(slot >= 0) { "slot must be >= 0: $slot" }
     }
 
-    companion object : KLogging()
+    companion object : KLoggingChannel()
 
     /** 인스턴스별 고유 fencing token. */
     val token: String = UUID.randomUUID().toString()
@@ -54,9 +55,9 @@ internal class ExposedJdbcGroupLock internal constructor(
     /**
      * [waitTime] 내에 슬롯 락 획득을 시도합니다.
      *
-     * @return 락 획득 성공 시 `true`, 타임아웃 또는 오류 시 `false`
+     * @return 락 획득 성공 시 `true`, 경합 실패(타임아웃) 시 `false`, DB 오류 시 `null`
      */
-    fun tryLock(waitTime: Duration, leaseTime: Duration): Boolean {
+    fun tryLock(waitTime: Duration, leaseTime: Duration): Boolean? {
         val deadline = System.currentTimeMillis() + waitTime.toMillis().coerceAtLeast(0L)
         var attempt = 0
 
@@ -66,8 +67,8 @@ internal class ExposedJdbcGroupLock internal constructor(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Throwable) {
-                log.warn(e) { "DB 오류 (재시도 유지): lockName=$lockName, slot=$slot, attempt=$attempt" }
-                false
+                log.warn(e) { "DB 오류로 슬롯 순회 중단: lockName=$lockName, slot=$slot, attempt=$attempt" }
+                return null
             }
 
             if (acquired) {
@@ -125,6 +126,7 @@ internal class ExposedJdbcGroupLock internal constructor(
                         it[LeaderGroupLockTable.lockedUntil] = lockedUntil
                     }
                 }.onFailure { e ->
+                    if (e is CancellationException) throw e
                     log.debug { "INSERT 실패 (PK 충돌 예상 또는 DB 오류): lockName=$lockName, slot=$slot, error=${e.message}" }
                     return@transaction false
                 }
@@ -140,6 +142,32 @@ internal class ExposedJdbcGroupLock internal constructor(
                 }
                 .empty()
         }
+    }
+
+    /**
+     * 현재 인스턴스(token)가 유효한 슬롯 락을 보유하고 있는지 확인합니다.
+     *
+     * 리스 만료 후 타 인스턴스가 재획득한 경우 `false`를 반환합니다.
+     */
+    fun isHeldByCurrentInstance(): Boolean = runCatching {
+        val lockNameVal = lockName
+        val slotVal = slot
+        val tokenVal = token
+        transaction(db) {
+            val now = Instant.now()
+            !LeaderGroupLockTable
+                .selectAll()
+                .where {
+                    (LeaderGroupLockTable.lockName eq lockNameVal) and
+                        (LeaderGroupLockTable.slot eq slotVal) and
+                        (LeaderGroupLockTable.token eq tokenVal) and
+                        (LeaderGroupLockTable.lockedUntil greater now)
+                }
+                .empty()
+        }
+    }.getOrElse { e ->
+        log.warn(e) { "isHeldByCurrentInstance DB 오류 (false 반환): lockName=$lockName, slot=$slot" }
+        false
     }
 
     /**

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcLock.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcLock.kt
@@ -2,7 +2,7 @@ package io.bluetape4k.leader.exposed.jdbc.lock
 
 import io.bluetape4k.leader.exposed.retry.RetryStrategy
 import io.bluetape4k.leader.exposed.tables.LeaderLockTable
-import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.CancellationException
@@ -45,7 +45,7 @@ internal class ExposedJdbcLock internal constructor(
     private val retryStrategy: RetryStrategy,
     private val lockOwner: String? = null,
 ) {
-    companion object : KLogging()
+    companion object : KLoggingChannel()
 
     /** 인스턴스별 고유 fencing token. unlock 시 zombie 방지에 사용됩니다. */
     val token: String = UUID.randomUUID().toString()
@@ -124,6 +124,7 @@ internal class ExposedJdbcLock internal constructor(
                         it[LeaderLockTable.lockedUntil] = lockedUntil
                     }
                 }.onFailure { e ->
+                    if (e is CancellationException) throw e
                     log.debug { "INSERT 실패 (PK 충돌 예상 또는 DB 오류): lockName=$lockName, error=${e.message}" }
                     return@transaction false
                 }

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLockTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLockTest.kt
@@ -4,8 +4,7 @@ import io.bluetape4k.exposed.tests.TestDB
 import io.bluetape4k.leader.exposed.jdbc.AbstractExposedJdbcLeaderTest
 import io.bluetape4k.leader.exposed.retry.RetryStrategy
 import io.bluetape4k.logging.KLogging
-import org.amshove.kluent.shouldBeFalse
-import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldBe
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -23,7 +22,7 @@ class ExposedJdbcGroupLockTest : AbstractExposedJdbcLeaderTest() {
         cleanTables(db)
         val lock = ExposedJdbcGroupLock(db, randomName(), slot = 0, RetryStrategy.Jitter())
 
-        lock.tryLock(Duration.ofSeconds(2), Duration.ofSeconds(10)).shouldBeTrue()
+        lock.tryLock(Duration.ofSeconds(2), Duration.ofSeconds(10)) shouldBe true
         lock.unlock()
     }
 
@@ -37,7 +36,7 @@ class ExposedJdbcGroupLockTest : AbstractExposedJdbcLeaderTest() {
         holder.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(30))
 
         val contender = ExposedJdbcGroupLock(db, lockName, slot = 0, RetryStrategy.Fixed(fixedMs = 10L))
-        contender.tryLock(Duration.ofMillis(100), Duration.ofSeconds(5)).shouldBeFalse()
+        contender.tryLock(Duration.ofMillis(100), Duration.ofSeconds(5)) shouldBe false
 
         holder.unlock()
     }
@@ -52,8 +51,8 @@ class ExposedJdbcGroupLockTest : AbstractExposedJdbcLeaderTest() {
         val lock0 = ExposedJdbcGroupLock(db, lockName, slot = 0, RetryStrategy.Jitter())
         val lock1 = ExposedJdbcGroupLock(db, lockName, slot = 1, RetryStrategy.Jitter())
 
-        lock0.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(10)).shouldBeTrue()
-        lock1.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(10)).shouldBeTrue()
+        lock0.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(10)) shouldBe true
+        lock1.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(10)) shouldBe true
 
         lock0.unlock()
         lock1.unlock()
@@ -74,13 +73,13 @@ class ExposedJdbcGroupLockTest : AbstractExposedJdbcLeaderTest() {
         var acquired = false
 
         while (System.nanoTime() < deadlineNanos && !acquired) {
-            acquired = newLock.tryLock(Duration.ofMillis(50), Duration.ofSeconds(10))
+            acquired = newLock.tryLock(Duration.ofMillis(50), Duration.ofSeconds(10)) == true
             if (!acquired) {
                 Thread.yield()
             }
         }
 
-        acquired.shouldBeTrue()
+        acquired shouldBe true
         if (acquired) {
             newLock.unlock()
         }
@@ -112,6 +111,45 @@ class ExposedJdbcGroupLockTest : AbstractExposedJdbcLeaderTest() {
         lock.unlock()
 
         lock.unlock()
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `isHeldByCurrentInstance - 락 획득 후 true를 반환한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lock = ExposedJdbcGroupLock(db, randomName(), slot = 0, RetryStrategy.Jitter())
+        lock.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(30))
+
+        lock.isHeldByCurrentInstance() shouldBe true
+        lock.unlock()
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `isHeldByCurrentInstance - 다른 인스턴스 token으로는 false를 반환한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val holder = ExposedJdbcGroupLock(db, lockName, slot = 0, RetryStrategy.Jitter())
+        holder.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(30))
+
+        val other = ExposedJdbcGroupLock(db, lockName, slot = 0, RetryStrategy.Jitter())
+        other.isHeldByCurrentInstance() shouldBe false
+
+        holder.unlock()
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `isHeldByCurrentInstance - unlock 후 false를 반환한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lock = ExposedJdbcGroupLock(db, randomName(), slot = 0, RetryStrategy.Jitter())
+        lock.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(30))
+        lock.unlock()
+
+        lock.isHeldByCurrentInstance() shouldBe false
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #59
Closes #60
Closes #61

PR #63의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: ExposedJdbcGroupLock isHeldByCurrentInstance() 추가 및 DB 오류 처리 개선 (#59, #60, #61)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 변경 요약

`leader-exposed-jdbc` 모듈의 3가지 이슈를 일괄 수정합니다.

### Fix #59 — ExposedJdbcGroupLock.isHeldByCurrentInstance() 추가

복합 PK (lockName, slot) + token + lockedUntil > NOW() 조건으로 소유 여부 확인.
DB 오류 시 false 반환 (never-throws 계약 유지).

### Fix #60 — DB 오류 vs 경합 실패 구별

tryLock() 반환 타입: Boolean → Boolean?
- true: 슬롯 획득 성공
- false: 경합 실패 (타임아웃)
- null: DB 오류 → 슬롯 순회 즉시 중단

### Chore #61 — KLogging → KLoggingChannel 전환

ExposedJdbcLock, ExposedJdbcGroupLock companion object 전환.

### 추가 수정

tryAcquireOnce() INSERT runCatching 내 CancellationException 재throw 누락 수정.

## 테스트
196 passing, 0 failed (H2 / PostgreSQL / MySQL_V8)

closes #59
closes #60
closes #61
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #59, #60, #61, milestone `0.1.0`, assignee `debop`
- PR: #63, head `33a554b4fde2e35f71e3c694d05d25fe0b53de7a`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
