### PR TITLE
Expose leader election lifecycle listeners

### DIFF
--- a/leader-core/README.ko.md
+++ b/leader-core/README.ko.md
@@ -62,6 +62,43 @@ classDiagram
 - `action` 내부에서 발생한 예외는 호출자에게 전파됩니다
 - `action` 완료 후 (또는 예외 발생 시) 락이 해제됩니다
 
+### 선출 생명주기 listener
+
+`LeaderElectionListenerRegistry` 구현체는 `addListener`, `removeListener`로 생명주기 callback을 등록할 수 있습니다.
+
+- `onElected(lockName)`: 보호된 작업이 시작되기 직전
+- `onRevoked(lockName)`: 현재 호출이 보유하던 락 또는 슬롯을 반납한 직후
+- `onSkipped(lockName)`: 리더십을 획득하지 못해 작업을 실행하지 않을 때
+
+suspend elector는 같은 생명주기를 `LeaderElectionEventPublisher.events`의 hot `Flow<LeaderElectionEvent>` stream으로도 제공합니다.
+
+```kotlin
+val election = LocalLeaderElector()
+val handle = election.addListener(object : LeaderElectionListener {
+    override fun onElected(lockName: String) {
+        println("elected: $lockName")
+    }
+})
+
+try {
+    election.runIfLeader("daily-job") { processData() }
+} finally {
+    handle.close()
+}
+```
+
+```kotlin
+val election = LocalSuspendLeaderElector()
+
+launch {
+    election.events.collect { event ->
+        println(event)
+    }
+}
+
+election.runIfLeader("nightly-sync") { syncToRemote() }
+```
+
 ### 옵션 클래스
 
 ```kotlin

--- a/leader-core/README.md
+++ b/leader-core/README.md
@@ -62,6 +62,43 @@ classDiagram
 - Exceptions from `action` are propagated to the caller
 - Lock is released after `action` completes (or on exception)
 
+### Election lifecycle listeners
+
+`LeaderElectionListenerRegistry` implementations support `addListener` and `removeListener` for lifecycle callbacks:
+
+- `onElected(lockName)` before the guarded action starts
+- `onRevoked(lockName)` after the held lock or slot is released by the current call
+- `onSkipped(lockName)` when the action is not run because leadership was not acquired
+
+For suspend electors, `LeaderElectionEventPublisher.events` exposes the same lifecycle as a hot `Flow<LeaderElectionEvent>`.
+
+```kotlin
+val election = LocalLeaderElector()
+val handle = election.addListener(object : LeaderElectionListener {
+    override fun onElected(lockName: String) {
+        println("elected: $lockName")
+    }
+})
+
+try {
+    election.runIfLeader("daily-job") { processData() }
+} finally {
+    handle.close()
+}
+```
+
+```kotlin
+val election = LocalSuspendLeaderElector()
+
+launch {
+    election.events.collect { event ->
+        println(event)
+    }
+}
+
+election.runIfLeader("nightly-sync") { syncToRemote() }
+```
+
 ### Options
 
 ```kotlin

--- a/leader-core/build.gradle.kts
+++ b/leader-core/build.gradle.kts
@@ -1,3 +1,15 @@
+kover {
+    reports {
+        verify {
+            rule {
+                bound {
+                    minValue = 80
+                }
+            }
+        }
+    }
+}
+
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionListener.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionListener.kt
@@ -1,0 +1,138 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import kotlinx.coroutines.flow.Flow
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * 리더 선출 실행 생명주기 이벤트를 수신하는 동기 리스너입니다.
+ *
+ * ## 동작/계약
+ * - [onElected]는 해당 호출이 리더 또는 그룹 슬롯을 획득하고 사용자 작업을 실행하기 직전에 호출됩니다.
+ * - [onSkipped]는 대기 시간 안에 리더 또는 그룹 슬롯을 획득하지 못해 사용자 작업이 실행되지 않을 때 호출됩니다.
+ * - [onRevoked]는 현재 구현에서 외부 lease loss 감지가 아니라, 이 호출이 보유하던 리더십/슬롯을 반납한 뒤 호출됩니다.
+ * - 리스너 일반 예외는 리더 작업 결과를 바꾸지 않도록 기록 후 무시됩니다.
+ *
+ * ```kotlin
+ * val listener = object : LeaderElectionListener {
+ *     override fun onElected(lockName: String) {
+ *         println("elected: $lockName")
+ *     }
+ * }
+ * ```
+ */
+interface LeaderElectionListener {
+
+    /** 리더 또는 그룹 슬롯을 획득했을 때 호출됩니다. */
+    fun onElected(lockName: String) = Unit
+
+    /** 리더십 또는 그룹 슬롯을 반납한 뒤 호출됩니다. */
+    fun onRevoked(lockName: String) = Unit
+
+    /** 리더 또는 그룹 슬롯을 획득하지 못해 사용자 작업을 건너뛰었을 때 호출됩니다. */
+    fun onSkipped(lockName: String) = Unit
+}
+
+/**
+ * 리더 선출 생명주기 이벤트입니다.
+ *
+ * suspend 환경에서는 callback 대신 [LeaderElectionEventPublisher.events]를 collect하면 리더 실행 생명주기를 stream으로
+ * 관찰할 수 있습니다.
+ */
+sealed interface LeaderElectionEvent {
+    /** 이벤트가 발생한 락 이름입니다. */
+    val lockName: String
+
+    /** 리더 또는 그룹 슬롯을 획득한 이벤트입니다. */
+    data class Elected(override val lockName: String) : LeaderElectionEvent
+
+    /** 리더십 또는 그룹 슬롯을 반납한 이벤트입니다. */
+    data class Revoked(override val lockName: String) : LeaderElectionEvent
+
+    /** 리더 또는 그룹 슬롯을 획득하지 못해 사용자 작업을 건너뛴 이벤트입니다. */
+    data class Skipped(override val lockName: String) : LeaderElectionEvent
+}
+
+/**
+ * 리더 선출 생명주기 이벤트 stream을 노출하는 계약입니다.
+ */
+interface LeaderElectionEventPublisher {
+
+    /**
+     * 리더 선출 이벤트 stream입니다.
+     *
+     * 구현체는 내부적으로 hot event source를 사용하며, collector가 활성화된 동안 발생한 이벤트를 전달합니다.
+     */
+    val events: Flow<LeaderElectionEvent>
+}
+
+/**
+ * [LeaderElectionListener] 등록/해제 계약입니다.
+ *
+ * 구현체는 반환된 [AutoCloseable]을 닫는 방식으로도 같은 리스너를 해제할 수 있습니다.
+ */
+interface LeaderElectionListenerRegistry {
+
+    /**
+     * [listener]를 등록하고, 닫으면 등록을 해제하는 handle을 반환합니다.
+     */
+    fun addListener(listener: LeaderElectionListener): AutoCloseable
+
+    /**
+     * [listener] 등록을 해제합니다.
+     *
+     * @return 실제로 등록되어 있던 리스너가 제거되었으면 `true`
+     */
+    fun removeListener(listener: LeaderElectionListener): Boolean
+}
+
+/**
+ * [LeaderElectionListenerRegistry]의 thread-safe 기본 구현입니다.
+ *
+ * [CopyOnWriteArrayList]를 사용하므로 리스너 호출 중 등록/해제가 발생해도 현재 dispatch는 안정적인 snapshot을 사용합니다.
+ */
+open class LeaderElectionListenerSupport : LeaderElectionListenerRegistry {
+
+    private val listeners = CopyOnWriteArrayList<LeaderElectionListener>()
+
+    override fun addListener(listener: LeaderElectionListener): AutoCloseable {
+        listeners.addIfAbsent(listener)
+        return AutoCloseable { removeListener(listener) }
+    }
+
+    override fun removeListener(listener: LeaderElectionListener): Boolean =
+        listeners.remove(listener)
+
+    /** 등록된 리스너에 선출 이벤트를 발행합니다. */
+    fun notifyElected(lockName: String) {
+        notify(lockName, "onElected") { it.onElected(lockName) }
+    }
+
+    /** 등록된 리스너에 반납 이벤트를 발행합니다. */
+    fun notifyRevoked(lockName: String) {
+        notify(lockName, "onRevoked") { it.onRevoked(lockName) }
+    }
+
+    /** 등록된 리스너에 skip 이벤트를 발행합니다. */
+    fun notifySkipped(lockName: String) {
+        notify(lockName, "onSkipped") { it.onSkipped(lockName) }
+    }
+
+    private fun notify(
+        lockName: String,
+        callbackName: String,
+        callback: (LeaderElectionListener) -> Unit,
+    ) {
+        listeners.forEach { listener ->
+            runCatching { callback(listener) }
+                .onFailure { e ->
+                    log.warn(e) {
+                        "LeaderElectionListener $callbackName failed and was ignored. lockName=$lockName"
+                    }
+                }
+        }
+    }
+
+    private companion object : KLogging()
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/ListeningLeaderElectors.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/ListeningLeaderElectors.kt
@@ -1,0 +1,144 @@
+package io.bluetape4k.leader
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * [LeaderElector]에 [LeaderElectionListener] dispatch를 추가하는 데코레이터입니다.
+ *
+ * 모든 backend 구현체에 적용할 수 있으며, [delegate]의 리더 선출/예외 전파 동작은 유지합니다.
+ */
+class ListeningLeaderElector(
+    private val delegate: LeaderElector,
+) : LeaderElector, LeaderElectionListenerRegistry {
+
+    private val listeners = LeaderElectionListenerSupport()
+
+    override fun addListener(listener: LeaderElectionListener): AutoCloseable =
+        listeners.addListener(listener)
+
+    override fun removeListener(listener: LeaderElectionListener): Boolean =
+        listeners.removeListener(listener)
+
+    override fun <T> runIfLeader(lockName: String, action: () -> T): T? {
+        var elected = false
+        val result = delegate.runIfLeader(lockName) {
+            elected = true
+            listeners.notifyElected(lockName)
+            try {
+                action()
+            } finally {
+                listeners.notifyRevoked(lockName)
+            }
+        }
+        if (!elected) {
+            listeners.notifySkipped(lockName)
+        }
+        return result
+    }
+
+    override fun <T> runAsyncIfLeader(
+        lockName: String,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> {
+        val elected = AtomicBoolean(false)
+        return delegate.runAsyncIfLeader(lockName, executor) {
+            elected.set(true)
+            listeners.notifyElected(lockName)
+            try {
+                action().whenComplete { _, _ -> listeners.notifyRevoked(lockName) }
+            } catch (e: Throwable) {
+                listeners.notifyRevoked(lockName)
+                CompletableFuture.failedFuture(e)
+            }
+        }.whenComplete { value, failure ->
+            if (!elected.get() && failure == null && value == null) {
+                listeners.notifySkipped(lockName)
+            }
+        }
+    }
+}
+
+/**
+ * [LeaderGroupElector]에 [LeaderElectionListener] dispatch를 추가하는 데코레이터입니다.
+ */
+class ListeningLeaderGroupElector(
+    private val delegate: LeaderGroupElector,
+) : LeaderGroupElector, LeaderElectionListenerRegistry {
+
+    private val listeners = LeaderElectionListenerSupport()
+
+    override val maxLeaders: Int get() = delegate.maxLeaders
+
+    override fun addListener(listener: LeaderElectionListener): AutoCloseable =
+        listeners.addListener(listener)
+
+    override fun removeListener(listener: LeaderElectionListener): Boolean =
+        listeners.removeListener(listener)
+
+    override fun activeCount(lockName: String): Int =
+        delegate.activeCount(lockName)
+
+    override fun availableSlots(lockName: String): Int =
+        delegate.availableSlots(lockName)
+
+    override fun state(lockName: String): LeaderGroupState =
+        delegate.state(lockName)
+
+    override fun <T> runIfLeader(lockName: String, action: () -> T): T? {
+        var elected = false
+        val result = delegate.runIfLeader(lockName) {
+            elected = true
+            listeners.notifyElected(lockName)
+            try {
+                action()
+            } finally {
+                listeners.notifyRevoked(lockName)
+            }
+        }
+        if (!elected) {
+            listeners.notifySkipped(lockName)
+        }
+        return result
+    }
+
+    override fun <T> runAsyncIfLeader(
+        lockName: String,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> {
+        val elected = AtomicBoolean(false)
+        return delegate.runAsyncIfLeader(lockName, executor) {
+            elected.set(true)
+            listeners.notifyElected(lockName)
+            try {
+                action().whenComplete { _, _ -> listeners.notifyRevoked(lockName) }
+            } catch (e: Throwable) {
+                listeners.notifyRevoked(lockName)
+                CompletableFuture.failedFuture(e)
+            }
+        }.whenComplete { value, failure ->
+            if (!elected.get() && failure == null && value == null) {
+                listeners.notifySkipped(lockName)
+            }
+        }
+    }
+}
+
+/**
+ * [LeaderElector]를 listener-aware 데코레이터로 감쌉니다.
+ */
+fun LeaderElector.withListeners(vararg listeners: LeaderElectionListener): ListeningLeaderElector =
+    ListeningLeaderElector(this).apply {
+        listeners.forEach { addListener(it) }
+    }
+
+/**
+ * [LeaderGroupElector]를 listener-aware 데코레이터로 감쌉니다.
+ */
+fun LeaderGroupElector.withListeners(vararg listeners: LeaderElectionListener): ListeningLeaderGroupElector =
+    ListeningLeaderGroupElector(this).apply {
+        listeners.forEach { addListener(it) }
+    }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/ListeningSuspendLeaderElectors.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/ListeningSuspendLeaderElectors.kt
@@ -1,0 +1,118 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.coroutines.flow.extensions.subject.PublishSubject
+import io.bluetape4k.leader.LeaderElectionEvent
+import io.bluetape4k.leader.LeaderElectionEventPublisher
+import io.bluetape4k.leader.LeaderElectionListener
+import io.bluetape4k.leader.LeaderElectionListenerRegistry
+import io.bluetape4k.leader.LeaderElectionListenerSupport
+import io.bluetape4k.leader.LeaderGroupState
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * [SuspendLeaderElector]에 [LeaderElectionListener] dispatch와 hot 이벤트 stream을 추가하는 데코레이터입니다.
+ */
+class ListeningSuspendLeaderElector(
+    private val delegate: SuspendLeaderElector,
+) : SuspendLeaderElector, LeaderElectionListenerRegistry, LeaderElectionEventPublisher {
+
+    private val listeners = LeaderElectionListenerSupport()
+    private val eventSubject = PublishSubject<LeaderElectionEvent>()
+
+    override val events: Flow<LeaderElectionEvent> = eventSubject
+
+    override fun addListener(listener: LeaderElectionListener): AutoCloseable =
+        listeners.addListener(listener)
+
+    override fun removeListener(listener: LeaderElectionListener): Boolean =
+        listeners.removeListener(listener)
+
+    override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? {
+        var elected = false
+        val result = delegate.runIfLeader(lockName) {
+            elected = true
+            listeners.notifyElected(lockName)
+            eventSubject.emit(LeaderElectionEvent.Elected(lockName))
+            try {
+                action()
+            } finally {
+                listeners.notifyRevoked(lockName)
+                eventSubject.emit(LeaderElectionEvent.Revoked(lockName))
+            }
+        }
+        if (!elected) {
+            listeners.notifySkipped(lockName)
+            eventSubject.emit(LeaderElectionEvent.Skipped(lockName))
+        }
+        return result
+    }
+}
+
+/**
+ * [SuspendLeaderGroupElector]에 [LeaderElectionListener] dispatch와 hot 이벤트 stream을 추가하는 데코레이터입니다.
+ */
+class ListeningSuspendLeaderGroupElector(
+    private val delegate: SuspendLeaderGroupElector,
+) : SuspendLeaderGroupElector, LeaderElectionListenerRegistry, LeaderElectionEventPublisher {
+
+    private val listeners = LeaderElectionListenerSupport()
+    private val eventSubject = PublishSubject<LeaderElectionEvent>()
+
+    override val maxLeaders: Int get() = delegate.maxLeaders
+    override val events: Flow<LeaderElectionEvent> = eventSubject
+
+    override fun addListener(listener: LeaderElectionListener): AutoCloseable =
+        listeners.addListener(listener)
+
+    override fun removeListener(listener: LeaderElectionListener): Boolean =
+        listeners.removeListener(listener)
+
+    override fun activeCount(lockName: String): Int =
+        delegate.activeCount(lockName)
+
+    override fun availableSlots(lockName: String): Int =
+        delegate.availableSlots(lockName)
+
+    override fun state(lockName: String): LeaderGroupState =
+        delegate.state(lockName)
+
+    override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? {
+        var elected = false
+        val result = delegate.runIfLeader(lockName) {
+            elected = true
+            listeners.notifyElected(lockName)
+            eventSubject.emit(LeaderElectionEvent.Elected(lockName))
+            try {
+                action()
+            } finally {
+                listeners.notifyRevoked(lockName)
+                eventSubject.emit(LeaderElectionEvent.Revoked(lockName))
+            }
+        }
+        if (!elected) {
+            listeners.notifySkipped(lockName)
+            eventSubject.emit(LeaderElectionEvent.Skipped(lockName))
+        }
+        return result
+    }
+}
+
+/**
+ * [SuspendLeaderElector]를 listener-aware 데코레이터로 감쌉니다.
+ */
+fun SuspendLeaderElector.withListeners(
+    vararg listeners: LeaderElectionListener,
+): ListeningSuspendLeaderElector =
+    ListeningSuspendLeaderElector(this).apply {
+        listeners.forEach { addListener(it) }
+    }
+
+/**
+ * [SuspendLeaderGroupElector]를 listener-aware 데코레이터로 감쌉니다.
+ */
+fun SuspendLeaderGroupElector.withListeners(
+    vararg listeners: LeaderElectionListener,
+): ListeningSuspendLeaderGroupElector =
+    ListeningSuspendLeaderGroupElector(this).apply {
+        listeners.forEach { addListener(it) }
+    }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElector.kt
@@ -1,7 +1,14 @@
 package io.bluetape4k.leader.coroutines
 
+import io.bluetape4k.coroutines.flow.extensions.subject.PublishSubject
+import io.bluetape4k.leader.LeaderElectionEvent
+import io.bluetape4k.leader.LeaderElectionEventPublisher
+import io.bluetape4k.leader.LeaderElectionListener
+import io.bluetape4k.leader.LeaderElectionListenerRegistry
+import io.bluetape4k.leader.LeaderElectionListenerSupport
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.support.requireNotBlank
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.ConcurrentHashMap
@@ -27,9 +34,19 @@ import java.util.concurrent.ConcurrentHashMap
  */
 class LocalSuspendLeaderElector(
     private val options: LeaderElectionOptions = LeaderElectionOptions.Default,
-): SuspendLeaderElector {
+): SuspendLeaderElector, LeaderElectionListenerRegistry, LeaderElectionEventPublisher {
 
     private val mutexes = ConcurrentHashMap<String, Mutex>()
+    private val listeners = LeaderElectionListenerSupport()
+    private val eventSubject = PublishSubject<LeaderElectionEvent>()
+
+    override val events: Flow<LeaderElectionEvent> = eventSubject
+
+    override fun addListener(listener: LeaderElectionListener): AutoCloseable =
+        listeners.addListener(listener)
+
+    override fun removeListener(listener: LeaderElectionListener): Boolean =
+        listeners.removeListener(listener)
 
     private fun getMutex(lockName: String): Mutex {
         lockName.requireNotBlank("lockName")
@@ -57,11 +74,19 @@ class LocalSuspendLeaderElector(
         val acquired = withTimeoutOrNull(options.waitTime) {
             mutex.lock()
             true
-        } ?: return null
+        } ?: run {
+            listeners.notifySkipped(lockName)
+            eventSubject.emit(LeaderElectionEvent.Skipped(lockName))
+            return null
+        }
+        listeners.notifyElected(lockName)
+        eventSubject.emit(LeaderElectionEvent.Elected(lockName))
         return try {
             action()
         } finally {
             if (acquired) mutex.unlock()
+            listeners.notifyRevoked(lockName)
+            eventSubject.emit(LeaderElectionEvent.Revoked(lockName))
         }
     }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElector.kt
@@ -1,12 +1,18 @@
 package io.bluetape4k.leader.coroutines
 
+import io.bluetape4k.coroutines.flow.extensions.subject.PublishSubject
+import io.bluetape4k.leader.LeaderElectionEvent
+import io.bluetape4k.leader.LeaderElectionEventPublisher
+import io.bluetape4k.leader.LeaderElectionListener
+import io.bluetape4k.leader.LeaderElectionListenerRegistry
+import io.bluetape4k.leader.LeaderElectionListenerSupport
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderGroupState
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requirePositiveNumber
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.ConcurrentHashMap
 
@@ -37,7 +43,7 @@ import java.util.concurrent.ConcurrentHashMap
  */
 class LocalSuspendLeaderGroupElector private constructor(
     private val options: LeaderGroupElectionOptions,
-): SuspendLeaderGroupElector {
+): SuspendLeaderGroupElector, LeaderElectionListenerRegistry, LeaderElectionEventPublisher {
 
     companion object: KLogging() {
         /**
@@ -61,6 +67,16 @@ class LocalSuspendLeaderGroupElector private constructor(
     }
 
     private val semaphores = ConcurrentHashMap<String, Semaphore>()
+    private val listeners = LeaderElectionListenerSupport()
+    private val eventSubject = PublishSubject<LeaderElectionEvent>()
+
+    override val events: Flow<LeaderElectionEvent> = eventSubject
+
+    override fun addListener(listener: LeaderElectionListener): AutoCloseable =
+        listeners.addListener(listener)
+
+    override fun removeListener(listener: LeaderElectionListener): Boolean =
+        listeners.removeListener(listener)
 
     private fun getSemaphore(lockName: String): Semaphore {
         lockName.requireNotBlank("lockName")
@@ -140,11 +156,19 @@ class LocalSuspendLeaderGroupElector private constructor(
         val acquired = withTimeoutOrNull(options.waitTime) {
             semaphore.acquire()
             true
-        } ?: return null
+        } ?: run {
+            listeners.notifySkipped(lockName)
+            eventSubject.emit(LeaderElectionEvent.Skipped(lockName))
+            return null
+        }
+        listeners.notifyElected(lockName)
+        eventSubject.emit(LeaderElectionEvent.Elected(lockName))
         return try {
             action()
         } finally {
             if (acquired) semaphore.release()
+            listeners.notifyRevoked(lockName)
+            eventSubject.emit(LeaderElectionEvent.Revoked(lockName))
         }
     }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderElector.kt
@@ -1,6 +1,9 @@
 package io.bluetape4k.leader.local
 
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderElectionListener
+import io.bluetape4k.leader.LeaderElectionListenerRegistry
+import io.bluetape4k.leader.LeaderElectionListenerSupport
 import io.bluetape4k.support.requireNotBlank
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
@@ -22,9 +25,16 @@ import kotlin.time.Duration
  */
 abstract class AbstractLocalLeaderElector(
     protected val options: LeaderElectionOptions = LeaderElectionOptions.Default,
-) {
+) : LeaderElectionListenerRegistry {
 
     private val locks = ConcurrentHashMap<String, ReentrantLock>()
+    private val listeners = LeaderElectionListenerSupport()
+
+    override fun addListener(listener: LeaderElectionListener): AutoCloseable =
+        listeners.addListener(listener)
+
+    override fun removeListener(listener: LeaderElectionListener): Boolean =
+        listeners.removeListener(listener)
 
     /**
      * [lockName]에 대한 [ReentrantLock]을 반환합니다. 없으면 새로 생성합니다.
@@ -54,7 +64,7 @@ abstract class AbstractLocalLeaderElector(
      * @param action 락을 획득한 상태에서 실행할 작업
      * @return [action] 실행 결과
      */
-    protected inline fun <T> withLeaderLock(lockName: String, action: () -> T): T =
+    protected fun <T> withLeaderLock(lockName: String, action: () -> T): T =
         getLock(lockName).withLock(action)
 
     /**
@@ -70,14 +80,19 @@ abstract class AbstractLocalLeaderElector(
      * @param action 락 획득 성공 시 실행할 작업
      * @return [action] 실행 결과, 획득 실패 시 `null`
      */
-    protected inline fun <T> tryWithLeaderLock(lockName: String, waitTime: Duration, action: () -> T): T? {
+    protected fun <T> tryWithLeaderLock(lockName: String, waitTime: Duration, action: () -> T): T? {
         val lock = getLock(lockName)
         val acquired = lock.tryLock(waitTime.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-        if (!acquired) return null
+        if (!acquired) {
+            listeners.notifySkipped(lockName)
+            return null
+        }
+        listeners.notifyElected(lockName)
         return try {
             action()
         } finally {
             lock.unlock()
+            listeners.notifyRevoked(lockName)
         }
     }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderGroupElector.kt
@@ -3,6 +3,9 @@ package io.bluetape4k.leader.local
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderGroupElectionState
 import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.LeaderElectionListener
+import io.bluetape4k.leader.LeaderElectionListenerRegistry
+import io.bluetape4k.leader.LeaderElectionListenerSupport
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requirePositiveNumber
 import java.util.concurrent.ConcurrentHashMap
@@ -26,7 +29,7 @@ import java.util.concurrent.TimeUnit
  */
 abstract class AbstractLocalLeaderGroupElector(
     protected val options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
-): LeaderGroupElectionState {
+): LeaderGroupElectionState, LeaderElectionListenerRegistry {
 
     init {
         options.maxLeaders.requirePositiveNumber("maxLeaders")
@@ -35,6 +38,13 @@ abstract class AbstractLocalLeaderGroupElector(
     override val maxLeaders: Int = options.maxLeaders
 
     private val semaphores = ConcurrentHashMap<String, Semaphore>()
+    private val listeners = LeaderElectionListenerSupport()
+
+    override fun addListener(listener: LeaderElectionListener): AutoCloseable =
+        listeners.addListener(listener)
+
+    override fun removeListener(listener: LeaderElectionListener): Boolean =
+        listeners.removeListener(listener)
 
     /**
      * [lockName]에 대한 [Semaphore]를 반환합니다. 없으면 `Semaphore(maxLeaders, fair=true)`를 생성합니다.
@@ -65,7 +75,7 @@ abstract class AbstractLocalLeaderGroupElector(
      * @param action 슬롯을 획득한 상태에서 실행할 작업
      * @return [action] 실행 결과
      */
-    protected inline fun <T> withPermit(lockName: String, action: () -> T): T {
+    protected fun <T> withPermit(lockName: String, action: () -> T): T {
         val semaphore = getSemaphore(lockName)
         semaphore.acquire()
         try {
@@ -87,14 +97,19 @@ abstract class AbstractLocalLeaderGroupElector(
      * @param action 슬롯 획득 성공 시 실행할 작업
      * @return [action] 실행 결과, 획득 실패 시 `null`
      */
-    protected inline fun <T> tryWithPermit(lockName: String, action: () -> T): T? {
+    protected fun <T> tryWithPermit(lockName: String, action: () -> T): T? {
         val semaphore = getSemaphore(lockName)
         val acquired = semaphore.tryAcquire(options.waitTime.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-        if (!acquired) return null
+        if (!acquired) {
+            listeners.notifySkipped(lockName)
+            return null
+        }
+        listeners.notifyElected(lockName)
         return try {
             action()
         } finally {
             semaphore.release()
+            listeners.notifyRevoked(lockName)
         }
     }
 

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionListenerTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionListenerTest.kt
@@ -1,0 +1,297 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.coroutines.LocalSuspendLeaderElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
+import io.bluetape4k.leader.coroutines.withListeners
+import io.bluetape4k.leader.local.LocalLeaderElector
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.milliseconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderElectionListenerTest {
+
+    @Test
+    fun `LocalLeaderElector - 선출과 반납 callback 을 순서대로 발행한다`() {
+        val election = LocalLeaderElector()
+        val listener = RecordingListener()
+
+        val handle = election.addListener(listener)
+        val result = election.runIfLeader("listener-job") { "done" }
+
+        result shouldBeEqualTo "done"
+        listener.events shouldBeEqualTo listOf("elected:listener-job", "revoked:listener-job")
+
+        handle.close()
+        election.runIfLeader("listener-job") { "done-again" }
+        listener.events shouldBeEqualTo listOf("elected:listener-job", "revoked:listener-job")
+    }
+
+    @Test
+    fun `LocalLeaderElector - 리더 미획득 시 skipped callback 을 발행한다`() {
+        val election = LocalLeaderElector(LeaderElectionOptions(waitTime = 50.milliseconds))
+        val listener = RecordingListener()
+        val lockName = "skip-listener-job"
+        val holderReady = CountDownLatch(1)
+        val holderDone = CountDownLatch(1)
+        election.addListener(listener)
+
+        val holder = Thread {
+            election.runIfLeader(lockName) {
+                holderReady.countDown()
+                holderDone.await()
+            }
+        }.apply { start() }
+
+        holderReady.await()
+        val skipped = election.runIfLeader(lockName) { "not-called" }
+
+        skipped shouldBeEqualTo null
+        listener.events.contains("skipped:$lockName") shouldBeEqualTo true
+
+        holderDone.countDown()
+        holder.join()
+    }
+
+    @Test
+    fun `ListeningLeaderElector - delegate 에 listener 이벤트를 더한다`() {
+        val listener = RecordingListener()
+        val election = StubLeaderElector(elected = true).withListeners(listener)
+
+        val result = election.runIfLeader("decorated-job") { "done" }
+
+        result shouldBeEqualTo "done"
+        listener.events shouldBeEqualTo listOf("elected:decorated-job", "revoked:decorated-job")
+    }
+
+    @Test
+    fun `ListeningLeaderElector - delegate skip 을 listener 이벤트로 발행한다`() {
+        val listener = RecordingListener()
+        val election = StubLeaderElector(elected = false).withListeners(listener)
+
+        val result = election.runIfLeader("decorated-skip-job") { "not-called" }
+
+        result shouldBeEqualTo null
+        listener.events shouldBeEqualTo listOf("skipped:decorated-skip-job")
+    }
+
+    @Test
+    fun `ListeningLeaderGroupElector - delegate 상태와 listener 이벤트를 더한다`() {
+        val listener = RecordingListener()
+        val election = StubLeaderGroupElector(elected = true).withListeners(listener)
+
+        val result = election.runIfLeader("decorated-group-job") { "done" }
+
+        result shouldBeEqualTo "done"
+        election.maxLeaders shouldBeEqualTo 2
+        election.activeCount("decorated-group-job") shouldBeEqualTo 1
+        election.availableSlots("decorated-group-job") shouldBeEqualTo 1
+        election.state("decorated-group-job") shouldBeEqualTo LeaderGroupState("decorated-group-job", 2, 1)
+        listener.events shouldBeEqualTo listOf("elected:decorated-group-job", "revoked:decorated-group-job")
+    }
+
+    @Test
+    fun `ListeningLeaderGroupElector - delegate skip 을 listener 이벤트로 발행한다`() {
+        val listener = RecordingListener()
+        val election = StubLeaderGroupElector(elected = false).withListeners(listener)
+
+        val result = election.runIfLeader("decorated-group-skip-job") { "not-called" }
+
+        result shouldBeEqualTo null
+        listener.events shouldBeEqualTo listOf("skipped:decorated-group-skip-job")
+    }
+
+    @Test
+    fun `ListeningLeaderGroupElector - async delegate 결과에도 listener 이벤트를 더한다`() {
+        val listener = RecordingListener()
+        val executor = Executor { it.run() }
+        val election = StubLeaderGroupElector(elected = true).withListeners(listener)
+
+        val result = election.runAsyncIfLeader("decorated-group-async-job", executor) {
+            CompletableFuture.completedFuture("done")
+        }.join()
+
+        result shouldBeEqualTo "done"
+        listener.events shouldBeEqualTo listOf("elected:decorated-group-async-job", "revoked:decorated-group-async-job")
+    }
+
+    @Test
+    fun `ListeningLeaderGroupElector - async delegate skip 을 listener 이벤트로 발행한다`() {
+        val listener = RecordingListener()
+        val executor = Executor { it.run() }
+        val election = StubLeaderGroupElector(elected = false).withListeners(listener)
+
+        val result = election.runAsyncIfLeader("decorated-group-async-skip-job", executor) {
+            CompletableFuture.completedFuture("not-called")
+        }.join()
+
+        result shouldBeEqualTo null
+        listener.events shouldBeEqualTo listOf("skipped:decorated-group-async-skip-job")
+    }
+
+    @Test
+    fun `LocalSuspendLeaderElector - Subject 로 선출 이벤트를 발행한다`() = runSuspendIO {
+        val election = LocalSuspendLeaderElector()
+        val collected = async(start = CoroutineStart.UNDISPATCHED) {
+            withTimeout(2_000) {
+                election.events.take(2).toList()
+            }
+        }
+
+        val result = election.runIfLeader("suspend-event-job") {
+            delay(1.milliseconds)
+            "done"
+        }
+
+        result shouldBeEqualTo "done"
+        collected.await() shouldBeEqualTo listOf(
+            LeaderElectionEvent.Elected("suspend-event-job"),
+            LeaderElectionEvent.Revoked("suspend-event-job"),
+        )
+    }
+
+    @Test
+    fun `ListeningSuspendLeaderElector - delegate 에 callback listener 를 더한다`() = runSuspendIO {
+        val listener = RecordingListener()
+        val election = LocalSuspendLeaderElector().withListeners(listener)
+
+        val result = election.runIfLeader("decorated-suspend-job") { "done" }
+
+        result shouldBeEqualTo "done"
+        listener.events shouldBeEqualTo listOf("elected:decorated-suspend-job", "revoked:decorated-suspend-job")
+    }
+
+    @Test
+    fun `ListeningSuspendLeaderGroupElector - Subject 로 선출 이벤트를 발행한다`() = runSuspendIO {
+        val listener = RecordingListener()
+        val election = StubSuspendLeaderGroupElector(elected = true).withListeners(listener)
+        val collected = async(start = CoroutineStart.UNDISPATCHED) {
+            withTimeout(2_000) {
+                election.events.take(2).toList()
+            }
+        }
+
+        val result = election.runIfLeader("decorated-suspend-group-job") { "done" }
+
+        result shouldBeEqualTo "done"
+        election.maxLeaders shouldBeEqualTo 2
+        election.activeCount("decorated-suspend-group-job") shouldBeEqualTo 1
+        election.availableSlots("decorated-suspend-group-job") shouldBeEqualTo 1
+        election.state("decorated-suspend-group-job") shouldBeEqualTo LeaderGroupState("decorated-suspend-group-job", 2, 1)
+        listener.events shouldBeEqualTo listOf(
+            "elected:decorated-suspend-group-job",
+            "revoked:decorated-suspend-group-job",
+        )
+        collected.await() shouldBeEqualTo listOf(
+            LeaderElectionEvent.Elected("decorated-suspend-group-job"),
+            LeaderElectionEvent.Revoked("decorated-suspend-group-job"),
+        )
+    }
+
+    @Test
+    fun `ListeningSuspendLeaderGroupElector - delegate skip 을 Subject 이벤트로 발행한다`() = runSuspendIO {
+        val listener = RecordingListener()
+        val election = StubSuspendLeaderGroupElector(elected = false).withListeners(listener)
+        val collected = async(start = CoroutineStart.UNDISPATCHED) {
+            withTimeout(2_000) {
+                election.events.take(1).toList()
+            }
+        }
+
+        val result = election.runIfLeader("decorated-suspend-group-skip-job") { "not-called" }
+
+        result shouldBeEqualTo null
+        listener.events shouldBeEqualTo listOf("skipped:decorated-suspend-group-skip-job")
+        collected.await() shouldBeEqualTo listOf(
+            LeaderElectionEvent.Skipped("decorated-suspend-group-skip-job"),
+        )
+    }
+
+    private class RecordingListener : LeaderElectionListener {
+        val events = CopyOnWriteArrayList<String>()
+
+        override fun onElected(lockName: String) {
+            events += "elected:$lockName"
+        }
+
+        override fun onRevoked(lockName: String) {
+            events += "revoked:$lockName"
+        }
+
+        override fun onSkipped(lockName: String) {
+            events += "skipped:$lockName"
+        }
+    }
+
+    private class StubLeaderElector(
+        private val elected: Boolean,
+    ) : LeaderElector {
+
+        override fun <T> runIfLeader(lockName: String, action: () -> T): T? =
+            if (elected) action() else null
+
+        override fun <T> runAsyncIfLeader(
+            lockName: String,
+            executor: Executor,
+            action: () -> CompletableFuture<T>,
+        ): CompletableFuture<T?> =
+            CompletableFuture.completedFuture(if (elected) action().join() else null)
+    }
+
+    private class StubLeaderGroupElector(
+        private val elected: Boolean,
+    ) : LeaderGroupElector {
+
+        override val maxLeaders: Int = 2
+
+        override fun activeCount(lockName: String): Int = 1
+
+        override fun availableSlots(lockName: String): Int = 1
+
+        override fun state(lockName: String): LeaderGroupState =
+            LeaderGroupState(lockName, maxLeaders, activeCount(lockName))
+
+        override fun <T> runIfLeader(lockName: String, action: () -> T): T? =
+            if (elected) action() else null
+
+        override fun <T> runAsyncIfLeader(
+            lockName: String,
+            executor: Executor,
+            action: () -> CompletableFuture<T>,
+        ): CompletableFuture<T?> =
+            if (elected) {
+                CompletableFuture.supplyAsync({ action().join() }, executor)
+            } else {
+                CompletableFuture.completedFuture(null)
+            }
+    }
+
+    private class StubSuspendLeaderGroupElector(
+        private val elected: Boolean,
+    ) : SuspendLeaderGroupElector {
+
+        override val maxLeaders: Int = 2
+
+        override fun activeCount(lockName: String): Int = 1
+
+        override fun availableSlots(lockName: String): Int = 1
+
+        override fun state(lockName: String): LeaderGroupState =
+            LeaderGroupState(lockName, maxLeaders, activeCount(lockName))
+
+        override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? =
+            if (elected) action() else null
+    }
+}

--- a/leader-micrometer/README.ko.md
+++ b/leader-micrometer/README.ko.md
@@ -12,6 +12,7 @@ bluetape4k leader election을 위한 Micrometer 계측 모듈입니다.
 
 - `leader-spring-boot`의 어노테이션 AOP를 위한 `MicrometerLeaderAopMetricsRecorder`
 - elector를 직접 호출할 때 사용하는 `InstrumentedLeaderElector`, `InstrumentedLeaderGroupElector`, `InstrumentedSuspendLeaderElector` 데코레이터
+- `LeaderElectionListenerRegistry` 생명주기 callback을 counter로 기록하는 `MicrometerLeaderElectionListener`
 
 이 모듈은 `leader-core`와 Micrometer core에만 의존합니다. Prometheus, Datadog, OTLP 같은 export 형식은 애플리케이션이 선택한 Micrometer registry가 결정합니다.
 
@@ -23,13 +24,17 @@ graph TD
     Recorder["MicrometerLeaderAopMetricsRecorder"]
     Direct["직접 elector 호출"]
     Decorators["Instrumented*Elector decorators"]
+    Listener["LeaderElectionListener callbacks"]
+    ListenerMetrics["MicrometerLeaderElectionListener"]
     Registry["MeterRegistry"]
     Backend["Prometheus / Datadog / OTLP"]
 
     Aop --> Recorder
     Direct --> Decorators
+    Listener --> ListenerMetrics
     Recorder --> Registry
     Decorators --> Registry
+    ListenerMetrics --> Registry
     Registry --> Backend
 ```
 
@@ -104,6 +109,21 @@ suspendElection.runIfLeader("sync-job") {
 
 데코레이터 생성자에 `lockName = "static-job"`을 넘기면 실제 호출 lock 이름과 무관하게 고정 `lock.name` 태그를 사용합니다.
 
+## Listener 이벤트 메트릭
+
+elector를 instrumented decorator로 감싸지 않고 생명주기 counter만 기록하려면 `MicrometerLeaderElectionListener`를 사용합니다.
+
+```kotlin
+val listener = MicrometerLeaderElectionListener(registry)
+val election = LocalLeaderElector().apply {
+    addListener(listener)
+}
+
+election.runIfLeader("daily-report") {
+    reportService.generate()
+}
+```
+
 ## Meter Catalog
 
 ### AOP Meter
@@ -125,6 +145,12 @@ suspendElection.runIfLeader("sync-job") {
 | `shedlock.leader.not_acquired` | Counter | `lock.name` | 데코레이터 skip |
 | `shedlock.leader.duration` | Timer | `lock.name` | 데코레이터 본문 실행 시간 |
 | `shedlock.leader.active` | Gauge | `lock.name` | 현재 JVM에서 실행 중인 데코레이터 본문 수 |
+
+### Listener 이벤트 Meter
+
+| Meter | 타입 | 태그 | 설명 |
+|-------|------|------|------|
+| `leader.election.events` | Counter | `lock.name`, `event` | 생명주기 callback: `elected`, `revoked`, `skipped` |
 
 Micrometer naming convention이 export backend에 맞춰 이름을 바꿉니다. Prometheus에서는 `leader_aop_attempts_total`, `leader_aop_execution_duration_seconds`, `shedlock_leader_acquired_total` 같은 이름으로 노출됩니다.
 

--- a/leader-micrometer/README.md
+++ b/leader-micrometer/README.md
@@ -12,6 +12,7 @@ Micrometer instrumentation for bluetape4k leader election.
 
 - `MicrometerLeaderAopMetricsRecorder` for Spring AOP annotations from `leader-spring-boot`
 - `InstrumentedLeaderElector`, `InstrumentedLeaderGroupElector`, and `InstrumentedSuspendLeaderElector` decorators for direct elector calls
+- `MicrometerLeaderElectionListener` for lifecycle callback counters from `LeaderElectionListenerRegistry`
 
 The module depends only on `leader-core` and Micrometer core. Export format is chosen by the application's Micrometer registry, such as Prometheus, Datadog, OTLP, or a composite registry.
 
@@ -23,13 +24,17 @@ graph TD
     Recorder["MicrometerLeaderAopMetricsRecorder"]
     Direct["Direct elector calls"]
     Decorators["Instrumented*Elector decorators"]
+    Listener["LeaderElectionListener callbacks"]
+    ListenerMetrics["MicrometerLeaderElectionListener"]
     Registry["MeterRegistry"]
     Backend["Prometheus / Datadog / OTLP"]
 
     Aop --> Recorder
     Direct --> Decorators
+    Listener --> ListenerMetrics
     Recorder --> Registry
     Decorators --> Registry
+    ListenerMetrics --> Registry
     Registry --> Backend
 ```
 
@@ -104,6 +109,21 @@ suspendElection.runIfLeader("sync-job") {
 
 Pass `lockName = "static-job"` to a decorator constructor when every call should use the same `lock.name` tag regardless of the runtime lock name.
 
+## Listener Event Metrics
+
+Use `MicrometerLeaderElectionListener` when you need lifecycle counters without wrapping the elector in an instrumented decorator.
+
+```kotlin
+val listener = MicrometerLeaderElectionListener(registry)
+val election = LocalLeaderElector().apply {
+    addListener(listener)
+}
+
+election.runIfLeader("daily-report") {
+    reportService.generate()
+}
+```
+
 ## Meter Catalog
 
 ### AOP Meters
@@ -125,6 +145,12 @@ Pass `lockName = "static-job"` to a decorator constructor when every call should
 | `shedlock.leader.not_acquired` | Counter | `lock.name` | Decorator skips |
 | `shedlock.leader.duration` | Timer | `lock.name` | Decorator body duration |
 | `shedlock.leader.active` | Gauge | `lock.name` | Currently running decorator bodies in this JVM |
+
+### Listener Event Meters
+
+| Meter | Type | Tags | Description |
+|-------|------|------|-------------|
+| `leader.election.events` | Counter | `lock.name`, `event` | Lifecycle callbacks: `elected`, `revoked`, `skipped` |
 
 Micrometer naming conventions convert names for the export backend. Prometheus exposes examples such as `leader_aop_attempts_total`, `leader_aop_execution_duration_seconds`, and `shedlock_leader_acquired_total`.
 

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerLeaderElectionListener.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerLeaderElectionListener.kt
@@ -1,0 +1,53 @@
+package io.bluetape4k.leader.micrometer
+
+import io.bluetape4k.leader.LeaderElectionListener
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * [LeaderElectionListener] 이벤트를 Micrometer counter로 기록하는 리스너입니다.
+ *
+ * ## 동작/계약
+ * - `leader.election.events` counter를 `lock.name`, `event` 태그와 함께 기록합니다.
+ * - `event` 값은 `elected`, `revoked`, `skipped`입니다.
+ * - direct elector 데코레이터의 `shedlock.leader.*` 실행 메트릭과 별도로, listener 기반 lifecycle 이벤트만 기록합니다.
+ *
+ * ```kotlin
+ * val listener = MicrometerLeaderElectionListener(registry)
+ * val election = LocalLeaderElector().withListeners(listener)
+ * election.runIfLeader("daily-job") { runJob() }
+ * ```
+ */
+class MicrometerLeaderElectionListener(
+    private val registry: MeterRegistry,
+) : LeaderElectionListener {
+
+    private val counters = ConcurrentHashMap<Pair<String, String>, Counter>()
+
+    override fun onElected(lockName: String) {
+        counter(lockName, EVENT_ELECTED).increment()
+    }
+
+    override fun onRevoked(lockName: String) {
+        counter(lockName, EVENT_REVOKED).increment()
+    }
+
+    override fun onSkipped(lockName: String) {
+        counter(lockName, EVENT_SKIPPED).increment()
+    }
+
+    private fun counter(lockName: String, event: String): Counter =
+        counters.computeIfAbsent(lockName to event) { (name, value) ->
+            Counter.builder(MicrometerNames.METER_LEADER_EVENTS)
+                .tag(MicrometerNames.TAG_LOCK_NAME, name)
+                .tag(MicrometerNames.TAG_EVENT, value)
+                .register(registry)
+        }
+
+    private companion object {
+        private const val EVENT_ELECTED = "elected"
+        private const val EVENT_REVOKED = "revoked"
+        private const val EVENT_SKIPPED = "skipped"
+    }
+}

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerNames.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerNames.kt
@@ -45,6 +45,9 @@ internal object MicrometerNames {
     /** 작업 실패 예외 유형 태그 (`throwable::class.simpleName`). */
     const val TAG_EXCEPTION = "exception"
 
+    /** 리더 선출 lifecycle 이벤트 태그 (`elected` / `revoked` / `skipped`). */
+    const val TAG_EVENT = "event"
+
     // --- Sentinel values ---
 
     /** 익명 클래스 등 `simpleName == null` 인 경우 [TAG_EXCEPTION] 태그 대체값. */
@@ -63,4 +66,7 @@ internal object MicrometerNames {
 
     /** 데코레이터 기반 현재 실행 중인 리더 작업 수 Gauge. */
     const val METER_LEADER_ACTIVE = "shedlock.leader.active"
+
+    /** listener 기반 리더 선출 lifecycle 이벤트 Counter. */
+    const val METER_LEADER_EVENTS = "leader.election.events"
 }

--- a/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/MicrometerLeaderElectionListenerTest.kt
+++ b/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/MicrometerLeaderElectionListenerTest.kt
@@ -1,0 +1,33 @@
+package io.bluetape4k.leader.micrometer
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.leader.local.LocalLeaderElector
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MicrometerLeaderElectionListenerTest {
+
+    @Test
+    fun `listener 이벤트를 Micrometer counter 로 기록한다`() {
+        val registry = SimpleMeterRegistry()
+        val listener = MicrometerLeaderElectionListener(registry)
+        val election = LocalLeaderElector().apply {
+            addListener(listener)
+        }
+
+        election.runIfLeader("metrics-listener-job") { "done" }
+
+        eventCount("metrics-listener-job", "elected", registry) shouldBeEqualTo 1.0
+        eventCount("metrics-listener-job", "revoked", registry) shouldBeEqualTo 1.0
+        eventCount("metrics-listener-job", "skipped", registry) shouldBeEqualTo 0.0
+    }
+
+    private fun eventCount(lockName: String, event: String, registry: SimpleMeterRegistry): Double =
+        registry.find(MicrometerNames.METER_LEADER_EVENTS)
+            .tag(MicrometerNames.TAG_LOCK_NAME, lockName)
+            .tag(MicrometerNames.TAG_EVENT, event)
+            .counter()
+            ?.count() ?: 0.0
+}


### PR DESCRIPTION
## Summary

Closes #40

PR #146의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `Expose leader election lifecycle listeners`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary
- Add `LeaderElectionListener` registration for local and delegated leader/group electors.
- Publish coroutine lifecycle events from suspend electors with internal `PublishSubject` and a read-only `Flow<LeaderElectionEvent>` public API.
- Add `MicrometerLeaderElectionListener` counters for `elected`, `revoked`, and `skipped` lifecycle callbacks.
- Document listener usage and enforce 80% Kover verification for `leader-core`.

Closes #40

## Verification
- `./gradlew --no-daemon --console=plain :leader-core:test :leader-core:koverLog :leader-micrometer:test :leader-micrometer:koverLog`
  - `leader-core` line coverage: 87.4296%
  - `leader-micrometer` line coverage: 95.2128%
- `./gradlew --no-daemon --console=plain :leader-core:koverVerify :leader-micrometer:koverVerify`

## Notes
- `onRevoked` means the current call released the lock/slot after action completion; it is not external lease-loss detection.
- `PublishSubject` remains internal so consumers cannot emit synthetic lifecycle events into the publisher.

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #40, milestone `0.1.0`, assignee `debop`
- PR: #146, head `4269685aaaffe35e93f668584b3c5b1eef183411`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
