### PR TITLE
feat(#82): SpEL TemplateParserContext 혼합 표현식 자동 감지 지원

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -36,6 +36,7 @@
 | #87 | test: Boot4 Freefair CTW double-fire 방지 검증 테스트 | ✅ 완료 | #113 merged |
 | #85 | feat: LeaderRunResult sealed interface — elected vs skipped 구분 | ✅ 완료 | #114 merged |
 | #81 | feat: FAIL_OPEN_RUN failureMode 구현 | ✅ 완료 | #116 merged |
+| #84 | feat: 메타 어노테이션 (@AliasFor) 지원 | ✅ 완료 | #117 open |
 
 ---
 
@@ -99,7 +100,7 @@
 | 이슈 | 제목 | 선행 조건 |
 |------|------|----------|
 | #82 | feat: SpEL TemplateParserContext 혼합 표현식 지원 | #41 ✅ |
-| #84 | feat: 메타 어노테이션 (@AliasFor) 지원 | #41 ✅ |
+| **#84** | **feat: 메타 어노테이션 (@AliasFor) 지원** | #41 ✅ | **✅ 완료 — PR #117** |
 | #78 | feat: 클래스/패키지 레벨 @LeaderElectionBackend 메타 어노테이션 | #41 ✅ |
 
 ### P3 — Wave 5 suspend/Mono 지원 (순차 의존, 난이도 높음)

--- a/WIP.md
+++ b/WIP.md
@@ -37,6 +37,7 @@
 | #85 | feat: LeaderRunResult sealed interface — elected vs skipped 구분 | ✅ 완료 | #114 merged |
 | #81 | feat: FAIL_OPEN_RUN failureMode 구현 | ✅ 완료 | #116 merged |
 | #84 | feat: 메타 어노테이션 (@AliasFor) 지원 | ✅ 완료 | #117 open |
+| #78 | feat: 클래스/패키지 레벨 @LeaderElectionBackend 메타 어노테이션 | ✅ 완료 | #118 open |
 
 ---
 
@@ -101,7 +102,7 @@
 |------|------|----------|
 | #82 | feat: SpEL TemplateParserContext 혼합 표현식 지원 | #41 ✅ |
 | **#84** | **feat: 메타 어노테이션 (@AliasFor) 지원** | #41 ✅ | **✅ 완료 — PR #117** |
-| #78 | feat: 클래스/패키지 레벨 @LeaderElectionBackend 메타 어노테이션 | #41 ✅ |
+| **#78** | **feat: 클래스/패키지 레벨 @LeaderElectionBackend 메타 어노테이션** | #41 ✅ | **✅ 완료 — PR #118** |
 
 ### P3 — Wave 5 suspend/Mono 지원 (순차 의존, 난이도 높음)
 

--- a/WIP.md
+++ b/WIP.md
@@ -82,10 +82,10 @@
 
 | 이슈 | 제목 | 선행 조건 |
 |------|------|----------|
-| **#94** | **fix: factory.create() pre-try I/O가 failureMode + LeaderElectionException wrap 우회** | 없음 |
-| #97 | test: SpelExpressionEvaluator null 결과 + `${...}` placeholder 경로 미테스트 | 없음 |
-| #96 | test: LeaderAnnotationValidatorBeanPostProcessor suspend/Mono/Flux/Flow/@Aspect skip 미테스트 | 없음 |
-| #95 | test: LeaderGroupElectionAspect 전체 테스트 부재 | 없음 |
+| **#94** | **fix: factory.create() pre-try I/O가 failureMode + LeaderElectionException wrap 우회** | ✅ #116에 포함 |
+| #97 | test: SpelExpressionEvaluator null 결과 + `${...}` placeholder 경로 미테스트 | ✅ #116에 포함 |
+| #96 | test: LeaderAnnotationValidatorBeanPostProcessor suspend/Mono/Flux/Flow/@Aspect skip 미테스트 | ✅ #116에 포함 |
+| #95 | test: LeaderGroupElectionAspect 전체 테스트 부재 | ✅ #116에 포함 |
 
 ### P1 — #75 완료 이후 연쇄 (지금 가능)
 

--- a/WIP.md
+++ b/WIP.md
@@ -34,22 +34,24 @@
 | #103 | feat: LeaderAopProperties Metrics 중첩 클래스 추가 (IDE 자동완성) | ✅ 완료 | #111 merged |
 | #102 | feat: LeaderMicrometerHealthAutoConfiguration 추가 | ✅ 완료 | #112 merged |
 | #87 | test: Boot4 Freefair CTW double-fire 방지 검증 테스트 | ✅ 완료 | #113 merged |
+| #85 | feat: LeaderRunResult sealed interface — elected vs skipped 구분 | ✅ 완료 | #114 merged |
+| #81 | feat: FAIL_OPEN_RUN failureMode 구현 | ✅ 완료 | #116 merged |
 
 ---
 
 ## 이슈 의존 관계
 
 ```
-#41 (AOP) ✅ ─── #75 (Micrometer) ✅ ──┬── #85 (elected/skipped SPI)
-                                        ├── #102 (HealthAutoConfiguration)
-                                        └── #103 (MetricsProperties)
+#41 (AOP) ✅ ─── #75 (Micrometer) ✅ ──┬── #85 (elected/skipped SPI) ✅
+                                        ├── #102 (HealthAutoConfiguration) ✅
+                                        └── #103 (MetricsProperties) ✅
 
 #41 ✅ ────────────────────────────────┬── #94 (bug: failureMode bypass) ← P0
                                        ├── #95 (test: LeaderGroupElectionAspect) ← P0
                                        ├── #96 (test: BPP suspend/Mono 분기) ← P0
                                        ├── #97 (test: SpEL null + placeholder) ← P0
                                        ├── #87 (Boot4 double-fire 검증)
-                                       ├── #81 (FAIL_OPEN_RUN + LeaderResult)
+                                       ├── #81 (FAIL_OPEN_RUN + LeaderResult) ✅
                                        └── #80 sub-issues ─── #88 → #89 → #90 → #91 → #92
 
 독립 기능 (병렬 가능):
@@ -89,8 +91,8 @@
 
 | 이슈 | 제목 | 선행 조건 | 우선순위 |
 |------|------|----------|---------|
-| **#85** | **feat: 백엔드 SPI elected vs skipped 명확 구분 (metrics 정확도)** | #75 ✅ | ⭐ 최우선 |
-| #81 | feat: FAIL_OPEN_RUN 모드 + LeaderResult sealed wrapper | #41 ✅ | 중간 |
+| **#85** | **feat: 백엔드 SPI elected vs skipped 명확 구분 (metrics 정확도)** | #75 ✅ | ✅ 완료 |
+| **#81** | **feat: FAIL_OPEN_RUN failureMode 구현** | #41 ✅ | **✅ 완료** |
 
 ### P2 — 독립 기능 확장 (병렬 가능)
 

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/spel/SpelExpressionEvaluator.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/spel/SpelExpressionEvaluator.kt
@@ -11,27 +11,38 @@ import org.springframework.expression.spel.standard.SpelExpressionParser
 import org.springframework.expression.spel.support.DataBindingMethodResolver
 import org.springframework.expression.spel.support.DataBindingPropertyAccessor
 import org.springframework.expression.spel.support.SimpleEvaluationContext
+import org.springframework.expression.spel.support.StandardEvaluationContext
 import org.springframework.util.StringValueResolver
 import java.lang.reflect.Method
 import java.time.Duration
 
 /**
- * Plain SpEL 평가기 — `@LeaderElection.name` / `@LeaderGroupElection.name` 평가용.
+ * Plain SpEL / Template SpEL 평가기 — `@LeaderElection.name` / `@LeaderGroupElection.name` 평가용.
  *
  * ## 평가 파이프라인
  * 1. `${...}` placeholder 해석 — Spring [StringValueResolver] (생성자 주입)
  * 2. literal fast-path — 정규식 매칭 시 SpEL 우회 (~100ns)
- * 3. plain SpEL parsing — Caffeine cache 적중 시 ~200ns, miss 시 parser invoke
- * 4. [SimpleEvaluationContext] 평가 — read-only property access 만 default 허용
+ * 3. **자동 감지** — `#{...}` 포함 시 template 모드, 그 외 plain SpEL
+ *    - Plain: `name = "#region"` — 전체 SpEL 표현식
+ *    - Template: `name = "prefix-#{#region}-suffix"` — 리터럴+SpEL 혼합 (`TemplateParserContext`)
+ * 4. Caffeine cache 적중 시 ~200ns, miss 시 parser invoke
+ * 5. [SimpleEvaluationContext] 평가 — read-only property access 만 default 허용
+ *
+ * ## Template 모드 (#82)
+ * `#{...}` 패턴 자동 감지 — `TemplateParserContext.DEFAULT_TEMPLATE_PARSER_CONTEXT` 사용.
+ * - ✅ `name = "daily-#{#region}"` → `"daily-KR"` (template)
+ * - ✅ `name = "#region"` → `"KR"` (plain SpEL)
+ * - ✅ `name = "my-lock"` → `"my-lock"` (literal fast-path)
  *
  * ## [Step 3-P-Sec-1][R-32] 보안 default
- * `withMethodResolvers()` 기본 제거 — `#root.target.shutdown()` 같은 임의 메서드 호출 차단
- * (CVE-2022-22947 회색지대). [allowMethodInvocation] = `true` 시에만 활성화.
+ * `withMethodResolvers()` 기본 제거 — `#root.target.shutdown()` 같은 임의 메서드 호출 차단.
+ * [allowMethodInvocation] = `true` 시에만 활성화.
  *
  * ## 캐시
  * Caffeine `maximumSize(1024) + expireAfterAccess(1h)` — DoS 방어.
+ * template 표현식은 캐시 키 앞에 `"T:"` 접두사로 구분.
  *
- * @param embeddedValueResolver Spring `${...}` placeholder 해석기 (`ConfigurableBeanFactory.beanExpressionResolver`)
+ * @param embeddedValueResolver Spring `${...}` placeholder 해석기
  * @param allowMethodInvocation `true` 시 `withMethodResolvers()` + `#root.target` 노출. default `false`
  */
 class SpelExpressionEvaluator(
@@ -49,21 +60,29 @@ class SpelExpressionEvaluator(
     /**
      * [expression] 을 평가하여 문자열 결과 반환.
      *
-     * 평가 순서: `${...}` 해석 → literal fast-path → SpEL parse → SimpleEvaluationContext 평가.
+     * 평가 순서: `${...}` 해석 → literal fast-path → 자동 감지(template/plain) → SpEL 평가.
      *
      * @return 평가된 락 이름
-     * @throws IllegalStateException SpEL 결과가 `null` 인 경우 (메서드 FQN + expression 포함)
+     * @throws IllegalStateException SpEL 결과가 `null` 인 경우
      */
     fun evaluate(expression: String, method: Method, args: Array<Any?>, target: Any): String {
         val resolved = resolveplaceholder(expression)
 
         if (LITERAL_PATTERN.matches(resolved)) return resolved
 
-        val parsed = expressionCache.get(resolved) { parser.parseExpression(it) }
         val ctx = buildContext(method, args, target)
 
-        return parsed.getValue(ctx, String::class.java)
-            ?: error("SpEL '$resolved' returned null at ${method.declaringClass.name}#${method.name}")
+        return if (TEMPLATE_DETECT.containsMatchIn(resolved)) {
+            val parsed = expressionCache.get("T:$resolved") {
+                parser.parseExpression(resolved, TEMPLATE_PARSER_CTX)
+            }
+            parsed.getValue(ctx, String::class.java)
+                ?: error("SpEL template '$resolved' returned null at ${method.declaringClass.name}#${method.name}")
+        } else {
+            val parsed = expressionCache.get(resolved) { parser.parseExpression(it) }
+            parsed.getValue(ctx, String::class.java)
+                ?: error("SpEL '$resolved' returned null at ${method.declaringClass.name}#${method.name}")
+        }
     }
 
     /**
@@ -73,13 +92,26 @@ class SpelExpressionEvaluator(
         val resolved = resolveplaceholder(expression)
         if (LITERAL_PATTERN.matches(resolved)) return
 
-        runCatching { expressionCache.get(resolved) { parser.parseExpression(it) } }
-            .onFailure { ex ->
+        if (TEMPLATE_DETECT.containsMatchIn(resolved)) {
+            runCatching {
+                expressionCache.get("T:$resolved") {
+                    parser.parseExpression(resolved, TEMPLATE_PARSER_CTX)
+                }
+            }.onFailure { ex ->
                 throw IllegalStateException(
-                    "Invalid SpEL expression '$resolved' on ${method.declaringClass.name}#${method.name}: ${ex.message}",
+                    "Invalid SpEL template '$resolved' on ${method.declaringClass.name}#${method.name}: ${ex.message}",
                     ex,
                 )
             }
+        } else {
+            runCatching { expressionCache.get(resolved) { parser.parseExpression(it) } }
+                .onFailure { ex ->
+                    throw IllegalStateException(
+                        "Invalid SpEL expression '$resolved' on ${method.declaringClass.name}#${method.name}: ${ex.message}",
+                        ex,
+                    )
+                }
+        }
     }
 
     /** 현재 캐시 크기. Health endpoint 노출용. */
@@ -88,8 +120,8 @@ class SpelExpressionEvaluator(
     private fun resolveplaceholder(expression: String): String =
         embeddedValueResolver?.resolveStringValue(expression) ?: expression
 
-    private fun buildContext(method: Method, args: Array<Any?>, target: Any): SimpleEvaluationContext {
-        val rootObject = if (allowMethodInvocation) RootCtx(method, args, target) else RootCtx(method, args, null)
+    private fun buildContext(method: Method, args: Array<Any?>?, target: Any?): SimpleEvaluationContext {
+        val rootObject = if (allowMethodInvocation) RootCtx(method, args ?: emptyArray(), target) else RootCtx(method, args ?: emptyArray(), null)
 
         val builder = SimpleEvaluationContext.forPropertyAccessors(
             DataBindingPropertyAccessor.forReadOnlyAccess(),
@@ -101,12 +133,13 @@ class SpelExpressionEvaluator(
 
         val ctx = builder.withRootObject(rootObject).build()
 
-        // 메서드 파라미터 이름 노출 (#argName, #a0, #p0)
-        val paramNames = parameterNameDiscoverer.getParameterNames(method)
-        for ((index, value) in args.withIndex()) {
-            ctx.setVariable("a$index", value)
-            ctx.setVariable("p$index", value)
-            paramNames?.getOrNull(index)?.let { ctx.setVariable(it, value) }
+        if (args != null) {
+            val paramNames = parameterNameDiscoverer.getParameterNames(method)
+            for ((index, value) in args.withIndex()) {
+                ctx.setVariable("a$index", value)
+                ctx.setVariable("p$index", value)
+                paramNames?.getOrNull(index)?.let { ctx.setVariable(it, value) }
+            }
         }
 
         return ctx
@@ -143,11 +176,18 @@ class SpelExpressionEvaluator(
      * 본 evaluator 는 직접 RootCtx 를 사용한다.
      */
     @Suppress("unused")
-    private fun unusedReference(): Class<*> = MethodBasedEvaluationContext::class.java
+    private fun unusedReference(): Pair<Class<*>, Class<*>> =
+        MethodBasedEvaluationContext::class.java to StandardEvaluationContext::class.java
 
     companion object: KLogging() {
         /** 정적 lock name 정규식 — 매칭 시 SpEL 평가 우회. */
         private val LITERAL_PATTERN = Regex("^[A-Za-z0-9_:.\\-]+$")
+
+        /** `#{...}` 패턴 감지 — template 모드 자동 선택용 (#82). */
+        private val TEMPLATE_DETECT = Regex("#\\{.+}")
+
+        /** Spring TemplateParserContext — 기본 `#{` / `}` 구분자. */
+        private val TEMPLATE_PARSER_CTX = org.springframework.expression.ParserContext.TEMPLATE_EXPRESSION
 
         /** Caffeine cache 상한. */
         const val MAX_CACHE_SIZE: Long = 1024L

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/spel/SpelExpressionEvaluatorTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/spel/SpelExpressionEvaluatorTest.kt
@@ -161,4 +161,57 @@ class SpelExpressionEvaluatorTest {
             SampleService(),
         ) shouldBeEqualTo "batch-EU"
     }
+
+    // ── #82: TemplateParserContext 혼합 표현식 ──
+
+    @Test
+    fun `template - prefix-#{#region}-suffix 혼합 표현식 평가`() {
+        val sut = newEvaluator()
+        sut.evaluate("prefix-#{#region}-suffix", method("process"), arrayOf("EU"), SampleService()) shouldBeEqualTo "prefix-EU-suffix"
+    }
+
+    @Test
+    fun `template - 리터럴만 있는 템플릿 표현식`() {
+        val sut = newEvaluator()
+        sut.evaluate("static-#{#region}", method("process"), arrayOf("KR"), SampleService()) shouldBeEqualTo "static-KR"
+    }
+
+    @Test
+    fun `template - 복수 SpEL 구간 평가`() {
+        val sut = newEvaluator()
+        // "#{#a0}-job-#{#a1}" 이 가능한지 테스트 — 메서드에 파라미터 2개 필요
+        val twoParamMethod = TwoParamService::class.java.getDeclaredMethod("process", String::class.java, String::class.java)
+        sut.evaluate(
+            "#{#env}-lock-#{#zone}",
+            twoParamMethod,
+            arrayOf("prod", "us-east"),
+            TwoParamService(),
+        ) shouldBeEqualTo "prod-lock-us-east"
+    }
+
+    @Test
+    fun `template - pre-parse 정상 통과`() {
+        val sut = newEvaluator()
+        sut.preParse("daily-#{#region}", method("process"))
+        sut.cacheSize() shouldBeEqualTo 1L  // template 표현식 cache 적재 ("T:daily-#{#region}")
+    }
+
+    @Test
+    fun `template - 잘못된 SpEL 구간 startup fail`() {
+        val sut = newEvaluator()
+        val ex = runCatching { sut.preParse("prefix-#{'unclosed}", method("process")) }.exceptionOrNull()
+        check(ex != null) { "expected throw" }
+        check(ex.message!!.contains("SpEL template")) { "message should mention 'SpEL template': ${ex.message}" }
+    }
+
+    @Test
+    fun `template - plain SpEL 과 자동 구분 — 해시만 있고 중괄호 없으면 plain 모드`() {
+        val sut = newEvaluator()
+        // #region 은 plain SpEL, "#{" 없으므로 template 모드 아님
+        sut.evaluate("#region", method("process"), arrayOf("EU"), SampleService()) shouldBeEqualTo "EU"
+    }
+
+    private class TwoParamService {
+        fun process(env: String, zone: String): String = "$env-$zone"
+    }
 }


### PR DESCRIPTION
## Summary

PR #119의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat(#82): SpEL TemplateParserContext 혼합 표현식 자동 감지 지원`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

[#82] `#{...}` 패턴 자동 감지 후 `TemplateParserContext`로 전환 — 리터럴+SpEL 혼합 표현식 지원.

## 동작 방식

| 표현식 | 모드 | 평가 결과 |
|--------|------|-----------|
| `"my-lock"` | literal fast-path | `"my-lock"` |
| `"#region"` | plain SpEL | `"EU"` (param 값) |
| `"'prefix-' + #region"` | plain SpEL | `"prefix-EU"` |
| `"prefix-#{#region}-suffix"` | **template** | `"prefix-EU-suffix"` |
| `"shard-#{#env}-#{#zone}"` | **template** | `"shard-prod-us-east"` |

## 설계 결정

- **자동 감지**: `#{...}` 포함 시 template 모드 — annotation 변경 불필요, 기존 코드 하위 호환
- 캐시 키 구분: template = `"T:"` 접두사, plain = 기존 키
- `ParserContext.TEMPLATE_EXPRESSION` 사용 (기본 구분자: `#{` / `}`)

## Changes

- `SpelExpressionEvaluator`: `TEMPLATE_DETECT` regex + `TEMPLATE_PARSER_CTX` 추가, `evaluate` / `preParse` template 분기
- 신규 테스트 6건 (`SpelExpressionEvaluatorTest`)

**160 tests passing**
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #119, head `7c997ef2c05018e8873ecc0d61f9248cc9320e31`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
