### PR TITLE
feat: LeaderRunResult sealed interface — elected vs skipped 구분 (#85)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -242,6 +242,19 @@ sequenceDiagram
 
 `runIfLeader(lockName, action)` — 선출 성공 시 `action()` 결과, 실패 시 `null` 반환.
 
+### 선출/미선출 구분: `LeaderRunResult`
+
+`runIfLeader()`는 (a) 락 미획득과 (b) `action()`이 정상적으로 `null`을 반환하는 두 경우 모두 `null`을 돌려줍니다. 두 경우를 명확히 구분해야 할 때(예: metrics 기록, 조건부 후처리) `runIfLeaderResult` / `runIfGroupLeaderResult`를 사용하세요.
+
+```kotlin
+when (val r = election.runIfLeaderResult("daily-job") { compute() }) {
+    is LeaderRunResult.Elected -> println("선출됨, 결과=${r.value}")
+    is LeaderRunResult.Skipped -> println("미선출 — 락 획득 실패")
+}
+```
+
+`LeaderRunResult`는 `Elected<T>(value: T?)`와 `Skipped` 두 변형을 가진 sealed interface입니다. 동기 `LeaderElector` 및 `LeaderGroupElector`에서만 제공되며, 비동기/코루틴 동등 메서드는 향후 릴리즈에서 추가될 예정입니다.
+
 ### 옵션 클래스
 
 ```kotlin

--- a/README.ko.md
+++ b/README.ko.md
@@ -244,7 +244,7 @@ sequenceDiagram
 
 ### 선출/미선출 구분: `LeaderRunResult`
 
-`runIfLeader()`는 (a) 락 미획득과 (b) `action()`이 정상적으로 `null`을 반환하는 두 경우 모두 `null`을 돌려줍니다. 두 경우를 명확히 구분해야 할 때(예: metrics 기록, 조건부 후처리) `runIfLeaderResult` / `runIfGroupLeaderResult`를 사용하세요.
+`runIfLeader()`는 (a) 락 미획득과 (b) `action()`이 정상적으로 `null`을 반환하는 두 경우 모두 `null`을 돌려줍니다. 두 경우를 명확히 구분해야 할 때(예: metrics 기록, 조건부 후처리) `runIfLeaderResult`를 사용하세요(`LeaderElector` 및 `LeaderGroupElector` 모두 동일 메서드명으로 제공).
 
 ```kotlin
 when (val r = election.runIfLeaderResult("daily-job") { compute() }) {

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ sequenceDiagram
 
 ### Distinguishing elected vs skipped: `LeaderRunResult`
 
-`runIfLeader()` returns `null` for two distinct cases: (a) lock not acquired and (b) `action()` legitimately returning `null`. Use `runIfLeaderResult` / `runIfGroupLeaderResult` when you need to tell them apart — for example, in metrics or conditional post-processing:
+`runIfLeader()` returns `null` for two distinct cases: (a) lock not acquired and (b) `action()` legitimately returning `null`. Use `runIfLeaderResult` (available on both `LeaderElector` and `LeaderGroupElector`) when you need to tell them apart — for example, in metrics or conditional post-processing:
 
 ```kotlin
 when (val r = election.runIfLeaderResult("daily-job") { compute() }) {

--- a/README.md
+++ b/README.md
@@ -242,6 +242,19 @@ sequenceDiagram
 
 `runIfLeader(lockName, action)` — returns `action()` result on success, `null` if not elected.
 
+### Distinguishing elected vs skipped: `LeaderRunResult`
+
+`runIfLeader()` returns `null` for two distinct cases: (a) lock not acquired and (b) `action()` legitimately returning `null`. Use `runIfLeaderResult` / `runIfGroupLeaderResult` when you need to tell them apart — for example, in metrics or conditional post-processing:
+
+```kotlin
+when (val r = election.runIfLeaderResult("daily-job") { compute() }) {
+    is LeaderRunResult.Elected -> println("elected, result=${r.value}")
+    is LeaderRunResult.Skipped -> println("skipped — lock not acquired")
+}
+```
+
+`LeaderRunResult` is a sealed interface with two variants: `Elected<T>(value: T?)` and `Skipped`. Available on synchronous `LeaderElector` and `LeaderGroupElector` only (async/suspend equivalents planned for a future release).
+
 ### Options
 
 ```kotlin

--- a/docs/lessons/2026-05-06-leader-run-result.md
+++ b/docs/lessons/2026-05-06-leader-run-result.md
@@ -1,0 +1,52 @@
+# Lessons Learned — LeaderRunResult sealed interface (2026-05-06)
+
+**관련 PR**: #85 (feat/85-leader-run-result)
+**영향 모듈**: leader-core, leader-spring-boot
+
+## L1: MockK relaxed mock은 interface default method를 우회한다
+
+### 문제
+`LeaderElector`에 `runIfLeaderResult` default 메서드를 추가한 후, `runIfLeader`를 mocking하는 기존 테스트가 모두 실패했다. MockK의 relaxed mock은 interface default method에 대해 자동으로 stub을 생성하며, 실제 default 구현(runIfLeader 호출)을 실행하지 않는다. 따라서 `runIfLeader`를 mocking해도 `runIfLeaderResult`가 호출되면 그 stub이 무시된다.
+
+### 교훈
+**MockK relaxed mock + interface default method 패턴**: mock되는 메서드가 실제 코드에서 호출되는 메서드인지 확인해야 한다. Aspect가 `runIfLeaderResult`를 호출하면 테스트도 반드시 `runIfLeaderResult`를 stub해야 한다. 구현 메서드(default impl 내부의 `runIfLeader`)를 stub하면 우회된다.
+
+---
+
+## L2: `elected` 플래그 클로저 패턴으로 기존 backend 수정 없이 null 모호성 해결
+
+### 문제
+`runIfLeader()`는 (a) lock 미획득과 (b) action()의 정상 null 반환 두 경우를 모두 `null`로 반환해서 metrics가 잘못된 CONTENTION을 기록했다.
+
+### 교훈
+기존 backend(`LocalLeaderElector`, `RedissonLeaderElector`, etc.) 수정 없이 interface default method에서 `elected` flag closure 패턴으로 해결 가능하다:
+
+```kotlin
+fun <T> runIfLeaderResult(lockName: String, action: () -> T): LeaderRunResult<T> {
+    var elected = false
+    val value = runIfLeader(lockName) { elected = true; action() }
+    return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
+}
+```
+
+이 패턴은 단일 호출자 컨텍스트에서 스레드 안전하며, 모든 기존 구현체에 자동으로 적용된다.
+
+---
+
+## L3: `-jvm-default=enable`은 기존 프로젝트 일관성 유지이며 변경 불필요
+
+### 문제
+advisor가 `-jvm-default=enable`이 deprecated이고 published library의 Java ABI에 영향을 미칠 수 있다고 경고했다.
+
+### 교훈
+프로젝트 전체에서 `@JvmDefault`를 사용하지 않고 `-jvm-default=enable`을 사용하므로, 모든 interface default method는 `DefaultImpls` 패턴으로 컴파일된다. 기존 코드가 일관되게 동작하고 테스트가 통과하므로 변경 불필요. 새 메서드도 동일 패턴을 따른다. ABI 변경이 필요한 시점(예: `all-compatibility` 모드 전환)은 별도 이슈로 처리.
+
+---
+
+## L4: BodyThrownMarker vs backend 예외 구분은 `runIfLeaderResult`와도 올바르게 동작
+
+### 문제
+`LeaderElectionAspect`의 `BodyThrownMarker` 패턴이 새 `runIfLeaderResult` default method와 올바르게 상호작용하는지 검증이 필요했다.
+
+### 교훈
+`runIfLeaderResult`는 `runIfLeader`를 내부에서 호출하고, `executeBody`에서 던진 `BodyThrownMarker`는 backend(`runIfLeader` 구현)를 통해 그대로 전파된다. 모든 backend 구현이 `try { return action() } finally { ... }` 또는 동등 패턴을 사용하므로 marker가 재포장되지 않는다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElector.kt
@@ -44,6 +44,10 @@ interface LeaderElector: AsyncLeaderElector {
      * action()이 null을 반환해도 [LeaderRunResult.Elected]로 구분되고,
      * lock 미획득은 [LeaderRunResult.Skipped]로 구분됩니다.
      *
+     * NOTE: 동기 [LeaderElector] 전용입니다.
+     * `SuspendLeaderElector` / `AsyncLeaderElector` / `VirtualThreadLeaderElector` 의 동등
+     * 메서드는 v1.x 후속 이슈에서 추가 예정입니다.
+     *
      * ```kotlin
      * when (val r = election.runIfLeaderResult("job-lock") { compute() }) {
      *     is LeaderRunResult.Elected -> println("elected, value=${r.value}")

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElector.kt
@@ -37,4 +37,28 @@ interface LeaderElector: AsyncLeaderElector {
      */
     fun <T> runIfLeader(lockName: String, action: () -> T): T?
 
+    /**
+     * 리더 선출 결과를 [LeaderRunResult]로 반환합니다.
+     *
+     * `runIfLeader`의 `null` 반환 모호성을 해결합니다:
+     * action()이 null을 반환해도 [LeaderRunResult.Elected]로 구분되고,
+     * lock 미획득은 [LeaderRunResult.Skipped]로 구분됩니다.
+     *
+     * ```kotlin
+     * when (val r = election.runIfLeaderResult("job-lock") { compute() }) {
+     *     is LeaderRunResult.Elected -> println("elected, value=${r.value}")
+     *     is LeaderRunResult.Skipped -> println("skipped — lock not acquired")
+     * }
+     * ```
+     *
+     * @param lockName 리더 선출에 사용할 락 이름
+     * @param action 리더 획득 성공 시 실행할 동기 작업
+     * @return [LeaderRunResult.Elected] (action 실행됨) 또는 [LeaderRunResult.Skipped] (lock 미획득)
+     */
+    fun <T> runIfLeaderResult(lockName: String, action: () -> T): LeaderRunResult<T> {
+        var elected = false
+        val value = runIfLeader(lockName) { elected = true; action() }
+        return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
+    }
+
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupElector.kt
@@ -45,4 +45,21 @@ interface LeaderGroupElector: AsyncLeaderGroupElector {
      * @return [action] 실행 결과, 슬롯 획득 실패 시 `null`
      */
     fun <T> runIfLeader(lockName: String, action: () -> T): T?
+
+    /**
+     * 리더 그룹 선출 결과를 [LeaderRunResult]로 반환합니다.
+     *
+     * `runIfLeader`의 `null` 반환 모호성을 해결합니다:
+     * action()이 null을 반환해도 [LeaderRunResult.Elected]로 구분되고,
+     * 슬롯 미획득은 [LeaderRunResult.Skipped]로 구분됩니다.
+     *
+     * @param lockName 리더 그룹 선출에 사용할 락 이름
+     * @param action 슬롯 획득 성공 시 실행할 동기 작업
+     * @return [LeaderRunResult.Elected] (action 실행됨) 또는 [LeaderRunResult.Skipped] (슬롯 미획득)
+     */
+    fun <T> runIfGroupLeaderResult(lockName: String, action: () -> T): LeaderRunResult<T> {
+        var elected = false
+        val value = runIfLeader(lockName) { elected = true; action() }
+        return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
+    }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupElector.kt
@@ -53,6 +53,10 @@ interface LeaderGroupElector: AsyncLeaderGroupElector {
      * action()이 null을 반환해도 [LeaderRunResult.Elected]로 구분되고,
      * 슬롯 미획득은 [LeaderRunResult.Skipped]로 구분됩니다.
      *
+     * NOTE: 동기 [LeaderGroupElector] 전용입니다.
+     * `SuspendLeaderGroupElector` / `AsyncLeaderGroupElector` 의 동등 메서드는
+     * v1.x 후속 이슈에서 추가 예정입니다.
+     *
      * @param lockName 리더 그룹 선출에 사용할 락 이름
      * @param action 슬롯 획득 성공 시 실행할 동기 작업
      * @return [LeaderRunResult.Elected] (action 실행됨) 또는 [LeaderRunResult.Skipped] (슬롯 미획득)

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupElector.kt
@@ -49,6 +49,7 @@ interface LeaderGroupElector: AsyncLeaderGroupElector {
     /**
      * 리더 그룹 선출 결과를 [LeaderRunResult]로 반환합니다.
      *
+     * [LeaderElector.runIfLeaderResult]와 동일 메서드명 — "Group" 컨텍스트는 인터페이스 타입으로 전달.
      * `runIfLeader`의 `null` 반환 모호성을 해결합니다:
      * action()이 null을 반환해도 [LeaderRunResult.Elected]로 구분되고,
      * 슬롯 미획득은 [LeaderRunResult.Skipped]로 구분됩니다.
@@ -61,7 +62,7 @@ interface LeaderGroupElector: AsyncLeaderGroupElector {
      * @param action 슬롯 획득 성공 시 실행할 동기 작업
      * @return [LeaderRunResult.Elected] (action 실행됨) 또는 [LeaderRunResult.Skipped] (슬롯 미획득)
      */
-    fun <T> runIfGroupLeaderResult(lockName: String, action: () -> T): LeaderRunResult<T> {
+    fun <T> runIfLeaderResult(lockName: String, action: () -> T): LeaderRunResult<T> {
         var elected = false
         val value = runIfLeader(lockName) { elected = true; action() }
         return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderRunResult.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderRunResult.kt
@@ -18,6 +18,9 @@ sealed interface LeaderRunResult<out T> {
      * 리더 선출 성공 — action 실행 완료.
      *
      * action 반환값이 null이어도 [Elected]로 분류됩니다.
+     *
+     * NOTE: T가 non-null 타입이어도 [value]는 `T?`로 선언됩니다.
+     * 이는 `runIfLeader()` 반환 타입 `T?`를 통한 클로저 패턴의 제약입니다.
      */
     data class Elected<out T>(val value: T?) : LeaderRunResult<T>
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderRunResult.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderRunResult.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.leader
+
+/**
+ * [LeaderElector.runIfLeaderResult] / [LeaderGroupElector.runIfGroupLeaderResult] 호출 결과를 나타내는 sealed interface.
+ *
+ * ## 목적
+ * [LeaderElector.runIfLeader]는 (a) lock 미획득 시와 (b) action()이 null을 반환할 때
+ * 모두 `null`을 반환하여 호출자가 두 경우를 구분할 수 없습니다.
+ * 이 타입은 그 모호성을 제거합니다.
+ *
+ * ## 상태
+ * - [Elected]: 리더 선출 성공 — action이 실행됨. action 반환값이 null이어도 [Elected]
+ * - [Skipped]: 리더 선출 실패 — lock 미획득으로 action이 실행되지 않음
+ */
+sealed interface LeaderRunResult<out T> {
+
+    /**
+     * 리더 선출 성공 — action 실행 완료.
+     *
+     * action 반환값이 null이어도 [Elected]로 분류됩니다.
+     */
+    data class Elected<out T>(val value: T?) : LeaderRunResult<T>
+
+    /** 리더 선출 실패 — lock 미획득으로 action이 실행되지 않음. */
+    data object Skipped : LeaderRunResult<Nothing>
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderRunResult.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderRunResult.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.leader
 
 /**
- * [LeaderElector.runIfLeaderResult] / [LeaderGroupElector.runIfGroupLeaderResult] 호출 결과를 나타내는 sealed interface.
+ * [LeaderElector.runIfLeaderResult] / [LeaderGroupElector.runIfLeaderResult] 호출 결과를 나타내는 sealed interface.
  *
  * ## 목적
  * [LeaderElector.runIfLeader]는 (a) lock 미획득 시와 (b) action()이 null을 반환할 때

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/metrics/SkipReason.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/metrics/SkipReason.kt
@@ -3,15 +3,13 @@ package io.bluetape4k.leader.metrics
 /**
  * `LeaderAopMetricsRecorder.onLockNotAcquired` 호출 시 전달하는 미선출 사유.
  *
- * ## best-effort 한계
- * 코어 SPI `runIfLeader(name, action): T?` 는 본문 `null` 반환과 미선출 구분 불가.
- * 본 PR `CONTENTION` 은 best-effort — 본문이 정상 `null` 반환한 경우도 CONTENTION 으로 기록될 수 있음.
- * 정확한 elected vs skipped 분리는 후속 [#85] sealed `LeaderRunResult` SPI 도입 시 가능.
+ * [#85] `LeaderRunResult` sealed SPI 도입으로 `CONTENTION` 은 이제 정확 — `runIfLeaderResult`
+ * 내부 `elected` 플래그로 본문 `null` 반환과 미선출을 명확히 구분.
  *
  * `FAIL_OPEN_FORCED` 는 후속 [#81] 에서 `FAIL_OPEN_RUN` failureMode 도입 시 함께 추가.
  */
 enum class SkipReason {
-    /** waitTime 내 락 획득 실패 (또는 본문 null 반환 — best-effort). */
+    /** waitTime 내 락 획득 실패. */
     CONTENTION,
 
     /** 백엔드 예외 발생 후 SKIP 모드로 흡수. */

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderRunResultTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderRunResultTest.kt
@@ -1,0 +1,92 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.leader.local.LocalLeaderElector
+import io.bluetape4k.leader.local.LocalLeaderGroupElector
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderRunResultTest {
+
+    companion object : KLogging()
+
+    private val election = LocalLeaderElector()
+    private val groupElection = LocalLeaderGroupElector(LeaderGroupElectionOptions(maxLeaders = 2))
+
+    private fun randomLockName() = "lock-${Base58.randomString(8)}"
+
+    // --- LeaderElector.runIfLeaderResult ---
+
+    @Test
+    fun `runIfLeaderResult - 리더 선출 성공 시 Elected 반환`() {
+        val result = election.runIfLeaderResult(randomLockName()) { "done" }
+
+        result shouldBeInstanceOf LeaderRunResult.Elected::class
+        (result as LeaderRunResult.Elected).value shouldBeEqualTo "done"
+    }
+
+    @Test
+    fun `runIfLeaderResult - action 이 null 반환해도 Elected 로 분류`() {
+        val result = election.runIfLeaderResult(randomLockName()) { null }
+
+        result shouldBeInstanceOf LeaderRunResult.Elected::class
+        (result as LeaderRunResult.Elected).value.shouldBeNull()
+    }
+
+    @Test
+    fun `runIfLeaderResult - 정수 결과도 Elected 로 반환`() {
+        val result = election.runIfLeaderResult(randomLockName()) { 42 }
+
+        result shouldBeInstanceOf LeaderRunResult.Elected::class
+        (result as LeaderRunResult.Elected).value shouldBeEqualTo 42
+    }
+
+    @Test
+    fun `LeaderRunResult Elected - when 분기 망라 가능 — Skipped 분기 도달 불가`() {
+        val result = election.runIfLeaderResult(randomLockName()) { "value" }
+        val output = when (result) {
+            is LeaderRunResult.Elected -> result.value
+            is LeaderRunResult.Skipped -> null
+        }
+        output shouldBeEqualTo "value"
+    }
+
+    // --- LeaderGroupElector.runIfGroupLeaderResult ---
+
+    @Test
+    fun `runIfGroupLeaderResult - 슬롯 획득 성공 시 Elected 반환`() {
+        val result = groupElection.runIfGroupLeaderResult(randomLockName()) { "group-done" }
+
+        result shouldBeInstanceOf LeaderRunResult.Elected::class
+        (result as LeaderRunResult.Elected).value shouldBeEqualTo "group-done"
+    }
+
+    @Test
+    fun `runIfGroupLeaderResult - action 이 null 반환해도 Elected 로 분류`() {
+        val result = groupElection.runIfGroupLeaderResult(randomLockName()) { null }
+
+        result shouldBeInstanceOf LeaderRunResult.Elected::class
+        (result as LeaderRunResult.Elected).value.shouldBeNull()
+    }
+
+    // --- data class / object 특성 ---
+
+    @Test
+    fun `LeaderRunResult Elected - 동일 value 면 equals`() {
+        val a = LeaderRunResult.Elected("hello")
+        val b = LeaderRunResult.Elected("hello")
+        a shouldBeEqualTo b
+    }
+
+    @Test
+    fun `LeaderRunResult Skipped - singleton object`() {
+        val a: LeaderRunResult<String> = LeaderRunResult.Skipped
+        val b: LeaderRunResult<Int> = LeaderRunResult.Skipped
+        (a === b) shouldBeEqualTo true
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderRunResultTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderRunResultTest.kt
@@ -56,19 +56,19 @@ class LeaderRunResultTest {
         output shouldBeEqualTo "value"
     }
 
-    // --- LeaderGroupElector.runIfGroupLeaderResult ---
+    // --- LeaderGroupElector.runIfLeaderResult ---
 
     @Test
-    fun `runIfGroupLeaderResult - 슬롯 획득 성공 시 Elected 반환`() {
-        val result = groupElection.runIfGroupLeaderResult(randomLockName()) { "group-done" }
+    fun `group runIfLeaderResult - 슬롯 획득 성공 시 Elected 반환`() {
+        val result = groupElection.runIfLeaderResult(randomLockName()) { "group-done" }
 
         result shouldBeInstanceOf LeaderRunResult.Elected::class
         (result as LeaderRunResult.Elected).value shouldBeEqualTo "group-done"
     }
 
     @Test
-    fun `runIfGroupLeaderResult - action 이 null 반환해도 Elected 로 분류`() {
-        val result = groupElection.runIfGroupLeaderResult(randomLockName()) { null }
+    fun `group runIfLeaderResult - action 이 null 반환해도 Elected 로 분류`() {
+        val result = groupElection.runIfLeaderResult(randomLockName()) { null }
 
         result shouldBeInstanceOf LeaderRunResult.Elected::class
         (result as LeaderRunResult.Elected).value.shouldBeNull()

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.spring.aop
 
 import io.bluetape4k.leader.LeaderElector
 import io.bluetape4k.leader.LeaderElectionException
+import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderElectorFactory
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.annotation.LeaderAspectFailureMode
@@ -87,27 +88,31 @@ class LeaderElectionAspect(
 
             fanOut { it.onLockAttempt(resolvedName, opts) }
 
-            val result = election.runIfLeader(resolvedName) {
+            val runResult = election.runIfLeaderResult(resolvedName) {
                 fanOut {
                     it.onLockAcquired(resolvedName, opts, (System.nanoTime() - start).nanoseconds)
                     it.onTaskStarted(resolvedName)
                 }
                 executeBody(pjp, resolvedName, start)
             }
-            if (result == null) {
-                fanOut { it.onLockNotAcquired(resolvedName, opts, SkipReason.CONTENTION) }
-                log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
-            } else {
-                val elapsed = System.nanoTime() - start
-                fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
-                log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
-                if (elapsed > meta.leaseTimeWarnThresholdNanos) {
-                    log.warn {
-                        "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${opts.leaseTime.toNanos()}"
+            when (runResult) {
+                is LeaderRunResult.Skipped -> {
+                    fanOut { it.onLockNotAcquired(resolvedName, opts, SkipReason.CONTENTION) }
+                    log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
+                    null
+                }
+                is LeaderRunResult.Elected -> {
+                    val elapsed = System.nanoTime() - start
+                    fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
+                    log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
+                    if (elapsed > meta.leaseTimeWarnThresholdNanos) {
+                        log.warn {
+                            "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${opts.leaseTime.toNanos()}"
+                        }
                     }
+                    runResult.value
                 }
             }
-            result
         } catch (e: CancellationException) {
             // [Rel-2] CancellationException 항상 우선 재throw
             throw e

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -74,7 +74,7 @@ class LeaderGroupElectionAspect(
 
             fanOut { it.onLockAttempt(resolvedName, coreOpts) }
 
-            val runResult = election.runIfGroupLeaderResult(resolvedName) {
+            val runResult = election.runIfLeaderResult(resolvedName) {
                 fanOut {
                     it.onLockAcquired(resolvedName, coreOpts, (System.nanoTime() - start).nanoseconds)
                     it.onTaskStarted(resolvedName)

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.spring.aop
 
 import io.bluetape4k.leader.LeaderGroupElector
 import io.bluetape4k.leader.LeaderGroupElectionException
+import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderGroupElectorFactory
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.annotation.LeaderAspectFailureMode
@@ -73,27 +74,31 @@ class LeaderGroupElectionAspect(
 
             fanOut { it.onLockAttempt(resolvedName, coreOpts) }
 
-            val result = election.runIfLeader(resolvedName) {
+            val runResult = election.runIfGroupLeaderResult(resolvedName) {
                 fanOut {
                     it.onLockAcquired(resolvedName, coreOpts, (System.nanoTime() - start).nanoseconds)
                     it.onTaskStarted(resolvedName)
                 }
                 executeBody(pjp, resolvedName, start)
             }
-            if (result == null) {
-                fanOut { it.onLockNotAcquired(resolvedName, coreOpts, SkipReason.CONTENTION) }
-                log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
-            } else {
-                val elapsed = System.nanoTime() - start
-                fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
-                log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
-                if (elapsed > meta.leaseTimeWarnThresholdNanos) {
-                    log.warn {
-                        "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${opts.leaseTime.toNanos()}"
+            when (runResult) {
+                is LeaderRunResult.Skipped -> {
+                    fanOut { it.onLockNotAcquired(resolvedName, coreOpts, SkipReason.CONTENTION) }
+                    log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
+                    null
+                }
+                is LeaderRunResult.Elected -> {
+                    val elapsed = System.nanoTime() - start
+                    fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
+                    log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
+                    if (elapsed > meta.leaseTimeWarnThresholdNanos) {
+                        log.warn {
+                            "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${opts.leaseTime.toNanos()}"
+                        }
                     }
+                    runResult.value
                 }
             }
-            result
         } catch (e: CancellationException) {
             throw e
         } catch (bodyMarker: BodyThrownMarker) {

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.spring.aop
 
 import io.bluetape4k.leader.LeaderElectionException
 import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderElectorFactory
 import io.bluetape4k.leader.annotation.LeaderAspectFailureMode
 import io.bluetape4k.leader.annotation.LeaderElection
@@ -100,7 +101,7 @@ class LeaderElectionAspectTest {
         every { pjp.proceed() } returns SAMPLE_RESULT
 
         val actionSlot = slot<() -> Any?>()
-        every { election.runIfLeader<Any?>(any(), capture(actionSlot)) } answers { actionSlot.captured.invoke() }
+        every { election.runIfLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
 
         val aspect = newAspect(listOf(recorder))
 
@@ -119,7 +120,7 @@ class LeaderElectionAspectTest {
         val method = SampleService::class.java.getDeclaredMethod("runSync")
         configureJoinPoint(method, target, emptyArray())
 
-        every { election.runIfLeader<Any?>(any(), any()) } returns null
+        every { election.runIfLeaderResult<Any?>(any(), any()) } returns LeaderRunResult.Skipped
 
         val aspect = newAspect(listOf(recorder))
 
@@ -136,7 +137,7 @@ class LeaderElectionAspectTest {
         every { pjp.proceed() } throws bodyEx
 
         val actionSlot = slot<() -> Any?>()
-        every { election.runIfLeader<Any?>(any(), capture(actionSlot)) } answers { actionSlot.captured.invoke() }
+        every { election.runIfLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
 
         val aspect = newAspect()
         val ex = assertThrows<RuntimeException> { aspect.aroundLeader(pjp) }
@@ -150,7 +151,7 @@ class LeaderElectionAspectTest {
         configureJoinPoint(method, target, emptyArray())
 
         val backendEx = RuntimeException("Connection to redis-prod-01.internal:6379 timeout")
-        every { election.runIfLeader<Any?>(any(), any()) } throws backendEx
+        every { election.runIfLeaderResult<Any?>(any(), any()) } throws backendEx
 
         val aspect = newAspect()
         val wrapped = assertThrows<LeaderElectionException> { aspect.aroundLeader(pjp) }
@@ -169,7 +170,7 @@ class LeaderElectionAspectTest {
         every { pjp.proceed() } throws cancelEx
 
         val actionSlot = slot<() -> Any?>()
-        every { election.runIfLeader<Any?>(any(), capture(actionSlot)) } answers { actionSlot.captured.invoke() }
+        every { election.runIfLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
 
         val aspect = newAspect()
         val ex = assertThrows<CancellationException> { aspect.aroundLeader(pjp) }
@@ -188,7 +189,7 @@ class LeaderElectionAspectTest {
         configureJoinPoint(skipMethod, skipTarget, emptyArray())
 
         val backendEx = RuntimeException("backend down")
-        every { election.runIfLeader<Any?>(any(), any()) } throws backendEx
+        every { election.runIfLeaderResult<Any?>(any(), any()) } throws backendEx
 
         val aspect = newAspect()
         aspect.aroundLeader(pjp).shouldBeNull()
@@ -202,7 +203,7 @@ class LeaderElectionAspectTest {
         every { pjp.proceed() } returns SAMPLE_RESULT
 
         val actionSlot = slot<() -> Any?>()
-        every { election.runIfLeader<Any?>(any(), capture(actionSlot)) } answers { actionSlot.captured.invoke() }
+        every { election.runIfLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
 
         val aspect = newAspect(recorders = emptyList())
         // recorders 0개 — fanOut 호출 없이 정상 동작
@@ -217,7 +218,7 @@ class LeaderElectionAspectTest {
         every { pjp.proceed() } returns SAMPLE_RESULT
 
         val actionSlot = slot<() -> Any?>()
-        every { election.runIfLeader<Any?>(any(), capture(actionSlot)) } answers { actionSlot.captured.invoke() }
+        every { election.runIfLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
 
         val throwingRecorder = mockk<LeaderAopMetricsRecorder>(relaxed = true)
         every { throwingRecorder.onLockAttempt(any(), any()) } throws RuntimeException("recorder failure")
@@ -237,7 +238,7 @@ class LeaderElectionAspectTest {
         val method = SampleService::class.java.getDeclaredMethod("runSync")
 
         val actionSlot = slot<() -> Any?>()
-        every { election.runIfLeader<Any?>(any(), capture(actionSlot)) } answers { actionSlot.captured.invoke() }
+        every { election.runIfLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
         every { factoryMock.create(any()) } returns election
         every { beanSelector.selectElectionFactory(any()) } returns
                 LeaderBeanSelector.Selected("testFactory", factoryMock)
@@ -271,11 +272,11 @@ class LeaderElectionAspectTest {
         val actionSlot = slot<() -> Any?>()
         val nameSlot = slot<String>()
         every {
-            election.runIfLeader<Any?>(
+            election.runIfLeaderResult<Any?>(
                 capture(nameSlot),
                 capture(actionSlot)
             )
-        } answers { actionSlot.captured.invoke() }
+        } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
 
         val aspect = newAspect()
         val result = aspect.aroundLeader(pjp)
@@ -290,7 +291,7 @@ class LeaderElectionAspectTest {
         val method = SampleService::class.java.getDeclaredMethod("runSync")
         configureJoinPoint(method, target, emptyArray())
 
-        every { election.runIfLeader<Any?>(any(), any()) } throws IllegalStateException("backend")
+        every { election.runIfLeaderResult<Any?>(any(), any()) } throws IllegalStateException("backend")
 
         val aspect = newAspect()
         val ex = assertThrows<LeaderElectionException> { aspect.aroundLeader(pjp) }

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectTest.kt
@@ -104,7 +104,7 @@ class LeaderGroupElectionAspectTest {
         every { pjp.proceed() } returns SAMPLE_RESULT
 
         val actionSlot = slot<() -> Any?>()
-        every { election.runIfGroupLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
+        every { election.runIfLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
 
         val aspect = newAspect(listOf(recorder))
 
@@ -123,7 +123,7 @@ class LeaderGroupElectionAspectTest {
         val method = SampleService::class.java.getDeclaredMethod("runSync")
         configureJoinPoint(method, target, emptyArray())
 
-        every { election.runIfGroupLeaderResult<Any?>(any(), any()) } returns LeaderRunResult.Skipped
+        every { election.runIfLeaderResult<Any?>(any(), any()) } returns LeaderRunResult.Skipped
 
         val aspect = newAspect(listOf(recorder))
 
@@ -140,7 +140,7 @@ class LeaderGroupElectionAspectTest {
         every { pjp.proceed() } throws bodyEx
 
         val actionSlot = slot<() -> Any?>()
-        every { election.runIfGroupLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
+        every { election.runIfLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
 
         val aspect = newAspect()
         val ex = assertThrows<RuntimeException> { aspect.aroundLeader(pjp) }
@@ -154,7 +154,7 @@ class LeaderGroupElectionAspectTest {
         configureJoinPoint(method, target, emptyArray())
 
         val backendEx = RuntimeException("Connection to redis-prod-01.internal:6379 timeout")
-        every { election.runIfGroupLeaderResult<Any?>(any(), any()) } throws backendEx
+        every { election.runIfLeaderResult<Any?>(any(), any()) } throws backendEx
 
         val aspect = newAspect()
         val wrapped = assertThrows<LeaderGroupElectionException> { aspect.aroundLeader(pjp) }
@@ -172,7 +172,7 @@ class LeaderGroupElectionAspectTest {
         every { pjp.proceed() } throws cancelEx
 
         val actionSlot = slot<() -> Any?>()
-        every { election.runIfGroupLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
+        every { election.runIfLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
 
         val aspect = newAspect()
         val ex = assertThrows<CancellationException> { aspect.aroundLeader(pjp) }
@@ -191,7 +191,7 @@ class LeaderGroupElectionAspectTest {
         configureJoinPoint(skipMethod, skipTarget, emptyArray())
 
         val backendEx = RuntimeException("backend down")
-        every { election.runIfGroupLeaderResult<Any?>(any(), any()) } throws backendEx
+        every { election.runIfLeaderResult<Any?>(any(), any()) } throws backendEx
 
         val aspect = newAspect()
         aspect.aroundLeader(pjp).shouldBeNull()
@@ -205,7 +205,7 @@ class LeaderGroupElectionAspectTest {
         every { pjp.proceed() } returns SAMPLE_RESULT
 
         val actionSlot = slot<() -> Any?>()
-        every { election.runIfGroupLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
+        every { election.runIfLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
 
         val aspect = newAspect(recorders = emptyList())
         aspect.aroundLeader(pjp) shouldBeEqualTo SAMPLE_RESULT
@@ -217,7 +217,7 @@ class LeaderGroupElectionAspectTest {
         val method = SampleService::class.java.getDeclaredMethod("runSync")
 
         val actionSlot = slot<() -> Any?>()
-        every { election.runIfGroupLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
+        every { election.runIfLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
         every { factoryMock.create(any()) } returns election
         every { beanSelector.selectGroupElectionFactory(any()) } returns
                 LeaderBeanSelector.Selected("testGroupFactory", factoryMock)
@@ -249,7 +249,7 @@ class LeaderGroupElectionAspectTest {
         val actionSlot = slot<() -> Any?>()
         val nameSlot = slot<String>()
         every {
-            election.runIfGroupLeaderResult<Any?>(capture(nameSlot), capture(actionSlot))
+            election.runIfLeaderResult<Any?>(capture(nameSlot), capture(actionSlot))
         } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
 
         val aspect = newAspect()
@@ -265,7 +265,7 @@ class LeaderGroupElectionAspectTest {
         val method = SampleService::class.java.getDeclaredMethod("runSync")
         configureJoinPoint(method, target, emptyArray())
 
-        every { election.runIfGroupLeaderResult<Any?>(any(), any()) } throws IllegalStateException("backend")
+        every { election.runIfLeaderResult<Any?>(any(), any()) } throws IllegalStateException("backend")
 
         val aspect = newAspect()
         val ex = assertThrows<LeaderGroupElectionException> { aspect.aroundLeader(pjp) }

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.spring.aop
 
 import io.bluetape4k.leader.LeaderGroupElectionException
 import io.bluetape4k.leader.LeaderGroupElector
+import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderGroupElectorFactory
 import io.bluetape4k.leader.annotation.LeaderAspectFailureMode
 import io.bluetape4k.leader.annotation.LeaderGroupElection
@@ -103,7 +104,7 @@ class LeaderGroupElectionAspectTest {
         every { pjp.proceed() } returns SAMPLE_RESULT
 
         val actionSlot = slot<() -> Any?>()
-        every { election.runIfLeader<Any?>(any(), capture(actionSlot)) } answers { actionSlot.captured.invoke() }
+        every { election.runIfGroupLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
 
         val aspect = newAspect(listOf(recorder))
 
@@ -122,7 +123,7 @@ class LeaderGroupElectionAspectTest {
         val method = SampleService::class.java.getDeclaredMethod("runSync")
         configureJoinPoint(method, target, emptyArray())
 
-        every { election.runIfLeader<Any?>(any(), any()) } returns null
+        every { election.runIfGroupLeaderResult<Any?>(any(), any()) } returns LeaderRunResult.Skipped
 
         val aspect = newAspect(listOf(recorder))
 
@@ -139,7 +140,7 @@ class LeaderGroupElectionAspectTest {
         every { pjp.proceed() } throws bodyEx
 
         val actionSlot = slot<() -> Any?>()
-        every { election.runIfLeader<Any?>(any(), capture(actionSlot)) } answers { actionSlot.captured.invoke() }
+        every { election.runIfGroupLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
 
         val aspect = newAspect()
         val ex = assertThrows<RuntimeException> { aspect.aroundLeader(pjp) }
@@ -153,7 +154,7 @@ class LeaderGroupElectionAspectTest {
         configureJoinPoint(method, target, emptyArray())
 
         val backendEx = RuntimeException("Connection to redis-prod-01.internal:6379 timeout")
-        every { election.runIfLeader<Any?>(any(), any()) } throws backendEx
+        every { election.runIfGroupLeaderResult<Any?>(any(), any()) } throws backendEx
 
         val aspect = newAspect()
         val wrapped = assertThrows<LeaderGroupElectionException> { aspect.aroundLeader(pjp) }
@@ -171,7 +172,7 @@ class LeaderGroupElectionAspectTest {
         every { pjp.proceed() } throws cancelEx
 
         val actionSlot = slot<() -> Any?>()
-        every { election.runIfLeader<Any?>(any(), capture(actionSlot)) } answers { actionSlot.captured.invoke() }
+        every { election.runIfGroupLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
 
         val aspect = newAspect()
         val ex = assertThrows<CancellationException> { aspect.aroundLeader(pjp) }
@@ -190,7 +191,7 @@ class LeaderGroupElectionAspectTest {
         configureJoinPoint(skipMethod, skipTarget, emptyArray())
 
         val backendEx = RuntimeException("backend down")
-        every { election.runIfLeader<Any?>(any(), any()) } throws backendEx
+        every { election.runIfGroupLeaderResult<Any?>(any(), any()) } throws backendEx
 
         val aspect = newAspect()
         aspect.aroundLeader(pjp).shouldBeNull()
@@ -204,7 +205,7 @@ class LeaderGroupElectionAspectTest {
         every { pjp.proceed() } returns SAMPLE_RESULT
 
         val actionSlot = slot<() -> Any?>()
-        every { election.runIfLeader<Any?>(any(), capture(actionSlot)) } answers { actionSlot.captured.invoke() }
+        every { election.runIfGroupLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
 
         val aspect = newAspect(recorders = emptyList())
         aspect.aroundLeader(pjp) shouldBeEqualTo SAMPLE_RESULT
@@ -216,7 +217,7 @@ class LeaderGroupElectionAspectTest {
         val method = SampleService::class.java.getDeclaredMethod("runSync")
 
         val actionSlot = slot<() -> Any?>()
-        every { election.runIfLeader<Any?>(any(), capture(actionSlot)) } answers { actionSlot.captured.invoke() }
+        every { election.runIfGroupLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
         every { factoryMock.create(any()) } returns election
         every { beanSelector.selectGroupElectionFactory(any()) } returns
                 LeaderBeanSelector.Selected("testGroupFactory", factoryMock)
@@ -248,8 +249,8 @@ class LeaderGroupElectionAspectTest {
         val actionSlot = slot<() -> Any?>()
         val nameSlot = slot<String>()
         every {
-            election.runIfLeader<Any?>(capture(nameSlot), capture(actionSlot))
-        } answers { actionSlot.captured.invoke() }
+            election.runIfGroupLeaderResult<Any?>(capture(nameSlot), capture(actionSlot))
+        } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
 
         val aspect = newAspect()
         val result = aspect.aroundLeader(pjp)
@@ -264,7 +265,7 @@ class LeaderGroupElectionAspectTest {
         val method = SampleService::class.java.getDeclaredMethod("runSync")
         configureJoinPoint(method, target, emptyArray())
 
-        every { election.runIfLeader<Any?>(any(), any()) } throws IllegalStateException("backend")
+        every { election.runIfGroupLeaderResult<Any?>(any(), any()) } throws IllegalStateException("backend")
 
         val aspect = newAspect()
         val ex = assertThrows<LeaderGroupElectionException> { aspect.aroundLeader(pjp) }


### PR DESCRIPTION
## Summary

Closes #85

PR #114의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: LeaderRunResult sealed interface — elected vs skipped 구분 (#85)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

`runIfLeader()` returns `null` for two distinct cases:
- (a) lock not acquired (skip)
- (b) `action()` legitimately returning `null` (elected with null value)

This PR introduces `LeaderRunResult<T>` sealed interface to disambiguate, primarily for metrics/monitoring use.

## Changes

### New API
- **`LeaderRunResult<out T>`** sealed interface with two variants:
  - `Elected<T>(value: T?)` — action executed; value may be null
  - `Skipped` — lock not acquired, action skipped
- **`LeaderElector.runIfLeaderResult()`** default method (single-leader)
- **`LeaderGroupElector.runIfLeaderResult()`** default method (multi-leader, same name for symmetry)

### Implementation
- `elected` flag closure pattern — no backend modification required
- Works with all existing implementations (LocalLeaderElector, RedissonLeaderElector, etc.)
- Aspect updated to call `runIfLeaderResult` — metrics now record accurate `CONTENTION` vs true action results

### Design Decisions
- `out T` covariance: `LeaderRunResult<String>` is subtype of `LeaderRunResult<Any?>`
- `data object Skipped : LeaderRunResult<Nothing>` — idiomatic Nothing singleton
- Sync `LeaderElector` / `LeaderGroupElector` only in v1.x; async/suspend follow-up planned
- Method naming symmetry: both interfaces use `runIfLeaderResult` (Group context carried by type, not method name)

### Docs
- KDoc: sync-only scope + `Elected.value T?` constraint documented
- `SkipReason.CONTENTION` KDoc updated to reflect authoritative classification
- README.md + README.ko.md: LeaderRunResult section added

## Test Plan

- `LeaderRunResultTest`: unit tests for Elected/Skipped variants + sealed when exhaustiveness
- `LeaderElectionAspectTest`: mock stubs updated to `runIfLeaderResult`
- `LeaderGroupElectionAspectTest`: same for group variant

```
:leader-core:test        260 passing
:leader-spring-boot:test  12 passing
```

## Reviewer Notes

- No existing backend changes required — default method pattern is backward compatible
- `-jvm-default=enable` is project-wide standard; no ABI change
- Thread safety of `var elected`: safe — lock release happens-before the flag read on same thread

Closes #85

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #85, milestone `0.1.0`, assignee `debop`
- PR: #114, head `0a6e38d0ebcde8f93e7d4f8e6c5af52ffc36172a`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
