### PR TITLE
feat: FAIL_OPEN_RUN failureMode 구현 (#81)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -353,6 +353,45 @@ val result = election.runIfLeader("job", ScoredElectionStrategy(scorer)) { doWor
 | 커스텀 스코어러 | 없음 | 가능 (`CandidateScorer`) |
 | 네트워크 RTT | 1회 (tryLock) | 2회 (list + elect) |
 
+## Spring Boot AOP
+
+`leader-spring-boot`는 AspectJ CTW(Freefair post-compile weaving) 기반의 `@LeaderElection` / `@LeaderGroupElection` 어노테이션을 제공합니다.
+
+```kotlin
+@Service
+class ReportService {
+    @LeaderElection(name = "daily-report-job")
+    fun generateReport(): String { /* 리더 노드에서만 실행 */ }
+
+    // Fail-open: 락을 획득하지 못해도 본문 실행
+    @LeaderElection(name = "nightly-cleanup", failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
+    fun cleanup(): String { /* 항상 실행, 분산 락은 베스트에포트 */ }
+}
+```
+
+### `failureMode`
+
+락을 **획득하지 못했을 때** (경쟁 또는 백엔드 오류) 동작을 제어합니다:
+
+| 값 | 동작 |
+|----|------|
+| `SKIP` (기본값) | `null` 반환 — 본문 미실행 |
+| `RETHROW` | 백엔드 오류를 `LeaderElectionException`으로 감싸 throw |
+| `FAIL_OPEN_RUN` | 락 없이 본문을 실행하여 결과 반환 |
+
+`FAIL_OPEN_RUN`은 스킵보다 실행이 안전한 경우(예: 멱등성이 보장된 태스크)에 적합합니다. 메트릭에 `SkipReason.FAIL_OPEN_FORCED`가 기록되어 락 없이 실행된 횟수를 대시보드에서 별도 추적할 수 있습니다.
+
+### 전역 기본값 (properties)
+
+```yaml
+bluetape4k:
+  leader:
+    aop:
+      default-failure-mode: FAIL_OPEN_RUN   # SKIP | RETHROW | FAIL_OPEN_RUN
+```
+
+---
+
 ## Micrometer 메트릭
 
 Spring Boot AOP(`@LeaderElection`)를 사용할 때 `leader-micrometer`를 추가하면 Prometheus/Datadog 메트릭이 자동으로 노출됩니다.

--- a/README.md
+++ b/README.md
@@ -351,6 +351,45 @@ val result = election.runIfLeader("job", ScoredElectionStrategy(scorer)) { doWor
 | Custom scorer | No | Yes (`CandidateScorer`) |
 | Network RTT | 1 (tryLock) | 2 (list + elect) |
 
+## Spring Boot AOP
+
+`leader-spring-boot` provides `@LeaderElection` and `@LeaderGroupElection` annotations backed by AspectJ CTW (Freefair post-compile weaving).
+
+```kotlin
+@Service
+class ReportService {
+    @LeaderElection(name = "daily-report-job")
+    fun generateReport(): String { /* runs only on elected node */ }
+
+    // Fail-open: run the body even when lock is not acquired or backend is unavailable
+    @LeaderElection(name = "nightly-cleanup", failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
+    fun cleanup(): String { /* always runs, lock is best-effort */ }
+}
+```
+
+### `failureMode`
+
+Controls what happens when the lock is **not** acquired (contention or backend error):
+
+| Value | Behaviour |
+|-------|-----------|
+| `SKIP` (default) | Return `null` — body is not executed |
+| `RETHROW` | Throw `LeaderElectionException` wrapping the backend error |
+| `FAIL_OPEN_RUN` | Run the method body anyway and return its result |
+
+`FAIL_OPEN_RUN` is designed for jobs where skipping is worse than running without the distributed lock guarantee (e.g., best-effort idempotent tasks). Metrics record `SkipReason.FAIL_OPEN_FORCED` so dashboards can track lock-free executions separately.
+
+### Global default via properties
+
+```yaml
+bluetape4k:
+  leader:
+    aop:
+      default-failure-mode: FAIL_OPEN_RUN   # SKIP | RETHROW | FAIL_OPEN_RUN
+```
+
+---
+
 ## Micrometer Metrics
 
 When using Spring Boot AOP (`@LeaderElection`), add `leader-micrometer` to expose Prometheus/Datadog metrics automatically.

--- a/docs/lessons/2026-05-06-fail-open-run.md
+++ b/docs/lessons/2026-05-06-fail-open-run.md
@@ -1,0 +1,43 @@
+# Lessons Learned — FAIL_OPEN_RUN failureMode (2026-05-06)
+
+**관련 PR**: #116
+**영향 모듈**: leader-core, leader-spring-boot
+
+## L1: SkipReason의 의미를 '원인'이 아닌 '결과 상태'로 설계해야 함
+
+### 문제
+초기 구현에서 backend 예외 + FAIL_OPEN_RUN 경우에 `BACKEND_ERROR`를 발행했다.
+코드 리뷰에서 이것이 `SkipReason.FAIL_OPEN_FORCED` KDoc의 "경쟁 또는 백엔드 예외 후 FAIL_OPEN_RUN으로 실행" 설명과 불일치를 지적받았다.
+
+### 교훈
+`SkipReason`은 락이 없는 **원인**(CONTENTION / BACKEND_ERROR)을 기록하는 것보다,
+실제로 락 없이 실행된 **사실** (`FAIL_OPEN_FORCED`)을 기록하는 것이 관측 가능성 관점에서 더 유용하다.
+대시보드 alert "락 없이 본문 실행 횟수"를 `FAIL_OPEN_FORCED` 하나로 집계할 수 있고,
+원인 구분은 INFO 로그 레벨에서 이미 `reason=CONTENTION` / `reason=BACKEND_ERROR`로 제공된다.
+
+**구현 패턴**: backend catch의 `onLockNotAcquired`를 `when (failureMode)` 분기 안으로 이동하여
+RETHROW/SKIP은 `BACKEND_ERROR`, FAIL_OPEN_RUN은 `FAIL_OPEN_FORCED`를 발행.
+
+---
+
+## L2: Lettuce connect()는 즉시 TCP 연결 — 백엔드 오류 시뮬레이션에 ToxiProxy 필요
+
+### 문제
+"연결을 닫아서 백엔드 오류를 시뮬레이션" 접근은 Lettuce의 공유 `StatefulRedisConnection`을 닫아버려 다른 테스트에 영향을 준다. Redisson.create()는 bad URL을 즉시 throw한다.
+
+### 교훈
+실제 백엔드 네트워크 장애를 시뮬레이션하려면 ToxiProxy를 사용해야 한다.
+패턴: `Network.newNetwork() → RedisServer(network) → ToxiproxyServer(network) → proxy.delete()`.
+공유 연결을 닫지 않아 다른 테스트에 영향 없음.
+
+---
+
+## L3: Freefair CTW는 main sourceSet만 위빙 — 통합 테스트는 직접 호출
+
+### 문제
+CTW는 컴파일 시점에 main 클래스만 위빙하므로 test 클래스의 `@LeaderElection` 어노테이션은 인터셉션되지 않는다.
+
+### 교훈
+통합 테스트에서는 `aspect.aroundLeader(pjp)` 직접 호출 패턴을 사용한다.
+`ProceedingJoinPoint`와 `MethodSignature`는 MockK로 모킹한다.
+`configureJoinPoint(method, target)` 헬퍼로 반복 제거.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -177,3 +177,4 @@ testcontainers-junit-jupiter = { module = "org.testcontainers:testcontainers-jun
 testcontainers-mongodb = { module = "org.testcontainers:testcontainers-mongodb", version.ref = "testcontainers" }
 testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql", version.ref = "testcontainers" }
 testcontainers-mysql = { module = "org.testcontainers:testcontainers-mysql", version.ref = "testcontainers" }
+testcontainers-toxiproxy = { module = "org.testcontainers:testcontainers-toxiproxy", version.ref = "testcontainers" }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/annotation/LeaderAspectFailureMode.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/annotation/LeaderAspectFailureMode.kt
@@ -1,20 +1,19 @@
 package io.bluetape4k.leader.annotation
 
 /**
- * 백엔드 예외 (Lettuce/Redisson/Mongo timeout 등) 발생 시 Aspect 의 처리 정책.
+ * 리더 락 획득 실패 (백엔드 예외 또는 경쟁) 시 Aspect 의 처리 정책.
  *
  * ## 옵션
  * - [RETHROW] (default): 백엔드 예외를 [io.bluetape4k.leader.LeaderElectionException] / `LeaderGroupElectionException` 으로 wrapping 후 호출자에게 전파.
  *   message 일반화로 host/credentials 인프라 정보 누출 차단. cause 보존.
- * - [SKIP]: 백엔드 예외 흡수 후 `null` 반환 (ShedLock skip 동등).
- *
- * ## `FAIL_OPEN_RUN` 미지원
- * "락 실패 시에도 본문 실행" 옵션은 본 PR sync `T?` 시그니처로는 elected vs forced 구분 불가능.
- * sealed `LeaderResult<T> { Elected, Skipped, FailedOpenRun }` SPI 도입과 함께 후속 [#81].
+ * - [SKIP]: 락 획득 실패 또는 백엔드 예외 시 흡수 후 `null` 반환 (ShedLock skip 동등).
+ * - [FAIL_OPEN_RUN]: 락 획득 실패 또는 백엔드 예외 시 락 없이 본문을 그대로 실행.
+ *   락 시스템 장애 상황에서 중단보다 계속 실행이 나은 circuit-breaker 시나리오용.
+ *   **주의**: 복수 인스턴스가 동시에 본문을 실행할 수 있으므로 idempotent 작업에만 사용.
  *
  * ## 본문 예외와 무관
- * 본 enum 은 backend 예외만 처리. 사용자 본문 (`pjp.proceed()`) throw 는 RETHROW 모드와 무관하게
- * 항상 그대로 전파된다 (wrapping 없음, [SKIP] 모드도 동일).
+ * 본 enum 은 락 획득 실패 처리만 담당. 사용자 본문 (`pjp.proceed()`) throw 는 failureMode 와 무관하게
+ * 항상 그대로 전파된다 (wrapping 없음).
  */
 enum class LeaderAspectFailureMode {
     /**
@@ -26,6 +25,16 @@ enum class LeaderAspectFailureMode {
     /** 백엔드 예외를 wrapping 후 호출자에게 전파. */
     RETHROW,
 
-    /** 백엔드 예외 흡수 후 `null` 반환 (ShedLock skip 동등). */
+    /** 락 획득 실패 또는 백엔드 예외 흡수 후 `null` 반환 (ShedLock skip 동등). */
     SKIP,
+
+    /**
+     * 락 획득 실패 또는 백엔드 예외 시 락 없이 본문을 실행 (fail-open).
+     *
+     * - 경쟁으로 Skipped → `onLockNotAcquired(FAIL_OPEN_FORCED)` emit 후 본문 실행
+     * - 백엔드 예외 → 경고 로그 후 본문 실행
+     *
+     * **주의**: 락이 없으므로 복수 인스턴스 동시 실행 가능. idempotent 작업에만 사용.
+     */
+    FAIL_OPEN_RUN,
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/metrics/SkipReason.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/metrics/SkipReason.kt
@@ -5,8 +5,6 @@ package io.bluetape4k.leader.metrics
  *
  * [#85] `LeaderRunResult` sealed SPI 도입으로 `CONTENTION` 은 이제 정확 — `runIfLeaderResult`
  * 내부 `elected` 플래그로 본문 `null` 반환과 미선출을 명확히 구분.
- *
- * `FAIL_OPEN_FORCED` 는 후속 [#81] 에서 `FAIL_OPEN_RUN` failureMode 도입 시 함께 추가.
  */
 enum class SkipReason {
     /** waitTime 내 락 획득 실패. */
@@ -14,4 +12,10 @@ enum class SkipReason {
 
     /** 백엔드 예외 발생 후 SKIP 모드로 흡수. */
     BACKEND_ERROR,
+
+    /**
+     * 락 미획득(경쟁) 또는 백엔드 예외 발생 후 `FAIL_OPEN_RUN` 모드로 락 없이 본문 실행.
+     * `onLockNotAcquired` 이벤트 발행 후 본문이 정상 실행되면 `onTaskFinished` 가 이어서 발행된다.
+     */
+    FAIL_OPEN_FORCED,
 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/annotation/LeaderAspectFailureModeTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/annotation/LeaderAspectFailureModeTest.kt
@@ -12,14 +12,14 @@ class LeaderAspectFailureModeTest {
     companion object : KLogging()
 
     @Test
-    fun `enum 항목 3개 존재 확인`() {
-        LeaderAspectFailureMode.entries.size shouldBeEqualTo 3
+    fun `enum 항목 4개 존재 확인`() {
+        LeaderAspectFailureMode.entries.size shouldBeEqualTo 4
     }
 
     @Test
-    fun `INHERIT, RETHROW, SKIP 모두 포함`() {
+    fun `INHERIT, RETHROW, SKIP, FAIL_OPEN_RUN 모두 포함`() {
         val entries = LeaderAspectFailureMode.entries.map { it.name }
-        entries shouldContainAll listOf("INHERIT", "RETHROW", "SKIP")
+        entries shouldContainAll listOf("INHERIT", "RETHROW", "SKIP", "FAIL_OPEN_RUN")
     }
 
     @Test
@@ -27,5 +27,6 @@ class LeaderAspectFailureModeTest {
         LeaderAspectFailureMode.valueOf("INHERIT") shouldBeEqualTo LeaderAspectFailureMode.INHERIT
         LeaderAspectFailureMode.valueOf("RETHROW") shouldBeEqualTo LeaderAspectFailureMode.RETHROW
         LeaderAspectFailureMode.valueOf("SKIP") shouldBeEqualTo LeaderAspectFailureMode.SKIP
+        LeaderAspectFailureMode.valueOf("FAIL_OPEN_RUN") shouldBeEqualTo LeaderAspectFailureMode.FAIL_OPEN_RUN
     }
 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/metrics/SkipReasonTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/metrics/SkipReasonTest.kt
@@ -12,19 +12,20 @@ class SkipReasonTest {
     companion object : KLogging()
 
     @Test
-    fun `enum 항목 2개 존재 확인`() {
-        SkipReason.entries.size shouldBeEqualTo 2
+    fun `enum 항목 3개 존재 확인`() {
+        SkipReason.entries.size shouldBeEqualTo 3
     }
 
     @Test
-    fun `CONTENTION, BACKEND_ERROR 모두 포함`() {
+    fun `CONTENTION, BACKEND_ERROR, FAIL_OPEN_FORCED 모두 포함`() {
         val entries = SkipReason.entries.map { it.name }
-        entries shouldContainAll listOf("CONTENTION", "BACKEND_ERROR")
+        entries shouldContainAll listOf("CONTENTION", "BACKEND_ERROR", "FAIL_OPEN_FORCED")
     }
 
     @Test
     fun `valueOf 동작 확인`() {
         SkipReason.valueOf("CONTENTION") shouldBeEqualTo SkipReason.CONTENTION
         SkipReason.valueOf("BACKEND_ERROR") shouldBeEqualTo SkipReason.BACKEND_ERROR
+        SkipReason.valueOf("FAIL_OPEN_FORCED") shouldBeEqualTo SkipReason.FAIL_OPEN_FORCED
     }
 }

--- a/leader-spring-boot/build.gradle.kts
+++ b/leader-spring-boot/build.gradle.kts
@@ -87,6 +87,7 @@ dependencies {
     testImplementation(project(":leader-mongodb"))
     testImplementation(libs.bluetape4k.testcontainers)
     testImplementation(libs.testcontainers.mongodb)
+    testImplementation(libs.testcontainers.toxiproxy)
     testImplementation(libs.r2dbc.h2)
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit.jupiter)

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -97,9 +97,21 @@ class LeaderElectionAspect(
             }
             when (runResult) {
                 is LeaderRunResult.Skipped -> {
-                    fanOut { it.onLockNotAcquired(resolvedName, opts, SkipReason.CONTENTION) }
-                    log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
-                    null
+                    if (meta.failureMode == LeaderAspectFailureMode.FAIL_OPEN_RUN) {
+                        fanOut {
+                            it.onLockNotAcquired(resolvedName, opts, SkipReason.FAIL_OPEN_FORCED)
+                            it.onTaskStarted(resolvedName)
+                        }
+                        log.debug { "leader.aop.fail-open lockName=$resolvedName reason=CONTENTION" }
+                        val result = executeBody(pjp, resolvedName, start)
+                        val elapsed = System.nanoTime() - start
+                        fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
+                        result
+                    } else {
+                        fanOut { it.onLockNotAcquired(resolvedName, opts, SkipReason.CONTENTION) }
+                        log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
+                        null
+                    }
                 }
                 is LeaderRunResult.Elected -> {
                     val elapsed = System.nanoTime() - start
@@ -123,16 +135,35 @@ class LeaderElectionAspect(
             // [Sec-3][R-33] backend 예외만 LeaderElectionException 으로 wrapping (host/credentials 누출 차단)
             val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
             val wrapped = LeaderElectionException("leader backend error for lock '$effectiveName'", backendEx)
-            fanOut {
-                it.onLockNotAcquired(effectiveName, opts, SkipReason.BACKEND_ERROR)
-                it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx)
-            }
             when (meta.failureMode) {
                 LeaderAspectFailureMode.INHERIT -> error("INHERIT must be resolved in resolveMetadata")
-                LeaderAspectFailureMode.RETHROW -> throw wrapped
+                LeaderAspectFailureMode.RETHROW -> {
+                    fanOut { it.onLockNotAcquired(effectiveName, opts, SkipReason.BACKEND_ERROR) }
+                    fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
+                    throw wrapped
+                }
                 LeaderAspectFailureMode.SKIP -> {
+                    fanOut { it.onLockNotAcquired(effectiveName, opts, SkipReason.BACKEND_ERROR) }
+                    fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
                     log.warn(backendEx) { "leader.aop.skipped lockName=$effectiveName reason=BACKEND_ERROR" }
                     null
+                }
+                LeaderAspectFailureMode.FAIL_OPEN_RUN -> {
+                    fanOut { it.onLockNotAcquired(effectiveName, opts, SkipReason.FAIL_OPEN_FORCED) }
+                    log.warn(backendEx) { "leader.aop.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
+                    fanOut { it.onTaskStarted(effectiveName) }
+                    try {
+                        val result = pjp.proceed()
+                        val elapsed = System.nanoTime() - start
+                        fanOut { it.onTaskFinished(effectiveName, elapsed.nanoseconds) }
+                        result
+                    } catch (ce: CancellationException) {
+                        fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, ce) }
+                        throw ce
+                    } catch (bodyEx: Throwable) {
+                        fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                        throw bodyEx
+                    }
                 }
             }
         }

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -83,9 +83,21 @@ class LeaderGroupElectionAspect(
             }
             when (runResult) {
                 is LeaderRunResult.Skipped -> {
-                    fanOut { it.onLockNotAcquired(resolvedName, coreOpts, SkipReason.CONTENTION) }
-                    log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
-                    null
+                    if (meta.failureMode == LeaderAspectFailureMode.FAIL_OPEN_RUN) {
+                        fanOut {
+                            it.onLockNotAcquired(resolvedName, coreOpts, SkipReason.FAIL_OPEN_FORCED)
+                            it.onTaskStarted(resolvedName)
+                        }
+                        log.debug { "leader.aop.fail-open lockName=$resolvedName reason=CONTENTION" }
+                        val result = executeBody(pjp, resolvedName, start)
+                        val elapsed = System.nanoTime() - start
+                        fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
+                        result
+                    } else {
+                        fanOut { it.onLockNotAcquired(resolvedName, coreOpts, SkipReason.CONTENTION) }
+                        log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
+                        null
+                    }
                 }
                 is LeaderRunResult.Elected -> {
                     val elapsed = System.nanoTime() - start
@@ -106,16 +118,35 @@ class LeaderGroupElectionAspect(
         } catch (backendEx: Throwable) {
             val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
             val wrapped = LeaderGroupElectionException("leader group backend error for lock '$effectiveName'", backendEx)
-            fanOut {
-                it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.BACKEND_ERROR)
-                it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx)
-            }
             when (meta.failureMode) {
                 LeaderAspectFailureMode.INHERIT -> error("INHERIT must be resolved in resolveMetadata")
-                LeaderAspectFailureMode.RETHROW -> throw wrapped
+                LeaderAspectFailureMode.RETHROW -> {
+                    fanOut { it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.BACKEND_ERROR) }
+                    fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
+                    throw wrapped
+                }
                 LeaderAspectFailureMode.SKIP -> {
+                    fanOut { it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.BACKEND_ERROR) }
+                    fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
                     log.warn(backendEx) { "leader.aop.skipped lockName=$effectiveName reason=BACKEND_ERROR" }
                     null
+                }
+                LeaderAspectFailureMode.FAIL_OPEN_RUN -> {
+                    fanOut { it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.FAIL_OPEN_FORCED) }
+                    log.warn(backendEx) { "leader.aop.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
+                    fanOut { it.onTaskStarted(effectiveName) }
+                    try {
+                        val result = pjp.proceed()
+                        val elapsed = System.nanoTime() - start
+                        fanOut { it.onTaskFinished(effectiveName, elapsed.nanoseconds) }
+                        result
+                    } catch (ce: CancellationException) {
+                        fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, ce) }
+                        throw ce
+                    } catch (bodyEx: Throwable) {
+                        fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                        throw bodyEx
+                    }
                 }
             }
         }

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/FailOpenRunIntegrationTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/FailOpenRunIntegrationTest.kt
@@ -1,0 +1,201 @@
+package io.bluetape4k.leader.spring.aop
+
+import eu.rekawek.toxiproxy.ToxiproxyClient
+import io.bluetape4k.leader.LeaderElectorFactory
+import io.bluetape4k.leader.annotation.LeaderAspectFailureMode
+import io.bluetape4k.leader.annotation.LeaderElection
+import io.bluetape4k.leader.lettuce.LettuceLeaderElectorFactory
+import io.bluetape4k.leader.spring.aop.properties.LeaderAopProperties
+import io.bluetape4k.leader.spring.aop.spel.SpelExpressionEvaluator
+import io.bluetape4k.leader.spring.aop.util.LockNameValidator
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.closeSafe
+import io.bluetape4k.testcontainers.infra.ToxiproxyServer
+import io.bluetape4k.testcontainers.storage.RedisServer
+import io.bluetape4k.utils.ShutdownQueue
+import io.lettuce.core.RedisClient
+import io.lettuce.core.SetArgs
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.codec.StringCodec
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.amshove.kluent.shouldBeEqualTo
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.reflect.MethodSignature
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.testcontainers.containers.Network
+import java.time.Duration
+
+/**
+ * [LeaderElectionAspect] FAIL_OPEN_RUN Lettuce + ToxiProxy 통합 테스트.
+ *
+ * ## 검증 시나리오
+ * 1. **경쟁(Contention)**: Redis 락을 외부에서 점유 후 Aspect 호출 → `Skipped` → FAIL_OPEN_RUN → 본문 실행
+ * 2. **백엔드 오류(ToxiProxy)**: ToxiProxy 프록시 삭제로 Redis 접근 차단 → FAIL_OPEN_RUN → 본문 실행
+ * 3. **경쟁 없음(정상)**: 락 미점유 상태 → `Elected` 경로 → 본문 실행
+ *
+ * ## CTW 제한
+ * Freefair CTW는 main sourceSet 에만 적용되므로 test 클래스에는 AOP 인터셉션이 없다.
+ * [LeaderElectionAspect.aroundLeader]를 직접 호출하여 실제 Lettuce backend 와 통합 검증.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FailOpenRunIntegrationTest {
+
+    companion object : KLogging() {
+        private const val RESULT = "lettuce-result"
+        private const val CONTENTION_LOCK = "fail-open-it-contention"
+        private const val BACKEND_LOCK = "fail-open-it-backend"
+
+        private val redis = RedisServer.Launcher.redis
+
+        private val client: RedisClient by lazy {
+            RedisClient.create(redis.url).also {
+                ShutdownQueue.register { runCatching { it.shutdown() } }
+            }
+        }
+
+        private val connection: StatefulRedisConnection<String, String> by lazy {
+            client.connect(StringCodec.UTF8).also {
+                ShutdownQueue.register { it.closeSafe() }
+            }
+        }
+    }
+
+    // ── 경쟁 시나리오용 ──
+    private class ContentionService {
+        @LeaderElection(name = CONTENTION_LOCK, failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
+        fun execute(): String? = RESULT
+    }
+
+    // ── ToxiProxy 백엔드 오류 시나리오용 ──
+    private class BackendErrorService {
+        @LeaderElection(name = BACKEND_LOCK, failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
+        fun execute(): String? = RESULT
+    }
+
+    // ── 정상 경로 검증용 ──
+    private class NormalService {
+        @LeaderElection(name = "fail-open-it-normal", failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
+        fun execute(): String? = RESULT
+    }
+
+    private val signature: MethodSignature = mockk()
+    private val pjp: ProceedingJoinPoint = mockk()
+    private val beanSelector: LeaderBeanSelector = mockk()
+
+    @BeforeEach
+    fun setUp() {
+        clearMocks(signature, pjp, beanSelector)
+    }
+
+    private fun configureJoinPoint(method: java.lang.reflect.Method, target: Any) {
+        every { signature.method } returns method
+        every { pjp.signature } returns signature
+        every { pjp.target } returns target
+        every { pjp.args } returns emptyArray()
+        every { pjp.proceed() } returns RESULT
+    }
+
+    private fun newAspect(
+        factory: LeaderElectorFactory,
+        waitTime: Duration = Duration.ZERO,
+    ): LeaderElectionAspect {
+        every { beanSelector.selectElectionFactory(any()) } returns
+                LeaderBeanSelector.Selected("lettuceFactory", factory)
+        return LeaderElectionAspect(
+            beanSelector = beanSelector,
+            props = LeaderAopProperties(
+                defaultWaitTime = waitTime,
+                defaultLeaseTime = Duration.ofSeconds(10),
+                lockNamePrefix = "",
+            ),
+            spel = SpelExpressionEvaluator(embeddedValueResolver = { it }, allowMethodInvocation = false),
+            lockNameValidator = LockNameValidator(prefix = ""),
+            recorders = emptyList(),
+        )
+    }
+
+    @Test
+    fun `FAIL_OPEN_RUN - Real Redis 경쟁(Skipped) 시 본문 실행`() {
+        // 락을 외부에서 SET NX 로 점유 — waitTime=0 인 Aspect 는 즉시 Skipped
+        connection.sync().set(CONTENTION_LOCK, "holder-token", SetArgs.Builder.nx().px(10_000))
+
+        try {
+            val factory = LettuceLeaderElectorFactory(connection)
+            val method = ContentionService::class.java.getDeclaredMethod("execute")
+            configureJoinPoint(method, ContentionService())
+
+            val aspect = newAspect(factory, waitTime = Duration.ZERO)
+            val result = aspect.aroundLeader(pjp)
+
+            // FAIL_OPEN_RUN: 경쟁으로 Skipped 됐지만 본문을 실행하여 결과 반환
+            result shouldBeEqualTo RESULT
+        } finally {
+            connection.sync().del(CONTENTION_LOCK)
+        }
+    }
+
+    @Test
+    fun `FAIL_OPEN_RUN - Real Redis 경쟁 없을 때는 정상 Elected 경로`() {
+        val factory = LettuceLeaderElectorFactory(connection)
+        val method = NormalService::class.java.getDeclaredMethod("execute")
+        configureJoinPoint(method, NormalService())
+
+        val aspect = newAspect(factory, waitTime = Duration.ofSeconds(2))
+        val result = aspect.aroundLeader(pjp)
+
+        // 경쟁 없음 → Elected → 본문 실행
+        result shouldBeEqualTo RESULT
+    }
+
+    @Test
+    fun `FAIL_OPEN_RUN - ToxiProxy 장애 주입으로 Redis 차단 시 본문 실행`() {
+        // ToxiProxy → Redis 연결을 별도 Docker 네트워크에서 구성 후 프록시 삭제로 장애 주입
+        Network.newNetwork().use { network ->
+            RedisServer()
+                .withNetwork(network)
+                .withNetworkAliases("redis")
+                .use { redisContainer ->
+                    ToxiproxyServer()
+                        .withNetwork(network)
+                        .use { toxiproxy ->
+                            redisContainer.start()
+                            toxiproxy.start()
+
+                            val toxiproxyClient = ToxiproxyClient(toxiproxy.host, toxiproxy.controlPort)
+                            val proxy = toxiproxyClient.createProxy(
+                                "redis-proxy",
+                                "0.0.0.0:8666",
+                                "redis:${RedisServer.PORT}",
+                            )
+                            val proxyPort = toxiproxy.getMappedPort(8666)
+                            val proxyRedisClient = RedisClient.create("redis://${toxiproxy.host}:$proxyPort")
+                            val proxyConnection = proxyRedisClient.connect(StringCodec.UTF8)
+
+                            try {
+                                // 프록시 통해 정상 연결 확인
+                                proxyConnection.sync().ping() shouldBeEqualTo "PONG"
+
+                                // 장애 주입 — 프록시 삭제로 Redis 접근 차단
+                                proxy.delete()
+
+                                val factory = LettuceLeaderElectorFactory(proxyConnection)
+                                val method = BackendErrorService::class.java.getDeclaredMethod("execute")
+                                configureJoinPoint(method, BackendErrorService())
+
+                                val aspect = newAspect(factory, waitTime = Duration.ofMillis(200))
+                                // 프록시 삭제 → Redis 명령 실패 → FAIL_OPEN_RUN → 본문 실행
+                                val result = aspect.aroundLeader(pjp)
+                                result shouldBeEqualTo RESULT
+                            } finally {
+                                runCatching { proxyConnection.closeSafe() }
+                                runCatching { proxyRedisClient.shutdown() }
+                            }
+                        }
+                }
+        }
+    }
+}

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectTest.kt
@@ -335,4 +335,89 @@ class LeaderElectionAspectTest {
         // SKIP 모드 → backend I/O 실패를 흡수하고 null 반환
         aspect.aroundLeader(pjp).shouldBeNull()
     }
+
+    // ── FAIL_OPEN_RUN 시나리오 ──
+
+    @Test
+    fun `FAIL_OPEN_RUN - 경쟁(Skipped) 시 락 없이 본문 실행 후 결과 반환`() {
+        class SampleFailOpen {
+            @LeaderElection(name = "fail-open-job", failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
+            fun run(): String? = SAMPLE_RESULT
+        }
+
+        val target = SampleFailOpen()
+        val method = SampleFailOpen::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target, emptyArray())
+        every { pjp.proceed() } returns SAMPLE_RESULT
+        every { election.runIfLeaderResult<Any?>(any(), any()) } returns LeaderRunResult.Skipped
+
+        val aspect = newAspect(listOf(recorder))
+        val result = aspect.aroundLeader(pjp)
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        verify(exactly = 1) { recorder.onLockNotAcquired("fail-open-job", any(), SkipReason.FAIL_OPEN_FORCED) }
+        verify(exactly = 1) { recorder.onTaskStarted("fail-open-job") }
+        verify(exactly = 1) { recorder.onTaskFinished("fail-open-job", any()) }
+    }
+
+    @Test
+    fun `FAIL_OPEN_RUN - 경쟁(Skipped) 시 본문 throw 는 그대로 전파`() {
+        class SampleFailOpen {
+            @LeaderElection(name = "fail-open-job", failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
+            fun run(): String? = SAMPLE_RESULT
+        }
+
+        val target = SampleFailOpen()
+        val method = SampleFailOpen::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target, emptyArray())
+        val bodyEx = RuntimeException("body failure during fail-open")
+        every { pjp.proceed() } throws bodyEx
+        every { election.runIfLeaderResult<Any?>(any(), any()) } returns LeaderRunResult.Skipped
+
+        val aspect = newAspect()
+        val ex = assertThrows<RuntimeException> { aspect.aroundLeader(pjp) }
+        ex shouldBeEqualTo bodyEx
+    }
+
+    @Test
+    fun `FAIL_OPEN_RUN - backend 예외 시 락 없이 본문 실행 후 결과 반환`() {
+        class SampleFailOpen {
+            @LeaderElection(name = "fail-open-job", failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
+            fun run(): String? = SAMPLE_RESULT
+        }
+
+        val target = SampleFailOpen()
+        val method = SampleFailOpen::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target, emptyArray())
+        every { pjp.proceed() } returns SAMPLE_RESULT
+        val backendEx = RuntimeException("redis down")
+        every { election.runIfLeaderResult<Any?>(any(), any()) } throws backendEx
+
+        val aspect = newAspect(listOf(recorder))
+        val result = aspect.aroundLeader(pjp)
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        verify(exactly = 1) { recorder.onLockNotAcquired("fail-open-job", any(), SkipReason.FAIL_OPEN_FORCED) }
+        verify(exactly = 1) { recorder.onTaskStarted("fail-open-job") }
+        verify(exactly = 1) { recorder.onTaskFinished("fail-open-job", any()) }
+    }
+
+    @Test
+    fun `FAIL_OPEN_RUN - backend 예외 후 본문 throw 는 그대로 전파`() {
+        class SampleFailOpen {
+            @LeaderElection(name = "fail-open-job", failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
+            fun run(): String? = SAMPLE_RESULT
+        }
+
+        val target = SampleFailOpen()
+        val method = SampleFailOpen::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target, emptyArray())
+        val bodyEx = IllegalStateException("body failure after backend error")
+        every { pjp.proceed() } throws bodyEx
+        every { election.runIfLeaderResult<Any?>(any(), any()) } throws RuntimeException("backend down")
+
+        val aspect = newAspect()
+        val ex = assertThrows<IllegalStateException> { aspect.aroundLeader(pjp) }
+        ex shouldBeEqualTo bodyEx
+    }
 }

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectTest.kt
@@ -310,4 +310,88 @@ class LeaderGroupElectionAspectTest {
 
         aspect.aroundLeader(pjp).shouldBeNull()
     }
+
+    // ── group FAIL_OPEN_RUN 시나리오 ──
+
+    @Test
+    fun `group FAIL_OPEN_RUN - 경쟁(Skipped) 시 락 없이 본문 실행 후 결과 반환`() {
+        class SampleFailOpen {
+            @LeaderGroupElection(name = "fail-open-group-job", maxLeaders = 2, failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
+            fun run(): String? = SAMPLE_RESULT
+        }
+
+        val target = SampleFailOpen()
+        val method = SampleFailOpen::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target, emptyArray())
+        every { pjp.proceed() } returns SAMPLE_RESULT
+        every { election.runIfLeaderResult<Any?>(any(), any()) } returns LeaderRunResult.Skipped
+
+        val aspect = newAspect(listOf(recorder))
+        val result = aspect.aroundLeader(pjp)
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        verify(exactly = 1) { recorder.onLockNotAcquired("fail-open-group-job", any(), SkipReason.FAIL_OPEN_FORCED) }
+        verify(exactly = 1) { recorder.onTaskStarted("fail-open-group-job") }
+        verify(exactly = 1) { recorder.onTaskFinished("fail-open-group-job", any()) }
+    }
+
+    @Test
+    fun `group FAIL_OPEN_RUN - 경쟁(Skipped) 시 본문 throw 는 그대로 전파`() {
+        class SampleFailOpen {
+            @LeaderGroupElection(name = "fail-open-group-job", maxLeaders = 2, failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
+            fun run(): String? = SAMPLE_RESULT
+        }
+
+        val target = SampleFailOpen()
+        val method = SampleFailOpen::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target, emptyArray())
+        val bodyEx = RuntimeException("body failure during group fail-open")
+        every { pjp.proceed() } throws bodyEx
+        every { election.runIfLeaderResult<Any?>(any(), any()) } returns LeaderRunResult.Skipped
+
+        val aspect = newAspect()
+        val ex = assertThrows<RuntimeException> { aspect.aroundLeader(pjp) }
+        ex shouldBeEqualTo bodyEx
+    }
+
+    @Test
+    fun `group FAIL_OPEN_RUN - backend 예외 시 락 없이 본문 실행 후 결과 반환`() {
+        class SampleFailOpen {
+            @LeaderGroupElection(name = "fail-open-group-job", maxLeaders = 2, failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
+            fun run(): String? = SAMPLE_RESULT
+        }
+
+        val target = SampleFailOpen()
+        val method = SampleFailOpen::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target, emptyArray())
+        every { pjp.proceed() } returns SAMPLE_RESULT
+        every { election.runIfLeaderResult<Any?>(any(), any()) } throws RuntimeException("redis cluster down")
+
+        val aspect = newAspect(listOf(recorder))
+        val result = aspect.aroundLeader(pjp)
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        verify(exactly = 1) { recorder.onLockNotAcquired("fail-open-group-job", any(), SkipReason.FAIL_OPEN_FORCED) }
+        verify(exactly = 1) { recorder.onTaskStarted("fail-open-group-job") }
+        verify(exactly = 1) { recorder.onTaskFinished("fail-open-group-job", any()) }
+    }
+
+    @Test
+    fun `group FAIL_OPEN_RUN - backend 예외 후 본문 throw 는 그대로 전파`() {
+        class SampleFailOpen {
+            @LeaderGroupElection(name = "fail-open-group-job", maxLeaders = 2, failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
+            fun run(): String? = SAMPLE_RESULT
+        }
+
+        val target = SampleFailOpen()
+        val method = SampleFailOpen::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target, emptyArray())
+        val bodyEx = IllegalStateException("body failure after group backend error")
+        every { pjp.proceed() } throws bodyEx
+        every { election.runIfLeaderResult<Any?>(any(), any()) } throws RuntimeException("backend down")
+
+        val aspect = newAspect()
+        val ex = assertThrows<IllegalStateException> { aspect.aroundLeader(pjp) }
+        ex shouldBeEqualTo bodyEx
+    }
 }


### PR DESCRIPTION
## Summary

Closes #81

PR #116의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: FAIL_OPEN_RUN failureMode 구현 (#81)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 개요

락 미획득(경쟁) 또는 백엔드 예외 발생 시 본문을 실행하는 `FAIL_OPEN_RUN` failureMode를 구현합니다.

## 변경 사항

### leader-core
- `LeaderAspectFailureMode`에 `FAIL_OPEN_RUN` 추가 (4번째 값)
- `SkipReason`에 `FAIL_OPEN_FORCED` 추가 (3번째 값)
  - FAIL_OPEN_RUN 모드에서 경쟁/백엔드 오류 모두 동일 reason 발행
  - 대시보드에서 '락 없이 본문 실행' 카운터를 정확히 추적 가능

### leader-spring-boot
- `LeaderElectionAspect` 수정
  - `Skipped` 분기: FAIL_OPEN_RUN → `executeBody()` 호출 (BodyThrownMarker 전파 유지)
  - `backend catch` 분기: `onLockNotAcquired`를 `when` 분기 안으로 이동
    - RETHROW/SKIP: `BACKEND_ERROR` reason 유지
    - FAIL_OPEN_RUN: `FAIL_OPEN_FORCED` reason + `pjp.proceed()` 직접 호출
- `LeaderGroupElectionAspect` 동일 패턴 적용
- 단위 테스트: FAIL_OPEN_RUN 4케이스 × 2 Aspect 추가
- 통합 테스트: `FailOpenRunIntegrationTest` (Lettuce + ToxiProxy)
  - 경쟁(Skipped), 정상(Elected), 백엔드 오류(proxy.delete()) 3시나리오

### 빌드
- `libs.versions.toml` + `build.gradle.kts`: `testcontainers-toxiproxy` 의존성 추가

### 문서
- README.md / README.ko.md: Spring Boot AOP 섹션 + `failureMode` 표 추가

## 테스트 결과

| 모듈 | 결과 |
|------|------|
| `leader-core` | 260 passing |
| `leader-spring-boot` | 154 passing |

## 관련 이슈

Closes #81
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #81, milestone `0.1.0`, assignee `debop`
- PR: #116, head `63c4c08a56433102b41e6b5d40efda3d1b2c5f09`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
