### PR TITLE
fix: leader-exposed daily review 2026-05-04 — R2DBC GroupLock contract + JDBC SELECT 강화

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - **`ExposedJdbcGroupLock.isHeldByCurrentInstance()`**: token + `lockedUntil > NOW()` 체크 누락 메서드 추가 (issue #59, PR #63)
 - **`ExposedJdbcGroupLock.tryLock()` DB 오류 전파**: `Boolean?` tri-state 반환으로 DB 오류와 슬롯 경합 실패 구분 가능 (issue #60, PR #63)
 - **Exposed Lock 클래스 `KLoggingChannel` 이식**: `KLogging` → `KLoggingChannel` (coroutine 컨텍스트 로거) (issue #61, PR #63)
+- **`ExposedR2dbcGroupLock.tryLock()` DB 오류 전파**: `Boolean?` tri-state 반환으로 JDBC 형제 모듈과 contract 통일 (daily review 2026-05-04)
+- **Exposed Lock SELECT 술어 강화**: JDBC `tryAcquireOnce` Step 3 SELECT에 `lockedUntil > NOW()` 추가 — split-brain 방지 + R2DBC 대칭 (daily review 2026-05-04)
 
 ### Changed
 

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLock.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLock.kt
@@ -132,13 +132,14 @@ internal class ExposedJdbcGroupLock internal constructor(
                 }
             }
 
-            // SELECT으로 token 소유 확인 (복합 PK 조건)
+            // SELECT으로 token 소유 + lease 유효성 확인 (R2DBC 형제 모듈과 대칭)
             !LeaderGroupLockTable
                 .selectAll()
                 .where {
                     (LeaderGroupLockTable.lockName eq lockNameVal) and
                         (LeaderGroupLockTable.slot eq slotVal) and
-                        (LeaderGroupLockTable.token eq tokenVal)
+                        (LeaderGroupLockTable.token eq tokenVal) and
+                        (LeaderGroupLockTable.lockedUntil greater now)
                 }
                 .empty()
         }

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcLock.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcLock.kt
@@ -130,10 +130,14 @@ internal class ExposedJdbcLock internal constructor(
                 }
             }
 
-            // Step 3: token 소유 확인
+            // Step 3: token 소유 + lease 유효성 확인 (R2DBC 형제 모듈과 대칭)
             !LeaderLockTable
                 .selectAll()
-                .where { (LeaderLockTable.lockName eq lockNameVal) and (LeaderLockTable.token eq tokenVal) }
+                .where {
+                    (LeaderLockTable.lockName eq lockNameVal) and
+                        (LeaderLockTable.token eq tokenVal) and
+                        (LeaderLockTable.lockedUntil greater now)
+                }
                 .empty()
         }
     }

--- a/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2dbcSuspendLeaderGroupElection.kt
+++ b/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2dbcSuspendLeaderGroupElection.kt
@@ -155,7 +155,14 @@ class ExposedR2dbcSuspendLeaderGroupElection private constructor(
             val slot = (start + i) % maxLeaders
             val lock = ExposedR2dbcGroupLock(db, lockName, slot, options.retryStrategy, options.lockOwner)
 
-            if (!lock.tryLock(perSlotWait, leaseTime)) continue
+            when (lock.tryLock(perSlotWait, leaseTime)) {
+                true -> { /* 획득 성공 — 아래 로직 계속 */ }
+                false -> continue
+                null -> {
+                    log.warn { "DB 오류로 슬롯 순회 중단: lockName=$lockName" }
+                    return null
+                }
+            }
 
             log.debug { "그룹 슬롯을 획득하여 작업을 수행합니다. lockName=$lockName, slot=$slot" }
             cachedActiveCount.incrementAndGet()

--- a/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcGroupLock.kt
+++ b/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcGroupLock.kt
@@ -35,8 +35,7 @@ import java.util.UUID
  *
  * ## DB 오류 vs 정상 경합 실패 구분
  * - **정상 경합 실패** (다른 노드가 슬롯 점유 중): `tryAcquireOnce()`가 `false` 반환
- * - **DB 오류** (연결 끊김, 타임아웃 등): `tryLock()`의 outer catch가 예외를 `warn` 로그 후 `false` 반환
- *   → retry 허용. 복구 불가 오류는 caller가 판단
+ * - **DB 오류** (연결 끊김, 타임아웃 등): `tryLock()`이 `null` 반환 → caller가 슬롯 순회를 중단할 수 있음 (JDBC 형제와 동일 contract)
  *
  * @param db Exposed [R2dbcDatabase] 인스턴스
  * @param lockName 그룹 락 식별자
@@ -63,9 +62,9 @@ internal class ExposedR2dbcGroupLock internal constructor(
     /**
      * [waitTime] 내에 슬롯 락 획득을 시도합니다.
      *
-     * @return 락 획득 성공 시 `true`, 타임아웃 또는 오류 시 `false`
+     * @return 락 획득 성공 시 `true`, 경합 실패(타임아웃) 시 `false`, DB 오류 시 `null`
      */
-    suspend fun tryLock(waitTime: Duration, leaseTime: Duration): Boolean {
+    suspend fun tryLock(waitTime: Duration, leaseTime: Duration): Boolean? {
         val deadline = System.currentTimeMillis() + waitTime.toMillis().coerceAtLeast(0L)
         var attempt = 0
 
@@ -77,8 +76,8 @@ internal class ExposedR2dbcGroupLock internal constructor(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Throwable) {
-                log.warn(e) { "DB 오류 (재시도 유지): lockName=$lockName, slot=$slot, attempt=$attempt" }
-                false
+                log.warn(e) { "DB 오류로 슬롯 순회 중단: lockName=$lockName, slot=$slot, attempt=$attempt" }
+                return null
             }
 
             if (acquired) {

--- a/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcSchemaInitializer.kt
+++ b/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcSchemaInitializer.kt
@@ -55,8 +55,9 @@ internal object ExposedR2dbcSchemaInitializer : KLoggingChannel() {
     /**
      * R2DBC URL 내 userinfo(특히 password)를 `***`로 마스킹합니다.
      *
-     * `r2dbc:` 접두사를 제거한 후 [URI]로 파싱하여 userinfo 부분만 치환합니다.
-     * 파싱 실패 시 원본 URL을 반환합니다 (best-effort).
+     * `r2dbc:` 접두사를 제거한 뒤 [URI]로 파싱하여 새 [URI]를 재구성하므로,
+     * userinfo는 `***`로, 나머지 컴포넌트(scheme/host/port/path/query/fragment)는 그대로 보존됩니다.
+     * 파싱 실패([java.net.URISyntaxException], [IllegalArgumentException] 등)시 원본 URL을 반환합니다 (best-effort).
      */
     internal fun sanitizeUrl(url: String): String {
         val (prefix, rest) = when {

--- a/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2dbcSuspendLeaderGroupElectionTest.kt
+++ b/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2dbcSuspendLeaderGroupElectionTest.kt
@@ -9,6 +9,7 @@ import io.bluetape4k.logging.debug
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
+import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterOrEqualTo
 import org.amshove.kluent.shouldBeInRange
@@ -93,7 +94,7 @@ class ExposedR2dbcSuspendLeaderGroupElectionTest : AbstractExposedR2dbcLeaderTes
         // ExposedR2dbcGroupLock으로 모든 슬롯을 직접 선점 (타이밍 의존성 제거)
         val locks = (0 until maxLeaders).map { slot ->
             ExposedR2dbcGroupLock(db, lockName, slot, RetryStrategy.Jitter()).also { lock ->
-                lock.tryLock(Duration.ofSeconds(2), Duration.ofSeconds(30)).shouldBeTrue()
+                lock.tryLock(Duration.ofSeconds(2), Duration.ofSeconds(30)) shouldBe true
             }
         }
 

--- a/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcGroupLockTest.kt
+++ b/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcGroupLockTest.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeGreaterOrEqualTo
@@ -29,7 +30,7 @@ class ExposedR2dbcGroupLockTest : AbstractExposedR2dbcLeaderTest() {
 
         val acquired = lock.tryLock(Duration.ofSeconds(2), Duration.ofSeconds(10))
 
-        acquired.shouldBeTrue()
+        acquired shouldBe true
         lock.unlock()
     }
 
@@ -45,8 +46,8 @@ class ExposedR2dbcGroupLockTest : AbstractExposedR2dbcLeaderTest() {
         val acquired0 = lock0.tryLock(Duration.ofSeconds(2), Duration.ofSeconds(10))
         val acquired1 = lock1.tryLock(Duration.ofSeconds(2), Duration.ofSeconds(10))
 
-        acquired0.shouldBeTrue()
-        acquired1.shouldBeTrue()
+        acquired0 shouldBe true
+        acquired1 shouldBe true
         lock0.unlock()
         lock1.unlock()
     }
@@ -63,7 +64,7 @@ class ExposedR2dbcGroupLockTest : AbstractExposedR2dbcLeaderTest() {
         val contender = ExposedR2dbcGroupLock(db, lockName, slot = 0, RetryStrategy.Fixed(fixedMs = 10L))
         val acquired = contender.tryLock(Duration.ofMillis(100), Duration.ofSeconds(5))
 
-        acquired.shouldBeFalse()
+        acquired shouldBe false
         holder.unlock()
     }
 
@@ -83,7 +84,7 @@ class ExposedR2dbcGroupLockTest : AbstractExposedR2dbcLeaderTest() {
         val newLock = ExposedR2dbcGroupLock(db, lockName, slot = 0, RetryStrategy.Jitter())
         val acquired = newLock.tryLock(Duration.ofSeconds(2), Duration.ofSeconds(10))
 
-        acquired.shouldBeTrue()
+        acquired shouldBe true
         newLock.unlock()
     }
 
@@ -99,7 +100,7 @@ class ExposedR2dbcGroupLockTest : AbstractExposedR2dbcLeaderTest() {
         lock.unlock()
 
         val reacquire = ExposedR2dbcGroupLock(db, lockName, slot = 0, RetryStrategy.Jitter())
-        reacquire.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(10)).shouldBeTrue()
+        reacquire.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(10)) shouldBe true
         reacquire.unlock()
     }
 
@@ -121,7 +122,7 @@ class ExposedR2dbcGroupLockTest : AbstractExposedR2dbcLeaderTest() {
         val db = setupDb(testDB)
         cleanTables(db)
         val lock = ExposedR2dbcGroupLock(db, randomName(), slot = 0, RetryStrategy.Jitter())
-        lock.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(10)).shouldBeTrue()
+        lock.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(10)) shouldBe true
 
         lock.isHeldByCurrentInstance().shouldBeTrue()
 
@@ -138,6 +139,21 @@ class ExposedR2dbcGroupLockTest : AbstractExposedR2dbcLeaderTest() {
         lock.unlock()
 
         lock.isHeldByCurrentInstance().shouldBeFalse()
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `isHeldByCurrentInstance - 다른 인스턴스 token으로는 false를 반환한다`(testDB: TestR2dbcDB) = runSuspendIO {
+        val db = setupDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val holder = ExposedR2dbcGroupLock(db, lockName, slot = 0, RetryStrategy.Jitter())
+        holder.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(30)) shouldBe true
+
+        val other = ExposedR2dbcGroupLock(db, lockName, slot = 0, RetryStrategy.Jitter())
+        other.isHeldByCurrentInstance().shouldBeFalse()
+
+        holder.unlock()
     }
 
     @ParameterizedTest
@@ -166,7 +182,7 @@ class ExposedR2dbcGroupLockTest : AbstractExposedR2dbcLeaderTest() {
         val jobs = (1..10).map {
             async {
                 val lock = ExposedR2dbcGroupLock(db, lockName, slot = 0, RetryStrategy.Fixed(fixedMs = 10L))
-                if (lock.tryLock(Duration.ofMillis(200), Duration.ofSeconds(5))) {
+                if (lock.tryLock(Duration.ofMillis(200), Duration.ofSeconds(5)) == true) {
                     successCount.incrementAndGet()
                     // action delay > waitTime(200ms) → 나머지 경합자들이 모두 타임아웃
                     kotlinx.coroutines.delay(300)
@@ -193,7 +209,7 @@ class ExposedR2dbcGroupLockTest : AbstractExposedR2dbcLeaderTest() {
         val jobs0 = (1..5).map {
             async {
                 val lock = ExposedR2dbcGroupLock(db, lockName, slot = 0, RetryStrategy.Fixed(fixedMs = 10L))
-                if (lock.tryLock(Duration.ofMillis(200), Duration.ofSeconds(5))) {
+                if (lock.tryLock(Duration.ofMillis(200), Duration.ofSeconds(5)) == true) {
                     slot0Count.incrementAndGet()
                     // action delay > waitTime(200ms) → 나머지 경합자들이 모두 타임아웃
                     kotlinx.coroutines.delay(300)
@@ -204,7 +220,7 @@ class ExposedR2dbcGroupLockTest : AbstractExposedR2dbcLeaderTest() {
         val jobs1 = (1..5).map {
             async {
                 val lock = ExposedR2dbcGroupLock(db, lockName, slot = 1, RetryStrategy.Fixed(fixedMs = 10L))
-                if (lock.tryLock(Duration.ofMillis(200), Duration.ofSeconds(5))) {
+                if (lock.tryLock(Duration.ofMillis(200), Duration.ofSeconds(5)) == true) {
                     slot1Count.incrementAndGet()
                     // action delay > waitTime(200ms) → 나머지 경합자들이 모두 타임아웃
                     kotlinx.coroutines.delay(300)

--- a/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcLockTest.kt
+++ b/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcLockTest.kt
@@ -124,6 +124,21 @@ class ExposedR2dbcLockTest : AbstractExposedR2dbcLeaderTest() {
 
     @ParameterizedTest
     @MethodSource("enableDialects")
+    fun `isHeldByCurrentInstance - 다른 인스턴스 token으로는 false를 반환한다`(testDB: TestR2dbcDB) = runSuspendIO {
+        val db = setupDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val holder = ExposedR2dbcLock(db, lockName, RetryStrategy.Jitter())
+        holder.tryLock(Duration.ofSeconds(1), Duration.ofSeconds(30)).shouldBeTrue()
+
+        val other = ExposedR2dbcLock(db, lockName, RetryStrategy.Jitter())
+        other.isHeldByCurrentInstance().shouldBeFalse()
+
+        holder.unlock()
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
     fun `isHeldByCurrentInstance - leaseTime 만료 시 false 반환`(testDB: TestR2dbcDB) = runSuspendIO {
         val db = setupDb(testDB)
         cleanTables(db)

--- a/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcSchemaInitializerTest.kt
+++ b/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcSchemaInitializerTest.kt
@@ -4,6 +4,9 @@ import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.exposed.r2dbc.AbstractExposedR2dbcLeaderTest
 import io.bluetape4k.leader.exposed.r2dbc.TestR2dbcDB
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
@@ -36,6 +39,22 @@ class ExposedR2dbcSchemaInitializerTest : AbstractExposedR2dbcLeaderTest() {
 
         ExposedR2dbcSchemaInitializer.ensureSchema(db)
         ExposedR2dbcSchemaInitializer.ensureSchema(db)
+        ExposedR2dbcSchemaInitializer.ensureSchema(db)
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `ensureSchema - 동시 호출 10건에도 예외 없이 단일 초기화로 수렴한다`(testDB: TestR2dbcDB) = runSuspendIO {
+        val db = connectDb(testDB)
+        ExposedR2dbcSchemaInitializer.resetFor(db)
+
+        coroutineScope {
+            (1..10).map {
+                async { ExposedR2dbcSchemaInitializer.ensureSchema(db) }
+            }.awaitAll()
+        }
+
+        // 후속 호출도 정상 (이미 초기화 완료)
         ExposedR2dbcSchemaInitializer.ensureSchema(db)
     }
 


### PR DESCRIPTION
## Summary

PR #64의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: leader-exposed daily review 2026-05-04 — R2DBC GroupLock contract + JDBC SELECT 강화`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 배경

자동 daily review (2026-05-04) — bluetape4k-design Step 6-R 6-Tier 리뷰 중 5개 리뷰 에이전트(`code-reviewer`, `silent-failure-hunter`, `type-design-analyzer`, `comment-analyzer`, `pr-test-analyzer`)를 PR #62 (leader-exposed-r2dbc 신규 모듈) 및 PR #63 (leader-exposed-jdbc 개선) 변경분에 병렬 실행.

## 발견 이슈 + 수정

### HIGH — R2DBC GroupLock에 JDBC PR #63 패턴 미적용
- `code-reviewer`, `silent-failure-hunter` (H-4), `type-design-analyzer` (#1) — 동일 이슈 3중 확인
- 형제 모듈 contract 비대칭: JDBC는 `Boolean?` (PR #63), R2DBC는 `Boolean` (DB 오류 흡수)
- 결과: R2DBC 그룹 선출은 DB 장애 시 `maxLeaders` 슬롯을 모두 순회하며 `waitTime` 만료까지 hang

**수정**: `ExposedR2dbcGroupLock.tryLock(): Boolean?` 변경 + `ExposedR2dbcSuspendLeaderGroupElection.runIfLeader`에 `when` 분기 패턴 적용 (JDBC와 동일)

### CRITICAL (silent-failure C-1) — JDBC SELECT의 `lockedUntil greater now` 누락
- R2DBC는 만료 비교 포함, JDBC는 누락 → 형제 비대칭
- `type-design-analyzer` (#4)도 동일 비대칭 지적

**수정**: `ExposedJdbcLock.tryAcquireOnce`, `ExposedJdbcGroupLock.tryAcquireOnce`의 Step 3 SELECT에 `lockedUntil greater now` 추가 (defense in depth + 형제 대칭)

### KDoc rot — `ExposedR2dbcSchemaInitializer.sanitizeUrl`
- `comment-analyzer` CRITICAL — 실제 동작은 URI **재구성**이지만 KDoc은 "userinfo만 치환"으로 표현
- `IllegalArgumentException` catch도 KDoc 미언급

**수정**: 정확한 재구성 동작 + 잡히는 예외 타입 명시

### 누락 테스트 (`pr-test-analyzer`)
1. `isHeldByCurrentInstance` — live different-token false 검증 (JDBC 동등)
2. `ensureSchema` — 동시 호출 10건 단일 초기화 수렴 검증 (JDBC 동등)

**추가**: `ExposedR2dbcGroupLockTest`, `ExposedR2dbcLockTest`, `ExposedR2dbcSchemaInitializerTest`

## 테스트 호환성 (R2DBC GroupLock 반환 타입 변경 영향)

- `tryLock(...).shouldBeTrue()` → `tryLock(...) shouldBe true` (Kluent `shouldBe`는 nullable 수용)
- `if (lock.tryLock(...))` → `if (lock.tryLock(...) == true)`

## 검증

- ✅ 컴파일 성공 (R2DBC + JDBC main + test)
- ✅ H2 dialect 모든 R2DBC GroupLock + SchemaInitializer 테스트 통과 (12/12 H2 + 12/12 SchemaInit)
- ⚠️ PostgreSQL/MySQL은 로컬 환경 Docker 부재로 미실행 — CI에서 자동 검증

## 변경 파일

- `leader-exposed-jdbc/src/main/kotlin/.../lock/ExposedJdbcLock.kt` — Step 3 SELECT 술어
- `leader-exposed-jdbc/src/main/kotlin/.../lock/ExposedJdbcGroupLock.kt` — Step 3 SELECT 술어
- `leader-exposed-r2dbc/src/main/kotlin/.../lock/ExposedR2dbcGroupLock.kt` — `tryLock: Boolean?`
- `leader-exposed-r2dbc/src/main/kotlin/.../lock/ExposedR2dbcSchemaInitializer.kt` — KDoc rot
- `leader-exposed-r2dbc/src/main/kotlin/.../ExposedR2dbcSuspendLeaderGroupElection.kt` — `when` 분기
- `leader-exposed-r2dbc/src/test/kotlin/.../lock/ExposedR2dbcGroupLockTest.kt` — 새 테스트 + Boolean? 적응
- `leader-exposed-r2dbc/src/test/kotlin/.../lock/ExposedR2dbcLockTest.kt` — 새 테스트
- `leader-exposed-r2dbc/src/test/kotlin/.../lock/ExposedR2dbcSchemaInitializerTest.kt` — concurrent 테스트
- `leader-exposed-r2dbc/src/test/kotlin/.../ExposedR2dbcSuspendLeaderGroupElectionTest.kt` — Boolean? 적응
- `CHANGELOG.md` — Fixed 섹션 항목 2건

## 후속 (별 이슈로 추적 권장)

- INSERT runCatching이 PK 충돌 외 SQL 예외도 흡수 (silent-failure C-2/H-1) — 드라이버별 PK 위반 예외 타입 좁히기
- KDoc 예제 보강 (comment-analyzer Medium): `runIfLeader` skip 예제, `activeCountSuspend` 캐시 vs DB 비교
- type-design Concern #6: H2 `MODE=MySQL` 요구사항을 `ExposedR2dbcSchemaInitializer` KDoc에도 명시
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #64, head `8722311512e1fc26615b6f24c958a7a96ae5a7de`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
