### PR TITLE
feat: #89 SuspendLeaderElectorFactory 백엔드 구현체 추가 (Lettuce/Redisson/MongoDB/ExposedR2DBC)

### DIFF
--- a/WIP.md
+++ b/WIP.md
@@ -36,6 +36,7 @@
 | #87 | test: Boot4 Freefair CTW double-fire 방지 검증 테스트 | ✅ 완료 | #113 merged |
 | #85 | feat: LeaderRunResult sealed interface — elected vs skipped 구분 | ✅ 완료 | #114 merged |
 | #81 | feat: FAIL_OPEN_RUN failureMode 구현 | ✅ 완료 | #116 merged |
+| #84 | feat: 메타 어노테이션 (@AliasFor) 지원 | ✅ 완료 | #117 open |
 
 ---
 
@@ -99,7 +100,7 @@
 | 이슈 | 제목 | 선행 조건 |
 |------|------|----------|
 | #82 | feat: SpEL TemplateParserContext 혼합 표현식 지원 | #41 ✅ |
-| #84 | feat: 메타 어노테이션 (@AliasFor) 지원 | #41 ✅ |
+| **#84** | **feat: 메타 어노테이션 (@AliasFor) 지원** | #41 ✅ | **✅ 완료 — PR #117** |
 | #78 | feat: 클래스/패키지 레벨 @LeaderElectionBackend 메타 어노테이션 | #41 ✅ |
 
 ### P3 — Wave 5 suspend/Mono 지원 (순차 의존, 난이도 높음)

--- a/WIP.md
+++ b/WIP.md
@@ -37,6 +37,7 @@
 | #85 | feat: LeaderRunResult sealed interface — elected vs skipped 구분 | ✅ 완료 | #114 merged |
 | #81 | feat: FAIL_OPEN_RUN failureMode 구현 | ✅ 완료 | #116 merged |
 | #84 | feat: 메타 어노테이션 (@AliasFor) 지원 | ✅ 완료 | #117 open |
+| #78 | feat: 클래스/패키지 레벨 @LeaderElectionBackend 메타 어노테이션 | ✅ 완료 | #118 open |
 
 ---
 
@@ -101,7 +102,7 @@
 |------|------|----------|
 | #82 | feat: SpEL TemplateParserContext 혼합 표현식 지원 | #41 ✅ |
 | **#84** | **feat: 메타 어노테이션 (@AliasFor) 지원** | #41 ✅ | **✅ 완료 — PR #117** |
-| #78 | feat: 클래스/패키지 레벨 @LeaderElectionBackend 메타 어노테이션 | #41 ✅ |
+| **#78** | **feat: 클래스/패키지 레벨 @LeaderElectionBackend 메타 어노테이션** | #41 ✅ | **✅ 완료 — PR #118** |
 
 ### P3 — Wave 5 suspend/Mono 지원 (순차 의존, 난이도 높음)
 

--- a/WIP.md
+++ b/WIP.md
@@ -36,8 +36,9 @@
 | #87 | test: Boot4 Freefair CTW double-fire 방지 검증 테스트 | ✅ 완료 | #113 merged |
 | #85 | feat: LeaderRunResult sealed interface — elected vs skipped 구분 | ✅ 완료 | #114 merged |
 | #81 | feat: FAIL_OPEN_RUN failureMode 구현 | ✅ 완료 | #116 merged |
-| #84 | feat: 메타 어노테이션 (@AliasFor) 지원 | ✅ 완료 | #117 open |
-| #78 | feat: 클래스/패키지 레벨 @LeaderElectionBackend 메타 어노테이션 | ✅ 완료 | #118 open |
+| #84 | feat: 메타 어노테이션 (@AliasFor) 지원 | ✅ 완료 | #117 merged |
+| #78 | feat: 클래스/패키지 레벨 @LeaderElectionBackend 메타 어노테이션 | ✅ 완료 | #118 merged |
+| #82 | feat: SpEL TemplateParserContext 혼합 표현식 지원 | ✅ 완료 | #119 merged |
 
 ---
 
@@ -100,10 +101,9 @@
 
 | 이슈 | 제목 | 선행 조건 |
 |------|------|----------|
-| **#82** | **feat: SpEL TemplateParserContext 혼합 표현식 지원** | #41 ✅ | **✅ 완료 — PR #119** |
-| **#84** | **feat: 메타 어노테이션 (@AliasFor) 지원** | #41 ✅ | **✅ 완료 — PR #117** |
-| **#78** | **feat: 클래스/패키지 레벨 @LeaderElectionBackend 메타 어노테이션** | #41 ✅ | **✅ 완료 — PR #118** |
-| **#82** | **feat: SpEL TemplateParserContext 혼합 표현식 지원** | #41 ✅ | **✅ 완료 — PR #119** |
+| **#82** | **feat: SpEL TemplateParserContext 혼합 표현식 지원** | #41 ✅ | **✅ 완료 — PR #119 merged** |
+| **#84** | **feat: 메타 어노테이션 (@AliasFor) 지원** | #41 ✅ | **✅ 완료 — PR #117 merged** |
+| **#78** | **feat: 클래스/패키지 레벨 @LeaderElectionBackend 메타 어노테이션** | #41 ✅ | **✅ 완료 — PR #118 merged** |
 
 ### P3 — Wave 5 suspend/Mono 지원 (순차 의존, 난이도 높음)
 

--- a/WIP.md
+++ b/WIP.md
@@ -82,10 +82,10 @@
 
 | 이슈 | 제목 | 선행 조건 |
 |------|------|----------|
-| **#94** | **fix: factory.create() pre-try I/O가 failureMode + LeaderElectionException wrap 우회** | 없음 |
-| #97 | test: SpelExpressionEvaluator null 결과 + `${...}` placeholder 경로 미테스트 | 없음 |
-| #96 | test: LeaderAnnotationValidatorBeanPostProcessor suspend/Mono/Flux/Flow/@Aspect skip 미테스트 | 없음 |
-| #95 | test: LeaderGroupElectionAspect 전체 테스트 부재 | 없음 |
+| **#94** | **fix: factory.create() pre-try I/O가 failureMode + LeaderElectionException wrap 우회** | ✅ #116에 포함 |
+| #97 | test: SpelExpressionEvaluator null 결과 + `${...}` placeholder 경로 미테스트 | ✅ #116에 포함 |
+| #96 | test: LeaderAnnotationValidatorBeanPostProcessor suspend/Mono/Flux/Flow/@Aspect skip 미테스트 | ✅ #116에 포함 |
+| #95 | test: LeaderGroupElectionAspect 전체 테스트 부재 | ✅ #116에 포함 |
 
 ### P1 — #75 완료 이후 연쇄 (지금 가능)
 

--- a/WIP.md
+++ b/WIP.md
@@ -100,9 +100,10 @@
 
 | 이슈 | 제목 | 선행 조건 |
 |------|------|----------|
-| #82 | feat: SpEL TemplateParserContext 혼합 표현식 지원 | #41 ✅ |
+| **#82** | **feat: SpEL TemplateParserContext 혼합 표현식 지원** | #41 ✅ | **✅ 완료 — PR #119** |
 | **#84** | **feat: 메타 어노테이션 (@AliasFor) 지원** | #41 ✅ | **✅ 완료 — PR #117** |
 | **#78** | **feat: 클래스/패키지 레벨 @LeaderElectionBackend 메타 어노테이션** | #41 ✅ | **✅ 완료 — PR #118** |
+| **#82** | **feat: SpEL TemplateParserContext 혼합 표현식 지원** | #41 ✅ | **✅ 완료 — PR #119** |
 
 ### P3 — Wave 5 suspend/Mono 지원 (순차 의존, 난이도 높음)
 

--- a/WIP.md
+++ b/WIP.md
@@ -34,22 +34,24 @@
 | #103 | feat: LeaderAopProperties Metrics 중첩 클래스 추가 (IDE 자동완성) | ✅ 완료 | #111 merged |
 | #102 | feat: LeaderMicrometerHealthAutoConfiguration 추가 | ✅ 완료 | #112 merged |
 | #87 | test: Boot4 Freefair CTW double-fire 방지 검증 테스트 | ✅ 완료 | #113 merged |
+| #85 | feat: LeaderRunResult sealed interface — elected vs skipped 구분 | ✅ 완료 | #114 merged |
+| #81 | feat: FAIL_OPEN_RUN failureMode 구현 | ✅ 완료 | #116 merged |
 
 ---
 
 ## 이슈 의존 관계
 
 ```
-#41 (AOP) ✅ ─── #75 (Micrometer) ✅ ──┬── #85 (elected/skipped SPI)
-                                        ├── #102 (HealthAutoConfiguration)
-                                        └── #103 (MetricsProperties)
+#41 (AOP) ✅ ─── #75 (Micrometer) ✅ ──┬── #85 (elected/skipped SPI) ✅
+                                        ├── #102 (HealthAutoConfiguration) ✅
+                                        └── #103 (MetricsProperties) ✅
 
 #41 ✅ ────────────────────────────────┬── #94 (bug: failureMode bypass) ← P0
                                        ├── #95 (test: LeaderGroupElectionAspect) ← P0
                                        ├── #96 (test: BPP suspend/Mono 분기) ← P0
                                        ├── #97 (test: SpEL null + placeholder) ← P0
                                        ├── #87 (Boot4 double-fire 검증)
-                                       ├── #81 (FAIL_OPEN_RUN + LeaderResult)
+                                       ├── #81 (FAIL_OPEN_RUN + LeaderResult) ✅
                                        └── #80 sub-issues ─── #88 → #89 → #90 → #91 → #92
 
 독립 기능 (병렬 가능):
@@ -89,8 +91,8 @@
 
 | 이슈 | 제목 | 선행 조건 | 우선순위 |
 |------|------|----------|---------|
-| **#85** | **feat: 백엔드 SPI elected vs skipped 명확 구분 (metrics 정확도)** | #75 ✅ | ⭐ 최우선 |
-| #81 | feat: FAIL_OPEN_RUN 모드 + LeaderResult sealed wrapper | #41 ✅ | 중간 |
+| **#85** | **feat: 백엔드 SPI elected vs skipped 명확 구분 (metrics 정확도)** | #75 ✅ | ✅ 완료 |
+| **#81** | **feat: FAIL_OPEN_RUN failureMode 구현** | #41 ✅ | **✅ 완료** |
 
 ### P2 — 독립 기능 확장 (병렬 가능)
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElectorFactory.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElectorFactory.kt
@@ -1,0 +1,19 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.leader.LeaderElectionOptions
+
+/**
+ * [LocalSuspendLeaderElector] 팩토리 — `kotlinx.coroutines.sync.Mutex` 기반 단일 JVM suspend 리더 선출 인스턴스 생성.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val factory = LocalSuspendLeaderElectorFactory()
+ * val elector = factory.create(LeaderElectionOptions.Default)
+ * val result = elector.runIfLeader("job-lock") { "done" }
+ * ```
+ */
+class LocalSuspendLeaderElectorFactory : SuspendLeaderElectorFactory {
+
+    override fun create(options: LeaderElectionOptions): SuspendLeaderElector =
+        LocalSuspendLeaderElector(options)
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElectorFactory.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElectorFactory.kt
@@ -14,6 +14,6 @@ import io.bluetape4k.leader.LeaderElectionOptions
  */
 class LocalSuspendLeaderElectorFactory : SuspendLeaderElectorFactory {
 
-    override fun create(options: LeaderElectionOptions): SuspendLeaderElector =
+    override suspend fun create(options: LeaderElectionOptions): SuspendLeaderElector =
         LocalSuspendLeaderElector(options)
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElectorFactory.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElectorFactory.kt
@@ -14,6 +14,6 @@ import io.bluetape4k.leader.LeaderGroupElectionOptions
  */
 class LocalSuspendLeaderGroupElectorFactory : SuspendLeaderGroupElectorFactory {
 
-    override fun create(options: LeaderGroupElectionOptions): SuspendLeaderGroupElector =
+    override suspend fun create(options: LeaderGroupElectionOptions): SuspendLeaderGroupElector =
         LocalSuspendLeaderGroupElector(options)
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElectorFactory.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElectorFactory.kt
@@ -1,0 +1,19 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+
+/**
+ * [LocalSuspendLeaderGroupElector] 팩토리 — `kotlinx.coroutines.sync.Semaphore` 기반 단일 JVM suspend 복수 리더 선출 인스턴스 생성.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val factory = LocalSuspendLeaderGroupElectorFactory()
+ * val elector = factory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+ * val result = elector.runIfLeader("batch-shard") { processChunk() }
+ * ```
+ */
+class LocalSuspendLeaderGroupElectorFactory : SuspendLeaderGroupElectorFactory {
+
+    override fun create(options: LeaderGroupElectionOptions): SuspendLeaderGroupElector =
+        LocalSuspendLeaderGroupElector(options)
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderElectorFactory.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderElectorFactory.kt
@@ -28,5 +28,5 @@ fun interface SuspendLeaderElectorFactory {
      * @param options 새 인스턴스에 적용할 옵션 (waitTime, leaseTime)
      * @return 호출 단위 옵션이 적용된 [SuspendLeaderElector] 인스턴스
      */
-    fun create(options: LeaderElectionOptions): SuspendLeaderElector
+    suspend fun create(options: LeaderElectionOptions): SuspendLeaderElector
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderElectorFactory.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderElectorFactory.kt
@@ -1,0 +1,32 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.leader.LeaderElectionOptions
+
+/**
+ * 호출 단위 옵션으로 [SuspendLeaderElector] 인스턴스를 생성하는 팩토리 SPI.
+ *
+ * ## 도입 배경
+ * [SuspendLeaderElector.runIfLeader]는 `(lockName, action)` 시그니처만 제공하며
+ * 옵션을 호출 단위로 받을 수단이 없다. AOP 어드바이스가 어노테이션 옵션마다 suspend 백엔드
+ * 인스턴스를 새로 생성/캐싱할 수 있도록 본 SPI를 추가한다.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val factory: SuspendLeaderElectorFactory = LocalSuspendLeaderElectorFactory()
+ * val elector = factory.create(LeaderElectionOptions(waitTime = 3.seconds, leaseTime = 30.seconds))
+ * val result = elector.runIfLeader("daily-job") { processData() }
+ * ```
+ *
+ * @see SuspendLeaderGroupElectorFactory 복수 리더 suspend 팩토리
+ * @see io.bluetape4k.leader.LeaderElectorFactory sync 버전 팩토리
+ */
+fun interface SuspendLeaderElectorFactory {
+
+    /**
+     * 주어진 [options]로 새로운 [SuspendLeaderElector] 인스턴스를 생성한다.
+     *
+     * @param options 새 인스턴스에 적용할 옵션 (waitTime, leaseTime)
+     * @return 호출 단위 옵션이 적용된 [SuspendLeaderElector] 인스턴스
+     */
+    fun create(options: LeaderElectionOptions): SuspendLeaderElector
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderGroupElectorFactory.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderGroupElectorFactory.kt
@@ -1,0 +1,27 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+
+/**
+ * 호출 단위 옵션으로 [SuspendLeaderGroupElector] 인스턴스를 생성하는 팩토리 SPI.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val factory: SuspendLeaderGroupElectorFactory = LocalSuspendLeaderGroupElectorFactory()
+ * val elector = factory.create(LeaderGroupElectionOptions(maxLeaders = 3, waitTime = 3.seconds))
+ * val result = elector.runIfLeader("batch-shard") { processChunk() }
+ * ```
+ *
+ * @see SuspendLeaderElectorFactory 단일 리더 suspend 팩토리
+ * @see io.bluetape4k.leader.LeaderGroupElectorFactory sync 버전 팩토리
+ */
+fun interface SuspendLeaderGroupElectorFactory {
+
+    /**
+     * 주어진 [options]로 새로운 [SuspendLeaderGroupElector] 인스턴스를 생성한다.
+     *
+     * @param options 새 인스턴스에 적용할 옵션 (maxLeaders, waitTime, leaseTime)
+     * @return 호출 단위 옵션이 적용된 [SuspendLeaderGroupElector] 인스턴스
+     */
+    fun create(options: LeaderGroupElectionOptions): SuspendLeaderGroupElector
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderGroupElectorFactory.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderGroupElectorFactory.kt
@@ -23,5 +23,5 @@ fun interface SuspendLeaderGroupElectorFactory {
      * @param options 새 인스턴스에 적용할 옵션 (maxLeaders, waitTime, leaseTime)
      * @return 호출 단위 옵션이 적용된 [SuspendLeaderGroupElector] 인스턴스
      */
-    fun create(options: LeaderGroupElectionOptions): SuspendLeaderGroupElector
+    suspend fun create(options: LeaderGroupElectionOptions): SuspendLeaderGroupElector
 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElectorFactoryTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElectorFactoryTest.kt
@@ -1,0 +1,65 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+
+/**
+ * [LocalSuspendLeaderElectorFactory] — SPI contract 테스트.
+ *
+ * - `create()` 가 새 [SuspendLeaderElector] 인스턴스를 반환하는지 검증
+ * - 반환된 인스턴스가 [runIfLeader] 를 정상 실행하는지 검증
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LocalSuspendLeaderElectorFactoryTest {
+
+    companion object: KLoggingChannel()
+
+    private val factory: SuspendLeaderElectorFactory = LocalSuspendLeaderElectorFactory()
+
+    private fun randomLockName() = "lock-${Base58.randomString(8)}"
+
+    @Test
+    fun `create - 기본 옵션으로 SuspendLeaderElector 인스턴스 반환`() {
+        val elector = factory.create(LeaderElectionOptions.Default)
+        elector.shouldNotBeNull()
+        elector.shouldBeInstanceOf<LocalSuspendLeaderElector>()
+    }
+
+    @Test
+    fun `create - 커스텀 옵션으로 인스턴스 반환`() {
+        val opts = LeaderElectionOptions(waitTime = Duration.ofSeconds(1), leaseTime = Duration.ofSeconds(10))
+        val elector = factory.create(opts)
+        elector.shouldNotBeNull()
+    }
+
+    @Test
+    fun `create - 호출마다 새 인스턴스 반환`() {
+        val a = factory.create(LeaderElectionOptions.Default)
+        val b = factory.create(LeaderElectionOptions.Default)
+        // 팩토리는 매번 새 인스턴스를 반환 (동일성 보장 안 함)
+        (a !== b).shouldBeEqualTo(true)
+    }
+
+    @Test
+    fun `create 후 runIfLeader - 리더 획득 성공 시 action 실행`() = runSuspendIO {
+        val elector = factory.create(LeaderElectionOptions.Default)
+        val result = elector.runIfLeader(randomLockName()) { "factory-ok" }
+        result shouldBeEqualTo "factory-ok"
+    }
+
+    @Test
+    fun `create 후 runIfLeader - Unit action 정상 실행`() = runSuspendIO {
+        val elector = factory.create(LeaderElectionOptions.Default)
+        var called = false
+        elector.runIfLeader(randomLockName()) { called = true }
+        called.shouldBeEqualTo(true)
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElectorFactoryTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElectorFactoryTest.kt
@@ -27,21 +27,21 @@ class LocalSuspendLeaderElectorFactoryTest {
     private fun randomLockName() = "lock-${Base58.randomString(8)}"
 
     @Test
-    fun `create - 기본 옵션으로 SuspendLeaderElector 인스턴스 반환`() {
+    fun `create - 기본 옵션으로 SuspendLeaderElector 인스턴스 반환`() = runSuspendIO {
         val elector = factory.create(LeaderElectionOptions.Default)
         elector.shouldNotBeNull()
         elector.shouldBeInstanceOf<LocalSuspendLeaderElector>()
     }
 
     @Test
-    fun `create - 커스텀 옵션으로 인스턴스 반환`() {
+    fun `create - 커스텀 옵션으로 인스턴스 반환`() = runSuspendIO {
         val opts = LeaderElectionOptions(waitTime = Duration.ofSeconds(1), leaseTime = Duration.ofSeconds(10))
         val elector = factory.create(opts)
         elector.shouldNotBeNull()
     }
 
     @Test
-    fun `create - 호출마다 새 인스턴스 반환`() {
+    fun `create - 호출마다 새 인스턴스 반환`() = runSuspendIO {
         val a = factory.create(LeaderElectionOptions.Default)
         val b = factory.create(LeaderElectionOptions.Default)
         // 팩토리는 매번 새 인스턴스를 반환 (동일성 보장 안 함)

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElectorFactoryTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElectorFactoryTest.kt
@@ -24,14 +24,14 @@ class LocalSuspendLeaderGroupElectorFactoryTest {
     private fun randomLockName() = "lock-${Base58.randomString(8)}"
 
     @Test
-    fun `create - 기본 옵션으로 SuspendLeaderGroupElector 인스턴스 반환`() {
+    fun `create - 기본 옵션으로 SuspendLeaderGroupElector 인스턴스 반환`() = runSuspendIO {
         val elector = factory.create(LeaderGroupElectionOptions.Default)
         elector.shouldNotBeNull()
         elector.shouldBeInstanceOf<LocalSuspendLeaderGroupElector>()
     }
 
     @Test
-    fun `create - 커스텀 maxLeaders 옵션으로 인스턴스 반환`() {
+    fun `create - 커스텀 maxLeaders 옵션으로 인스턴스 반환`() = runSuspendIO {
         val opts = LeaderGroupElectionOptions(maxLeaders = 5, waitTime = Duration.ofSeconds(1), leaseTime = Duration.ofSeconds(10))
         val elector = factory.create(opts)
         elector.shouldNotBeNull()
@@ -39,7 +39,7 @@ class LocalSuspendLeaderGroupElectorFactoryTest {
     }
 
     @Test
-    fun `create - 호출마다 새 인스턴스 반환`() {
+    fun `create - 호출마다 새 인스턴스 반환`() = runSuspendIO {
         val a = factory.create(LeaderGroupElectionOptions.Default)
         val b = factory.create(LeaderGroupElectionOptions.Default)
         (a !== b).shouldBeEqualTo(true)

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElectorFactoryTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElectorFactoryTest.kt
@@ -1,0 +1,64 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+
+/**
+ * [LocalSuspendLeaderGroupElectorFactory] — SPI contract 테스트.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LocalSuspendLeaderGroupElectorFactoryTest {
+
+    companion object: KLoggingChannel()
+
+    private val factory: SuspendLeaderGroupElectorFactory = LocalSuspendLeaderGroupElectorFactory()
+
+    private fun randomLockName() = "lock-${Base58.randomString(8)}"
+
+    @Test
+    fun `create - 기본 옵션으로 SuspendLeaderGroupElector 인스턴스 반환`() {
+        val elector = factory.create(LeaderGroupElectionOptions.Default)
+        elector.shouldNotBeNull()
+        elector.shouldBeInstanceOf<LocalSuspendLeaderGroupElector>()
+    }
+
+    @Test
+    fun `create - 커스텀 maxLeaders 옵션으로 인스턴스 반환`() {
+        val opts = LeaderGroupElectionOptions(maxLeaders = 5, waitTime = Duration.ofSeconds(1), leaseTime = Duration.ofSeconds(10))
+        val elector = factory.create(opts)
+        elector.shouldNotBeNull()
+        elector.maxLeaders shouldBeEqualTo 5
+    }
+
+    @Test
+    fun `create - 호출마다 새 인스턴스 반환`() {
+        val a = factory.create(LeaderGroupElectionOptions.Default)
+        val b = factory.create(LeaderGroupElectionOptions.Default)
+        (a !== b).shouldBeEqualTo(true)
+    }
+
+    @Test
+    fun `create 후 runIfLeader - 슬롯 획득 성공 시 action 실행`() = runSuspendIO {
+        val elector = factory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+        val result = elector.runIfLeader(randomLockName()) { "group-factory-ok" }
+        result shouldBeEqualTo "group-factory-ok"
+    }
+
+    @Test
+    fun `create 후 runIfLeader - activeCount 정상 동작`() = runSuspendIO {
+        val lockName = randomLockName()
+        val elector = factory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+        elector.runIfLeader(lockName) {
+            elector.activeCount(lockName) shouldBeEqualTo 1
+        }
+        elector.activeCount(lockName) shouldBeEqualTo 0
+    }
+}

--- a/leader-exposed-r2dbc/README.ko.md
+++ b/leader-exposed-r2dbc/README.ko.md
@@ -57,6 +57,8 @@ classDiagram
 |--------|-----------|------|
 | `ExposedR2dbcSuspendLeaderElection` | `SuspendLeaderElection` | `ExposedR2dbcLock` 기반 코루틴 단일 리더 |
 | `ExposedR2dbcSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` | `ExposedR2dbcGroupLock` 기반 코루틴 복수 리더 |
+| `ExposedR2DbcSuspendLeaderElectorFactory` | `SuspendLeaderElectorFactory` | 팩토리: 호출마다 `ExposedR2dbcSuspendLeaderElection` 생성 |
+| `ExposedR2DbcSuspendLeaderGroupElectorFactory` | `SuspendLeaderGroupElectorFactory` | 팩토리: 호출마다 `ExposedR2dbcSuspendLeaderGroupElection` 생성 |
 
 ## 사용법
 
@@ -135,6 +137,26 @@ val options = ExposedR2dbcLeaderElectionOptions(
     lockOwner = "worker-1",
 )
 val election = ExposedR2dbcSuspendLeaderElection(db, options)
+```
+
+### SPI 팩토리 사용
+
+```kotlin
+val factory: SuspendLeaderElectorFactory = ExposedR2DbcSuspendLeaderElectorFactory(db)
+
+coroutineScope {
+    val elector = factory.create(LeaderElectionOptions.Default)
+    val result = elector.runIfLeader("daily-job") { generateReport() }
+}
+```
+
+```kotlin
+val groupFactory: SuspendLeaderGroupElectorFactory = ExposedR2DbcSuspendLeaderGroupElectorFactory(db)
+
+coroutineScope {
+    val elector = groupFactory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+    val result = elector.runIfLeader("parallel-batch") { processChunk() }
+}
 ```
 
 ## 락 전략

--- a/leader-exposed-r2dbc/README.md
+++ b/leader-exposed-r2dbc/README.md
@@ -57,6 +57,8 @@ classDiagram
 |-------|-----------|-------------|
 | `ExposedR2dbcSuspendLeaderElection` | `SuspendLeaderElection` | Coroutine single-leader via `ExposedR2dbcLock` |
 | `ExposedR2dbcSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` | Coroutine multi-leader via `ExposedR2dbcGroupLock` |
+| `ExposedR2DbcSuspendLeaderElectorFactory` | `SuspendLeaderElectorFactory` | Factory: creates `ExposedR2dbcSuspendLeaderElection` per call |
+| `ExposedR2DbcSuspendLeaderGroupElectorFactory` | `SuspendLeaderGroupElectorFactory` | Factory: creates `ExposedR2dbcSuspendLeaderGroupElection` per call |
 
 ## Usage
 
@@ -135,6 +137,26 @@ val options = ExposedR2dbcLeaderElectionOptions(
     lockOwner = "worker-1",
 )
 val election = ExposedR2dbcSuspendLeaderElection(db, options)
+```
+
+### Using SPI factories
+
+```kotlin
+val factory: SuspendLeaderElectorFactory = ExposedR2DbcSuspendLeaderElectorFactory(db)
+
+coroutineScope {
+    val elector = factory.create(LeaderElectionOptions.Default)
+    val result = elector.runIfLeader("daily-job") { generateReport() }
+}
+```
+
+```kotlin
+val groupFactory: SuspendLeaderGroupElectorFactory = ExposedR2DbcSuspendLeaderGroupElectorFactory(db)
+
+coroutineScope {
+    val elector = groupFactory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+    val result = elector.runIfLeader("parallel-batch") { processChunk() }
+}
 ```
 
 ## Lock Strategy

--- a/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderElectorFactory.kt
+++ b/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderElectorFactory.kt
@@ -1,0 +1,35 @@
+package io.bluetape4k.leader.exposed.r2dbc
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
+
+/**
+ * [ExposedR2DbcSuspendLeaderElector] 팩토리 — Exposed R2DBC 기반 suspend 단일 리더 선출.
+ *
+ * ## 옵션 처리
+ * Exposed R2DBC 백엔드 고유 옵션 (`retryStrategy`, `recordHistory`)은 [baseOptions]로 factory 생성 시 고정되며,
+ * 매 호출마다 `baseOptions.copy(leaderOptions = options)`로 `waitTime`/`leaseTime` 만 교체한다.
+ *
+ * `ExposedR2DbcSuspendLeaderElector(...)` 호출은 companion `suspend operator fun invoke`로 라우팅되어
+ * [ExposedR2dbcSchemaInitializer.ensureSchema]가 함께 실행된다.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val factory = ExposedR2DbcSuspendLeaderElectorFactory(r2dbcDatabase)
+ * val elector = factory.create(LeaderElectionOptions(waitTime = 3.seconds, leaseTime = 30.seconds))
+ * val result = elector.runIfLeader("daily-job") { processData() }
+ * ```
+ *
+ * @param db Exposed [R2dbcDatabase] 인스턴스
+ * @param baseOptions Exposed R2DBC 고유 옵션 기본값
+ */
+class ExposedR2DbcSuspendLeaderElectorFactory(
+    private val db: R2dbcDatabase,
+    private val baseOptions: ExposedR2dbcLeaderElectionOptions = ExposedR2dbcLeaderElectionOptions.Default,
+) : SuspendLeaderElectorFactory {
+
+    override suspend fun create(options: LeaderElectionOptions): SuspendLeaderElector =
+        ExposedR2DbcSuspendLeaderElector(db, baseOptions.copy(leaderOptions = options))
+}

--- a/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElectorFactory.kt
+++ b/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElectorFactory.kt
@@ -1,0 +1,35 @@
+package io.bluetape4k.leader.exposed.r2dbc
+
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElectorFactory
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
+
+/**
+ * [ExposedR2DbcSuspendLeaderGroupElector] 팩토리 — Exposed R2DBC 기반 suspend 복수 리더 선출.
+ *
+ * ## 옵션 처리
+ * Exposed R2DBC 백엔드 고유 옵션 (`retryStrategy`, `recordHistory`)은 [baseOptions]로 factory 생성 시 고정되며,
+ * 매 호출마다 `baseOptions.copy(leaderGroupOptions = options)`로 `maxLeaders`/`waitTime`/`leaseTime` 만 교체한다.
+ *
+ * `ExposedR2DbcSuspendLeaderGroupElector(...)` 호출은 companion `suspend operator fun invoke`로 라우팅되어
+ * [ExposedR2dbcSchemaInitializer.ensureSchema]가 함께 실행된다.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val factory = ExposedR2DbcSuspendLeaderGroupElectorFactory(r2dbcDatabase)
+ * val elector = factory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+ * val result = elector.runIfLeader("batch-shard") { processChunk() }
+ * ```
+ *
+ * @param db Exposed [R2dbcDatabase] 인스턴스
+ * @param baseOptions Exposed R2DBC 고유 옵션 기본값
+ */
+class ExposedR2DbcSuspendLeaderGroupElectorFactory(
+    private val db: R2dbcDatabase,
+    private val baseOptions: ExposedR2dbcLeaderGroupElectionOptions = ExposedR2dbcLeaderGroupElectionOptions.Default,
+) : SuspendLeaderGroupElectorFactory {
+
+    override suspend fun create(options: LeaderGroupElectionOptions): SuspendLeaderGroupElector =
+        ExposedR2DbcSuspendLeaderGroupElector(db, baseOptions.copy(leaderGroupOptions = options))
+}

--- a/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderElectorFactoryTest.kt
+++ b/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderElectorFactoryTest.kt
@@ -1,0 +1,74 @@
+package io.bluetape4k.leader.exposed.r2dbc
+
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.time.Duration
+
+/**
+ * [ExposedR2DbcSuspendLeaderElectorFactory] — SPI contract 테스트.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExposedR2DbcSuspendLeaderElectorFactoryTest : AbstractExposedR2dbcLeaderTest() {
+
+    companion object : KLoggingChannel()
+
+    private fun makeFactory(testDB: TestR2dbcDB): SuspendLeaderElectorFactory {
+        val db = setupDb(testDB)
+        return ExposedR2DbcSuspendLeaderElectorFactory(db)
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `create - 기본 옵션으로 ExposedR2DbcSuspendLeaderElector 인스턴스 반환`(testDB: TestR2dbcDB) = runSuspendIO {
+        val factory = makeFactory(testDB)
+        val elector = factory.create(LeaderElectionOptions.Default)
+        elector.shouldNotBeNull()
+        elector.shouldBeInstanceOf<ExposedR2DbcSuspendLeaderElector>()
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `create - 커스텀 옵션으로 인스턴스 반환`(testDB: TestR2dbcDB) = runSuspendIO {
+        val factory = makeFactory(testDB)
+        val opts = LeaderElectionOptions(waitTime = Duration.ofSeconds(1), leaseTime = Duration.ofSeconds(10))
+        val elector = factory.create(opts)
+        elector.shouldNotBeNull()
+        elector.shouldBeInstanceOf<ExposedR2DbcSuspendLeaderElector>()
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `create - 호출마다 새 인스턴스 반환`(testDB: TestR2dbcDB) = runSuspendIO {
+        val factory = makeFactory(testDB)
+        val a = factory.create(LeaderElectionOptions.Default)
+        val b = factory.create(LeaderElectionOptions.Default)
+        (a !== b).shouldBeEqualTo(true)
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `create 후 runIfLeader - 리더 획득 성공 시 action 실행`(testDB: TestR2dbcDB) = runSuspendIO {
+        val factory = makeFactory(testDB)
+        val elector = factory.create(LeaderElectionOptions.Default)
+        val result = elector.runIfLeader(randomName()) { "factory-ok" }
+        result shouldBeEqualTo "factory-ok"
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `create 후 runIfLeader - Unit action 정상 실행`(testDB: TestR2dbcDB) = runSuspendIO {
+        val factory = makeFactory(testDB)
+        val elector = factory.create(LeaderElectionOptions.Default)
+        var called = false
+        elector.runIfLeader(randomName()) { called = true }
+        called.shouldBeEqualTo(true)
+    }
+}

--- a/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElectorFactoryTest.kt
+++ b/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElectorFactoryTest.kt
@@ -1,0 +1,64 @@
+package io.bluetape4k.leader.exposed.r2dbc
+
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElectorFactory
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.time.Duration
+
+/**
+ * [ExposedR2DbcSuspendLeaderGroupElectorFactory] — SPI contract 테스트.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExposedR2DbcSuspendLeaderGroupElectorFactoryTest : AbstractExposedR2dbcLeaderTest() {
+
+    companion object : KLoggingChannel()
+
+    private fun makeFactory(testDB: TestR2dbcDB): SuspendLeaderGroupElectorFactory {
+        val db = setupDb(testDB)
+        return ExposedR2DbcSuspendLeaderGroupElectorFactory(db)
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `create - 기본 옵션으로 ExposedR2DbcSuspendLeaderGroupElector 인스턴스 반환`(testDB: TestR2dbcDB) = runSuspendIO {
+        val factory = makeFactory(testDB)
+        val elector = factory.create(LeaderGroupElectionOptions.Default)
+        elector.shouldNotBeNull()
+        elector.shouldBeInstanceOf<ExposedR2DbcSuspendLeaderGroupElector>()
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `create - 커스텀 maxLeaders 옵션으로 인스턴스 반환`(testDB: TestR2dbcDB) = runSuspendIO {
+        val factory = makeFactory(testDB)
+        val opts = LeaderGroupElectionOptions(maxLeaders = 5, waitTime = Duration.ofSeconds(1), leaseTime = Duration.ofSeconds(10))
+        val elector = factory.create(opts)
+        elector.shouldNotBeNull()
+        elector.maxLeaders shouldBeEqualTo 5
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `create - 호출마다 새 인스턴스 반환`(testDB: TestR2dbcDB) = runSuspendIO {
+        val factory = makeFactory(testDB)
+        val a = factory.create(LeaderGroupElectionOptions.Default)
+        val b = factory.create(LeaderGroupElectionOptions.Default)
+        (a !== b).shouldBeEqualTo(true)
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `create 후 runIfLeader - 슬롯 획득 성공 시 action 실행`(testDB: TestR2dbcDB) = runSuspendIO {
+        val factory = makeFactory(testDB)
+        val elector = factory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+        val result = elector.runIfLeader(randomName()) { "group-factory-ok" }
+        result shouldBeEqualTo "group-factory-ok"
+    }
+}

--- a/leader-mongodb/README.ko.md
+++ b/leader-mongodb/README.ko.md
@@ -55,6 +55,8 @@ classDiagram
 | `MongoLeaderGroupElection` | `LeaderGroupElection` | 슬롯 기반 `MongoLock`을 이용한 블로킹 복수 리더 |
 | `MongoSuspendLeaderElection` | `SuspendLeaderElection` | `MongoSuspendLock` 기반 코루틴 단일 리더 |
 | `MongoSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` | 슬롯 기반 `MongoSuspendLock`을 이용한 코루틴 복수 리더 |
+| `MongoSuspendLeaderElectorFactory` | `SuspendLeaderElectorFactory` | 팩토리: 호출마다 `MongoSuspendLeaderElection` 생성 |
+| `MongoSuspendLeaderGroupElectorFactory` | `SuspendLeaderGroupElectorFactory` | 팩토리: 호출마다 `MongoSuspendLeaderGroupElection` 생성 |
 
 ## 컬렉션
 
@@ -152,6 +154,31 @@ val options = MongoLeaderElectionOptions(
     retryDelay = Duration.ofMillis(100),
 )
 val election = MongoLeaderElection(lockCollection, options)
+```
+
+### SPI 팩토리 사용
+
+```kotlin
+val coroutineCollection = coroutineDb.getCollection<Document>("bluetape4k_leader_locks")
+val factory: SuspendLeaderElectorFactory =
+    MongoSuspendLeaderElectorFactory(coroutineCollection)
+
+coroutineScope {
+    val elector = factory.create(LeaderElectionOptions.Default)
+    val result = elector.runIfLeader("daily-job") { doWork() }
+}
+```
+
+```kotlin
+val syncGroupCollection = db.getCollection("bluetape4k_leader_group_locks")
+val coroutineGroupCollection = coroutineDb.getCollection<Document>("bluetape4k_leader_group_locks")
+val groupFactory: SuspendLeaderGroupElectorFactory =
+    MongoSuspendLeaderGroupElectorFactory(syncGroupCollection, coroutineGroupCollection)
+
+coroutineScope {
+    val elector = groupFactory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+    val result = elector.runIfLeader("parallel-job") { processChunk() }
+}
 ```
 
 ## 락 내부 동작

--- a/leader-mongodb/README.md
+++ b/leader-mongodb/README.md
@@ -55,6 +55,8 @@ classDiagram
 | `MongoLeaderGroupElection` | `LeaderGroupElection` | Blocking multi-leader via slot-based `MongoLock` |
 | `MongoSuspendLeaderElection` | `SuspendLeaderElection` | Coroutine single-leader via `MongoSuspendLock` |
 | `MongoSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` | Coroutine multi-leader via slot-based `MongoSuspendLock` |
+| `MongoSuspendLeaderElectorFactory` | `SuspendLeaderElectorFactory` | Factory: creates `MongoSuspendLeaderElection` per call |
+| `MongoSuspendLeaderGroupElectorFactory` | `SuspendLeaderGroupElectorFactory` | Factory: creates `MongoSuspendLeaderGroupElection` per call |
 
 ## Collections
 
@@ -152,6 +154,31 @@ val options = MongoLeaderElectionOptions(
     retryDelay = Duration.ofMillis(100),
 )
 val election = MongoLeaderElection(lockCollection, options)
+```
+
+### Using SPI factories
+
+```kotlin
+val coroutineCollection = coroutineDb.getCollection<Document>("bluetape4k_leader_locks")
+val factory: SuspendLeaderElectorFactory =
+    MongoSuspendLeaderElectorFactory(coroutineCollection)
+
+coroutineScope {
+    val elector = factory.create(LeaderElectionOptions.Default)
+    val result = elector.runIfLeader("daily-job") { doWork() }
+}
+```
+
+```kotlin
+val syncGroupCollection = db.getCollection("bluetape4k_leader_group_locks")
+val coroutineGroupCollection = coroutineDb.getCollection<Document>("bluetape4k_leader_group_locks")
+val groupFactory: SuspendLeaderGroupElectorFactory =
+    MongoSuspendLeaderGroupElectorFactory(syncGroupCollection, coroutineGroupCollection)
+
+coroutineScope {
+    val elector = groupFactory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+    val result = elector.runIfLeader("parallel-job") { processChunk() }
+}
 ```
 
 ## Lock Internals

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderElectorFactory.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderElectorFactory.kt
@@ -1,0 +1,36 @@
+package io.bluetape4k.leader.mongodb
+
+import com.mongodb.kotlin.client.coroutine.MongoCollection
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
+import org.bson.Document
+
+/**
+ * [MongoSuspendLeaderElector] 팩토리 — MongoDB 분산 락 기반 suspend 단일 리더 선출.
+ *
+ * ## 옵션 처리
+ * MongoDB 백엔드 고유 옵션 (`retryDelay`, `recordHistory`)은 [baseOptions]로 factory 생성 시 고정되며,
+ * 매 호출마다 `baseOptions.copy(leaderOptions = options)`로 `waitTime`/`leaseTime` 만 교체한다.
+ *
+ * `MongoSuspendLeaderElector(...)` 호출은 companion `suspend operator fun invoke`로 라우팅되어
+ * [io.bluetape4k.leader.mongodb.lock.MongoSuspendLock.ensureIndexes]가 함께 실행된다.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val factory = MongoSuspendLeaderElectorFactory(coroutineCollection)
+ * val elector = factory.create(LeaderElectionOptions(waitTime = 3.seconds, leaseTime = 30.seconds))
+ * val result = elector.runIfLeader("daily-job") { processData() }
+ * ```
+ *
+ * @param collection 락 컬렉션 (coroutine 드라이버)
+ * @param baseOptions MongoDB 고유 옵션 기본값
+ */
+class MongoSuspendLeaderElectorFactory(
+    private val collection: MongoCollection<Document>,
+    private val baseOptions: MongoLeaderElectionOptions = MongoLeaderElectionOptions.Default,
+) : SuspendLeaderElectorFactory {
+
+    override suspend fun create(options: LeaderElectionOptions): SuspendLeaderElector =
+        MongoSuspendLeaderElector(collection, baseOptions.copy(leaderOptions = options))
+}

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderGroupElectorFactory.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderGroupElectorFactory.kt
@@ -1,0 +1,43 @@
+package io.bluetape4k.leader.mongodb
+
+import com.mongodb.client.MongoCollection
+import com.mongodb.kotlin.client.coroutine.MongoCollection as CoroutineMongoCollection
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElectorFactory
+import org.bson.Document
+
+/**
+ * [MongoSuspendLeaderGroupElector] 팩토리 — MongoDB 기반 suspend 복수 리더 선출.
+ *
+ * ## 옵션 처리
+ * MongoDB 백엔드 고유 옵션은 [baseOptions]로 factory 생성 시 고정되며,
+ * 매 호출마다 `baseOptions.copy(leaderGroupOptions = options)`로 `maxLeaders`/`waitTime`/`leaseTime` 만 교체한다.
+ *
+ * `MongoSuspendLeaderGroupElector(...)` 호출은 companion `suspend operator fun invoke`로 라우팅되어
+ * [io.bluetape4k.leader.mongodb.lock.MongoSuspendLock.ensureIndexes]가 함께 실행된다.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val factory = MongoSuspendLeaderGroupElectorFactory(syncCollection, coroutineCollection)
+ * val elector = factory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+ * val result = elector.runIfLeader("batch-shard") { processChunk() }
+ * ```
+ *
+ * @param groupCollection 락 컬렉션 (sync 드라이버 — activeCount에 사용)
+ * @param coroutineGroupCollection 락 컬렉션 (coroutine 드라이버 — tryLock/unlock에 사용)
+ * @param baseOptions MongoDB 고유 옵션 기본값
+ */
+class MongoSuspendLeaderGroupElectorFactory(
+    private val groupCollection: MongoCollection<Document>,
+    private val coroutineGroupCollection: CoroutineMongoCollection<Document>,
+    private val baseOptions: MongoLeaderGroupElectionOptions = MongoLeaderGroupElectionOptions.Default,
+) : SuspendLeaderGroupElectorFactory {
+
+    override suspend fun create(options: LeaderGroupElectionOptions): SuspendLeaderGroupElector =
+        MongoSuspendLeaderGroupElector(
+            groupCollection,
+            coroutineGroupCollection,
+            baseOptions.copy(leaderGroupOptions = options),
+        )
+}

--- a/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderElectorFactoryTest.kt
+++ b/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderElectorFactoryTest.kt
@@ -1,0 +1,61 @@
+package io.bluetape4k.leader.mongodb
+
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+
+/**
+ * [MongoSuspendLeaderElectorFactory] — SPI contract 테스트.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MongoSuspendLeaderElectorFactoryTest : AbstractMongoLeaderTest() {
+
+    companion object : KLogging()
+
+    private val factory: SuspendLeaderElectorFactory =
+        MongoSuspendLeaderElectorFactory(coroutineLockCollection)
+
+    @Test
+    fun `create - 기본 옵션으로 MongoSuspendLeaderElector 인스턴스 반환`() = runSuspendIO {
+        val elector = factory.create(LeaderElectionOptions.Default)
+        elector.shouldNotBeNull()
+        elector.shouldBeInstanceOf<MongoSuspendLeaderElector>()
+    }
+
+    @Test
+    fun `create - 커스텀 옵션으로 인스턴스 반환`() = runSuspendIO {
+        val opts = LeaderElectionOptions(waitTime = Duration.ofSeconds(1), leaseTime = Duration.ofSeconds(10))
+        val elector = factory.create(opts)
+        elector.shouldNotBeNull()
+        elector.shouldBeInstanceOf<MongoSuspendLeaderElector>()
+    }
+
+    @Test
+    fun `create - 호출마다 새 인스턴스 반환`() = runSuspendIO {
+        val a = factory.create(LeaderElectionOptions.Default)
+        val b = factory.create(LeaderElectionOptions.Default)
+        (a !== b).shouldBeEqualTo(true)
+    }
+
+    @Test
+    fun `create 후 runIfLeader - 리더 획득 성공 시 action 실행`() = runSuspendIO {
+        val elector = factory.create(LeaderElectionOptions.Default)
+        val result = elector.runIfLeader(randomName()) { "factory-ok" }
+        result shouldBeEqualTo "factory-ok"
+    }
+
+    @Test
+    fun `create 후 runIfLeader - Unit action 정상 실행`() = runSuspendIO {
+        val elector = factory.create(LeaderElectionOptions.Default)
+        var called = false
+        elector.runIfLeader(randomName()) { called = true }
+        called.shouldBeEqualTo(true)
+    }
+}

--- a/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderGroupElectorFactoryTest.kt
+++ b/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderGroupElectorFactoryTest.kt
@@ -1,0 +1,53 @@
+package io.bluetape4k.leader.mongodb
+
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElectorFactory
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+
+/**
+ * [MongoSuspendLeaderGroupElectorFactory] — SPI contract 테스트.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MongoSuspendLeaderGroupElectorFactoryTest : AbstractMongoLeaderTest() {
+
+    companion object : KLogging()
+
+    private val factory: SuspendLeaderGroupElectorFactory =
+        MongoSuspendLeaderGroupElectorFactory(groupLockCollection, coroutineGroupLockCollection)
+
+    @Test
+    fun `create - 기본 옵션으로 MongoSuspendLeaderGroupElector 인스턴스 반환`() = runSuspendIO {
+        val elector = factory.create(LeaderGroupElectionOptions.Default)
+        elector.shouldNotBeNull()
+        elector.shouldBeInstanceOf<MongoSuspendLeaderGroupElector>()
+    }
+
+    @Test
+    fun `create - 커스텀 maxLeaders 옵션으로 인스턴스 반환`() = runSuspendIO {
+        val opts = LeaderGroupElectionOptions(maxLeaders = 5, waitTime = Duration.ofSeconds(1), leaseTime = Duration.ofSeconds(10))
+        val elector = factory.create(opts)
+        elector.shouldNotBeNull()
+        elector.maxLeaders shouldBeEqualTo 5
+    }
+
+    @Test
+    fun `create - 호출마다 새 인스턴스 반환`() = runSuspendIO {
+        val a = factory.create(LeaderGroupElectionOptions.Default)
+        val b = factory.create(LeaderGroupElectionOptions.Default)
+        (a !== b).shouldBeEqualTo(true)
+    }
+
+    @Test
+    fun `create 후 runIfLeader - 슬롯 획득 성공 시 action 실행`() = runSuspendIO {
+        val elector = factory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+        val result = elector.runIfLeader(randomName()) { "group-factory-ok" }
+        result shouldBeEqualTo "group-factory-ok"
+    }
+}

--- a/leader-redis-lettuce/README.ko.md
+++ b/leader-redis-lettuce/README.ko.md
@@ -65,6 +65,8 @@ classDiagram
 | `LettuceLeaderGroupElection` | `LeaderGroupElection` | `LettuceSemaphore` 기반 블로킹 복수 리더 |
 | `LettuceSuspendLeaderElection` | `SuspendLeaderElection` | `LettuceSuspendLock` 기반 코루틴 단일 리더 |
 | `LettuceSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` | `LettuceSuspendSemaphore` 기반 코루틴 복수 리더 |
+| `LettuceSuspendLeaderElectorFactory` | `SuspendLeaderElectorFactory` | 팩토리: 호출마다 `LettuceSuspendLeaderElection` 생성 |
+| `LettuceSuspendLeaderGroupElectorFactory` | `SuspendLeaderGroupElectorFactory` | 팩토리: 호출마다 `LettuceSuspendLeaderGroupElection` 생성 |
 
 ## 사용 예시
 
@@ -135,6 +137,26 @@ val options = LeaderElectionOptions(
     leaseTime = Duration.ofSeconds(30)
 )
 val election = LettuceLeaderElection(connection, options)
+```
+
+### SPI 팩토리 사용
+
+```kotlin
+val factory: SuspendLeaderElectorFactory = LettuceSuspendLeaderElectorFactory(connection)
+
+coroutineScope {
+    val elector = factory.create(LeaderElectionOptions.Default)
+    val result = elector.runIfLeader("daily-job") { doWork() }
+}
+```
+
+```kotlin
+val groupFactory: SuspendLeaderGroupElectorFactory = LettuceSuspendLeaderGroupElectorFactory(connection)
+
+coroutineScope {
+    val elector = groupFactory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+    val result = elector.runIfLeader("parallel-job") { processChunk() }
+}
 ```
 
 ## 락 내부 동작

--- a/leader-redis-lettuce/README.md
+++ b/leader-redis-lettuce/README.md
@@ -65,6 +65,8 @@ classDiagram
 | `LettuceLeaderGroupElection` | `LeaderGroupElection` | Blocking multi-leader via `LettuceSemaphore` |
 | `LettuceSuspendLeaderElection` | `SuspendLeaderElection` | Coroutine single-leader via `LettuceSuspendLock` |
 | `LettuceSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` | Coroutine multi-leader via `LettuceSuspendSemaphore` |
+| `LettuceSuspendLeaderElectorFactory` | `SuspendLeaderElectorFactory` | Factory: creates `LettuceSuspendLeaderElection` per call |
+| `LettuceSuspendLeaderGroupElectorFactory` | `SuspendLeaderGroupElectorFactory` | Factory: creates `LettuceSuspendLeaderGroupElection` per call |
 
 ## Usage
 
@@ -135,6 +137,26 @@ val options = LeaderElectionOptions(
     leaseTime = Duration.ofSeconds(30)
 )
 val election = LettuceLeaderElection(connection, options)
+```
+
+### Using factories
+
+```kotlin
+val factory: SuspendLeaderElectorFactory = LettuceSuspendLeaderElectorFactory(connection)
+
+coroutineScope {
+    val elector = factory.create(LeaderElectionOptions.Default)
+    val result = elector.runIfLeader("daily-job") { doWork() }
+}
+```
+
+```kotlin
+val groupFactory: SuspendLeaderGroupElectorFactory = LettuceSuspendLeaderGroupElectorFactory(connection)
+
+coroutineScope {
+    val elector = groupFactory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+    val result = elector.runIfLeader("parallel-job") { processChunk() }
+}
 ```
 
 ## Lock Internals

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElectorFactory.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElectorFactory.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
+import io.lettuce.core.api.StatefulRedisConnection
+
+/**
+ * [LettuceSuspendLeaderElector] 팩토리 — Lettuce Redis 클라이언트 기반 suspend 단일 리더 선출.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val factory = LettuceSuspendLeaderElectorFactory(connection)
+ * val elector = factory.create(LeaderElectionOptions(waitTime = 3.seconds, leaseTime = 30.seconds))
+ * val result = elector.runIfLeader("daily-job") { processData() }
+ * ```
+ *
+ * @param connection 공유 Redis connection. 호출자가 수명 관리.
+ */
+class LettuceSuspendLeaderElectorFactory(
+    private val connection: StatefulRedisConnection<String, String>,
+) : SuspendLeaderElectorFactory {
+
+    override suspend fun create(options: LeaderElectionOptions): SuspendLeaderElector =
+        LettuceSuspendLeaderElector(connection, options)
+}

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElectorFactory.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElectorFactory.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElectorFactory
+import io.lettuce.core.api.StatefulRedisConnection
+
+/**
+ * [LettuceSuspendLeaderGroupElector] 팩토리 — Lettuce Redis 클라이언트 기반 suspend 복수 리더 선출.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val factory = LettuceSuspendLeaderGroupElectorFactory(connection)
+ * val elector = factory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+ * val result = elector.runIfLeader("batch-shard") { processChunk() }
+ * ```
+ *
+ * @param connection 공유 Redis connection. 호출자가 수명 관리.
+ */
+class LettuceSuspendLeaderGroupElectorFactory(
+    private val connection: StatefulRedisConnection<String, String>,
+) : SuspendLeaderGroupElectorFactory {
+
+    override suspend fun create(options: LeaderGroupElectionOptions): SuspendLeaderGroupElector =
+        LettuceSuspendLeaderGroupElector(connection, options)
+}

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElectorFactoryTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElectorFactoryTest.kt
@@ -1,0 +1,60 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+
+/**
+ * [LettuceSuspendLeaderElectorFactory] — SPI contract 테스트.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LettuceSuspendLeaderElectorFactoryTest : AbstractLettuceLeaderTest() {
+
+    companion object : KLogging()
+
+    private val factory: SuspendLeaderElectorFactory = LettuceSuspendLeaderElectorFactory(connection)
+
+    @Test
+    fun `create - 기본 옵션으로 LettuceSuspendLeaderElector 인스턴스 반환`() = runSuspendIO {
+        val elector = factory.create(LeaderElectionOptions.Default)
+        elector.shouldNotBeNull()
+        elector.shouldBeInstanceOf<LettuceSuspendLeaderElector>()
+    }
+
+    @Test
+    fun `create - 커스텀 옵션으로 인스턴스 반환`() = runSuspendIO {
+        val opts = LeaderElectionOptions(waitTime = Duration.ofSeconds(1), leaseTime = Duration.ofSeconds(10))
+        val elector = factory.create(opts)
+        elector.shouldNotBeNull()
+        elector.shouldBeInstanceOf<LettuceSuspendLeaderElector>()
+    }
+
+    @Test
+    fun `create - 호출마다 새 인스턴스 반환`() = runSuspendIO {
+        val a = factory.create(LeaderElectionOptions.Default)
+        val b = factory.create(LeaderElectionOptions.Default)
+        (a !== b).shouldBeEqualTo(true)
+    }
+
+    @Test
+    fun `create 후 runIfLeader - 리더 획득 성공 시 action 실행`() = runSuspendIO {
+        val elector = factory.create(LeaderElectionOptions.Default)
+        val result = elector.runIfLeader(randomName()) { "factory-ok" }
+        result shouldBeEqualTo "factory-ok"
+    }
+
+    @Test
+    fun `create 후 runIfLeader - Unit action 정상 실행`() = runSuspendIO {
+        val elector = factory.create(LeaderElectionOptions.Default)
+        var called = false
+        elector.runIfLeader(randomName()) { called = true }
+        called.shouldBeEqualTo(true)
+    }
+}

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElectorFactoryTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElectorFactoryTest.kt
@@ -1,0 +1,62 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElectorFactory
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+
+/**
+ * [LettuceSuspendLeaderGroupElectorFactory] — SPI contract 테스트.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LettuceSuspendLeaderGroupElectorFactoryTest : AbstractLettuceLeaderTest() {
+
+    companion object : KLogging()
+
+    private val factory: SuspendLeaderGroupElectorFactory = LettuceSuspendLeaderGroupElectorFactory(connection)
+
+    @Test
+    fun `create - 기본 옵션으로 LettuceSuspendLeaderGroupElector 인스턴스 반환`() = runSuspendIO {
+        val elector = factory.create(LeaderGroupElectionOptions.Default)
+        elector.shouldNotBeNull()
+        elector.shouldBeInstanceOf<LettuceSuspendLeaderGroupElector>()
+    }
+
+    @Test
+    fun `create - 커스텀 maxLeaders 옵션으로 인스턴스 반환`() = runSuspendIO {
+        val opts = LeaderGroupElectionOptions(maxLeaders = 5, waitTime = Duration.ofSeconds(1), leaseTime = Duration.ofSeconds(10))
+        val elector = factory.create(opts)
+        elector.shouldNotBeNull()
+        elector.maxLeaders shouldBeEqualTo 5
+    }
+
+    @Test
+    fun `create - 호출마다 새 인스턴스 반환`() = runSuspendIO {
+        val a = factory.create(LeaderGroupElectionOptions.Default)
+        val b = factory.create(LeaderGroupElectionOptions.Default)
+        (a !== b).shouldBeEqualTo(true)
+    }
+
+    @Test
+    fun `create 후 runIfLeader - 슬롯 획득 성공 시 action 실행`() = runSuspendIO {
+        val elector = factory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+        val result = elector.runIfLeader(randomName()) { "group-factory-ok" }
+        result shouldBeEqualTo "group-factory-ok"
+    }
+
+    @Test
+    fun `create 후 runIfLeader - activeCount 정상 동작`() = runSuspendIO {
+        val lockName = randomName()
+        val elector = factory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+        elector.runIfLeader(lockName) {
+            elector.activeCount(lockName) shouldBeEqualTo 1
+        }
+        elector.activeCount(lockName) shouldBeEqualTo 0
+    }
+}

--- a/leader-redis-redisson/README.ko.md
+++ b/leader-redis-redisson/README.ko.md
@@ -64,6 +64,8 @@ classDiagram
 | `RedissonLeaderGroupElection` | `LeaderGroupElection` | `RSemaphore` 기반 블로킹 복수 리더 |
 | `RedissonSuspendLeaderElection` | `SuspendLeaderElection` | 코루틴, PID 시드 Snowflake 락 ID |
 | `RedissonSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` | `RSemaphoreAsync` 기반 코루틴 복수 리더 |
+| `RedissonSuspendLeaderElectorFactory` | `SuspendLeaderElectorFactory` | 팩토리: 호출마다 `RedissonSuspendLeaderElection` 생성 |
+| `RedissonSuspendLeaderGroupElectorFactory` | `SuspendLeaderGroupElectorFactory` | 팩토리: 호출마다 `RedissonSuspendLeaderGroupElection` 생성 |
 
 ## 코루틴 락 ID 설계
 
@@ -154,6 +156,26 @@ val options = LeaderElectionOptions(
     leaseTime = Duration.ofSeconds(30)
 )
 val election = RedissonLeaderElection(client, options)
+```
+
+### SPI 팩토리 사용
+
+```kotlin
+val factory: SuspendLeaderElectorFactory = RedissonSuspendLeaderElectorFactory(client)
+
+coroutineScope {
+    val elector = factory.create(LeaderElectionOptions.Default)
+    val result = elector.runIfLeader("daily-job") { doWork() }
+}
+```
+
+```kotlin
+val groupFactory: SuspendLeaderGroupElectorFactory = RedissonSuspendLeaderGroupElectorFactory(client)
+
+coroutineScope {
+    val elector = groupFactory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+    val result = elector.runIfLeader("parallel-job") { processChunk() }
+}
 ```
 
 ## 테스트 인프라

--- a/leader-redis-redisson/README.md
+++ b/leader-redis-redisson/README.md
@@ -64,6 +64,8 @@ classDiagram
 | `RedissonLeaderGroupElection` | `LeaderGroupElection` | Blocking multi-leader via `RSemaphore` |
 | `RedissonSuspendLeaderElection` | `SuspendLeaderElection` | Coroutine, PID-seeded Snowflake lock ID |
 | `RedissonSuspendLeaderGroupElection` | `SuspendLeaderGroupElection` | Coroutine multi-leader via `RSemaphoreAsync` |
+| `RedissonSuspendLeaderElectorFactory` | `SuspendLeaderElectorFactory` | Factory: creates `RedissonSuspendLeaderElection` per call |
+| `RedissonSuspendLeaderGroupElectorFactory` | `SuspendLeaderGroupElectorFactory` | Factory: creates `RedissonSuspendLeaderGroupElection` per call |
 
 ## Coroutine Lock ID Design
 
@@ -160,6 +162,26 @@ val election = RedissonLeaderElection(client, options)
 
 ```kotlin
 val election = RedissonSuspendLeaderElection(client, LeaderElectionOptions.Default)
+```
+
+### Using SPI factories
+
+```kotlin
+val factory: SuspendLeaderElectorFactory = RedissonSuspendLeaderElectorFactory(client)
+
+coroutineScope {
+    val elector = factory.create(LeaderElectionOptions.Default)
+    val result = elector.runIfLeader("daily-job") { doWork() }
+}
+```
+
+```kotlin
+val groupFactory: SuspendLeaderGroupElectorFactory = RedissonSuspendLeaderGroupElectorFactory(client)
+
+coroutineScope {
+    val elector = groupFactory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+    val result = elector.runIfLeader("parallel-job") { processChunk() }
+}
 ```
 
 ## Test Infrastructure

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElectorFactory.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElectorFactory.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
+import org.redisson.api.RedissonClient
+
+/**
+ * [RedissonSuspendLeaderElector] 팩토리 — Redisson 분산 락 기반 suspend 단일 리더 선출.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val factory = RedissonSuspendLeaderElectorFactory(redissonClient)
+ * val elector = factory.create(LeaderElectionOptions(waitTime = 3.seconds, leaseTime = 30.seconds))
+ * val result = elector.runIfLeader("daily-job") { processData() }
+ * ```
+ *
+ * @param redissonClient 공유 Redisson 클라이언트. 호출자가 수명 관리.
+ */
+class RedissonSuspendLeaderElectorFactory(
+    private val redissonClient: RedissonClient,
+) : SuspendLeaderElectorFactory {
+
+    override suspend fun create(options: LeaderElectionOptions): SuspendLeaderElector =
+        RedissonSuspendLeaderElector(redissonClient, options)
+}

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElectorFactory.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElectorFactory.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElectorFactory
+import org.redisson.api.RedissonClient
+
+/**
+ * [RedissonSuspendLeaderGroupElector] 팩토리 — Redisson 분산 Semaphore 기반 suspend 복수 리더 선출.
+ *
+ * ## 사용 예
+ * ```kotlin
+ * val factory = RedissonSuspendLeaderGroupElectorFactory(redissonClient)
+ * val elector = factory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+ * val result = elector.runIfLeader("batch-shard") { processChunk() }
+ * ```
+ *
+ * @param redissonClient 공유 Redisson 클라이언트. 호출자가 수명 관리.
+ */
+class RedissonSuspendLeaderGroupElectorFactory(
+    private val redissonClient: RedissonClient,
+) : SuspendLeaderGroupElectorFactory {
+
+    override suspend fun create(options: LeaderGroupElectionOptions): SuspendLeaderGroupElector =
+        RedissonSuspendLeaderGroupElector(redissonClient, options)
+}

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElectorFactoryTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElectorFactoryTest.kt
@@ -1,0 +1,60 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+
+/**
+ * [RedissonSuspendLeaderElectorFactory] — SPI contract 테스트.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RedissonSuspendLeaderElectorFactoryTest : AbstractRedissonLeaderTest() {
+
+    companion object : KLogging()
+
+    private val factory: SuspendLeaderElectorFactory = RedissonSuspendLeaderElectorFactory(redissonClient)
+
+    @Test
+    fun `create - 기본 옵션으로 RedissonSuspendLeaderElector 인스턴스 반환`() = runSuspendIO {
+        val elector = factory.create(LeaderElectionOptions.Default)
+        elector.shouldNotBeNull()
+        elector.shouldBeInstanceOf<RedissonSuspendLeaderElector>()
+    }
+
+    @Test
+    fun `create - 커스텀 옵션으로 인스턴스 반환`() = runSuspendIO {
+        val opts = LeaderElectionOptions(waitTime = Duration.ofSeconds(1), leaseTime = Duration.ofSeconds(10))
+        val elector = factory.create(opts)
+        elector.shouldNotBeNull()
+        elector.shouldBeInstanceOf<RedissonSuspendLeaderElector>()
+    }
+
+    @Test
+    fun `create - 호출마다 새 인스턴스 반환`() = runSuspendIO {
+        val a = factory.create(LeaderElectionOptions.Default)
+        val b = factory.create(LeaderElectionOptions.Default)
+        (a !== b).shouldBeEqualTo(true)
+    }
+
+    @Test
+    fun `create 후 runIfLeader - 리더 획득 성공 시 action 실행`() = runSuspendIO {
+        val elector = factory.create(LeaderElectionOptions.Default)
+        val result = elector.runIfLeader(randomName()) { "factory-ok" }
+        result shouldBeEqualTo "factory-ok"
+    }
+
+    @Test
+    fun `create 후 runIfLeader - Unit action 정상 실행`() = runSuspendIO {
+        val elector = factory.create(LeaderElectionOptions.Default)
+        var called = false
+        elector.runIfLeader(randomName()) { called = true }
+        called.shouldBeEqualTo(true)
+    }
+}

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElectorFactoryTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElectorFactoryTest.kt
@@ -1,0 +1,52 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElectorFactory
+import io.bluetape4k.logging.KLogging
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Duration
+
+/**
+ * [RedissonSuspendLeaderGroupElectorFactory] — SPI contract 테스트.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RedissonSuspendLeaderGroupElectorFactoryTest : AbstractRedissonLeaderTest() {
+
+    companion object : KLogging()
+
+    private val factory: SuspendLeaderGroupElectorFactory = RedissonSuspendLeaderGroupElectorFactory(redissonClient)
+
+    @Test
+    fun `create - 기본 옵션으로 RedissonSuspendLeaderGroupElector 인스턴스 반환`() = runSuspendIO {
+        val elector = factory.create(LeaderGroupElectionOptions.Default)
+        elector.shouldNotBeNull()
+        elector.shouldBeInstanceOf<RedissonSuspendLeaderGroupElector>()
+    }
+
+    @Test
+    fun `create - 커스텀 maxLeaders 옵션으로 인스턴스 반환`() = runSuspendIO {
+        val opts = LeaderGroupElectionOptions(maxLeaders = 5, waitTime = Duration.ofSeconds(1), leaseTime = Duration.ofSeconds(10))
+        val elector = factory.create(opts)
+        elector.shouldNotBeNull()
+        elector.maxLeaders shouldBeEqualTo 5
+    }
+
+    @Test
+    fun `create - 호출마다 새 인스턴스 반환`() = runSuspendIO {
+        val a = factory.create(LeaderGroupElectionOptions.Default)
+        val b = factory.create(LeaderGroupElectionOptions.Default)
+        (a !== b).shouldBeEqualTo(true)
+    }
+
+    @Test
+    fun `create 후 runIfLeader - 슬롯 획득 성공 시 action 실행`() = runSuspendIO {
+        val elector = factory.create(LeaderGroupElectionOptions(maxLeaders = 3))
+        val result = elector.runIfLeader(randomName()) { "group-factory-ok" }
+        result shouldBeEqualTo "group-factory-ok"
+    }
+}


### PR DESCRIPTION
## Summary

Closes #89

PR #122의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: #89 SuspendLeaderElectorFactory 백엔드 구현체 추가 (Lettuce/Redisson/MongoDB/ExposedR2DBC)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 개요

`SuspendLeaderElectorFactory` 및 `SuspendLeaderGroupElectorFactory` SPI를 4개 백엔드에 구현합니다.

> **선행 PR**: #120 (`feat/88-suspend-factory`) — SPI 인터페이스의 `create()`를 `suspend fun`으로 변경. 해당 PR 머지 전까지 이 PR은 `feat/88-suspend-factory`를 base로 합니다.

## 변경 내용

### 구현체 추가 (8개 클래스)

| 모듈 | 클래스 |
|------|--------|
| `leader-redis-lettuce` | `LettuceSuspendLeaderElectorFactory` |
| `leader-redis-lettuce` | `LettuceSuspendLeaderGroupElectorFactory` |
| `leader-redis-redisson` | `RedissonSuspendLeaderElectorFactory` |
| `leader-redis-redisson` | `RedissonSuspendLeaderGroupElectorFactory` |
| `leader-mongodb` | `MongoSuspendLeaderElectorFactory` |
| `leader-mongodb` | `MongoSuspendLeaderGroupElectorFactory` |
| `leader-exposed-r2dbc` | `ExposedR2DbcSuspendLeaderElectorFactory` |
| `leader-exposed-r2dbc` | `ExposedR2DbcSuspendLeaderGroupElectorFactory` |

### 테스트 추가 (8개 테스트 클래스, 55개 테스트)

- Lettuce: 10개 (단일/그룹 팩토리 각 5개)
- Redisson: 9개 (단일 5개, 그룹 4개)
- MongoDB: 9개 (단일 5개, 그룹 4개)
- ExposedR2DBC: 27개 (9개 × 3 DB: H2/PostgreSQL/MySQL8)

### 문서 업데이트

4개 모듈 `README.md` + `README.ko.md` — Implementations 테이블 및 Factory 사용 예시 추가

## 설계 포인트

- MongoDB/ExposedR2DBC는 `baseOptions.copy(leaderOptions = options)` 패턴 사용 — 모듈별 옵션과 호출별 선출 옵션 분리
- MongoDB Group factory는 sync + coroutine 두 collection을 constructor로 수령 (dual-collection 설계 유지)
- 모든 factory는 호출자가 수명 관리 (lifecycle은 factory가 소유하지 않음)

## 테스트 결과

```
leader-redis-lettuce:   10 passing
leader-redis-redisson:   9 passing
leader-mongodb:          9 passing
leader-exposed-r2dbc:   27 passing (×3 DB)
Total: 55 tests passing
```

Closes #89
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #89, milestone `0.1.0`, assignee `debop`
- PR: #122, head `1631346308bcb9e33885b3f03e47ccab99fd6788`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
