### PR TITLE
feat: Mono<T> 반환 타입 지원 + LeaderElectionInfo CoroutineContext 주입 (#91, #92)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,6 +95,7 @@ kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5" }
 kotlinx-coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core" }
 kotlinx-coroutines-reactive = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactive" }
+kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test" }
 kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "kotlinx-atomicfu" }
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LeaderElectionInfo.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LeaderElectionInfo.kt
@@ -1,0 +1,20 @@
+package io.bluetape4k.leader.coroutines
+
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * 리더 선출 결과를 CoroutineContext 로 전파하는 element.
+ *
+ * `@LeaderElection` / `@LeaderGroupElection` AOP 본문 실행 시 aspect 가 주입.
+ * suspend / `Mono` 반환 메서드에서 `coroutineContext[LeaderElectionInfo]` 로 접근 가능.
+ *
+ * @property lockName 선출에 사용된 락 이름
+ * @property wasElected 리더로 선출되어 본문이 실행 중인지 여부
+ */
+data class LeaderElectionInfo(
+    val lockName: String,
+    val wasElected: Boolean,
+) : CoroutineContext.Element {
+    companion object Key : CoroutineContext.Key<LeaderElectionInfo>
+    override val key: CoroutineContext.Key<*> get() = Key
+}

--- a/leader-spring-boot/build.gradle.kts
+++ b/leader-spring-boot/build.gradle.kts
@@ -68,6 +68,8 @@ dependencies {
     compileOnly(libs.spring.context)
     compileOnly(libs.spring.tx)
 
+    compileOnly(libs.kotlinx.coroutines.reactor)
+
     // Caffeine — LeaderBeanSelector factory cache
     implementation(libs.caffeine)
 

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.leader.LeaderElectorFactory
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.annotation.LeaderAspectFailureMode
 import io.bluetape4k.leader.annotation.LeaderElection
+import io.bluetape4k.leader.coroutines.LeaderElectionInfo
 import io.bluetape4k.leader.coroutines.SuspendLeaderElector
 import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
 import io.bluetape4k.leader.metrics.LeaderAopMetricsRecorder
@@ -20,11 +21,15 @@ import io.bluetape4k.leader.spring.aop.util.LockNameValidator
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import kotlinx.coroutines.reactor.mono
+import kotlinx.coroutines.withContext
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.reflect.MethodSignature
 import org.springframework.beans.factory.SmartInitializingSingleton
+import reactor.core.publisher.Mono
 import java.lang.reflect.Method
 import java.util.concurrent.CancellationException
 import java.util.concurrent.ConcurrentHashMap
@@ -35,30 +40,22 @@ import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.toKotlinDuration
 
 /**
- * `@LeaderElection` 어노테이션 처리 Aspect — sync `T?` 및 suspend `T?` 지원.
+ * `@LeaderElection` 어노테이션 처리 Aspect — sync `T?`, suspend `T?`, `Mono<T>` 지원.
  *
- * ## [T4.1a Option A] final class @Aspect
- * Boot 4 CTW (Freefair post-compile weaving). autoconfig 가 `@Bean` 으로 등록 — `@Component` 미부착.
+ * ## CTW (Freefair post-compile weaving)
+ * `@EnableAspectJAutoProxy` 미사용. autoconfig 가 `@Bean` 으로 등록.
  *
  * ## suspend 지원 (#90)
- * - suspend 메서드 감지: 마지막 파라미터가 [Continuation] 인지 확인
- * - `startCoroutineUninterceptedOrReturn` + `suspendCoroutineUninterceptedOrReturn` intrinsics 패턴 사용
- * - [SuspendLeaderElectorFactory] 는 suspend fun — `computeIfAbsent` 불가, "accept rare double-create" 패턴 사용
- * - `SuspendLeaderElector.runIfLeader()` 는 `T?` 반환 — null == 미선출.
- *   선출 후 액션이 null 반환 시 미선출과 구별 불가 (알려진 한계 — v1).
+ * 마지막 파라미터가 [Continuation] 인 메서드 → [aroundLeaderSuspend] 분기.
+ * `startCoroutineUninterceptedOrReturn` + `suspendCoroutineUninterceptedOrReturn` intrinsics 패턴.
  *
- * ## [Step 3-P] 보강 사항
- * - **Sec-3 (R-33)**: backend 예외만 [LeaderElectionException] 으로 wrapping
- * - **Rel-1**: body 예외 vs backend 예외 분리 — body throw 는 wrapping 없이 그대로 전파
- * - **Rel-2**: [CancellationException] 항상 우선 재throw
- * - **Perf-1**: metrics fan-out 시 `metrics.isEmpty()` fast-path
- * - **Perf-2**: Method-level cache — annotation lookup + lease threshold 사전계산 + factory bean name resolution
- * - **Fix-94**: [resolveLockName] + [factory.create] 를 try 안으로 이동
+ * ## Mono 지원 (#91)
+ * 반환 타입이 `reactor.core.publisher.Mono` 인 메서드 → [aroundLeaderMono] 분기.
+ * `Mono.defer { mono { suspendElector.runIfLeader(...) } }` 패턴 — subscribe 당 락 1회.
  *
- * @param beanSelector factory 빈 선택기
- * @param props AOP 전역 속성
- * @param spel SpEL 평가기
- * @param recorders 등록된 metrics recorder 리스트 (0개 = NoOp fast-path)
+ * ## LeaderElectionInfo (#92)
+ * suspend / Mono 분기 본문 실행 시 [LeaderElectionInfo] 를 `withContext` 로 주입.
+ * 사용자는 `coroutineContext[LeaderElectionInfo]` 로 선출 정보 접근 가능.
  */
 @Aspect
 class LeaderElectionAspect(
@@ -69,16 +66,9 @@ class LeaderElectionAspect(
     private val recorders: List<LeaderAopMetricsRecorder>,
 ) : SmartInitializingSingleton {
 
-    /** [Step 3-P-Perf-2] Method-level cache — annotation + parsed options + factory lookup. */
     private val metadataCache = ConcurrentHashMap<Method, AdviceMetadata>()
-
-    /** [C1][R-26] FactoryCacheKey 기반 cross-backend collision-safe 캐싱. */
     private val factoryCache = ConcurrentHashMap<FactoryCacheKey, LeaderElector>()
-
-    /** suspend 엘렉터 캐시 — FactoryCacheKey(suspendElectorFactoryBeanName, options). */
     private val suspendElectorCache = ConcurrentHashMap<FactoryCacheKey, SuspendLeaderElector>()
-
-    /** [Perf-1] recorder 0개일 때 fast-path 활성화. */
     private val hasRecorders = recorders.isNotEmpty()
 
     @Around("@annotation(io.bluetape4k.leader.annotation.LeaderElection)")
@@ -93,9 +83,12 @@ class LeaderElectionAspect(
             return aroundLeaderSuspend(pjp, meta)
         }
 
+        if (meta.isMono) {
+            return aroundLeaderMono(pjp, meta)
+        }
+
         val opts = meta.options
 
-        // [Fix-94] resolveLockName + factory.create 를 try 안으로 이동
         var lockName: String? = null
         val start = System.nanoTime()
 
@@ -188,13 +181,7 @@ class LeaderElectionAspect(
 
     /**
      * suspend 메서드 처리 — `startCoroutineUninterceptedOrReturn` intrinsics 패턴.
-     *
-     * [ProceedingJoinPoint.args] 마지막 원소(Continuation)를 inner continuation 으로 교체하여
-     * 리더 선출 로직과 suspend body 를 올바르게 연결한다.
-     *
-     * ## null 반환 한계 (v1)
-     * [SuspendLeaderElector.runIfLeader] 는 `T?` 반환 — null 이 "미선출"인지
-     * "액션 결과 null" 인지 구별 불가. null 은 "미선출"로 처리.
+     * 본문 실행 시 [LeaderElectionInfo] 를 `withContext` 로 CoroutineContext 에 주입.
      */
     private fun aroundLeaderSuspend(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
         @Suppress("UNCHECKED_CAST")
@@ -219,26 +206,28 @@ class LeaderElectionAspect(
                         it.onLockAcquired(resolvedName, meta.options, (System.nanoTime() - start).nanoseconds)
                         it.onTaskStarted(resolvedName)
                     }
-                    try {
-                        @Suppress("UNCHECKED_CAST")
-                        val bodyResult = suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
-                            val newArgs = pjp.args.copyOf()
-                            newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
-                            pjp.proceed(newArgs)
+                    withContext(LeaderElectionInfo(lockName = resolvedName, wasElected = true)) {
+                        try {
+                            @Suppress("UNCHECKED_CAST")
+                            val bodyResult = suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
+                                val newArgs = pjp.args.copyOf()
+                                newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
+                                pjp.proceed(newArgs)
+                            }
+                            val elapsed = System.nanoTime() - start
+                            fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
+                            if (elapsed > meta.leaseTimeWarnThresholdNanos) {
+                                log.warn { "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${meta.options.leaseTime.inWholeNanoseconds}" }
+                            }
+                            log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
+                            bodyResult
+                        } catch (ce: CancellationException) {
+                            fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, ce) }
+                            throw ce
+                        } catch (bodyEx: Throwable) {
+                            fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                            throw BodyThrownMarker(bodyEx)
                         }
-                        val elapsed = System.nanoTime() - start
-                        fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
-                        if (elapsed > meta.leaseTimeWarnThresholdNanos) {
-                            log.warn { "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${meta.options.leaseTime.inWholeNanoseconds}" }
-                        }
-                        log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
-                        bodyResult
-                    } catch (ce: CancellationException) {
-                        fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, ce) }
-                        throw ce
-                    } catch (bodyEx: Throwable) {
-                        fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, bodyEx) }
-                        throw BodyThrownMarker(bodyEx)
                     }
                 }
 
@@ -321,9 +310,116 @@ class LeaderElectionAspect(
     }
 
     /**
-     * [Rel-1] body 실행 — 사용자 본문 throw 는 wrapping 없이 그대로 전파.
-     * [CancellationException] 우선 재throw [Rel-2].
+     * `Mono` 반환 타입 메서드 처리 — `Mono.defer { mono { suspendElector.runIfLeader(...) } }` 패턴.
+     *
+     * `Mono.defer` 로 subscribe 당 락 1회 보장.
+     * [LeaderElectionInfo] 를 `withContext` 로 주입하여 CoroutineContext 전파.
      */
+    private fun aroundLeaderMono(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
+        val method = (pjp.signature as MethodSignature).method
+
+        return Mono.defer {
+            val start = System.nanoTime()
+            mono {
+                var lockName: String? = null
+                try {
+                    val resolvedName = resolveLockName(meta, method, pjp.args, pjp.target)
+                    lockName = resolvedName
+                    val cacheKey = FactoryCacheKey(meta.suspendElectorFactoryBeanName, meta.options)
+                    val elector = suspendElectorCache[cacheKey]
+                        ?: meta.suspendElectorFactory!!.create(meta.options)
+                            .also { suspendElectorCache.putIfAbsent(cacheKey, it) }
+
+                    fanOut { it.onLockAttempt(resolvedName, meta.options) }
+
+                    val result = elector.runIfLeader(resolvedName) {
+                        fanOut {
+                            it.onLockAcquired(resolvedName, meta.options, (System.nanoTime() - start).nanoseconds)
+                            it.onTaskStarted(resolvedName)
+                        }
+                        withContext(LeaderElectionInfo(lockName = resolvedName, wasElected = true)) {
+                            try {
+                                @Suppress("UNCHECKED_CAST")
+                                val bodyResult = (pjp.proceed() as Mono<*>).awaitSingleOrNull()
+                                val elapsed = System.nanoTime() - start
+                                fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
+                                if (elapsed > meta.leaseTimeWarnThresholdNanos) {
+                                    log.warn { "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${meta.options.leaseTime.inWholeNanoseconds}" }
+                                }
+                                log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
+                                bodyResult
+                            } catch (ce: CancellationException) {
+                                fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, ce) }
+                                throw ce
+                            } catch (bodyEx: Throwable) {
+                                fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                                throw BodyThrownMarker(bodyEx)
+                            }
+                        }
+                    }
+
+                    if (result == null) {
+                        if (meta.failureMode == LeaderAspectFailureMode.FAIL_OPEN_RUN) {
+                            fanOut {
+                                it.onLockNotAcquired(resolvedName, meta.options, SkipReason.FAIL_OPEN_FORCED)
+                                it.onTaskStarted(resolvedName)
+                            }
+                            log.debug { "leader.aop.fail-open lockName=$resolvedName reason=CONTENTION" }
+                            @Suppress("UNCHECKED_CAST")
+                            val failOpenResult = (pjp.proceed() as Mono<*>).awaitSingleOrNull()
+                            fanOut { it.onTaskFinished(resolvedName, (System.nanoTime() - start).nanoseconds) }
+                            failOpenResult
+                        } else {
+                            fanOut { it.onLockNotAcquired(resolvedName, meta.options, SkipReason.CONTENTION) }
+                            log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
+                            null
+                        }
+                    } else {
+                        result
+                    }
+                } catch (ce: CancellationException) {
+                    throw ce
+                } catch (bm: BodyThrownMarker) {
+                    throw bm.cause
+                } catch (backendEx: Throwable) {
+                    val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
+                    val wrapped = LeaderElectionException("leader backend error for lock '$effectiveName'", backendEx)
+                    when (meta.failureMode) {
+                        LeaderAspectFailureMode.INHERIT -> error("INHERIT must be resolved in resolveMetadata")
+                        LeaderAspectFailureMode.RETHROW -> {
+                            fanOut { it.onLockNotAcquired(effectiveName, meta.options, SkipReason.BACKEND_ERROR) }
+                            fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
+                            throw wrapped
+                        }
+                        LeaderAspectFailureMode.SKIP -> {
+                            fanOut { it.onLockNotAcquired(effectiveName, meta.options, SkipReason.BACKEND_ERROR) }
+                            fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
+                            log.warn(backendEx) { "leader.aop.skipped lockName=$effectiveName reason=BACKEND_ERROR" }
+                            null
+                        }
+                        LeaderAspectFailureMode.FAIL_OPEN_RUN -> {
+                            fanOut { it.onLockNotAcquired(effectiveName, meta.options, SkipReason.FAIL_OPEN_FORCED) }
+                            log.warn(backendEx) { "leader.aop.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
+                            fanOut { it.onTaskStarted(effectiveName) }
+                            try {
+                                @Suppress("UNCHECKED_CAST")
+                                val failOpenResult = (pjp.proceed() as Mono<*>).awaitSingleOrNull()
+                                fanOut { it.onTaskFinished(effectiveName, (System.nanoTime() - start).nanoseconds) }
+                                failOpenResult
+                            } catch (ce: CancellationException) {
+                                fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, ce) }
+                                throw ce
+                            } catch (bodyEx: Throwable) {
+                                fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                                throw bodyEx
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private fun executeBody(pjp: ProceedingJoinPoint, lockName: String, start: Long): Any? {
         return try {
             pjp.proceed()
@@ -336,12 +432,9 @@ class LeaderElectionAspect(
         }
     }
 
-    /** Body throw vs backend throw 구분용 internal marker — outer catch 에서 cause 만 re-throw. */
     private class BodyThrownMarker(override val cause: Throwable) : RuntimeException(cause)
 
-    override fun afterSingletonsInstantiated() {
-        // BPP/Validator 가 별도로 검증 — Aspect 는 캐시 워밍 미수행
-    }
+    override fun afterSingletonsInstantiated() {}
 
     private fun resolveLockName(meta: AdviceMetadata, method: Method, args: Array<Any?>, target: Any): String {
         val rawName = if (meta.literalName != null) {
@@ -372,7 +465,8 @@ class LeaderElectionAspect(
         }
 
         val isSuspend = method.parameterTypes.lastOrNull() == Continuation::class.java
-        val (suspendElectorFactory, suspendElectorFactoryBeanName) = if (isSuspend) {
+        val isMono = !isSuspend && method.returnType.name == "reactor.core.publisher.Mono"
+        val (suspendElectorFactory, suspendElectorFactoryBeanName) = if (isSuspend || isMono) {
             val suspendSelected = beanSelector.selectSuspendElectorFactory(ann.bean, method)
             suspendSelected.bean to suspendSelected.beanName
         } else {
@@ -388,6 +482,7 @@ class LeaderElectionAspect(
             failureMode = effectiveFailureMode,
             leaseTimeWarnThresholdNanos = (leaseTime.inWholeNanoseconds * LEASE_WARN_RATIO).toLong(),
             isSuspend = isSuspend,
+            isMono = isMono,
             suspendElectorFactory = suspendElectorFactory,
             suspendElectorFactoryBeanName = suspendElectorFactoryBeanName,
         )
@@ -410,6 +505,7 @@ class LeaderElectionAspect(
         val failureMode: LeaderAspectFailureMode,
         val leaseTimeWarnThresholdNanos: Long,
         val isSuspend: Boolean,
+        val isMono: Boolean,
         val suspendElectorFactory: SuspendLeaderElectorFactory?,
         val suspendElectorFactoryBeanName: String,
     )

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.leader.LeaderGroupElectorFactory
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.annotation.LeaderAspectFailureMode
 import io.bluetape4k.leader.annotation.LeaderGroupElection
+import io.bluetape4k.leader.coroutines.LeaderElectionInfo
 import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
 import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElectorFactory
 import io.bluetape4k.leader.metrics.LeaderAopMetricsRecorder
@@ -21,11 +22,15 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireGe
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import kotlinx.coroutines.reactor.mono
+import kotlinx.coroutines.withContext
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.reflect.MethodSignature
 import org.springframework.beans.factory.SmartInitializingSingleton
+import reactor.core.publisher.Mono
 import java.lang.reflect.Method
 import java.util.concurrent.CancellationException
 import java.util.concurrent.ConcurrentHashMap
@@ -36,7 +41,7 @@ import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.toKotlinDuration
 
 /**
- * `@LeaderGroupElection` 어노테이션 처리 Aspect — sync `T?` 및 suspend `T?` 지원.
+ * `@LeaderGroupElection` 어노테이션 처리 Aspect — sync `T?`, suspend `T?`, `Mono<T>` 지원.
  *
  * [LeaderElectionAspect] 와 동일 패턴 + `maxLeaders` 분기. backend 예외는
  * [LeaderGroupElectionException] 으로 wrapping.
@@ -44,7 +49,11 @@ import kotlin.time.toKotlinDuration
  * ## suspend 지원 (#90)
  * [LeaderElectionAspect.aroundLeaderSuspend] 와 동일 패턴 — [SuspendLeaderGroupElectorFactory] 사용.
  *
- * Fix-94: [resolveLockName] + [factory.create] 를 try 안으로 이동.
+ * ## Mono 지원 (#91)
+ * 반환 타입이 `reactor.core.publisher.Mono` 인 메서드 → [aroundLeaderMono] 분기.
+ *
+ * ## LeaderElectionInfo (#92)
+ * suspend / Mono 분기 본문 실행 시 [LeaderElectionInfo] 를 `withContext` 로 주입.
  */
 @Aspect
 class LeaderGroupElectionAspect(
@@ -70,6 +79,10 @@ class LeaderGroupElectionAspect(
 
         if (meta.isSuspend) {
             return aroundLeaderSuspend(pjp, meta)
+        }
+
+        if (meta.isMono) {
+            return aroundLeaderMono(pjp, meta)
         }
 
         val opts = meta.options
@@ -167,6 +180,7 @@ class LeaderGroupElectionAspect(
 
     /**
      * suspend 메서드 처리 — [LeaderElectionAspect.aroundLeaderSuspend] 와 동일 패턴.
+     * 본문 실행 시 [LeaderElectionInfo] 를 `withContext` 로 주입.
      */
     private fun aroundLeaderSuspend(pjp: ProceedingJoinPoint, meta: GroupAdviceMetadata): Any? {
         @Suppress("UNCHECKED_CAST")
@@ -192,26 +206,28 @@ class LeaderGroupElectionAspect(
                         it.onLockAcquired(resolvedName, coreOpts, (System.nanoTime() - start).nanoseconds)
                         it.onTaskStarted(resolvedName)
                     }
-                    try {
-                        @Suppress("UNCHECKED_CAST")
-                        val bodyResult = suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
-                            val newArgs = pjp.args.copyOf()
-                            newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
-                            pjp.proceed(newArgs)
+                    withContext(LeaderElectionInfo(lockName = resolvedName, wasElected = true)) {
+                        try {
+                            @Suppress("UNCHECKED_CAST")
+                            val bodyResult = suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
+                                val newArgs = pjp.args.copyOf()
+                                newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
+                                pjp.proceed(newArgs)
+                            }
+                            val elapsed = System.nanoTime() - start
+                            fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
+                            if (elapsed > meta.leaseTimeWarnThresholdNanos) {
+                                log.warn { "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${meta.options.leaseTime.inWholeNanoseconds}" }
+                            }
+                            log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
+                            bodyResult
+                        } catch (ce: CancellationException) {
+                            fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, ce) }
+                            throw ce
+                        } catch (bodyEx: Throwable) {
+                            fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                            throw BodyThrownMarker(bodyEx)
                         }
-                        val elapsed = System.nanoTime() - start
-                        fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
-                        if (elapsed > meta.leaseTimeWarnThresholdNanos) {
-                            log.warn { "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${meta.options.leaseTime.inWholeNanoseconds}" }
-                        }
-                        log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
-                        bodyResult
-                    } catch (ce: CancellationException) {
-                        fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, ce) }
-                        throw ce
-                    } catch (bodyEx: Throwable) {
-                        fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, bodyEx) }
-                        throw BodyThrownMarker(bodyEx)
                     }
                 }
 
@@ -293,6 +309,116 @@ class LeaderGroupElectionAspect(
         return suspendBlock.startCoroutineUninterceptedOrReturn(continuation)
     }
 
+    /**
+     * `Mono` 반환 타입 메서드 처리 — `Mono.defer { mono { suspendElector.runIfLeader(...) } }` 패턴.
+     * [LeaderElectionInfo] 를 `withContext` 로 주입.
+     */
+    private fun aroundLeaderMono(pjp: ProceedingJoinPoint, meta: GroupAdviceMetadata): Any? {
+        val method = (pjp.signature as MethodSignature).method
+        val coreOpts = meta.options.toCoreOptions()
+
+        return Mono.defer {
+            val start = System.nanoTime()
+            mono {
+                var lockName: String? = null
+                try {
+                    val resolvedName = resolveLockName(meta, method, pjp.args, pjp.target)
+                    lockName = resolvedName
+                    val cacheKey = GroupFactoryCacheKey(meta.suspendElectorFactoryBeanName, meta.options)
+                    val elector = suspendElectorCache[cacheKey]
+                        ?: meta.suspendElectorFactory!!.create(meta.options)
+                            .also { suspendElectorCache.putIfAbsent(cacheKey, it) }
+
+                    fanOut { it.onLockAttempt(resolvedName, coreOpts) }
+
+                    val result = elector.runIfLeader(resolvedName) {
+                        fanOut {
+                            it.onLockAcquired(resolvedName, coreOpts, (System.nanoTime() - start).nanoseconds)
+                            it.onTaskStarted(resolvedName)
+                        }
+                        withContext(LeaderElectionInfo(lockName = resolvedName, wasElected = true)) {
+                            try {
+                                @Suppress("UNCHECKED_CAST")
+                                val bodyResult = (pjp.proceed() as Mono<*>).awaitSingleOrNull()
+                                val elapsed = System.nanoTime() - start
+                                fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
+                                if (elapsed > meta.leaseTimeWarnThresholdNanos) {
+                                    log.warn { "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${meta.options.leaseTime.inWholeNanoseconds}" }
+                                }
+                                log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
+                                bodyResult
+                            } catch (ce: CancellationException) {
+                                fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, ce) }
+                                throw ce
+                            } catch (bodyEx: Throwable) {
+                                fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                                throw BodyThrownMarker(bodyEx)
+                            }
+                        }
+                    }
+
+                    if (result == null) {
+                        if (meta.failureMode == LeaderAspectFailureMode.FAIL_OPEN_RUN) {
+                            fanOut {
+                                it.onLockNotAcquired(resolvedName, coreOpts, SkipReason.FAIL_OPEN_FORCED)
+                                it.onTaskStarted(resolvedName)
+                            }
+                            log.debug { "leader.aop.fail-open lockName=$resolvedName reason=CONTENTION" }
+                            @Suppress("UNCHECKED_CAST")
+                            val failOpenResult = (pjp.proceed() as Mono<*>).awaitSingleOrNull()
+                            fanOut { it.onTaskFinished(resolvedName, (System.nanoTime() - start).nanoseconds) }
+                            failOpenResult
+                        } else {
+                            fanOut { it.onLockNotAcquired(resolvedName, coreOpts, SkipReason.CONTENTION) }
+                            log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
+                            null
+                        }
+                    } else {
+                        result
+                    }
+                } catch (ce: CancellationException) {
+                    throw ce
+                } catch (bm: BodyThrownMarker) {
+                    throw bm.cause
+                } catch (backendEx: Throwable) {
+                    val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
+                    val wrapped = LeaderGroupElectionException("leader group backend error for lock '$effectiveName'", backendEx)
+                    when (meta.failureMode) {
+                        LeaderAspectFailureMode.INHERIT -> error("INHERIT must be resolved in resolveMetadata")
+                        LeaderAspectFailureMode.RETHROW -> {
+                            fanOut { it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.BACKEND_ERROR) }
+                            fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
+                            throw wrapped
+                        }
+                        LeaderAspectFailureMode.SKIP -> {
+                            fanOut { it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.BACKEND_ERROR) }
+                            fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
+                            log.warn(backendEx) { "leader.aop.skipped lockName=$effectiveName reason=BACKEND_ERROR" }
+                            null
+                        }
+                        LeaderAspectFailureMode.FAIL_OPEN_RUN -> {
+                            fanOut { it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.FAIL_OPEN_FORCED) }
+                            log.warn(backendEx) { "leader.aop.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
+                            fanOut { it.onTaskStarted(effectiveName) }
+                            try {
+                                @Suppress("UNCHECKED_CAST")
+                                val failOpenResult = (pjp.proceed() as Mono<*>).awaitSingleOrNull()
+                                fanOut { it.onTaskFinished(effectiveName, (System.nanoTime() - start).nanoseconds) }
+                                failOpenResult
+                            } catch (ce: CancellationException) {
+                                fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, ce) }
+                                throw ce
+                            } catch (bodyEx: Throwable) {
+                                fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                                throw bodyEx
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private fun executeBody(pjp: ProceedingJoinPoint, lockName: String, start: Long): Any? {
         return try {
             pjp.proceed()
@@ -305,12 +431,9 @@ class LeaderGroupElectionAspect(
         }
     }
 
-    /** Body throw vs backend throw 구분용 internal marker. */
     private class BodyThrownMarker(override val cause: Throwable) : RuntimeException(cause)
 
-    override fun afterSingletonsInstantiated() {
-        // BPP/Validator 가 별도 검증 — Aspect 는 캐시 워밍 미수행
-    }
+    override fun afterSingletonsInstantiated() {}
 
     private fun resolveLockName(
         meta: GroupAdviceMetadata,
@@ -352,7 +475,8 @@ class LeaderGroupElectionAspect(
         }
 
         val isSuspend = method.parameterTypes.lastOrNull() == Continuation::class.java
-        val (suspendElectorFactory, suspendElectorFactoryBeanName) = if (isSuspend) {
+        val isMono = !isSuspend && method.returnType.name == "reactor.core.publisher.Mono"
+        val (suspendElectorFactory, suspendElectorFactoryBeanName) = if (isSuspend || isMono) {
             val suspendSelected = beanSelector.selectSuspendGroupElectorFactory(ann.bean, method)
             suspendSelected.bean to suspendSelected.beanName
         } else {
@@ -368,6 +492,7 @@ class LeaderGroupElectionAspect(
             failureMode = effectiveFailureMode,
             leaseTimeWarnThresholdNanos = (leaseTime.inWholeNanoseconds * LEASE_WARN_RATIO).toLong(),
             isSuspend = isSuspend,
+            isMono = isMono,
             suspendElectorFactory = suspendElectorFactory,
             suspendElectorFactoryBeanName = suspendElectorFactoryBeanName,
         )
@@ -393,6 +518,7 @@ class LeaderGroupElectionAspect(
         val failureMode: LeaderAspectFailureMode,
         val leaseTimeWarnThresholdNanos: Long,
         val isSuspend: Boolean,
+        val isMono: Boolean,
         val suspendElectorFactory: SuspendLeaderGroupElectorFactory?,
         val suspendElectorFactoryBeanName: String,
     )

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessor.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessor.kt
@@ -19,7 +19,7 @@ import java.lang.reflect.Modifier
  * ## 검출 항목
  * - `final` / `private` 메서드 (proxy 적용 불가)
  * - `@LeaderGroupElection.maxLeaders` ≤ 1
- * - reactive 반환 (`Mono` / `Flux` / `Flow`) — sync only PR
+ * - reactive 반환 (`Flux` / `Flow`) — 미지원 (`Mono`는 #91 이후 지원)
  * - SpEL pre-parse 실패
  * - 같은 클래스에 어노테이션 부착 메서드 2+ (best-effort self-invocation WARN)
  *
@@ -87,11 +87,10 @@ class LeaderAnnotationValidatorBeanPostProcessor(
         if (Modifier.isPrivate(method.modifiers)) violations += "private method (proxy 적용 불가)"
 
         val returnTypeName = method.returnType.name
-        if (returnTypeName.endsWith(".Mono") ||
-            returnTypeName.endsWith(".Flux") ||
+        if (returnTypeName.endsWith(".Flux") ||
             returnTypeName == "kotlinx.coroutines.flow.Flow"
         ) {
-            violations += "$returnTypeName 반환 타입 (sync only PR — see #80)"
+            violations += "$returnTypeName 반환 타입 (미지원 — Mono는 #91 이후 지원, Flux/Flow 미지원)"
         }
 
         // [#84] composed 어노테이션(@AliasFor) 지원 — findMergedAnnotation 으로 합성 어노테이션 속성 해석

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessorTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessorTest.kt
@@ -153,13 +153,13 @@ class LeaderAnnotationValidatorBeanPostProcessorTest {
     }
 
     @Test
-    fun `Mono 반환 타입 strict true - startup fail`() {
+    fun `Mono 반환 타입 - 위반 없음 (#91 이후 지원)`() {
         class SampleMono {
             @LeaderElection(name = "mono-job")
             open fun process(): Mono<String> = Mono.just("ok")
         }
         val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = true, spel = spel)
-        assertFailsWith<IllegalStateException> { bpp.postProcessAfterInitialization(SampleMono(), "sample") }
+        assertNotFails { bpp.postProcessAfterInitialization(SampleMono(), "sample") }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #91
Closes #92

PR #133의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: Mono<T> 반환 타입 지원 + LeaderElectionInfo CoroutineContext 주입 (#91, #92)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 개요

Issue #91 + #92 를 하나의 PR로 통합 구현.

- **#91**: `LeaderElectionAspect` / `LeaderGroupElectionAspect` 에 `Mono<T>` 반환 타입 지원 추가
- **#92**: `LeaderElectionInfo` CoroutineContext.Element 추가 — suspend/Mono 분기에서 `withContext` 로 주입

---

## 변경 내역

### `leader-core`

- `LeaderElectionInfo.kt` 신규 — `CoroutineContext.Element` 구현체
  - `lockName: String`, `wasElected: Boolean` 필드
  - `companion object Key` 패턴

### `leader-spring-boot`

- `LeaderElectionAspect` / `LeaderGroupElectionAspect`
  - `aroundLeaderMono` 메서드 추가 — `Mono.defer { mono { elector.runIfLeader(...) } }` 패턴
  - `aroundLeaderSuspend` / `aroundLeaderMono` 본문 실행 시 `withContext(LeaderElectionInfo(...))` 주입
  - `AdviceMetadata` / `GroupAdviceMetadata` 에 `isMono: Boolean` 추가
  - `resolveMetadata`: `isMono` 감지 (`method.returnType.name.endsWith(".Mono")`) — ClassNotFoundException 회피
  - Mono 메서드도 `suspendElectorFactory` 경유 (코루틴 컨텍스트 공유)
- `build.gradle.kts`: `compileOnly(libs.kotlinx.coroutines.reactor)` 추가
- `gradle/libs.versions.toml`: `kotlinx-coroutines-reactor` 항목 추가
- `LeaderAnnotationValidatorBeanPostProcessor`: Mono 위반 체크 제거 (Flux/Flow만 미지원 유지)
- `LeaderAnnotationValidatorBeanPostProcessorTest`: Mono 케이스 `assertNotFails` 로 변경

---

## 테스트 결과

```
Module : :leader-spring-boot
Result : 169 passing
Time   : 1m 17s
```

---

## 검증 커맨드

```bash
./gradlew :leader-spring-boot:test
```

Closes #91
Closes #92
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #91, #92, milestone `0.1.0`, assignee `debop`
- PR: #133, head `530937887eadae656f01bee67a5b673e17f98ab5`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
