### PR TITLE
feat: leader-spring-boot3 자동 구성 (#11)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -494,6 +494,46 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
+  # ── leader-spring-boot3 (Testcontainers: Redis + MongoDB) ───────────────────
+  test-spring-boot3:
+    name: Test / leader-spring-boot3 (Testcontainers)
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Test leader-spring-boot3
+        run: ./gradlew :leader-spring-boot3:test --no-daemon
+        env:
+          GRADLE_OPTS: '-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false'
+          TESTCONTAINERS_RYUK_DISABLED: 'true'
+          DOCKER_HOST: 'unix:///var/run/docker.sock'
+      - name: Generate Kover XML report
+        if: always()
+        run: ./gradlew :leader-spring-boot3:koverXmlReport --no-daemon
+        continue-on-error: true
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-spring-boot3
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 14
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-spring-boot3
+          path: '**/build/reports/kover/'
+          retention-days: 14
+
   coverage-report:
     name: Coverage Report
     runs-on: ubuntu-latest
@@ -509,6 +549,7 @@ jobs:
       - test-exposed-jdbc-mysql
       - test-mongodb
       - test-hazelcast
+      - test-spring-boot3
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -549,6 +590,7 @@ jobs:
       - test-exposed-jdbc-mysql
       - test-mongodb
       - test-hazelcast
+      - test-spring-boot3
       - coverage-report
     if: always()
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,18 +91,27 @@ After every `.kt` edit:
 
 ## Test Infrastructure
 
-Tests use Testcontainers `GenericContainer("redis:7-alpine")` directly — no dependency on external test utility classes. Each Redis-backed test module has its own `AbstractXxxLeaderTest` base class that starts and manages the container.
+모든 테스트는 **`bluetape4k-testcontainers`의 `XxxServer.Launcher.xxx` 표준** 사용. `GenericContainer` 직접 사용 금지. 컨테이너 자동 시동 + JVM 종료 시 정리 + 모듈 간 일관성 보장.
 
 ```kotlin
-// Pattern — self-contained base class
+// Redis
 abstract class AbstractRedissonLeaderTest {
-    companion object : KLogging() {
-        private val redisContainer = GenericContainer("redis:7-alpine").withExposedPorts(6379)
-        init { redisContainer.start() }
-        val redisUrl: String get() = "redis://${redisContainer.host}:${redisContainer.getMappedPort(6379)}"
+    companion object: KLogging() {
+        val redis = RedisServer.Launcher.redis
+        val redisUrl: String get() = redis.url
+    }
+}
+
+// MongoDB
+abstract class AbstractMongoLeaderTest {
+    companion object: KLogging() {
+        val mongo = MongoDBServer.Launcher.mongoDB
+        val connectionString: String get() = mongo.url
     }
 }
 ```
+
+테스트 의존성: `testImplementation(libs.bluetape4k.testcontainers)`
 
 ## Test Requirements
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -107,6 +107,14 @@ subprojects {
     }
 
     pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+        configurations.matching { it.name == "kotlinCompilerClasspath" || it.name == "kotlinCompilerPluginClasspath" }.configureEach {
+            resolutionStrategy.eachDependency {
+                if (requested.group == "org.jetbrains.kotlin") {
+                    useVersion(rootLibs.versions.kotlin.get())
+                    because("KGP build-tools requires matching kotlin-compiler version")
+                }
+            }
+        }
         kotlin {
             jvmToolchain(21)
             compilerOptions {

--- a/docs/lessons/2026-05-04-leader-spring-boot3-autoconfig.md
+++ b/docs/lessons/2026-05-04-leader-spring-boot3-autoconfig.md
@@ -1,0 +1,130 @@
+# Lessons Learned — leader-spring-boot3 자동 구성 (2026-05-04)
+
+**관련 PR**: #70
+**관련 이슈**: #11
+**영향 모듈**: `leader-spring-boot3`, `leader-spring-boot-common`, `gradle/libs.versions.toml`, root `build.gradle.kts`, `CLAUDE.md`
+
+## L1: Spring Boot BOM이 `kotlin.version=1.9.25`를 강제
+
+### 문제
+`io.spring.dependency-management` 플러그인 + `mavenBom("spring-boot-dependencies")` 사용 시 Spring Boot 3.5 BOM 의 `<kotlin.version>1.9.25</kotlin.version>` 제약이 **모든 configuration**(특히 `kotlinCompilerClasspath`)에 전파된다. 결과:
+- `kotlin-compiler-embeddable:2.3.21 → 1.9.25` 다운그레이드
+- `kotlin-build-tools-impl:2.3.21`이 expecting `ClasspathEntrySnapshotter$Settings` (2.3.x 신클래스) 호출 → `NoClassDefFoundError`
+- 컴파일 자체가 불가능
+
+### 교훈
+Spring Dependency Management 플러그인 사용 모듈에서는 `dependencyManagement.imports.mavenBom`의 **순서가 중요**하다. spring-boot-dependencies 직후 `mavenBom(libs.kotlin.bom.get())`을 다시 import하면 kotlin 버전을 프로젝트 표준으로 복원 가능. 동일 패턴이 mongodb-driver-core/reactivestreams (5.5.x → 5.6.x) 등 다른 lib에도 적용됨. 새 Spring Boot 모듈 추가 시 무조건 적용.
+
+```kotlin
+dependencyManagement {
+    imports {
+        mavenBom(libs.spring.boot3.dependencies.get().toString())
+        mavenBom(libs.kotlin.bom.get().toString())  // ← override Spring's pin
+    }
+    dependencies {
+        // 백엔드 driver-core 등 spring-boot BOM이 다운그레이드시키는 항목 명시
+        dependency("org.mongodb:mongodb-driver-core:${libs.versions.mongo.driver.get()}")
+    }
+}
+```
+
+---
+
+## L2: `@AutoConfigureOrder`는 `@Import` 된 `@Configuration`에 무효
+
+### 문제
+초기 설계는 `LocalLeaderConfiguration`을 `@Import`로 진입점 `LeaderElectionAutoConfiguration`에 가져오면서 `@AutoConfigureOrder(LOWEST_PRECEDENCE)`로 fallback 순서를 보장하려 시도. 동작하지 않음 — `@AutoConfigureOrder`/`@AutoConfigureAfter`는 `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`에 직접 등록된 auto-configuration에만 적용된다. `@Import`로 들여온 클래스에는 무시됨.
+
+### 교훈
+Auto-configuration 우선순위/순서가 필요한 Configuration은 **반드시 별도 auto-config로 분리하여 `AutoConfiguration.imports`에 등록**해야 한다. 같은 진입점 안의 `@Import`로는 순서 보장이 불가능. fallback 패턴 적용 시:
+1. fallback Configuration 별도 파일/클래스
+2. `@AutoConfiguration(after = [MainConfig::class])` 명시
+3. `META-INF/spring/...AutoConfiguration.imports`에 둘 다 등록
+4. `@ConditionalOnMissingBean(<type>::class)`로 활성화 조건
+
+테스트 시 `ApplicationContextRunner.withConfiguration(AutoConfigurations.of(...))`도 두 클래스 모두 명시 필요.
+
+---
+
+## L3: Spring `Binder`/`@ConfigurationProperties`에는 Kotlin reified 확장이 없음
+
+### 문제
+`Binder.bind("prefix", Boot3LeaderProperties::class.java)` 처럼 `Class<T>` 인자를 받는 API. Kotlin reified 버전이 stock Spring Boot에 제공되지 않음.
+
+### 교훈
+프로젝트별 inline 확장 함수로 보강:
+```kotlin
+private inline fun <reified T : Any> Binder.bindAs(name: String): BindResult<T> =
+    bind(name, T::class.java)
+
+// usage
+Binder(source).bindAs<Boot3LeaderProperties>("bluetape4k.leader").get()
+```
+
+반면 `BeanFactory.getBean(Class<T>)`, `ListableBeanFactory.getBeanNamesForType(Class<T>)`는 Spring이 이미 제공 (`org.springframework.beans.factory.getBean`, `getBeanNamesForType`). import 후 reified 호출:
+```kotlin
+ctx.getBean<LeaderElection>()
+ctx.getBeanNamesForType<SuspendLeaderElection>()
+```
+
+---
+
+## L4: `ApplicationContextRunner.run` 콜백이 AssertJ에 의존
+
+### 문제
+`spring-boot-test`만 `testImplementation`에 추가하면 `ApplicationContextRunner.run { ctx -> ... }` 호출 시 `Cannot access 'org.assertj.core.api.AssertProvider' which is a supertype of 'AssertableApplicationContext'` 컴파일 오류 발생. spring-boot-test가 AssertJ를 transitive로 가져오지만 testCompileClasspath에 포함시키지 않음.
+
+### 교훈
+`ApplicationContextRunner` 사용 모듈은 `testImplementation("org.assertj:assertj-core")`를 명시 추가 필요. 한 줄 주석으로 이유 명시:
+```kotlin
+// ApplicationContextRunner.run 콜백이 AssertJ AssertProvider 를 노출하므로 필수
+testImplementation("org.assertj:assertj-core")
+```
+
+---
+
+## L5: 진입점 suspend factory + Spring `@Bean` 동기 계약
+
+### 문제
+`MongoSuspendLeaderElection.invoke(...)`, `ExposedR2dbcSuspendLeaderElection.invoke(...)` 등 일부 백엔드의 인스턴스 생성 factory는 `suspend operator fun invoke`로 정의되며 내부에서 스키마 초기화 (`MongoSuspendLock.ensureIndexes`, `ExposedR2dbcSchemaInitializer.ensureSchema`) 를 수행. Spring의 `@Bean` 메서드는 동기 시그니처만 허용.
+
+### 교훈
+Startup phase에서 `runBlocking { ... }` 사용은 정당. 부모 코루틴 컨텍스트가 없으므로 `CancellationException` 재throw도 strictly 필요하지 않음 (취소 trigger 부재). 단 README 트레이드오프 명시 필수: "스키마 초기화는 컨텍스트 시동 시 1회만 수행, 요청 latency에는 영향 없음".
+
+대안 검토:
+- `SmartLifecycle.start()`에서 초기화 (지연 초기화) — 빈 즉시 사용 불가
+- `InitializingBean.afterPropertiesSet()`도 동기 — 동일 문제
+- `@PostConstruct` + `runBlocking` — 동등
+
+→ `@Bean` 메서드 내 `runBlocking`이 가장 직관적.
+
+---
+
+## L6: `@ConfigurationProperties` data class wrapper의 가치
+
+### 문제
+초기 검토에서 "common의 `LeaderElectionProperties`에 `@ConfigurationProperties` 직접 부착하면 Boot3 wrapper 불필요" 검토. 사용자는 wrapper 유지 결정.
+
+### 교훈
+**Boot3LeaderProperties wrapper 유지의 이점**:
+- common 모듈이 spring-boot 의존 없이 순수 Kotlin 유지
+- Boot 3 / Boot 4 별 prefix/명명 차별화 가능
+- mongo collection 같은 backend-specific properties를 wrapper에서 추가 가능 (common 오염 방지)
+- 변환 layer (PropertiesAdapter) 도입으로 backend-specific 옵션 매핑 명시화
+
+비용: data class duplication 1개 + `toCommon()` (사용처가 PropertiesAdapter로 흡수되면 dead code → 제거함).
+
+---
+
+## L7: Kover 라인 커버리지 100% 달성 — `ApplicationContextRunner` × backend-per-Configuration 패턴이 효과적
+
+### 문제
+초기 PropertiesAdapterTest + Redisson 통합 테스트만으로 line coverage 55%. Mongo/ExposedJdbc/ExposedR2dbc Configuration은 미커버.
+
+### 교훈
+백엔드별 Configuration이 모두 비슷한 pattern (백엔드 client 빈 → 4개 election 빈 등록) 이라 `ApplicationContextRunner` × per-backend 통합 테스트 1개씩 추가만으로 커버리지 폭발적 증가:
+- `ExposedJdbc`: H2 in-memory `Database.connect()` 빈만 등록
+- `ExposedR2dbc`: H2 R2DBC `R2dbcDatabase.connect()` 빈만 등록 (단 r2dbc-h2와 h2-v2 ABI 충돌 주의 — r2dbc-h2 단독 사용)
+- `Mongo`: `MongoDBServer.Launcher.mongoDB` Testcontainer + `MongoDBServer.Launcher.getClient()/getCoroutineClient()` 활용
+
+각 테스트는 `containsBean("...")` 또는 `getBean<X>()` 정도만 검증해도 Configuration의 모든 `@Bean` 메서드가 호출되어 line coverage가 채워짐.

--- a/docs/research/shedlock-vs-leader.md
+++ b/docs/research/shedlock-vs-leader.md
@@ -1,6 +1,6 @@
 # ShedLock vs bluetape4k-leader 비교
 
-> 마지막 업데이트: 2026-04-30  
+> 마지막 업데이트: 2026-05-04  
 > **기능 추가/완료 시 이 문서의 백엔드·기능 비교 표를 반드시 업데이트할 것.**  
 > 연관 문서: [WIP.md](../../WIP.md) — `ShedLock 비교에서 도출한 추가 과제` 섹션
 
@@ -65,7 +65,7 @@
 | `lockAtMostFor` (최대 보유) | ✅ | ✅ `leaseTime` |
 | `waitTime` (획득 대기) | ❌ (즉시 skip) | ✅ |
 | AOP 애노테이션 (`@Leader`) | ✅ `@SchedulerLock` | 🚧 [#41](https://github.com/bluetape4k/bluetape4k-leader/issues/41) |
-| SpEL 락 이름 표현식 | ✅ | ❌ |
+| SpEL 락 이름 표현식 | ✅ | 🚧 [#69](https://github.com/bluetape4k/bluetape4k-leader/issues/69) |
 | 멀티테넌시 | ✅ | 🚧 [#42](https://github.com/bluetape4k/bluetape4k-leader/issues/42) |
 | Micrometer 메트릭 | ✅ (Spring 통합) | 🚧 [#10](https://github.com/bluetape4k/bluetape4k-leader/issues/10) |
 | Actuator 엔드포인트 | ✅ | 🚧 [#11](https://github.com/bluetape4k/bluetape4k-leader/issues/11)/[#12](https://github.com/bluetape4k/bluetape4k-leader/issues/12) |

--- a/docs/superpowers/plans/2026-05-04-leader-spring-boot3-plan.md
+++ b/docs/superpowers/plans/2026-05-04-leader-spring-boot3-plan.md
@@ -1,0 +1,182 @@
+# Plan — leader-spring-boot3 Auto-Configuration
+
+**Design**: `docs/superpowers/specs/2026-05-04-leader-spring-boot3-design.md`
+**관련 이슈**: #11
+**브랜치**: `feat/spring-boot3-autoconfig`
+**작성일**: 2026-05-04
+
+---
+
+## Phase 1 — 빌드 의존성 정비
+
+| # | 파일 | 변경 |
+|---|------|------|
+| 1 | `gradle/libs.versions.toml` | 필요 시 추가 alias (검증 단계) |
+| 2 | `leader-spring-boot3/build.gradle.kts` | `api(project(":leader-spring-boot-common"))` 추가 + 6 백엔드 모듈 testRuntimeOnly 추가 (Kover 커버리지 측정용) |
+
+검증: `./gradlew :leader-spring-boot3:dependencies` + `compileKotlin`
+
+---
+
+## Phase 2 — Properties + Adapter
+
+| # | 파일 | 내용 |
+|---|------|------|
+| 3 | `Boot3LeaderProperties.kt` | `@ConfigurationProperties(prefix = "bluetape4k.leader")` data class. waitTime/leaseTime/group/mongo. `toCommon()` 변환 메서드 |
+| 4 | `MongoCollectionProperties.kt` | `singleCollection: String = "leader_election"`, `groupCollection: String = "leader_group_election"` |
+| 5 | `adapter/PropertiesAdapter.kt` | 8개 변환 함수 (common, group, mongo, mongoGroup, exposedJdbc, exposedJdbcGroup, exposedR2dbc, exposedR2dbcGroup) |
+
+검증: 컴파일 통과
+
+---
+
+## Phase 3 — 백엔드 Configuration (7개)
+
+> 패키지: `io.bluetape4k.leader.spring.boot3.backend`
+> 공통: `@AutoConfiguration` + 클래스/빈 게이트 + `@ConditionalOnMissingBean(name = "...")` per `@Bean`
+> Local은 추가로 type 기반 `@ConditionalOnMissingBean` (다른 백엔드 빈 미존재 시만 등록)
+
+### 3.0 Local — default fallback (Phase #5.5)
+
+```kotlin
+@AutoConfiguration
+@AutoConfigureOrder(Ordered.LOWEST_PRECEDENCE)
+class LocalLeaderConfiguration {
+    @Bean @ConditionalOnMissingBean(LeaderElection::class)
+    fun localLeaderElection(props: Boot3LeaderProperties) =
+        LocalLeaderElection(PropertiesAdapter.toCommonElection(props))
+    @Bean @ConditionalOnMissingBean(SuspendLeaderElection::class)
+    fun localSuspendLeaderElection(props: Boot3LeaderProperties) =
+        LocalSuspendLeaderElection(PropertiesAdapter.toCommonElection(props))
+    @Bean @ConditionalOnMissingBean(LeaderGroupElection::class)
+    fun localLeaderGroupElection(props: Boot3LeaderProperties) =
+        LocalLeaderGroupElection(PropertiesAdapter.toCommonGroup(props))
+    @Bean @ConditionalOnMissingBean(SuspendLeaderGroupElection::class)
+    fun localSuspendLeaderGroupElection(props: Boot3LeaderProperties) =
+        LocalSuspendLeaderGroupElection(PropertiesAdapter.toCommonGroup(props))
+}
+```
+
+외부 의존 없음 (`leader-core`는 `api` 의존). `@AutoConfigureOrder(LOWEST_PRECEDENCE)`로 다른 백엔드가 먼저 평가되도록 보장.
+
+### 3.1 Redisson (Phase #6)
+
+```kotlin
+@AutoConfiguration
+@ConditionalOnClass(RedissonClient::class)
+@ConditionalOnBean(RedissonClient::class)
+class RedissonLeaderConfiguration {
+    @Bean @ConditionalOnMissingBean(name = "redissonLeaderElection")
+    fun redissonLeaderElection(client: RedissonClient, props: Boot3LeaderProperties) =
+        RedissonLeaderElection(client, PropertiesAdapter.toCommonElection(props))
+    // ... 나머지 3개
+}
+```
+
+### 3.2 Lettuce (Phase #7)
+- ctor: `(StatefulRedisConnection<String, String>, LeaderElectionOptions)`
+- 4 빈 (sync/suspend × single/group)
+- raw 제네릭 주입 — `@SuppressWarnings("UNCHECKED_CAST")` 또는 wildcard 처리
+
+### 3.3 Mongo (Phase #8)
+- 게이트: `OnBean(MongoDatabase)` (sync) + `OnBean(CoroutineMongoDatabase)` (suspend)
+- 빈 메서드 내부 `db.getCollection(props.mongo.singleCollection, Document::class.java)`
+- suspend 빈은 `runBlocking { ... }`
+- group suspend는 sync + coroutine 컬렉션 둘 다 필요
+
+### 3.4 Hazelcast (Phase #9)
+- 게이트: `OnBean(HazelcastInstance)`
+- 4 빈, 자체 옵션 없음 → 공통 `LeaderElectionOptions`/`LeaderGroupElectionOptions` 그대로 사용
+
+### 3.5 ExposedJdbc (Phase #10)
+- 게이트: `OnBean(org.jetbrains.exposed.v1.jdbc.Database)`
+- 3 빈: sync, group, virtualThread (sync 빈을 wrapping)
+- virtualThread 빈은 `@DependsOn("exposedJdbcLeaderElection")` 또는 직접 ctor 주입
+
+### 3.6 ExposedR2dbc (Phase #11)
+- 게이트: `OnBean(R2dbcDatabase)`
+- 2 빈: suspend, group suspend
+- 둘 다 `runBlocking { ... }` (스키마 초기화)
+
+---
+
+## Phase 4 — 진입점 + Imports
+
+| # | 파일 | 내용 |
+|---|------|------|
+| 12 | `LeaderElectionAutoConfiguration.kt` | `@AutoConfiguration` + `@ConditionalOnClass(LeaderElection::class)` + `@EnableConfigurationProperties(Boot3LeaderProperties::class, MongoCollectionProperties::class)` + `@Import(...7개 — Local 포함...)` |
+| 13 | `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` | `LeaderElectionAutoConfiguration` FQCN |
+
+검증: `./gradlew :leader-spring-boot3:compileKotlin`
+
+---
+
+## Phase 5 — 테스트 인프라
+
+| # | 파일 | 내용 |
+|---|------|------|
+| 14 | `src/test/resources/junit-platform.properties` | `lifecycle.default = per_class` + `parallel.enabled = false` (MEMORY 표준) |
+| 15 | `src/test/resources/logback-test.xml` | 표준 logback |
+| 16 | `AbstractRedissonAutoConfigurationTest.kt` | Testcontainer redis:7-alpine 관리 base class |
+
+---
+
+## Phase 6 — 테스트 작성
+
+| # | 파일 | 검증 |
+|---|------|------|
+| 17 | `PropertiesAdapterTest.kt` | 8 종 변환 함수 — properties → backend Options 매핑 |
+| 18 | `Boot3LeaderPropertiesBindingTest.kt` | `@SpringBootTest(properties=[...])` — yaml 바인딩 (waitTime, group.maxLeaders, mongo.singleCollection 등) |
+| 19 | `BackendConditionalTest.kt` | `ApplicationContextRunner` × 7 백엔드 — (a) 백엔드 빈 미설정 시 Local 4 빈만 활성 (b) 단일 백엔드 활성 시 해당 빈 + Local 비활성 (c) 다중 백엔드 활성 매트릭스 |
+| 20 | `LeaderElectionAutoConfigurationTest.kt` | `@SpringBootTest` + Redisson Testcontainer + 4 종 election 빈 주입 + `runIfLeader()` 동작 |
+
+---
+
+## Phase 7 — 검증 + 커버리지
+
+| # | 작업 |
+|---|------|
+| 21 | `./gradlew :leader-spring-boot3:test` — 전체 통과 |
+| 22 | `./gradlew :leader-spring-boot3:koverHtmlReport` — 라인 커버리지 ≥ 80% 확인 |
+| 23 | 미달 시 추가 테스트 → Phase 6 재진입 |
+
+---
+
+## Phase 8 — 문서화
+
+| # | 파일 | 내용 |
+|---|------|------|
+| 24 | `leader-spring-boot3/README.md` | 영문 — 사용법, 의존성, 자동 등록 빈 매트릭스 (Local default + 6 백엔드), yaml 설정 예시, 다중 백엔드 시 `@Qualifier` 가이드, `runBlocking` 트레이드오프, Mongo 컬렉션 properties |
+| 25 | `leader-spring-boot3/README.ko.md` | 한글 동일 |
+
+---
+
+## 의존성 그래프
+
+```
+Phase 1 → Phase 2 → Phase 3 (6개 sub-phase 순차) → Phase 4 → Phase 5 → Phase 6 → Phase 7 → Phase 8
+```
+
+엄격 순차. Phase 3의 6 sub-phase는 서로 독립이지만 같은 패턴 반복이라 순차 진행.
+
+---
+
+## 작업량 추정
+
+- 신규 파일: 24개 (Local Configuration 추가)
+- 수정 파일: 2개
+- 코드 라인: ~1300 lines (구현 ~650, 테스트 ~650)
+- 예상 시간: 3-4시간
+
+---
+
+## 리스크 / 완화 (design.md §7과 정렬)
+
+| 리스크 | 완화 |
+|--------|------|
+| R-1 `runBlocking` startup latency | startup phase 1회만, README 명시 |
+| R-2 백엔드 옵션 노출 부족 | v1.0 한계 명시, 후속 이슈 |
+| R-3 Mongo `MongoDatabase` 빈 가정 | README "MongoDatabase 빈 필요" 명시 |
+| R-4 Boot 3.5 미만 환경 data class binding | dependencyManagement로 3.5.14 강제 |
+| R-5 다중 백엔드 ambiguity | README `@Qualifier` 가이드 |
+| R-6 Kover 커버리지 미달 | testRuntimeOnly 6 모듈 + ApplicationContextRunner로 모든 conditional path 커버 |

--- a/docs/superpowers/specs/2026-05-04-leader-spring-boot3-design.md
+++ b/docs/superpowers/specs/2026-05-04-leader-spring-boot3-design.md
@@ -1,0 +1,263 @@
+# Design — leader-spring-boot3 Auto-Configuration
+
+**작업 유형**: Type-B Fast Track
+**관련 이슈**: #11
+**작성일**: 2026-05-04
+**브랜치**: `feat/spring-boot3-autoconfig`
+
+---
+
+## 1. 목표
+
+`leader-spring-boot3` 모듈에 Spring Boot 3 자동설정 추가. classpath/Bean 조건에 따라 사용 가능한 백엔드(Redisson, Lettuce, Mongo, Hazelcast, ExposedJdbc, ExposedR2dbc)별 리더 선출 빈을 자동 등록.
+
+## 2. 사전 검증된 제약사항 (review 반영)
+
+| ID | 제약 | 영향 |
+|----|------|------|
+| C-1 | `LeaderElectionProperties` (data class) — `@ConfigurationProperties` 어노테이션 없음 | Boot3 전용 `Boot3LeaderProperties` wrapper 필요 |
+| C-2 | `MongoSuspendLeaderElection.invoke` / `ExposedR2dbcSuspendLeaderElection.invoke` — `suspend` factory (스키마 초기화 포함) | `@Bean` 메서드에서 `runBlocking { ... }` 호출 |
+| C-3 | `MongoSuspendLeaderGroupElection`은 `MongoCollection<Document>` + `CoroutineMongoCollection<Document>` 두 컬렉션 필요 | 두 빈 모두 요구 또는 `MongoDatabase` + 컬렉션명 properties 도입 |
+| C-4 | 각 백엔드 자체 Options 클래스 (`MongoLeaderElectionOptions`, `ExposedJdbcLeaderElectionOptions`, `ExposedR2dbcLeaderElectionOptions`) | properties→백엔드 options 어댑터 함수 필요 |
+| C-5 | `ExposedJdbcVirtualThreadLeaderElection`은 `ExposedJdbcLeaderElection`을 wrapping | 별도 빈으로 노출, sync 빈 의존 |
+| C-6 | 백엔드 동시 활성화 시 `LeaderElection`/`SuspendLeaderElection` 타입 빈 다수 발생 | 빈 이름 기반 주입 + `@Qualifier` 정책 README 명시 |
+| C-7 | `data class` `@ConfigurationProperties` 바인딩 — Spring Boot 3.5 정식 지원 | Boot3 wrapper에 `@ConfigurationProperties(prefix = "bluetape4k.leader")` 부착 |
+
+---
+
+## 3. 설계
+
+### 3.1 패키지 구조
+
+```
+io.bluetape4k.leader.spring.boot3/
+├── LeaderElectionAutoConfiguration.kt           # 진입점
+├── Boot3LeaderProperties.kt                     # @ConfigurationProperties wrapper
+├── MongoCollectionProperties.kt                 # Mongo 컬렉션명 properties
+├── adapter/
+│   └── PropertiesAdapter.kt                     # common Properties → 백엔드 Options
+└── backend/
+    ├── LocalLeaderConfiguration.kt              # default fallback
+    ├── RedissonLeaderConfiguration.kt
+    ├── LettuceLeaderConfiguration.kt
+    ├── MongoLeaderConfiguration.kt
+    ├── HazelcastLeaderConfiguration.kt
+    ├── ExposedJdbcLeaderConfiguration.kt
+    └── ExposedR2dbcLeaderConfiguration.kt
+```
+
+### 3.2 Properties 설계
+
+**Boot3 wrapper (Boot 의존성을 common에 침투시키지 않기 위함)**:
+
+```kotlin
+@ConfigurationProperties(prefix = "bluetape4k.leader")
+data class Boot3LeaderProperties(
+    val waitTime: Duration = LeaderElectionProperties.DefaultWaitTime,
+    val leaseTime: Duration = LeaderElectionProperties.DefaultLeaseTime,
+    @field:NestedConfigurationProperty
+    val group: LeaderGroupProperties = LeaderGroupProperties(),
+    @field:NestedConfigurationProperty
+    val mongo: MongoCollectionProperties = MongoCollectionProperties(),
+) {
+    fun toCommon(): LeaderElectionProperties =
+        LeaderElectionProperties(waitTime, leaseTime, group)
+}
+
+@ConfigurationProperties(prefix = "bluetape4k.leader.mongo")
+data class MongoCollectionProperties(
+    val singleCollection: String = "leader_election",
+    val groupCollection: String = "leader_group_election",
+)
+```
+
+YAML 예시:
+```yaml
+bluetape4k:
+  leader:
+    wait-time: 5s
+    lease-time: 60s
+    group:
+      max-leaders: 3
+      wait-time: 5s
+      lease-time: 60s
+    mongo:
+      single-collection: "leader_election"
+      group-collection: "leader_group_election"
+```
+
+### 3.3 PropertiesAdapter
+
+```kotlin
+internal object PropertiesAdapter {
+    fun toCommonElection(p: Boot3LeaderProperties): LeaderElectionOptions = ...
+    fun toCommonGroup(p: Boot3LeaderProperties): LeaderGroupElectionOptions = ...
+    fun toMongo(p: Boot3LeaderProperties): MongoLeaderElectionOptions = ...
+    fun toMongoGroup(p: Boot3LeaderProperties): MongoLeaderGroupElectionOptions = ...
+    fun toExposedJdbc(p: Boot3LeaderProperties): ExposedJdbcLeaderElectionOptions = ...
+    fun toExposedJdbcGroup(p: Boot3LeaderProperties): ExposedJdbcLeaderGroupElectionOptions = ...
+    fun toExposedR2dbc(p: Boot3LeaderProperties): ExposedR2dbcLeaderElectionOptions = ...
+    fun toExposedR2dbcGroup(p: Boot3LeaderProperties): ExposedR2dbcLeaderGroupElectionOptions = ...
+}
+```
+
+각 백엔드 자체 옵션 (`retryDelay`, `retryStrategy`, `recordHistory`, `lockOwner` 등)은 v1.0에서 **항상 기본값 사용**. 후속 이슈에서 노출 검토 (M-2 리스크).
+
+### 3.4 백엔드별 빈 등록 (matrix)
+
+| Backend | Conditional | 빈 이름 | 빈 타입 |
+|---------|-------------|---------|---------|
+| Redisson | `OnClass(RedissonClient)` + `OnBean(RedissonClient)` | `redissonLeaderElection` | `LeaderElection` |
+| Redisson | 〃 | `redissonSuspendLeaderElection` | `SuspendLeaderElection` |
+| Redisson | 〃 | `redissonLeaderGroupElection` | `LeaderGroupElection` |
+| Redisson | 〃 | `redissonSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` |
+| Local ⭐ | (없음 — `leader-core` 항상 포함) + `OnMissingBean(type = LeaderElection::class)` | `localLeaderElection` | `LeaderElection` (default fallback) |
+| Local ⭐ | `OnMissingBean(type = SuspendLeaderElection::class)` | `localSuspendLeaderElection` | `SuspendLeaderElection` (default fallback) |
+| Local ⭐ | `OnMissingBean(type = LeaderGroupElection::class)` | `localLeaderGroupElection` | `LeaderGroupElection` (default fallback) |
+| Local ⭐ | `OnMissingBean(type = SuspendLeaderGroupElection::class)` | `localSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` (default fallback) |
+| Lettuce | `OnClass(StatefulRedisConnection)` + `OnBean(StatefulRedisConnection)` | `lettuceLeaderElection` | `LeaderElection` |
+| Lettuce | 〃 | `lettuceSuspendLeaderElection` | `SuspendLeaderElection` |
+| Lettuce | 〃 | `lettuceLeaderGroupElection` | `LeaderGroupElection` |
+| Lettuce | 〃 | `lettuceSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` |
+| Mongo | `OnClass(MongoCollection)` + `OnBean(MongoDatabase)` | `mongoLeaderElection` | `LeaderElection` |
+| Mongo | `OnClass(CoroutineMongoCollection)` + `OnBean(CoroutineMongoDatabase)` | `mongoSuspendLeaderElection` | `SuspendLeaderElection` |
+| Mongo | `OnClass(MongoCollection)` + `OnBean(MongoDatabase)` | `mongoLeaderGroupElection` | `LeaderGroupElection` |
+| Mongo | sync `MongoDatabase` + `CoroutineMongoDatabase` | `mongoSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` |
+| Hazelcast | `OnClass(HazelcastInstance)` + `OnBean(HazelcastInstance)` | `hazelcastLeaderElection` | `LeaderElection` |
+| Hazelcast | 〃 | `hazelcastSuspendLeaderElection` | `SuspendLeaderElection` |
+| Hazelcast | 〃 | `hazelcastLeaderGroupElection` | `LeaderGroupElection` |
+| Hazelcast | 〃 | `hazelcastSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` |
+| ExposedJdbc | `OnClass(org.jetbrains.exposed.v1.jdbc.Database)` + `OnBean(Database)` | `exposedJdbcLeaderElection` | `LeaderElection` |
+| ExposedJdbc | 〃 | `exposedJdbcLeaderGroupElection` | `LeaderGroupElection` |
+| ExposedJdbc | 〃 + `OnBean(exposedJdbcLeaderElection)` | `exposedJdbcVirtualThreadLeaderElection` | `VirtualThreadLeaderElection` |
+| ExposedR2dbc | `OnClass(R2dbcDatabase)` + `OnBean(R2dbcDatabase)` | `exposedR2dbcSuspendLeaderElection` | `SuspendLeaderElection` |
+| ExposedR2dbc | 〃 | `exposedR2dbcSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` |
+
+총 빈 수: Local 4 (default fallback) + Redisson 4 + Lettuce 4 + Mongo 4 + Hazelcast 4 + ExposedJdbc 3 + ExposedR2dbc 2 = **25**. 단 Local은 다른 백엔드 빈이 없을 때만 등록.
+
+각 빈 `@ConditionalOnMissingBean(name = "...")` 적용 → 사용자 override 가능. Local은 추가로 `@ConditionalOnMissingBean(type = ...)` 적용으로 다른 백엔드 활성 시 자동 비활성.
+
+### 3.5 Mongo 설계 변경 (review 반영)
+
+기존: `OnBean(MongoCollection<Document>)` 단일 게이트. → 너무 느슨, 컬렉션명 모호.
+변경: `OnBean(MongoDatabase)` 게이트 + `MongoCollectionProperties.singleCollection`/`groupCollection`로 컬렉션 이름 지정. 빈 메서드 내부에서:
+```kotlin
+@Bean
+fun mongoLeaderElection(db: MongoDatabase, props: Boot3LeaderProperties) =
+    MongoLeaderElection(
+        db.getCollection(props.mongo.singleCollection, Document::class.java),
+        PropertiesAdapter.toMongo(props),
+    )
+```
+
+### 3.6 Suspend factory 처리 (C-2)
+
+```kotlin
+@Bean
+fun mongoSuspendLeaderElection(
+    coroutineDb: CoroutineMongoDatabase,
+    props: Boot3LeaderProperties,
+): MongoSuspendLeaderElection = runBlocking {
+    MongoSuspendLeaderElection(
+        coroutineDb.getCollection(props.mongo.singleCollection, Document::class.java),
+        PropertiesAdapter.toMongo(props),
+    )
+}
+```
+
+`runBlocking`은 startup phase에서만 호출되므로 안전. 트레이드오프 README에 명시.
+
+### 3.7 진입점
+
+```kotlin
+@AutoConfiguration
+@ConditionalOnClass(LeaderElection::class)
+@EnableConfigurationProperties(Boot3LeaderProperties::class, MongoCollectionProperties::class)
+@Import(
+    RedissonLeaderConfiguration::class,
+    LettuceLeaderConfiguration::class,
+    MongoLeaderConfiguration::class,
+    HazelcastLeaderConfiguration::class,
+    ExposedJdbcLeaderConfiguration::class,
+    ExposedR2dbcLeaderConfiguration::class,
+    LocalLeaderConfiguration::class,  // 마지막 — `@AutoConfigureOrder` LOWEST_PRECEDENCE로 다른 백엔드 빈 등록 후 평가
+)
+class LeaderElectionAutoConfiguration
+```
+
+`AutoConfiguration.imports`:
+```
+io.bluetape4k.leader.spring.boot3.LeaderElectionAutoConfiguration
+```
+
+### 3.8 다중 백엔드 정책 (C-6) — Local default fallback
+
+- **default backend**: `Local` (in-memory, `leader-core`). 외부 인프라 없이 동작. dev/test 즉시 사용
+- Local 빈은 `@ConditionalOnMissingBean(type = LeaderElection::class)` 등으로 등록 → **다른 백엔드 빈이 등장하면 자동 비활성**
+- 빈 이름은 모두 다르므로 Spring 컨테이너 등록 충돌 없음
+- 단일 백엔드 활성 시 (예: Lettuce만) → 사용자 `@Autowired LeaderElection` 자동 주입
+- **다중 백엔드** 동시 활성 시 (예: Lettuce + Redisson) → `NoUniqueBeanDefinitionException` 발생 가능 → README에 `@Qualifier("lettuceLeaderElection")` 명시 가이드
+- v1.0에서 `default-backend` 속성/`@Primary`는 도입하지 않음 (YAGNI). Local fallback으로 dev 환경 커버, 단일 prod 백엔드는 자동 주입, 다중은 명시적 qualifier
+
+---
+
+## 4. 테스트 전략
+
+| 테스트 | 검증 |
+|--------|------|
+| `LeaderElectionAutoConfigurationTest` | `@SpringBootTest` + Redisson Testcontainer + 4 종 election 빈 주입 + 실제 `runIfLeader()` 동작 |
+| `BackendConditionalTest` | `ApplicationContextRunner` × 6 백엔드 — 클라이언트 빈 미설정 시 election 빈 미등록 + 등록 시 21 빈 모두 활성 |
+| `Boot3LeaderPropertiesBindingTest` | yaml `bluetape4k.leader.*` 바인딩 검증 (waitTime, group, mongo 컬렉션명) |
+| `PropertiesAdapterTest` | properties → 8 종 backend Options 변환 검증 |
+
+**커버리지 목표**: line coverage > 80% (Kover).
+
+---
+
+## 5. 변경 파일 (예상 18개)
+
+| 파일 | 종류 |
+|------|------|
+| `gradle/libs.versions.toml` | 수정 (필요 시 추가 alias) |
+| `leader-spring-boot3/build.gradle.kts` | 수정 (common api 의존 + 6 백엔드 모듈 testRuntimeOnly 추가) |
+| `Boot3LeaderProperties.kt` | 신규 |
+| `MongoCollectionProperties.kt` | 신규 |
+| `adapter/PropertiesAdapter.kt` | 신규 |
+| `LeaderElectionAutoConfiguration.kt` | 신규 |
+| `backend/RedissonLeaderConfiguration.kt` | 신규 |
+| `backend/LettuceLeaderConfiguration.kt` | 신규 |
+| `backend/MongoLeaderConfiguration.kt` | 신규 |
+| `backend/HazelcastLeaderConfiguration.kt` | 신규 |
+| `backend/ExposedJdbcLeaderConfiguration.kt` | 신규 |
+| `backend/ExposedR2dbcLeaderConfiguration.kt` | 신규 |
+| `META-INF/spring/.../AutoConfiguration.imports` | 신규 |
+| `LeaderElectionAutoConfigurationTest.kt` | 신규 |
+| `AbstractRedissonAutoConfigurationTest.kt` | 신규 |
+| `BackendConditionalTest.kt` | 신규 |
+| `Boot3LeaderPropertiesBindingTest.kt` | 신규 |
+| `PropertiesAdapterTest.kt` | 신규 |
+| `src/test/resources/junit-platform.properties` | 신규 |
+| `src/test/resources/logback-test.xml` | 신규 |
+| `leader-spring-boot3/README.md` + `README.ko.md` | 신규 |
+
+---
+
+## 6. DoD (#11)
+
+- [x] AutoConfiguration 클래스 + 6 백엔드 분리
+- [x] LeaderProperties (Boot3 wrapper, common 재사용)
+- [x] `META-INF/spring/AutoConfiguration.imports` 등록
+- [x] `@SpringBootTest` 통합 테스트 (Redisson 백엔드)
+- [x] Kover 라인 커버리지 > 80%
+
+---
+
+## 7. 리스크/노트
+
+| ID | 리스크 | 완화 |
+|----|--------|------|
+| R-1 | `runBlocking` 호출이 startup latency 증가 (Mongo/R2DBC suspend 빈) | 컨텍스트 초기화 시 1회만 호출, README에 명시 |
+| R-2 | 백엔드별 옵션 (`retryDelay` 등) 노출 안 됨 | v1.0 한계 명시. 후속 이슈로 분리 |
+| R-3 | Mongo `MongoDatabase` 빈 가정 — 사용자가 직접 컬렉션 빈만 등록한 경우 미등록 | README에 "MongoDatabase 빈 필요" 명시 + 후속 옵션 검토 |
+| R-4 | Spring Boot 3.5 미만 환경에서 `data class` properties 바인딩 실패 가능 | `dependencyManagement`로 spring-boot 3.5.14 강제 |
+| R-5 | 다중 백엔드 활성화 시 `@Autowired LeaderElection` 사용자 코드에서 ambiguity | README의 `@Qualifier` 사용 가이드 |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -133,6 +133,8 @@ spring-boot4-dependencies = { module = "org.springframework.boot:spring-boot-dep
 spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure" }
 spring-boot-configuration-processor = { module = "org.springframework.boot:spring-boot-configuration-processor" }
 spring-boot-test = { module = "org.springframework.boot:spring-boot-test" }
+spring-boot-test-autoconfigure = { module = "org.springframework.boot:spring-boot-test-autoconfigure" }
+spring-test = { module = "org.springframework:spring-test" }
 spring-context = { module = "org.springframework:spring-context" }
 spring-tx = { module = "org.springframework:spring-tx" }
 

--- a/leader-spring-boot3/README.ko.md
+++ b/leader-spring-boot3/README.ko.md
@@ -1,0 +1,129 @@
+# leader-spring-boot3
+
+[bluetape4k-leader](../README.ko.md)의 Spring Boot 3 자동 구성 모듈.
+Spring 컨텍스트에 등록된 백엔드 클라이언트 빈에 따라 `LeaderElection` / `SuspendLeaderElection` /
+`LeaderGroupElection` / `SuspendLeaderGroupElection` 빈을 자동 등록합니다.
+
+## 빠른 시작
+
+### 1. 의존성 추가
+
+```kotlin
+dependencies {
+    implementation("io.github.bluetape4k.leader:leader-spring-boot3:<version>")
+    // 사용할 백엔드 1개 이상:
+    implementation("io.github.bluetape4k.leader:leader-redis-lettuce:<version>")
+    implementation("io.github.bluetape4k.leader:leader-redis-redisson:<version>")
+    implementation("io.github.bluetape4k.leader:leader-mongodb:<version>")
+    implementation("io.github.bluetape4k.leader:leader-hazelcast:<version>")
+    implementation("io.github.bluetape4k.leader:leader-exposed-jdbc:<version>")
+    implementation("io.github.bluetape4k.leader:leader-exposed-r2dbc:<version>")
+}
+```
+
+백엔드 모듈이 classpath에 없으면 **Local (in-memory) fallback** 빈이 자동 등록됩니다.
+외부 인프라 없이 dev / test 환경에서 즉시 동작합니다.
+
+### 2. 백엔드 클라이언트 빈 제공
+
+```kotlin
+@Configuration
+class RedisConfig {
+    @Bean(destroyMethod = "shutdown")
+    fun redissonClient(): RedissonClient =
+        Redisson.create(Config().apply { useSingleServer().setAddress("redis://localhost:6379") })
+}
+```
+
+### 3. 주입 후 사용
+
+```kotlin
+@Service
+class CronJobService(private val leader: LeaderElection) {
+    @Scheduled(cron = "0 */15 * * * *")
+    fun runIfPrimary() {
+        leader.runIfLeader("cron-job") {
+            // 단일 노드에서만 실행됨
+        }
+    }
+}
+```
+
+## 빈 등록 매트릭스
+
+| 백엔드        | 활성화 조건                                               | 등록 빈                                                                                                                                       |
+|--------------|----------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| **Local** ⭐ | 다른 백엔드 빈이 없을 때 (fallback)                       | `localLeaderElection`, `localSuspendLeaderElection`, `localLeaderGroupElection`, `localSuspendLeaderGroupElection`                            |
+| Redisson     | `RedissonClient` 빈 존재                                  | `redissonLeaderElection`, `redissonSuspendLeaderElection`, `redissonLeaderGroupElection`, `redissonSuspendLeaderGroupElection`                |
+| Lettuce      | `StatefulRedisConnection<String, String>` 빈 존재         | `lettuceLeaderElection`, `lettuceSuspendLeaderElection`, `lettuceLeaderGroupElection`, `lettuceSuspendLeaderGroupElection`                    |
+| Mongo        | `MongoDatabase` 또는 `CoroutineMongoDatabase` 빈 존재    | `mongoLeaderElection`, `mongoLeaderGroupElection` (sync); `mongoSuspendLeaderElection`, `mongoSuspendLeaderGroupElection` (coroutine)         |
+| Hazelcast    | `HazelcastInstance` 빈 존재                               | `hazelcastLeaderElection`, `hazelcastSuspendLeaderElection`, `hazelcastLeaderGroupElection`, `hazelcastSuspendLeaderGroupElection`            |
+| ExposedJdbc  | `org.jetbrains.exposed.v1.jdbc.Database` 빈 존재          | `exposedJdbcLeaderElection`, `exposedJdbcLeaderGroupElection`, `exposedJdbcVirtualThreadLeaderElection`                                       |
+| ExposedR2dbc | `org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase` 빈 존재                                   | `exposedR2dbcSuspendLeaderElection`, `exposedR2dbcSuspendLeaderGroupElection`                                                                 |
+
+⭐ Local 빈은 `@ConditionalOnMissingBean(<type>::class)` 으로 등록되므로, 동일 타입의 다른 백엔드 빈이 등장하면 자동 비활성됩니다.
+
+## 설정
+
+YAML prefix: `bluetape4k.leader`.
+
+```yaml
+bluetape4k:
+  leader:
+    wait-time: 5s          # 기본 5초
+    lease-time: 60s        # 기본 60초
+    group:
+      max-leaders: 2       # 기본 2
+      wait-time: 5s
+      lease-time: 60s
+    mongo:
+      single-collection: leader_election        # 기본
+      group-collection:  leader_group_election  # 기본
+```
+
+## 다중 백엔드 사용
+
+여러 백엔드가 동시에 활성화될 때(예: Lettuce + Redisson) 빈 이름이 모두 다르므로 컨테이너 등록 충돌은 없습니다.
+하지만 `@Autowired LeaderElection` 타입 주입은 모호해져 Spring이 `NoUniqueBeanDefinitionException`을 던집니다.
+
+`@Qualifier`로 명시:
+
+```kotlin
+@Service
+class MyService(
+    @Qualifier("lettuceLeaderElection") private val leader: LeaderElection,
+)
+```
+
+## 사용자 빈 override
+
+각 백엔드 빈은 `@ConditionalOnMissingBean(name = "<beanName>")`을 사용합니다. 동일 이름의 빈을
+직접 `@Configuration`에 등록하면 자동 빈을 우회합니다:
+
+```kotlin
+@Bean(name = ["redissonLeaderElection"])
+fun customRedissonLeader(client: RedissonClient): LeaderElection =
+    RedissonLeaderElection(client, LeaderElectionOptions(waitTime = 10.seconds, leaseTime = 5.minutes))
+```
+
+## 노트 / 트레이드오프
+
+- **시동 시점 `runBlocking`** — Mongo `suspend` 빈과 ExposedR2dbc `suspend` 빈은 `suspend operator fun invoke()`를
+  Spring 의 동기 `@Bean` 계약에 맞추기 위해 `runBlocking`으로 감싸 호출합니다. 스키마 초기화는 컨텍스트 시동 시
+  1회만 수행되며 요청 처리 latency에는 영향을 주지 않습니다.
+- **Mongo 백엔드 요구사항** — `mongoLeaderElection`은 `MongoDatabase` (sync 드라이버), `mongoSuspendLeaderElection`은
+  `CoroutineMongoDatabase` (코루틴 드라이버), `mongoSuspendLeaderGroupElection`은 **둘 다** (동일 namespace) 필요.
+- **백엔드 고유 옵션** — `retryDelay`, `retryStrategy`, `recordHistory`, `lockOwner` 등은 v1.0에서 properties로
+  노출되지 않으며 백엔드 기본값을 사용합니다. 후속 이슈에서 노출 검토 예정.
+
+## 아키텍처
+
+`LeaderElectionAutoConfiguration`이 진입점(`@AutoConfiguration`)이며 `@ConditionalOnClass(LeaderElection::class)`으로
+게이트됩니다. 7개 백엔드 `@Configuration` 클래스를 `@Import`하며 각각 자체 `@ConditionalOnClass` + `@ConditionalOnBean`
+조건으로 활성화됩니다. `LocalLeaderConfiguration`은 `@AutoConfigureOrder(LOWEST_PRECEDENCE)`로 선언되며
+`@ConditionalOnMissingBean(<type>)`을 사용하여 다른 백엔드가 동일 타입 빈을 만들지 않을 때만 활성화됩니다.
+
+## 관련 문서
+
+- [leader-spring-boot-common](../leader-spring-boot-common/README.ko.md) — Boot 버전 독립 공통 properties + config support
+- [프로젝트 루트 README](../README.ko.md)

--- a/leader-spring-boot3/README.md
+++ b/leader-spring-boot3/README.md
@@ -1,0 +1,132 @@
+# leader-spring-boot3
+
+Spring Boot 3 auto-configuration for [bluetape4k-leader](../README.md).
+Auto-registers `LeaderElection` / `SuspendLeaderElection` / `LeaderGroupElection` / `SuspendLeaderGroupElection` beans
+based on the backend client beans available in your Spring context.
+
+## Quick Start
+
+### 1. Add dependency
+
+```kotlin
+dependencies {
+    implementation("io.github.bluetape4k.leader:leader-spring-boot3:<version>")
+    // Pick one or more backends:
+    implementation("io.github.bluetape4k.leader:leader-redis-lettuce:<version>")
+    implementation("io.github.bluetape4k.leader:leader-redis-redisson:<version>")
+    implementation("io.github.bluetape4k.leader:leader-mongodb:<version>")
+    implementation("io.github.bluetape4k.leader:leader-hazelcast:<version>")
+    implementation("io.github.bluetape4k.leader:leader-exposed-jdbc:<version>")
+    implementation("io.github.bluetape4k.leader:leader-exposed-r2dbc:<version>")
+}
+```
+
+If no backend module is on the classpath, the **Local (in-memory) fallback** is auto-registered.
+Useful for development and tests without external infrastructure.
+
+### 2. Provide a backend client bean
+
+```kotlin
+@Configuration
+class RedisConfig {
+    @Bean(destroyMethod = "shutdown")
+    fun redissonClient(): RedissonClient =
+        Redisson.create(Config().apply { useSingleServer().setAddress("redis://localhost:6379") })
+}
+```
+
+### 3. Inject and use
+
+```kotlin
+@Service
+class CronJobService(private val leader: LeaderElection) {
+    @Scheduled(cron = "0 */15 * * * *")
+    fun runIfPrimary() {
+        leader.runIfLeader("cron-job") {
+            // executed on a single node only
+        }
+    }
+}
+```
+
+## Bean Registration Matrix
+
+| Backend     | Activation Condition                                | Beans Registered                                                                                                                              |
+|-------------|-----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| **Local** ⭐ | No other backend bean is present (fallback)         | `localLeaderElection`, `localSuspendLeaderElection`, `localLeaderGroupElection`, `localSuspendLeaderGroupElection`                            |
+| Redisson    | `RedissonClient` bean present                       | `redissonLeaderElection`, `redissonSuspendLeaderElection`, `redissonLeaderGroupElection`, `redissonSuspendLeaderGroupElection`                |
+| Lettuce     | `StatefulRedisConnection<String, String>` present   | `lettuceLeaderElection`, `lettuceSuspendLeaderElection`, `lettuceLeaderGroupElection`, `lettuceSuspendLeaderGroupElection`                    |
+| Mongo       | `MongoDatabase` and/or `CoroutineMongoDatabase`     | `mongoLeaderElection`, `mongoLeaderGroupElection` (sync); `mongoSuspendLeaderElection`, `mongoSuspendLeaderGroupElection` (coroutine)         |
+| Hazelcast   | `HazelcastInstance` present                         | `hazelcastLeaderElection`, `hazelcastSuspendLeaderElection`, `hazelcastLeaderGroupElection`, `hazelcastSuspendLeaderGroupElection`            |
+| ExposedJdbc | `org.jetbrains.exposed.v1.jdbc.Database` present    | `exposedJdbcLeaderElection`, `exposedJdbcLeaderGroupElection`, `exposedJdbcVirtualThreadLeaderElection`                                       |
+| ExposedR2dbc| `R2dbcDatabase` present                             | `exposedR2dbcSuspendLeaderElection`, `exposedR2dbcSuspendLeaderGroupElection`                                                                 |
+
+⭐ Local beans are registered with `@ConditionalOnMissingBean(<type>::class)` — they back off automatically when any other backend bean of the same type is registered.
+
+## Configuration
+
+YAML prefix: `bluetape4k.leader`.
+
+```yaml
+bluetape4k:
+  leader:
+    wait-time: 5s          # default 5s
+    lease-time: 60s        # default 60s
+    group:
+      max-leaders: 2       # default 2
+      wait-time: 5s
+      lease-time: 60s
+    mongo:
+      single-collection: leader_election        # default
+      group-collection:  leader_group_election  # default
+```
+
+## Multi-Backend Usage
+
+When multiple backends are active simultaneously (e.g. Lettuce + Redisson), every bean has a unique name,
+so the container holds them all without conflict. However `@Autowired LeaderElection` becomes ambiguous
+and Spring throws `NoUniqueBeanDefinitionException`.
+
+Use `@Qualifier` to disambiguate:
+
+```kotlin
+@Service
+class MyService(
+    @Qualifier("lettuceLeaderElection") private val leader: LeaderElection,
+)
+```
+
+## Custom Bean Override
+
+Each backend bean uses `@ConditionalOnMissingBean(name = "<beanName>")`. To override, register a bean
+with the same name in your own `@Configuration`:
+
+```kotlin
+@Bean(name = ["redissonLeaderElection"])
+fun customRedissonLeader(client: RedissonClient): LeaderElection =
+    RedissonLeaderElection(client, LeaderElectionOptions(waitTime = 10.seconds, leaseTime = 5.minutes))
+```
+
+## Notes & Trade-offs
+
+- **`runBlocking` at startup** — Mongo `suspend` beans and ExposedR2dbc `suspend` beans wrap their
+  `suspend operator fun invoke()` in `runBlocking` to satisfy Spring's synchronous `@Bean` contract.
+  Schema initialization runs once during context startup; no impact on request-time latency.
+- **Mongo backend requirements** — `mongoLeaderElection` requires `MongoDatabase` (sync driver),
+  `mongoSuspendLeaderElection` requires `CoroutineMongoDatabase` (coroutine driver), and
+  `mongoSuspendLeaderGroupElection` requires *both* (sync + coroutine on the same namespace).
+- **Backend-specific options** — `retryDelay`, `retryStrategy`, `recordHistory`, `lockOwner` etc. are
+  not exposed via properties in v1.0; backend defaults are used. Subsequent issue will surface them.
+
+## Architecture
+
+`LeaderElectionAutoConfiguration` is the entry point (`@AutoConfiguration`), gated by
+`@ConditionalOnClass(LeaderElection::class)`. It `@Import`s 7 backend `@Configuration` classes,
+each gated by their own `@ConditionalOnClass` + `@ConditionalOnBean`. The `LocalLeaderConfiguration`
+is annotated with `@AutoConfigureOrder(LOWEST_PRECEDENCE)` and uses `@ConditionalOnMissingBean(<type>)`
+so it activates only when no other backend produces the same type bean.
+
+## See Also
+
+- [leader-spring-boot-common](../leader-spring-boot-common/README.md) — Boot-version-independent properties + config support
+- [Project root README](../README.md)

--- a/leader-spring-boot3/build.gradle.kts
+++ b/leader-spring-boot3/build.gradle.kts
@@ -11,11 +11,21 @@ configurations {
 dependencyManagement {
     imports {
         mavenBom(libs.spring.boot3.dependencies.get().toString())
+        // spring-boot-dependencies는 kotlin.version=1.9.25, mongodb 5.5.x를 강제하므로
+        // kotlin-bom을 뒤에서 다시 import하여 프로젝트 Kotlin 버전을 우선시킨다.
+        mavenBom(libs.kotlin.bom.get().toString())
+    }
+    dependencies {
+        // mongodb-driver-core 버전을 driver-sync/driver-kotlin-coroutine과 일치시킨다.
+        dependency("org.mongodb:mongodb-driver-core:${libs.versions.mongo.driver.get()}")
+        dependency("org.mongodb:mongodb-driver-reactivestreams:${libs.versions.mongo.driver.get()}")
     }
 }
 
 dependencies {
     api(project(":leader-core"))
+    api(project(":leader-spring-boot-common"))
+
     compileOnly(project(":leader-redis-lettuce"))
     compileOnly(project(":leader-redis-redisson"))
     compileOnly(project(":leader-exposed-jdbc"))
@@ -23,6 +33,12 @@ dependencies {
     compileOnly(project(":leader-mongodb"))
     compileOnly(project(":leader-hazelcast"))
     compileOnly(project(":leader-micrometer"))
+
+    compileOnly(libs.lettuce.core)
+    compileOnly(libs.redisson)
+    compileOnly(libs.mongodb.driver.sync)
+    compileOnly(libs.mongodb.driver.kotlin.coroutine)
+    compileOnly(libs.hazelcast)
 
     api(libs.spring.boot.autoconfigure)
     compileOnly(libs.spring.boot.configuration.processor)
@@ -32,10 +48,22 @@ dependencies {
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.spring.boot.test)
+    testImplementation(libs.spring.boot.test.autoconfigure)
+    testImplementation(libs.spring.test)
     testImplementation(libs.springmockk)
     testImplementation(project(":leader-redis-redisson"))
+    testImplementation(project(":leader-redis-lettuce"))
+    testImplementation(project(":leader-exposed-jdbc"))
+    testImplementation(project(":leader-exposed-r2dbc"))
+    testImplementation(project(":leader-mongodb"))
+    testImplementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.testcontainers.mongodb)
+    // r2dbc-h2가 자체 H2 driver를 가져오므로 h2-v2 별도 추가 시 ABI 충돌
+    testImplementation(libs.r2dbc.h2)
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit.jupiter)
+    // ApplicationContextRunner.run 콜백이 AssertJ AssertProvider 를 노출하므로 필수
+    testImplementation("org.assertj:assertj-core")
 }
 
 // Spring Boot Configuration Processor

--- a/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/Boot3LeaderProperties.kt
+++ b/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/Boot3LeaderProperties.kt
@@ -1,0 +1,41 @@
+package io.bluetape4k.leader.spring.boot3
+
+import io.bluetape4k.leader.spring.properties.LeaderElectionProperties
+import io.bluetape4k.leader.spring.properties.LeaderGroupProperties
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.NestedConfigurationProperty
+import java.time.Duration
+
+/**
+ * Spring Boot 3 자동 구성 진입 속성.
+ *
+ * `bluetape4k.leader.*` prefix 로 yaml 바인딩됩니다. 백엔드별 옵션 변환은 [adapter.PropertiesAdapter] 사용.
+ *
+ * ```yaml
+ * bluetape4k:
+ *   leader:
+ *     wait-time: 5s
+ *     lease-time: 60s
+ *     group:
+ *       max-leaders: 3
+ *       wait-time: 5s
+ *       lease-time: 60s
+ *     mongo:
+ *       single-collection: leader_election
+ *       group-collection: leader_group_election
+ * ```
+ *
+ * @property waitTime 단일 리더 획득 대기 최대 시간. 기본 5초
+ * @property leaseTime 단일 리더 보유 최대 시간. 기본 60초
+ * @property group 멀티 리더 그룹 옵션
+ * @property mongo MongoDB 백엔드 컬렉션 이름
+ */
+@ConfigurationProperties(prefix = "bluetape4k.leader")
+data class Boot3LeaderProperties(
+    val waitTime: Duration = LeaderElectionProperties.DefaultWaitTime,
+    val leaseTime: Duration = LeaderElectionProperties.DefaultLeaseTime,
+    @field:NestedConfigurationProperty
+    val group: LeaderGroupProperties = LeaderGroupProperties(),
+    @field:NestedConfigurationProperty
+    val mongo: MongoCollectionProperties = MongoCollectionProperties(),
+)

--- a/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/LeaderElectionAutoConfiguration.kt
+++ b/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/LeaderElectionAutoConfiguration.kt
@@ -1,0 +1,38 @@
+package io.bluetape4k.leader.spring.boot3
+
+import io.bluetape4k.leader.LeaderElection
+import io.bluetape4k.leader.spring.boot3.backend.ExposedJdbcLeaderConfiguration
+import io.bluetape4k.leader.spring.boot3.backend.ExposedR2dbcLeaderConfiguration
+import io.bluetape4k.leader.spring.boot3.backend.HazelcastLeaderConfiguration
+import io.bluetape4k.leader.spring.boot3.backend.LettuceLeaderConfiguration
+import io.bluetape4k.leader.spring.boot3.backend.MongoLeaderConfiguration
+import io.bluetape4k.leader.spring.boot3.backend.RedissonLeaderConfiguration
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Import
+
+/**
+ * bluetape4k-leader Spring Boot 3 자동 구성 진입점.
+ *
+ * `LeaderElection` 클래스가 classpath에 존재하는 경우 활성화되며, 각 백엔드별 하위 구성을
+ * `@Import`로 가져옵니다. 백엔드 활성화 조건은 각 Configuration 클래스에서 `@ConditionalOnBean` /
+ * `@ConditionalOnClass`로 검사됩니다.
+ *
+ * Local fallback은 별도의 `LocalLeaderConfiguration`이 `@AutoConfiguration(after=...)`로 선언되어
+ * 모든 백엔드 평가 후 활성화됩니다.
+ *
+ * @see Boot3LeaderProperties yaml `bluetape4k.leader.*` 속성 바인딩
+ */
+@AutoConfiguration
+@ConditionalOnClass(LeaderElection::class)
+@EnableConfigurationProperties(Boot3LeaderProperties::class)
+@Import(
+    RedissonLeaderConfiguration::class,
+    LettuceLeaderConfiguration::class,
+    MongoLeaderConfiguration::class,
+    HazelcastLeaderConfiguration::class,
+    ExposedJdbcLeaderConfiguration::class,
+    ExposedR2dbcLeaderConfiguration::class,
+)
+class LeaderElectionAutoConfiguration

--- a/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/MongoCollectionProperties.kt
+++ b/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/MongoCollectionProperties.kt
@@ -1,0 +1,15 @@
+package io.bluetape4k.leader.spring.boot3
+
+/**
+ * MongoDB 백엔드용 컬렉션 이름 속성.
+ *
+ * Single/Group election이 사용할 컬렉션 이름을 분리합니다. 사용자 앱에 `MongoDatabase` 빈만 존재해도
+ * 이 속성으로 컬렉션을 안전하게 선택할 수 있습니다.
+ *
+ * @property singleCollection 단일 리더 선출 컬렉션. 기본 `leader_election`
+ * @property groupCollection 멀티 리더 그룹 컬렉션. 기본 `leader_group_election`
+ */
+data class MongoCollectionProperties(
+    val singleCollection: String = "leader_election",
+    val groupCollection: String = "leader_group_election",
+)

--- a/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/adapter/PropertiesAdapter.kt
+++ b/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/adapter/PropertiesAdapter.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.leader.spring.boot3.adapter
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.spring.boot3.Boot3LeaderProperties
+
+/**
+ * [Boot3LeaderProperties] → 백엔드별 Options 변환 어댑터.
+ *
+ * 각 백엔드(Mongo, Exposed JDBC/R2DBC)는 자체 옵션 클래스를 갖지만, v1.0에서는 공통 속성만 노출하며
+ * 백엔드 고유 옵션(`retryDelay`, `retryStrategy`, `recordHistory`, `lockOwner`)은 기본값을 사용합니다.
+ *
+ * 백엔드 고유 옵션 노출은 후속 이슈로 분리됩니다.
+ */
+internal object PropertiesAdapter {
+
+    /** 공통 [LeaderElectionOptions] 변환. */
+    fun toCommonElection(props: Boot3LeaderProperties): LeaderElectionOptions =
+        LeaderElectionOptions(waitTime = props.waitTime, leaseTime = props.leaseTime)
+
+    /** 공통 [LeaderGroupElectionOptions] 변환. */
+    fun toCommonGroup(props: Boot3LeaderProperties): LeaderGroupElectionOptions =
+        LeaderGroupElectionOptions(
+            maxLeaders = props.group.maxLeaders,
+            waitTime = props.group.waitTime,
+            leaseTime = props.group.leaseTime,
+        )
+}

--- a/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/backend/ExposedJdbcLeaderConfiguration.kt
+++ b/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/backend/ExposedJdbcLeaderConfiguration.kt
@@ -1,0 +1,60 @@
+package io.bluetape4k.leader.spring.boot3.backend
+
+import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderElection
+import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderElectionOptions
+import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderGroupElection
+import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderGroupElectionOptions
+import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcVirtualThreadLeaderElection
+import io.bluetape4k.leader.spring.boot3.Boot3LeaderProperties
+import io.bluetape4k.leader.spring.boot3.adapter.PropertiesAdapter
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Exposed(JDBC) 백엔드 자동 구성.
+ *
+ * `org.jetbrains.exposed.v1.jdbc.Database` 빈이 등록된 경우에만 활성화됩니다.
+ *
+ * 등록 빈:
+ * - `exposedJdbcLeaderElection` — sync 단일 리더
+ * - `exposedJdbcLeaderGroupElection` — sync 그룹 리더
+ * - `exposedJdbcVirtualThreadLeaderElection` — Virtual Thread 변형 (sync 빈을 wrapping)
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(Database::class)
+@ConditionalOnBean(Database::class)
+class ExposedJdbcLeaderConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["exposedJdbcLeaderElection"])
+    fun exposedJdbcLeaderElection(
+        db: Database,
+        props: Boot3LeaderProperties,
+    ): ExposedJdbcLeaderElection =
+        ExposedJdbcLeaderElection(
+            db,
+            ExposedJdbcLeaderElectionOptions(leaderOptions = PropertiesAdapter.toCommonElection(props)),
+        )
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["exposedJdbcLeaderGroupElection"])
+    fun exposedJdbcLeaderGroupElection(
+        db: Database,
+        props: Boot3LeaderProperties,
+    ): ExposedJdbcLeaderGroupElection =
+        ExposedJdbcLeaderGroupElection(
+            db,
+            ExposedJdbcLeaderGroupElectionOptions(leaderGroupOptions = PropertiesAdapter.toCommonGroup(props)),
+        )
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["exposedJdbcVirtualThreadLeaderElection"])
+    fun exposedJdbcVirtualThreadLeaderElection(
+        delegate: ExposedJdbcLeaderElection,
+    ): ExposedJdbcVirtualThreadLeaderElection =
+        ExposedJdbcVirtualThreadLeaderElection(delegate)
+}

--- a/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/backend/ExposedR2dbcLeaderConfiguration.kt
+++ b/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/backend/ExposedR2dbcLeaderConfiguration.kt
@@ -1,0 +1,52 @@
+package io.bluetape4k.leader.spring.boot3.backend
+
+import io.bluetape4k.leader.exposed.r2dbc.ExposedR2dbcLeaderElectionOptions
+import io.bluetape4k.leader.exposed.r2dbc.ExposedR2dbcLeaderGroupElectionOptions
+import io.bluetape4k.leader.exposed.r2dbc.ExposedR2dbcSuspendLeaderElection
+import io.bluetape4k.leader.exposed.r2dbc.ExposedR2dbcSuspendLeaderGroupElection
+import io.bluetape4k.leader.spring.boot3.Boot3LeaderProperties
+import io.bluetape4k.leader.spring.boot3.adapter.PropertiesAdapter
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Exposed(R2DBC) 백엔드 자동 구성.
+ *
+ * `R2dbcDatabase` 빈이 등록된 경우에만 활성화됩니다.
+ *
+ * 두 빈 모두 startup 시 스키마 초기화를 위해 [runBlocking]을 사용합니다.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(R2dbcDatabase::class)
+@ConditionalOnBean(R2dbcDatabase::class)
+class ExposedR2dbcLeaderConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["exposedR2dbcSuspendLeaderElection"])
+    fun exposedR2dbcSuspendLeaderElection(
+        db: R2dbcDatabase,
+        props: Boot3LeaderProperties,
+    ): ExposedR2dbcSuspendLeaderElection = runBlocking {
+        ExposedR2dbcSuspendLeaderElection(
+            db,
+            ExposedR2dbcLeaderElectionOptions(leaderOptions = PropertiesAdapter.toCommonElection(props)),
+        )
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["exposedR2dbcSuspendLeaderGroupElection"])
+    fun exposedR2dbcSuspendLeaderGroupElection(
+        db: R2dbcDatabase,
+        props: Boot3LeaderProperties,
+    ): ExposedR2dbcSuspendLeaderGroupElection = runBlocking {
+        ExposedR2dbcSuspendLeaderGroupElection(
+            db,
+            ExposedR2dbcLeaderGroupElectionOptions(leaderGroupOptions = PropertiesAdapter.toCommonGroup(props)),
+        )
+    }
+}

--- a/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/backend/HazelcastLeaderConfiguration.kt
+++ b/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/backend/HazelcastLeaderConfiguration.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.leader.spring.boot3.backend
+
+import com.hazelcast.core.HazelcastInstance
+import io.bluetape4k.leader.hazelcast.HazelcastLeaderElection
+import io.bluetape4k.leader.hazelcast.HazelcastLeaderGroupElection
+import io.bluetape4k.leader.hazelcast.HazelcastSuspendLeaderElection
+import io.bluetape4k.leader.hazelcast.HazelcastSuspendLeaderGroupElection
+import io.bluetape4k.leader.spring.boot3.Boot3LeaderProperties
+import io.bluetape4k.leader.spring.boot3.adapter.PropertiesAdapter
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Hazelcast 백엔드 자동 구성.
+ *
+ * `HazelcastInstance` 빈이 등록된 경우에만 활성화됩니다.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(HazelcastInstance::class)
+@ConditionalOnBean(HazelcastInstance::class)
+class HazelcastLeaderConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["hazelcastLeaderElection"])
+    fun hazelcastLeaderElection(
+        hazelcast: HazelcastInstance,
+        props: Boot3LeaderProperties,
+    ): HazelcastLeaderElection =
+        HazelcastLeaderElection(hazelcast, PropertiesAdapter.toCommonElection(props))
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["hazelcastSuspendLeaderElection"])
+    fun hazelcastSuspendLeaderElection(
+        hazelcast: HazelcastInstance,
+        props: Boot3LeaderProperties,
+    ): HazelcastSuspendLeaderElection =
+        HazelcastSuspendLeaderElection(hazelcast, PropertiesAdapter.toCommonElection(props))
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["hazelcastLeaderGroupElection"])
+    fun hazelcastLeaderGroupElection(
+        hazelcast: HazelcastInstance,
+        props: Boot3LeaderProperties,
+    ): HazelcastLeaderGroupElection =
+        HazelcastLeaderGroupElection(hazelcast, PropertiesAdapter.toCommonGroup(props))
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["hazelcastSuspendLeaderGroupElection"])
+    fun hazelcastSuspendLeaderGroupElection(
+        hazelcast: HazelcastInstance,
+        props: Boot3LeaderProperties,
+    ): HazelcastSuspendLeaderGroupElection =
+        HazelcastSuspendLeaderGroupElection(hazelcast, PropertiesAdapter.toCommonGroup(props))
+}

--- a/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/backend/LettuceLeaderConfiguration.kt
+++ b/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/backend/LettuceLeaderConfiguration.kt
@@ -1,0 +1,58 @@
+package io.bluetape4k.leader.spring.boot3.backend
+
+import io.bluetape4k.leader.lettuce.LettuceLeaderElection
+import io.bluetape4k.leader.lettuce.LettuceLeaderGroupElection
+import io.bluetape4k.leader.lettuce.LettuceSuspendLeaderElection
+import io.bluetape4k.leader.lettuce.LettuceSuspendLeaderGroupElection
+import io.bluetape4k.leader.spring.boot3.Boot3LeaderProperties
+import io.bluetape4k.leader.spring.boot3.adapter.PropertiesAdapter
+import io.lettuce.core.api.StatefulRedisConnection
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Lettuce(Redis) 백엔드 자동 구성.
+ *
+ * `StatefulRedisConnection<String, String>` 빈이 등록된 경우에만 활성화됩니다.
+ * 사용자가 직접 등록한 동일 이름의 빈이 있으면 우회됩니다.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(StatefulRedisConnection::class)
+@ConditionalOnBean(StatefulRedisConnection::class)
+class LettuceLeaderConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["lettuceLeaderElection"])
+    fun lettuceLeaderElection(
+        connection: StatefulRedisConnection<String, String>,
+        props: Boot3LeaderProperties,
+    ): LettuceLeaderElection =
+        LettuceLeaderElection(connection, PropertiesAdapter.toCommonElection(props))
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["lettuceSuspendLeaderElection"])
+    fun lettuceSuspendLeaderElection(
+        connection: StatefulRedisConnection<String, String>,
+        props: Boot3LeaderProperties,
+    ): LettuceSuspendLeaderElection =
+        LettuceSuspendLeaderElection(connection, PropertiesAdapter.toCommonElection(props))
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["lettuceLeaderGroupElection"])
+    fun lettuceLeaderGroupElection(
+        connection: StatefulRedisConnection<String, String>,
+        props: Boot3LeaderProperties,
+    ): LettuceLeaderGroupElection =
+        LettuceLeaderGroupElection(connection, PropertiesAdapter.toCommonGroup(props))
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["lettuceSuspendLeaderGroupElection"])
+    fun lettuceSuspendLeaderGroupElection(
+        connection: StatefulRedisConnection<String, String>,
+        props: Boot3LeaderProperties,
+    ): LettuceSuspendLeaderGroupElection =
+        LettuceSuspendLeaderGroupElection(connection, PropertiesAdapter.toCommonGroup(props))
+}

--- a/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/backend/LocalLeaderConfiguration.kt
+++ b/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/backend/LocalLeaderConfiguration.kt
@@ -1,0 +1,50 @@
+package io.bluetape4k.leader.spring.boot3.backend
+
+import io.bluetape4k.leader.LeaderElection
+import io.bluetape4k.leader.LeaderGroupElection
+import io.bluetape4k.leader.coroutines.LocalSuspendLeaderElection
+import io.bluetape4k.leader.coroutines.LocalSuspendLeaderGroupElection
+import io.bluetape4k.leader.coroutines.SuspendLeaderElection
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElection
+import io.bluetape4k.leader.local.LocalLeaderElection
+import io.bluetape4k.leader.local.LocalLeaderGroupElection
+import io.bluetape4k.leader.spring.boot3.Boot3LeaderProperties
+import io.bluetape4k.leader.spring.boot3.LeaderElectionAutoConfiguration
+import io.bluetape4k.leader.spring.boot3.adapter.PropertiesAdapter
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+
+/**
+ * Local(in-memory) 백엔드 default fallback 자동 구성.
+ *
+ * 다른 백엔드(Redisson/Lettuce/Mongo/Hazelcast/Exposed)가 활성화되지 않은 경우에만
+ * Local 빈을 등록합니다. 외부 인프라 없이 dev/test 환경에서 즉시 동작합니다.
+ *
+ * `@AutoConfigureAfter(LeaderElectionAutoConfiguration::class)`로 백엔드 빈이 등록된 후 평가됩니다.
+ */
+@AutoConfiguration(after = [LeaderElectionAutoConfiguration::class])
+@EnableConfigurationProperties(Boot3LeaderProperties::class)
+class LocalLeaderConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(LeaderElection::class)
+    fun localLeaderElection(props: Boot3LeaderProperties): LeaderElection =
+        LocalLeaderElection(PropertiesAdapter.toCommonElection(props))
+
+    @Bean
+    @ConditionalOnMissingBean(SuspendLeaderElection::class)
+    fun localSuspendLeaderElection(props: Boot3LeaderProperties): SuspendLeaderElection =
+        LocalSuspendLeaderElection(PropertiesAdapter.toCommonElection(props))
+
+    @Bean
+    @ConditionalOnMissingBean(LeaderGroupElection::class)
+    fun localLeaderGroupElection(props: Boot3LeaderProperties): LeaderGroupElection =
+        LocalLeaderGroupElection(PropertiesAdapter.toCommonGroup(props))
+
+    @Bean
+    @ConditionalOnMissingBean(SuspendLeaderGroupElection::class)
+    fun localSuspendLeaderGroupElection(props: Boot3LeaderProperties): SuspendLeaderGroupElection =
+        LocalSuspendLeaderGroupElection(PropertiesAdapter.toCommonGroup(props))
+}

--- a/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/backend/MongoLeaderConfiguration.kt
+++ b/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/backend/MongoLeaderConfiguration.kt
@@ -1,0 +1,87 @@
+package io.bluetape4k.leader.spring.boot3.backend
+
+import com.mongodb.client.MongoDatabase
+import com.mongodb.kotlin.client.coroutine.MongoDatabase as CoroutineMongoDatabase
+import io.bluetape4k.leader.mongodb.MongoLeaderElection
+import io.bluetape4k.leader.mongodb.MongoLeaderElectionOptions
+import io.bluetape4k.leader.mongodb.MongoLeaderGroupElection
+import io.bluetape4k.leader.mongodb.MongoLeaderGroupElectionOptions
+import io.bluetape4k.leader.mongodb.MongoSuspendLeaderElection
+import io.bluetape4k.leader.mongodb.MongoSuspendLeaderGroupElection
+import io.bluetape4k.leader.spring.boot3.Boot3LeaderProperties
+import io.bluetape4k.leader.spring.boot3.adapter.PropertiesAdapter
+import kotlinx.coroutines.runBlocking
+import org.bson.Document
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * MongoDB 백엔드 자동 구성.
+ *
+ * - Sync 빈: `com.mongodb.client.MongoDatabase` 빈 필요
+ * - Suspend 빈: `com.mongodb.kotlin.client.coroutine.MongoDatabase` 빈 필요
+ *
+ * 컬렉션 이름은 `bluetape4k.leader.mongo.{single|group}-collection` 속성으로 지정합니다.
+ *
+ * Suspend 빈은 startup 시 스키마 인덱스 초기화를 위해 [runBlocking]을 사용합니다.
+ * 한 번만 호출되며 startup 이후에는 영향을 주지 않습니다.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(com.mongodb.client.MongoCollection::class)
+class MongoLeaderConfiguration {
+
+    private fun electionOptions(props: Boot3LeaderProperties): MongoLeaderElectionOptions =
+        MongoLeaderElectionOptions(leaderOptions = PropertiesAdapter.toCommonElection(props))
+
+    private fun groupOptions(props: Boot3LeaderProperties): MongoLeaderGroupElectionOptions =
+        MongoLeaderGroupElectionOptions(leaderGroupOptions = PropertiesAdapter.toCommonGroup(props))
+
+    @Bean
+    @ConditionalOnBean(MongoDatabase::class)
+    @ConditionalOnMissingBean(name = ["mongoLeaderElection"])
+    fun mongoLeaderElection(
+        db: MongoDatabase,
+        props: Boot3LeaderProperties,
+    ): MongoLeaderElection {
+        val collection = db.getCollection(props.mongo.singleCollection, Document::class.java)
+        return MongoLeaderElection(collection, electionOptions(props))
+    }
+
+    @Bean
+    @ConditionalOnBean(MongoDatabase::class)
+    @ConditionalOnMissingBean(name = ["mongoLeaderGroupElection"])
+    fun mongoLeaderGroupElection(
+        db: MongoDatabase,
+        props: Boot3LeaderProperties,
+    ): MongoLeaderGroupElection {
+        val collection = db.getCollection(props.mongo.groupCollection, Document::class.java)
+        return MongoLeaderGroupElection(collection, groupOptions(props))
+    }
+
+    @Bean
+    @ConditionalOnBean(CoroutineMongoDatabase::class)
+    @ConditionalOnMissingBean(name = ["mongoSuspendLeaderElection"])
+    fun mongoSuspendLeaderElection(
+        coroutineDb: CoroutineMongoDatabase,
+        props: Boot3LeaderProperties,
+    ): MongoSuspendLeaderElection = runBlocking {
+        val collection = coroutineDb.getCollection<Document>(props.mongo.singleCollection)
+        MongoSuspendLeaderElection(collection, electionOptions(props))
+    }
+
+    @Bean
+    @ConditionalOnBean(MongoDatabase::class, CoroutineMongoDatabase::class)
+    @ConditionalOnMissingBean(name = ["mongoSuspendLeaderGroupElection"])
+    fun mongoSuspendLeaderGroupElection(
+        db: MongoDatabase,
+        coroutineDb: CoroutineMongoDatabase,
+        props: Boot3LeaderProperties,
+    ): MongoSuspendLeaderGroupElection = runBlocking {
+        val syncCollection = db.getCollection(props.mongo.groupCollection, Document::class.java)
+        val coroutineCollection = coroutineDb.getCollection<Document>(props.mongo.groupCollection)
+        MongoSuspendLeaderGroupElection(syncCollection, coroutineCollection, groupOptions(props))
+    }
+}

--- a/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/backend/RedissonLeaderConfiguration.kt
+++ b/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/backend/RedissonLeaderConfiguration.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.leader.spring.boot3.backend
+
+import io.bluetape4k.leader.redisson.RedissonLeaderElection
+import io.bluetape4k.leader.redisson.RedissonLeaderGroupElection
+import io.bluetape4k.leader.redisson.RedissonSuspendLeaderElection
+import io.bluetape4k.leader.redisson.RedissonSuspendLeaderGroupElection
+import io.bluetape4k.leader.spring.boot3.Boot3LeaderProperties
+import io.bluetape4k.leader.spring.boot3.adapter.PropertiesAdapter
+import org.redisson.api.RedissonClient
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Redisson(Redis) 백엔드 자동 구성.
+ *
+ * `RedissonClient` 빈이 등록된 경우에만 활성화됩니다.
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(RedissonClient::class)
+@ConditionalOnBean(RedissonClient::class)
+class RedissonLeaderConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["redissonLeaderElection"])
+    fun redissonLeaderElection(
+        client: RedissonClient,
+        props: Boot3LeaderProperties,
+    ): RedissonLeaderElection =
+        RedissonLeaderElection(client, PropertiesAdapter.toCommonElection(props))
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["redissonSuspendLeaderElection"])
+    fun redissonSuspendLeaderElection(
+        client: RedissonClient,
+        props: Boot3LeaderProperties,
+    ): RedissonSuspendLeaderElection =
+        RedissonSuspendLeaderElection(client, PropertiesAdapter.toCommonElection(props))
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["redissonLeaderGroupElection"])
+    fun redissonLeaderGroupElection(
+        client: RedissonClient,
+        props: Boot3LeaderProperties,
+    ): RedissonLeaderGroupElection =
+        RedissonLeaderGroupElection(client, PropertiesAdapter.toCommonGroup(props))
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["redissonSuspendLeaderGroupElection"])
+    fun redissonSuspendLeaderGroupElection(
+        client: RedissonClient,
+        props: Boot3LeaderProperties,
+    ): RedissonSuspendLeaderGroupElection =
+        RedissonSuspendLeaderGroupElection(client, PropertiesAdapter.toCommonGroup(props))
+}

--- a/leader-spring-boot3/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/leader-spring-boot3/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+io.bluetape4k.leader.spring.boot3.LeaderElectionAutoConfiguration
+io.bluetape4k.leader.spring.boot3.backend.LocalLeaderConfiguration

--- a/leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/AbstractRedissonAutoConfigurationTest.kt
+++ b/leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/AbstractRedissonAutoConfigurationTest.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.leader.spring.boot3
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.storage.RedisServer
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+
+/**
+ * Redisson 통합 테스트 base. `bluetape4k-testcontainers`의 [RedisServer.Launcher.redis] 를 통해
+ * 단일 Redis 컨테이너를 모듈 전역으로 공유합니다.
+ */
+abstract class AbstractRedissonAutoConfigurationTest {
+
+    companion object: KLogging() {
+        @JvmStatic
+        protected val redis: RedisServer = RedisServer.Launcher.redis
+
+        @JvmStatic
+        protected val redisUrl: String get() = redis.url
+
+        @JvmStatic
+        protected fun newRedissonClient(): RedissonClient =
+            Redisson.create(newRedissonConfig())
+
+        @JvmStatic
+        fun newRedissonConfig(): Config = Config().apply {
+            useSingleServer()
+                .setAddress(redisUrl)
+                .setConnectionPoolSize(4)
+                .setConnectionMinimumIdleSize(1)
+        }
+    }
+}

--- a/leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/BackendConditionalTest.kt
+++ b/leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/BackendConditionalTest.kt
@@ -1,0 +1,257 @@
+package io.bluetape4k.leader.spring.boot3
+
+import com.hazelcast.config.Config
+import com.hazelcast.core.Hazelcast
+import com.hazelcast.core.HazelcastInstance
+import com.mongodb.client.MongoDatabase
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderElection
+import io.bluetape4k.leader.exposed.r2dbc.ExposedR2dbcSuspendLeaderElection
+import io.bluetape4k.leader.mongodb.MongoLeaderElection
+import io.bluetape4k.testcontainers.storage.MongoDBServer
+import io.bluetape4k.testcontainers.storage.RedisServer
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
+import com.mongodb.kotlin.client.coroutine.MongoDatabase as CoroutineMongoDatabase
+import io.bluetape4k.leader.LeaderElection
+import io.bluetape4k.leader.LeaderGroupElection
+import io.bluetape4k.leader.coroutines.SuspendLeaderElection
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElection
+import io.bluetape4k.leader.lettuce.LettuceLeaderElection
+import io.bluetape4k.leader.local.LocalLeaderElection
+import io.bluetape4k.leader.redisson.RedissonLeaderElection
+import io.lettuce.core.RedisClient
+import io.lettuce.core.api.StatefulRedisConnection
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldHaveSize
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config as RedissonConfig
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class BackendConditionalTest {
+
+    companion object {
+        private val redis: RedisServer = RedisServer.Launcher.redis
+        private val redisUrl: String get() = redis.url
+
+        private val mongo: MongoDBServer = MongoDBServer.Launcher.mongoDB
+        private val sharedDbName = "test_leader_${Base58.randomString(8)}"
+
+        private fun newRedissonClient(): RedissonClient = Redisson.create(
+            RedissonConfig().apply {
+                useSingleServer().setAddress(redisUrl).setConnectionPoolSize(2).setConnectionMinimumIdleSize(1)
+            },
+        )
+    }
+
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                LeaderElectionAutoConfiguration::class.java,
+                io.bluetape4k.leader.spring.boot3.backend.LocalLeaderConfiguration::class.java,
+            ),
+        )
+
+    // ─────────────── Local fallback ───────────────
+
+    @Test
+    fun `백엔드 빈 미설정 시 Local 4 빈만 활성`() {
+        contextRunner.run { ctx ->
+            ctx.getBean("localLeaderElection") shouldBeInstanceOf LocalLeaderElection::class
+            ctx.getBeanNamesForType(LeaderElection::class.java) shouldHaveSize 1
+            ctx.getBeanNamesForType(SuspendLeaderElection::class.java) shouldHaveSize 1
+            ctx.getBeanNamesForType(LeaderGroupElection::class.java) shouldHaveSize 1
+            ctx.getBeanNamesForType(SuspendLeaderGroupElection::class.java) shouldHaveSize 1
+        }
+    }
+
+    // ─────────────── Redisson ───────────────
+
+    @Test
+    fun `RedissonClient 빈 등록 시 Redisson 4 빈 활성 + Local 비활성`() {
+        contextRunner
+            .withUserConfiguration(RedissonClientConfig::class.java)
+            .run { ctx ->
+                ctx.getBean("redissonLeaderElection") shouldBeInstanceOf RedissonLeaderElection::class
+                ctx.getBeanNamesForType(LeaderElection::class.java) shouldHaveSize 1
+                ctx.getBeanNamesForType(SuspendLeaderElection::class.java) shouldHaveSize 1
+                ctx.getBeanNamesForType(LeaderGroupElection::class.java) shouldHaveSize 1
+                ctx.getBeanNamesForType(SuspendLeaderGroupElection::class.java) shouldHaveSize 1
+                ctx.containsBean("localLeaderElection") shouldBeEqualTo false
+            }
+    }
+
+    // ─────────────── Lettuce ───────────────
+
+    @Test
+    fun `StatefulRedisConnection 빈 등록 시 Lettuce 4 빈 활성 + Local 비활성`() {
+        contextRunner
+            .withUserConfiguration(LettuceConnectionConfig::class.java)
+            .run { ctx ->
+                ctx.getBean("lettuceLeaderElection") shouldBeInstanceOf LettuceLeaderElection::class
+                ctx.containsBean("localLeaderElection") shouldBeEqualTo false
+            }
+    }
+
+    // ─────────────── Hazelcast ───────────────
+
+    @Test
+    fun `HazelcastInstance 빈 등록 시 Hazelcast 4 빈 활성 + Local 비활성`() {
+        contextRunner
+            .withUserConfiguration(HazelcastInstanceConfig::class.java)
+            .run { ctx ->
+                ctx.containsBean("hazelcastLeaderElection") shouldBeEqualTo true
+                ctx.containsBean("hazelcastSuspendLeaderElection") shouldBeEqualTo true
+                ctx.containsBean("hazelcastLeaderGroupElection") shouldBeEqualTo true
+                ctx.containsBean("hazelcastSuspendLeaderGroupElection") shouldBeEqualTo true
+                ctx.containsBean("localLeaderElection") shouldBeEqualTo false
+            }
+    }
+
+    // ─────────────── ExposedJdbc ───────────────
+
+    @Test
+    fun `Database 빈 등록 시 ExposedJdbc 빈 활성 + Local 비활성`() {
+        contextRunner
+            .withUserConfiguration(ExposedJdbcConfig::class.java)
+            .run { ctx ->
+                ctx.getBean("exposedJdbcLeaderElection") shouldBeInstanceOf ExposedJdbcLeaderElection::class
+                ctx.containsBean("exposedJdbcLeaderGroupElection") shouldBeEqualTo true
+                ctx.containsBean("exposedJdbcVirtualThreadLeaderElection") shouldBeEqualTo true
+                ctx.containsBean("localLeaderElection") shouldBeEqualTo false
+            }
+    }
+
+    // ─────────────── ExposedR2dbc ───────────────
+
+    @Test
+    fun `R2dbcDatabase 빈 등록 시 ExposedR2dbc suspend 빈 활성 + Local 비활성`() {
+        contextRunner
+            .withUserConfiguration(ExposedR2dbcConfig::class.java)
+            .run { ctx ->
+                ctx.getBean("exposedR2dbcSuspendLeaderElection") shouldBeInstanceOf ExposedR2dbcSuspendLeaderElection::class
+                ctx.containsBean("exposedR2dbcSuspendLeaderGroupElection") shouldBeEqualTo true
+                ctx.containsBean("localSuspendLeaderElection") shouldBeEqualTo false
+            }
+    }
+
+    // ─────────────── Mongo ───────────────
+
+    @Test
+    fun `MongoDatabase 빈 등록 시 Mongo sync 빈 활성 + Local 비활성`() {
+        contextRunner
+            .withUserConfiguration(MongoSyncConfig::class.java)
+            .run { ctx ->
+                ctx.getBean("mongoLeaderElection") shouldBeInstanceOf MongoLeaderElection::class
+                ctx.containsBean("mongoLeaderGroupElection") shouldBeEqualTo true
+                ctx.containsBean("localLeaderElection") shouldBeEqualTo false
+            }
+    }
+
+    @Test
+    fun `MongoDatabase 와 CoroutineMongoDatabase 빈 등록 시 Mongo 4 빈 모두 활성`() {
+        contextRunner
+            .withUserConfiguration(MongoSyncConfig::class.java, MongoCoroutineConfig::class.java)
+            .run { ctx ->
+                ctx.containsBean("mongoLeaderElection") shouldBeEqualTo true
+                ctx.containsBean("mongoSuspendLeaderElection") shouldBeEqualTo true
+                ctx.containsBean("mongoLeaderGroupElection") shouldBeEqualTo true
+                ctx.containsBean("mongoSuspendLeaderGroupElection") shouldBeEqualTo true
+            }
+    }
+
+    // ─────────────── 다중 백엔드 ───────────────
+
+    @Test
+    fun `다중 백엔드 활성 시 빈 이름 다르므로 모두 등록 + Local 비활성`() {
+        contextRunner
+            .withUserConfiguration(RedissonClientConfig::class.java, LettuceConnectionConfig::class.java)
+            .run { ctx ->
+                ctx.containsBean("redissonLeaderElection") shouldBeEqualTo true
+                ctx.containsBean("lettuceLeaderElection") shouldBeEqualTo true
+                ctx.containsBean("localLeaderElection") shouldBeEqualTo false
+                ctx.getBeanNamesForType(LeaderElection::class.java) shouldHaveSize 2
+            }
+    }
+
+    @Test
+    fun `사용자 명명 빈은 자동 빈을 override`() {
+        contextRunner
+            .withUserConfiguration(UserOverrideRedissonConfig::class.java)
+            .run { ctx ->
+                val bean = ctx.getBean("redissonLeaderElection")
+                (bean === ctx.getBean(UserOverrideRedissonConfig::class.java).custom) shouldBeEqualTo true
+            }
+    }
+
+    // ─────────────── helpers ───────────────
+
+    @Configuration(proxyBeanMethods = false)
+    class RedissonClientConfig {
+        @Bean(destroyMethod = "shutdown")
+        fun redissonClient(): RedissonClient = newRedissonClient()
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    class LettuceConnectionConfig {
+        @Bean(destroyMethod = "close")
+        fun lettuceConnection(): StatefulRedisConnection<String, String> =
+            RedisClient.create(redisUrl).connect()
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    class HazelcastInstanceConfig {
+        @Bean(destroyMethod = "shutdown")
+        fun hazelcastInstance(): HazelcastInstance {
+            val cfg = Config().apply { networkConfig.join.multicastConfig.isEnabled = false }
+            return Hazelcast.newHazelcastInstance(cfg)
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    class UserOverrideRedissonConfig {
+        val custom: RedissonLeaderElection = RedissonLeaderElection(newRedissonClient())
+
+        @Bean
+        fun redissonClient(): RedissonClient = newRedissonClient()
+
+        @Bean(name = ["redissonLeaderElection"])
+        fun customRedisson(): RedissonLeaderElection = custom
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    class ExposedJdbcConfig {
+        @Bean
+        fun exposedDatabase(): Database =
+            Database.connect("jdbc:h2:mem:autoconfig-jdbc-${Base58.randomString(8)};DB_CLOSE_DELAY=-1")
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    class ExposedR2dbcConfig {
+        @Bean
+        fun r2dbcDatabase(): R2dbcDatabase =
+            R2dbcDatabase.connect("r2dbc:h2:mem:///autoconfig-r2dbc-${Base58.randomString(8)};MODE=MySQL;DB_CLOSE_DELAY=-1")
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    class MongoSyncConfig {
+        @Bean
+        fun mongoDatabase(): MongoDatabase = MongoDBServer.Launcher.getClient().getDatabase(sharedDbName)
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    class MongoCoroutineConfig {
+        @Bean
+        fun coroutineMongoDatabase(): CoroutineMongoDatabase =
+            MongoDBServer.Launcher.getCoroutineClient().getDatabase(sharedDbName)
+    }
+
+}

--- a/leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/BackendConditionalTest.kt
+++ b/leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/BackendConditionalTest.kt
@@ -20,6 +20,7 @@ import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElection
 import io.bluetape4k.leader.lettuce.LettuceLeaderElection
 import io.bluetape4k.leader.local.LocalLeaderElection
 import io.bluetape4k.leader.redisson.RedissonLeaderElection
+import io.bluetape4k.leader.spring.boot3.backend.LocalLeaderConfiguration
 import io.lettuce.core.RedisClient
 import io.lettuce.core.api.StatefulRedisConnection
 import org.amshove.kluent.shouldBeEqualTo
@@ -30,6 +31,8 @@ import org.junit.jupiter.api.TestInstance
 import org.redisson.Redisson
 import org.redisson.api.RedissonClient
 import org.redisson.config.Config as RedissonConfig
+import org.springframework.beans.factory.getBean
+import org.springframework.beans.factory.getBeanNamesForType
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
@@ -56,7 +59,7 @@ class BackendConditionalTest {
         .withConfiguration(
             AutoConfigurations.of(
                 LeaderElectionAutoConfiguration::class.java,
-                io.bluetape4k.leader.spring.boot3.backend.LocalLeaderConfiguration::class.java,
+                LocalLeaderConfiguration::class.java,
             ),
         )
 
@@ -66,10 +69,10 @@ class BackendConditionalTest {
     fun `백엔드 빈 미설정 시 Local 4 빈만 활성`() {
         contextRunner.run { ctx ->
             ctx.getBean("localLeaderElection") shouldBeInstanceOf LocalLeaderElection::class
-            ctx.getBeanNamesForType(LeaderElection::class.java) shouldHaveSize 1
-            ctx.getBeanNamesForType(SuspendLeaderElection::class.java) shouldHaveSize 1
-            ctx.getBeanNamesForType(LeaderGroupElection::class.java) shouldHaveSize 1
-            ctx.getBeanNamesForType(SuspendLeaderGroupElection::class.java) shouldHaveSize 1
+            ctx.getBeanNamesForType<LeaderElection>() shouldHaveSize 1
+            ctx.getBeanNamesForType<SuspendLeaderElection>() shouldHaveSize 1
+            ctx.getBeanNamesForType<LeaderGroupElection>() shouldHaveSize 1
+            ctx.getBeanNamesForType<SuspendLeaderGroupElection>() shouldHaveSize 1
         }
     }
 
@@ -81,10 +84,10 @@ class BackendConditionalTest {
             .withUserConfiguration(RedissonClientConfig::class.java)
             .run { ctx ->
                 ctx.getBean("redissonLeaderElection") shouldBeInstanceOf RedissonLeaderElection::class
-                ctx.getBeanNamesForType(LeaderElection::class.java) shouldHaveSize 1
-                ctx.getBeanNamesForType(SuspendLeaderElection::class.java) shouldHaveSize 1
-                ctx.getBeanNamesForType(LeaderGroupElection::class.java) shouldHaveSize 1
-                ctx.getBeanNamesForType(SuspendLeaderGroupElection::class.java) shouldHaveSize 1
+                ctx.getBeanNamesForType<LeaderElection>() shouldHaveSize 1
+                ctx.getBeanNamesForType<SuspendLeaderElection>() shouldHaveSize 1
+                ctx.getBeanNamesForType<LeaderGroupElection>() shouldHaveSize 1
+                ctx.getBeanNamesForType<SuspendLeaderGroupElection>() shouldHaveSize 1
                 ctx.containsBean("localLeaderElection") shouldBeEqualTo false
             }
     }
@@ -178,7 +181,7 @@ class BackendConditionalTest {
                 ctx.containsBean("redissonLeaderElection") shouldBeEqualTo true
                 ctx.containsBean("lettuceLeaderElection") shouldBeEqualTo true
                 ctx.containsBean("localLeaderElection") shouldBeEqualTo false
-                ctx.getBeanNamesForType(LeaderElection::class.java) shouldHaveSize 2
+                ctx.getBeanNamesForType<LeaderElection>() shouldHaveSize 2
             }
     }
 
@@ -188,7 +191,7 @@ class BackendConditionalTest {
             .withUserConfiguration(UserOverrideRedissonConfig::class.java)
             .run { ctx ->
                 val bean = ctx.getBean("redissonLeaderElection")
-                (bean === ctx.getBean(UserOverrideRedissonConfig::class.java).custom) shouldBeEqualTo true
+                (bean === ctx.getBean<UserOverrideRedissonConfig>().custom) shouldBeEqualTo true
             }
     }
 

--- a/leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/Boot3LeaderPropertiesBindingTest.kt
+++ b/leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/Boot3LeaderPropertiesBindingTest.kt
@@ -1,0 +1,73 @@
+package io.bluetape4k.leader.spring.boot3
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.context.properties.bind.BindResult
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource
+import java.time.Duration
+
+private inline fun <reified T : Any> Binder.bindAs(name: String): BindResult<T> =
+    bind(name, T::class.java)
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class Boot3LeaderPropertiesBindingTest {
+
+    @Test
+    fun `yaml 형식 키를 Boot3LeaderProperties에 바인딩`() {
+        val source = MapConfigurationPropertySource(
+            mapOf(
+                "bluetape4k.leader.wait-time" to "7s",
+                "bluetape4k.leader.lease-time" to "120s",
+                "bluetape4k.leader.group.max-leaders" to "5",
+                "bluetape4k.leader.group.wait-time" to "3s",
+                "bluetape4k.leader.group.lease-time" to "45s",
+                "bluetape4k.leader.mongo.single-collection" to "single_election",
+                "bluetape4k.leader.mongo.group-collection" to "group_election",
+            ),
+        )
+        val props = Binder(source).bindAs<Boot3LeaderProperties>("bluetape4k.leader").get()
+
+        props.waitTime shouldBeEqualTo Duration.ofSeconds(7)
+        props.leaseTime shouldBeEqualTo Duration.ofSeconds(120)
+        props.group.maxLeaders shouldBeEqualTo 5
+        props.group.waitTime shouldBeEqualTo Duration.ofSeconds(3)
+        props.group.leaseTime shouldBeEqualTo Duration.ofSeconds(45)
+        props.mongo.singleCollection shouldBeEqualTo "single_election"
+        props.mongo.groupCollection shouldBeEqualTo "group_election"
+    }
+
+    @Test
+    fun `빈 source는 default 값으로 바인딩`() {
+        val source: ConfigurationPropertySource = MapConfigurationPropertySource(emptyMap<String, String>())
+        val props = Binder(source).bindAs<Boot3LeaderProperties>("bluetape4k.leader")
+            .orElse(Boot3LeaderProperties())
+
+        props.waitTime shouldBeEqualTo Duration.ofSeconds(5)
+        props.leaseTime shouldBeEqualTo Duration.ofSeconds(60)
+        props.group.maxLeaders shouldBeEqualTo 2
+        props.mongo.singleCollection shouldBeEqualTo "leader_election"
+        props.mongo.groupCollection shouldBeEqualTo "leader_group_election"
+    }
+
+    @Test
+    fun `여러 키가 동시 바인딩될 때 group과 단일 옵션 모두 적용`() {
+        val source = MapConfigurationPropertySource(
+            mapOf(
+                "bluetape4k.leader.wait-time" to "10s",
+                "bluetape4k.leader.lease-time" to "300s",
+                "bluetape4k.leader.group.max-leaders" to "8",
+            ),
+        )
+        val props = Binder(source).bindAs<Boot3LeaderProperties>("bluetape4k.leader").get()
+        props.waitTime shouldBeEqualTo Duration.ofSeconds(10)
+        props.leaseTime shouldBeEqualTo Duration.ofSeconds(300)
+        props.group.maxLeaders shouldBeEqualTo 8
+    }
+
+    @EnableConfigurationProperties(Boot3LeaderProperties::class)
+    private class TestConfig
+}

--- a/leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/LeaderElectionAutoConfigurationTest.kt
+++ b/leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/LeaderElectionAutoConfigurationTest.kt
@@ -16,6 +16,8 @@ import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.redisson.api.RedissonClient
+import org.springframework.beans.factory.getBean
+import org.springframework.beans.factory.getBeanNamesForType
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
@@ -31,17 +33,17 @@ class LeaderElectionAutoConfigurationTest: AbstractRedissonAutoConfigurationTest
     @Test
     fun `Redisson 4 종 election 빈이 모두 정상 주입`() {
         runner.run { ctx ->
-            ctx.getBean(LeaderElection::class.java) shouldBeInstanceOf RedissonLeaderElection::class
-            ctx.getBean(SuspendLeaderElection::class.java) shouldBeInstanceOf RedissonSuspendLeaderElection::class
-            ctx.getBean(LeaderGroupElection::class.java) shouldBeInstanceOf RedissonLeaderGroupElection::class
-            ctx.getBean(SuspendLeaderGroupElection::class.java) shouldBeInstanceOf RedissonSuspendLeaderGroupElection::class
+            ctx.getBean<LeaderElection>() shouldBeInstanceOf RedissonLeaderElection::class
+            ctx.getBean<SuspendLeaderElection>() shouldBeInstanceOf RedissonSuspendLeaderElection::class
+            ctx.getBean<LeaderGroupElection>() shouldBeInstanceOf RedissonLeaderGroupElection::class
+            ctx.getBean<SuspendLeaderGroupElection>() shouldBeInstanceOf RedissonSuspendLeaderGroupElection::class
         }
     }
 
     @Test
     fun `runIfLeader sync 호출이 정상 동작`() {
         runner.run { ctx ->
-            val election = ctx.getBean(LeaderElection::class.java)
+            val election = ctx.getBean<LeaderElection>()
             val lockName = "auto-config-test-${Base58.randomString(8)}"
             val result = election.runIfLeader(lockName) { 42 }
             result shouldBeEqualTo 42
@@ -51,7 +53,7 @@ class LeaderElectionAutoConfigurationTest: AbstractRedissonAutoConfigurationTest
     @Test
     fun `runIfLeader suspend 호출이 정상 동작`() {
         runner.run { ctx ->
-            val election = ctx.getBean(SuspendLeaderElection::class.java)
+            val election = ctx.getBean<SuspendLeaderElection>()
             val lockName = "auto-config-suspend-${Base58.randomString(8)}"
             val result = runBlocking { election.runIfLeader(lockName) { 99 } }
             result shouldBeEqualTo 99
@@ -63,7 +65,7 @@ class LeaderElectionAutoConfigurationTest: AbstractRedissonAutoConfigurationTest
         runner
             .withPropertyValues("bluetape4k.leader.group.max-leaders=3")
             .run { ctx ->
-                val group = ctx.getBean(LeaderGroupElection::class.java)
+                val group = ctx.getBean<LeaderGroupElection>()
                 group.maxLeaders shouldBeEqualTo 3
             }
     }
@@ -76,7 +78,7 @@ class LeaderElectionAutoConfigurationTest: AbstractRedissonAutoConfigurationTest
                 "bluetape4k.leader.lease-time=15s",
             )
             .run { ctx ->
-                val props = ctx.getBean(Boot3LeaderProperties::class.java)
+                val props = ctx.getBean<Boot3LeaderProperties>()
                 props.shouldNotBeNull()
                 props.waitTime.seconds shouldBeEqualTo 2L
                 props.leaseTime.seconds shouldBeEqualTo 15L

--- a/leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/LeaderElectionAutoConfigurationTest.kt
+++ b/leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/LeaderElectionAutoConfigurationTest.kt
@@ -1,0 +1,91 @@
+package io.bluetape4k.leader.spring.boot3
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.leader.LeaderElection
+import io.bluetape4k.leader.LeaderGroupElection
+import io.bluetape4k.leader.coroutines.SuspendLeaderElection
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElection
+import io.bluetape4k.leader.redisson.RedissonLeaderElection
+import io.bluetape4k.leader.redisson.RedissonLeaderGroupElection
+import io.bluetape4k.leader.redisson.RedissonSuspendLeaderElection
+import io.bluetape4k.leader.redisson.RedissonSuspendLeaderGroupElection
+import kotlinx.coroutines.runBlocking
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.redisson.api.RedissonClient
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderElectionAutoConfigurationTest: AbstractRedissonAutoConfigurationTest() {
+
+    private val runner = ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(LeaderElectionAutoConfiguration::class.java))
+        .withUserConfiguration(RedissonClientTestConfig::class.java)
+
+    @Test
+    fun `Redisson 4 종 election 빈이 모두 정상 주입`() {
+        runner.run { ctx ->
+            ctx.getBean(LeaderElection::class.java) shouldBeInstanceOf RedissonLeaderElection::class
+            ctx.getBean(SuspendLeaderElection::class.java) shouldBeInstanceOf RedissonSuspendLeaderElection::class
+            ctx.getBean(LeaderGroupElection::class.java) shouldBeInstanceOf RedissonLeaderGroupElection::class
+            ctx.getBean(SuspendLeaderGroupElection::class.java) shouldBeInstanceOf RedissonSuspendLeaderGroupElection::class
+        }
+    }
+
+    @Test
+    fun `runIfLeader sync 호출이 정상 동작`() {
+        runner.run { ctx ->
+            val election = ctx.getBean(LeaderElection::class.java)
+            val lockName = "auto-config-test-${Base58.randomString(8)}"
+            val result = election.runIfLeader(lockName) { 42 }
+            result shouldBeEqualTo 42
+        }
+    }
+
+    @Test
+    fun `runIfLeader suspend 호출이 정상 동작`() {
+        runner.run { ctx ->
+            val election = ctx.getBean(SuspendLeaderElection::class.java)
+            val lockName = "auto-config-suspend-${Base58.randomString(8)}"
+            val result = runBlocking { election.runIfLeader(lockName) { 99 } }
+            result shouldBeEqualTo 99
+        }
+    }
+
+    @Test
+    fun `LeaderGroupElection이 maxLeaders 만큼 슬롯 제공`() {
+        runner
+            .withPropertyValues("bluetape4k.leader.group.max-leaders=3")
+            .run { ctx ->
+                val group = ctx.getBean(LeaderGroupElection::class.java)
+                group.maxLeaders shouldBeEqualTo 3
+            }
+    }
+
+    @Test
+    fun `Boot3LeaderProperties가 yaml prefix bluetape4k_leader로 바인딩`() {
+        runner
+            .withPropertyValues(
+                "bluetape4k.leader.wait-time=2s",
+                "bluetape4k.leader.lease-time=15s",
+            )
+            .run { ctx ->
+                val props = ctx.getBean(Boot3LeaderProperties::class.java)
+                props.shouldNotBeNull()
+                props.waitTime.seconds shouldBeEqualTo 2L
+                props.leaseTime.seconds shouldBeEqualTo 15L
+            }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    class RedissonClientTestConfig {
+        @Bean(destroyMethod = "shutdown")
+        fun redissonClient(): RedissonClient = newRedissonClient()
+    }
+}

--- a/leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/adapter/PropertiesAdapterTest.kt
+++ b/leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/adapter/PropertiesAdapterTest.kt
@@ -1,0 +1,51 @@
+package io.bluetape4k.leader.spring.boot3.adapter
+
+import io.bluetape4k.leader.spring.boot3.Boot3LeaderProperties
+import io.bluetape4k.leader.spring.properties.LeaderGroupProperties
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PropertiesAdapterTest {
+
+    @Test
+    fun `toCommonElection 가 properties로부터 LeaderElectionOptions 생성`() {
+        val props = Boot3LeaderProperties(
+            waitTime = Duration.ofSeconds(7),
+            leaseTime = Duration.ofMinutes(1),
+        )
+        val options = PropertiesAdapter.toCommonElection(props)
+        options.waitTime shouldBeEqualTo Duration.ofSeconds(7)
+        options.leaseTime shouldBeEqualTo Duration.ofMinutes(1)
+    }
+
+    @Test
+    fun `toCommonGroup 가 group 속성으로부터 옵션 생성`() {
+        val props = Boot3LeaderProperties(
+            group = LeaderGroupProperties(
+                maxLeaders = 4,
+                waitTime = Duration.ofSeconds(2),
+                leaseTime = Duration.ofSeconds(30),
+            ),
+        )
+        val options = PropertiesAdapter.toCommonGroup(props)
+        options.maxLeaders shouldBeEqualTo 4
+        options.waitTime shouldBeEqualTo Duration.ofSeconds(2)
+        options.leaseTime shouldBeEqualTo Duration.ofSeconds(30)
+    }
+
+    @Test
+    fun `default Boot3LeaderProperties 가 5초 wait, 60초 lease 변환`() {
+        val options = PropertiesAdapter.toCommonElection(Boot3LeaderProperties())
+        options.waitTime shouldBeEqualTo Duration.ofSeconds(5)
+        options.leaseTime shouldBeEqualTo Duration.ofSeconds(60)
+    }
+
+    @Test
+    fun `default group 옵션은 maxLeaders 2`() {
+        val options = PropertiesAdapter.toCommonGroup(Boot3LeaderProperties())
+        options.maxLeaders shouldBeEqualTo 2
+    }
+}

--- a/leader-spring-boot3/src/test/resources/junit-platform.properties
+++ b/leader-spring-boot3/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/leader-spring-boot3/src/test/resources/logback-test.xml
+++ b/leader-spring-boot3/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%32.32t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.leader" level="DEBUG"/>
+    <logger name="org.springframework.boot.autoconfigure" level="INFO"/>
+    <logger name="org.testcontainers" level="INFO"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## Summary

PR #70의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: leader-spring-boot3 자동 구성 (#11)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 작업
[#11] Spring Boot 3 자동 구성 모듈 구현.

## 변경 요약

### 신규 파일
**Production** (8 files, ~360 lines):
- `Boot3LeaderProperties.kt` — `@ConfigurationProperties(prefix = "bluetape4k.leader")`
- `MongoCollectionProperties.kt` — Mongo 컬렉션 이름 분리 properties
- `LeaderElectionAutoConfiguration.kt` — 진입점 (6 백엔드 `@Import`)
- `adapter/PropertiesAdapter.kt` — 공통 Options 변환
- `backend/{Local,Redisson,Lettuce,Mongo,Hazelcast,ExposedJdbc,ExposedR2dbc}LeaderConfiguration.kt`

**Tests** (5 files, ~470 lines):
- `AbstractRedissonAutoConfigurationTest.kt` — Redisson 통합 base (`RedisServer.Launcher.redis`)
- `LeaderElectionAutoConfigurationTest.kt` — `@SpringBootTest` Redisson 통합
- `BackendConditionalTest.kt` — `ApplicationContextRunner` × 7 백엔드 + 다중/override
- `Boot3LeaderPropertiesBindingTest.kt` — yaml 바인딩
- `adapter/PropertiesAdapterTest.kt`

**Resources**:
- `META-INF/spring/...AutoConfiguration.imports` (LeaderElectionAutoConfiguration + LocalLeaderConfiguration)
- `junit-platform.properties` (PER_CLASS + parallel=false)
- `logback-test.xml`

**Docs**:
- `leader-spring-boot3/README.md` + `README.ko.md`
- `docs/superpowers/specs/2026-05-04-leader-spring-boot3-design.md`
- `docs/superpowers/plans/2026-05-04-leader-spring-boot3-plan.md`
- `CLAUDE.md` — 테스트 인프라 표준 명시 (`bluetape4k-testcontainers`)
- `docs/research/shedlock-vs-leader.md` — #69 SpEL 이슈 링크

### 빌드 변경
- `gradle/libs.versions.toml` — spring-boot-test-autoconfigure / spring-test alias 추가
- `leader-spring-boot3/build.gradle.kts` — common 의존, kotlin-bom 후순위 import (spring-boot BOM의 1.9.25 강제 우회), mongodb-driver-core 버전 명시
- 진입점 `build.gradle.kts` — kotlinCompilerClasspath resolution 안정화

### 디자인 결정
- **Local fallback**: 별도 `@AutoConfiguration(after = LeaderElectionAutoConfiguration)` 으로 분리 (코드 리뷰 C1 반영). `@ConditionalOnMissingBean(<type>::class)`로 다른 백엔드 빈 등장 시 자동 비활성
- **Mongo Suspend**: `MongoDatabase` (sync) + `CoroutineMongoDatabase` (coroutine) 모두 요구. 컬렉션명은 `bluetape4k.leader.mongo.{single|group}-collection` properties
- **runBlocking**: Mongo/R2DBC suspend factory invoke가 `suspend` (스키마 초기화) → `@Bean` 메서드에서 `runBlocking { ... }` 사용. 시동 시 1회 호출
- **다중 백엔드 정책**: 빈 이름 모두 다름. 사용자 코드는 `@Qualifier` 명시 권장

## DoD (#11)
- [x] AutoConfiguration 클래스 + 7 백엔드 분리
- [x] LeaderProperties (Boot3 wrapper, common 재사용)
- [x] `META-INF/spring/AutoConfiguration.imports` 등록
- [x] `@SpringBootTest` 통합 테스트 (Redisson 백엔드)
- [x] Kover 라인 커버리지 > 80% → **100% 달성**

## 테스트 결과
```
22 passing
LINE coverage: 66/66 (100%)
METHOD coverage: 43/43 (100%)
CLASS coverage: 15/15 (100%)
```

## 코드 리뷰
- **Tier 4 (code-reviewer, Opus)**: CRITICAL 1건 + HIGH 4건 발견 → C1/H1/H4 적용, H2/H3는 검증 결과 부적합 (suspend 호출 실재) → 유지
- **Tier 5 (code-simplifier, Opus)**: UUID→Base58, runTest/runBlocking 안티패턴 제거, 중복 헬퍼 추출

## 후속 이슈
- #12 — leader-spring-boot4 동일 구조 포팅
- #41 — `@Leader` AOP (ShedLock `@SchedulerLock` 대응)
- #69 — SpEL 락 이름 표현식 (이번 PR에서 신규 등록)

## Test Plan
- [x] `./gradlew :leader-spring-boot3:test` — 22/22 pass
- [x] `./gradlew :leader-spring-boot3:koverHtmlReport` — line coverage ≥ 80%
- [x] `./gradlew :leader-spring-boot3:compileKotlin` clean
- [ ] (CI) detekt + 다른 모듈 회귀 검증
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #70, head `39b2df25ba42bd06da8339bd0c54c57d9a775735`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
