### PR TITLE
feat: #90 suspend method 지원 — @LeaderElection/@LeaderGroupElection AOP

### DIFF
--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderBeanSelector.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderBeanSelector.kt
@@ -3,6 +3,8 @@ package io.bluetape4k.leader.spring.aop
 import io.bluetape4k.leader.LeaderElectorFactory
 import io.bluetape4k.leader.LeaderGroupElectorFactory
 import io.bluetape4k.leader.annotation.LeaderElectionBackend
+import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElectorFactory
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.beans.factory.ListableBeanFactory
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
@@ -45,6 +47,18 @@ class LeaderBeanSelector(
      */
     fun selectGroupElectionFactory(explicitBeanName: String, method: Method? = null): Selected<LeaderGroupElectorFactory> =
         select(explicitBeanName, method, LeaderGroupElectorFactory::class.java)
+
+    /**
+     * suspend 단일 리더 [SuspendLeaderElectorFactory] 빈 선택.
+     */
+    fun selectSuspendElectorFactory(explicitBeanName: String, method: Method? = null): Selected<SuspendLeaderElectorFactory> =
+        select(explicitBeanName, method, SuspendLeaderElectorFactory::class.java)
+
+    /**
+     * suspend 다중 리더 [SuspendLeaderGroupElectorFactory] 빈 선택.
+     */
+    fun selectSuspendGroupElectorFactory(explicitBeanName: String, method: Method? = null): Selected<SuspendLeaderGroupElectorFactory> =
+        select(explicitBeanName, method, SuspendLeaderGroupElectorFactory::class.java)
 
     private fun <T : Any> select(explicitBeanName: String, method: Method?, type: Class<T>): Selected<T> {
         // Step 1: 어노테이션 bean 필드 명시

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -7,6 +7,8 @@ import io.bluetape4k.leader.LeaderElectorFactory
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.annotation.LeaderAspectFailureMode
 import io.bluetape4k.leader.annotation.LeaderElection
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
 import io.bluetape4k.leader.metrics.LeaderAopMetricsRecorder
 import io.bluetape4k.leader.metrics.SkipReason
 import io.bluetape4k.leader.spring.aop.cache.FactoryCacheKey
@@ -26,22 +28,32 @@ import org.springframework.beans.factory.SmartInitializingSingleton
 import java.lang.reflect.Method
 import java.util.concurrent.CancellationException
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.toKotlinDuration
 
 /**
- * `@LeaderElection` 어노테이션 처리 Aspect — sync `T?` only.
+ * `@LeaderElection` 어노테이션 처리 Aspect — sync `T?` 및 suspend `T?` 지원.
  *
  * ## [T4.1a Option A] final class @Aspect
  * Boot 4 CTW (Freefair post-compile weaving). autoconfig 가 `@Bean` 으로 등록 — `@Component` 미부착.
  *
+ * ## suspend 지원 (#90)
+ * - suspend 메서드 감지: 마지막 파라미터가 [Continuation] 인지 확인
+ * - `startCoroutineUninterceptedOrReturn` + `suspendCoroutineUninterceptedOrReturn` intrinsics 패턴 사용
+ * - [SuspendLeaderElectorFactory] 는 suspend fun — `computeIfAbsent` 불가, "accept rare double-create" 패턴 사용
+ * - `SuspendLeaderElector.runIfLeader()` 는 `T?` 반환 — null == 미선출.
+ *   선출 후 액션이 null 반환 시 미선출과 구별 불가 (알려진 한계 — v1).
+ *
  * ## [Step 3-P] 보강 사항
- * - **Sec-3 (R-33)**: backend 예외만 [LeaderElectionException] 으로 wrapping (host/credentials 누출 차단)
+ * - **Sec-3 (R-33)**: backend 예외만 [LeaderElectionException] 으로 wrapping
  * - **Rel-1**: body 예외 vs backend 예외 분리 — body throw 는 wrapping 없이 그대로 전파
- * - **Rel-2**: [CancellationException] 항상 우선 재throw (CLAUDE.md memory feedback_cancellation_exception)
+ * - **Rel-2**: [CancellationException] 항상 우선 재throw
  * - **Perf-1**: metrics fan-out 시 `metrics.isEmpty()` fast-path
  * - **Perf-2**: Method-level cache — annotation lookup + lease threshold 사전계산 + factory bean name resolution
- * - **Fix-94**: [resolveLockName] + [factory.create] 를 try 안으로 이동 — backend I/O 실패가 failureMode 우회하던 버그 수정
+ * - **Fix-94**: [resolveLockName] + [factory.create] 를 try 안으로 이동
  *
  * @param beanSelector factory 빈 선택기
  * @param props AOP 전역 속성
@@ -63,6 +75,9 @@ class LeaderElectionAspect(
     /** [C1][R-26] FactoryCacheKey 기반 cross-backend collision-safe 캐싱. */
     private val factoryCache = ConcurrentHashMap<FactoryCacheKey, LeaderElector>()
 
+    /** suspend 엘렉터 캐시 — FactoryCacheKey(suspendElectorFactoryBeanName, options). */
+    private val suspendElectorCache = ConcurrentHashMap<FactoryCacheKey, SuspendLeaderElector>()
+
     /** [Perf-1] recorder 0개일 때 fast-path 활성화. */
     private val hasRecorders = recorders.isNotEmpty()
 
@@ -73,10 +88,14 @@ class LeaderElectionAspect(
         val args = pjp.args
 
         val meta = metadataCache.computeIfAbsent(method) { resolveMetadata(it, target) }
+
+        if (meta.isSuspend) {
+            return aroundLeaderSuspend(pjp, meta)
+        }
+
         val opts = meta.options
 
         // [Fix-94] resolveLockName + factory.create 를 try 안으로 이동
-        // catch 에서 lockName 이 필요하므로 nullable var 로 선언, 성공 시 resolvedName 을 val 로 분리
         var lockName: String? = null
         val start = System.nanoTime()
 
@@ -127,13 +146,10 @@ class LeaderElectionAspect(
                 }
             }
         } catch (e: CancellationException) {
-            // [Rel-2] CancellationException 항상 우선 재throw
             throw e
         } catch (bodyMarker: BodyThrownMarker) {
-            // [Rel-1] body 예외는 wrapping 없이 그대로 전파 — failureMode 무관
             throw bodyMarker.cause
         } catch (backendEx: Throwable) {
-            // [Sec-3][R-33] backend 예외만 LeaderElectionException 으로 wrapping (host/credentials 누출 차단)
             val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
             val wrapped = LeaderElectionException("leader backend error for lock '$effectiveName'", backendEx)
             when (meta.failureMode) {
@@ -171,11 +187,142 @@ class LeaderElectionAspect(
     }
 
     /**
+     * suspend 메서드 처리 — `startCoroutineUninterceptedOrReturn` intrinsics 패턴.
+     *
+     * [ProceedingJoinPoint.args] 마지막 원소(Continuation)를 inner continuation 으로 교체하여
+     * 리더 선출 로직과 suspend body 를 올바르게 연결한다.
+     *
+     * ## null 반환 한계 (v1)
+     * [SuspendLeaderElector.runIfLeader] 는 `T?` 반환 — null 이 "미선출"인지
+     * "액션 결과 null" 인지 구별 불가. null 은 "미선출"로 처리.
+     */
+    private fun aroundLeaderSuspend(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
+        @Suppress("UNCHECKED_CAST")
+        val continuation = pjp.args.last() as Continuation<Any?>
+        val start = System.nanoTime()
+        val method = (pjp.signature as MethodSignature).method
+
+        val suspendBlock: suspend () -> Any? = {
+            var lockName: String? = null
+            try {
+                val resolvedName = resolveLockName(meta, method, pjp.args, pjp.target)
+                lockName = resolvedName
+                val cacheKey = FactoryCacheKey(meta.suspendElectorFactoryBeanName, meta.options)
+                val elector = suspendElectorCache[cacheKey]
+                    ?: meta.suspendElectorFactory!!.create(meta.options)
+                        .also { suspendElectorCache.putIfAbsent(cacheKey, it) }
+
+                fanOut { it.onLockAttempt(resolvedName, meta.options) }
+
+                val result = elector.runIfLeader(resolvedName) {
+                    fanOut {
+                        it.onLockAcquired(resolvedName, meta.options, (System.nanoTime() - start).nanoseconds)
+                        it.onTaskStarted(resolvedName)
+                    }
+                    try {
+                        @Suppress("UNCHECKED_CAST")
+                        val bodyResult = suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
+                            val newArgs = pjp.args.copyOf()
+                            newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
+                            pjp.proceed(newArgs)
+                        }
+                        val elapsed = System.nanoTime() - start
+                        fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
+                        if (elapsed > meta.leaseTimeWarnThresholdNanos) {
+                            log.warn { "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${meta.options.leaseTime.inWholeNanoseconds}" }
+                        }
+                        log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
+                        bodyResult
+                    } catch (ce: CancellationException) {
+                        fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, ce) }
+                        throw ce
+                    } catch (bodyEx: Throwable) {
+                        fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                        throw BodyThrownMarker(bodyEx)
+                    }
+                }
+
+                if (result == null) {
+                    if (meta.failureMode == LeaderAspectFailureMode.FAIL_OPEN_RUN) {
+                        fanOut {
+                            it.onLockNotAcquired(resolvedName, meta.options, SkipReason.FAIL_OPEN_FORCED)
+                            it.onTaskStarted(resolvedName)
+                        }
+                        log.debug { "leader.aop.fail-open lockName=$resolvedName reason=CONTENTION" }
+                        try {
+                            @Suppress("UNCHECKED_CAST")
+                            val failOpenResult = suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
+                                val newArgs = pjp.args.copyOf()
+                                newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
+                                pjp.proceed(newArgs)
+                            }
+                            fanOut { it.onTaskFinished(resolvedName, (System.nanoTime() - start).nanoseconds) }
+                            failOpenResult
+                        } catch (ce: CancellationException) {
+                            fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, ce) }
+                            throw ce
+                        } catch (bodyEx: Throwable) {
+                            fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                            throw bodyEx
+                        }
+                    } else {
+                        fanOut { it.onLockNotAcquired(resolvedName, meta.options, SkipReason.CONTENTION) }
+                        log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
+                        null
+                    }
+                } else {
+                    result
+                }
+            } catch (ce: CancellationException) {
+                throw ce
+            } catch (bm: BodyThrownMarker) {
+                throw bm.cause
+            } catch (backendEx: Throwable) {
+                val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
+                val wrapped = LeaderElectionException("leader backend error for lock '$effectiveName'", backendEx)
+                when (meta.failureMode) {
+                    LeaderAspectFailureMode.INHERIT -> error("INHERIT must be resolved in resolveMetadata")
+                    LeaderAspectFailureMode.RETHROW -> {
+                        fanOut { it.onLockNotAcquired(effectiveName, meta.options, SkipReason.BACKEND_ERROR) }
+                        fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
+                        throw wrapped
+                    }
+                    LeaderAspectFailureMode.SKIP -> {
+                        fanOut { it.onLockNotAcquired(effectiveName, meta.options, SkipReason.BACKEND_ERROR) }
+                        fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
+                        log.warn(backendEx) { "leader.aop.skipped lockName=$effectiveName reason=BACKEND_ERROR" }
+                        null
+                    }
+                    LeaderAspectFailureMode.FAIL_OPEN_RUN -> {
+                        fanOut { it.onLockNotAcquired(effectiveName, meta.options, SkipReason.FAIL_OPEN_FORCED) }
+                        log.warn(backendEx) { "leader.aop.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
+                        fanOut { it.onTaskStarted(effectiveName) }
+                        try {
+                            @Suppress("UNCHECKED_CAST")
+                            val failOpenResult = suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
+                                val newArgs = pjp.args.copyOf()
+                                newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
+                                pjp.proceed(newArgs)
+                            }
+                            fanOut { it.onTaskFinished(effectiveName, (System.nanoTime() - start).nanoseconds) }
+                            failOpenResult
+                        } catch (ce: CancellationException) {
+                            fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, ce) }
+                            throw ce
+                        } catch (bodyEx: Throwable) {
+                            fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                            throw bodyEx
+                        }
+                    }
+                }
+            }
+        }
+        return suspendBlock.startCoroutineUninterceptedOrReturn(continuation)
+    }
+
+    /**
      * [Rel-1] body 실행 — 사용자 본문 throw 는 wrapping 없이 그대로 전파.
      * [CancellationException] 우선 재throw [Rel-2].
-     *
-     * body 예외는 [BodyThrownMarker] 로 감싸서 outer catch 가 backend 예외와 구분할 수 있게 한다.
-     * outer catch 가 [BodyThrownMarker] 를 만나면 cause 를 그대로 re-throw (wrapping 없음).
      */
     private fun executeBody(pjp: ProceedingJoinPoint, lockName: String, start: Long): Any? {
         return try {
@@ -192,11 +339,8 @@ class LeaderElectionAspect(
     /** Body throw vs backend throw 구분용 internal marker — outer catch 에서 cause 만 re-throw. */
     private class BodyThrownMarker(override val cause: Throwable) : RuntimeException(cause)
 
-    /**
-     * [T2.14] SpEL pre-parse hook — startup 시점 모든 `@LeaderElection` 메서드의 SpEL 검증.
-     */
     override fun afterSingletonsInstantiated() {
-        // BPP/Validator 가 별도로 검증 — Aspect 는 캐시 워밍만 시도 (실패 시 startup 진행, 호출 시점 fail)
+        // BPP/Validator 가 별도로 검증 — Aspect 는 캐시 워밍 미수행
     }
 
     private fun resolveLockName(meta: AdviceMetadata, method: Method, args: Array<Any?>, target: Any): String {
@@ -219,14 +363,20 @@ class LeaderElectionAspect(
 
         val opts = LeaderElectionOptions(waitTime = waitTime, leaseTime = leaseTime)
         val selected = beanSelector.selectElectionFactory(ann.bean, method)
-
-        // literal fast-path 분류 — SpEL 평가 우회 가능 여부 사전 판단
         val literal = if (LITERAL_PATTERN.matches(ann.name)) ann.name else null
 
         val effectiveFailureMode = if (ann.failureMode == LeaderAspectFailureMode.INHERIT) {
             props.failureMode
         } else {
             ann.failureMode
+        }
+
+        val isSuspend = method.parameterTypes.lastOrNull() == Continuation::class.java
+        val (suspendElectorFactory, suspendElectorFactoryBeanName) = if (isSuspend) {
+            val suspendSelected = beanSelector.selectSuspendElectorFactory(ann.bean, method)
+            suspendSelected.bean to suspendSelected.beanName
+        } else {
+            null to ""
         }
 
         return AdviceMetadata(
@@ -237,6 +387,9 @@ class LeaderElectionAspect(
             factory = selected.bean,
             failureMode = effectiveFailureMode,
             leaseTimeWarnThresholdNanos = (leaseTime.inWholeNanoseconds * LEASE_WARN_RATIO).toLong(),
+            isSuspend = isSuspend,
+            suspendElectorFactory = suspendElectorFactory,
+            suspendElectorFactoryBeanName = suspendElectorFactoryBeanName,
         )
     }
 
@@ -256,6 +409,9 @@ class LeaderElectionAspect(
         val factory: LeaderElectorFactory,
         val failureMode: LeaderAspectFailureMode,
         val leaseTimeWarnThresholdNanos: Long,
+        val isSuspend: Boolean,
+        val suspendElectorFactory: SuspendLeaderElectorFactory?,
+        val suspendElectorFactoryBeanName: String,
     )
 
     companion object: KLogging() {

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -7,6 +7,8 @@ import io.bluetape4k.leader.LeaderGroupElectorFactory
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.annotation.LeaderAspectFailureMode
 import io.bluetape4k.leader.annotation.LeaderGroupElection
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElectorFactory
 import io.bluetape4k.leader.metrics.LeaderAopMetricsRecorder
 import io.bluetape4k.leader.metrics.SkipReason
 import io.bluetape4k.leader.spring.aop.cache.GroupFactoryCacheKey
@@ -27,17 +29,22 @@ import org.springframework.beans.factory.SmartInitializingSingleton
 import java.lang.reflect.Method
 import java.util.concurrent.CancellationException
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.toKotlinDuration
 
 /**
- * `@LeaderGroupElection` 어노테이션 처리 Aspect — sync `T?` only.
+ * `@LeaderGroupElection` 어노테이션 처리 Aspect — sync `T?` 및 suspend `T?` 지원.
  *
  * [LeaderElectionAspect] 와 동일 패턴 + `maxLeaders` 분기. backend 예외는
  * [LeaderGroupElectionException] 으로 wrapping.
  *
- * Fix-94: [resolveLockName] + [factory.create] 를 try 안으로 이동 —
- * backend I/O 실패가 failureMode 우회하던 버그 수정.
+ * ## suspend 지원 (#90)
+ * [LeaderElectionAspect.aroundLeaderSuspend] 와 동일 패턴 — [SuspendLeaderGroupElectorFactory] 사용.
+ *
+ * Fix-94: [resolveLockName] + [factory.create] 를 try 안으로 이동.
  */
 @Aspect
 class LeaderGroupElectionAspect(
@@ -50,6 +57,7 @@ class LeaderGroupElectionAspect(
 
     private val metadataCache = ConcurrentHashMap<Method, GroupAdviceMetadata>()
     private val factoryCache = ConcurrentHashMap<GroupFactoryCacheKey, LeaderGroupElector>()
+    private val suspendElectorCache = ConcurrentHashMap<GroupFactoryCacheKey, SuspendLeaderGroupElector>()
     private val hasRecorders = recorders.isNotEmpty()
 
     @Around("@annotation(io.bluetape4k.leader.annotation.LeaderGroupElection)")
@@ -59,10 +67,14 @@ class LeaderGroupElectionAspect(
         val args = pjp.args
 
         val meta = metadataCache.computeIfAbsent(method) { resolveMetadata(it, target) }
+
+        if (meta.isSuspend) {
+            return aroundLeaderSuspend(pjp, meta)
+        }
+
         val opts = meta.options
         val coreOpts = opts.toCoreOptions()
 
-        // [Fix-94] resolveLockName + factory.create 를 try 안으로 이동
         var lockName: String? = null
         val start = System.nanoTime()
 
@@ -153,6 +165,134 @@ class LeaderGroupElectionAspect(
         }
     }
 
+    /**
+     * suspend 메서드 처리 — [LeaderElectionAspect.aroundLeaderSuspend] 와 동일 패턴.
+     */
+    private fun aroundLeaderSuspend(pjp: ProceedingJoinPoint, meta: GroupAdviceMetadata): Any? {
+        @Suppress("UNCHECKED_CAST")
+        val continuation = pjp.args.last() as Continuation<Any?>
+        val start = System.nanoTime()
+        val method = (pjp.signature as MethodSignature).method
+        val coreOpts = meta.options.toCoreOptions()
+
+        val suspendBlock: suspend () -> Any? = {
+            var lockName: String? = null
+            try {
+                val resolvedName = resolveLockName(meta, method, pjp.args, pjp.target)
+                lockName = resolvedName
+                val cacheKey = GroupFactoryCacheKey(meta.suspendElectorFactoryBeanName, meta.options)
+                val elector = suspendElectorCache[cacheKey]
+                    ?: meta.suspendElectorFactory!!.create(meta.options)
+                        .also { suspendElectorCache.putIfAbsent(cacheKey, it) }
+
+                fanOut { it.onLockAttempt(resolvedName, coreOpts) }
+
+                val result = elector.runIfLeader(resolvedName) {
+                    fanOut {
+                        it.onLockAcquired(resolvedName, coreOpts, (System.nanoTime() - start).nanoseconds)
+                        it.onTaskStarted(resolvedName)
+                    }
+                    try {
+                        @Suppress("UNCHECKED_CAST")
+                        val bodyResult = suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
+                            val newArgs = pjp.args.copyOf()
+                            newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
+                            pjp.proceed(newArgs)
+                        }
+                        val elapsed = System.nanoTime() - start
+                        fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
+                        if (elapsed > meta.leaseTimeWarnThresholdNanos) {
+                            log.warn { "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${meta.options.leaseTime.inWholeNanoseconds}" }
+                        }
+                        log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
+                        bodyResult
+                    } catch (ce: CancellationException) {
+                        fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, ce) }
+                        throw ce
+                    } catch (bodyEx: Throwable) {
+                        fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                        throw BodyThrownMarker(bodyEx)
+                    }
+                }
+
+                if (result == null) {
+                    if (meta.failureMode == LeaderAspectFailureMode.FAIL_OPEN_RUN) {
+                        fanOut {
+                            it.onLockNotAcquired(resolvedName, coreOpts, SkipReason.FAIL_OPEN_FORCED)
+                            it.onTaskStarted(resolvedName)
+                        }
+                        log.debug { "leader.aop.fail-open lockName=$resolvedName reason=CONTENTION" }
+                        try {
+                            @Suppress("UNCHECKED_CAST")
+                            val failOpenResult = suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
+                                val newArgs = pjp.args.copyOf()
+                                newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
+                                pjp.proceed(newArgs)
+                            }
+                            fanOut { it.onTaskFinished(resolvedName, (System.nanoTime() - start).nanoseconds) }
+                            failOpenResult
+                        } catch (ce: CancellationException) {
+                            fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, ce) }
+                            throw ce
+                        } catch (bodyEx: Throwable) {
+                            fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                            throw bodyEx
+                        }
+                    } else {
+                        fanOut { it.onLockNotAcquired(resolvedName, coreOpts, SkipReason.CONTENTION) }
+                        log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
+                        null
+                    }
+                } else {
+                    result
+                }
+            } catch (ce: CancellationException) {
+                throw ce
+            } catch (bm: BodyThrownMarker) {
+                throw bm.cause
+            } catch (backendEx: Throwable) {
+                val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
+                val wrapped = LeaderGroupElectionException("leader group backend error for lock '$effectiveName'", backendEx)
+                when (meta.failureMode) {
+                    LeaderAspectFailureMode.INHERIT -> error("INHERIT must be resolved in resolveMetadata")
+                    LeaderAspectFailureMode.RETHROW -> {
+                        fanOut { it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.BACKEND_ERROR) }
+                        fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
+                        throw wrapped
+                    }
+                    LeaderAspectFailureMode.SKIP -> {
+                        fanOut { it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.BACKEND_ERROR) }
+                        fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
+                        log.warn(backendEx) { "leader.aop.skipped lockName=$effectiveName reason=BACKEND_ERROR" }
+                        null
+                    }
+                    LeaderAspectFailureMode.FAIL_OPEN_RUN -> {
+                        fanOut { it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.FAIL_OPEN_FORCED) }
+                        log.warn(backendEx) { "leader.aop.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
+                        fanOut { it.onTaskStarted(effectiveName) }
+                        try {
+                            @Suppress("UNCHECKED_CAST")
+                            val failOpenResult = suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
+                                val newArgs = pjp.args.copyOf()
+                                newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
+                                pjp.proceed(newArgs)
+                            }
+                            fanOut { it.onTaskFinished(effectiveName, (System.nanoTime() - start).nanoseconds) }
+                            failOpenResult
+                        } catch (ce: CancellationException) {
+                            fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, ce) }
+                            throw ce
+                        } catch (bodyEx: Throwable) {
+                            fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                            throw bodyEx
+                        }
+                    }
+                }
+            }
+        }
+        return suspendBlock.startCoroutineUninterceptedOrReturn(continuation)
+    }
+
     private fun executeBody(pjp: ProceedingJoinPoint, lockName: String, start: Long): Any? {
         return try {
             pjp.proceed()
@@ -211,6 +351,14 @@ class LeaderGroupElectionAspect(
             ann.failureMode
         }
 
+        val isSuspend = method.parameterTypes.lastOrNull() == Continuation::class.java
+        val (suspendElectorFactory, suspendElectorFactoryBeanName) = if (isSuspend) {
+            val suspendSelected = beanSelector.selectSuspendGroupElectorFactory(ann.bean, method)
+            suspendSelected.bean to suspendSelected.beanName
+        } else {
+            null to ""
+        }
+
         return GroupAdviceMetadata(
             nameExpression = ann.name,
             literalName = literal,
@@ -219,6 +367,9 @@ class LeaderGroupElectionAspect(
             factory = selected.bean,
             failureMode = effectiveFailureMode,
             leaseTimeWarnThresholdNanos = (leaseTime.inWholeNanoseconds * LEASE_WARN_RATIO).toLong(),
+            isSuspend = isSuspend,
+            suspendElectorFactory = suspendElectorFactory,
+            suspendElectorFactoryBeanName = suspendElectorFactoryBeanName,
         )
     }
 
@@ -241,6 +392,9 @@ class LeaderGroupElectionAspect(
         val factory: LeaderGroupElectorFactory,
         val failureMode: LeaderAspectFailureMode,
         val leaseTimeWarnThresholdNanos: Long,
+        val isSuspend: Boolean,
+        val suspendElectorFactory: SuspendLeaderGroupElectorFactory?,
+        val suspendElectorFactoryBeanName: String,
     )
 
     companion object: KLogging() {

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/autoconfigure/LeaderAopFactoryAutoConfiguration.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/autoconfigure/LeaderAopFactoryAutoConfiguration.kt
@@ -4,23 +4,37 @@ import com.hazelcast.core.HazelcastInstance
 import com.mongodb.client.MongoClient
 import io.bluetape4k.leader.LeaderElectorFactory
 import io.bluetape4k.leader.LeaderGroupElectorFactory
+import io.bluetape4k.leader.coroutines.LocalSuspendLeaderElectorFactory
+import io.bluetape4k.leader.coroutines.LocalSuspendLeaderGroupElectorFactory
+import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElectorFactory
 import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderElectorFactory
 import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderGroupElectorFactory
+import io.bluetape4k.leader.exposed.r2dbc.ExposedR2DbcSuspendLeaderElectorFactory
+import io.bluetape4k.leader.exposed.r2dbc.ExposedR2DbcSuspendLeaderGroupElectorFactory
 import io.bluetape4k.leader.hazelcast.HazelcastLeaderElectorFactory
 import io.bluetape4k.leader.hazelcast.HazelcastLeaderGroupElectorFactory
 import io.bluetape4k.leader.lettuce.LettuceLeaderElectorFactory
 import io.bluetape4k.leader.lettuce.LettuceLeaderGroupElectorFactory
+import io.bluetape4k.leader.lettuce.LettuceSuspendLeaderElectorFactory
+import io.bluetape4k.leader.lettuce.LettuceSuspendLeaderGroupElectorFactory
 import io.bluetape4k.leader.local.LocalLeaderElectorFactory
 import io.bluetape4k.leader.local.LocalLeaderGroupElectorFactory
 import io.bluetape4k.leader.mongodb.MongoLeaderElectorFactory
 import io.bluetape4k.leader.mongodb.MongoLeaderGroupElectorFactory
+import io.bluetape4k.leader.mongodb.MongoSuspendLeaderElectorFactory
+import io.bluetape4k.leader.mongodb.MongoSuspendLeaderGroupElectorFactory
 import io.bluetape4k.leader.redisson.RedissonLeaderElectorFactory
 import io.bluetape4k.leader.redisson.RedissonLeaderGroupElectorFactory
+import io.bluetape4k.leader.redisson.RedissonSuspendLeaderElectorFactory
+import io.bluetape4k.leader.redisson.RedissonSuspendLeaderGroupElectorFactory
 import io.lettuce.core.api.StatefulRedisConnection
 import org.aspectj.lang.annotation.Aspect
 import org.bson.Document
 import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
 import org.redisson.api.RedissonClient
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.config.BeanDefinition
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
@@ -32,7 +46,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Role
 
 /**
- * AutoConfig Phase 1 — 6 backend factory `@Bean` 등록.
+ * AutoConfig Phase 1 — 6 backend factory `@Bean` 등록 (sync + suspend).
  *
  * ## [Codex H3] 분리 사유
  * factory `@Bean` 등록을 [LeaderAopAutoConfiguration] 의 Aspect/BPP 등록과 분리하여
@@ -63,6 +77,16 @@ class LeaderAopFactoryAutoConfiguration {
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     fun localLeaderGroupElectionFactory(): LeaderGroupElectorFactory = LocalLeaderGroupElectorFactory()
 
+    @Bean(name = ["localSuspendLeaderElectorFactory"])
+    @ConditionalOnMissingBean(name = ["localSuspendLeaderElectorFactory"])
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    fun localSuspendLeaderElectorFactory(): SuspendLeaderElectorFactory = LocalSuspendLeaderElectorFactory()
+
+    @Bean(name = ["localSuspendLeaderGroupElectorFactory"])
+    @ConditionalOnMissingBean(name = ["localSuspendLeaderGroupElectorFactory"])
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    fun localSuspendLeaderGroupElectorFactory(): SuspendLeaderGroupElectorFactory = LocalSuspendLeaderGroupElectorFactory()
+
     // ── Lettuce ──────────────────────────────────────────────────
 
     @Configuration(proxyBeanMethods = false)
@@ -84,6 +108,24 @@ class LeaderAopFactoryAutoConfiguration {
         fun lettuceLeaderGroupElectionFactory(
             connection: StatefulRedisConnection<String, String>,
         ): LeaderGroupElectorFactory = LettuceLeaderGroupElectorFactory(connection)
+
+        @Bean(name = ["lettuceSuspendLeaderElectorFactory"])
+        @ConditionalOnBean(StatefulRedisConnection::class)
+        @ConditionalOnMissingBean(name = ["lettuceSuspendLeaderElectorFactory"])
+        @ConditionalOnClass(name = ["io.bluetape4k.leader.lettuce.LettuceSuspendLeaderElectorFactory"])
+        @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+        fun lettuceSuspendLeaderElectorFactory(
+            connection: StatefulRedisConnection<String, String>,
+        ): SuspendLeaderElectorFactory = LettuceSuspendLeaderElectorFactory(connection)
+
+        @Bean(name = ["lettuceSuspendLeaderGroupElectorFactory"])
+        @ConditionalOnBean(StatefulRedisConnection::class)
+        @ConditionalOnMissingBean(name = ["lettuceSuspendLeaderGroupElectorFactory"])
+        @ConditionalOnClass(name = ["io.bluetape4k.leader.lettuce.LettuceSuspendLeaderGroupElectorFactory"])
+        @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+        fun lettuceSuspendLeaderGroupElectorFactory(
+            connection: StatefulRedisConnection<String, String>,
+        ): SuspendLeaderGroupElectorFactory = LettuceSuspendLeaderGroupElectorFactory(connection)
     }
 
     // ── Redisson ─────────────────────────────────────────────────
@@ -105,6 +147,22 @@ class LeaderAopFactoryAutoConfiguration {
         @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
         fun redissonLeaderGroupElectionFactory(client: RedissonClient): LeaderGroupElectorFactory =
             RedissonLeaderGroupElectorFactory(client)
+
+        @Bean(name = ["redissonSuspendLeaderElectorFactory"])
+        @ConditionalOnBean(RedissonClient::class)
+        @ConditionalOnMissingBean(name = ["redissonSuspendLeaderElectorFactory"])
+        @ConditionalOnClass(name = ["io.bluetape4k.leader.redisson.RedissonSuspendLeaderElectorFactory"])
+        @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+        fun redissonSuspendLeaderElectorFactory(client: RedissonClient): SuspendLeaderElectorFactory =
+            RedissonSuspendLeaderElectorFactory(client)
+
+        @Bean(name = ["redissonSuspendLeaderGroupElectorFactory"])
+        @ConditionalOnBean(RedissonClient::class)
+        @ConditionalOnMissingBean(name = ["redissonSuspendLeaderGroupElectorFactory"])
+        @ConditionalOnClass(name = ["io.bluetape4k.leader.redisson.RedissonSuspendLeaderGroupElectorFactory"])
+        @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+        fun redissonSuspendLeaderGroupElectorFactory(client: RedissonClient): SuspendLeaderGroupElectorFactory =
+            RedissonSuspendLeaderGroupElectorFactory(client)
     }
 
     // ── MongoDB sync ─────────────────────────────────────────────
@@ -118,7 +176,7 @@ class LeaderAopFactoryAutoConfiguration {
         @ConditionalOnMissingBean(name = ["mongoLeaderElectionFactory"])
         @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
         fun mongoLeaderElectionFactory(
-            @org.springframework.beans.factory.annotation.Qualifier("leaderLockMongoCollection")
+            @Qualifier("leaderLockMongoCollection")
             collection: com.mongodb.client.MongoCollection<Document>,
         ): LeaderElectorFactory = MongoLeaderElectorFactory(collection)
 
@@ -127,9 +185,41 @@ class LeaderAopFactoryAutoConfiguration {
         @ConditionalOnMissingBean(name = ["mongoLeaderGroupElectionFactory"])
         @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
         fun mongoLeaderGroupElectionFactory(
-            @org.springframework.beans.factory.annotation.Qualifier("leaderGroupLockMongoCollection")
+            @Qualifier("leaderGroupLockMongoCollection")
             groupCollection: com.mongodb.client.MongoCollection<Document>,
         ): LeaderGroupElectorFactory = MongoLeaderGroupElectorFactory(groupCollection)
+    }
+
+    // ── MongoDB suspend (coroutine driver) ───────────────────────
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(
+        name = [
+            "com.mongodb.kotlin.client.coroutine.MongoCollection",
+            "io.bluetape4k.leader.mongodb.MongoSuspendLeaderElectorFactory",
+        ]
+    )
+    class MongoSuspendFactoryConfig {
+
+        @Bean(name = ["mongoSuspendLeaderElectorFactory"])
+        @ConditionalOnBean(name = ["leaderLockMongoCoroutineCollection"])
+        @ConditionalOnMissingBean(name = ["mongoSuspendLeaderElectorFactory"])
+        @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+        fun mongoSuspendLeaderElectorFactory(
+            @Qualifier("leaderLockMongoCoroutineCollection")
+            collection: com.mongodb.kotlin.client.coroutine.MongoCollection<Document>,
+        ): SuspendLeaderElectorFactory = MongoSuspendLeaderElectorFactory(collection)
+
+        @Bean(name = ["mongoSuspendLeaderGroupElectorFactory"])
+        @ConditionalOnBean(name = ["leaderGroupLockMongoCollection", "leaderGroupLockMongoCoroutineCollection"])
+        @ConditionalOnMissingBean(name = ["mongoSuspendLeaderGroupElectorFactory"])
+        @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+        fun mongoSuspendLeaderGroupElectorFactory(
+            @Qualifier("leaderGroupLockMongoCollection")
+            syncGroupCollection: com.mongodb.client.MongoCollection<Document>,
+            @Qualifier("leaderGroupLockMongoCoroutineCollection")
+            coroutineGroupCollection: com.mongodb.kotlin.client.coroutine.MongoCollection<Document>,
+        ): SuspendLeaderGroupElectorFactory = MongoSuspendLeaderGroupElectorFactory(syncGroupCollection, coroutineGroupCollection)
     }
 
     // ── Hazelcast ────────────────────────────────────────────────
@@ -172,5 +262,26 @@ class LeaderAopFactoryAutoConfiguration {
         @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
         fun exposedJdbcLeaderGroupElectionFactory(db: Database): LeaderGroupElectorFactory =
             ExposedJdbcLeaderGroupElectorFactory(db)
+    }
+
+    // ── Exposed R2DBC suspend ─────────────────────────────────────
+
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(R2dbcDatabase::class, ExposedR2DbcSuspendLeaderElectorFactory::class)
+    class ExposedR2dbcSuspendFactoryConfig {
+
+        @Bean(name = ["exposedR2dbcSuspendLeaderElectorFactory"])
+        @ConditionalOnBean(R2dbcDatabase::class)
+        @ConditionalOnMissingBean(name = ["exposedR2dbcSuspendLeaderElectorFactory"])
+        @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+        fun exposedR2dbcSuspendLeaderElectorFactory(db: R2dbcDatabase): SuspendLeaderElectorFactory =
+            ExposedR2DbcSuspendLeaderElectorFactory(db)
+
+        @Bean(name = ["exposedR2dbcSuspendLeaderGroupElectorFactory"])
+        @ConditionalOnBean(R2dbcDatabase::class)
+        @ConditionalOnMissingBean(name = ["exposedR2dbcSuspendLeaderGroupElectorFactory"])
+        @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+        fun exposedR2dbcSuspendLeaderGroupElectorFactory(db: R2dbcDatabase): SuspendLeaderGroupElectorFactory =
+            ExposedR2DbcSuspendLeaderGroupElectorFactory(db)
     }
 }

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessor.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessor.kt
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.config.BeanPostProcessor
 import org.springframework.core.annotation.AnnotatedElementUtils
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
-import kotlin.coroutines.Continuation
 
 /**
  * `@LeaderElection` / `@LeaderGroupElection` 부착 메서드 footgun 검출 BeanPostProcessor.
@@ -20,7 +19,6 @@ import kotlin.coroutines.Continuation
  * ## 검출 항목
  * - `final` / `private` 메서드 (proxy 적용 불가)
  * - `@LeaderGroupElection.maxLeaders` ≤ 1
- * - suspend 메서드 (sync only PR — 후속 [#80])
  * - reactive 반환 (`Mono` / `Flux` / `Flow`) — sync only PR
  * - SpEL pre-parse 실패
  * - 같은 클래스에 어노테이션 부착 메서드 2+ (best-effort self-invocation WARN)
@@ -87,7 +85,6 @@ class LeaderAnnotationValidatorBeanPostProcessor(
 
         if (Modifier.isFinal(method.modifiers)) violations += "final method (proxy 적용 불가)"
         if (Modifier.isPrivate(method.modifiers)) violations += "private method (proxy 적용 불가)"
-        if (isSuspend(method)) violations += "suspend method (sync only PR — see #80)"
 
         val returnTypeName = method.returnType.name
         if (returnTypeName.endsWith(".Mono") ||
@@ -118,9 +115,6 @@ class LeaderAnnotationValidatorBeanPostProcessor(
             log.warn { msg }
         }
     }
-
-    private fun isSuspend(method: Method): Boolean =
-        method.parameterTypes.lastOrNull() == Continuation::class.java
 
     companion object: KLogging()
 }

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessorTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessorTest.kt
@@ -8,9 +8,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.aspectj.lang.annotation.Aspect
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.assertNotFails
+import org.junit.jupiter.api.Test
 import org.springframework.core.annotation.AliasFor
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -61,7 +61,7 @@ class LeaderAnnotationValidatorBeanPostProcessorTest {
             open fun ok() {}  // Kotlin default-final 회피 — open 명시
         }
         val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = true, spel = spel)
-        assertDoesNotThrow { bpp.postProcessAfterInitialization(Sample(), "sample") }
+        assertNotFails { bpp.postProcessAfterInitialization(Sample(), "sample") }
     }
 
     @Test
@@ -82,7 +82,7 @@ class LeaderAnnotationValidatorBeanPostProcessorTest {
             fun finalMethod() {}
         }
         val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = false, spel = spel)
-        assertDoesNotThrow { bpp.postProcessAfterInitialization(Sample(), "sample") }
+        assertNotFails { bpp.postProcessAfterInitialization(Sample(), "sample") }
     }
 
     @Test
@@ -116,7 +116,7 @@ class LeaderAnnotationValidatorBeanPostProcessorTest {
         }
         val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = true, spel = spel)
         // self-inv 자체는 strict 모드에서도 WARN 만 (정확 검출 불가)
-        assertDoesNotThrow { bpp.postProcessAfterInitialization(Sample(), "sample") }
+        assertNotFails { bpp.postProcessAfterInitialization(Sample(), "sample") }
     }
 
     @Test
@@ -133,23 +133,23 @@ class LeaderAnnotationValidatorBeanPostProcessorTest {
     // ── #96: 누락 분기 — suspend / Mono / Flux / Flow / @Aspect ──
 
     @Test
-    fun `suspend method strict true - startup fail`() {
+    fun `suspend method strict true - 위반 없음 (#90 지원)`() {
         class SampleSuspend {
             @LeaderElection(name = "suspend-job")
             open suspend fun doWork(): String = "ok"
         }
         val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = true, spel = spel)
-        assertFailsWith<IllegalStateException> { bpp.postProcessAfterInitialization(SampleSuspend(), "sample") }
+        assertNotFails { bpp.postProcessAfterInitialization(SampleSuspend(), "sample") }
     }
 
     @Test
-    fun `suspend method strict false - WARN 만 (throw 안 함)`() {
+    fun `suspend method strict false - 위반 없음 (#90 지원)`() {
         class SampleSuspend {
             @LeaderElection(name = "suspend-job")
             open suspend fun doWork(): String = "ok"
         }
         val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = false, spel = spel)
-        assertDoesNotThrow { bpp.postProcessAfterInitialization(SampleSuspend(), "sample") }
+        assertNotFails { bpp.postProcessAfterInitialization(SampleSuspend(), "sample") }
     }
 
     @Test
@@ -203,7 +203,7 @@ class LeaderAnnotationValidatorBeanPostProcessorTest {
             open fun run(): String = "ok"
         }
         val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = true, spel = spel)
-        assertDoesNotThrow { bpp.postProcessAfterInitialization(SampleComposed(), "sample") }
+        assertNotFails { bpp.postProcessAfterInitialization(SampleComposed(), "sample") }
     }
 
     @Test


### PR DESCRIPTION
## Summary

PR #132의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: #90 suspend method 지원 — @LeaderElection/@LeaderGroupElection AOP`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 개요

Issue #90 — `@LeaderElection` / `@LeaderGroupElection` AOP에서 suspend 메서드 지원.

이 PR은 PR1 (suspend 지원)이며, PR2 (#91+#92: Mono/Flux + LeaderElectionInfo)는 이후 별도 PR로 진행합니다.

## 변경 내용

### `LeaderAnnotationValidatorBeanPostProcessor`
- suspend 메서드 위반 검출 제거 (v1 sync-only → #90에서 정식 지원)
- 관련 `isSuspend()` 헬퍼 메서드 및 `Continuation` import 제거

### `LeaderBeanSelector`
- `selectSuspendElectorFactory()` 추가
- `selectSuspendGroupElectorFactory()` 추가

### `LeaderAopFactoryAutoConfiguration`
- suspend factory 빈 등록 (Local/Lettuce/Redisson/MongoDB coroutine/ExposedR2DBC 백엔드)
- `localSuspendLeaderElectorFactory`, `localSuspendLeaderGroupElectorFactory` — always-on fallback

### `LeaderElectionAspect`
- `aroundLeaderSuspend()` 구현
  - `startCoroutineUninterceptedOrReturn` + `suspendCoroutineUninterceptedOrReturn` intrinsics 패턴
  - `BodyThrownMarker`로 body 예외 ↔ backend 예외 구분
  - `RETHROW / SKIP / FAIL_OPEN_RUN` failureMode 완전 동등성
  - `SuspendLeaderElector` 캐시: accept-rare-double-create 패턴 (suspend `create()` 대응)

### `LeaderGroupElectionAspect`
- `aroundSuspendGroup()` 구현 (LeaderElectionAspect 미러)

### `LeaderAnnotationValidatorBeanPostProcessorTest`
- `assertDoesNotThrow {}` → `assertNotFails {}` (bluetape4k assertions)
- suspend 테스트 케이스 → 통과(pass)로 전환

## 기술 세부 사항

### suspend bridge 패턴 (CTW 환경)
```kotlin
val suspendBlock: suspend () -> Any? = {
    val result = elector.runIfLeader(name) {
        suspendCoroutineUninterceptedOrReturn { innerCont ->
            val newArgs = pjp.args.copyOf()
            newArgs[newArgs.lastIndex] = innerCont
            pjp.proceed(newArgs)
        }
    }
    result
}
return suspendBlock.startCoroutineUninterceptedOrReturn(continuation)
```

## 테스트 결과

```
Module : :leader-spring-boot
Result : 169 passing, 0 failed, 0 skipped
Time   : 1m 27s
```

## 검증 커맨드

```bash
./gradlew :leader-spring-boot:test
```
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #132, head `c03dd988182082cbff49e3ad357de2c65c742967`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
