### PR TITLE
docs: close module README drift

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -169,6 +169,12 @@ val options = LeaderElectionOptions(
 val election = RedissonLeaderElector(client, options)
 ```
 
+### 마이그레이션 노트
+
+- Kotlin API option은 `kotlin.time.Duration`을 사용합니다. `java.time.Duration.ofSeconds(...)` 대신 `5.seconds`, `60.seconds`, `1.minutes`를 사용하세요.
+- Spring Boot YAML은 계속 Spring duration binding을 사용합니다 (`5s`, `60s`, `PT1M`).
+- Spring bean 이름은 `LeaderElector` 용어를 사용합니다. `redissonLeaderElectionFactory`, `lettuceSuspendLeaderElectorFactory` 같은 이름을 우선 사용하세요.
+
 ### 로컬 방식 (인메모리, Redis 불필요)
 
 ```kotlin
@@ -379,8 +385,8 @@ class ReportService {
 
 | 값 | 동작 |
 |----|------|
-| `SKIP` (기본값) | `null` 반환 — 본문 미실행 |
-| `RETHROW` | 백엔드 오류를 `LeaderElectionException`으로 감싸 throw |
+| `RETHROW` (기본값) | 백엔드 오류를 `LeaderElectionException`으로 감싸 throw |
+| `SKIP` | `null` 반환 — 본문 미실행 |
 | `FAIL_OPEN_RUN` | 락 없이 본문을 실행하여 결과 반환 |
 
 `FAIL_OPEN_RUN`은 스킵보다 실행이 안전한 경우(예: 멱등성이 보장된 태스크)에 적합합니다. 메트릭에 `SkipReason.FAIL_OPEN_FORCED`가 기록되어 락 없이 실행된 횟수를 대시보드에서 별도 추적할 수 있습니다.
@@ -391,7 +397,7 @@ class ReportService {
 bluetape4k:
   leader:
     aop:
-      default-failure-mode: FAIL_OPEN_RUN   # SKIP | RETHROW | FAIL_OPEN_RUN
+      failure-mode: FAIL_OPEN_RUN   # RETHROW | SKIP | FAIL_OPEN_RUN
 ```
 
 ---
@@ -474,15 +480,15 @@ class MetricsPreRegistrar(private val recorder: MicrometerLeaderAopMetricsRecord
 
 ### Health Indicator
 
-`spring-boot-actuator`가 classpath에 있으면 `leaderMicrometerHealthContributor` 빈이 자동 등록됩니다:
+`spring-boot-actuator`가 classpath에 있으면 `leaderMetricsHealthIndicator` 빈이 자동 등록됩니다:
 
 ```
-GET /actuator/health/leaderMicrometerHealthContributor
+GET /actuator/health/leaderMetricsHealthIndicator
 {
   "status": "UP",
   "details": {
-    "metrics.registered": true,
-    "attempts.total": 42.0
+    "active": 0,
+    "trackedLocks": 2
   }
 }
 ```
@@ -508,10 +514,11 @@ fun myRecorder(): LeaderAopMetricsRecorder = MyCustomRecorder()
 | 복수 리더 그룹 | `LeaderGroupElector` | 미지원 |
 | Redis (Lettuce) | 지원 | 지원 |
 | Redis (Redisson) | 지원 | 지원 |
-| Spring 연동 | 예정 | 지원 (핵심 기능) |
+| Spring 연동 | 지원 (Boot 4 + AspectJ CTW) | 지원 (핵심 기능) |
 | JDBC/SQL | 지원 (Exposed JDBC) | 지원 |
-| MongoDB | 예정 | 지원 |
+| MongoDB | 지원 | 지원 |
 | Hazelcast | 지원 | 지원 |
+| ZooKeeper | 지원 | 미지원 |
 
 ## 요구사항
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ val options = LeaderElectionOptions(
 val election = RedissonLeaderElector(client, options)
 ```
 
+### Migration notes
+
+- Kotlin API options use `kotlin.time.Duration`. Prefer `5.seconds`, `60.seconds`, `1.minutes` over `java.time.Duration.ofSeconds(...)`.
+- Spring Boot YAML still uses Spring's duration binding (`5s`, `60s`, `PT1M`).
+- Spring bean names use `LeaderElector` terminology. Prefer `redissonLeaderElectionFactory`, `lettuceSuspendLeaderElectorFactory`, and similar names.
+
 ### Local (in-process, no Redis)
 
 ```kotlin
@@ -377,8 +383,8 @@ Controls what happens when the lock is **not** acquired (contention or backend e
 
 | Value | Behaviour |
 |-------|-----------|
-| `SKIP` (default) | Return `null` — body is not executed |
-| `RETHROW` | Throw `LeaderElectionException` wrapping the backend error |
+| `RETHROW` (default) | Throw `LeaderElectionException` wrapping the backend error |
+| `SKIP` | Return `null` — body is not executed |
 | `FAIL_OPEN_RUN` | Run the method body anyway and return its result |
 
 `FAIL_OPEN_RUN` is designed for jobs where skipping is worse than running without the distributed lock guarantee (e.g., best-effort idempotent tasks). Metrics record `SkipReason.FAIL_OPEN_FORCED` so dashboards can track lock-free executions separately.
@@ -389,7 +395,7 @@ Controls what happens when the lock is **not** acquired (contention or backend e
 bluetape4k:
   leader:
     aop:
-      default-failure-mode: FAIL_OPEN_RUN   # SKIP | RETHROW | FAIL_OPEN_RUN
+      failure-mode: FAIL_OPEN_RUN   # RETHROW | SKIP | FAIL_OPEN_RUN
 ```
 
 ---
@@ -472,15 +478,15 @@ class MetricsPreRegistrar(private val recorder: MicrometerLeaderAopMetricsRecord
 
 ### Health Indicator
 
-When `spring-boot-actuator` is on the classpath, a `leaderMicrometerHealthContributor` bean is registered automatically:
+When `spring-boot-actuator` is on the classpath, a `leaderMetricsHealthIndicator` bean is registered automatically:
 
 ```
-GET /actuator/health/leaderMicrometerHealthContributor
+GET /actuator/health/leaderMetricsHealthIndicator
 {
   "status": "UP",
   "details": {
-    "metrics.registered": true,
-    "attempts.total": 42.0
+    "active": 0,
+    "trackedLocks": 2
   }
 }
 ```
@@ -506,10 +512,11 @@ fun myRecorder(): LeaderAopMetricsRecorder = MyCustomRecorder()
 | Multi-leader (group) | `LeaderGroupElector` | No |
 | Redis (Lettuce) | Yes | Yes |
 | Redis (Redisson) | Yes | Yes |
-| Spring integration | Planned | Yes (core feature) |
+| Spring integration | Yes (Boot 4 + AspectJ CTW) | Yes (core feature) |
 | JDBC/SQL | Yes (Exposed JDBC) | Yes |
-| MongoDB | Planned | Yes |
+| MongoDB | Yes | Yes |
 | Hazelcast | Yes | Yes |
+| ZooKeeper | Yes | No |
 
 ## Requirements
 

--- a/WIP.md
+++ b/WIP.md
@@ -43,6 +43,7 @@
 | [#80](https://github.com/bluetape4k/bluetape4k-leader/issues/80)/[#88-#92](https://github.com/bluetape4k/bluetape4k-leader/issues?q=88+89+90+91+92) | leader-aop suspend / Mono / context propagation 지원 | ✅ 완료 | [#120](https://github.com/bluetape4k/bluetape4k-leader/pull/120)/[#122](https://github.com/bluetape4k/bluetape4k-leader/pull/122)/[#132](https://github.com/bluetape4k/bluetape4k-leader/pull/132)/[#133](https://github.com/bluetape4k/bluetape4k-leader/pull/133) merged |
 | [#10](https://github.com/bluetape4k/bluetape4k-leader/issues/10)/[#136](https://github.com/bluetape4k/bluetape4k-leader/pull/136) | leader-micrometer 독립 모듈 / instrumented elector | ✅ 완료 | [#136](https://github.com/bluetape4k/bluetape4k-leader/pull/136) merged |
 | [#115](https://github.com/bluetape4k/bluetape4k-leader/issues/115) | docs: README rename drift — *Election → *Elector | ✅ 완료 | [#123](https://github.com/bluetape4k/bluetape4k-leader/pull/123) merged |
+| [#129](https://github.com/bluetape4k/bluetape4k-leader/issues/129) | docs: leader-spring-boot, leader-micrometer README 부재 + 마이그레이션 문서 | ✅ 완료 | [#143](https://github.com/bluetape4k/bluetape4k-leader/pull/143) merged |
 | [#128](https://github.com/bluetape4k/bluetape4k-leader/issues/128) | fix: Hazelcast suspend elector CancellationException 재전파 | ✅ 완료 | [#138](https://github.com/bluetape4k/bluetape4k-leader/pull/138) merged |
 | [#34](https://github.com/bluetape4k/bluetape4k-leader/issues/34) | feat: leader-zookeeper (Apache Curator 기반) | ✅ 완료 | [#138](https://github.com/bluetape4k/bluetape4k-leader/pull/138) merged |
 
@@ -58,6 +59,18 @@
 | [#76](https://github.com/bluetape4k/bluetape4k-leader/issues/76) | 닫음 | [#105](https://github.com/bluetape4k/bluetape4k-leader/pull/105) |
 | [#80](https://github.com/bluetape4k/bluetape4k-leader/issues/80) | 닫음 | [#120](https://github.com/bluetape4k/bluetape4k-leader/pull/120), [#122](https://github.com/bluetape4k/bluetape4k-leader/pull/122), [#132](https://github.com/bluetape4k/bluetape4k-leader/pull/132), [#133](https://github.com/bluetape4k/bluetape4k-leader/pull/133) |
 | [#115](https://github.com/bluetape4k/bluetape4k-leader/issues/115) | 닫음 | [#123](https://github.com/bluetape4k/bluetape4k-leader/pull/123) |
+
+## 남은 이슈 우선순위 (2026-05-09)
+
+| 우선순위 | 이슈 | 이유 | 상태 |
+|----------|------|------|------|
+| P0 | [#129](https://github.com/bluetape4k/bluetape4k-leader/issues/129) | 새 핵심 모듈 README 부재 + Duration/Bean rename 문서 drift | ✅ 완료 - [#143](https://github.com/bluetape4k/bluetape4k-leader/pull/143) |
+| P1 | [#137](https://github.com/bluetape4k/bluetape4k-leader/issues/137) | Prometheus export 검증은 metrics 완성도와 운영 가시성에 직접 영향 | 다음 작업 |
+| P2 | [#40](https://github.com/bluetape4k/bluetape4k-leader/issues/40) | 이벤트 리스너는 metrics, audit, 상태 전파의 공통 확장 지점 | 대기 |
+| P3 | [#68](https://github.com/bluetape4k/bluetape4k-leader/issues/68) | leader 상태 API는 운영/metrics/audit 확장의 기반 | 대기 |
+| P4 | [#73](https://github.com/bluetape4k/bluetape4k-leader/issues/73), [#74](https://github.com/bluetape4k/bluetape4k-leader/issues/74), [#77](https://github.com/bluetape4k/bluetape4k-leader/issues/77), [#79](https://github.com/bluetape4k/bluetape4k-leader/issues/79), [#38](https://github.com/bluetape4k/bluetape4k-leader/issues/38) | lease renewal / lockAtLeastFor / explicit extend는 같은 lease semantics 축 | 대기 |
+| P5 | [#37](https://github.com/bluetape4k/bluetape4k-leader/issues/37), [#36](https://github.com/bluetape4k/bluetape4k-leader/issues/36) | Ktor 통합과 examples는 core API 안정 후 적용 | 대기 |
+| P6 | [#42](https://github.com/bluetape4k/bluetape4k-leader/issues/42), [#50](https://github.com/bluetape4k/bluetape4k-leader/issues/50), [#72](https://github.com/bluetape4k/bluetape4k-leader/issues/72), [#39](https://github.com/bluetape4k/bluetape4k-leader/issues/39) | API/스토리지 설계 영향이 커서 별도 design pass 필요 | 대기 |
 
 ## 이슈 의존 관계
 
@@ -85,7 +98,6 @@
 
 백로그 (낮은 우선순위):
   #137 (leader-micrometer Prometheus export 검증/연동)
-  #129 (leader-spring-boot, leader-micrometer README 부재 + 마이그레이션 문서)
   #40 (이벤트 리스너) → #75 이후 자연스럽게 연동 가능
   #68 (Election 상태 조회 API)
   #72 (LeaderGroup leaderId 지원)
@@ -146,7 +158,6 @@
 | 이슈 | 제목 | 비고 |
 |------|------|------|
 | #137 | leader-micrometer Prometheus export 검증/연동 | `bluetape4k-micrometer`, `bluetape4k-testcontainers` PrometheusServer 활용 검토 |
-| #129 | leader-spring-boot, leader-micrometer 모듈 README 부재 + Duration/Bean 리네이밍 미반영 | 실제 README 부재 확인 — 닫지 않음 |
 | #40 | 리더 이벤트 리스너 (onElected / onRevoked) | #75 이후 자연 연동 |
 | #68 | Election 상태 조회 API (시작 시각, 남은 slot 등) | #41 이후 |
 | #72 | @LeaderGroupElection leaderId 지원 (Group API 변경) | 파괴적 변경 — 별도 마이너 |

--- a/leader-core/README.ko.md
+++ b/leader-core/README.ko.md
@@ -66,14 +66,14 @@ classDiagram
 
 ```kotlin
 LeaderElectionOptions(
-    waitTime: Duration = Duration.ofSeconds(5),   // 락 획득 최대 대기 시간
-    leaseTime: Duration = Duration.ofSeconds(60)  // 락 보유(임대) 최대 시간
+    waitTime: Duration = 5.seconds,   // 락 획득 최대 대기 시간
+    leaseTime: Duration = 60.seconds  // 락 보유(임대) 최대 시간
 )
 
 LeaderGroupElectionOptions(
     maxLeaders: Int = 2,                          // 최대 동시 리더 수
-    waitTime: Duration = Duration.ofSeconds(5),
-    leaseTime: Duration = Duration.ofSeconds(60)
+    waitTime: Duration = 5.seconds,
+    leaseTime: Duration = 60.seconds
 )
 ```
 

--- a/leader-core/README.md
+++ b/leader-core/README.md
@@ -66,14 +66,14 @@ classDiagram
 
 ```kotlin
 LeaderElectionOptions(
-    waitTime: Duration = Duration.ofSeconds(5),   // max wait for lock acquisition
-    leaseTime: Duration = Duration.ofSeconds(60)  // max lock hold time
+    waitTime: Duration = 5.seconds,   // max wait for lock acquisition
+    leaseTime: Duration = 60.seconds  // max lock hold time
 )
 
 LeaderGroupElectionOptions(
     maxLeaders: Int = 2,                          // max concurrent leaders
-    waitTime: Duration = Duration.ofSeconds(5),
-    leaseTime: Duration = Duration.ofSeconds(60)
+    waitTime: Duration = 5.seconds,
+    leaseTime: Duration = 60.seconds
 )
 ```
 

--- a/leader-exposed-jdbc/README.ko.md
+++ b/leader-exposed-jdbc/README.ko.md
@@ -141,8 +141,8 @@ val result2 = db.runVirtualIfLeader("nightly-sync") { syncData() }
 ```kotlin
 val options = ExposedJdbcLeaderElectionOptions(
     leaderOptions = LeaderElectionOptions(
-        waitTime = Duration.ofSeconds(5),
-        leaseTime = Duration.ofMinutes(1)
+        waitTime = 5.seconds,
+        leaseTime = 1.minutes
     ),
     retryStrategy = RetryStrategy.Jitter(baseDelayMs = 50),
     recordHistory = true,

--- a/leader-exposed-jdbc/README.md
+++ b/leader-exposed-jdbc/README.md
@@ -141,8 +141,8 @@ val result2 = db.runVirtualIfLeader("nightly-sync") { syncData() }
 ```kotlin
 val options = ExposedJdbcLeaderElectionOptions(
     leaderOptions = LeaderElectionOptions(
-        waitTime = Duration.ofSeconds(5),
-        leaseTime = Duration.ofMinutes(1)
+        waitTime = 5.seconds,
+        leaseTime = 1.minutes
     ),
     retryStrategy = RetryStrategy.Jitter(baseDelayMs = 50),
     recordHistory = true,

--- a/leader-exposed-r2dbc/README.ko.md
+++ b/leader-exposed-r2dbc/README.ko.md
@@ -129,8 +129,8 @@ val result = db.suspendRunIfLeaderGroup("worker-pool") {
 ```kotlin
 val options = ExposedR2dbcLeaderElectionOptions(
     leaderOptions = LeaderElectionOptions(
-        waitTime = Duration.ofSeconds(3),
-        leaseTime = Duration.ofSeconds(30),
+        waitTime = 3.seconds,
+        leaseTime = 30.seconds,
     ),
     retryStrategy = RetryStrategy.Jitter(baseDelayMs = 50L),
     recordHistory = true,

--- a/leader-exposed-r2dbc/README.md
+++ b/leader-exposed-r2dbc/README.md
@@ -129,8 +129,8 @@ val result = db.suspendRunIfLeaderGroup("worker-pool") {
 ```kotlin
 val options = ExposedR2dbcLeaderElectionOptions(
     leaderOptions = LeaderElectionOptions(
-        waitTime = Duration.ofSeconds(3),
-        leaseTime = Duration.ofSeconds(30),
+        waitTime = 3.seconds,
+        leaseTime = 30.seconds,
     ),
     retryStrategy = RetryStrategy.Jitter(baseDelayMs = 50L),
     recordHistory = true,

--- a/leader-hazelcast/README.ko.md
+++ b/leader-hazelcast/README.ko.md
@@ -57,6 +57,8 @@ classDiagram
 | `HazelcastLeaderGroupElector` | `LeaderGroupElector` | 블로킹 + 비동기 복수 리더 (슬롯 기반) |
 | `HazelcastSuspendLeaderElector` | `SuspendLeaderElector` | 코루틴 단일 리더 |
 | `HazelcastSuspendLeaderGroupElector` | `SuspendLeaderGroupElector` | 코루틴 복수 리더 (슬롯 기반) |
+| `HazelcastLeaderElectorFactory` | `LeaderElectorFactory` | 팩토리: 호출마다 `HazelcastLeaderElector` 생성 |
+| `HazelcastLeaderGroupElectorFactory` | `LeaderGroupElectorFactory` | 팩토리: 호출마다 `HazelcastLeaderGroupElector` 생성 |
 
 ## 사용법
 
@@ -143,10 +145,20 @@ hazelcast.suspendRunIfLeaderGroup("job", options) { doWork() }
 
 ```kotlin
 val options = LeaderElectionOptions(
-    waitTime = Duration.ofSeconds(3),
-    leaseTime = Duration.ofSeconds(60)
+    waitTime = 3.seconds,
+    leaseTime = 60.seconds
 )
 val election = HazelcastLeaderElector(hazelcast, options)
+```
+
+### Factory 사용
+
+```kotlin
+val factory: LeaderElectorFactory = HazelcastLeaderElectorFactory(hazelcast)
+val election = factory.create(LeaderElectionOptions.Default)
+
+val groupFactory: LeaderGroupElectorFactory = HazelcastLeaderGroupElectorFactory(hazelcast)
+val groupElection = groupFactory.create(LeaderGroupElectionOptions(maxLeaders = 3))
 ```
 
 ## 락 내부 구현

--- a/leader-hazelcast/README.md
+++ b/leader-hazelcast/README.md
@@ -55,6 +55,8 @@ classDiagram
 | `HazelcastLeaderGroupElector` | `LeaderGroupElector` | Blocking + async multi-leader (slot-based) |
 | `HazelcastSuspendLeaderElector` | `SuspendLeaderElector` | Coroutine single-leader |
 | `HazelcastSuspendLeaderGroupElector` | `SuspendLeaderGroupElector` | Coroutine multi-leader (slot-based) |
+| `HazelcastLeaderElectorFactory` | `LeaderElectorFactory` | Factory: creates `HazelcastLeaderElector` per call |
+| `HazelcastLeaderGroupElectorFactory` | `LeaderGroupElectorFactory` | Factory: creates `HazelcastLeaderGroupElector` per call |
 
 ## Usage
 
@@ -141,10 +143,20 @@ hazelcast.suspendRunIfLeaderGroup("job", options) { doWork() }
 
 ```kotlin
 val options = LeaderElectionOptions(
-    waitTime = Duration.ofSeconds(3),
-    leaseTime = Duration.ofSeconds(60)
+    waitTime = 3.seconds,
+    leaseTime = 60.seconds
 )
 val election = HazelcastLeaderElector(hazelcast, options)
+```
+
+### Using factories
+
+```kotlin
+val factory: LeaderElectorFactory = HazelcastLeaderElectorFactory(hazelcast)
+val election = factory.create(LeaderElectionOptions.Default)
+
+val groupFactory: LeaderGroupElectorFactory = HazelcastLeaderGroupElectorFactory(hazelcast)
+val groupElection = groupFactory.create(LeaderGroupElectionOptions(maxLeaders = 3))
 ```
 
 ## Lock Internals

--- a/leader-micrometer/README.ko.md
+++ b/leader-micrometer/README.ko.md
@@ -1,0 +1,195 @@
+# leader-micrometer
+
+[English](README.md)
+
+bluetape4k leader election을 위한 Micrometer 계측 모듈입니다.
+
+---
+
+## 개요
+
+`leader-micrometer`는 두 가지 계측 경로를 제공합니다.
+
+- `leader-spring-boot`의 어노테이션 AOP를 위한 `MicrometerLeaderAopMetricsRecorder`
+- elector를 직접 호출할 때 사용하는 `InstrumentedLeaderElector`, `InstrumentedLeaderGroupElector`, `InstrumentedSuspendLeaderElector` 데코레이터
+
+이 모듈은 `leader-core`와 Micrometer core에만 의존합니다. Prometheus, Datadog, OTLP 같은 export 형식은 애플리케이션이 선택한 Micrometer registry가 결정합니다.
+
+## 아키텍처
+
+```mermaid
+graph TD
+    Aop["@LeaderElection<br/>@LeaderGroupElection"]
+    Recorder["MicrometerLeaderAopMetricsRecorder"]
+    Direct["직접 elector 호출"]
+    Decorators["Instrumented*Elector decorators"]
+    Registry["MeterRegistry"]
+    Backend["Prometheus / Datadog / OTLP"]
+
+    Aop --> Recorder
+    Direct --> Decorators
+    Recorder --> Registry
+    Decorators --> Registry
+    Registry --> Backend
+```
+
+## 의존성
+
+```kotlin
+implementation("io.github.bluetape4k.leader:leader-micrometer:0.1.0-SNAPSHOT")
+
+// 애플리케이션에서 사용할 registry를 선택합니다.
+implementation("io.micrometer:micrometer-registry-prometheus")
+```
+
+Spring Boot AOP 메트릭을 사용할 때:
+
+```kotlin
+implementation("io.github.bluetape4k.leader:leader-spring-boot:0.1.0-SNAPSHOT")
+implementation("org.springframework.boot:spring-boot-starter-actuator")
+```
+
+## Spring AOP 메트릭
+
+`leader-spring-boot`, `leader-micrometer`, `MeterRegistry` bean이 함께 있으면 Spring 자동 구성이 `MicrometerLeaderAopMetricsRecorder`를 등록합니다.
+
+```yaml
+bluetape4k:
+  leader:
+    aop:
+      metrics:
+        enabled: true
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus
+```
+
+```kotlin
+@Service
+class ReportJobs {
+    @LeaderElection(name = "daily-report")
+    fun generate(): Report? =
+        reportService.generate()
+}
+```
+
+## 직접 Elector 메트릭
+
+elector를 직접 호출한다면 데코레이터를 사용합니다.
+
+```kotlin
+val delegate = RedissonLeaderElector(redisson)
+val election = InstrumentedLeaderElector(delegate, registry)
+
+val result = election.runIfLeader("daily-report") {
+    reportService.generate()
+}
+```
+
+```kotlin
+val group = InstrumentedLeaderGroupElector(groupDelegate, registry)
+group.runIfLeader("batch-shard") {
+    processShard()
+}
+```
+
+```kotlin
+val suspendElection = InstrumentedSuspendLeaderElector(suspendDelegate, registry)
+suspendElection.runIfLeader("sync-job") {
+    syncService.sync()
+}
+```
+
+데코레이터 생성자에 `lockName = "static-job"`을 넘기면 실제 호출 lock 이름과 무관하게 고정 `lock.name` 태그를 사용합니다.
+
+## Meter Catalog
+
+### AOP Meter
+
+| Meter | 타입 | 태그 | 설명 |
+|-------|------|------|------|
+| `leader.aop.attempts` | Counter | `lock.name` | 락 획득 시도 |
+| `leader.aop.acquired` | Counter | `lock.name` | 리더 실행 성공 |
+| `leader.aop.lock.not.acquired` | Counter | `lock.name`, `reason` | 경쟁, backend 오류, fail-open 경로에 의한 skip |
+| `leader.aop.execution.duration` | Timer | `lock.name` | 성공한 본문 실행 시간 |
+| `leader.aop.task.failed` | Counter | `lock.name`, `exception` | 사용자 본문 예외 |
+| `leader.aop.active` | Gauge | `lock.name` | 현재 JVM에서 실행 중인 리더 본문 수 |
+
+### 직접 Elector Meter
+
+| Meter | 타입 | 태그 | 설명 |
+|-------|------|------|------|
+| `shedlock.leader.acquired` | Counter | `lock.name` | 데코레이터 실행 성공 |
+| `shedlock.leader.not_acquired` | Counter | `lock.name` | 데코레이터 skip |
+| `shedlock.leader.duration` | Timer | `lock.name` | 데코레이터 본문 실행 시간 |
+| `shedlock.leader.active` | Gauge | `lock.name` | 현재 JVM에서 실행 중인 데코레이터 본문 수 |
+
+Micrometer naming convention이 export backend에 맞춰 이름을 바꿉니다. Prometheus에서는 `leader_aop_attempts_total`, `leader_aop_execution_duration_seconds`, `shedlock_leader_acquired_total` 같은 이름으로 노출됩니다.
+
+## Prometheus Export
+
+Spring Boot에서는 Prometheus registry와 Actuator endpoint를 추가합니다.
+
+```kotlin
+implementation("io.micrometer:micrometer-registry-prometheus")
+implementation("org.springframework.boot:spring-boot-starter-actuator")
+```
+
+```yaml
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus,health
+  endpoint:
+    prometheus:
+      access: unrestricted
+```
+
+Scrape:
+
+```text
+GET /actuator/prometheus
+```
+
+유용한 PromQL:
+
+```promql
+sum by (lock_name) (rate(leader_aop_acquired_total[5m]))
+sum by (lock_name, reason) (rate(leader_aop_lock_not_acquired_total[5m]))
+histogram_quantile(0.95, sum by (lock_name, le) (rate(leader_aop_execution_duration_seconds_bucket[5m])))
+max by (lock_name) (leader_aop_active)
+```
+
+`leader.aop.active`, `shedlock.leader.active`는 JVM 로컬 gauge입니다. 여러 인스턴스를 볼 때는 의도적으로 합산해야 하는 경우가 아니라면 `max by (lock_name)`을 우선 사용하세요.
+
+Prometheus container 기반 통합 검증은 issue #137에서 추적합니다. 이 모듈의 단위 테스트는 이미 Micrometer registry 기준 meter 등록과 값을 검증합니다.
+
+## 사전 등록
+
+첫 실행 전에도 dashboard에 0 값 series를 보이게 하려면 정적 lock 이름을 사전 등록합니다.
+
+```kotlin
+@Component
+class MetricsPreRegistrar(
+    private val recorder: MicrometerLeaderAopMetricsRecorder,
+) : SmartInitializingSingleton {
+    override fun afterSingletonsInstantiated() {
+        recorder.registerMetricsFor("daily-report", "nightly-cleanup")
+    }
+}
+```
+
+## Cardinality 가이드
+
+`lock.name` cardinality는 제한해야 합니다. 요청 ID, 사용자 ID, 무제한 tenant ID를 그대로 lock 이름에 넣지 마세요. 동적 이름이 필요하다면 애플리케이션 레벨에서 집계하거나 안정적인 job family만 등록하세요.
+
+## 정리
+
+더 이상 사용하지 않는 정적 lock 이름은 `removeMetricsFor(lockName)`으로 registry에서 제거할 수 있습니다.
+
+```kotlin
+recorder.removeMetricsFor("old-nightly-job")
+```

--- a/leader-micrometer/README.md
+++ b/leader-micrometer/README.md
@@ -1,0 +1,195 @@
+# leader-micrometer
+
+[한국어](README.ko.md)
+
+Micrometer instrumentation for bluetape4k leader election.
+
+---
+
+## Overview
+
+`leader-micrometer` provides two instrumentation paths:
+
+- `MicrometerLeaderAopMetricsRecorder` for Spring AOP annotations from `leader-spring-boot`
+- `InstrumentedLeaderElector`, `InstrumentedLeaderGroupElector`, and `InstrumentedSuspendLeaderElector` decorators for direct elector calls
+
+The module depends only on `leader-core` and Micrometer core. Export format is chosen by the application's Micrometer registry, such as Prometheus, Datadog, OTLP, or a composite registry.
+
+## Architecture
+
+```mermaid
+graph TD
+    Aop["@LeaderElection<br/>@LeaderGroupElection"]
+    Recorder["MicrometerLeaderAopMetricsRecorder"]
+    Direct["Direct elector calls"]
+    Decorators["Instrumented*Elector decorators"]
+    Registry["MeterRegistry"]
+    Backend["Prometheus / Datadog / OTLP"]
+
+    Aop --> Recorder
+    Direct --> Decorators
+    Recorder --> Registry
+    Decorators --> Registry
+    Registry --> Backend
+```
+
+## Dependency
+
+```kotlin
+implementation("io.github.bluetape4k.leader:leader-micrometer:0.1.0-SNAPSHOT")
+
+// Choose the registry in the application.
+implementation("io.micrometer:micrometer-registry-prometheus")
+```
+
+For Spring Boot AOP metrics:
+
+```kotlin
+implementation("io.github.bluetape4k.leader:leader-spring-boot:0.1.0-SNAPSHOT")
+implementation("org.springframework.boot:spring-boot-starter-actuator")
+```
+
+## Spring AOP Metrics
+
+When `leader-spring-boot`, `leader-micrometer`, and a `MeterRegistry` bean are present, Spring auto-configuration registers `MicrometerLeaderAopMetricsRecorder`.
+
+```yaml
+bluetape4k:
+  leader:
+    aop:
+      metrics:
+        enabled: true
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus
+```
+
+```kotlin
+@Service
+class ReportJobs {
+    @LeaderElection(name = "daily-report")
+    fun generate(): Report? =
+        reportService.generate()
+}
+```
+
+## Direct Elector Metrics
+
+Use decorators when calling electors directly.
+
+```kotlin
+val delegate = RedissonLeaderElector(redisson)
+val election = InstrumentedLeaderElector(delegate, registry)
+
+val result = election.runIfLeader("daily-report") {
+    reportService.generate()
+}
+```
+
+```kotlin
+val group = InstrumentedLeaderGroupElector(groupDelegate, registry)
+group.runIfLeader("batch-shard") {
+    processShard()
+}
+```
+
+```kotlin
+val suspendElection = InstrumentedSuspendLeaderElector(suspendDelegate, registry)
+suspendElection.runIfLeader("sync-job") {
+    syncService.sync()
+}
+```
+
+Pass `lockName = "static-job"` to a decorator constructor when every call should use the same `lock.name` tag regardless of the runtime lock name.
+
+## Meter Catalog
+
+### AOP Meters
+
+| Meter | Type | Tags | Description |
+|-------|------|------|-------------|
+| `leader.aop.attempts` | Counter | `lock.name` | Lock acquisition attempts |
+| `leader.aop.acquired` | Counter | `lock.name` | Successful leader executions |
+| `leader.aop.lock.not.acquired` | Counter | `lock.name`, `reason` | Skipped execution by contention, backend error, or fail-open path |
+| `leader.aop.execution.duration` | Timer | `lock.name` | Successful body duration |
+| `leader.aop.task.failed` | Counter | `lock.name`, `exception` | User body failures |
+| `leader.aop.active` | Gauge | `lock.name` | Currently running leader bodies in this JVM |
+
+### Direct Elector Meters
+
+| Meter | Type | Tags | Description |
+|-------|------|------|-------------|
+| `shedlock.leader.acquired` | Counter | `lock.name` | Successful decorator executions |
+| `shedlock.leader.not_acquired` | Counter | `lock.name` | Decorator skips |
+| `shedlock.leader.duration` | Timer | `lock.name` | Decorator body duration |
+| `shedlock.leader.active` | Gauge | `lock.name` | Currently running decorator bodies in this JVM |
+
+Micrometer naming conventions convert names for the export backend. Prometheus exposes examples such as `leader_aop_attempts_total`, `leader_aop_execution_duration_seconds`, and `shedlock_leader_acquired_total`.
+
+## Prometheus Export
+
+In Spring Boot, add the Prometheus registry and expose the endpoint.
+
+```kotlin
+implementation("io.micrometer:micrometer-registry-prometheus")
+implementation("org.springframework.boot:spring-boot-starter-actuator")
+```
+
+```yaml
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus,health
+  endpoint:
+    prometheus:
+      access: unrestricted
+```
+
+Scrape:
+
+```text
+GET /actuator/prometheus
+```
+
+Useful PromQL:
+
+```promql
+sum by (lock_name) (rate(leader_aop_acquired_total[5m]))
+sum by (lock_name, reason) (rate(leader_aop_lock_not_acquired_total[5m]))
+histogram_quantile(0.95, sum by (lock_name, le) (rate(leader_aop_execution_duration_seconds_bucket[5m])))
+max by (lock_name) (leader_aop_active)
+```
+
+`leader.aop.active` and `shedlock.leader.active` are JVM-local gauges. Prefer `max by (lock_name)` across instances unless you intentionally need per-instance totals.
+
+Prometheus container-based integration coverage is tracked by issue #137. Unit tests in this module already verify meter registration and values against Micrometer registries.
+
+## Pre-Registration
+
+Pre-register static lock names when dashboards should show zero-valued series before the first run.
+
+```kotlin
+@Component
+class MetricsPreRegistrar(
+    private val recorder: MicrometerLeaderAopMetricsRecorder,
+) : SmartInitializingSingleton {
+    override fun afterSingletonsInstantiated() {
+        recorder.registerMetricsFor("daily-report", "nightly-cleanup")
+    }
+}
+```
+
+## Cardinality Guidance
+
+Keep `lock.name` bounded. Do not put request IDs, user IDs, or unbounded tenant IDs directly into lock names unless the metrics backend is sized for that cardinality. If dynamic names are required, aggregate them at the application layer or register only stable job families.
+
+## Cleanup
+
+Use `removeMetricsFor(lockName)` when a static lock name is retired and no longer needs to remain in the registry.
+
+```kotlin
+recorder.removeMetricsFor("old-nightly-job")
+```

--- a/leader-mongodb/README.ko.md
+++ b/leader-mongodb/README.ko.md
@@ -148,10 +148,10 @@ val result = election.runIfLeader("task-group") {
 ```kotlin
 val options = MongoLeaderElectionOptions(
     leaderOptions = LeaderElectionOptions(
-        waitTime = Duration.ofSeconds(5),
-        leaseTime = Duration.ofSeconds(60),
+        waitTime = 5.seconds,
+        leaseTime = 60.seconds,
     ),
-    retryDelay = Duration.ofMillis(100),
+    retryDelay = 100.milliseconds,
 )
 val election = MongoLeaderElector(lockCollection, options)
 ```

--- a/leader-mongodb/README.md
+++ b/leader-mongodb/README.md
@@ -148,10 +148,10 @@ val result = election.runIfLeader("task-group") {
 ```kotlin
 val options = MongoLeaderElectionOptions(
     leaderOptions = LeaderElectionOptions(
-        waitTime = Duration.ofSeconds(5),
-        leaseTime = Duration.ofSeconds(60),
+        waitTime = 5.seconds,
+        leaseTime = 60.seconds,
     ),
-    retryDelay = Duration.ofMillis(100),
+    retryDelay = 100.milliseconds,
 )
 val election = MongoLeaderElector(lockCollection, options)
 ```

--- a/leader-redis-lettuce/README.ko.md
+++ b/leader-redis-lettuce/README.ko.md
@@ -133,8 +133,8 @@ coroutineScope {
 
 ```kotlin
 val options = LeaderElectionOptions(
-    waitTime = Duration.ofSeconds(3),
-    leaseTime = Duration.ofSeconds(30)
+    waitTime = 3.seconds,
+    leaseTime = 30.seconds
 )
 val election = LettuceLeaderElector(connection, options)
 ```

--- a/leader-redis-lettuce/README.md
+++ b/leader-redis-lettuce/README.md
@@ -133,8 +133,8 @@ coroutineScope {
 
 ```kotlin
 val options = LeaderElectionOptions(
-    waitTime = Duration.ofSeconds(3),
-    leaseTime = Duration.ofSeconds(30)
+    waitTime = 3.seconds,
+    leaseTime = 30.seconds
 )
 val election = LettuceLeaderElector(connection, options)
 ```

--- a/leader-redis-redisson/README.ko.md
+++ b/leader-redis-redisson/README.ko.md
@@ -152,8 +152,8 @@ coroutineScope {
 
 ```kotlin
 val options = LeaderElectionOptions(
-    waitTime = Duration.ofSeconds(3),
-    leaseTime = Duration.ofSeconds(30)
+    waitTime = 3.seconds,
+    leaseTime = 30.seconds
 )
 val election = RedissonLeaderElector(client, options)
 ```

--- a/leader-redis-redisson/README.md
+++ b/leader-redis-redisson/README.md
@@ -152,8 +152,8 @@ coroutineScope {
 
 ```kotlin
 val options = LeaderElectionOptions(
-    waitTime = Duration.ofSeconds(3),
-    leaseTime = Duration.ofSeconds(30)
+    waitTime = 3.seconds,
+    leaseTime = 30.seconds
 )
 val election = RedissonLeaderElector(client, options)
 ```

--- a/leader-spring-boot/README.ko.md
+++ b/leader-spring-boot/README.ko.md
@@ -1,0 +1,207 @@
+# leader-spring-boot
+
+[English](README.md)
+
+bluetape4k 리더 선출을 위한 Spring Boot 4 자동 구성과 AspectJ CTW 기반 어노테이션 지원 모듈입니다.
+
+---
+
+## 개요
+
+`leader-spring-boot`는 Spring 애플리케이션에 bluetape4k leader backend를 연결하고 어노테이션 기반 실행 가드를 제공합니다.
+
+- `@LeaderElection`: 단일 분산 리더 실행
+- `@LeaderGroupElection`: 슬롯 기반 복수 리더 실행
+- `@LeaderElectionBackend`: 메서드, 클래스, 패키지 단위 backend 선택
+- Local, Lettuce, Redisson, Exposed JDBC/R2DBC, MongoDB, Hazelcast, Micrometer 자동 구성
+
+AOP 계층은 Freefair post-compile weaving을 통한 AspectJ compile-time weaving을 전제로 합니다. Spring runtime proxy AOP에 의존하지 않습니다.
+
+## 아키텍처
+
+```mermaid
+graph TD
+    Props["LeaderProperties<br/>bluetape4k.leader.*"]
+    AopProps["LeaderAopProperties<br/>bluetape4k.leader.aop.*"]
+    FactoryAuto["LeaderAopFactoryAutoConfiguration"]
+    MetricsAuto["LeaderMicrometerAutoConfiguration"]
+    AspectAuto["LeaderAopAutoConfiguration"]
+    Selector["LeaderBeanSelector"]
+    SpEL["SpelExpressionEvaluator"]
+    Aspect["LeaderElectionAspect<br/>LeaderGroupElectionAspect"]
+    Backends["LeaderElectorFactory<br/>LeaderGroupElectorFactory<br/>Suspend factories"]
+
+    Props --> FactoryAuto
+    AopProps --> AspectAuto
+    FactoryAuto --> Backends
+    FactoryAuto --> MetricsAuto
+    MetricsAuto --> AspectAuto
+    AspectAuto --> Selector
+    AspectAuto --> SpEL
+    Selector --> Aspect
+    SpEL --> Aspect
+    Backends --> Aspect
+```
+
+## 의존성
+
+```kotlin
+implementation("io.github.bluetape4k.leader:leader-spring-boot:0.1.0-SNAPSHOT")
+
+// backend 모듈을 하나 이상 추가합니다.
+implementation("io.github.bluetape4k.leader:leader-redis-redisson:0.1.0-SNAPSHOT")
+
+// 선택: Micrometer/Actuator 연동.
+implementation("io.github.bluetape4k.leader:leader-micrometer:0.1.0-SNAPSHOT")
+implementation("org.springframework.boot:spring-boot-starter-actuator")
+```
+
+어노테이션이 붙은 애플리케이션 메서드를 weaving하려면 소비 애플리케이션에 AspectJ compile-time weaving을 활성화합니다.
+
+```kotlin
+plugins {
+    id("io.freefair.aspectj.post-compile-weaving") version "9.5.0"
+}
+```
+
+## 설정
+
+```yaml
+bluetape4k:
+  leader:
+    wait-time: 5s
+    lease-time: 60s
+    group:
+      max-leaders: 3
+      wait-time: 5s
+      lease-time: 60s
+    aop:
+      enabled: true
+      strict: false
+      failure-mode: RETHROW
+      default-wait-time: 5s
+      default-lease-time: 60s
+      lock-name-prefix: "${spring.application.name:}:"
+      metrics:
+        enabled: true
+      spel:
+        allow-method-invocation: false
+```
+
+Spring 설정 속성은 Spring Boot duration binding을 사용하므로 `5s`, `60s`, `PT1M`을 그대로 쓸 수 있습니다. Kotlin 코드의 core `LeaderElectionOptions`, `LeaderGroupElectionOptions`는 `kotlin.time.Duration`을 사용합니다.
+
+## Backend Factory
+
+`LeaderAopFactoryAutoConfiguration`은 backend client bean이 있을 때 해당 factory bean을 등록합니다.
+
+| Backend | 필요한 bean | Factory bean 예 |
+|---------|-------------|-----------------|
+| Local | 없음 | `localLeaderElectionFactory`, `localSuspendLeaderElectorFactory` |
+| Lettuce | `StatefulRedisConnection<String, String>` | `lettuceLeaderElectionFactory`, `lettuceSuspendLeaderElectorFactory` |
+| Redisson | `RedissonClient` | `redissonLeaderElectionFactory`, `redissonSuspendLeaderElectorFactory` |
+| Exposed JDBC | `Database` | `exposedJdbcLeaderElectionFactory` |
+| Exposed R2DBC | `R2dbcDatabase` | `exposedR2dbcSuspendLeaderElectorFactory` |
+| MongoDB | `MongoClient` | `mongoLeaderElectionFactory`, `mongoSuspendLeaderElectorFactory` |
+| Hazelcast | `HazelcastInstance` | `hazelcastLeaderElectionFactory` |
+
+여러 backend가 동시에 있으면 어노테이션의 `bean = "..."`으로 사용할 factory를 명시합니다.
+
+## 어노테이션 사용
+
+```kotlin
+@Service
+class SettlementJobs {
+    @Scheduled(cron = "0 0 2 * * *")
+    @LeaderElection(name = "daily-settlement", leaseTime = "30m")
+    fun settleDaily(): SettlementReport? =
+        settlementService.settle()
+
+    @LeaderGroupElection(name = "'region-sync-' + #region", maxLeaders = 3)
+    fun syncRegion(region: String) {
+        syncService.sync(region)
+    }
+}
+```
+
+지원 반환 형태:
+
+| 형태 | 동작 |
+|------|------|
+| `T?` / `Unit` | 리더에서 본문 실행 후 결과 반환, 미선출 시 `null` / no-op |
+| `suspend fun` | `SuspendLeaderElectorFactory` 사용, `LeaderElectionInfo`를 `CoroutineContext`로 전파 |
+| `Mono<T>` | Reactor context로 `LeaderElectionInfo` 전파 |
+| `Flux<T>` / `Flow<T>` | 장기 stream은 lease renewal이 필요하므로 issue #74에서 별도 추적 |
+
+## SpEL Lock Name
+
+`name`은 정적 이름, Spring placeholder, plain SpEL, template SpEL을 지원합니다.
+
+```kotlin
+@LeaderElection(name = "daily-report")
+fun dailyReport() = report()
+
+@LeaderElection(name = "'tenant-' + #tenantId + '-invoice'")
+fun invoice(tenantId: String) = invoiceService.run(tenantId)
+
+@LeaderElection(name = "job-#{#region}-${spring.application.name}")
+fun regionalJob(region: String) = jobService.run(region)
+```
+
+SpEL 메서드 호출은 기본 비활성화입니다. 신뢰 가능한 표현식에만 명시적으로 켭니다.
+
+```yaml
+bluetape4k.leader.aop.spel.allow-method-invocation: true
+```
+
+## 메타 어노테이션
+
+`@LeaderElection`, `@LeaderGroupElection`은 Spring `@AliasFor` 기반 합성 어노테이션으로 사용할 수 있습니다.
+
+```kotlin
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@LeaderElection(name = "", leaseTime = "5m")
+annotation class DailyLeaderJob(
+    @get:AliasFor(annotation = LeaderElection::class, attribute = "name")
+    val name: String,
+)
+```
+
+Backend 선택도 메서드, 클래스, 패키지 레벨로 올릴 수 있습니다.
+
+```kotlin
+@LeaderElectionBackend("redissonLeaderElectionFactory")
+class RedisBackedJobs {
+    @LeaderElection(name = "daily-report")
+    fun report() = reportService.run()
+}
+```
+
+## Failure Mode
+
+| Mode | 동작 |
+|------|------|
+| `RETHROW` | backend 실패를 `LeaderElectionException` / `LeaderGroupElectionException`으로 감싸 전파 |
+| `SKIP` | backend 실패 또는 경쟁 상황을 skip으로 처리 |
+| `FAIL_OPEN_RUN` | backend 장애 또는 락 미획득 시 락 없이 본문 실행 |
+| `INHERIT` | 어노테이션 sentinel. `bluetape4k.leader.aop.failure-mode` 사용 |
+
+`FAIL_OPEN_RUN`은 여러 노드가 동시에 본문을 실행할 수 있으므로 멱등 작업에만 사용해야 합니다.
+
+## 자동 구성 순서
+
+1. `LeaderElectionAutoConfiguration`: 공통 backend 속성 바인딩
+2. `LeaderAopFactoryAutoConfiguration`: backend factory 등록
+3. `LeaderMicrometerAutoConfiguration`: `MeterRegistry`가 있으면 `MicrometerLeaderAopMetricsRecorder` 등록
+4. `LeaderAopAutoConfiguration`: Aspect, SpEL evaluator, lock-name validator, annotation validator 등록
+5. `LeaderMicrometerHealthAutoConfiguration`: Actuator가 있으면 health indicator 등록
+
+## 마이그레이션 노트
+
+- Core option 생성자는 `kotlin.time.Duration`을 사용합니다: `LeaderElectionOptions(waitTime = 5.seconds, leaseTime = 60.seconds)`.
+- Spring property class는 Spring Boot duration binding을 유지하므로 YAML의 `5s`, `60s`, `PT1M`은 계속 유효합니다.
+- Bean 이름은 `LeaderElector` 용어를 사용합니다. `redissonLeaderElectionFactory`, `localSuspendLeaderElectorFactory` 같은 이름을 사용하고, 과거 `LeaderElection` 기반 bean 이름은 피하세요.
+
+## 테스트
+
+자동 구성 테스트는 `ApplicationContextRunner`를 사용하고, 인프라 backend 테스트는 `bluetape4k-testcontainers`의 singleton server를 사용합니다. 이 모듈은 AspectJ CTW와 Spring Boot 통합 특성 때문에 targeted integration test 중심으로 검증합니다.

--- a/leader-spring-boot/README.md
+++ b/leader-spring-boot/README.md
@@ -1,0 +1,207 @@
+# leader-spring-boot
+
+[한국어](README.ko.md)
+
+Spring Boot 4 auto-configuration and AspectJ CTW support for bluetape4k leader election.
+
+---
+
+## Overview
+
+`leader-spring-boot` wires bluetape4k leader backends into Spring applications and provides annotation-based execution guards:
+
+- `@LeaderElection` for a single distributed leader
+- `@LeaderGroupElection` for slot-based multi-leader execution
+- `@LeaderElectionBackend` for backend selection at method, class, or package level
+- Spring Boot auto-configuration for local, Lettuce, Redisson, Exposed JDBC/R2DBC, MongoDB, Hazelcast, and Micrometer integration
+
+The AOP layer is built for AspectJ compile-time weaving via Freefair post-compile weaving. It does not rely on Spring runtime proxy AOP.
+
+## Architecture
+
+```mermaid
+graph TD
+    Props["LeaderProperties<br/>bluetape4k.leader.*"]
+    AopProps["LeaderAopProperties<br/>bluetape4k.leader.aop.*"]
+    FactoryAuto["LeaderAopFactoryAutoConfiguration"]
+    MetricsAuto["LeaderMicrometerAutoConfiguration"]
+    AspectAuto["LeaderAopAutoConfiguration"]
+    Selector["LeaderBeanSelector"]
+    SpEL["SpelExpressionEvaluator"]
+    Aspect["LeaderElectionAspect<br/>LeaderGroupElectionAspect"]
+    Backends["LeaderElectorFactory<br/>LeaderGroupElectorFactory<br/>Suspend factories"]
+
+    Props --> FactoryAuto
+    AopProps --> AspectAuto
+    FactoryAuto --> Backends
+    FactoryAuto --> MetricsAuto
+    MetricsAuto --> AspectAuto
+    AspectAuto --> Selector
+    AspectAuto --> SpEL
+    Selector --> Aspect
+    SpEL --> Aspect
+    Backends --> Aspect
+```
+
+## Dependency
+
+```kotlin
+implementation("io.github.bluetape4k.leader:leader-spring-boot:0.1.0-SNAPSHOT")
+
+// Add at least one backend module.
+implementation("io.github.bluetape4k.leader:leader-redis-redisson:0.1.0-SNAPSHOT")
+
+// Optional metrics.
+implementation("io.github.bluetape4k.leader:leader-micrometer:0.1.0-SNAPSHOT")
+implementation("org.springframework.boot:spring-boot-starter-actuator")
+```
+
+For annotated application methods, enable AspectJ compile-time weaving in the consuming application:
+
+```kotlin
+plugins {
+    id("io.freefair.aspectj.post-compile-weaving") version "9.5.0"
+}
+```
+
+## Configuration
+
+```yaml
+bluetape4k:
+  leader:
+    wait-time: 5s
+    lease-time: 60s
+    group:
+      max-leaders: 3
+      wait-time: 5s
+      lease-time: 60s
+    aop:
+      enabled: true
+      strict: false
+      failure-mode: RETHROW
+      default-wait-time: 5s
+      default-lease-time: 60s
+      lock-name-prefix: "${spring.application.name:}:"
+      metrics:
+        enabled: true
+      spel:
+        allow-method-invocation: false
+```
+
+Spring configuration properties use Spring Boot duration binding (`5s`, `60s`, `PT1M`). Core `LeaderElectionOptions` and `LeaderGroupElectionOptions` use `kotlin.time.Duration` in Kotlin code.
+
+## Backend Factories
+
+`LeaderAopFactoryAutoConfiguration` registers factory beans when the matching backend client is present.
+
+| Backend | Required bean | Factory bean examples |
+|---------|---------------|-----------------------|
+| Local | none | `localLeaderElectionFactory`, `localSuspendLeaderElectorFactory` |
+| Lettuce | `StatefulRedisConnection<String, String>` | `lettuceLeaderElectionFactory`, `lettuceSuspendLeaderElectorFactory` |
+| Redisson | `RedissonClient` | `redissonLeaderElectionFactory`, `redissonSuspendLeaderElectorFactory` |
+| Exposed JDBC | `Database` | `exposedJdbcLeaderElectionFactory` |
+| Exposed R2DBC | `R2dbcDatabase` | `exposedR2dbcSuspendLeaderElectorFactory` |
+| MongoDB | `MongoClient` | `mongoLeaderElectionFactory`, `mongoSuspendLeaderElectorFactory` |
+| Hazelcast | `HazelcastInstance` | `hazelcastLeaderElectionFactory` |
+
+Use `bean = "..."` on the annotation when more than one backend is available.
+
+## Annotation Usage
+
+```kotlin
+@Service
+class SettlementJobs {
+    @Scheduled(cron = "0 0 2 * * *")
+    @LeaderElection(name = "daily-settlement", leaseTime = "30m")
+    fun settleDaily(): SettlementReport? =
+        settlementService.settle()
+
+    @LeaderGroupElection(name = "'region-sync-' + #region", maxLeaders = 3)
+    fun syncRegion(region: String) {
+        syncService.sync(region)
+    }
+}
+```
+
+Supported return shapes:
+
+| Shape | Behavior |
+|-------|----------|
+| `T?` / `Unit` | Runs on the leader and returns the body result, or skips with `null` / no-op |
+| `suspend fun` | Uses `SuspendLeaderElectorFactory` and propagates `LeaderElectionInfo` in `CoroutineContext` |
+| `Mono<T>` | Uses Reactor context propagation for `LeaderElectionInfo` |
+| `Flux<T>` / `Flow<T>` | Tracked separately in issue #74 because long-lived streams require lease renewal |
+
+## SpEL Lock Names
+
+`name` supports static names, Spring placeholders, plain SpEL, and template SpEL.
+
+```kotlin
+@LeaderElection(name = "daily-report")
+fun dailyReport() = report()
+
+@LeaderElection(name = "'tenant-' + #tenantId + '-invoice'")
+fun invoice(tenantId: String) = invoiceService.run(tenantId)
+
+@LeaderElection(name = "job-#{#region}-${spring.application.name}")
+fun regionalJob(region: String) = jobService.run(region)
+```
+
+Method invocation in SpEL is disabled by default. Enable it only for trusted expressions:
+
+```yaml
+bluetape4k.leader.aop.spel.allow-method-invocation: true
+```
+
+## Meta-Annotations
+
+`@LeaderElection` and `@LeaderGroupElection` can be composed with Spring `@AliasFor`.
+
+```kotlin
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@LeaderElection(name = "", leaseTime = "5m")
+annotation class DailyLeaderJob(
+    @get:AliasFor(annotation = LeaderElection::class, attribute = "name")
+    val name: String,
+)
+```
+
+Backend selection can also be lifted to method, class, or package level:
+
+```kotlin
+@LeaderElectionBackend("redissonLeaderElectionFactory")
+class RedisBackedJobs {
+    @LeaderElection(name = "daily-report")
+    fun report() = reportService.run()
+}
+```
+
+## Failure Modes
+
+| Mode | Behavior |
+|------|----------|
+| `RETHROW` | Wrap backend failures in `LeaderElectionException` / `LeaderGroupElectionException` |
+| `SKIP` | Treat backend failure or contention as skipped execution |
+| `FAIL_OPEN_RUN` | Run the method body without a lock when the backend is unavailable or the lock is not acquired |
+| `INHERIT` | Annotation sentinel; uses `bluetape4k.leader.aop.failure-mode` |
+
+`FAIL_OPEN_RUN` is only appropriate for idempotent work because multiple nodes may execute the body concurrently.
+
+## Auto-Configuration Order
+
+1. `LeaderElectionAutoConfiguration` binds shared backend properties.
+2. `LeaderAopFactoryAutoConfiguration` registers backend factories.
+3. `LeaderMicrometerAutoConfiguration` registers `MicrometerLeaderAopMetricsRecorder` when `MeterRegistry` exists.
+4. `LeaderAopAutoConfiguration` registers the Aspect, SpEL evaluator, lock-name validator, and annotation validator.
+5. `LeaderMicrometerHealthAutoConfiguration` registers the Actuator health indicator when Actuator is present.
+
+## Migration Notes
+
+- Core option constructors use `kotlin.time.Duration`: `LeaderElectionOptions(waitTime = 5.seconds, leaseTime = 60.seconds)`.
+- Spring property classes still use Spring Boot duration binding, so YAML values such as `5s`, `60s`, and `PT1M` remain valid.
+- Bean names use `LeaderElector` terminology. Prefer names such as `redissonLeaderElectionFactory` and `localSuspendLeaderElectorFactory`; avoid older `LeaderElection` bean names.
+
+## Testing
+
+Use `ApplicationContextRunner` for auto-configuration tests and keep infrastructure-backed tests on the singleton servers from `bluetape4k-testcontainers`. The module keeps a lower Kover threshold because AspectJ CTW and Spring Boot integration are verified by targeted integration tests.

--- a/leader-zookeeper/README.ko.md
+++ b/leader-zookeeper/README.ko.md
@@ -50,6 +50,10 @@ classDiagram
 | `ZooKeeperLeaderGroupElector` | `LeaderGroupElector` | 블로킹 + 비동기 복수 리더 |
 | `ZooKeeperSuspendLeaderElector` | `SuspendLeaderElector` | 코루틴 단일 리더 |
 | `ZooKeeperSuspendLeaderGroupElector` | `SuspendLeaderGroupElector` | 코루틴 복수 리더 |
+| `ZooKeeperLeaderElectorFactory` | `LeaderElectorFactory` | 팩토리: 호출마다 `ZooKeeperLeaderElector` 생성 |
+| `ZooKeeperLeaderGroupElectorFactory` | `LeaderGroupElectorFactory` | 팩토리: 호출마다 `ZooKeeperLeaderGroupElector` 생성 |
+| `ZooKeeperSuspendLeaderElectorFactory` | `SuspendLeaderElectorFactory` | 팩토리: 호출마다 `ZooKeeperSuspendLeaderElector` 생성 |
+| `ZooKeeperSuspendLeaderGroupElectorFactory` | `SuspendLeaderGroupElectorFactory` | 팩토리: 호출마다 `ZooKeeperSuspendLeaderGroupElector` 생성 |
 
 ## 사용법
 
@@ -121,6 +125,16 @@ curator.runIfLeaderGroup("job", LeaderGroupElectionOptions(maxLeaders = 2)) { do
 
 curator.suspendRunIfLeader("job") { doWork() }
 curator.suspendRunIfLeaderGroup("job", LeaderGroupElectionOptions(maxLeaders = 2)) { doWork() }
+```
+
+### Factory 사용
+
+```kotlin
+val factory: LeaderElectorFactory = ZooKeeperLeaderElectorFactory(curator)
+val election = factory.create(LeaderElectionOptions.Default)
+
+val suspendFactory: SuspendLeaderElectorFactory = ZooKeeperSuspendLeaderElectorFactory(curator)
+val suspendElection = suspendFactory.create(LeaderElectionOptions.Default)
 ```
 
 ## 설정 옵션

--- a/leader-zookeeper/README.md
+++ b/leader-zookeeper/README.md
@@ -50,6 +50,10 @@ classDiagram
 | `ZooKeeperLeaderGroupElector` | `LeaderGroupElector` | Blocking + async multi-leader |
 | `ZooKeeperSuspendLeaderElector` | `SuspendLeaderElector` | Coroutine single-leader |
 | `ZooKeeperSuspendLeaderGroupElector` | `SuspendLeaderGroupElector` | Coroutine multi-leader |
+| `ZooKeeperLeaderElectorFactory` | `LeaderElectorFactory` | Factory: creates `ZooKeeperLeaderElector` per call |
+| `ZooKeeperLeaderGroupElectorFactory` | `LeaderGroupElectorFactory` | Factory: creates `ZooKeeperLeaderGroupElector` per call |
+| `ZooKeeperSuspendLeaderElectorFactory` | `SuspendLeaderElectorFactory` | Factory: creates `ZooKeeperSuspendLeaderElector` per call |
+| `ZooKeeperSuspendLeaderGroupElectorFactory` | `SuspendLeaderGroupElectorFactory` | Factory: creates `ZooKeeperSuspendLeaderGroupElector` per call |
 
 ## Usage
 
@@ -121,6 +125,16 @@ curator.runIfLeaderGroup("job", LeaderGroupElectionOptions(maxLeaders = 2)) { do
 
 curator.suspendRunIfLeader("job") { doWork() }
 curator.suspendRunIfLeaderGroup("job", LeaderGroupElectionOptions(maxLeaders = 2)) { doWork() }
+```
+
+### Using factories
+
+```kotlin
+val factory: LeaderElectorFactory = ZooKeeperLeaderElectorFactory(curator)
+val election = factory.create(LeaderElectionOptions.Default)
+
+val suspendFactory: SuspendLeaderElectorFactory = ZooKeeperSuspendLeaderElectorFactory(curator)
+val suspendElection = suspendFactory.create(LeaderElectionOptions.Default)
 ```
 
 ## Configuration


### PR DESCRIPTION
## Summary

Closes #129

PR #143의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `docs: close module README drift`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary
- add bilingual README files for leader-spring-boot and leader-micrometer
- document AOP usage, SpEL, meta-annotations, failure modes, auto-configuration order, metrics, and Prometheus export examples
- update root/backend README examples for kotlin.time Duration and current LeaderElector factory naming
- add remaining issue priority table to WIP

Closes #129

## Verification
- git diff --check

## Notes
- Prometheus container integration remains tracked by #137.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #129, milestone `0.1.0`, assignee `debop`
- PR: #143, head `63d6f942d144eb8d47ba88bdf9d202c9f52e202e`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
