### PR TITLE
feat: LeaderMicrometerHealthAutoConfiguration 추가 — Boot 4 HealthIndicator 통합 (#102)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -136,6 +136,7 @@ spring-boot3-dependencies = { module = "org.springframework.boot:spring-boot-dep
 spring-boot4-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot4" }
 spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure" }
 spring-boot-actuator = { module = "org.springframework.boot:spring-boot-actuator" }
+spring-boot-health = { module = "org.springframework.boot:spring-boot-health" }
 spring-boot-configuration-processor = { module = "org.springframework.boot:spring-boot-configuration-processor" }
 spring-boot-test = { module = "org.springframework.boot:spring-boot-test" }
 spring-boot-test-autoconfigure = { module = "org.springframework.boot:spring-boot-test-autoconfigure" }

--- a/leader-spring-boot/build.gradle.kts
+++ b/leader-spring-boot/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     api(libs.aspectjweaver)
     api(libs.aspectjrt)
     compileOnly(libs.spring.boot.actuator)
+    compileOnly(libs.spring.boot.health)
     compileOnly(libs.spring.boot.configuration.processor)
     compileOnly(libs.spring.context)
     compileOnly(libs.spring.tx)

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/metrics/LeaderMetricsHealthIndicator.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/metrics/LeaderMetricsHealthIndicator.kt
@@ -1,0 +1,45 @@
+package io.bluetape4k.leader.spring.metrics
+
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.boot.health.contributor.AbstractHealthIndicator
+import org.springframework.boot.health.contributor.Health
+
+/**
+ * Leader AOP metrics 상태를 Spring Boot Actuator health endpoint에 노출하는 HealthIndicator.
+ *
+ * `MicrometerLeaderAopMetricsRecorder`가 등록된 경우에만 활성화된다.
+ * `leader.aop.active` Gauge를 조회하여 현재 실행 중인 leader 작업 수를 detail로 표시한다.
+ *
+ * ## Actuator 응답 예
+ * ```json
+ * {
+ *   "status": "UP",
+ *   "details": {
+ *     "active": 2,
+ *     "trackedLocks": 3
+ *   }
+ * }
+ * ```
+ *
+ * @param registry Micrometer [MeterRegistry]
+ */
+class LeaderMetricsHealthIndicator(
+    private val registry: MeterRegistry,
+) : AbstractHealthIndicator("Leader AOP metrics health check failed") {
+
+    companion object {
+        private const val METER_ACTIVE = "leader.aop.active"
+        private const val DETAIL_ACTIVE = "active"
+        private const val DETAIL_TRACKED_LOCKS = "trackedLocks"
+    }
+
+    override fun doHealthCheck(builder: Health.Builder) {
+        val activeGauges = registry.find(METER_ACTIVE).gauges()
+        val totalActive = activeGauges.sumOf { it.value().toInt() }
+        val trackedLocks = activeGauges.size
+
+        builder.up()
+            .withDetail(DETAIL_ACTIVE, totalActive)
+            .withDetail(DETAIL_TRACKED_LOCKS, trackedLocks)
+    }
+}

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/metrics/LeaderMicrometerHealthAutoConfiguration.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/metrics/LeaderMicrometerHealthAutoConfiguration.kt
@@ -1,0 +1,62 @@
+package io.bluetape4k.leader.spring.metrics
+
+import io.bluetape4k.leader.micrometer.MicrometerLeaderAopMetricsRecorder
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.beans.factory.config.BeanDefinition
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.health.contributor.HealthIndicator
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Role
+
+/**
+ * Leader AOP Micrometer HealthIndicator AutoConfiguration.
+ *
+ * `MicrometerLeaderAopMetricsRecorder` 빈이 등록된 경우 [LeaderMetricsHealthIndicator]를
+ * Spring Boot Actuator health endpoint에 자동 등록한다.
+ *
+ * ## AutoConfig 순서
+ * ```
+ * LeaderMicrometerAutoConfiguration  ← MicrometerLeaderAopMetricsRecorder 등록
+ *   ↓
+ * LeaderMicrometerHealthAutoConfiguration  ← 본 클래스 (LeaderMetricsHealthIndicator 등록)
+ * ```
+ *
+ * ## 비활성화
+ * ```yaml
+ * bluetape4k:
+ *   leader:
+ *     aop:
+ *       metrics:
+ *         enabled: false   # HealthIndicator도 함께 비활성화
+ * ```
+ */
+@AutoConfiguration(after = [LeaderMicrometerAutoConfiguration::class])
+@ConditionalOnClass(
+    name = [
+        "org.springframework.boot.health.contributor.HealthIndicator",
+        "io.bluetape4k.leader.micrometer.MicrometerLeaderAopMetricsRecorder",
+    ],
+)
+@ConditionalOnBean(MicrometerLeaderAopMetricsRecorder::class)
+@ConditionalOnProperty(
+    prefix = "bluetape4k.leader.aop.metrics",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+class LeaderMicrometerHealthAutoConfiguration {
+
+    /**
+     * `MeterRegistry` 빈이 존재하고 사용자가 직접 [LeaderMetricsHealthIndicator]를
+     * 등록하지 않은 경우에만 자동 등록한다.
+     */
+    @Bean("leaderMetricsHealthIndicator")
+    @ConditionalOnMissingBean(name = ["leaderMetricsHealthIndicator"])
+    @Role(BeanDefinition.ROLE_APPLICATION)
+    fun leaderMetricsHealthIndicator(registry: MeterRegistry): HealthIndicator =
+        LeaderMetricsHealthIndicator(registry)
+}

--- a/leader-spring-boot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/leader-spring-boot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -2,4 +2,5 @@ io.bluetape4k.leader.spring.LeaderElectionAutoConfiguration
 io.bluetape4k.leader.spring.backend.LocalLeaderConfiguration
 io.bluetape4k.leader.spring.aop.autoconfigure.LeaderAopFactoryAutoConfiguration
 io.bluetape4k.leader.spring.metrics.LeaderMicrometerAutoConfiguration
+io.bluetape4k.leader.spring.metrics.LeaderMicrometerHealthAutoConfiguration
 io.bluetape4k.leader.spring.aop.autoconfigure.LeaderAopAutoConfiguration

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/metrics/LeaderMicrometerHealthAutoConfigurationTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/metrics/LeaderMicrometerHealthAutoConfigurationTest.kt
@@ -1,0 +1,141 @@
+package io.bluetape4k.leader.spring.metrics
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.micrometer.MicrometerLeaderAopMetricsRecorder
+import io.bluetape4k.leader.spring.aop.autoconfigure.LeaderAopAutoConfiguration
+import io.bluetape4k.leader.spring.aop.autoconfigure.LeaderAopFactoryAutoConfiguration
+import io.bluetape4k.logging.KLogging
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.getBeansOfType
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.health.contributor.Health
+import org.springframework.boot.health.contributor.HealthIndicator
+import org.springframework.boot.health.contributor.Status
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderMicrometerHealthAutoConfigurationTest {
+
+    companion object : KLogging()
+
+    private val runner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                LeaderAopFactoryAutoConfiguration::class.java,
+                LeaderMicrometerAutoConfiguration::class.java,
+                LeaderMicrometerHealthAutoConfiguration::class.java,
+                LeaderAopAutoConfiguration::class.java,
+            )
+        )
+
+    @Test
+    fun `MicrometerLeaderAopMetricsRecorder 존재 시 leaderMetricsHealthIndicator 자동 등록`() {
+        runner
+            .withUserConfiguration(MeterRegistryConfig::class.java)
+            .run { ctx ->
+                ctx.getBean("leaderMetricsHealthIndicator", HealthIndicator::class.java).shouldNotBeNull()
+            }
+    }
+
+    @Test
+    fun `MicrometerLeaderAopMetricsRecorder 없을 때 HealthIndicator 미등록`() {
+        runner.run { ctx ->
+            ctx.getBeansOfType<HealthIndicator>().isEmpty() shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `metrics_enabled=false 시 HealthIndicator 미등록`() {
+        runner
+            .withUserConfiguration(MeterRegistryConfig::class.java)
+            .withPropertyValues("bluetape4k.leader.aop.metrics.enabled=false")
+            .run { ctx ->
+                ctx.getBeansOfType<HealthIndicator>().isEmpty() shouldBeEqualTo true
+            }
+    }
+
+    @Test
+    fun `사용자 정의 leaderMetricsHealthIndicator 우선`() {
+        runner
+            .withUserConfiguration(MeterRegistryConfig::class.java, CustomHealthIndicatorConfig::class.java)
+            .run { ctx ->
+                val indicator = ctx.getBean("leaderMetricsHealthIndicator", HealthIndicator::class.java)
+                indicator shouldBeInstanceOf CustomHealthIndicator::class
+            }
+    }
+
+    @Test
+    fun `health() 호출 시 UP 상태 및 active detail 포함`() {
+        runner
+            .withUserConfiguration(MeterRegistryConfig::class.java)
+            .run { ctx ->
+                val indicator = ctx.getBean("leaderMetricsHealthIndicator", HealthIndicator::class.java)
+                val health = requireNotNull(indicator.health()) { "health() must not return null" }
+
+                health.status shouldBeEqualTo Status.UP
+                health.details["active"].shouldNotBeNull()
+                health.details["trackedLocks"].shouldNotBeNull()
+            }
+    }
+
+    @Test
+    fun `active 작업 존재 시 active detail에 반영`() {
+        runner
+            .withUserConfiguration(MeterRegistryConfig::class.java)
+            .run { ctx ->
+                val recorder = ctx.getBean(MicrometerLeaderAopMetricsRecorder::class.java)
+                val indicator = ctx.getBean("leaderMetricsHealthIndicator", HealthIndicator::class.java)
+
+                recorder.onLockAttempt("job-lock", LeaderElectionOptions.Default)
+                recorder.onLockAcquired("job-lock", LeaderElectionOptions.Default, kotlin.time.Duration.ZERO)
+                recorder.onTaskStarted("job-lock")
+
+                val health = requireNotNull(indicator.health()) { "health() must not return null" }
+                health.status shouldBeEqualTo Status.UP
+                (health.details["active"] as Int) shouldBeEqualTo 1
+                (health.details["trackedLocks"] as Int) shouldBeEqualTo 1
+
+                // 정리
+                recorder.onTaskFinished("job-lock", kotlin.time.Duration.ZERO)
+            }
+    }
+
+    @Test
+    fun `active 작업 없을 때 active=0`() {
+        runner
+            .withUserConfiguration(MeterRegistryConfig::class.java)
+            .run { ctx ->
+                val indicator = ctx.getBean("leaderMetricsHealthIndicator", HealthIndicator::class.java)
+                val health = requireNotNull(indicator.health()) { "health() must not return null" }
+
+                health.status shouldBeEqualTo Status.UP
+                (health.details["active"] as Int) shouldBeEqualTo 0
+                (health.details["trackedLocks"] as Int) shouldBeEqualTo 0
+            }
+    }
+
+    // ── Config helpers ──────────────────────────────────────────────
+
+    @Configuration(proxyBeanMethods = false)
+    class MeterRegistryConfig {
+        @Bean
+        fun simpleMeterRegistry(): SimpleMeterRegistry = SimpleMeterRegistry()
+    }
+
+    class CustomHealthIndicator : HealthIndicator {
+        override fun health(): Health = Health.Builder().up().build()
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    class CustomHealthIndicatorConfig {
+        @Bean("leaderMetricsHealthIndicator")
+        fun leaderMetricsHealthIndicator(): HealthIndicator = CustomHealthIndicator()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #102

PR #112의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: LeaderMicrometerHealthAutoConfiguration 추가 — Boot 4 HealthIndicator 통합 (#102)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 변경 내용

### 배경
PR #101에서 metrics 통합은 완료했으나, Boot 4의 HealthIndicator API 경로가 변경되어 HealthContributor 통합은 후속 PR로 미뤘다.
- Boot 4: `org.springframework.boot.health.contributor.HealthIndicator` (새 모듈 `spring-boot-health`)

### 구현
**`LeaderMetricsHealthIndicator`** (새 파일)
- `AbstractHealthIndicator` 상속
- `MeterRegistry`에서 `leader.aop.active` Gauge 조회
- detail: `active` (현재 실행 중인 leader 작업 수), `trackedLocks` (추적 중인 lock 이름 수)

**`LeaderMicrometerHealthAutoConfiguration`** (새 파일)
- `@AutoConfiguration(after = [LeaderMicrometerAutoConfiguration::class])`
- `@ConditionalOnBean(MicrometerLeaderAopMetricsRecorder::class)`
- bean name: `leaderMetricsHealthIndicator` → Actuator `/health`에 `leaderMetrics`로 노출
- `@ConditionalOnMissingBean(name = ["leaderMetricsHealthIndicator"])` — 사용자 재정의 지원

**build.gradle.kts** — `compileOnly(libs.spring.boot.health)` 추가  
**AutoConfiguration.imports** — `LeaderMicrometerHealthAutoConfiguration` 등록

## 테스트
- `LeaderMicrometerHealthAutoConfigurationTest` 7개 테스트 추가
  - Recorder 존재/부재 시 자동 등록/미등록
  - `metrics.enabled=false` 시 미등록
  - 사용자 정의 indicator 우선 적용
  - `active` 작업 반영 검증
- 전체 `leader-spring-boot` 138개 통과

## 체크리스트
- [x] 테스트 통과
- [x] README 변경 없음 (내부 AutoConfig 추가)

Closes #102
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #102, milestone `0.1.0`, assignee `debop`
- PR: #112, head `1d9f57bcce7e419ef0b3388c9dce66f835a14d1f`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
