### PR TITLE
feat(#78): 클래스/패키지 레벨 @LeaderElectionBackend 메타 어노테이션 — 7단계 factory fallback

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -36,6 +36,7 @@
 | #87 | test: Boot4 Freefair CTW double-fire 방지 검증 테스트 | ✅ 완료 | #113 merged |
 | #85 | feat: LeaderRunResult sealed interface — elected vs skipped 구분 | ✅ 완료 | #114 merged |
 | #81 | feat: FAIL_OPEN_RUN failureMode 구현 | ✅ 완료 | #116 merged |
+| #84 | feat: 메타 어노테이션 (@AliasFor) 지원 | ✅ 완료 | #117 open |
 
 ---
 
@@ -99,7 +100,7 @@
 | 이슈 | 제목 | 선행 조건 |
 |------|------|----------|
 | #82 | feat: SpEL TemplateParserContext 혼합 표현식 지원 | #41 ✅ |
-| #84 | feat: 메타 어노테이션 (@AliasFor) 지원 | #41 ✅ |
+| **#84** | **feat: 메타 어노테이션 (@AliasFor) 지원** | #41 ✅ | **✅ 완료 — PR #117** |
 | #78 | feat: 클래스/패키지 레벨 @LeaderElectionBackend 메타 어노테이션 | #41 ✅ |
 
 ### P3 — Wave 5 suspend/Mono 지원 (순차 의존, 난이도 높음)

--- a/WIP.md
+++ b/WIP.md
@@ -82,10 +82,10 @@
 
 | 이슈 | 제목 | 선행 조건 |
 |------|------|----------|
-| **#94** | **fix: factory.create() pre-try I/O가 failureMode + LeaderElectionException wrap 우회** | 없음 |
-| #97 | test: SpelExpressionEvaluator null 결과 + `${...}` placeholder 경로 미테스트 | 없음 |
-| #96 | test: LeaderAnnotationValidatorBeanPostProcessor suspend/Mono/Flux/Flow/@Aspect skip 미테스트 | 없음 |
-| #95 | test: LeaderGroupElectionAspect 전체 테스트 부재 | 없음 |
+| **#94** | **fix: factory.create() pre-try I/O가 failureMode + LeaderElectionException wrap 우회** | ✅ #116에 포함 |
+| #97 | test: SpelExpressionEvaluator null 결과 + `${...}` placeholder 경로 미테스트 | ✅ #116에 포함 |
+| #96 | test: LeaderAnnotationValidatorBeanPostProcessor suspend/Mono/Flux/Flow/@Aspect skip 미테스트 | ✅ #116에 포함 |
+| #95 | test: LeaderGroupElectionAspect 전체 테스트 부재 | ✅ #116에 포함 |
 
 ### P1 — #75 완료 이후 연쇄 (지금 가능)
 

--- a/WIP.md
+++ b/WIP.md
@@ -34,22 +34,24 @@
 | #103 | feat: LeaderAopProperties Metrics 중첩 클래스 추가 (IDE 자동완성) | ✅ 완료 | #111 merged |
 | #102 | feat: LeaderMicrometerHealthAutoConfiguration 추가 | ✅ 완료 | #112 merged |
 | #87 | test: Boot4 Freefair CTW double-fire 방지 검증 테스트 | ✅ 완료 | #113 merged |
+| #85 | feat: LeaderRunResult sealed interface — elected vs skipped 구분 | ✅ 완료 | #114 merged |
+| #81 | feat: FAIL_OPEN_RUN failureMode 구현 | ✅ 완료 | #116 merged |
 
 ---
 
 ## 이슈 의존 관계
 
 ```
-#41 (AOP) ✅ ─── #75 (Micrometer) ✅ ──┬── #85 (elected/skipped SPI)
-                                        ├── #102 (HealthAutoConfiguration)
-                                        └── #103 (MetricsProperties)
+#41 (AOP) ✅ ─── #75 (Micrometer) ✅ ──┬── #85 (elected/skipped SPI) ✅
+                                        ├── #102 (HealthAutoConfiguration) ✅
+                                        └── #103 (MetricsProperties) ✅
 
 #41 ✅ ────────────────────────────────┬── #94 (bug: failureMode bypass) ← P0
                                        ├── #95 (test: LeaderGroupElectionAspect) ← P0
                                        ├── #96 (test: BPP suspend/Mono 분기) ← P0
                                        ├── #97 (test: SpEL null + placeholder) ← P0
                                        ├── #87 (Boot4 double-fire 검증)
-                                       ├── #81 (FAIL_OPEN_RUN + LeaderResult)
+                                       ├── #81 (FAIL_OPEN_RUN + LeaderResult) ✅
                                        └── #80 sub-issues ─── #88 → #89 → #90 → #91 → #92
 
 독립 기능 (병렬 가능):
@@ -89,8 +91,8 @@
 
 | 이슈 | 제목 | 선행 조건 | 우선순위 |
 |------|------|----------|---------|
-| **#85** | **feat: 백엔드 SPI elected vs skipped 명확 구분 (metrics 정확도)** | #75 ✅ | ⭐ 최우선 |
-| #81 | feat: FAIL_OPEN_RUN 모드 + LeaderResult sealed wrapper | #41 ✅ | 중간 |
+| **#85** | **feat: 백엔드 SPI elected vs skipped 명확 구분 (metrics 정확도)** | #75 ✅ | ✅ 완료 |
+| **#81** | **feat: FAIL_OPEN_RUN failureMode 구현** | #41 ✅ | **✅ 완료** |
 
 ### P2 — 독립 기능 확장 (병렬 가능)
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/annotation/LeaderElectionBackend.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/annotation/LeaderElectionBackend.kt
@@ -1,0 +1,43 @@
+package io.bluetape4k.leader.annotation
+
+/**
+ * 클래스 또는 메서드 단위로 사용할 [io.bluetape4k.leader.LeaderElectorFactory] /
+ * [io.bluetape4k.leader.LeaderGroupElectorFactory] 빈을 지정하는 어노테이션.
+ *
+ * ## 탐색 우선순위 (7단계 fallback)
+ *
+ * 1. `@LeaderElection(bean = "...")` 또는 `@LeaderGroupElection(bean = "...")` 메서드 필드 명시
+ * 2. 메서드 `@LeaderElectionBackend`
+ * 3. 선언 클래스 `@LeaderElectionBackend`
+ * 4. 패키지 `@LeaderElectionBackend` (`package.kt` 또는 `package-info.java`)
+ * 5. 단일 등록 factory 빈
+ * 6. `@Primary` factory 빈
+ * 7. ambiguous → [org.springframework.beans.factory.NoUniqueBeanDefinitionException]
+ *
+ * ## 사용 예
+ * ```kotlin
+ * // 클래스 단위 — 클래스 내 모든 @LeaderElection 메서드에 적용
+ * @LeaderElectionBackend("redissonLeaderElectionFactory")
+ * class PaymentService {
+ *     @LeaderElection(name = "payment-lock")
+ *     fun process() { ... }
+ * }
+ *
+ * // 메서드 단위 — 클래스 레벨 설정 오버라이드
+ * class AnalyticsService {
+ *     @LeaderElectionBackend("mongoLeaderElectionFactory")
+ *     @LeaderElection(name = "analytics-lock")
+ *     fun analyze() { ... }
+ * }
+ *
+ * // 패키지 단위 (package.kt)
+ * @file:LeaderElectionBackend("mongoLeaderElectionFactory")
+ * package com.example.analytics
+ * ```
+ *
+ * @property bean 사용할 factory 빈 이름 (literal only)
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS, AnnotationTarget.FILE)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+annotation class LeaderElectionBackend(val bean: String)

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderBeanSelector.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderBeanSelector.kt
@@ -2,19 +2,25 @@ package io.bluetape4k.leader.spring.aop
 
 import io.bluetape4k.leader.LeaderElectorFactory
 import io.bluetape4k.leader.LeaderGroupElectorFactory
+import io.bluetape4k.leader.annotation.LeaderElectionBackend
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.beans.factory.ListableBeanFactory
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException
+import org.springframework.core.annotation.AnnotatedElementUtils
+import java.lang.reflect.Method
 
 /**
  * AOP advice 가 호출 단위로 사용할 [LeaderElectorFactory] / [LeaderGroupElectorFactory] 빈을 선택한다.
  *
- * ## 우선순위
- * 1. 어노테이션 `bean` 명시 → `getBean(name, Type::class)` (literal only)
- * 2. 단일 factory 빈 등록 → 그것 사용
- * 3. `@Primary` 후보 → 그것 사용
- * 4. ambiguous → [NoUniqueBeanDefinitionException] (사용자가 `bean` 필드 명시 필요)
+ * ## 우선순위 (#78 — 7단계 fallback)
+ * 1. 어노테이션 `bean` 명시 (`@LeaderElection(bean = "...")`)
+ * 2. 메서드 `@LeaderElectionBackend`
+ * 3. 선언 클래스 `@LeaderElectionBackend`
+ * 4. 패키지 `@LeaderElectionBackend` (`@file:LeaderElectionBackend(...)`)
+ * 5. 단일 factory 빈
+ * 6. `@Primary` factory 빈
+ * 7. ambiguous → [NoUniqueBeanDefinitionException]
  *
  * @param beanFactory Spring [BeanFactory]
  */
@@ -25,26 +31,35 @@ class LeaderBeanSelector(
     /**
      * 단일 리더 [LeaderElectorFactory] 빈 선택.
      *
-     * @param explicitBeanName 어노테이션 `bean` 필드. 빈 문자열 시 자동 선택
+     * @param explicitBeanName 어노테이션 `bean` 필드. 빈 문자열 시 하위 단계 탐색
+     * @param method 호출 메서드 — `@LeaderElectionBackend` 탐색용
      * @return 선택된 factory + 빈 이름
-     * @throws NoSuchBeanDefinitionException [explicitBeanName] 이 명시되었지만 빈 미존재
+     * @throws NoSuchBeanDefinitionException 명시 빈 미존재
      * @throws NoUniqueBeanDefinitionException 자동 선택 시 ambiguous
      */
-    fun selectElectionFactory(explicitBeanName: String): Selected<LeaderElectorFactory> =
-        select(explicitBeanName, LeaderElectorFactory::class.java)
+    fun selectElectionFactory(explicitBeanName: String, method: Method? = null): Selected<LeaderElectorFactory> =
+        select(explicitBeanName, method, LeaderElectorFactory::class.java)
 
     /**
      * 다중 리더 [LeaderGroupElectorFactory] 빈 선택.
      */
-    fun selectGroupElectionFactory(explicitBeanName: String): Selected<LeaderGroupElectorFactory> =
-        select(explicitBeanName, LeaderGroupElectorFactory::class.java)
+    fun selectGroupElectionFactory(explicitBeanName: String, method: Method? = null): Selected<LeaderGroupElectorFactory> =
+        select(explicitBeanName, method, LeaderGroupElectorFactory::class.java)
 
-    private fun <T : Any> select(explicitBeanName: String, type: Class<T>): Selected<T> {
+    private fun <T : Any> select(explicitBeanName: String, method: Method?, type: Class<T>): Selected<T> {
+        // Step 1: 어노테이션 bean 필드 명시
         if (explicitBeanName.isNotBlank()) {
-            val bean = beanFactory.getBean(explicitBeanName, type)
-            return Selected(explicitBeanName, bean)
+            return Selected(explicitBeanName, beanFactory.getBean(explicitBeanName, type))
         }
 
+        // Step 2-4: @LeaderElectionBackend 탐색 (메서드 → 클래스 → 패키지)
+        if (method != null) {
+            resolveFromBackendAnnotation(method)?.let { backendBeanName ->
+                return Selected(backendBeanName, beanFactory.getBean(backendBeanName, type))
+            }
+        }
+
+        // Step 5-7: 자동 선택
         val listable = beanFactory as? ListableBeanFactory
             ?: return Selected("", beanFactory.getBean(type))
 
@@ -55,7 +70,6 @@ class LeaderBeanSelector(
                 val (name, bean) = beans.entries.first()
                 Selected(name, bean)
             }
-
             else -> {
                 val primaryBean = runCatching { beanFactory.getBean(type) }.getOrNull()
                 if (primaryBean != null) {
@@ -68,6 +82,29 @@ class LeaderBeanSelector(
                 }
             }
         }
+    }
+
+    /**
+     * 메서드 → 선언 클래스 → 패키지 순으로 [LeaderElectionBackend] 탐색.
+     */
+    private fun resolveFromBackendAnnotation(method: Method): String? {
+        // Step 2: 메서드 @LeaderElectionBackend
+        AnnotatedElementUtils.findMergedAnnotation(method, LeaderElectionBackend::class.java)
+            ?.bean?.takeIf { it.isNotBlank() }?.let { return it }
+
+        val declaringClass = method.declaringClass
+
+        // Step 3: 선언 클래스 @LeaderElectionBackend
+        AnnotatedElementUtils.findMergedAnnotation(declaringClass, LeaderElectionBackend::class.java)
+            ?.bean?.takeIf { it.isNotBlank() }?.let { return it }
+
+        // Step 4: 패키지 @LeaderElectionBackend (@file:LeaderElectionBackend)
+        declaringClass.`package`?.annotations
+            ?.filterIsInstance<LeaderElectionBackend>()
+            ?.firstOrNull()
+            ?.bean?.takeIf { it.isNotBlank() }?.let { return it }
+
+        return null
     }
 
     /** 선택된 빈 + 빈 이름 (cache key 로 사용). */

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -217,7 +217,7 @@ class LeaderElectionAspect(
         val leaseTime = DurationParser.parseOrDefault(ann.leaseTime, props.defaultLeaseTime)
 
         val opts = LeaderElectionOptions(waitTime = waitTime, leaseTime = leaseTime)
-        val selected = beanSelector.selectElectionFactory(ann.bean)
+        val selected = beanSelector.selectElectionFactory(ann.bean, method)
 
         // literal fast-path 분류 — SpEL 평가 우회 가능 여부 사전 판단
         val literal = if (LITERAL_PATTERN.matches(ann.name)) ann.name else null

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -201,7 +201,7 @@ class LeaderGroupElectionAspect(
             waitTime = waitTime,
             leaseTime = leaseTime,
         )
-        val selected = beanSelector.selectGroupElectionFactory(ann.bean)
+        val selected = beanSelector.selectGroupElectionFactory(ann.bean, method)
         val literal = if (LITERAL_PATTERN.matches(ann.name)) ann.name else null
 
         val effectiveFailureMode = if (ann.failureMode == LeaderAspectFailureMode.INHERIT) {

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/FailOpenRunIntegrationTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/FailOpenRunIntegrationTest.kt
@@ -103,7 +103,7 @@ class FailOpenRunIntegrationTest {
         factory: LeaderElectorFactory,
         waitTime: Duration = Duration.ZERO,
     ): LeaderElectionAspect {
-        every { beanSelector.selectElectionFactory(any()) } returns
+        every { beanSelector.selectElectionFactory(any(), any()) } returns
                 LeaderBeanSelector.Selected("lettuceFactory", factory)
         return LeaderElectionAspect(
             beanSelector = beanSelector,

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderBeanSelectorTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderBeanSelectorTest.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.leader.spring.aop
 
 import io.bluetape4k.leader.LeaderElectorFactory
+import io.bluetape4k.leader.annotation.LeaderElection
+import io.bluetape4k.leader.annotation.LeaderElectionBackend
 import io.bluetape4k.logging.KLogging
 import io.mockk.clearMocks
 import io.mockk.every
@@ -87,5 +89,72 @@ class LeaderBeanSelectorTest {
 
         val sut = LeaderBeanSelector(bf)
         assertThrows<NoUniqueBeanDefinitionException> { sut.selectElectionFactory("") }
+    }
+
+    // ── #78: @LeaderElectionBackend 탐색 테스트 ──
+
+    private class WithMethodBackend {
+        @LeaderElectionBackend("redissonFactory")
+        @LeaderElection(name = "test")
+        fun doWork() {}
+    }
+
+    @LeaderElectionBackend("mongoFactory")
+    private class WithClassBackend {
+        @LeaderElection(name = "test")
+        fun doWork() {}
+    }
+
+    private class NoBackendAnnotation {
+        @LeaderElection(name = "test")
+        fun doWork() {}
+    }
+
+    @Test
+    fun `step2 - 메서드 @LeaderElectionBackend 우선 선택`() {
+        val method = WithMethodBackend::class.java.getDeclaredMethod("doWork")
+        every { bf.getBean("redissonFactory", LeaderElectorFactory::class.java) } returns factoryA
+
+        val sut = LeaderBeanSelector(bf)
+        val selected = sut.selectElectionFactory("", method)
+
+        selected.beanName shouldBeEqualTo "redissonFactory"
+        selected.bean shouldBeEqualTo factoryA
+    }
+
+    @Test
+    fun `step3 - 클래스 @LeaderElectionBackend 탐색`() {
+        val method = WithClassBackend::class.java.getDeclaredMethod("doWork")
+        every { bf.getBean("mongoFactory", LeaderElectorFactory::class.java) } returns factoryB
+
+        val sut = LeaderBeanSelector(bf)
+        val selected = sut.selectElectionFactory("", method)
+
+        selected.beanName shouldBeEqualTo "mongoFactory"
+        selected.bean shouldBeEqualTo factoryB
+    }
+
+    @Test
+    fun `step1 우선 - explicit bean이 있으면 @LeaderElectionBackend 무시`() {
+        val method = WithMethodBackend::class.java.getDeclaredMethod("doWork")
+        every { bf.getBean("explicitFactory", LeaderElectorFactory::class.java) } returns factoryA
+
+        val sut = LeaderBeanSelector(bf)
+        val selected = sut.selectElectionFactory("explicitFactory", method)
+
+        selected.beanName shouldBeEqualTo "explicitFactory"
+        selected.bean shouldBeEqualTo factoryA
+    }
+
+    @Test
+    fun `@LeaderElectionBackend 없음 - 단일 빈 자동 선택으로 fallback`() {
+        val method = NoBackendAnnotation::class.java.getDeclaredMethod("doWork")
+        every { bf.getBeansOfType(LeaderElectorFactory::class.java) } returns mapOf("only" to factoryA)
+
+        val sut = LeaderBeanSelector(bf)
+        val selected = sut.selectElectionFactory("", method)
+
+        selected.beanName shouldBeEqualTo "only"
+        selected.bean shouldBeEqualTo factoryA
     }
 }

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectTest.kt
@@ -81,7 +81,7 @@ class LeaderElectionAspectTest {
 
     private fun newAspect(recorders: List<LeaderAopMetricsRecorder> = emptyList()): LeaderElectionAspect {
         every { factoryMock.create(any()) } returns election
-        every { beanSelector.selectElectionFactory(any()) } returns
+        every { beanSelector.selectElectionFactory(any(), any()) } returns
                 LeaderBeanSelector.Selected("testFactory", factoryMock)
 
         return LeaderElectionAspect(
@@ -240,7 +240,7 @@ class LeaderElectionAspectTest {
         val actionSlot = slot<() -> Any?>()
         every { election.runIfLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
         every { factoryMock.create(any()) } returns election
-        every { beanSelector.selectElectionFactory(any()) } returns
+        every { beanSelector.selectElectionFactory(any(), any()) } returns
                 LeaderBeanSelector.Selected("testFactory", factoryMock)
 
         val aspect = LeaderElectionAspect(
@@ -259,7 +259,7 @@ class LeaderElectionAspectTest {
         }
 
         // beanSelector.selectElectionFactory 는 100번이 아니라 1번만 호출 (cache hit)
-        verify(exactly = 1) { beanSelector.selectElectionFactory(any()) }
+        verify(exactly = 1) { beanSelector.selectElectionFactory(any(), any()) }
     }
 
     @Test

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectTest.kt
@@ -84,7 +84,7 @@ class LeaderGroupElectionAspectTest {
 
     private fun newAspect(recorders: List<LeaderAopMetricsRecorder> = emptyList()): LeaderGroupElectionAspect {
         every { factoryMock.create(any()) } returns election
-        every { beanSelector.selectGroupElectionFactory(any()) } returns
+        every { beanSelector.selectGroupElectionFactory(any(), any()) } returns
                 LeaderBeanSelector.Selected("testGroupFactory", factoryMock)
 
         return LeaderGroupElectionAspect(
@@ -219,7 +219,7 @@ class LeaderGroupElectionAspectTest {
         val actionSlot = slot<() -> Any?>()
         every { election.runIfLeaderResult<Any?>(any(), capture(actionSlot)) } answers { LeaderRunResult.Elected(actionSlot.captured.invoke()) }
         every { factoryMock.create(any()) } returns election
-        every { beanSelector.selectGroupElectionFactory(any()) } returns
+        every { beanSelector.selectGroupElectionFactory(any(), any()) } returns
                 LeaderBeanSelector.Selected("testGroupFactory", factoryMock)
 
         val aspect = LeaderGroupElectionAspect(
@@ -236,7 +236,7 @@ class LeaderGroupElectionAspectTest {
             aspect.aroundLeader(pjp)
         }
 
-        verify(exactly = 1) { beanSelector.selectGroupElectionFactory(any()) }
+        verify(exactly = 1) { beanSelector.selectGroupElectionFactory(any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
## Summary

PR #118의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat(#78): 클래스/패키지 레벨 @LeaderElectionBackend 메타 어노테이션 — 7단계 factory fallback`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

[#78] 클래스/패키지 단위로 factory 빈을 지정하는 `@LeaderElectionBackend` 어노테이션 추가.

모놀리식 멀티-도메인 앱에서 도메인별 다른 backend 사용 시 유리합니다.

## 7단계 탐색 우선순위

| 단계 | 탐색 위치 |
|------|-----------|
| 1 | `@LeaderElection(bean = "...")` 메서드 필드 명시 |
| 2 | 메서드 `@LeaderElectionBackend` |
| 3 | 선언 클래스 `@LeaderElectionBackend` |
| 4 | 패키지 `@LeaderElectionBackend` (`@file:LeaderElectionBackend(...)`) |
| 5 | 단일 등록 factory 빈 |
| 6 | `@Primary` factory 빈 |
| 7 | ambiguous → `NoUniqueBeanDefinitionException` |

## 사용 예

```kotlin
// 클래스 레벨 — 클래스 내 모든 @LeaderElection 메서드에 적용
@LeaderElectionBackend("redissonLeaderElectionFactory")
class PaymentService {
    @LeaderElection(name = "payment-lock")
    fun process() { ... }
}

// 메서드 레벨 — 클래스 레벨 오버라이드
class AnalyticsService {
    @LeaderElectionBackend("mongoLeaderElectionFactory")
    @LeaderElection(name = "analytics-lock")
    fun analyze() { ... }
}

// 패키지 레벨 (package.kt)
@file:LeaderElectionBackend("mongoLeaderElectionFactory")
package com.example.analytics
```

## Changes

- `leader-core`: `LeaderElectionBackend` 어노테이션 신규 추가
- `LeaderBeanSelector`: `selectElectionFactory` / `selectGroupElectionFactory`에 `Method?` 파라미터 추가, 7단계 fallback 구현
- `LeaderElectionAspect` / `LeaderGroupElectionAspect`: `method` 파라미터 전달
- 신규 테스트 4건 (메서드/클래스 레벨 탐색 + 우선순위 검증)

**158 tests passing**
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #118, head `b38a67a8dcd76f74e705bd88655002c63ea65b4a`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
