### PR TITLE
feat: leader-aop Micrometer metrics 통합 (#75)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -35,7 +35,7 @@ graph TD
     SBCommon["leader-spring-boot-common\n(Boot 버전 독립)"]
     SB3["leader-spring-boot3\n(AOP + 자동 구성)"]
     SB4["leader-spring-boot4\n(AOP + 자동 구성)"]
-    Metrics["leader-micrometer\n(예정)"]
+    Metrics["leader-micrometer\n(Micrometer 메트릭)"]
     Ktor["leader-ktor\n(예정)"]
     ZK["leader-zookeeper\n(예정)"]
 
@@ -66,7 +66,7 @@ graph TD
 | `leader-exposed-jdbc` | 안정 | Exposed JDBC 백엔드 (H2, PostgreSQL, MySQL) |
 | `leader-exposed-r2dbc` | 안정 | Exposed R2DBC 백엔드 (코루틴 네이티브, H2/PostgreSQL/MySQL) |
 | `leader-mongodb` | 안정 | MongoDB 백엔드 (`findOneAndUpdate` + TTL 인덱스) |
-| `leader-micrometer` | 예정 | Micrometer 메트릭 연동 |
+| `leader-micrometer` | 안정 | Micrometer 메트릭 연동 (`MicrometerLeaderAopMetricsRecorder`) |
 | `leader-spring-boot-common` | 안정 | `@LeaderElection` / `@LeaderGroupElection` AOP 어노테이션 + Boot 버전 독립 인프라 |
 | `leader-spring-boot3` | 안정 | Spring Boot 3 자동 구성 + AOP (Spring 프록시) |
 | `leader-spring-boot4` | 안정 | Spring Boot 4 자동 구성 + AOP (AspectJ 포스트 컴파일 위빙) |
@@ -345,6 +345,85 @@ val result = election.runIfLeader("job", ScoredElectionStrategy(scorer)) { doWor
 | 후보별 TTL | 없음 (락 레벨) | 있음 (노드별 만료) |
 | 커스텀 스코어러 | 없음 | 가능 (`CandidateScorer`) |
 | 네트워크 RTT | 1회 (tryLock) | 2회 (list + elect) |
+
+## Micrometer 메트릭
+
+Spring Boot AOP(`@LeaderElection`)를 사용할 때 `leader-micrometer`를 추가하면 Prometheus/Datadog 메트릭이 자동으로 노출됩니다.
+
+### 의존성 추가
+
+```kotlin
+// Spring Boot 3
+implementation("io.github.bluetape4k.leader:leader-spring-boot3:0.1.0-SNAPSHOT")
+implementation("io.github.bluetape4k.leader:leader-micrometer:0.1.0-SNAPSHOT")
+// Spring Boot 4
+implementation("io.github.bluetape4k.leader:leader-spring-boot4:0.1.0-SNAPSHOT")
+implementation("io.github.bluetape4k.leader:leader-micrometer:0.1.0-SNAPSHOT")
+```
+
+`MeterRegistry` 빈이 존재하면 `MicrometerLeaderAopMetricsRecorder`가 자동 등록됩니다. 비활성화:
+
+```yaml
+bluetape4k:
+  leader:
+    aop:
+      metrics:
+        enabled: false
+```
+
+### 메터 카탈로그
+
+| 메터 이름 | 타입 | 설명 |
+|-----------|------|------|
+| `leader.aop.attempts` | Counter | `lock.name`별 락 획득 시도 횟수 |
+| `leader.aop.acquired` | Counter | 리더 선출 성공 횟수 |
+| `leader.aop.lock.not.acquired` | Counter | 실행 건너뜀 횟수; `reason` 태그로 사유 구분 (`CONTENTION` / `BACKEND_ERROR`) |
+| `leader.aop.execution.duration` | Timer | 리더 작업 실행 시간 |
+| `leader.aop.task.failed` | Counter | 작업 본문 예외 발생 횟수; `exception` 태그로 예외 클래스명 구분 |
+| `leader.aop.active` | Gauge | 현재 실행 중인 리더 작업 수 (JVM 로컬) |
+
+모든 메터는 `lock.name` 태그를 공유합니다. Micrometer의 `NamingConvention`이 백엔드별로 이름을 변환합니다 (Prometheus: `leader_aop_attempts_total` 등).
+
+> **멀티 인스턴스 주의:** `leader.aop.active`는 JVM 로컬 값입니다. Prometheus에서 클러스터 전체 리더 수를 보려면 `sum` 대신 `max by (lock_name) (leader_aop_active)`를 사용하세요.
+
+### 메터 사전 등록 (선택)
+
+앱 기동 시 정적 lock 이름을 미리 등록하면 첫 실행 전에도 dashboard에 0이 표시됩니다:
+
+```kotlin
+@Component
+class MetricsPreRegistrar(private val recorder: MicrometerLeaderAopMetricsRecorder) : SmartInitializingSingleton {
+    override fun afterSingletonsInstantiated() {
+        recorder.registerMetricsFor("daily-report-job", "nightly-cleanup")
+    }
+}
+```
+
+### Health Indicator
+
+`spring-boot-actuator`가 classpath에 있으면 `leaderMicrometerHealthContributor` 빈이 자동 등록됩니다:
+
+```
+GET /actuator/health/leaderMicrometerHealthContributor
+{
+  "status": "UP",
+  "details": {
+    "metrics.registered": true,
+    "attempts.total": 42.0
+  }
+}
+```
+
+### 커스텀 Recorder
+
+자체 `LeaderAopMetricsRecorder` 빈을 등록하면 기본 Micrometer 구현체를 대체합니다:
+
+```kotlin
+@Bean
+fun myRecorder(): LeaderAopMetricsRecorder = MyCustomRecorder()
+```
+
+---
 
 ## ShedLock과의 비교
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ graph TD
     SBCommon["leader-spring-boot-common\n(Boot version-independent)"]
     SB3["leader-spring-boot3\n(AOP + AutoConfig)"]
     SB4["leader-spring-boot4\n(AOP + AutoConfig)"]
-    Metrics["leader-micrometer\n(planned)"]
+    Metrics["leader-micrometer\n(Micrometer metrics)"]
     Ktor["leader-ktor\n(planned)"]
     ZK["leader-zookeeper\n(planned)"]
 
@@ -66,7 +66,7 @@ graph TD
 | `leader-exposed-jdbc` | Stable | Exposed JDBC backend (H2, PostgreSQL, MySQL) |
 | `leader-exposed-r2dbc` | Stable | Exposed R2DBC backend (coroutine-native, H2/PostgreSQL/MySQL) |
 | `leader-mongodb` | Stable | MongoDB backend (`findOneAndUpdate` + TTL index) |
-| `leader-micrometer` | Planned | Micrometer metrics integration |
+| `leader-micrometer` | Stable | Micrometer metrics integration (`MicrometerLeaderAopMetricsRecorder`) |
 | `leader-spring-boot-common` | Stable | `@LeaderElection` / `@LeaderGroupElection` AOP annotations + Boot-version-independent infrastructure |
 | `leader-spring-boot3` | Stable | Spring Boot 3 auto-configuration + AOP (Spring proxy) |
 | `leader-spring-boot4` | Stable | Spring Boot 4 auto-configuration + AOP (AspectJ post-compile weaving) |
@@ -343,6 +343,85 @@ val result = election.runIfLeader("job", ScoredElectionStrategy(scorer)) { doWor
 | TTL per candidate | No (lock-level TTL) | Yes (per-node expiry) |
 | Custom scorer | No | Yes (`CandidateScorer`) |
 | Network RTT | 1 (tryLock) | 2 (list + elect) |
+
+## Micrometer Metrics
+
+When using Spring Boot AOP (`@LeaderElection`), add `leader-micrometer` to expose Prometheus/Datadog metrics automatically.
+
+### Dependency
+
+```kotlin
+// Spring Boot 3
+implementation("io.github.bluetape4k.leader:leader-spring-boot3:0.1.0-SNAPSHOT")
+implementation("io.github.bluetape4k.leader:leader-micrometer:0.1.0-SNAPSHOT")
+// Spring Boot 4
+implementation("io.github.bluetape4k.leader:leader-spring-boot4:0.1.0-SNAPSHOT")
+implementation("io.github.bluetape4k.leader:leader-micrometer:0.1.0-SNAPSHOT")
+```
+
+`MicrometerLeaderAopMetricsRecorder` is auto-registered when a `MeterRegistry` bean is present. Disable with:
+
+```yaml
+bluetape4k:
+  leader:
+    aop:
+      metrics:
+        enabled: false
+```
+
+### Meter Catalog
+
+| Meter name | Type | Description |
+|------------|------|-------------|
+| `leader.aop.attempts` | Counter | Lock acquisition attempts per `lock.name` |
+| `leader.aop.acquired` | Counter | Successful leader elections |
+| `leader.aop.lock.not.acquired` | Counter | Skipped executions; tagged with `reason` (`CONTENTION` / `BACKEND_ERROR`) |
+| `leader.aop.execution.duration` | Timer | Elapsed time of the leader action |
+| `leader.aop.task.failed` | Counter | Action body exceptions; tagged with `exception` class name |
+| `leader.aop.active` | Gauge | Currently running leader actions (JVM-local) |
+
+All meters are tagged with `lock.name`. Micrometer's `NamingConvention` converts names per backend (e.g., `leader_aop_attempts_total` for Prometheus).
+
+> **Multi-instance note:** `leader.aop.active` is JVM-local. Use `max by (lock_name) (leader_aop_active)` in Prometheus — not `sum` — to avoid counting each node's gauge separately.
+
+### Pre-registration (optional)
+
+Pre-register static lock names at startup so metrics appear in dashboards even before the first execution:
+
+```kotlin
+@Component
+class MetricsPreRegistrar(private val recorder: MicrometerLeaderAopMetricsRecorder) : SmartInitializingSingleton {
+    override fun afterSingletonsInstantiated() {
+        recorder.registerMetricsFor("daily-report-job", "nightly-cleanup")
+    }
+}
+```
+
+### Health Indicator
+
+When `spring-boot-actuator` is on the classpath, a `leaderMicrometerHealthContributor` bean is registered automatically:
+
+```
+GET /actuator/health/leaderMicrometerHealthContributor
+{
+  "status": "UP",
+  "details": {
+    "metrics.registered": true,
+    "attempts.total": 42.0
+  }
+}
+```
+
+### Custom recorder
+
+Provide your own `LeaderAopMetricsRecorder` bean to replace the default Micrometer implementation:
+
+```kotlin
+@Bean
+fun myRecorder(): LeaderAopMetricsRecorder = MyCustomRecorder()
+```
+
+---
 
 ## Comparison with ShedLock
 

--- a/docs/lessons/2026-05-05-leader-micrometer-metrics.md
+++ b/docs/lessons/2026-05-05-leader-micrometer-metrics.md
@@ -1,0 +1,80 @@
+# Lessons Learned — leader-micrometer metrics 통합 (2026-05-05)
+
+**관련 PR**: feat/leader-micrometer-metrics (Issue #75)
+**영향 모듈**: `leader-micrometer`, `leader-spring-boot3`, `leader-spring-boot4`, `leader-spring-boot-common`
+
+---
+
+## L1: `@ConfigurationProperties` 어노테이션 누락이 전체 AutoConfig를 중단시킨다
+
+### 문제
+`LeaderAopProperties`에 `@ConfigurationProperties(prefix = "bluetape4k.leader.aop")` 어노테이션이 없었다.
+`@EnableConfigurationProperties(LeaderAopProperties::class)`는 이 어노테이션이 없으면 바인딩을 거부하고 애플리케이션 컨텍스트 시작 자체가 실패한다.
+
+이 버그는 `ApplicationContextRunner` 기반 통합 테스트 이전에는 발견되지 않았다. 기존 통합 테스트들이 `@SpringBootTest`를 사용하지 않거나 해당 AutoConfig를 로드하지 않았기 때문이다.
+
+### 교훈
+- 새 AutoConfiguration 클래스를 작성할 때 `@EnableConfigurationProperties` 대상 클래스에 `@ConfigurationProperties`가 있는지 반드시 확인한다.
+- `ApplicationContextRunner`를 사용한 AutoConfig 슬라이스 테스트가 이런 종류의 버그를 가장 빠르게 잡아낸다.
+
+---
+
+## L2: `@ConditionalOnBean` same-class ordering 문제 → 별도 AutoConfig로 분리
+
+### 문제
+`@AutoConfiguration` 클래스 내부에 nested `@Configuration` + `@ConditionalOnBean(SomeBean::class)`을 쓰면, nested 클래스의 조건이 외부 클래스의 `@Bean` 메서드가 등록되기 **전에** 평가된다.
+
+```kotlin
+// 이 패턴은 동작하지 않는다
+@AutoConfiguration
+class FooAutoConfiguration {
+    @Bean
+    fun recorder(): Recorder = ...  // ← 아직 미등록 상태에서
+
+    @Configuration
+    @ConditionalOnBean(Recorder::class)  // ← false로 평가됨
+    class HealthConfig {
+        @Bean fun health(): HealthIndicator = ...  // 등록 안 됨
+    }
+}
+```
+
+### 교훈
+- `@ConditionalOnBean`이 외부 클래스의 `@Bean`에 의존하는 경우 반드시 별도 AutoConfiguration 클래스로 분리하고 `@AutoConfiguration(after = [FooAutoConfiguration::class])`로 순서를 명시한다.
+- `AutoConfiguration.imports`에 두 클래스를 모두 등록해야 Spring Boot가 순서 힌트를 올바르게 반영한다.
+
+---
+
+## L3: `@ConditionalOnClass`에 `name=` 방식으로 classpath 안전 가드
+
+### 문제
+`@ConditionalOnClass(name = ["io.micrometer.core.instrument.MeterRegistry"])`만 가드하면, `leader-micrometer` 모듈이 `compileOnly`로 선언된 경우 `MeterRegistry`는 있지만 `MicrometerLeaderAopMetricsRecorder`가 없는 환경에서 `NoClassDefFoundError`가 발생할 수 있다.
+
+Spring의 `@ConditionalOnClass`는 ASM 바이트코드 파싱으로 class body를 읽기 때문에, `@Bean` 반환 타입에 사용된 클래스가 classpath에 없으면 조건 평가 자체가 실패한다.
+
+### 교훈
+- `compileOnly` 의존성으로 선언된 클래스가 `@Bean` 반환 타입이나 필드 타입으로 사용될 경우, `@ConditionalOnClass(name = [...])` 배열에 해당 클래스도 포함한다.
+- class literal(`value = [Foo::class]`)은 컴파일 타임에 이미 classpath에 있는 클래스만 사용 가능 — 선택적 의존성에는 항상 `name=` 방식을 사용한다.
+
+---
+
+## L4: lock name prefix가 테스트 환경에서 `:` prefix를 추가한다
+
+### 문제
+`LeaderAopProperties.DEFAULT_LOCK_NAME_PREFIX = "\${spring.application.name:}:"` 는 `spring.application.name`이 설정되지 않으면 빈 문자열로 해석되어 prefix가 `":"` 가 된다.
+
+따라서 `@LeaderElection(name = "test-lock")` 은 실제 lock name을 `:test-lock`으로 사용하고, 테스트에서 `registry.get("leader.aop.attempts").tag("lock.name", "test-lock")` 조회가 `MeterNotFoundException`으로 실패한다.
+
+### 교훈
+- `ApplicationContextRunner` 기반 AOP 통합 테스트에서는 `.withPropertyValues("bluetape4k.leader.aop.lock-name-prefix=")` 로 prefix를 빈 문자열로 설정해야 태그가 예측 가능하다.
+
+---
+
+## L5: `(x >= 0.0).shouldBeTrue()` 대신 `x shouldBeGreaterOrEqualTo 0.0`
+
+### 문제
+CLAUDE.md에 명시된 Kluent 스타일 규칙 위반. `(x >= y).shouldBeTrue()`는 실패 시 assertion 메시지가 `expected true but was false`로만 나와 디버깅이 어렵다.
+
+### 교훈
+- Kluent 비교 매처(`shouldBeGreaterOrEqualTo`, `shouldBeLessOrEqualTo`, `shouldBeGreaterThan` 등)를 사용한다.
+- `(expression).shouldBeTrue()` / `.shouldBeFalse()` 패턴은 boolean 속성 확인 외에는 사용하지 않는다.

--- a/docs/superpowers/plans/2026-05-05-leader-micrometer-metrics-plan.md
+++ b/docs/superpowers/plans/2026-05-05-leader-micrometer-metrics-plan.md
@@ -1,0 +1,391 @@
+# Implementation Plan — leader-aop Micrometer Metrics (#75)
+
+- **Issue**: #75 `feat: leader-aop Micrometer metrics 통합`
+- **작성일**: 2026-05-05
+- **대상 모듈**: `leader-micrometer` (구현체), `leader-spring-boot3`, `leader-spring-boot4` (AutoConfig)
+- **Spec 참조**: `docs/superpowers/specs/2026-05-05-leader-micrometer-metrics-design.md`
+
+---
+
+## 0. 요약
+
+본 PR은 다음 산출물을 생성한다.
+
+1. `MicrometerLeaderAopMetricsRecorder` — 6개 콜백을 6개 Micrometer 미터에 기록하는 단일 SPI 구현체
+2. `MicrometerNames` — 메터/태그 이름 상수
+3. `LeaderMicrometerAutoConfiguration` × 2 (Boot3 / Boot4) — `MeterRegistry` 존재 시 recorder 빈을 자동 등록 (`HealthContributor`는 Boot3 only)
+4. 단위 테스트 + Boot3/Boot4 통합 테스트 (Kover 80% / 60%)
+5. `README.md` + `README.ko.md` (메터 표 + 카디널리티 경고)
+
+**확정된 아키텍처 결정** (Spec 검토 + advisor 합의):
+
+- `leader-micrometer/build.gradle.kts`: `api(project(":leader-core"))` → `api(project(":leader-spring-boot-common"))` **교체**
+- 메터 이름: `leader.aop.attempts`, `leader.aop.acquired`, `leader.aop.lock.not.acquired`, `leader.aop.execution.duration`, `leader.aop.task.failed`, `leader.aop.active`
+- `onTaskFailed` active gauge 감소: `updateAndGet { if (it > 0) it - 1 else 0 }` (음수 방지)
+- AutoConfig 순서: `LeaderAopFactoryAutoConfiguration` → `LeaderMicrometerAutoConfiguration` → `LeaderAopAutoConfiguration`
+- `leader-spring-boot-common/LeaderAopHealthIndicator.kt` **수정 금지** (모듈 경계 보존)
+- 신규 `HealthContributor` 빈은 `leader-spring-boot3/.../metrics/LeaderMicrometerAutoConfiguration.kt` 안에서 등록
+- `deregisterMetricsFor` API 필수 (Gauge 메모리 누수 예방)
+- Gauge 등록은 `Gauge.builder("leader.aop.active", counter) { it.get().toDouble() }` 람다 — `!!` 금지
+- `typealias NotAcquiredKey = Pair<String, SkipReason>`, `typealias FailedKey = Pair<String, String>`
+- 신규 `lock.name`이 처음 등록될 때 `log.warn` 출력 (카디널리티 경고)
+
+---
+
+## Task List
+
+### T1. [complexity: low] build.gradle.kts 의존성 교체
+
+**파일**: `leader-micrometer/build.gradle.kts`
+
+**작업**:
+- `api(project(":leader-core"))` → `api(project(":leader-spring-boot-common"))` 로 라인 교체
+  (`leader-core`는 `leader-spring-boot-common`이 transitive로 노출하므로 별도 명시 불필요)
+- `api(libs.micrometer.core)` 유지
+- `testImplementation(libs.micrometer.registry.prometheus)` 유지 (단순 미터레지스트리 검증용)
+- `testImplementation(libs.bluetape4k.junit5)` / `kotlinx.coroutines.test` 유지
+
+**검증**: `./gradlew :leader-micrometer:dependencies | grep "leader-spring-boot-common"`
+
+**의존**: 없음 (가장 먼저 수행 — 후속 task의 import 기반)
+
+---
+
+### T2. [complexity: low] MicrometerNames.kt 상수 파일 생성
+
+**파일**: `leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerNames.kt`
+
+**작업**: `internal object MicrometerNames` 안에 다음 상수 정의 (KDoc 포함).
+
+```kotlin
+internal object MicrometerNames {
+    const val METER_ATTEMPTS = "leader.aop.attempts"
+    const val METER_ACQUIRED = "leader.aop.acquired"
+    const val METER_NOT_ACQUIRED = "leader.aop.lock.not.acquired"
+    const val METER_EXECUTION_DURATION = "leader.aop.execution.duration"
+    const val METER_TASK_FAILED = "leader.aop.task.failed"
+    const val METER_ACTIVE = "leader.aop.active"
+
+    const val TAG_LOCK_NAME = "lock.name"
+    const val TAG_REASON = "reason"
+    const val TAG_EXCEPTION = "exception"
+
+    const val UNKNOWN_EXCEPTION = "Unknown"
+}
+```
+
+**의존**: 없음
+
+---
+
+### T3. [complexity: high] MicrometerLeaderAopMetricsRecorder 구현
+
+**파일**: `leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerLeaderAopMetricsRecorder.kt`
+
+**작업**: Spec §4.1 기준 단일 클래스. 핵심 구성 요소:
+
+1. **클래스 시그니처**
+   ```kotlin
+   class MicrometerLeaderAopMetricsRecorder(
+       private val registry: MeterRegistry,
+   ) : LeaderAopMetricsRecorder
+   ```
+
+2. **typealias 정의** (파일 상단, top-level private)
+   ```kotlin
+   private typealias NotAcquiredKey = Pair<String, SkipReason>
+   private typealias FailedKey = Pair<String, String>
+   ```
+
+3. **6개 캐시 필드** (`ConcurrentHashMap` 6개)
+   - `attemptCounters: ConcurrentHashMap<String, Counter>`
+   - `acquiredCounters: ConcurrentHashMap<String, Counter>`
+   - `notAcquiredCounters: ConcurrentHashMap<NotAcquiredKey, Counter>`
+   - `executionTimers: ConcurrentHashMap<String, Timer>`
+   - `failedCounters: ConcurrentHashMap<FailedKey, Counter>`
+   - `activeGauges: ConcurrentHashMap<String, AtomicInteger>`
+
+4. **6개 콜백 구현** — 모두 try/finally 패턴 (recorder는 throw 금지)
+   - `onLockAttempt(name, options)` → `attemptCounter(name).increment()` + 신규 lockName 등록 시 `log.warn` (카디널리티 경고)
+   - `onLockAcquired(name, options, acquireElapsed)` → `acquiredCounter(name).increment()` (acquireElapsed는 v2 보류)
+   - `onLockNotAcquired(name, options, reason)` → `notAcquiredCounter(name, reason).increment()`
+   - `onTaskStarted(name)` → `activeGauge(name).incrementAndGet()`
+   - `onTaskFinished(name, executionTime)` → try { `executionTimer(name).record(executionTime.toJavaDuration())` } finally { `activeGauge(name).decrementAndGet()` }
+   - `onTaskFailed(name, executionTime, throwable)` → try { `failedCounter(name, throwable::class.simpleName ?: "Unknown").increment()` } finally { `activeGauge(name).updateAndGet { if (it > 0) it - 1 else 0 }` } **(음수 방지)**
+
+5. **public API**
+   - `fun registerMetricsFor(vararg lockNames: String)` — 멱등. attempt/acquired/timer/active 4종을 사전 등록 (notAcquired/failed는 reason/exception 카디널리티 미지로 lazy 유지)
+   - `fun deregisterMetricsFor(vararg lockNames: String)` — `ConcurrentHashMap.remove` + `registry.remove(meter)` (Gauge는 `registry.find(...).tag(TAG_LOCK_NAME, name).gauge()` 로 조회 후 제거)
+
+6. **private helpers** (computeIfAbsent + Counter/Timer/Gauge 빌더)
+   - `attemptCounter(name)`, `acquiredCounter(name)`, `notAcquiredCounter(name, reason)`, `executionTimer(name)`, `failedCounter(name, exceptionName)`, `activeGauge(name)`
+   - `buildActiveGauge(lockName: String): AtomicInteger` — Spec §3.5 람다 패턴 (`{ it.get().toDouble() }`) 사용. **`!!` 금지**.
+   - `Gauge.builder(METER_ACTIVE, counter) { it.get().toDouble() }.tag(TAG_LOCK_NAME, lockName).register(registry)`
+
+7. **카디널리티 경고 로깅** — `attemptCounter(name)` 안에서 `computeIfAbsent`의 람다가 호출될 때마다 (= 신규 lockName 첫 등장) `log.warn("Registering new lock.name='{}' for leader.aop metrics — beware tag cardinality if using dynamic SpEL", name)` 출력. KLogging companion 사용.
+
+8. **격리(Isolation) 보장** — 본 클래스 자체에서 throw 금지. `Counter.increment()` 등 Micrometer API 외부 throw는 무시 가능 수준이므로 별도 try/catch 미적용. 단, `log.warn`이 매번 호출되지 않도록 `computeIfAbsent` 람다 안에서만 호출.
+
+**KDoc**: 클래스/모든 public 함수에 KDoc. 클래스 KDoc에는 카디널리티 경고 + multi-instance Prometheus 집계 시 `max by (lock_name) (leader_aop_active)` 사용 권장 명시.
+
+**의존**: T1 (의존성), T2 (상수)
+
+---
+
+### T4. [complexity: medium] Boot3 LeaderMicrometerAutoConfiguration
+
+**파일**: `leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/metrics/LeaderMicrometerAutoConfiguration.kt`
+
+**작업**:
+
+1. **AutoConfig 본체**
+   ```kotlin
+   @AutoConfiguration(
+       after = [LeaderAopFactoryAutoConfiguration::class],
+       before = [LeaderAopAutoConfiguration::class],
+   )
+   @ConditionalOnClass(name = ["io.micrometer.core.instrument.MeterRegistry"])
+   @ConditionalOnProperty(
+       prefix = "bluetape4k.leader.aop.metrics",
+       name = ["enabled"],
+       havingValue = "true",
+       matchIfMissing = true,
+   )
+   class LeaderMicrometerAutoConfiguration
+   ```
+
+2. **Recorder @Bean**
+   ```kotlin
+   @Bean
+   @ConditionalOnBean(MeterRegistry::class)
+   @ConditionalOnMissingBean(MicrometerLeaderAopMetricsRecorder::class)
+   @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+   fun micrometerLeaderAopMetricsRecorder(
+       registry: MeterRegistry,
+   ): LeaderAopMetricsRecorder = MicrometerLeaderAopMetricsRecorder(registry)
+   ```
+
+3. **HealthContributor @Bean** (Boot3 only — Spec §4.4)
+   ```kotlin
+   @Bean
+   @ConditionalOnBean(value = [MeterRegistry::class, MicrometerLeaderAopMetricsRecorder::class])
+   @ConditionalOnClass(name = ["org.springframework.boot.actuate.health.HealthContributor"])
+   @ConditionalOnMissingBean(name = ["leaderMicrometerHealthContributor"])
+   fun leaderMicrometerHealthContributor(registry: MeterRegistry): HealthIndicator { ... }
+   ```
+   - `attempts.total = registry.find(METER_ATTEMPTS).counters().sumOf { it.count() }`
+   - `metrics.registered = counters.isNotEmpty()`
+   - 항상 `Health.up()` 반환 (attempts 0 일 때도)
+   - `leaderMicrometerHealthContributor`라는 빈 이름 명시 (`leaderAopHealthIndicator`와 충돌 방지)
+
+4. **격리 검증** — `LeaderAopHealthIndicator`(common 모듈)는 그대로 유지. 본 빈은 별개 health 노드로 추가만 한다.
+
+**의존**: T3
+
+---
+
+### T5. [complexity: medium] Boot4 LeaderMicrometerAutoConfiguration
+
+**파일**: `leader-spring-boot4/src/main/kotlin/io/bluetape4k/leader/spring/boot4/metrics/LeaderMicrometerAutoConfiguration.kt`
+
+**작업**:
+
+1. T4와 **시그니처 동일**한 `MicrometerLeaderAopMetricsRecorder` 등록 빈만 작성.
+2. `HealthContributor` 빈은 **추가하지 않음** (Spec §4.4 — Boot4 health 통합은 본 PR 범위 외, `org.springframework.boot.health.contributor.HealthIndicator` 신규 패키지 미지원).
+3. `@AutoConfiguration(after = [LeaderAopFactoryAutoConfiguration::class], before = [LeaderAopAutoConfiguration::class])` — Boot4의 factory/aop autoconfig 클래스 참조.
+4. `@ConditionalOnProperty` 동일.
+
+**의존**: T3
+
+---
+
+### T6. [complexity: medium] AutoConfiguration.imports 순서 등록
+
+**파일** (둘 다 동일하게 수정):
+- `leader-spring-boot3/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`
+- `leader-spring-boot4/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`
+
+**작업**: 다음 순서로 라인 삽입.
+
+```
+io.bluetape4k.leader.spring.boot3.LeaderElectionAutoConfiguration
+io.bluetape4k.leader.spring.boot3.backend.LocalLeaderConfiguration
+io.bluetape4k.leader.spring.boot3.aop.autoconfigure.LeaderAopFactoryAutoConfiguration
+io.bluetape4k.leader.spring.boot3.metrics.LeaderMicrometerAutoConfiguration   ← 추가 (Factory 뒤, AOP 앞)
+io.bluetape4k.leader.spring.boot3.aop.autoconfigure.LeaderAopAutoConfiguration
+```
+
+**메모리 규칙 적용**: `feedback_autoconfig_order_separate.md` — `@AutoConfigureBefore/After`만으로는 imports 순서 미보장. 본 파일에서 직접 순서 명시 필수.
+
+Boot4 imports도 동일 패턴 (`boot4` 패키지로).
+
+**의존**: T4, T5
+
+---
+
+### T7. [complexity: medium] 단위 테스트 — MicrometerLeaderAopMetricsRecorderTest
+
+**파일**: `leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/MicrometerLeaderAopMetricsRecorderTest.kt`
+
+**작업**: Spec §6.1 기준 14개 테스트 케이스. `SimpleMeterRegistry` 사용 (Testcontainers 불필요).
+
+테스트 클래스 헤더:
+- `@TestInstance(TestInstance.Lifecycle.PER_CLASS)` (메모리 규칙 `feedback_junit_platform_per_class.md`)
+- `KLogging companion`
+- JUnit 5 + Kluent matcher (`shouldBeEqualTo`, `shouldBeGreaterOrEqualTo`)
+
+테스트 케이스 (모두 backtick-quoted Korean/English):
+
+1. `onLockAttempt - attempts counter with lock name tag increments`
+2. `onLockAcquired - acquired counter with lock name tag increments`
+3. `onLockNotAcquired CONTENTION - reason tag equals CONTENTION`
+4. `onLockNotAcquired BACKEND_ERROR - reason tag equals BACKEND_ERROR`
+5. `onTaskFinished - execution duration timer count increments`
+6. `onTaskFailed - task failed counter with exception tag`
+7. `onTaskFailed without prior onTaskStarted - active gauge stays non-negative` ← **음수 방지 핵심 검증**
+8. `onTaskStarted - active gauge becomes 1`
+9. `onTaskStarted then onTaskFinished - active gauge returns to 0`
+10. `onTaskStarted then onTaskFailed - active gauge returns to 0`
+11. `registerMetricsFor - meters appear before first callback`
+12. `registerMetricsFor - idempotent second call does not duplicate meters` ← **멱등성 검증 (mandatory)**
+13. `concurrent onTaskStarted and onTaskFinished - active gauge thread safe` ← **mandatory**: `coroutineScope { repeat(1000) { launch { recorder.onTaskStarted("k"); recorder.onTaskFinished("k", 1.milliseconds) } } }` 후 active = 0 검증
+14. `deregisterMetricsFor - removes meters from registry` ← `registry.find(METER_ACTIVE).tag(TAG_LOCK_NAME, name).gauge()` 가 null 반환
+
+모든 assertion은 `tag(TAG_LOCK_NAME, "test-lock")` 명시.
+
+**의존**: T3
+
+---
+
+### T8. [complexity: medium] Boot3 통합 테스트
+
+**파일**: `leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/metrics/LeaderMicrometerAutoConfigurationBoot3Test.kt`
+
+**작업**: `@SpringBootTest(classes = [TestApp::class])` 기반.
+
+테스트 케이스 (Spec §6.2):
+
+1. `MeterRegistry 빈 존재 시 MicrometerLeaderAopMetricsRecorder 자동 등록` — `SimpleMeterRegistry` 빈 등록 후 context에서 `MicrometerLeaderAopMetricsRecorder` 빈 조회 성공
+2. `MeterRegistry 빈 없을 때 recorder 빈 미등록` — `@ConditionalOnBean(MeterRegistry)` 검증. context에서 `getBeansOfType(LeaderAopMetricsRecorder).isEmpty()` 검증
+3. `enabled=false 시 빈 미등록` — `@TestPropertySource(properties = ["bluetape4k.leader.aop.metrics.enabled=false"])`
+4. `사용자 정의 LeaderAopMetricsRecorder가 우선` — TestConfig 에서 `@Bean fun customRecorder(): LeaderAopMetricsRecorder = NoOpRecorder()` 등록 후 `MicrometerLeaderAopMetricsRecorder` 빈 미등록 검증
+5. `LeaderElectionAspect 통과 시 attempts+acquired+timer 전체 검증` — `LocalLeaderElection` + `@LeaderElection` 메서드 호출 → `registry.get(METER_ATTEMPTS).counter().count()` ≥ 1, `registry.get(METER_EXECUTION_DURATION).timer().count()` ≥ 1
+6. `backend 예외 시 lock.not.acquired reason=BACKEND_ERROR 증가` — Mock LeaderElection 이 throw → `tag(TAG_REASON, "BACKEND_ERROR")` counter 증가 검증
+7. `leaderMicrometerHealthContributor 빈 등록 검증` — `Health.up()` + `details["metrics.registered"]` 존재
+
+`junit-platform.properties` 메모리 규칙 + Kover 60% (메모리 규칙 `feedback_kover_unit_test_only_threshold.md`).
+
+**의존**: T4, T6
+
+---
+
+### T9. [complexity: medium] Boot4 통합 테스트
+
+**파일**: `leader-spring-boot4/src/test/kotlin/io/bluetape4k/leader/spring/boot4/metrics/LeaderMicrometerAutoConfigurationBoot4Test.kt`
+
+**작업**: T8과 **동일 시나리오**. 차이점:
+- 패키지/AutoConfig 클래스 → `boot4`
+- HealthContributor 검증 케이스 **제외** (Boot4 미등록)
+- AspectJ post-compile weaving 환경 — `@LeaderElection` 메서드는 `open` 불필요
+
+**의존**: T5, T6
+
+---
+
+### T10. [complexity: low] junit-platform.properties (leader-micrometer)
+
+**파일**: `leader-micrometer/src/test/resources/junit-platform.properties`
+
+**작업**: 메모리 규칙 `feedback_junit_platform_per_class.md` 표준 적용.
+
+```properties
+junit.jupiter.testinstance.lifecycle.default=per_class
+junit.jupiter.execution.parallel.enabled=false
+```
+
+기존 다른 모듈 (`leader-redis-redisson`, `leader-mongodb` 등) 의 동일 파일 내용 그대로 복사.
+
+**의존**: T7
+
+---
+
+### T11. [complexity: low] KDoc 정비 + README.md + README.ko.md
+
+**파일**:
+- `leader-micrometer/README.md`
+- `leader-micrometer/README.ko.md`
+
+**작업** (둘 다 동일 구조 — 영/한):
+
+1. **Overview** — leader-aop의 SPI(`LeaderAopMetricsRecorder`)에 대한 Micrometer 기반 기본 구현체 소개
+2. **Installation** — Gradle 의존성 (`io.github.bluetape4k.leader:bluetape4k-leader-micrometer`)
+3. **Usage**
+   - Spring Boot 자동 설정 (별도 코드 불필요 — `MeterRegistry` 빈만 있으면 활성)
+   - 수동 등록 예시 (non-Spring 환경): `MicrometerLeaderAopMetricsRecorder(registry)` → `LeaderElectionAspect(... recorders = listOf(recorder))`
+   - `registerMetricsFor("job-a", "job-b")` 사전 등록 권장 (대시보드 NaN 방지)
+   - `deregisterMetricsFor` 호출 시점 가이드 (동적 SpEL 사용 시 잡 제거 직후)
+4. **Metrics Reference** — Spec §3.1 표 그대로 인용 (메터 6종 + 태그)
+5. **Cardinality Warning**
+   - `lock.name` 동적 SpEL 사용 시 카디널리티 폭발 위험
+   - `exception` 태그는 `simpleName` 사용 (anonymous class → "Unknown")
+   - 신규 lockName 등록 시 `log.warn` 출력 안내
+6. **Multi-Instance Aggregation**
+   - `leader.aop.active` 는 JVM-local
+   - PromQL 권장: `max by (lock_name) (leader_aop_active)` (sum 사용 시 인스턴스 수 × 실제값)
+7. **Configuration**
+   - `bluetape4k.leader.aop.metrics.enabled` (default true) — false 설정 시 빈 미등록
+8. **Custom Recorder Override** — `@ConditionalOnMissingBean` 기반, 사용자 정의 recorder 가 우선
+9. **Out of Scope** — Observation API / acquire_time Timer / Boot4 HealthIndicator (Spec §5)
+
+또한 `MicrometerLeaderAopMetricsRecorder` / `registerMetricsFor` / `deregisterMetricsFor` 의 KDoc 에는 동일한 카디널리티 경고와 multi-instance 가이드를 1줄씩 첨부.
+
+**의존**: T3, T4, T5
+
+---
+
+## 후행 검증 단계 (PR 직전)
+
+이슈 `#75 DoD` 와 메모리 규칙 (`feedback_pr_code_review.md`, `feedback_workflow_review_before_docs.md`) 에 따라 다음 순서를 강제한다.
+
+1. **컴파일 + 테스트** — `./gradlew :leader-micrometer:test :leader-spring-boot3:test :leader-spring-boot4:test`
+2. **Detekt** — `./gradlew detekt`
+3. **Kover 커버리지** — `leader-micrometer 80%`, `boot3/4 60%` (`feedback_coverage_kover.md`, `feedback_kover_unit_test_only_threshold.md`)
+4. **6중 코드 리뷰** — `bluetape4k-design Step 6-R` 6-Tier 리뷰 실행, **CRITICAL/HIGH 0** 확인
+5. **README/KDoc 갱신** — 리뷰 후 API 변경이 있을 경우 T11 재실행 (Step 6 → Step 6-R 후 재진입)
+6. **PR 생성** — Korean conventional commit prefix (`feat: leader-micrometer ...`)
+
+---
+
+## 의존 그래프 요약
+
+```
+T1 (gradle) ──┬─→ T3 (recorder) ──┬─→ T4 (boot3 autoconfig) ──┬─→ T6 (imports) ──┬─→ T8 (boot3 test)
+T2 (names)  ──┘                   │                           │                  └─→ T9 (boot4 test)
+                                  ├─→ T5 (boot4 autoconfig) ──┘
+                                  ├─→ T7 (unit test) ──→ T10 (junit-platform.properties)
+                                  └─→ T11 (README + KDoc)
+```
+
+병렬 가능 그룹:
+- T1 + T2 (선행 없음)
+- T4 + T5 + T7 (T3 완료 후)
+- T8 + T9 (T4/T5/T6 완료 후)
+- T10 + T11 (각 선행 완료 후)
+
+---
+
+## 라우팅 요약
+
+| Task | Complexity | 추천 모델 |
+|---|---|---|
+| T1 | low | Haiku |
+| T2 | low | Haiku |
+| T3 | high | **Opus** (Gauge 람다 / deregister / 음수 방지 / 카디널리티 로깅 / thread-safety) |
+| T4 | medium | Sonnet |
+| T5 | medium | Sonnet |
+| T6 | medium | Sonnet |
+| T7 | medium | Sonnet |
+| T8 | medium | Sonnet |
+| T9 | medium | Sonnet |
+| T10 | low | Haiku |
+| T11 | low | Haiku |

--- a/docs/superpowers/plans/2026-05-05-leader-micrometer-metrics-plan.md
+++ b/docs/superpowers/plans/2026-05-05-leader-micrometer-metrics-plan.md
@@ -34,7 +34,7 @@
 
 ## Task List
 
-### T1. [complexity: low] build.gradle.kts 의존성 교체
+### T1. [complexity: low] build.gradle.kts 의존성 교체 + Kover threshold
 
 **파일**: `leader-micrometer/build.gradle.kts`
 
@@ -42,8 +42,21 @@
 - `api(project(":leader-core"))` → `api(project(":leader-spring-boot-common"))` 로 라인 교체
   (`leader-core`는 `leader-spring-boot-common`이 transitive로 노출하므로 별도 명시 불필요)
 - `api(libs.micrometer.core)` 유지
-- `testImplementation(libs.micrometer.registry.prometheus)` 유지 (단순 미터레지스트리 검증용)
+- `testImplementation(libs.micrometer.registry.prometheus)` 유지
 - `testImplementation(libs.bluetape4k.junit5)` / `kotlinx.coroutines.test` 유지
+- **Kover 80% threshold 추가** (`feedback_coverage_kover.md`):
+  ```kotlin
+  kover {
+      reports {
+          verify {
+              rule {
+                  minBound(80)
+              }
+          }
+      }
+  }
+  ```
+  기존 다른 모듈 (`leader-core`, `leader-redis-lettuce` 등)의 Kover 설정 블록 참조하여 동일 패턴 적용.
 
 **검증**: `./gradlew :leader-micrometer:dependencies | grep "leader-spring-boot-common"`
 
@@ -84,6 +97,14 @@ internal object MicrometerNames {
 
 **작업**: Spec §4.1 기준 단일 클래스. 핵심 구성 요소:
 
+0. **명시적 import 블록** (파일 상단 — IDE 자동 완성 오류 방지)
+   ```kotlin
+   import io.bluetape4k.leader.LeaderElectionOptions          // ✅ NOT io.bluetape4k.leader.options.*
+   import io.bluetape4k.leader.spring.aop.metrics.LeaderAopMetricsRecorder
+   import io.bluetape4k.leader.spring.aop.metrics.SkipReason
+   import kotlin.time.toJavaDuration
+   ```
+
 1. **클래스 시그니처**
    ```kotlin
    class MicrometerLeaderAopMetricsRecorder(
@@ -122,7 +143,8 @@ internal object MicrometerNames {
    - `buildActiveGauge(lockName: String): AtomicInteger` — Spec §3.5 람다 패턴 (`{ it.get().toDouble() }`) 사용. **`!!` 금지**.
    - `Gauge.builder(METER_ACTIVE, counter) { it.get().toDouble() }.tag(TAG_LOCK_NAME, lockName).register(registry)`
 
-7. **카디널리티 경고 로깅** — `attemptCounter(name)` 안에서 `computeIfAbsent`의 람다가 호출될 때마다 (= 신규 lockName 첫 등장) `log.warn("Registering new lock.name='{}' for leader.aop metrics — beware tag cardinality if using dynamic SpEL", name)` 출력. KLogging companion 사용.
+7. **카디널리티 경고 로깅** — `attemptCounter(name)` 안에서 `computeIfAbsent`의 람다가 호출될 때만 (= 신규 lockName 첫 등장) `log.warn("Registering new lock.name='{}' for leader.aop metrics — beware tag cardinality if using dynamic SpEL", name)` 출력. KLogging companion 사용.
+   > ⚠️ **`registerMetricsFor`는 cardinality warn을 발생시키지 않는다.** `registerMetricsFor`는 `attemptCounter(name)` 헬퍼를 통하지 않고 `attemptCounters.computeIfAbsent(name) { buildAttemptCounter(name) }` 를 직접 호출해야 한다. 이렇게 해야 사전 등록된 정적 lock name이 warn을 유발하지 않고, 런타임에 예상치 못한 동적 lock name만 warn을 유발한다.
 
 8. **격리(Isolation) 보장** — 본 클래스 자체에서 throw 금지. `Counter.increment()` 등 Micrometer API 외부 throw는 무시 가능 수준이므로 별도 try/catch 미적용. 단, `log.warn`이 매번 호출되지 않도록 `computeIfAbsent` 람다 안에서만 호출.
 
@@ -166,13 +188,19 @@ internal object MicrometerNames {
    ```
 
 3. **HealthContributor @Bean** (Boot3 only — Spec §4.4)
+   Spring Boot의 동일 `@Configuration` 클래스 내 `@ConditionalOnBean`은 빈 순서 미보장으로 신뢰 불가. **별도 inner `@Configuration` 클래스**로 분리:
    ```kotlin
-   @Bean
-   @ConditionalOnBean(value = [MeterRegistry::class, MicrometerLeaderAopMetricsRecorder::class])
+   @Configuration(proxyBeanMethods = false)
+   @ConditionalOnBean(MicrometerLeaderAopMetricsRecorder::class)
    @ConditionalOnClass(name = ["org.springframework.boot.actuate.health.HealthContributor"])
-   @ConditionalOnMissingBean(name = ["leaderMicrometerHealthContributor"])
-   fun leaderMicrometerHealthContributor(registry: MeterRegistry): HealthIndicator { ... }
+   inner class HealthConfig {
+       @Bean
+       @ConditionalOnMissingBean(name = ["leaderMicrometerHealthContributor"])
+       fun leaderMicrometerHealthContributor(registry: MeterRegistry): HealthIndicator { ... }
+   }
    ```
+   - 반환 타입은 `HealthIndicator` (단일 노드). `CompositeHealthContributor`가 아님.
+   - `leaderMicrometerHealthContributor` 빈 이름 명시 (`leaderAopHealthIndicator`와 충돌 방지)
    - `attempts.total = registry.find(METER_ATTEMPTS).counters().sumOf { it.count() }`
    - `metrics.registered = counters.isNotEmpty()`
    - 항상 `Health.up()` 반환 (attempts 0 일 때도)
@@ -248,7 +276,7 @@ Boot4 imports도 동일 패턴 (`boot4` 패키지로).
 10. `onTaskStarted then onTaskFailed - active gauge returns to 0`
 11. `registerMetricsFor - meters appear before first callback`
 12. `registerMetricsFor - idempotent second call does not duplicate meters` ← **멱등성 검증 (mandatory)**
-13. `concurrent onTaskStarted and onTaskFinished - active gauge thread safe` ← **mandatory**: `coroutineScope { repeat(1000) { launch { recorder.onTaskStarted("k"); recorder.onTaskFinished("k", 1.milliseconds) } } }` 후 active = 0 검증
+13. `concurrent onTaskStarted and onTaskFinished - active gauge thread safe` ← **mandatory**: JVM 실제 스레드 병렬성 사용. `runBlocking(Dispatchers.Default) { coroutineScope { repeat(1000) { launch { recorder.onTaskStarted("k"); recorder.onTaskFinished("k", 1.milliseconds) } } } }` 후 active = 0 검증. `Dispatchers.Default` 명시 필수 (단일 스레드 디스패처 사용 시 AtomicInteger의 thread-safety가 검증되지 않음)
 14. `deregisterMetricsFor - removes meters from registry` ← `registry.find(METER_ACTIVE).tag(TAG_LOCK_NAME, name).gauge()` 가 null 반환
 
 모든 assertion은 `tag(TAG_LOCK_NAME, "test-lock")` 명시.
@@ -269,7 +297,11 @@ Boot4 imports도 동일 패턴 (`boot4` 패키지로).
 2. `MeterRegistry 빈 없을 때 recorder 빈 미등록` — `@ConditionalOnBean(MeterRegistry)` 검증. context에서 `getBeansOfType(LeaderAopMetricsRecorder).isEmpty()` 검증
 3. `enabled=false 시 빈 미등록` — `@TestPropertySource(properties = ["bluetape4k.leader.aop.metrics.enabled=false"])`
 4. `사용자 정의 LeaderAopMetricsRecorder가 우선` — TestConfig 에서 `@Bean fun customRecorder(): LeaderAopMetricsRecorder = NoOpRecorder()` 등록 후 `MicrometerLeaderAopMetricsRecorder` 빈 미등록 검증
-5. `LeaderElectionAspect 통과 시 attempts+acquired+timer 전체 검증` — `LocalLeaderElection` + `@LeaderElection` 메서드 호출 → `registry.get(METER_ATTEMPTS).counter().count()` ≥ 1, `registry.get(METER_EXECUTION_DURATION).timer().count()` ≥ 1
+5. `LeaderElectionAspect 통과 시 attempts+acquired+timer+active 전체 검증` — `LocalLeaderElection` + `@LeaderElection` 메서드 호출 → 다음을 **모두** 검증:
+   - `registry.get(METER_ATTEMPTS).tag(TAG_LOCK_NAME, "test-lock").counter().count()` ≥ 1
+   - `registry.get(METER_ACQUIRED).tag(TAG_LOCK_NAME, "test-lock").counter().count()` ≥ 1
+   - `registry.get(METER_EXECUTION_DURATION).tag(TAG_LOCK_NAME, "test-lock").timer().count()` ≥ 1
+   - `registry.find(METER_ACTIVE).tag(TAG_LOCK_NAME, "test-lock").gauge()?.value()` == 0.0 (메서드 반환 후)
 6. `backend 예외 시 lock.not.acquired reason=BACKEND_ERROR 증가` — Mock LeaderElection 이 throw → `tag(TAG_REASON, "BACKEND_ERROR")` counter 증가 검증
 7. `leaderMicrometerHealthContributor 빈 등록 검증` — `Health.up()` + `details["metrics.registered"]` 존재
 
@@ -283,18 +315,27 @@ Boot4 imports도 동일 패턴 (`boot4` 패키지로).
 
 **파일**: `leader-spring-boot4/src/test/kotlin/io/bluetape4k/leader/spring/boot4/metrics/LeaderMicrometerAutoConfigurationBoot4Test.kt`
 
-**작업**: T8과 **동일 시나리오**. 차이점:
-- 패키지/AutoConfig 클래스 → `boot4`
-- HealthContributor 검증 케이스 **제외** (Boot4 미등록)
-- AspectJ post-compile weaving 환경 — `@LeaderElection` 메서드는 `open` 불필요
+**작업**: T8과 동일한 테스트 케이스를 아래 목록으로 명시 구현. 패키지/클래스만 `boot4` 로 변경.
+
+테스트 케이스 (HealthContributor 제외):
+1. `MeterRegistry 빈 존재 시 MicrometerLeaderAopMetricsRecorder 자동 등록`
+2. `MeterRegistry 빈 없을 때 recorder 빈 미등록`
+3. `enabled=false 시 빈 미등록`
+4. `사용자 정의 LeaderAopMetricsRecorder가 우선`
+5. `LeaderElectionAspect 통과 시 attempts+acquired+timer+active 전체 검증` — T8 #5와 동일 assertion (4가지 모두 검증)
+6. `backend 예외 시 lock.not.acquired reason=BACKEND_ERROR 증가`
+
+> **Boot4 차이점**: AspectJ post-compile weaving 환경. `@LeaderElection` 메서드에 `open` 불필요. Boot4 `LeaderAopAutoConfiguration` 클래스 FQN은 `io.bluetape4k.leader.spring.boot4.aop.autoconfigure.LeaderAopAutoConfiguration` (boot3와 다름 — 패키지 확인 필수).
 
 **의존**: T5, T6
 
 ---
 
-### T10. [complexity: low] junit-platform.properties (leader-micrometer)
+### T10. [complexity: low] junit-platform.properties + logback-test.xml (leader-micrometer)
 
-**파일**: `leader-micrometer/src/test/resources/junit-platform.properties`
+**파일**:
+- `leader-micrometer/src/test/resources/junit-platform.properties`
+- `leader-micrometer/src/test/resources/logback-test.xml`
 
 **작업**: 메모리 규칙 `feedback_junit_platform_per_class.md` 표준 적용.
 
@@ -303,9 +344,9 @@ junit.jupiter.testinstance.lifecycle.default=per_class
 junit.jupiter.execution.parallel.enabled=false
 ```
 
-기존 다른 모듈 (`leader-redis-redisson`, `leader-mongodb` 등) 의 동일 파일 내용 그대로 복사.
+`logback-test.xml`은 다른 모듈의 기존 파일 그대로 복사. `log.warn` 카디널리티 경고가 테스트 로그에 출력되도록 최소 WARN 레벨 설정.
 
-**의존**: T7
+**의존**: 없음 ← T7 실행 **전에** 반드시 완료해야 함
 
 ---
 
@@ -361,16 +402,16 @@ junit.jupiter.execution.parallel.enabled=false
 ```
 T1 (gradle) ──┬─→ T3 (recorder) ──┬─→ T4 (boot3 autoconfig) ──┬─→ T6 (imports) ──┬─→ T8 (boot3 test)
 T2 (names)  ──┘                   │                           │                  └─→ T9 (boot4 test)
+T10 (junit) ──────────────────────│───────────────────────────│──────────────────→ T7 (unit test)
                                   ├─→ T5 (boot4 autoconfig) ──┘
-                                  ├─→ T7 (unit test) ──→ T10 (junit-platform.properties)
                                   └─→ T11 (README + KDoc)
 ```
 
 병렬 가능 그룹:
-- T1 + T2 (선행 없음)
-- T4 + T5 + T7 (T3 완료 후)
-- T8 + T9 (T4/T5/T6 완료 후)
-- T10 + T11 (각 선행 완료 후)
+- **T1 + T2 + T10** (선행 없음 — T10은 T7 실행 전에 완료 필수)
+- **T4 + T5 + T7** (T1+T2+T3+T10 완료 후)
+- **T8 + T9** (T4/T5/T6 완료 후)
+- **T11** (T3+T4+T5 완료 후)
 
 ---
 

--- a/docs/superpowers/specs/2026-05-05-leader-micrometer-metrics-design.md
+++ b/docs/superpowers/specs/2026-05-05-leader-micrometer-metrics-design.md
@@ -1,0 +1,489 @@
+# leader-aop Micrometer Metrics 통합 설계
+
+- **Issue**: #75 `feat: leader-aop Micrometer metrics 통합`
+- **작성일**: 2026-05-05
+- **대상 모듈**: `leader-micrometer` (신규), `leader-spring-boot3`, `leader-spring-boot4`
+- **상태**: Design (구현 전)
+
+---
+
+## 1. Background
+
+### 1.1 문제 정의
+
+현재 `leader-spring-boot-common`의 `LeaderElectionAspect`는 6개의 라이프사이클 콜백을 정의한 `LeaderAopMetricsRecorder` SPI를 통해 관측 지점을 노출하고 있다. 그러나 운영 환경에서 사용 가능한 **기본 구현체(default implementation)** 가 없어, 사용자는 자체적으로 SPI를 구현해야 메트릭을 얻을 수 있다.
+
+본 작업은 가장 보편적인 메트릭 백엔드인 **Micrometer** 기반의 `MicrometerLeaderAopMetricsRecorder`를 제공하여, Spring Boot 3/4 환경에서 별도 구현 없이 Prometheus / Datadog / CloudWatch 등으로 leader-aop 메트릭을 즉시 송출할 수 있도록 한다.
+
+### 1.2 ShedLock 비교
+
+ShedLock의 `MicrometerLockProvider` 패턴을 참고 설계 기준으로 채택하되, leader-aop가 가진 다음 강점을 반영한다.
+
+| 항목 | ShedLock | leader-aop (본 설계) |
+|---|---|---|
+| 락 획득 시도 / 성공 카운터 | O | O |
+| 락 미획득 카운터 | O (단일 카운터) | O + `reason` 태그 (CONTENTION / BACKEND_ERROR) |
+| 작업 실행 시간 Timer | O | O |
+| **작업 실패 카운터** | X | **O + `exception` 태그** |
+| **현재 활성 leader 게이지** | X | **O (`AtomicInteger` 기반)** |
+| Spring Boot AutoConfig | X (수동 등록) | **O (Boot3 + Boot4 둘 다)** |
+| 락 획득 소요 시간 | X | (옵션, v2 후보) |
+
+### 1.3 비목표 (Non-goals)
+
+- Micrometer **Observation API** / OpenTelemetry tracing 통합 → Issue #85 이후 별도 작업으로 분리
+- `LeaderElection` SPI 자체에 대한 메트릭 (락 백엔드 호출 단위 메트릭) → 본 PR은 **AOP 레이어** 만 담당
+- async / suspend / reactive 반환 타입 지원 → leader-aop v1.x 범위 외
+
+---
+
+## 2. Architecture
+
+### 2.1 모듈 배치 원칙
+
+`leader-micrometer`는 **Spring Boot 버전에 의존하지 않는다.** Boot3 / Boot4 모두 동일한 `MicrometerLeaderAopMetricsRecorder`를 사용하며, 각 Spring Boot 버전 모듈은 자신의 AutoConfiguration 안에서 동일한 시그니처의 `@Bean` 메서드 하나로 이를 등록한다.
+
+```
+leader-core
+  └── leader-spring-boot-common  (LeaderAopMetricsRecorder 인터페이스 보유)
+        ├── leader-micrometer    (MicrometerLeaderAopMetricsRecorder 구현)
+        │     ▲
+        │     │ (api dependency)
+        │     │
+        ├── leader-spring-boot3  (MicrometerAutoConfiguration → @Bean)
+        └── leader-spring-boot4  (MicrometerAutoConfiguration → @Bean)
+```
+
+### 2.2 의존 관계
+
+`leader-micrometer/build.gradle.kts` 변경 사항:
+
+```kotlin
+dependencies {
+    api(project(":leader-spring-boot-common"))         // LeaderAopMetricsRecorder 인터페이스
+    api(Libs.micrometer_core)                          // MeterRegistry, Counter, Timer, Gauge
+    // (테스트) testImplementation(Libs.micrometer_registry_prometheus 또는 SimpleMeterRegistry 포함)
+}
+```
+
+`leader-spring-boot-common`의 `LeaderAopMetricsRecorder` 인터페이스를 외부로 노출해야 하므로 `api(...)`로 선언한다.
+
+### 2.3 패키지 구조
+
+```
+io.bluetape4k.leader.micrometer
+  ├── MicrometerLeaderAopMetricsRecorder.kt      // 구현체 (단일 파일)
+  ├── MicrometerNames.kt                          // (선택) 메터/태그 이름 상수
+  └── package-info / KDoc
+
+io.bluetape4k.leader.spring.boot3.metrics
+  └── LeaderMicrometerAutoConfiguration.kt        // Boot3용 AutoConfig
+
+io.bluetape4k.leader.spring.boot4.metrics
+  └── LeaderMicrometerAutoConfiguration.kt        // Boot4용 AutoConfig (동일 시그니처)
+```
+
+---
+
+## 3. Metrics Design
+
+### 3.1 메터 일람
+
+총 **6개의 메터**를 등록한다. 모든 메터는 공통 prefix `leader.aop.*`를 사용한다.
+
+| Meter name | Type | Tags | 트리거 콜백 | 의미 |
+|---|---|---|---|---|
+| `leader.aop.attempts` | Counter | `lock.name` | `onLockAttempt` | 락 획득 시도 횟수 |
+| `leader.aop.acquired` | Counter | `lock.name` | `onLockAcquired` | 락 획득 성공 (= leader 선출) 횟수 |
+| `leader.aop.lock.not.acquired` | Counter | `lock.name`, `reason` | `onLockNotAcquired` | 미획득. `reason ∈ {CONTENTION, BACKEND_ERROR}` |
+| `leader.aop.execution.duration` | Timer | `lock.name` | `onTaskFinished` | 정상 종료된 작업의 attempt → completion 경과 시간 |
+| `leader.aop.task.failed` | Counter | `lock.name`, `exception` | `onTaskFailed` | 작업 본문에서 던진 예외 발생 횟수. `exception` = `throwable::class.simpleName` |
+| `leader.aop.active` | Gauge (`AtomicInteger`) | `lock.name` | `onTaskStarted` (+1) / `onTaskFinished` & `onTaskFailed` (-1) | 동시 실행 중인 leader 작업 수 (JVM-local) |
+
+> **`leader.aop.active`는 JVM-local 값이다.** 멀티 인스턴스 클러스터에서 Prometheus 집계 시 `sum` 대신 `max by (lock_name) (leader_aop_active)`를 사용해야 올바른 값을 얻을 수 있다. `sum`을 사용하면 인스턴스 수 × actual count가 된다.
+
+### 3.2 네이밍 근거
+
+- **Prefix `leader.aop.`** : leader-core 자체 메트릭(향후 #76 등)과 명확히 구분하기 위해 `aop` 세그먼트를 둔다.
+- **완전 dot-separated**: Micrometer의 `NamingConvention`이 백엔드별로 자동 변환(Prometheus는 `leader_aop_attempts_total`, Datadog은 `leader.aop.attempts.count` 등)하므로, **모든 세그먼트를 점(.)으로만 구분**한다. underscore 혼용 금지 — `execution_time` 대신 `execution.duration`, `lock_not_acquired` 대신 `lock.not.acquired`.
+- **`lock.name`** : ShedLock 관례(`name`)와 차별화하면서, leader-aop의 SpEL 결과 락 이름임을 명확히 한다. dot-prefix는 Micrometer 권장 태그 네이밍.
+
+### 3.3 태그 카디널리티 가이드
+
+- `lock.name`: 사용자가 SpEL로 결정. **동적 SpEL 사용 시 카디널리티 폭발 주의**가 필요. 본 모듈은 정책을 강제하지 않으며, KDoc 및 README에 경고 문구를 명시한다.
+- `reason`: enum 2개 (`CONTENTION` / `BACKEND_ERROR`) → 안전.
+- `exception`: `simpleName`만 사용 → 일반적으로 수십 개 이내, 안전.
+
+### 3.4 메터 캐싱 전략 (ShedLock 패턴 채택)
+
+콜백마다 `registry.counter(name, tags)`를 호출하면 매 호출 내부 lookup이 발생한다. 따라서 **`ConcurrentHashMap<String, Meter>` 단위 캐싱**을 적용한다.
+
+> ShedLock과 달리 우리는 콜백 시그니처에 `Duration`이 직접 전달되므로 **ThreadLocal Timer.Sample** 패턴은 불필요하다. `timer.record(executionTime)`을 직접 호출한다.
+
+```kotlin
+// 타입 별칭 — Pair는 data class이므로 equals/hashCode 정상 동작
+private typealias NotAcquiredKey = Pair<String, SkipReason>
+private typealias FailedKey      = Pair<String, String>
+
+private val attemptCounters     = ConcurrentHashMap<String, Counter>()
+private val acquiredCounters    = ConcurrentHashMap<String, Counter>()
+private val notAcquiredCounters = ConcurrentHashMap<NotAcquiredKey, Counter>()
+private val executionTimers     = ConcurrentHashMap<String, Timer>()
+private val failedCounters      = ConcurrentHashMap<FailedKey, Counter>()
+private val activeGauges        = ConcurrentHashMap<String, AtomicInteger>()
+```
+
+`computeIfAbsent`로 lazy 등록. `notAcquiredCounters`와 `failedCounters`는 `reason`/`exception` 카디널리티가 미지이므로 `registerMetricsFor`에서 사전 등록하지 않는다.
+
+### 3.5 사전 등록 (Pre-registration)
+
+ShedLock의 `registerMetricsFor(vararg names: String)` 패턴을 채택한다. 첫 호출 전까지 메트릭이 시계열 백엔드에 노출되지 않는 문제를 해결한다.
+
+```kotlin
+fun registerMetricsFor(vararg lockNames: String) {
+    lockNames.forEach { name ->
+        attemptCounters.computeIfAbsent(name) { buildCounter("leader.aop.attempts", name) }
+        acquiredCounters.computeIfAbsent(name) { buildCounter("leader.aop.acquired", name) }
+        executionTimers.computeIfAbsent(name) { buildTimer(name) }
+        activeGauges.computeIfAbsent(name) { buildActiveGauge(name) }
+        // notAcquired / failed는 reason / exception 카디널리티가 미지이므로 lazy 유지
+    }
+}
+
+// Gauge 등록 — 올바른 Micrometer 람다 패턴 (!! 금지, toDouble() 명시)
+private fun buildActiveGauge(lockName: String): AtomicInteger {
+    val counter = AtomicInteger(0)
+    Gauge.builder("leader.aop.active", counter) { it.get().toDouble() }
+         .tag("lock.name", lockName)
+         .register(registry)
+    return counter
+}
+```
+
+**`registerMetricsFor`는 멱등**해야 한다. `computeIfAbsent`가 이를 보장한다 — 동일 이름으로 두 번 호출해도 미터가 중복 등록되지 않는다.
+
+**SmartInitializingSingleton 권장**: `@PostConstruct`보다 `SmartInitializingSingleton.afterSingletonsInstantiated()` 또는 `ApplicationReadyEvent`에서 호출해야, `CompositeMeterRegistry`의 모든 delegate가 완전히 바인딩된 후 Gauge가 등록된다.
+
+**Gauge 해제 (`deregisterMetricsFor`)**: 동적 SpEL로 lock.name이 변경되거나 잡이 제거된 경우, `ConcurrentHashMap`에 남은 `AtomicInteger`와 `MeterRegistry` 내부 참조가 메모리 누수로 이어진다. 구현체는 `deregisterMetricsFor(vararg lockNames: String)` API도 제공해야 한다.
+
+```kotlin
+fun deregisterMetricsFor(vararg lockNames: String) {
+    lockNames.forEach { name ->
+        attemptCounters.remove(name)?.let { registry.remove(it) }
+        acquiredCounters.remove(name)?.let { registry.remove(it) }
+        executionTimers.remove(name)?.let { registry.remove(it) }
+        activeGauges.remove(name)?.also { gauge ->
+            registry.find("leader.aop.active").tag("lock.name", name).gauge()
+                ?.let { registry.remove(it) }
+        }
+    }
+}
+```
+
+---
+
+## 4. Implementation Design
+
+### 4.1 `MicrometerLeaderAopMetricsRecorder`
+
+```kotlin
+package io.bluetape4k.leader.micrometer
+
+import io.bluetape4k.leader.LeaderElectionOptions          // ✅ 올바른 패키지
+import io.bluetape4k.leader.spring.aop.metrics.LeaderAopMetricsRecorder
+import io.bluetape4k.leader.spring.aop.metrics.SkipReason
+import io.micrometer.core.instrument.*
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+
+class MicrometerLeaderAopMetricsRecorder(
+    private val registry: MeterRegistry,
+) : LeaderAopMetricsRecorder {
+
+    // --- caches (3.4 참조) ---
+    private val attemptCounters     = ConcurrentHashMap<String, Counter>()
+    private val acquiredCounters    = ConcurrentHashMap<String, Counter>()
+    private val notAcquiredCounters = ConcurrentHashMap<Pair<String, SkipReason>, Counter>()
+    private val executionTimers     = ConcurrentHashMap<String, Timer>()
+    private val failedCounters      = ConcurrentHashMap<Pair<String, String>, Counter>()
+    private val activeGauges        = ConcurrentHashMap<String, AtomicInteger>()
+
+    // --- callbacks ---
+    override fun onLockAttempt(name: String, options: LeaderElectionOptions) {
+        attemptCounter(name).increment()
+    }
+
+    override fun onLockAcquired(name: String, options: LeaderElectionOptions, acquireElapsed: Duration) {
+        acquiredCounter(name).increment()
+        // (옵션 v2) acquireTimer(name).record(acquireElapsed.toJavaDuration())
+    }
+
+    override fun onLockNotAcquired(name: String, options: LeaderElectionOptions, reason: SkipReason) {
+        notAcquiredCounter(name, reason).increment()
+    }
+
+    override fun onTaskStarted(name: String) {
+        activeGauge(name).incrementAndGet()
+    }
+
+    override fun onTaskFinished(name: String, executionTime: Duration) {
+        try {
+            executionTimer(name).record(executionTime.toJavaDuration())
+        } finally {
+            activeGauge(name).decrementAndGet()
+        }
+    }
+
+    override fun onTaskFailed(name: String, executionTime: Duration, throwable: Throwable) {
+        try {
+            failedCounter(name, throwable::class.simpleName ?: "Unknown").increment()
+        } finally {
+            // ⚠️ onTaskFailed는 onTaskStarted 없이도 호출될 수 있다 (backend error path).
+            // decrementAndGet() 전에 현재 값이 0보다 큰지 확인해 음수 방지.
+            activeGauge(name).updateAndGet { if (it > 0) it - 1 else 0 }
+        }
+    }
+
+    // NOTE: onTaskFailed에서 executionTime을 execution.duration 타이머에 기록하지 않는다 (의도적).
+    // 실패한 실행의 소요 시간은 task.failed counter의 exception 태그로 분류한다.
+    // 실패 latency 분석이 필요한 경우 v2에서 outcome 태그 추가를 검토한다.
+
+    // --- pre-registration ---
+    fun registerMetricsFor(vararg lockNames: String) { /* 3.5 참조 */ }
+
+    // --- private helpers (computeIfAbsent + Counter/Timer/Gauge 등록) ---
+}
+```
+
+### 4.2 격리(Isolation) 보장
+
+`LeaderElectionAspect`는 metrics recorder의 throw가 본 작업 흐름에 영향을 주지 않도록 **try/catch로 감싸서 호출**해야 한다. (이는 기존 aspect 동작이 이미 그러하다고 가정하나, 본 spec 검토 시 확인하고 필요 시 보강한다.)
+
+본 구현체 자체는 **throw를 발생시키지 않는다** — `Micrometer`의 `Counter.increment()` 등이 internal exception을 던질 가능성은 무시 가능 수준.
+
+### 4.3 Spring Boot AutoConfiguration
+
+#### 4.3.1 Boot3 / Boot4 공통 시그니처
+
+```kotlin
+@AutoConfiguration
+@ConditionalOnClass(name = ["io.micrometer.core.instrument.MeterRegistry"])
+@ConditionalOnProperty(prefix = "bluetape4k.leader.aop.metrics", name = ["enabled"], havingValue = "true", matchIfMissing = true)
+class LeaderMicrometerAutoConfiguration {
+
+    @Bean
+    @ConditionalOnBean(MeterRegistry::class)
+    @ConditionalOnMissingBean(MicrometerLeaderAopMetricsRecorder::class)
+    fun micrometerLeaderAopMetricsRecorder(
+        registry: MeterRegistry,
+    ): LeaderAopMetricsRecorder = MicrometerLeaderAopMetricsRecorder(registry)
+}
+```
+
+> 메모리 규칙(`feedback_conditional_on_property_all_phases.md`)에 따라 `@ConditionalOnProperty`는 모든 Phase에 적용한다.
+
+#### 4.3.2 AutoConfig 등록 순서
+
+`LeaderAopAutoConfiguration`보다 **먼저** 등록되어야, Aspect가 recorder 빈을 `ObjectProvider`로 주입받을 수 있다. `LeaderAopFactoryAutoConfiguration`과는 의존 관계 없으므로 Factory 이후에 놓아도 된다.
+
+올바른 순서:
+```
+META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+  ...
+  io.bluetape4k.leader.spring.boot3.aop.LeaderAopFactoryAutoConfiguration
+  io.bluetape4k.leader.spring.boot3.metrics.LeaderMicrometerAutoConfiguration   ← Factory 이후, AOP 이전
+  io.bluetape4k.leader.spring.boot3.aop.LeaderAopAutoConfiguration
+```
+
+`@AutoConfigureBefore(LeaderAopAutoConfiguration::class)` + `@AutoConfigureAfter(LeaderAopFactoryAutoConfiguration::class)` 함께 명시(이중 안전).
+
+> **이전 spec 오류 수정**: Micrometer 설정을 Factory보다 앞에 놓을 이유가 없다. Recorder 빈은 Factory 빈에 의존하지 않으므로, 올바른 제약은 "AOP보다 앞" 뿐이다.
+
+#### 4.3.3 Boot3 vs Boot4 차이
+
+코드 레벨로는 **identical**. 패키지만 `boot3` ↔ `boot4`로 다름. 의존하는 Spring Boot 버전 차이로 인해 컴파일 시 분리가 필요할 뿐이다.
+
+### 4.4 HealthIndicator 연동 (Boot 3 only, 본 PR 범위)
+
+> ⛔ **`leader-spring-boot-common`의 `LeaderAopHealthIndicator`는 수정하지 않는다.**  
+> `leader-spring-boot-common`에 `MeterRegistry` 의존을 추가하면 Micrometer가 없는 환경에서 `ClassNotFoundException`이 발생하고, 모듈 경계(`leader-spring-boot-common`은 SPI만 포함)를 위반한다.
+
+대신, **`leader-spring-boot3`** 내에서 `MicrometerLeaderAopMetricsRecorder` 빈이 존재할 때 `LeaderAopHealthIndicator`를 교체 혹은 보완하는 별도 `HealthContributor` 빈을 등록한다.
+
+```kotlin
+// leader-spring-boot3/.../metrics/LeaderMicrometerAutoConfiguration.kt 내부 추가 @Bean
+@Bean
+@ConditionalOnBean(MeterRegistry::class, MicrometerLeaderAopMetricsRecorder::class)
+@ConditionalOnClass(name = ["org.springframework.boot.actuate.health.HealthContributor"])
+fun leaderMicrometerHealthContributor(registry: MeterRegistry): HealthIndicator {
+    return HealthIndicator {
+        val counters = registry.find("leader.aop.attempts").counters()
+        val attempts = counters.sumOf { it.count() }
+        Health.up()
+            .withDetail("attempts.total", attempts)
+            .withDetail("metrics.registered", counters.isNotEmpty())
+            .build()
+    }
+}
+```
+
+`counters.isEmpty()` (아직 attempts 없음) 상태도 `UP`으로 반환하되 `metrics.registered = false`로 명확히 구분한다.
+
+Boot4 HealthIndicator 연동은 본 PR 범위 외.
+
+---
+
+## 5. Out of Scope
+
+| 항목 | 처리 |
+|---|---|
+| Micrometer Observation API / Tracing span | Issue #85 이후 별도 PR |
+| `leader.aop.acquire_time` Timer (acquireElapsed) | v2 후보로 KDoc에만 표시 |
+| Boot4 HealthIndicator 메트릭 노출 | 본 PR 범위 외 |
+| async / suspend / reactive 반환 메트릭 | leader-aop v2 |
+| Tag 카디널리티 자동 보호(allow-list) | v2 후보 |
+
+---
+
+## 6. Test Plan
+
+### 6.1 단위 테스트 (`leader-micrometer/src/test`)
+
+`SimpleMeterRegistry`를 사용하여 의존성 없이 검증.
+
+```kotlin
+class MicrometerLeaderAopMetricsRecorderTest {
+    private lateinit var registry: SimpleMeterRegistry
+    private lateinit var recorder: MicrometerLeaderAopMetricsRecorder
+
+    @BeforeEach fun setup() { ... }
+
+    // ✅ 모든 assertion은 tag("lock.name", "test-lock")을 명시적으로 포함해야 함
+    // 예: registry.get("leader.aop.attempts").tag("lock.name", "test-lock").counter().count()
+
+    @Test fun `onLockAttempt - attempts counter with lock name tag increments`() { ... }
+    @Test fun `onLockAcquired - acquired counter with lock name tag increments`() { ... }
+    @Test fun `onLockNotAcquired CONTENTION - reason tag equals CONTENTION`() { ... }
+    @Test fun `onLockNotAcquired BACKEND_ERROR - reason tag equals BACKEND_ERROR`() { ... }
+    @Test fun `onTaskFinished - execution duration timer count increments`() { ... }
+    @Test fun `onTaskFailed - task failed counter with exception tag`() { ... }
+    @Test fun `onTaskFailed without prior onTaskStarted - active gauge stays non-negative`() { ... }  // backend error path
+    @Test fun `onTaskStarted - active gauge becomes 1`() { ... }   // 중간 상태 검증
+    @Test fun `onTaskStarted then onTaskFinished - active gauge returns to 0`() { ... }
+    @Test fun `onTaskStarted then onTaskFailed - active gauge returns to 0`() { ... }
+    @Test fun `registerMetricsFor - meters appear before first callback`() { ... }
+    @Test fun `registerMetricsFor - idempotent second call does not duplicate meters`() { ... }  // ✅ mandatory
+    @Test fun `concurrent onTaskStarted and onTaskFinished - active gauge thread safe`() { ... }  // ✅ mandatory (not optional)
+    @Test fun `deregisterMetricsFor - removes meters from registry`() { ... }
+    // MeterRegistry 미존재 → recorder 빈 미등록 → Boot3/Boot4 AutoConfig 테스트에서 검증
+}
+```
+
+### 6.2 Boot3 통합 테스트 (`leader-spring-boot3`)
+
+```kotlin
+@SpringBootTest(classes = [TestApp::class])
+class LeaderMicrometerAutoConfigurationBoot3Test {
+    @Test fun `MeterRegistry 빈 존재 시 MicrometerLeaderAopMetricsRecorder 자동 등록`() { ... }
+    @Test fun `MeterRegistry 빈 없을 때 recorder 빈 미등록`() { ... }   // ✅ @ConditionalOnBean 검증
+    @Test fun `enabled=false 시 빈 미등록`() { ... }
+    @Test fun `사용자 정의 LeaderAopMetricsRecorder가 우선`() { ... }   // @ConditionalOnMissingBean 검증
+    // E2E: 전체 happy-path 검증 — attempts, acquired, execution.duration, active 모두 assert
+    @Test fun `LeaderElectionAspect 통과 시 attempts+acquired+timer 전체 검증`() { ... }
+    // E2E: backend error path
+    @Test fun `backend 예외 시 lock.not.acquired reason=BACKEND_ERROR 증가`() { ... }
+}
+```
+
+### 6.3 Boot4 통합 테스트 (`leader-spring-boot4`)
+
+Boot3과 동일 시나리오. 패키지/AutoConfig 클래스만 다름.
+
+### 6.4 커버리지 목표
+
+- `leader-micrometer`: **80%** 이상 (단순 모듈, 분기 적음)
+- `leader-spring-boot3/4`의 `LeaderMicrometerAutoConfiguration`: 메모리 규칙 (`feedback_kover_unit_test_only_threshold.md`)에 따라 통합 모듈 기준 **60%**
+
+---
+
+## 7. DoD Checklist
+
+이슈 #75 DoD 중 본 PR에 포함되는 항목:
+
+- [ ] `leader-micrometer/build.gradle.kts`에서 기존 `api(project(":leader-core"))` → `api(project(":leader-spring-boot-common"))`로 **교체** (`leader-core`는 `leader-spring-boot-common`의 transitive dep으로 충분)
+- [ ] `MicrometerLeaderAopMetricsRecorder` 구현 (6 콜백 + `registerMetricsFor` + `deregisterMetricsFor`)
+- [ ] `ConcurrentHashMap` 기반 메터 캐싱 적용
+- [ ] `leader-spring-boot3`에 `LeaderMicrometerAutoConfiguration` + `AutoConfiguration.imports` 등록
+- [ ] `leader-spring-boot4`에 동일 등록
+- [ ] AutoConfig 순서: `LeaderAopFactoryAutoConfiguration` → `LeaderMicrometerAutoConfiguration` → `LeaderAopAutoConfiguration`
+- [ ] `@ConditionalOnProperty(... matchIfMissing = true)` (기본 활성)
+- [ ] 단위 테스트 (SimpleMeterRegistry 기반) — 6 콜백 + 사전 등록 + isolation
+- [ ] Boot3 / Boot4 통합 테스트 — AutoConfig + ConditionalOnMissingBean + E2E
+- [ ] Kover 커버리지 통과 (`leader-micrometer` 80%, AutoConfig 60%)
+- [ ] `leader-micrometer/README.md` + `README.ko.md` 작성 (메터 표 + 사용 예시 + 카디널리티 경고)
+- [ ] 모든 public API에 KDoc
+- [ ] 6중 코드 리뷰 (CRITICAL/HIGH 0)
+
+**제외(Deferred):**
+- [ ] ~~Micrometer Observation API / Tracing span~~ → #85 이후
+- [ ] ~~`leader.aop.acquire_time` Timer~~ → v2
+
+---
+
+## 8. Files to Create / Modify
+
+### 8.1 생성 (Create)
+
+| 경로 | 내용 |
+|---|---|
+| `leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerLeaderAopMetricsRecorder.kt` | 핵심 구현체 |
+| `leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerNames.kt` | (선택) 메터/태그 이름 상수 |
+| `leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/MicrometerLeaderAopMetricsRecorderTest.kt` | 단위 테스트 |
+| `leader-micrometer/src/test/resources/junit-platform.properties` | PER_CLASS + parallel=false (메모리 규칙) |
+| `leader-micrometer/README.md` | 영문 사용 가이드 |
+| `leader-micrometer/README.ko.md` | 한글 사용 가이드 |
+| `leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/metrics/LeaderMicrometerAutoConfiguration.kt` | Boot3 AutoConfig |
+| `leader-spring-boot4/src/main/kotlin/io/bluetape4k/leader/spring/boot4/metrics/LeaderMicrometerAutoConfiguration.kt` | Boot4 AutoConfig (시그니처 동일) |
+| `leader-spring-boot3/src/test/kotlin/.../LeaderMicrometerAutoConfigurationBoot3Test.kt` | Boot3 통합 테스트 |
+| `leader-spring-boot4/src/test/kotlin/.../LeaderMicrometerAutoConfigurationBoot4Test.kt` | Boot4 통합 테스트 |
+
+### 8.2 수정 (Modify)
+
+| 경로 | 변경 |
+|---|---|
+| `leader-micrometer/build.gradle.kts` | `api(project(":leader-core"))` → `api(project(":leader-spring-boot-common"))`로 **교체** |
+| `leader-spring-boot3/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` | `LeaderMicrometerAutoConfiguration`을 `LeaderAopFactoryAutoConfiguration` 뒤, `LeaderAopAutoConfiguration` 앞에 추가 |
+| `leader-spring-boot4/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` | 동일 |
+| `leader-bom/build.gradle.kts` | **변경 불필요** — `leader-micrometer`는 이미 BOM에 등록되어 있음 (`api(project(":leader-micrometer"))` 확인됨) |
+
+### 8.3 검증 (Verify only — 변경 없을 가능성)
+
+- `leader-spring-boot-common/.../LeaderAopMetricsRecorder.kt` — 인터페이스가 본 spec의 시그니처와 일치하는지 (특히 `onLockNotAcquired`의 `SkipReason` 파라미터 존재 여부)
+- `leader-spring-boot-common/.../LeaderElectionAspect.kt` — recorder 호출이 try/catch로 격리되어 있는지
+
+---
+
+## 9. Risks & Mitigations
+
+| Risk | 영향 | 완화책 |
+|---|---|---|
+| `lock.name` 카디널리티 폭발 (동적 SpEL 남용) | TSDB 메모리 / 비용 폭증 | README 경고 + KDoc 명시 + 신규 lock.name 등록 시 `log.warn` 출력. v2에서 allow-list 검토 |
+| `exception` 태그 카디널리티 (anonymous class 등) | 동일 | `simpleName` 사용. `null` → `"Unknown"`로 정규화 |
+| Gauge 메모리 누수 (동적 lock.name 미해제) | 메모리 누수 / TSDB 비용 | `deregisterMetricsFor` API 제공. KDoc 및 README에 동적 SpEL 사용 시 반드시 호출하도록 명시 |
+| `leader.aop.active` JVM-local → multi-instance 오해 | 잘못된 대시보드 집계 | KDoc + README에 `max by (lock_name)` 권장 PromQL 예시 명시 |
+| Micrometer 미존재 환경에서 ClassLoading 실패 | AutoConfig 실패 | `@ConditionalOnClass(name = [...])`로 보호 |
+| 사용자 정의 recorder 무시 | 기능 손상 | `@ConditionalOnMissingBean`으로 우선권 보장 |
+| `onTaskFailed` 음수 active gauge | 게이지 영구 음수 | `updateAndGet { if (it > 0) it - 1 else 0 }` 패턴 적용 |
+| Boot3/Boot4 AutoConfig 코드 중복 | 유지보수 부담 | 시그니처 동일 → 변경 시 두 파일 동시 패치 |
+
+---
+
+## 10. Future Work (post-#75)
+
+1. **#85 Observation API 통합** — `MicrometerObservationLeaderAopMetricsRecorder` 추가, OpenTelemetry trace 연계
+2. `leader.aop.acquire_time` Timer 추가 (`acquireElapsed` 활용)
+3. Tag allow-list / cardinality limiter 옵션
+4. Boot4 HealthIndicator 메트릭 노출
+5. `leader-core` SPI 자체에 대한 백엔드 단위 메트릭 (Redis 호출 latency 등)

--- a/leader-micrometer/build.gradle.kts
+++ b/leader-micrometer/build.gradle.kts
@@ -1,9 +1,21 @@
+kover {
+    reports {
+        verify {
+            rule {
+                bound {
+                    minValue = 80
+                }
+            }
+        }
+    }
+}
+
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }
 
 dependencies {
-    api(project(":leader-core"))
+    api(project(":leader-spring-boot-common"))
     api(libs.micrometer.core)
 
     testImplementation(libs.bluetape4k.junit5)

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerLeaderAopMetricsRecorder.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerLeaderAopMetricsRecorder.kt
@@ -1,0 +1,229 @@
+package io.bluetape4k.leader.micrometer
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.spring.aop.metrics.LeaderAopMetricsRecorder
+import io.bluetape4k.leader.spring.aop.metrics.SkipReason
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+
+private typealias NotAcquiredKey = Pair<String, SkipReason>
+private typealias FailedKey = Pair<String, String>
+
+/**
+ * [LeaderAopMetricsRecorder] Micrometer 기반 구현체.
+ *
+ * leader-aop 의 6 개 콜백을 Micrometer Counter/Timer/Gauge 로 매핑하여 Prometheus, Datadog 등
+ * 임의의 백엔드로 export 할 수 있도록 한다.
+ *
+ * ## 메터 카탈로그
+ *
+ * | 메터 이름 (`MicrometerNames.*`)              | 타입    | 콜백              |
+ * |--------------------------------------------|--------|------------------|
+ * | `leader.aop.attempts`                      | Counter | onLockAttempt    |
+ * | `leader.aop.acquired`                      | Counter | onLockAcquired   |
+ * | `leader.aop.lock.not.acquired`             | Counter | onLockNotAcquired |
+ * | `leader.aop.execution.duration`            | Timer   | onTaskFinished   |
+ * | `leader.aop.task.failed`                   | Counter | onTaskFailed     |
+ * | `leader.aop.active`                        | Gauge   | onTaskStarted/Finished/Failed |
+ *
+ * 모든 메터는 `lock.name` 태그를 공유하며, `not.acquired` 는 `reason`, `task.failed` 는 `exception` 태그를 추가로 가진다.
+ * 메터/태그 이름 상수는 [MicrometerNames] 참조.
+ *
+ * ## 카디널리티 경고
+ *
+ * `lock.name` 은 [io.bluetape4k.leader.spring.LeaderElection.name] SpEL 결과 그대로 태그가 된다.
+ * 동적 SpEL (`'tenant-' + #tenantId`) 을 그대로 노출하면 메터 인스턴스가 무한 증식해 백엔드를 고사시킬 수 있다.
+ * 첫 등록 시 한 번 WARN 로그를 남기지만 — 정적 화이트리스트 사용을 권장한다.
+ *
+ * ## 멀티 인스턴스 환경
+ *
+ * `leader.aop.active` Gauge 는 **JVM-local** 값이다. Prometheus 에서 클러스터 전체 leader 수를 보려면
+ * `sum` 이 아니라 `max by (lock_name) (leader_aop_active)` 를 사용해야 한다 — leader 가 1 명이어도
+ * 모든 인스턴스 합산 시 N 으로 보이는 함정을 피한다.
+ *
+ * ## 사전/사후 등록
+ *
+ * - [registerMetricsFor] : 정적 lock 이름들을 부트 시점에 등록 → 첫 호출 전에도 dashboard 에 0 이 표시됨.
+ *   `SmartInitializingSingleton` 과 함께 사용 권장.
+ * - [deregisterMetricsFor] : 동적 SpEL 로 생성된 더 이상 사용하지 않는 lock 이름의 메터를 회수 →
+ *   `MeterRegistry` 메모리 누수 방지.
+ *
+ * @see MicrometerNames
+ * @see LeaderAopMetricsRecorder
+ */
+class MicrometerLeaderAopMetricsRecorder(
+    private val registry: MeterRegistry,
+): LeaderAopMetricsRecorder {
+
+    companion object: KLogging()
+
+    private val attemptCounters = ConcurrentHashMap<String, Counter>()
+    private val acquiredCounters = ConcurrentHashMap<String, Counter>()
+    private val notAcquiredCounters = ConcurrentHashMap<NotAcquiredKey, Counter>()
+    private val executionTimers = ConcurrentHashMap<String, Timer>()
+    private val failedCounters = ConcurrentHashMap<FailedKey, Counter>()
+    private val activeGauges = ConcurrentHashMap<String, AtomicInteger>()
+
+    override fun onLockAttempt(name: String, options: LeaderElectionOptions) {
+        attemptCounter(name).increment()
+    }
+
+    override fun onLockAcquired(name: String, options: LeaderElectionOptions, acquireElapsed: Duration) {
+        // acquireElapsed → v2 후보 (leader.aop.acquire.duration)
+        acquiredCounter(name).increment()
+    }
+
+    override fun onLockNotAcquired(name: String, options: LeaderElectionOptions, reason: SkipReason) {
+        notAcquiredCounter(name, reason).increment()
+    }
+
+    override fun onTaskStarted(name: String) {
+        activeGauge(name).incrementAndGet()
+    }
+
+    override fun onTaskFinished(name: String, executionTime: Duration) {
+        try {
+            executionTimer(name).record(executionTime.toJavaDuration())
+        } finally {
+            activeGauge(name).decrementAndGet()
+        }
+    }
+
+    override fun onTaskFailed(name: String, executionTime: Duration, throwable: Throwable) {
+        try {
+            failedCounter(name, throwable::class.simpleName ?: MicrometerNames.UNKNOWN_EXCEPTION).increment()
+        } finally {
+            // onTaskFailed 는 onTaskStarted 없이도 호출될 수 있다 (backend error path).
+            // decrementAndGet 전에 값이 0 보다 큰지 확인해 음수 방지.
+            activeGauge(name).updateAndGet { if (it > 0) it - 1 else 0 }
+        }
+    }
+
+    /**
+     * 정적으로 알려진 lock 이름들의 메터를 미리 등록한다.
+     *
+     * 첫 콜백 발생 전에도 dashboard 에 0 값이 표시되도록 하기 위함이다 — Prometheus 의 `rate()` 함수는
+     * 시리즈가 존재하지 않는 구간을 NaN 으로 표시하므로 사전 등록이 운영상 유리하다.
+     *
+     * **멱등 (idempotent)** : 이미 등록된 lock 이름은 재등록되지 않는다 (`computeIfAbsent` 사용).
+     *
+     * **사전 등록 대상** :
+     * - `leader.aop.attempts` Counter
+     * - `leader.aop.acquired` Counter
+     * - `leader.aop.execution.duration` Timer
+     * - `leader.aop.active` Gauge
+     *
+     * **사전 등록 제외** :
+     * - `leader.aop.lock.not.acquired` — `reason` 태그 카디널리티가 미지 (호출 전엔 어떤 reason 이 발생할지 알 수 없음)
+     * - `leader.aop.task.failed` — `exception` 태그 카디널리티가 미지 (예외 클래스 사전 예측 불가)
+     *
+     * 이 함수는 카디널리티 WARN 로그를 발생시키지 않는다 — 사전 등록된 정적 lock 이름이 WARN 을 유발하면
+     * 운영 시 발생하는 진짜 동적 SpEL WARN 신호의 의미가 퇴색되기 때문이다.
+     *
+     * `SmartInitializingSingleton` 또는 `ApplicationReadyEvent` 리스너에서 호출하기를 권장한다.
+     */
+    fun registerMetricsFor(vararg lockNames: String) {
+        lockNames.forEach { name ->
+            // attemptCounter 헬퍼를 통하지 않고 직접 computeIfAbsent — 카디널리티 WARN 회피 의도.
+            attemptCounters.computeIfAbsent(name) { buildAttemptCounter(it) }
+            acquiredCounters.computeIfAbsent(name) { buildAcquiredCounter(it) }
+            executionTimers.computeIfAbsent(name) { buildExecutionTimer(it) }
+            activeGauges.computeIfAbsent(name) { buildActiveGauge(it) }
+            // notAcquiredCounters / failedCounters : reason/exception 카디널리티 미지 → lazy 유지.
+        }
+    }
+
+    /**
+     * 더 이상 사용하지 않는 lock 이름의 메터를 [MeterRegistry] 에서 제거한다.
+     *
+     * 동적 SpEL (`'tenant-' + #tenantId`) 로 생성된 lock 이름이나 은퇴한 잡의 lock 이름을 정리해
+     * `MeterRegistry` 의 메모리 누수와 시계열 백엔드의 카디널리티 폭증을 방지한다.
+     *
+     * **정리 대상** : 해당 `lockName` 으로 등록된 모든 6 종 메터 (Counter/Timer/Gauge) +
+     * `notAcquired` 의 모든 reason 변종, `failed` 의 모든 exception 변종.
+     *
+     * 호출 후 동일 lock 이름으로 콜백이 다시 발생하면 메터는 자동 재생성된다 (이때는 카디널리티 WARN 발생).
+     */
+    fun deregisterMetricsFor(vararg lockNames: String) {
+        lockNames.forEach { name ->
+            attemptCounters.remove(name)?.let { registry.remove(it) }
+            acquiredCounters.remove(name)?.let { registry.remove(it) }
+            executionTimers.remove(name)?.let { registry.remove(it) }
+            activeGauges.remove(name)?.also {
+                registry.find(MicrometerNames.METER_ACTIVE)
+                    .tag(MicrometerNames.TAG_LOCK_NAME, name)
+                    .gauge()
+                    ?.let { gauge -> registry.remove(gauge) }
+            }
+            notAcquiredCounters.keys.filter { it.first == name }.forEach { key ->
+                notAcquiredCounters.remove(key)?.let { registry.remove(it) }
+            }
+            failedCounters.keys.filter { it.first == name }.forEach { key ->
+                failedCounters.remove(key)?.let { registry.remove(it) }
+            }
+        }
+    }
+
+    // 카디널리티 WARN 은 여기에서만 발생 — registerMetricsFor 는 의도적으로 우회한다.
+    private fun attemptCounter(name: String): Counter =
+        attemptCounters.computeIfAbsent(name) {
+            log.warn { "leader-micrometer: new lock.name='$name' registered — beware tag cardinality if using dynamic SpEL" }
+            buildAttemptCounter(name)
+        }
+
+    private fun acquiredCounter(name: String): Counter =
+        acquiredCounters.computeIfAbsent(name) { buildAcquiredCounter(it) }
+
+    private fun notAcquiredCounter(name: String, reason: SkipReason): Counter =
+        notAcquiredCounters.computeIfAbsent(name to reason) { (n, r) ->
+            Counter.builder(MicrometerNames.METER_NOT_ACQUIRED)
+                .tag(MicrometerNames.TAG_LOCK_NAME, n)
+                .tag(MicrometerNames.TAG_REASON, r.name)
+                .register(registry)
+        }
+
+    private fun executionTimer(name: String): Timer =
+        executionTimers.computeIfAbsent(name) { buildExecutionTimer(it) }
+
+    private fun failedCounter(name: String, exceptionName: String): Counter =
+        failedCounters.computeIfAbsent(name to exceptionName) { (n, e) ->
+            Counter.builder(MicrometerNames.METER_TASK_FAILED)
+                .tag(MicrometerNames.TAG_LOCK_NAME, n)
+                .tag(MicrometerNames.TAG_EXCEPTION, e)
+                .register(registry)
+        }
+
+    private fun activeGauge(name: String): AtomicInteger =
+        activeGauges.computeIfAbsent(name) { buildActiveGauge(it) }
+
+    private fun buildAttemptCounter(name: String): Counter =
+        Counter.builder(MicrometerNames.METER_ATTEMPTS)
+            .tag(MicrometerNames.TAG_LOCK_NAME, name)
+            .register(registry)
+
+    private fun buildAcquiredCounter(name: String): Counter =
+        Counter.builder(MicrometerNames.METER_ACQUIRED)
+            .tag(MicrometerNames.TAG_LOCK_NAME, name)
+            .register(registry)
+
+    private fun buildExecutionTimer(name: String): Timer =
+        Timer.builder(MicrometerNames.METER_EXECUTION_DURATION)
+            .tag(MicrometerNames.TAG_LOCK_NAME, name)
+            .register(registry)
+
+    private fun buildActiveGauge(name: String): AtomicInteger {
+        val counter = AtomicInteger(0)
+        Gauge.builder(MicrometerNames.METER_ACTIVE, counter) { it.get().toDouble() }
+            .tag(MicrometerNames.TAG_LOCK_NAME, name)
+            .register(registry)
+        return counter
+    }
+}

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerNames.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerNames.kt
@@ -1,0 +1,52 @@
+package io.bluetape4k.leader.micrometer
+
+/**
+ * leader-aop Micrometer 메터/태그 이름 상수.
+ *
+ * 모든 메터 이름은 `leader.aop.` prefix를 공유한다.
+ * Micrometer의 [io.micrometer.core.instrument.config.NamingConvention]이 백엔드별로 자동 변환한다
+ * (Prometheus: `leader_aop_attempts_total`, Datadog: `leader.aop.attempts.count` 등).
+ */
+internal object MicrometerNames {
+
+    // --- Meter names ---
+
+    /** 락 획득 시도 횟수 Counter. */
+    const val METER_ATTEMPTS = "leader.aop.attempts"
+
+    /** 락 획득 성공(leader 선출) Counter. */
+    const val METER_ACQUIRED = "leader.aop.acquired"
+
+    /** 락 미획득 Counter. [TAG_REASON] 태그로 사유 구분. */
+    const val METER_NOT_ACQUIRED = "leader.aop.lock.not.acquired"
+
+    /** 정상 완료된 작업의 실행 시간 Timer. */
+    const val METER_EXECUTION_DURATION = "leader.aop.execution.duration"
+
+    /** 작업 본문 예외 발생 Counter. [TAG_EXCEPTION] 태그로 예외 유형 구분. */
+    const val METER_TASK_FAILED = "leader.aop.task.failed"
+
+    /**
+     * 현재 실행 중인 leader 작업 수 Gauge.
+     *
+     * **JVM-local 값** — 멀티 인스턴스 클러스터에서 Prometheus 집계 시
+     * `sum` 대신 `max by (lock_name) (leader_aop_active)` 사용을 권장한다.
+     */
+    const val METER_ACTIVE = "leader.aop.active"
+
+    // --- Tag keys ---
+
+    /** SpEL로 결정된 락 이름 태그. */
+    const val TAG_LOCK_NAME = "lock.name"
+
+    /** 락 미획득 사유 태그 (`CONTENTION` / `BACKEND_ERROR`). */
+    const val TAG_REASON = "reason"
+
+    /** 작업 실패 예외 유형 태그 (`throwable::class.simpleName`). */
+    const val TAG_EXCEPTION = "exception"
+
+    // --- Sentinel values ---
+
+    /** 익명 클래스 등 `simpleName == null` 인 경우 [TAG_EXCEPTION] 태그 대체값. */
+    const val UNKNOWN_EXCEPTION = "Unknown"
+}

--- a/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/MicrometerLeaderAopMetricsRecorderTest.kt
+++ b/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/MicrometerLeaderAopMetricsRecorderTest.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeGreaterOrEqualTo
 import org.amshove.kluent.shouldBeNull
-import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -115,7 +114,7 @@ class MicrometerLeaderAopMetricsRecorderTest {
             .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
             .gauge()?.value() ?: 0.0
 
-        (gaugeValue >= 0.0).shouldBeTrue()
+        gaugeValue shouldBeGreaterOrEqualTo 0.0
         gaugeValue shouldBeEqualTo 0.0
     }
 

--- a/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/MicrometerLeaderAopMetricsRecorderTest.kt
+++ b/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/MicrometerLeaderAopMetricsRecorderTest.kt
@@ -1,0 +1,229 @@
+package io.bluetape4k.leader.micrometer
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.spring.aop.metrics.SkipReason
+import io.bluetape4k.logging.KLogging
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.milliseconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MicrometerLeaderAopMetricsRecorderTest {
+
+    companion object : KLogging()
+
+    private lateinit var registry: SimpleMeterRegistry
+    private lateinit var recorder: MicrometerLeaderAopMetricsRecorder
+
+    private val lockName = "test-lock"
+    private val defaultOptions = LeaderElectionOptions.Default
+
+    @BeforeEach
+    fun setup() {
+        registry = SimpleMeterRegistry()
+        recorder = MicrometerLeaderAopMetricsRecorder(registry)
+    }
+
+    @Test
+    fun `onLockAttempt - attempts counter with lock name tag increments`() {
+        recorder.onLockAttempt(lockName, defaultOptions)
+        recorder.onLockAttempt(lockName, defaultOptions)
+
+        val count = registry.get(MicrometerNames.METER_ATTEMPTS)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .counter().count()
+
+        count shouldBeEqualTo 2.0
+    }
+
+    @Test
+    fun `onLockAcquired - acquired counter with lock name tag increments`() {
+        recorder.onLockAcquired(lockName, defaultOptions, 10.milliseconds)
+
+        val count = registry.get(MicrometerNames.METER_ACQUIRED)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .counter().count()
+
+        count shouldBeEqualTo 1.0
+    }
+
+    @Test
+    fun `onLockNotAcquired CONTENTION - reason tag equals CONTENTION`() {
+        recorder.onLockNotAcquired(lockName, defaultOptions, SkipReason.CONTENTION)
+
+        val count = registry.get(MicrometerNames.METER_NOT_ACQUIRED)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .tag(MicrometerNames.TAG_REASON, SkipReason.CONTENTION.name)
+            .counter().count()
+
+        count shouldBeEqualTo 1.0
+    }
+
+    @Test
+    fun `onLockNotAcquired BACKEND_ERROR - reason tag equals BACKEND_ERROR`() {
+        recorder.onLockNotAcquired(lockName, defaultOptions, SkipReason.BACKEND_ERROR)
+
+        val count = registry.get(MicrometerNames.METER_NOT_ACQUIRED)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .tag(MicrometerNames.TAG_REASON, SkipReason.BACKEND_ERROR.name)
+            .counter().count()
+
+        count shouldBeEqualTo 1.0
+    }
+
+    @Test
+    fun `onTaskFinished - execution duration timer count increments`() {
+        recorder.onTaskStarted(lockName)
+        recorder.onTaskFinished(lockName, 100.milliseconds)
+
+        val timerCount = registry.get(MicrometerNames.METER_EXECUTION_DURATION)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .timer().count()
+
+        timerCount shouldBeGreaterOrEqualTo 1L
+    }
+
+    @Test
+    fun `onTaskFailed - task failed counter with exception tag`() {
+        recorder.onTaskFailed(lockName, 50.milliseconds, IllegalStateException("test"))
+
+        val count = registry.get(MicrometerNames.METER_TASK_FAILED)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .tag(MicrometerNames.TAG_EXCEPTION, "IllegalStateException")
+            .counter().count()
+
+        count shouldBeEqualTo 1.0
+    }
+
+    @Test
+    fun `onTaskFailed without prior onTaskStarted - active gauge stays non-negative`() {
+        // backend error path: onTaskFailed가 onTaskStarted 없이 호출될 수 있다
+        recorder.onTaskFailed(lockName, 0.milliseconds, RuntimeException("backend error"))
+
+        val gaugeValue = registry.find(MicrometerNames.METER_ACTIVE)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .gauge()?.value() ?: 0.0
+
+        (gaugeValue >= 0.0).shouldBeTrue()
+        gaugeValue shouldBeEqualTo 0.0
+    }
+
+    @Test
+    fun `onTaskStarted - active gauge becomes 1`() {
+        recorder.onTaskStarted(lockName)
+
+        val gaugeValue = registry.find(MicrometerNames.METER_ACTIVE)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .gauge()?.value() ?: 0.0
+
+        gaugeValue shouldBeEqualTo 1.0
+    }
+
+    @Test
+    fun `onTaskStarted then onTaskFinished - active gauge returns to 0`() {
+        recorder.onTaskStarted(lockName)
+        recorder.onTaskFinished(lockName, 100.milliseconds)
+
+        val gaugeValue = registry.find(MicrometerNames.METER_ACTIVE)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .gauge()?.value() ?: 0.0
+
+        gaugeValue shouldBeEqualTo 0.0
+    }
+
+    @Test
+    fun `onTaskStarted then onTaskFailed - active gauge returns to 0`() {
+        recorder.onTaskStarted(lockName)
+        recorder.onTaskFailed(lockName, 50.milliseconds, IllegalArgumentException("fail"))
+
+        val gaugeValue = registry.find(MicrometerNames.METER_ACTIVE)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .gauge()?.value() ?: 0.0
+
+        gaugeValue shouldBeEqualTo 0.0
+    }
+
+    @Test
+    fun `registerMetricsFor - meters appear before first callback`() {
+        recorder.registerMetricsFor(lockName)
+
+        val attemptsCount = registry.get(MicrometerNames.METER_ATTEMPTS)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .counter().count()
+        val acquiredCount = registry.get(MicrometerNames.METER_ACQUIRED)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .counter().count()
+        val timerCount = registry.get(MicrometerNames.METER_EXECUTION_DURATION)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .timer().count()
+        val gaugeValue = registry.find(MicrometerNames.METER_ACTIVE)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .gauge()?.value()
+
+        attemptsCount shouldBeEqualTo 0.0
+        acquiredCount shouldBeEqualTo 0.0
+        timerCount shouldBeEqualTo 0L
+        gaugeValue shouldBeEqualTo 0.0
+    }
+
+    @Test
+    fun `registerMetricsFor - idempotent second call does not duplicate meters`() {
+        recorder.registerMetricsFor(lockName)
+        recorder.registerMetricsFor(lockName)
+
+        // 중복 등록 없이 하나만 존재해야 한다
+        val attemptCounters = registry.find(MicrometerNames.METER_ATTEMPTS)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .counters()
+
+        attemptCounters.size shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `concurrent onTaskStarted and onTaskFinished - active gauge thread safe`() {
+        runBlocking(Dispatchers.Default) {
+            coroutineScope {
+                repeat(1000) {
+                    launch {
+                        recorder.onTaskStarted(lockName)
+                        recorder.onTaskFinished(lockName, 1.milliseconds)
+                    }
+                }
+            }
+        }
+
+        val gaugeValue = registry.find(MicrometerNames.METER_ACTIVE)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .gauge()?.value() ?: 0.0
+
+        gaugeValue shouldBeEqualTo 0.0
+    }
+
+    @Test
+    fun `deregisterMetricsFor - removes meters from registry`() {
+        recorder.registerMetricsFor(lockName)
+
+        // 등록 확인
+        registry.find(MicrometerNames.METER_ACTIVE)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .gauge().shouldNotBeNull()
+
+        recorder.deregisterMetricsFor(lockName)
+
+        // 제거 확인
+        registry.find(MicrometerNames.METER_ACTIVE)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .gauge().shouldBeNull()
+    }
+}

--- a/leader-micrometer/src/test/resources/junit-platform.properties
+++ b/leader-micrometer/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/leader-micrometer/src/test/resources/logback-test.xml
+++ b/leader-micrometer/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%32.32t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.leader" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+
+</configuration>

--- a/leader-spring-boot-common/src/main/kotlin/io/bluetape4k/leader/spring/aop/properties/LeaderAopProperties.kt
+++ b/leader-spring-boot-common/src/main/kotlin/io/bluetape4k/leader/spring/aop/properties/LeaderAopProperties.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.spring.aop.properties
 
 import io.bluetape4k.leader.spring.aop.LeaderAspectFailureMode
+import org.springframework.boot.context.properties.ConfigurationProperties
 import java.time.Duration
 
 /**
@@ -29,6 +30,7 @@ import java.time.Duration
  * @property lockNamePrefix [Step 3-P-Sec-2][R-34] SpEL 평가 결과 앞에 자동 prefix. empty string opt-out
  * @property spel SpEL 보안 옵션
  */
+@ConfigurationProperties(prefix = "bluetape4k.leader.aop")
 data class LeaderAopProperties(
     val enabled: Boolean = true,
     val strict: Boolean = false,

--- a/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/metrics/LeaderMicrometerAutoConfiguration.kt
+++ b/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/metrics/LeaderMicrometerAutoConfiguration.kt
@@ -36,7 +36,10 @@ import org.springframework.context.annotation.Role
     after = [LeaderAopFactoryAutoConfiguration::class],
     before = [LeaderAopAutoConfiguration::class],
 )
-@ConditionalOnClass(name = ["io.micrometer.core.instrument.MeterRegistry"])
+@ConditionalOnClass(name = [
+    "io.micrometer.core.instrument.MeterRegistry",
+    "io.bluetape4k.leader.micrometer.MicrometerLeaderAopMetricsRecorder",
+])
 @ConditionalOnProperty(
     prefix = "bluetape4k.leader.aop.metrics",
     name = ["enabled"],

--- a/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/metrics/LeaderMicrometerAutoConfiguration.kt
+++ b/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/metrics/LeaderMicrometerAutoConfiguration.kt
@@ -1,0 +1,61 @@
+package io.bluetape4k.leader.spring.boot3.metrics
+
+import io.bluetape4k.leader.micrometer.MicrometerLeaderAopMetricsRecorder
+import io.bluetape4k.leader.spring.aop.metrics.LeaderAopMetricsRecorder
+import io.bluetape4k.leader.spring.boot3.aop.autoconfigure.LeaderAopAutoConfiguration
+import io.bluetape4k.leader.spring.boot3.aop.autoconfigure.LeaderAopFactoryAutoConfiguration
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.beans.factory.config.BeanDefinition
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Role
+
+/**
+ * Spring Boot 3 Micrometer metrics AutoConfiguration.
+ *
+ * `MeterRegistry` 빈이 존재할 때 [MicrometerLeaderAopMetricsRecorder]를 자동 등록한다.
+ * [LeaderAopAutoConfiguration] 보다 먼저 평가되어 Aspect 초기화 시 recorder가 주입된다.
+ *
+ * ## AutoConfig 순서
+ * ```
+ * LeaderAopFactoryAutoConfiguration (backend factories)
+ *   ↓
+ * LeaderMicrometerAutoConfiguration  ← 본 클래스
+ *   ↓
+ * LeaderAopAutoConfiguration (Aspect + BPP)
+ * ```
+ *
+ * ## 비활성화
+ * `bluetape4k.leader.aop.metrics.enabled=false` 설정으로 recorder 빈 등록 전체를 비활성화할 수 있다.
+ */
+@AutoConfiguration(
+    after = [LeaderAopFactoryAutoConfiguration::class],
+    before = [LeaderAopAutoConfiguration::class],
+)
+@ConditionalOnClass(name = ["io.micrometer.core.instrument.MeterRegistry"])
+@ConditionalOnProperty(
+    prefix = "bluetape4k.leader.aop.metrics",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+class LeaderMicrometerAutoConfiguration {
+
+    /**
+     * `MeterRegistry` 빈이 존재하고 사용자가 직접 [LeaderAopMetricsRecorder]를 등록하지 않은 경우에만
+     * [MicrometerLeaderAopMetricsRecorder]를 자동 등록한다.
+     *
+     * 사용자 정의 recorder가 우선된다 (`@ConditionalOnMissingBean(LeaderAopMetricsRecorder::class)`).
+     */
+    @Bean
+    @ConditionalOnBean(MeterRegistry::class)
+    @ConditionalOnMissingBean(LeaderAopMetricsRecorder::class)
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    fun micrometerLeaderAopMetricsRecorder(registry: MeterRegistry): MicrometerLeaderAopMetricsRecorder =
+        MicrometerLeaderAopMetricsRecorder(registry)
+
+}

--- a/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/metrics/LeaderMicrometerHealthAutoConfiguration.kt
+++ b/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/metrics/LeaderMicrometerHealthAutoConfiguration.kt
@@ -1,0 +1,44 @@
+package io.bluetape4k.leader.spring.boot3.metrics
+
+import io.bluetape4k.leader.micrometer.MicrometerLeaderAopMetricsRecorder
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+
+/**
+ * Spring Boot 3 Micrometer leader metrics HealthContributor AutoConfiguration.
+ *
+ * [LeaderMicrometerAutoConfiguration]이 등록한 [MicrometerLeaderAopMetricsRecorder] 빈이 있을 때만 활성화된다.
+ * 별도 AutoConfig 클래스로 분리하여 동일 클래스 내 `@ConditionalOnBean` 순서 문제를 회피한다.
+ *
+ * 사용자가 커스텀 [io.bluetape4k.leader.spring.aop.metrics.LeaderAopMetricsRecorder]를 등록한 경우
+ * [MicrometerLeaderAopMetricsRecorder]가 등록되지 않으므로 이 AutoConfig도 비활성화된다.
+ */
+@AutoConfiguration(after = [LeaderMicrometerAutoConfiguration::class])
+@ConditionalOnClass(HealthIndicator::class)
+@ConditionalOnBean(MicrometerLeaderAopMetricsRecorder::class)
+@ConditionalOnProperty(
+    prefix = "bluetape4k.leader.aop.metrics",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+class LeaderMicrometerHealthAutoConfiguration {
+
+    @Bean(name = ["leaderMicrometerHealthContributor"])
+    @ConditionalOnMissingBean(name = ["leaderMicrometerHealthContributor"])
+    fun leaderMicrometerHealthContributor(registry: MeterRegistry): HealthIndicator = HealthIndicator {
+        val counters = registry.find("leader.aop.attempts").counters()
+        val attemptsTotal = counters.sumOf { it.count() }
+        Health.up()
+            .withDetail("metrics.registered", counters.isNotEmpty())
+            .withDetail("attempts.total", attemptsTotal)
+            .build()
+    }
+}

--- a/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/metrics/LeaderMicrometerHealthAutoConfiguration.kt
+++ b/leader-spring-boot3/src/main/kotlin/io/bluetape4k/leader/spring/boot3/metrics/LeaderMicrometerHealthAutoConfiguration.kt
@@ -21,7 +21,11 @@ import org.springframework.context.annotation.Bean
  * [MicrometerLeaderAopMetricsRecorder]가 등록되지 않으므로 이 AutoConfig도 비활성화된다.
  */
 @AutoConfiguration(after = [LeaderMicrometerAutoConfiguration::class])
-@ConditionalOnClass(HealthIndicator::class)
+@ConditionalOnClass(name = [
+    "io.micrometer.core.instrument.MeterRegistry",
+    "io.bluetape4k.leader.micrometer.MicrometerLeaderAopMetricsRecorder",
+    "org.springframework.boot.actuate.health.HealthIndicator",
+])
 @ConditionalOnBean(MicrometerLeaderAopMetricsRecorder::class)
 @ConditionalOnProperty(
     prefix = "bluetape4k.leader.aop.metrics",

--- a/leader-spring-boot3/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/leader-spring-boot3/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,4 +1,6 @@
 io.bluetape4k.leader.spring.boot3.LeaderElectionAutoConfiguration
 io.bluetape4k.leader.spring.boot3.backend.LocalLeaderConfiguration
 io.bluetape4k.leader.spring.boot3.aop.autoconfigure.LeaderAopFactoryAutoConfiguration
+io.bluetape4k.leader.spring.boot3.metrics.LeaderMicrometerAutoConfiguration
+io.bluetape4k.leader.spring.boot3.metrics.LeaderMicrometerHealthAutoConfiguration
 io.bluetape4k.leader.spring.boot3.aop.autoconfigure.LeaderAopAutoConfiguration

--- a/leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/metrics/LeaderMicrometerAutoConfigurationBoot3Test.kt
+++ b/leader-spring-boot3/src/test/kotlin/io/bluetape4k/leader/spring/boot3/metrics/LeaderMicrometerAutoConfigurationBoot3Test.kt
@@ -1,0 +1,207 @@
+package io.bluetape4k.leader.spring.boot3.metrics
+
+import io.bluetape4k.leader.LeaderElection as CoreLeaderElection
+import io.bluetape4k.leader.LeaderElectionFactory
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.micrometer.MicrometerLeaderAopMetricsRecorder
+import io.bluetape4k.leader.spring.aop.LeaderAspectFailureMode
+import io.bluetape4k.leader.spring.aop.LeaderElection
+import io.bluetape4k.leader.spring.aop.metrics.LeaderAopMetricsRecorder
+import io.bluetape4k.leader.spring.aop.metrics.SkipReason
+import io.bluetape4k.leader.spring.boot3.aop.autoconfigure.LeaderAopAutoConfiguration
+import io.bluetape4k.leader.spring.boot3.aop.autoconfigure.LeaderAopFactoryAutoConfiguration
+import io.bluetape4k.logging.KLogging
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.context.annotation.Primary
+import org.springframework.beans.factory.getBeansOfType
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.actuate.health.Status
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.util.concurrent.CompletableFuture
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderMicrometerAutoConfigurationBoot3Test {
+
+    companion object : KLogging()
+
+    private val runner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                LeaderAopFactoryAutoConfiguration::class.java,
+                LeaderMicrometerAutoConfiguration::class.java,
+                LeaderMicrometerHealthAutoConfiguration::class.java,
+                LeaderAopAutoConfiguration::class.java,
+            )
+        )
+
+    @Test
+    fun `MeterRegistry 빈 존재 시 MicrometerLeaderAopMetricsRecorder 자동 등록`() {
+        runner
+            .withUserConfiguration(MeterRegistryConfig::class.java)
+            .run { ctx ->
+                ctx.getBean(MicrometerLeaderAopMetricsRecorder::class.java).shouldNotBeNull()
+            }
+    }
+
+    @Test
+    fun `MeterRegistry 빈 없을 때 recorder 빈 미등록`() {
+        runner.run { ctx ->
+            ctx.getBeansOfType<LeaderAopMetricsRecorder>().isEmpty().shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `enabled=false 시 빈 미등록`() {
+        runner
+            .withUserConfiguration(MeterRegistryConfig::class.java)
+            .withPropertyValues("bluetape4k.leader.aop.metrics.enabled=false")
+            .run { ctx ->
+                ctx.getBeansOfType<LeaderAopMetricsRecorder>().isEmpty().shouldBeTrue()
+            }
+    }
+
+    @Test
+    fun `사용자 정의 LeaderAopMetricsRecorder가 우선`() {
+        runner
+            .withUserConfiguration(MeterRegistryConfig::class.java, CustomRecorderConfig::class.java)
+            .run { ctx ->
+                ctx.getBeansOfType<MicrometerLeaderAopMetricsRecorder>().isEmpty().shouldBeTrue()
+                ctx.getBean(LeaderAopMetricsRecorder::class.java) shouldBeInstanceOf LeaderAopMetricsRecorder.NoOp::class
+                // MicrometerLeaderAopMetricsRecorder 미등록 → HealthContributor도 미등록
+                ctx.containsBean("leaderMicrometerHealthContributor") shouldBeEqualTo false
+            }
+    }
+
+    @Test
+    fun `LeaderElectionAspect 통과 시 attempts+acquired+timer+active 전체 검증`() {
+        runner
+            .withUserConfiguration(MeterRegistryConfig::class.java, TestLeaderServiceConfig::class.java)
+            .withPropertyValues("bluetape4k.leader.aop.lock-name-prefix=")
+            .run { ctx ->
+                val service = ctx.getBean(TestLeaderService::class.java)
+                val registry = ctx.getBean(SimpleMeterRegistry::class.java)
+
+                service.doWork()
+
+                // LocalLeaderElection 은 항상 성공하므로 attempts + acquired 모두 증가
+                registry.get("leader.aop.attempts")
+                    .tag("lock.name", "test-lock")
+                    .counter().count() shouldBeGreaterOrEqualTo 1.0
+                registry.get("leader.aop.acquired")
+                    .tag("lock.name", "test-lock")
+                    .counter().count() shouldBeGreaterOrEqualTo 1.0
+                registry.get("leader.aop.execution.duration")
+                    .tag("lock.name", "test-lock")
+                    .timer().count() shouldBeGreaterOrEqualTo 1L
+                registry.find("leader.aop.active")
+                    .tag("lock.name", "test-lock")
+                    .gauge()?.value() shouldBeEqualTo 0.0
+            }
+    }
+
+    @Test
+    fun `backend 예외 발생 시 lock_not_acquired reason=BACKEND_ERROR 메트릭 증가`() {
+        runner
+            .withUserConfiguration(
+                MeterRegistryConfig::class.java,
+                ThrowingFactoryConfig::class.java,
+                SkipModeServiceConfig::class.java,
+            )
+            .withPropertyValues("bluetape4k.leader.aop.lock-name-prefix=")
+            .run { ctx ->
+                val service = ctx.getBean(SkipModeService::class.java)
+                val registry = ctx.getBean(SimpleMeterRegistry::class.java)
+
+                // SKIP 모드: backend 예외 흡수 후 null 반환 → onLockNotAcquired(BACKEND_ERROR)
+                service.doSkipWork()
+
+                registry.get("leader.aop.lock.not.acquired")
+                    .tag("lock.name", "skip-lock")
+                    .tag("reason", "BACKEND_ERROR")
+                    .counter().count() shouldBeGreaterOrEqualTo 1.0
+            }
+    }
+
+    @Test
+    fun `leaderMicrometerHealthContributor 빈 등록 검증`() {
+        runner
+            .withUserConfiguration(MeterRegistryConfig::class.java)
+            .run { ctx ->
+                val healthIndicator = ctx.getBean(
+                    "leaderMicrometerHealthContributor",
+                    HealthIndicator::class.java,
+                )
+                healthIndicator.shouldNotBeNull()
+                val health = healthIndicator.health()
+                health.status shouldBeEqualTo Status.UP
+                health.details.containsKey("metrics.registered").shouldBeTrue()
+                health.details.containsKey("attempts.total").shouldBeTrue()
+            }
+    }
+
+    // ── Config helpers ──────────────────────────────────────────────
+
+    @Configuration(proxyBeanMethods = false)
+    class MeterRegistryConfig {
+        @Bean
+        fun simpleMeterRegistry(): SimpleMeterRegistry = SimpleMeterRegistry()
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    class CustomRecorderConfig {
+        @Bean
+        fun customRecorder(): LeaderAopMetricsRecorder = LeaderAopMetricsRecorder.NoOp
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    class TestLeaderServiceConfig {
+        @Bean
+        fun testLeaderService(): TestLeaderService = TestLeaderService()
+    }
+
+    open class TestLeaderService {
+        @LeaderElection(name = "test-lock")
+        open fun doWork(): String? = "done"
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    class ThrowingFactoryConfig {
+        @Bean
+        @Primary
+        fun throwingLeaderElectionFactory(): LeaderElectionFactory = LeaderElectionFactory { _ ->
+            object : CoreLeaderElection {
+                override fun <T> runIfLeader(lockName: String, action: () -> T): T? {
+                    throw RuntimeException("Simulated backend error")
+                }
+
+                override fun <T> runAsyncIfLeader(
+                    lockName: String,
+                    executor: java.util.concurrent.Executor,
+                    action: () -> CompletableFuture<T>,
+                ): CompletableFuture<T?> =
+                    CompletableFuture.failedFuture(RuntimeException("Simulated backend error"))
+            }
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    class SkipModeServiceConfig {
+        @Bean
+        fun skipModeService(): SkipModeService = SkipModeService()
+    }
+
+    open class SkipModeService {
+        @LeaderElection(name = "skip-lock", failureMode = LeaderAspectFailureMode.SKIP)
+        open fun doSkipWork(): String? = "done"
+    }
+}

--- a/leader-spring-boot4/src/main/kotlin/io/bluetape4k/leader/spring/boot4/metrics/LeaderMicrometerAutoConfiguration.kt
+++ b/leader-spring-boot4/src/main/kotlin/io/bluetape4k/leader/spring/boot4/metrics/LeaderMicrometerAutoConfiguration.kt
@@ -1,0 +1,61 @@
+package io.bluetape4k.leader.spring.boot4.metrics
+
+import io.bluetape4k.leader.micrometer.MicrometerLeaderAopMetricsRecorder
+import io.bluetape4k.leader.spring.aop.metrics.LeaderAopMetricsRecorder
+import io.bluetape4k.leader.spring.boot4.aop.autoconfigure.LeaderAopAutoConfiguration
+import io.bluetape4k.leader.spring.boot4.aop.autoconfigure.LeaderAopFactoryAutoConfiguration
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.beans.factory.config.BeanDefinition
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Role
+
+/**
+ * Spring Boot 4 Micrometer metrics AutoConfiguration.
+ *
+ * `MeterRegistry` 빈이 존재할 때 [MicrometerLeaderAopMetricsRecorder]를 자동 등록한다.
+ *
+ * ## Boot 4 제약
+ * Boot 4에서 HealthIndicator 경로가 `org.springframework.boot.health.contributor`로 이동했다.
+ * `leader-spring-boot-common`의 `LeaderAopHealthIndicator`는 Boot 3 경로 기준이므로
+ * Boot 4 HealthContributor 통합은 이 PR 범위 외 (후속 PR 별도 처리 예정).
+ *
+ * ## AutoConfig 순서
+ * ```
+ * LeaderAopFactoryAutoConfiguration (backend factories)
+ *   ↓
+ * LeaderMicrometerAutoConfiguration  ← 본 클래스
+ *   ↓
+ * LeaderAopAutoConfiguration (Aspect + BPP)
+ * ```
+ */
+@AutoConfiguration(
+    after = [LeaderAopFactoryAutoConfiguration::class],
+    before = [LeaderAopAutoConfiguration::class],
+)
+@ConditionalOnClass(name = ["io.micrometer.core.instrument.MeterRegistry"])
+@ConditionalOnProperty(
+    prefix = "bluetape4k.leader.aop.metrics",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+class LeaderMicrometerAutoConfiguration {
+
+    /**
+     * `MeterRegistry` 빈이 존재하고 사용자가 직접 [LeaderAopMetricsRecorder]를 등록하지 않은 경우에만
+     * [MicrometerLeaderAopMetricsRecorder]를 자동 등록한다.
+     *
+     * 사용자 정의 recorder가 우선된다 (`@ConditionalOnMissingBean(LeaderAopMetricsRecorder::class)`).
+     */
+    @Bean
+    @ConditionalOnBean(MeterRegistry::class)
+    @ConditionalOnMissingBean(LeaderAopMetricsRecorder::class)
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    fun micrometerLeaderAopMetricsRecorder(registry: MeterRegistry): MicrometerLeaderAopMetricsRecorder =
+        MicrometerLeaderAopMetricsRecorder(registry)
+}

--- a/leader-spring-boot4/src/main/kotlin/io/bluetape4k/leader/spring/boot4/metrics/LeaderMicrometerAutoConfiguration.kt
+++ b/leader-spring-boot4/src/main/kotlin/io/bluetape4k/leader/spring/boot4/metrics/LeaderMicrometerAutoConfiguration.kt
@@ -37,7 +37,10 @@ import org.springframework.context.annotation.Role
     after = [LeaderAopFactoryAutoConfiguration::class],
     before = [LeaderAopAutoConfiguration::class],
 )
-@ConditionalOnClass(name = ["io.micrometer.core.instrument.MeterRegistry"])
+@ConditionalOnClass(name = [
+    "io.micrometer.core.instrument.MeterRegistry",
+    "io.bluetape4k.leader.micrometer.MicrometerLeaderAopMetricsRecorder",
+])
 @ConditionalOnProperty(
     prefix = "bluetape4k.leader.aop.metrics",
     name = ["enabled"],

--- a/leader-spring-boot4/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/leader-spring-boot4/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,4 +1,5 @@
 io.bluetape4k.leader.spring.boot4.LeaderElectionAutoConfiguration
 io.bluetape4k.leader.spring.boot4.backend.LocalLeaderConfiguration
 io.bluetape4k.leader.spring.boot4.aop.autoconfigure.LeaderAopFactoryAutoConfiguration
+io.bluetape4k.leader.spring.boot4.metrics.LeaderMicrometerAutoConfiguration
 io.bluetape4k.leader.spring.boot4.aop.autoconfigure.LeaderAopAutoConfiguration

--- a/leader-spring-boot4/src/test/kotlin/io/bluetape4k/leader/spring/boot4/metrics/LeaderMicrometerAutoConfigurationBoot4Test.kt
+++ b/leader-spring-boot4/src/test/kotlin/io/bluetape4k/leader/spring/boot4/metrics/LeaderMicrometerAutoConfigurationBoot4Test.kt
@@ -1,0 +1,145 @@
+package io.bluetape4k.leader.spring.boot4.metrics
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.micrometer.MicrometerLeaderAopMetricsRecorder
+import io.bluetape4k.leader.spring.aop.metrics.LeaderAopMetricsRecorder
+import io.bluetape4k.leader.spring.aop.metrics.SkipReason
+import io.bluetape4k.leader.spring.boot4.aop.autoconfigure.LeaderAopAutoConfiguration
+import io.bluetape4k.leader.spring.boot4.aop.autoconfigure.LeaderAopFactoryAutoConfiguration
+import io.bluetape4k.logging.KLogging
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterOrEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.getBeansOfType
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Spring Boot 4 `LeaderMicrometerAutoConfiguration` 통합 테스트.
+ *
+ * ## Boot 4 고려사항
+ * Boot4는 Freefair AspectJ post-compile weaving을 사용한다.
+ * `@LeaderElection`-annotated 메서드는 컴파일 시 advice가 woven되어
+ * Spring AOP runtime proxy와 함께 사용하면 double-advice 위험이 있다.
+ * 따라서 테스트 5/6은 AOP proxy를 거치지 않고 recorder를 직접 호출하여 메트릭을 검증한다.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderMicrometerAutoConfigurationBoot4Test {
+
+    companion object : KLogging()
+
+    private val runner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                LeaderAopFactoryAutoConfiguration::class.java,
+                LeaderMicrometerAutoConfiguration::class.java,
+                LeaderAopAutoConfiguration::class.java,
+            )
+        )
+
+    @Test
+    fun `MeterRegistry 빈 존재 시 MicrometerLeaderAopMetricsRecorder 자동 등록`() {
+        runner
+            .withUserConfiguration(MeterRegistryConfig::class.java)
+            .run { ctx ->
+                ctx.getBean(MicrometerLeaderAopMetricsRecorder::class.java).shouldNotBeNull()
+            }
+    }
+
+    @Test
+    fun `MeterRegistry 빈 없을 때 recorder 빈 미등록`() {
+        runner.run { ctx ->
+            ctx.getBeansOfType<LeaderAopMetricsRecorder>().isEmpty().shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `enabled=false 시 빈 미등록`() {
+        runner
+            .withUserConfiguration(MeterRegistryConfig::class.java)
+            .withPropertyValues("bluetape4k.leader.aop.metrics.enabled=false")
+            .run { ctx ->
+                ctx.getBeansOfType<LeaderAopMetricsRecorder>().isEmpty().shouldBeTrue()
+            }
+    }
+
+    @Test
+    fun `사용자 정의 LeaderAopMetricsRecorder가 우선`() {
+        runner
+            .withUserConfiguration(MeterRegistryConfig::class.java, CustomRecorderConfig::class.java)
+            .run { ctx ->
+                ctx.getBeansOfType<MicrometerLeaderAopMetricsRecorder>().isEmpty().shouldBeTrue()
+                ctx.getBean(LeaderAopMetricsRecorder::class.java) shouldBeInstanceOf LeaderAopMetricsRecorder.NoOp::class
+            }
+    }
+
+    @Test
+    fun `recorder 콜백 호출 시 attempts+acquired+timer+active 전체 검증`() {
+        // Boot4는 AspectJ CTW + Spring AOP 동시 활성 시 double-advice 위험이 있어
+        // recorder를 직접 호출하여 메트릭 기록을 검증한다.
+        runner
+            .withUserConfiguration(MeterRegistryConfig::class.java)
+            .run { ctx ->
+                val recorder = ctx.getBean(MicrometerLeaderAopMetricsRecorder::class.java)
+                val registry = ctx.getBean(SimpleMeterRegistry::class.java)
+                val options = LeaderElectionOptions.Default
+
+                recorder.onLockAttempt("test-lock", options)
+                recorder.onLockAcquired("test-lock", options, 5.milliseconds)
+                recorder.onTaskStarted("test-lock")
+                recorder.onTaskFinished("test-lock", 100.milliseconds)
+
+                registry.get("leader.aop.attempts")
+                    .tag("lock.name", "test-lock")
+                    .counter().count() shouldBeGreaterOrEqualTo 1.0
+                registry.get("leader.aop.acquired")
+                    .tag("lock.name", "test-lock")
+                    .counter().count() shouldBeGreaterOrEqualTo 1.0
+                registry.get("leader.aop.execution.duration")
+                    .tag("lock.name", "test-lock")
+                    .timer().count() shouldBeGreaterOrEqualTo 1L
+                registry.find("leader.aop.active")
+                    .tag("lock.name", "test-lock")
+                    .gauge()?.value() shouldBeEqualTo 0.0
+            }
+    }
+
+    @Test
+    fun `backend 예외 발생 시 lock_not_acquired reason=BACKEND_ERROR 메트릭 증가`() {
+        runner
+            .withUserConfiguration(MeterRegistryConfig::class.java)
+            .run { ctx ->
+                val recorder = ctx.getBean(MicrometerLeaderAopMetricsRecorder::class.java)
+                val registry = ctx.getBean(SimpleMeterRegistry::class.java)
+
+                recorder.onLockNotAcquired("test-lock", LeaderElectionOptions.Default, SkipReason.BACKEND_ERROR)
+
+                registry.get("leader.aop.lock.not.acquired")
+                    .tag("lock.name", "test-lock")
+                    .tag("reason", "BACKEND_ERROR")
+                    .counter().count() shouldBeEqualTo 1.0
+            }
+    }
+
+    // ── Config helpers ──────────────────────────────────────────────
+
+    @Configuration(proxyBeanMethods = false)
+    class MeterRegistryConfig {
+        @Bean
+        fun simpleMeterRegistry(): SimpleMeterRegistry = SimpleMeterRegistry()
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    class CustomRecorderConfig {
+        @Bean
+        fun customRecorder(): LeaderAopMetricsRecorder = LeaderAopMetricsRecorder.NoOp
+    }
+}


### PR DESCRIPTION
## Summary

PR #101의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: leader-aop Micrometer metrics 통합 (#75)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 개요

Issue #75 — `leader-aop` AOP 레이어에 Micrometer metrics 통합.

Spring Boot AOP(`@LeaderElection`)로 보호된 메서드 실행 시 Prometheus/Datadog 등 임의의 Micrometer 백엔드로 리더 선출 메트릭을 export합니다.

---

## 변경 사항

### 신규 모듈: `leader-micrometer`

- **`MicrometerNames`** — 6개 meter 이름 + 태그 키 상수 (`leader.aop.*`)
- **`MicrometerLeaderAopMetricsRecorder`** — `LeaderAopMetricsRecorder` SPI 구현체
  - 6개 콜백을 Counter/Timer/Gauge로 매핑
  - `registerMetricsFor()` — 부트 시점 사전 등록 (dashboard 0값 표시)
  - `deregisterMetricsFor()` — 동적 SpEL lock name 정리 (카디널리티 폭증 방지)

### `leader-spring-boot3`

- **`LeaderMicrometerAutoConfiguration`** — `MeterRegistry` 빈 존재 시 recorder 자동 등록
- **`LeaderMicrometerHealthAutoConfiguration`** — `@ConditionalOnBean` 순서 문제를 별도 AutoConfig 분리로 해결
- `AutoConfiguration.imports`에 두 클래스 등록

### `leader-spring-boot4`

- **`LeaderMicrometerAutoConfiguration`** — Boot 4 recorder 자동 등록
- Boot 4 HealthIndicator 경로 변경 대응은 후속 PR 예정

### `leader-spring-boot-common` (부수 수정)

- **`LeaderAopProperties`** — `@ConfigurationProperties` 어노테이션 누락 수정 (production 버그 fix)
  - 이 어노테이션 없이는 `@EnableConfigurationProperties`가 바인딩을 거부해 앱 시작 실패

### README

- `leader-micrometer` 상태: `예정` → `안정`
- Micrometer 메트릭 섹션 추가 (EN + KO)

---

## 메터 카탈로그

| 메터 이름 | 타입 | 태그 |
|-----------|------|------|
| `leader.aop.attempts` | Counter | `lock.name` |
| `leader.aop.acquired` | Counter | `lock.name` |
| `leader.aop.lock.not.acquired` | Counter | `lock.name`, `reason` |
| `leader.aop.execution.duration` | Timer | `lock.name` |
| `leader.aop.task.failed` | Counter | `lock.name`, `exception` |
| `leader.aop.active` | Gauge | `lock.name` |

---

## AutoConfig 순서

```
LeaderAopFactoryAutoConfiguration
  ↓
LeaderMicrometerAutoConfiguration   ← recorder 빈 등록
  ↓
LeaderMicrometerHealthAutoConfiguration  ← HealthContributor (after recorder)
  ↓
LeaderAopAutoConfiguration          ← Aspect + BPP
```

---

## 테스트 결과

| 모듈 | 결과 | 수 |
|------|------|----|
| `leader-micrometer` | ✅ PASS | 14 |
| `leader-spring-boot3` (metrics) | ✅ PASS | 7 |
| `leader-spring-boot4` | ✅ PASS | 28 |
| `leader-spring-boot-common` | ✅ PASS | 87 |

---

## 체크리스트

- [x] 모든 테스트 통과
- [x] Tier 4+5 코드 리뷰 완료 (CRITICAL/HIGH 0)
- [x] `@ConditionalOnClass` classpath 안전 가드 (`name=` 방식으로 3개 클래스 가드)
- [x] `@ConditionalOnBean` 순서 문제 별도 AutoConfig 분리로 해결
- [x] `LeaderAopProperties` `@ConfigurationProperties` 누락 수정
- [x] README.md + README.ko.md 동기화
- [x] Korean KDoc 업데이트

## TODO (후속 PR)

- [ ] Boot 4 `LeaderMicrometerHealthAutoConfiguration`
- [ ] `bluetape4k.leader.aop.metrics.*` `@ConfigurationProperties` 클래스 추가 (IDE 자동완성)
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #101, head `679bd8b0c3210c19c3ffc3a8bba9c61710d43242`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
