### PR TITLE
chore: CI paths-filter 적용 및 retry=3 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,6 +544,100 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 7
 
+  # ── leader-mongodb 테스트 (Testcontainers: MongoDB) ─────────────────────
+  test-mongodb:
+    name: Test / leader-mongodb
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['leader-mongodb'] == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Test leader-mongodb
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-mongodb:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+      - name: Generate Kover XML report
+        if: always()
+        run: ./gradlew :leader-mongodb:koverXmlReport --no-daemon
+        continue-on-error: true
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-mongodb
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 7
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-mongodb
+          path: '**/build/reports/kover/'
+          retention-days: 7
+
+  # ── leader-hazelcast 테스트 (Testcontainers: Hazelcast) ──────────────────
+  test-hazelcast:
+    name: Test / leader-hazelcast
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['leader-hazelcast'] == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Test leader-hazelcast
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-hazelcast:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+      - name: Generate Kover XML report
+        if: always()
+        run: ./gradlew :leader-hazelcast:koverXmlReport --no-daemon
+        continue-on-error: true
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-hazelcast
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 7
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-hazelcast
+          path: '**/build/reports/kover/'
+          retention-days: 7
+
   # ── 10. Coverage 집계 ─────────────────────────────────────────────────────
   coverage-report:
     name: Coverage Report
@@ -558,6 +652,8 @@ jobs:
       - test-exposed-jdbc-postgresql
       - test-exposed-jdbc-mysql
       - test-spring-boot
+      - test-mongodb
+      - test-hazelcast
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -599,6 +695,8 @@ jobs:
       - test-exposed-jdbc-postgresql
       - test-exposed-jdbc-mysql
       - test-spring-boot
+      - test-mongodb
+      - test-hazelcast
       - coverage-report
     if: always()
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,8 +259,9 @@ jobs:
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
         env:
-          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
 
       - name: Generate Kover XML report
         if: always()
@@ -311,8 +312,9 @@ jobs:
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
         env:
-          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
 
       - name: Generate Kover XML report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 permissions:
   contents: read
+  actions: read
+  checks: read
+  statuses: read
+  packages: read
 
 on:
   workflow_dispatch:
@@ -69,7 +73,45 @@ jobs:
       - uses: actions/checkout@v4
       - uses: gradle/actions/wrapper-validation@v4
 
-  # ── 2. 전체 빌드 (테스트 제외) ───────────────────────────────────────────
+  # ── 2. 변경된 모듈 감지 ──────────────────────────────────────────────────
+  changes:
+    name: Detect changed modules
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: validate-wrapper
+    outputs:
+      leader-core: ${{ steps.filter.outputs.leader-core }}
+      leader-redis: ${{ steps.filter.outputs.leader-redis }}
+      leader-exposed: ${{ steps.filter.outputs.leader-exposed }}
+      leader-mongodb: ${{ steps.filter.outputs.leader-mongodb }}
+      leader-hazelcast: ${{ steps.filter.outputs.leader-hazelcast }}
+      leader-spring-boot: ${{ steps.filter.outputs.leader-spring-boot }}
+      leader-micrometer: ${{ steps.filter.outputs.leader-micrometer }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            leader-core:
+              - 'leader-core/**'
+            leader-redis:
+              - 'leader-redis-lettuce/**'
+              - 'leader-redis-redisson/**'
+            leader-exposed:
+              - 'leader-exposed-core/**'
+              - 'leader-exposed-jdbc/**'
+              - 'leader-exposed-r2dbc/**'
+            leader-mongodb:
+              - 'leader-mongodb/**'
+            leader-hazelcast:
+              - 'leader-hazelcast/**'
+            leader-spring-boot:
+              - 'leader-spring-boot/**'
+            leader-micrometer:
+              - 'leader-micrometer/**'
+
+  # ── 3. 전체 빌드 (테스트 제외) ───────────────────────────────────────────
   build:
     name: Build (compile only)
     runs-on: ubuntu-latest
@@ -93,12 +135,13 @@ jobs:
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
-  # ── 3. leader-core 테스트 (Docker 불필요) ────────────────────────────────
+  # ── 4. leader-core 테스트 (Docker 불필요) ────────────────────────────────
   test-core:
     name: Test / leader-core
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['leader-core'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -113,7 +156,12 @@ jobs:
           cache-read-only: true
 
       - name: Test leader-core
-        run: ./gradlew :leader-core:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-core:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
@@ -143,7 +191,8 @@ jobs:
     name: Test / leader-micrometer
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['leader-micrometer'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -155,7 +204,12 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
       - name: Test leader-micrometer
-        run: ./gradlew :leader-micrometer:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-micrometer:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       - name: Generate Kover XML report
@@ -177,12 +231,13 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 7
 
-  # ── 4. leader-redis-lettuce 테스트 (Testcontainers) ─────────────────────
+  # ── 5. leader-redis-lettuce 테스트 (Testcontainers) ─────────────────────
   test-redis-lettuce:
     name: Test / leader-redis-lettuce
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['leader-redis'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -197,7 +252,12 @@ jobs:
           cache-read-only: true
 
       - name: Test leader-redis-lettuce
-        run: ./gradlew :leader-redis-lettuce:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-redis-lettuce:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
@@ -223,12 +283,13 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 7
 
-  # ── 5. leader-redis-redisson 테스트 (Testcontainers) ────────────────────
+  # ── 6. leader-redis-redisson 테스트 (Testcontainers) ────────────────────
   test-redis-redisson:
     name: Test / leader-redis-redisson
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['leader-redis'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -243,7 +304,12 @@ jobs:
           cache-read-only: true
 
       - name: Test leader-redis-redisson
-        run: ./gradlew :leader-redis-redisson:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-redis-redisson:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
@@ -269,12 +335,13 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 7
 
-  # ── 6. leader-exposed-jdbc 테스트 (H2 in-memory) ──────────────────────────
+  # ── 7. leader-exposed-jdbc 테스트 (H2 in-memory) ──────────────────────────
   test-exposed-jdbc-h2:
     name: Test / leader-exposed-jdbc (H2)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['leader-exposed'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -289,7 +356,12 @@ jobs:
           cache-read-only: true
 
       - name: Test leader-exposed-jdbc (H2)
-        run: ./gradlew :leader-exposed-jdbc:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-exposed-jdbc:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           LEADER_TEST_DB: "H2"
@@ -315,12 +387,13 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 7
 
-  # ── 7. leader-exposed-jdbc 테스트 (PostgreSQL, Testcontainers) ────────────
+  # ── 8. leader-exposed-jdbc 테스트 (PostgreSQL, Testcontainers) ────────────
   test-exposed-jdbc-postgresql:
     name: Test / leader-exposed-jdbc (PostgreSQL)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['leader-exposed'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -335,7 +408,12 @@ jobs:
           cache-read-only: true
 
       - name: Test leader-exposed-jdbc (PostgreSQL)
-        run: ./gradlew :leader-exposed-jdbc:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-exposed-jdbc:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
@@ -363,12 +441,13 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 7
 
-  # ── 8. leader-exposed-jdbc 테스트 (MySQL 8, Testcontainers) ──────────────
+  # ── 9. leader-exposed-jdbc 테스트 (MySQL 8, Testcontainers) ──────────────
   test-exposed-jdbc-mysql:
     name: Test / leader-exposed-jdbc (MySQL 8)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['leader-exposed'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -383,7 +462,12 @@ jobs:
           cache-read-only: true
 
       - name: Test leader-exposed-jdbc (MySQL 8)
-        run: ./gradlew :leader-exposed-jdbc:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-exposed-jdbc:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
@@ -416,7 +500,8 @@ jobs:
     name: Test / leader-spring-boot (Testcontainers)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['leader-spring-boot'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -428,7 +513,12 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
       - name: Test leader-spring-boot
-        run: ./gradlew :leader-spring-boot:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-spring-boot:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: '-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false'
           TESTCONTAINERS_RYUK_DISABLED: 'true'
@@ -452,7 +542,7 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 7
 
-  # ── 9. Coverage 집계 ─────────────────────────────────────────────────────
+  # ── 10. Coverage 집계 ─────────────────────────────────────────────────────
   coverage-report:
     name: Coverage Report
     runs-on: ubuntu-latest
@@ -490,7 +580,7 @@ jobs:
           path: coverage-artifacts/
           retention-days: 14
 
-  # ── 10. 결과 집계 ─────────────────────────────────────────────────────────
+  # ── 11. 결과 집계 ─────────────────────────────────────────────────────────
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
@@ -498,6 +588,7 @@ jobs:
     needs:
       - gitleaks
       - build
+      - changes
       - test-core
       - test-micrometer
       - test-redis-lettuce
@@ -518,4 +609,4 @@ jobs:
             echo "CI failed"
             exit 1
           fi
-          echo "CI passed"
+          echo "CI passed (skipped jobs treated as success)"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,7 +73,12 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
       - name: Test leader-core
-        run: ./gradlew :leader-core:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-core:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       - name: Generate Kover XML report
@@ -112,7 +117,12 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
       - name: Test leader-redis-lettuce
-        run: ./gradlew :leader-redis-lettuce:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-redis-lettuce:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
@@ -153,7 +163,12 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
       - name: Test leader-redis-redisson
-        run: ./gradlew :leader-redis-redisson:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-redis-redisson:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
@@ -194,7 +209,12 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
       - name: Test leader-exposed-core (H2)
-        run: ./gradlew :leader-exposed-core:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-exposed-core:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           LEADER_TEST_DB: "H2"
@@ -234,7 +254,12 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
       - name: Test leader-exposed-core (PostgreSQL)
-        run: ./gradlew :leader-exposed-core:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-exposed-core:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
@@ -276,7 +301,12 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
       - name: Test leader-exposed-core (MySQL 8)
-        run: ./gradlew :leader-exposed-core:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-exposed-core:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
@@ -318,7 +348,12 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
       - name: Test leader-exposed-jdbc (H2)
-        run: ./gradlew :leader-exposed-jdbc:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-exposed-jdbc:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           LEADER_TEST_DB: "H2"
@@ -358,7 +393,12 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
       - name: Test leader-exposed-jdbc (PostgreSQL)
-        run: ./gradlew :leader-exposed-jdbc:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-exposed-jdbc:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
@@ -400,7 +440,12 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
       - name: Test leader-exposed-jdbc (MySQL 8)
-        run: ./gradlew :leader-exposed-jdbc:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-exposed-jdbc:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
@@ -442,7 +487,12 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
       - name: Test leader-mongodb
-        run: ./gradlew :leader-mongodb:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-mongodb:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
@@ -483,7 +533,12 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
       - name: Test leader-hazelcast
-        run: ./gradlew :leader-hazelcast:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-hazelcast:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
@@ -524,7 +579,12 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
       - name: Test leader-micrometer
-        run: ./gradlew :leader-micrometer:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-micrometer:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       - name: Generate Kover XML report
@@ -563,7 +623,12 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
       - name: Test leader-spring-boot
-        run: ./gradlew :leader-spring-boot:test --no-daemon
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-spring-boot:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
         env:
           GRADLE_OPTS: '-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false'
           TESTCONTAINERS_RYUK_DISABLED: 'true'


### PR DESCRIPTION
## Summary

Closes #134

PR #135의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `chore: CI paths-filter 적용 및 retry=3 추가`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 변경 내용

Closes #134

### ci.yml
- `permissions` 블록 확장 (actions/checks/statuses/packages read 추가)
- `changes` job 추가 (dorny/paths-filter@v3): 변경된 모듈만 test job 실행
  - `leader-core`, `leader-redis` (lettuce+redisson), `leader-exposed` (core+jdbc+r2dbc), `leader-mongodb`, `leader-hazelcast`, `leader-spring-boot`, `leader-micrometer`
- 모든 test job (8개): `needs: [build, changes]` + `if: needs.changes.outputs['<key>'] == 'true' || github.event_name == 'workflow_dispatch'`
- 모든 test job `run:` 명령을 bash retry loop (3회, 실패 시 10초 대기)로 감싸기
- `ci-status` job: `changes` needs 추가, 메시지 업데이트 (skipped = success)

### nightly.yml
- 변경 없음 (항상 전체 테스트 실행)
- 모든 test job (13개) `run:` 명령을 bash retry loop (3회, 실패 시 10초 대기)로 감싸기

### 검증
- ci.yml: 8개 test job 모두 if 조건 + retry 적용 확인
- nightly.yml: 13개 test job 모두 retry 적용 확인
- `workflow_dispatch` 트리거 시 paths-filter 우회 → 전체 실행 보장
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #134, milestone `0.1.0`, assignee `debop`
- PR: #135, head `ba8c04823ab5815bbb731a587bb5db2e43edcad0`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
