### PR TITLE
fix: factory.create() I/O 실패가 failureMode 우회하던 버그 수정 (#94)

### DIFF
--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -39,6 +39,7 @@ import kotlin.time.Duration.Companion.nanoseconds
  * - **Rel-2**: [CancellationException] 항상 우선 재throw (CLAUDE.md memory feedback_cancellation_exception)
  * - **Perf-1**: metrics fan-out 시 `metrics.isEmpty()` fast-path
  * - **Perf-2**: Method-level cache — annotation lookup + lease threshold 사전계산 + factory bean name resolution
+ * - **Fix-94**: [resolveLockName] + [factory.create] 를 try 안으로 이동 — backend I/O 실패가 failureMode 우회하던 버그 수정
  *
  * @param beanSelector factory 빈 선택기
  * @param props AOP 전역 속성
@@ -70,35 +71,39 @@ class LeaderElectionAspect(
         val args = pjp.args
 
         val meta = metadataCache.computeIfAbsent(method) { resolveMetadata(it, target) }
-        val lockName = resolveLockName(meta, method, args, target)
         val opts = meta.options
-        val factoryBeanName = meta.factoryBeanName
-        val factory = meta.factory
 
-        val cacheKey = FactoryCacheKey(factoryBeanName, opts)
-        val election = factoryCache.computeIfAbsent(cacheKey) { factory.create(opts) }
-
-        fanOut { it.onLockAttempt(lockName, opts) }
+        // [Fix-94] resolveLockName + factory.create 를 try 안으로 이동
+        // catch 에서 lockName 이 필요하므로 nullable var 로 선언, 성공 시 resolvedName 을 val 로 분리
+        var lockName: String? = null
         val start = System.nanoTime()
 
         return try {
-            val result = election.runIfLeader(lockName) {
+            val resolvedName = resolveLockName(meta, method, args, target)
+            lockName = resolvedName
+
+            val cacheKey = FactoryCacheKey(meta.factoryBeanName, opts)
+            val election = factoryCache.computeIfAbsent(cacheKey) { meta.factory.create(opts) }
+
+            fanOut { it.onLockAttempt(resolvedName, opts) }
+
+            val result = election.runIfLeader(resolvedName) {
                 fanOut {
-                    it.onLockAcquired(lockName, opts, (System.nanoTime() - start).nanoseconds)
-                    it.onTaskStarted(lockName)
+                    it.onLockAcquired(resolvedName, opts, (System.nanoTime() - start).nanoseconds)
+                    it.onTaskStarted(resolvedName)
                 }
-                executeBody(pjp, lockName, start)
+                executeBody(pjp, resolvedName, start)
             }
             if (result == null) {
-                fanOut { it.onLockNotAcquired(lockName, opts, SkipReason.CONTENTION) }
-                log.debug { "leader.aop.skipped lockName=$lockName reason=CONTENTION" }
+                fanOut { it.onLockNotAcquired(resolvedName, opts, SkipReason.CONTENTION) }
+                log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
             } else {
                 val elapsed = System.nanoTime() - start
-                fanOut { it.onTaskFinished(lockName, elapsed.nanoseconds) }
-                log.debug { "leader.aop.elected lockName=$lockName elapsedNs=$elapsed" }
+                fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
+                log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
                 if (elapsed > meta.leaseTimeWarnThresholdNanos) {
                     log.warn {
-                        "leader.aop.lease-warn lockName=$lockName elapsedNs=$elapsed leaseTimeNs=${opts.leaseTime.toNanos()}"
+                        "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${opts.leaseTime.toNanos()}"
                     }
                 }
             }
@@ -110,17 +115,18 @@ class LeaderElectionAspect(
             // [Rel-1] body 예외는 wrapping 없이 그대로 전파 — failureMode 무관
             throw bodyMarker.cause
         } catch (backendEx: Throwable) {
-            // [Sec-3][R-33] backend 예외만 LeaderElectionException 으로 wrapping
-            val wrapped = LeaderElectionException("leader backend error for lock '$lockName'", backendEx)
+            // [Sec-3][R-33] backend 예외만 LeaderElectionException 으로 wrapping (host/credentials 누출 차단)
+            val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
+            val wrapped = LeaderElectionException("leader backend error for lock '$effectiveName'", backendEx)
             fanOut {
-                it.onLockNotAcquired(lockName, opts, SkipReason.BACKEND_ERROR)
-                it.onTaskFailed(lockName, (System.nanoTime() - start).nanoseconds, backendEx)
+                it.onLockNotAcquired(effectiveName, opts, SkipReason.BACKEND_ERROR)
+                it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx)
             }
             when (meta.failureMode) {
                 LeaderAspectFailureMode.INHERIT -> error("INHERIT must be resolved in resolveMetadata")
                 LeaderAspectFailureMode.RETHROW -> throw wrapped
                 LeaderAspectFailureMode.SKIP -> {
-                    log.warn(backendEx) { "leader.aop.skipped lockName=$lockName reason=BACKEND_ERROR" }
+                    log.warn(backendEx) { "leader.aop.skipped lockName=$effectiveName reason=BACKEND_ERROR" }
                     null
                 }
             }

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -33,6 +33,9 @@ import kotlin.time.Duration.Companion.nanoseconds
  *
  * [LeaderElectionAspect] 와 동일 패턴 + `maxLeaders` 분기. backend 예외는
  * [LeaderGroupElectionException] 으로 wrapping.
+ *
+ * Fix-94: [resolveLockName] + [factory.create] 를 try 안으로 이동 —
+ * backend I/O 실패가 failureMode 우회하던 버그 수정.
  */
 @Aspect
 class LeaderGroupElectionAspect(
@@ -54,36 +57,39 @@ class LeaderGroupElectionAspect(
         val args = pjp.args
 
         val meta = metadataCache.computeIfAbsent(method) { resolveMetadata(it, target) }
-        val lockName = resolveLockName(meta, method, args, target)
         val opts = meta.options
         val coreOpts = opts.toCoreOptions()
-        val factoryBeanName = meta.factoryBeanName
-        val factory = meta.factory
 
-        val cacheKey = GroupFactoryCacheKey(factoryBeanName, opts)
-        val election = factoryCache.computeIfAbsent(cacheKey) { factory.create(opts) }
-
-        fanOut { it.onLockAttempt(lockName, coreOpts) }
+        // [Fix-94] resolveLockName + factory.create 를 try 안으로 이동
+        var lockName: String? = null
         val start = System.nanoTime()
 
         return try {
-            val result = election.runIfLeader(lockName) {
+            val resolvedName = resolveLockName(meta, method, args, target)
+            lockName = resolvedName
+
+            val cacheKey = GroupFactoryCacheKey(meta.factoryBeanName, opts)
+            val election = factoryCache.computeIfAbsent(cacheKey) { meta.factory.create(opts) }
+
+            fanOut { it.onLockAttempt(resolvedName, coreOpts) }
+
+            val result = election.runIfLeader(resolvedName) {
                 fanOut {
-                    it.onLockAcquired(lockName, coreOpts, (System.nanoTime() - start).nanoseconds)
-                    it.onTaskStarted(lockName)
+                    it.onLockAcquired(resolvedName, coreOpts, (System.nanoTime() - start).nanoseconds)
+                    it.onTaskStarted(resolvedName)
                 }
-                executeBody(pjp, lockName, start)
+                executeBody(pjp, resolvedName, start)
             }
             if (result == null) {
-                fanOut { it.onLockNotAcquired(lockName, coreOpts, SkipReason.CONTENTION) }
-                log.debug { "leader.aop.skipped lockName=$lockName reason=CONTENTION" }
+                fanOut { it.onLockNotAcquired(resolvedName, coreOpts, SkipReason.CONTENTION) }
+                log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
             } else {
                 val elapsed = System.nanoTime() - start
-                fanOut { it.onTaskFinished(lockName, elapsed.nanoseconds) }
-                log.debug { "leader.aop.elected lockName=$lockName elapsedNs=$elapsed" }
+                fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
+                log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
                 if (elapsed > meta.leaseTimeWarnThresholdNanos) {
                     log.warn {
-                        "leader.aop.lease-warn lockName=$lockName elapsedNs=$elapsed leaseTimeNs=${opts.leaseTime.toNanos()}"
+                        "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${opts.leaseTime.toNanos()}"
                     }
                 }
             }
@@ -93,16 +99,17 @@ class LeaderGroupElectionAspect(
         } catch (bodyMarker: BodyThrownMarker) {
             throw bodyMarker.cause
         } catch (backendEx: Throwable) {
-            val wrapped = LeaderGroupElectionException("leader group backend error for lock '$lockName'", backendEx)
+            val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
+            val wrapped = LeaderGroupElectionException("leader group backend error for lock '$effectiveName'", backendEx)
             fanOut {
-                it.onLockNotAcquired(lockName, coreOpts, SkipReason.BACKEND_ERROR)
-                it.onTaskFailed(lockName, (System.nanoTime() - start).nanoseconds, backendEx)
+                it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.BACKEND_ERROR)
+                it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx)
             }
             when (meta.failureMode) {
                 LeaderAspectFailureMode.INHERIT -> error("INHERIT must be resolved in resolveMetadata")
                 LeaderAspectFailureMode.RETHROW -> throw wrapped
                 LeaderAspectFailureMode.SKIP -> {
-                    log.warn(backendEx) { "leader.aop.skipped lockName=$lockName reason=BACKEND_ERROR" }
+                    log.warn(backendEx) { "leader.aop.skipped lockName=$effectiveName reason=BACKEND_ERROR" }
                     null
                 }
             }

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectTest.kt
@@ -296,4 +296,42 @@ class LeaderElectionAspectTest {
         val ex = assertThrows<LeaderElectionException> { aspect.aroundLeader(pjp) }
         ex shouldBeInstanceOf LeaderElectionException::class
     }
+
+    // ── Fix-94: factory.create() I/O 실패가 failureMode 우회하던 버그 회귀 테스트 ──
+
+    @Test
+    fun `Fix-94 - factory create 실패 RETHROW - LeaderElectionException wrapping + lockName 포함 + host 누출 없음`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("runSync")
+        configureJoinPoint(method, target, emptyArray())
+
+        val backendEx = RuntimeException("Connection to redis-prod-01.internal:6379 refused")
+        val aspect = newAspect()
+        // factory.create 가 backend I/O 실패로 throw — try 블록 안으로 이동되어야 failureMode 가 적용됨
+        every { factoryMock.create(any()) } throws backendEx
+
+        val wrapped = assertThrows<LeaderElectionException> { aspect.aroundLeader(pjp) }
+        wrapped.cause shouldBeEqualTo backendEx
+        // lockName 은 포함, backend host 정보는 누출 안 됨 (R-33)
+        wrapped.message!!.contains("static-job") shouldBeEqualTo true
+        wrapped.message!!.contains("redis-prod-01") shouldBeEqualTo false
+    }
+
+    @Test
+    fun `Fix-94 - factory create 실패 SKIP - null 반환으로 흡수`() {
+        class SampleSkipOnCreate {
+            @LeaderElection(name = "create-fail-job", failureMode = LeaderAspectFailureMode.SKIP)
+            fun run(): String? = SAMPLE_RESULT
+        }
+
+        val skipTarget = SampleSkipOnCreate()
+        val skipMethod = SampleSkipOnCreate::class.java.getDeclaredMethod("run")
+        configureJoinPoint(skipMethod, skipTarget, emptyArray())
+
+        val aspect = newAspect()
+        every { factoryMock.create(any()) } throws RuntimeException("factory backend init error")
+
+        // SKIP 모드 → backend I/O 실패를 흡수하고 null 반환
+        aspect.aroundLeader(pjp).shouldBeNull()
+    }
 }


### PR DESCRIPTION
## Summary

Closes #94

PR #107의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: factory.create() I/O 실패가 failureMode 우회하던 버그 수정 (#94)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 문제

`LeaderElectionAspect` / `LeaderGroupElectionAspect` 에서 `resolveLockName()` 과 `factory.create()` 가 outer `try` 블록 **밖**에 있어서, backend I/O 실패(예: MongoDB `ensureIndexes()`, Redis 연결 거부) 시:

- `failureMode=SKIP` → 예외가 흡수되지 않고 그대로 throw
- `failureMode=RETHROW` → `LeaderElectionException` wrapping 없이 raw backend 예외 노출 (R-33 위반)

## 수정 내용

- `resolveLockName()`, `factory.create()`, `fanOut(onLockAttempt)` 를 `try` 블록 안으로 이동
- catch 블록에서 `lockName` null 안전 처리: `effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"`
- `LeaderGroupElectionAspect` 동일 패턴 적용

## 테스트 추가

`LeaderElectionAspectTest` 에 회귀 테스트 2개 추가:
- RETHROW 모드: `factory.create()` 실패 → `LeaderElectionException` wrapping, lockName 포함, host 정보 누출 없음
- SKIP 모드: `factory.create()` 실패 → null 반환으로 흡수

**테스트 결과**: 110 passing

Closes #94
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #94, milestone `0.1.0`, assignee `debop`
- PR: #107, head `a05de878d2ac73a7db92a3b1a97dcc856b417c52`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
