### PR TITLE
fix: LeaderAopProperties에 @ConfigurationProperties 추가 (PR #41 daily review 2026-05-05)

### DIFF
--- a/leader-spring-boot-common/src/main/kotlin/io/bluetape4k/leader/spring/aop/properties/LeaderAopProperties.kt
+++ b/leader-spring-boot-common/src/main/kotlin/io/bluetape4k/leader/spring/aop/properties/LeaderAopProperties.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.spring.aop.properties
 
 import io.bluetape4k.leader.spring.aop.LeaderAspectFailureMode
+import org.springframework.boot.context.properties.ConfigurationProperties
 import java.time.Duration
 
 /**
@@ -29,6 +30,7 @@ import java.time.Duration
  * @property lockNamePrefix [Step 3-P-Sec-2][R-34] SpEL 평가 결과 앞에 자동 prefix. empty string opt-out
  * @property spel SpEL 보안 옵션
  */
+@ConfigurationProperties(prefix = LeaderAopProperties.PREFIX)
 data class LeaderAopProperties(
     val enabled: Boolean = true,
     val strict: Boolean = false,

--- a/leader-spring-boot-common/src/test/kotlin/io/bluetape4k/leader/spring/aop/properties/LeaderAopPropertiesBindingTest.kt
+++ b/leader-spring-boot-common/src/test/kotlin/io/bluetape4k/leader/spring/aop/properties/LeaderAopPropertiesBindingTest.kt
@@ -1,0 +1,53 @@
+package io.bluetape4k.leader.spring.aop.properties
+
+import io.bluetape4k.leader.spring.aop.LeaderAspectFailureMode
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.boot.context.properties.bind.Binder
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource
+import java.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderAopPropertiesBindingTest {
+
+    @Test
+    fun `bluetape4k_leader_aop_ YAML 키가 LeaderAopProperties에 바인딩된다`() {
+        val source = MapConfigurationPropertySource(
+            mapOf(
+                "bluetape4k.leader.aop.enabled" to "false",
+                "bluetape4k.leader.aop.strict" to "true",
+                "bluetape4k.leader.aop.failure-mode" to "SKIP",
+                "bluetape4k.leader.aop.default-wait-time" to "PT7S",
+                "bluetape4k.leader.aop.default-lease-time" to "PT3M",
+                "bluetape4k.leader.aop.lock-name-prefix" to "myapp:",
+                "bluetape4k.leader.aop.spel.allow-method-invocation" to "true",
+            ),
+        )
+        val props = Binder(source).bind(LeaderAopProperties.PREFIX, LeaderAopProperties::class.java).get()
+
+        props.enabled shouldBeEqualTo false
+        props.strict shouldBeEqualTo true
+        props.failureMode shouldBeEqualTo LeaderAspectFailureMode.SKIP
+        props.defaultWaitTime shouldBeEqualTo Duration.ofSeconds(7)
+        props.defaultLeaseTime shouldBeEqualTo Duration.ofMinutes(3)
+        props.lockNamePrefix shouldBeEqualTo "myapp:"
+        props.spel.allowMethodInvocation shouldBeEqualTo true
+    }
+
+    @Test
+    fun `빈 source는 default 값으로 바인딩된다`() {
+        val source = MapConfigurationPropertySource(emptyMap<String, String>())
+        val props = Binder(source)
+            .bind(LeaderAopProperties.PREFIX, LeaderAopProperties::class.java)
+            .orElse(LeaderAopProperties())
+
+        props.enabled shouldBeEqualTo true
+        props.strict shouldBeEqualTo false
+        props.failureMode shouldBeEqualTo LeaderAspectFailureMode.RETHROW
+        props.defaultWaitTime shouldBeEqualTo LeaderAopProperties.DEFAULT_WAIT_TIME
+        props.defaultLeaseTime shouldBeEqualTo LeaderAopProperties.DEFAULT_LEASE_TIME
+        props.lockNamePrefix shouldBeEqualTo LeaderAopProperties.DEFAULT_LOCK_NAME_PREFIX
+        props.spel.allowMethodInvocation shouldBeEqualTo false
+    }
+}


### PR DESCRIPTION
## Summary

PR #93의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: LeaderAopProperties에 @ConfigurationProperties 추가 (PR #41 daily review 2026-05-05)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 배경
2026-05-05 daily review (자동 routine, scope: 지난 24h 변경분) 진행 중 PR #41 (leader-aop merge commit 26690cd) 에서 발견된 CRITICAL 결함입니다.

## 문제
`LeaderAopProperties` data class 가 `@ConfigurationProperties(prefix = "bluetape4k.leader.aop")` 어노테이션 없이 머지되었습니다.

- `leader-spring-boot3/.../aop/autoconfigure/LeaderAopAutoConfiguration.kt:52` 와 `leader-spring-boot4/.../aop/autoconfigure/LeaderAopAutoConfiguration.kt:50` 모두 `@EnableConfigurationProperties(LeaderAopProperties::class)` 로 등록.
- 그러나 클래스 자체에 `@ConfigurationProperties` 가 없으면 Spring Boot 가 prefix 를 인식하지 못해 YAML 바인딩이 일어나지 않습니다.
- 결과: 사용자가 `application.yml` 에 설정한 모든 키가 silently 무시되고 Kotlin default 값만 적용됨.
  - `enabled = false` 로 AOP 비활성화 불가
  - 보안 critical `spel.allow-method-invocation = true` opt-in 불가
  - 전역 `failureMode` / `defaultWaitTime` / `defaultLeaseTime` / `lockNamePrefix` 모두 override 불가

Spec `docs/superpowers/specs/2026-05-04-leader-aop-design.md` §4.4 line 179 와 KDoc `PREFIX = "bluetape4k.leader.aop"` 모두 어노테이션 부착을 명시.

## 변경
- `LeaderAopProperties` 에 `@ConfigurationProperties(prefix = LeaderAopProperties.PREFIX)` 추가 + import
- `LeaderAopPropertiesBindingTest` 신규: 7 key 바인딩 + 빈 source default 회귀 방지 (2 tests)

## 검증
```
./gradlew :leader-spring-boot-common:test :leader-spring-boot3:test :leader-spring-boot4:test
```
- `LeaderAopPropertiesBindingTest` 2 tests 통과
- 기존 boot-common/3/4 회귀 0건

## 참고 — daily review 동시 발견 후속 이슈
다음은 본 PR 범위 외 — 별도 이슈로 등록 예정:
1. `LeaderElectionAspect.kt:71,77` / `LeaderGroupElectionAspect.kt:54,61` — `factoryCache.computeIfAbsent { factory.create(opts) }` 가 outer try 밖에서 실행되어 Mongo `ensureIndexes()` 등 backend I/O 실패 시 `failureMode=SKIP` 무시 + `LeaderElectionException` wrap 우회
2. `LeaderGroupElectionAspect` 전체 테스트 부재 — backend exception wrapping/maxLeaders<2 guard/metrics 검증 누락
3. `LeaderAnnotationValidatorBeanPostProcessor` 의 suspend / Mono / Flux / Flow / `@Aspect` skip 분기 미테스트
4. `SpelExpressionEvaluator` null 결과 + `${...}` placeholder 경로 미테스트
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #93, head `ff3c0e76f9a94039bfa4acf4d0c3a98f56064540`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
