### PR TITLE
feat: Leader state snapshot API 추가

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -164,10 +164,27 @@ val result = election.runIfLeader("parallel-batch") {
 ```kotlin
 val options = LeaderElectionOptions(
     waitTime = 3.seconds,   // 락 획득 최대 대기 시간
-    leaseTime = 30.seconds  // 락 보유(임대) 최대 시간
+    leaseTime = 30.seconds, // 락 보유(임대) 최대 시간
+    nodeId = "worker-a"     // 상태 스냅샷에 노출할 노드 식별자
 )
 val election = RedissonLeaderElector(client, options)
 ```
+
+### 상태 스냅샷
+
+```kotlin
+val single = election.state("daily-report-job")
+if (single.isOccupied) {
+    println("leader=${single.leader?.leaderId}")
+}
+
+val group = groupElection.state("parallel-batch")
+println("active=${group.activeCount}/${group.maxLeaders}")
+println("available=${group.availableSlots}")
+println("leaders=${group.leaders.map { it.leaderId }}")
+```
+
+상태 API는 진단과 메트릭을 위한 best-effort 스냅샷입니다. 이 값으로 작업 실행 여부를 직접 판단하지 말고, 항상 `runIfLeader`를 사용해 backend가 원자적으로 락을 획득하게 해야 합니다.
 
 ### 마이그레이션 노트
 

--- a/README.md
+++ b/README.md
@@ -164,10 +164,27 @@ val result = election.runIfLeader("parallel-batch") {
 ```kotlin
 val options = LeaderElectionOptions(
     waitTime = 3.seconds,   // how long to wait for the lock
-    leaseTime = 30.seconds  // how long to hold the lock
+    leaseTime = 30.seconds, // how long to hold the lock
+    nodeId = "worker-a"     // id exposed by state snapshots
 )
 val election = RedissonLeaderElector(client, options)
 ```
+
+### State snapshots
+
+```kotlin
+val single = election.state("daily-report-job")
+if (single.isOccupied) {
+    println("leader=${single.leader?.leaderId}")
+}
+
+val group = groupElection.state("parallel-batch")
+println("active=${group.activeCount}/${group.maxLeaders}")
+println("available=${group.availableSlots}")
+println("leaders=${group.leaders.map { it.leaderId }}")
+```
+
+State APIs return best-effort snapshots for diagnostics and metrics. Do not use a snapshot to decide whether to run work; always use `runIfLeader` so the backend can acquire the lock atomically.
 
 ### Migration notes
 

--- a/docs/superpowers/notes/2026-05-09-issue-68-6-tier-review.md
+++ b/docs/superpowers/notes/2026-05-09-issue-68-6-tier-review.md
@@ -1,0 +1,53 @@
+# 6-Tier Code Review — Issue #68 Leader State Snapshots
+
+- **Issue**: #68
+- **작성일**: 2026-05-09
+- **범위**: `leader-core` public state API, local blocking/async/virtual-thread/suspend state registry, docs/tests
+
+## 1. API / Compatibility
+
+- `LeaderElectionState`를 추가하고 single elector 인터페이스가 이를 상속한다.
+- 외부 구현체 소스 호환성을 위해 `state(lockName)` 기본 구현은 empty snapshot을 반환한다.
+- `LeaderElectionOptions` / `LeaderGroupElectionOptions`에 기본값 있는 `nodeId`를 마지막 파라미터로 추가해 기존 positional 호출을 유지한다.
+- `LeaderGroupState.leaders`도 기본값 있는 마지막 파라미터로 추가했다.
+
+**Risk**: non-local backend single elector는 실제 holder metadata를 override하지 않으면 empty snapshot을 반환한다. 이 PR은 API와 local 정확성 수직 경로를 먼저 제공한다.
+
+## 2. Correctness / Race
+
+- local single은 acquire 성공 직후 lease를 등록하고 finally에서 제거한다.
+- local group은 semaphore acquire 성공 후 registry에 slot lease를 등록하고 finally에서 제거한다.
+- 상태 조회는 lock acquire primitive가 아니라 best-effort snapshot으로 문서화했다.
+
+**Risk**: local group slot은 저장소 슬롯이 아닌 JVM-local 관측 slot이다.
+
+## 3. Backend Consistency
+
+- 기존 group backend의 `activeCount` / `availableSlots` 동작은 유지된다.
+- `LeaderGroupState.leaders`는 backend가 leader list를 채우지 않으면 빈 목록일 수 있도록 계약화했다.
+
+**Risk**: Redis/Mongo/Hazelcast/ZooKeeper/Exposed single backend의 정확한 `Occupied` 구현은 후속 backend metadata 작업이 필요하다.
+
+## 4. Coroutine / Cancellation
+
+- suspend single/group 모두 acquire 후 registry 등록, `finally`에서 registry 제거와 unlock/release를 수행한다.
+- 기존 cancellation propagation 경로를 바꾸지 않았다.
+
+## 5. Tests / Coverage
+
+- `LeaderStateTest`로 model validation을 추가했다.
+- `LocalLeaderElectionTest`에 occupied -> empty 상태 전이를 추가했다.
+- `LocalLeaderGroupElectionTest`에 active leaders list 검증을 추가했다.
+- `:leader-core:test`: 288 passing
+- `:leader-core:koverXmlReport`: line coverage 565/642 = 88.0%
+- `compileKotlin`: 전체 모듈 compile 통과
+
+## 6. Docs / Maintainability
+
+- root README / Korean README에 state snapshot 사용 예와 best-effort 경고를 추가했다.
+- `leader-core` README / Korean README에 single/group state API 예시를 추가했다.
+- 새 public API에는 KDoc을 추가했다.
+
+## Verdict
+
+PR 생성 가능. 단, #68의 전체 backend 정확성까지 한 PR에서 닫으려면 backend별 holder metadata override가 추가로 필요하다. 현재 PR은 core API와 local 구현을 안전하게 제공하는 리뷰 단위로 제한한다.

--- a/docs/superpowers/plans/2026-05-09-leader-state-plan.md
+++ b/docs/superpowers/plans/2026-05-09-leader-state-plan.md
@@ -1,0 +1,132 @@
+# Implementation Plan — Leader Election State Snapshot (#68)
+
+- **Issue**: #68 `feat: Leader Election 을 요청 전에 Leader Election 의 상태 제공`
+- **작성일**: 2026-05-09
+- **Spec 참조**: `docs/superpowers/specs/2026-05-09-leader-state-design.md`
+
+---
+
+## 0. 요약
+
+상태 조회 공통 모델을 `leader-core`에 추가하고, 모든 elector 계열에서 `state(lockName)`를 호출할 수 있게 한다. 구현은 local 계열을 먼저 정확히 잠그고, storage backend는 이미 저장하는 owner/lockedAt/TTL 정보 또는 metadata를 이용해 best-effort 상태를 반환한다.
+
+## Task List
+
+### T1. Core state model 추가
+
+**파일**
+
+- `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderStatus.kt`
+- `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLease.kt`
+- `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderState.kt`
+- `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionState.kt`
+- `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderNodeId.kt`
+
+**작업**
+
+- 단일 리더 상태 모델과 validation 추가
+- JVM process 단위 stable `LeaderNodeId.Default` 제공
+- KDoc에 best-effort snapshot 계약 명시
+
+### T2. Options / interfaces 확장
+
+**파일**
+
+- `LeaderElectionOptions.kt`
+- `LeaderGroupElectionOptions.kt`
+- `LeaderElector.kt`
+- `AsyncLeaderElector.kt`
+- `VirtualThreadLeaderElector.kt`
+- `SuspendLeaderElector.kt`
+- `LeaderGroupState.kt`
+
+**작업**
+
+- options에 `nodeId` 기본값 추가
+- single elector 인터페이스가 `LeaderElectionState`를 상속하도록 변경
+- group state에 `leaders: List<LeaderLease> = emptyList()` 추가
+
+### T3. Local blocking/async/virtual-thread 구현
+
+**파일**
+
+- `AbstractLocalLeaderElector.kt`
+- `AbstractLocalLeaderGroupElector.kt`
+- 관련 local elector tests
+
+**작업**
+
+- acquire 성공 시 lease registry 저장
+- release 시 제거
+- `state(lockName)` 구현
+- group semaphore slot registry 추가
+
+### T4. Local suspend 구현
+
+**파일**
+
+- `LocalSuspendLeaderElector.kt`
+- `LocalSuspendLeaderGroupElector.kt`
+- 관련 suspend tests
+
+**작업**
+
+- Mutex/Semaphore acquire 성공 시 lease registry 저장
+- cancellation/finally 경로에서도 lease 제거
+- `state(lockName)` 구현
+
+### T5. Storage backend 상태 조회 구현
+
+**대상**
+
+- Exposed JDBC/R2DBC: table row 기반 조회
+- MongoDB: lock document 기반 조회
+- Lettuce/Redisson/Hazelcast/ZooKeeper: metadata 기반 조회 또는 holder token 기반 조회
+
+**원칙**
+
+- 상태 조회 실패는 leader execution 실패로 전파하지 않는다.
+- 이미 `activeCount`가 있는 group backend는 leader list 조회 실패 시 count 기반 snapshot으로 degrade한다.
+
+### T6. Tests
+
+**필수 테스트**
+
+- model validation
+- local single 상태: empty -> occupied -> empty
+- local group 상태: available slots, active leaders, release 후 empty
+- suspend single/group 상태: `runTest` / existing `runSuspendIO` 패턴
+- backend별 최소 happy path test 또는 기존 integration test 확장
+
+### T7. Documentation
+
+**파일**
+
+- `README.md`
+- `README.ko.md`
+- 필요 시 module README
+
+**작업**
+
+- 상태 조회 사용 예시 추가
+- snapshot/best-effort 의미와 lock acquire 판단에 사용하지 말라는 주의 추가
+
+### T8. Verification / Review
+
+**검증**
+
+- `repo-diff`로 변경 범위 확인
+- affected module tests
+- 전체 build 또는 가능한 범위의 `check`
+- 6-Tier code review:
+  1. API/compatibility
+  2. Correctness/race
+  3. Backend consistency
+  4. Coroutine/cancellation
+  5. Tests/coverage
+  6. Docs/maintainability
+
+**PR**
+
+- Issue #68 link
+- 구현 범위, known degradation, test evidence 명시

--- a/docs/superpowers/specs/2026-05-09-leader-state-design.md
+++ b/docs/superpowers/specs/2026-05-09-leader-state-design.md
@@ -1,0 +1,153 @@
+# Leader Election State Snapshot 설계
+
+- **Issue**: #68 `feat: Leader Election 을 요청 전에 Leader Election 의 상태 제공`
+- **작성일**: 2026-05-09
+- **대상 모듈**: `leader-core`, 각 backend elector 모듈
+- **상태**: Design (구현 전)
+
+---
+
+## 1. Background
+
+현재 `LeaderGroupElectionState`는 `activeCount`, `availableSlots`, `state()`를 제공하지만, `LeaderGroupState`에는 실제 슬롯을 점유한 리더 정보가 없다. 단일 `LeaderElection` 계열은 선출 전 상태 조회 계약 자체가 없다.
+
+운영 메트릭, 사전 진단, UI/API 노출을 위해 다음 스냅샷이 필요하다.
+
+- 단일 리더: `Empty` / `Occupied`, 현재 리더 식별자, 선출 시각, lease 만료 시각
+- 그룹 리더: 남은 슬롯 수 / 최대 슬롯 수, 현재 슬롯 점유 리더 목록과 선출 시각
+
+## 2. Goals
+
+1. 단일 리더 상태 조회를 공개 API로 추가한다.
+2. 그룹 상태 모델에 현재 리더 목록을 추가한다.
+3. 기존 `activeCount` / `availableSlots` 계약은 유지한다.
+4. 상태 조회는 best-effort 스냅샷으로 정의한다. 조회 직후 다른 노드가 lock을 획득/해제할 수 있다.
+5. lock 획득 실패 여부 판단에는 상태 API를 사용하지 않는다. 기존 원자적 acquire 경로가 authoritative source다.
+
+## 3. Non-goals
+
+- 리더 선출 이력 저장 및 조회. 이력은 향후 `leader-micrometer` / history 이슈에서 다룬다.
+- 상태 조회를 분산 consensus read로 보장하지 않는다.
+- lease 연장/최소 lease 보장 로직은 #38/#77에서 다룬다.
+
+## 4. Public API
+
+### 4.1 `LeaderStatus`
+
+```kotlin
+enum class LeaderStatus {
+    Empty,
+    Occupied,
+}
+```
+
+단일 리더 상태를 명시한다. enum 이름은 Kotlin 스타일과 KDoc 가독성을 위해 PascalCase를 사용한다.
+
+### 4.2 `LeaderLease`
+
+```kotlin
+data class LeaderLease(
+    val leaderId: String,
+    val electedAt: Instant? = null,
+    val leaseUntil: Instant? = null,
+    val slot: Int? = null,
+) : Serializable
+```
+
+- `leaderId`: 가능한 경우 사용자/노드 식별자. backend가 token만 보유하는 경우 fencing token 또는 backend holder id를 사용한다.
+- `electedAt`: lock 획득 시각. backend가 정확한 시각을 보유하지 않으면 `null`.
+- `leaseUntil`: lease 만료 시각. local 구현처럼 자동 TTL이 없는 경우 `electedAt + leaseTime` 근사값을 사용한다.
+- `slot`: 그룹 리더 슬롯 번호. 단일 리더는 `null`.
+
+### 4.3 `LeaderState`
+
+```kotlin
+data class LeaderState(
+    val lockName: String,
+    val status: LeaderStatus,
+    val leader: LeaderLease? = null,
+) : Serializable {
+    val isEmpty: Boolean get() = status == LeaderStatus.Empty
+    val isOccupied: Boolean get() = status == LeaderStatus.Occupied
+}
+```
+
+`status == Empty`이면 `leader == null`이어야 한다. `status == Occupied`이면 `leader != null`이어야 한다.
+
+### 4.4 `LeaderElectionState`
+
+```kotlin
+interface LeaderElectionState {
+    fun state(lockName: String): LeaderState
+}
+```
+
+`LeaderElector`, `AsyncLeaderElector`, `VirtualThreadLeaderElector`, `SuspendLeaderElector`는 이 인터페이스를 상속한다. `LeaderElector`가 `AsyncLeaderElector`를 상속하므로 동기/비동기 구현체는 하나의 `state()` 구현을 공유한다.
+
+### 4.5 `LeaderGroupState` 확장
+
+기존 생성자 호환성을 보존하기 위해 `leaders`를 기본값이 있는 마지막 파라미터로 추가한다.
+
+```kotlin
+data class LeaderGroupState(
+    val lockName: String,
+    val maxLeaders: Int,
+    val activeCount: Int,
+    val leaders: List<LeaderLease> = emptyList(),
+) : Serializable
+```
+
+검증 규칙:
+
+- `leaders.size <= maxLeaders`
+- `activeCount`는 기존처럼 `0..maxLeaders`
+- backend가 현재 리더 목록을 제공할 수 있으면 `activeCount == leaders.size`
+- backend가 리더 목록을 아직 제공하지 못하는 transitional 구현에서는 `leaders`가 빈 목록일 수 있다. 이 경우 `activeCount`가 authoritative 값이다.
+
+## 5. Backend State Strategy
+
+### 5.1 Local
+
+`AbstractLocalLeaderElector`, `LocalSuspendLeaderElector`, `AbstractLocalLeaderGroupElector`, `LocalSuspendLeaderGroupElector`에 in-memory lease registry를 둔다.
+
+- acquire 성공 직후 `LeaderLease(leaderId = options.nodeId, electedAt = now, leaseUntil = now + leaseTime)` 저장
+- action 완료 후 unlock/release 직전에 제거
+- group은 slot 개념이 없는 semaphore 기반이므로 `slot`은 acquire 순번 기반 local slot id를 할당한다.
+
+`LeaderElectionOptions`와 `LeaderGroupElectionOptions`에 `nodeId`를 추가하되 기본값은 JVM 프로세스 단위 stable id로 둔다. 랜덤값을 생성자 기본값에서 매번 만들지 않는다.
+
+### 5.2 Exposed JDBC/R2DBC
+
+`LeaderLockTable`, `LeaderGroupLockTable`은 이미 `lockOwner`, `lockedAt`, `lockedUntil`, `slot`을 보유한다. 상태 조회는 만료되지 않은 row를 읽어 `LeaderLease`로 매핑한다.
+
+### 5.3 MongoDB
+
+lock document에 기존 `token`, `expireAt`가 있다. `tryLock` 성공 시 `owner`, `lockedAt` 필드를 함께 저장하고, 상태 조회는 `_id` / `expireAt > now` 조건으로 읽는다.
+
+### 5.4 Lettuce / Hazelcast / ZooKeeper / Redisson
+
+각 저장소가 현재 token 또는 holder id를 보유한다. 정확한 `electedAt`이 없으면 #68 구현에서 별도 metadata key/map/node를 함께 기록한다. metadata는 lock lease와 같은 TTL로 설정하고 unlock 시 삭제한다.
+
+상태 조회 실패는 leader 실행을 막지 않는다. backend 예외는 기존 상태 API 관례처럼 warn 로그 후 empty snapshot 또는 count 기반 snapshot으로 degrade한다.
+
+## 6. Compatibility
+
+- `LeaderGroupState(lockName, maxLeaders, activeCount)` 호출은 `leaders` 기본값으로 계속 컴파일된다.
+- `LeaderElector` 계열에 `state()`가 추가되므로 외부 구현체는 소스 호환 수정이 필요하다. 현재 저장소의 구현체는 모두 업데이트한다.
+- `LeaderElectionOptions` / `LeaderGroupElectionOptions`에 `nodeId` 기본값을 추가한다. 기존 positional constructor 호출은 유지된다.
+
+## 7. Testing
+
+- core model validation tests
+- local single/group blocking/async/virtual-thread state tests
+- local suspend single/group state tests
+- backend별 상태 조회 unit/integration tests는 저장소 접근 비용에 맞춰 최소 하나 이상의 happy path + release 후 empty path를 둔다.
+
+## 8. Review Notes
+
+Spec review 결과:
+
+- API: 상태는 lock 획득의 근거가 아니라 관측 스냅샷이어야 한다.
+- Compatibility: `LeaderGroupState` 확장은 마지막 기본값 파라미터로 제한한다.
+- Observability: `LeaderLease`는 `electedAt`과 `leaseUntil`을 모두 가져야 이후 Prometheus export에서 gauge/label 계산이 가능하다.
+- Backend: 정확한 owner를 제공하지 못하는 backend는 token을 `leaderId`로 노출하되 README/KDoc에서 best-effort라고 명시한다.

--- a/leader-core/README.ko.md
+++ b/leader-core/README.ko.md
@@ -283,10 +283,19 @@ println(election.availableSlots("parallel-batch")) // 잔여 슬롯 수
 ### 상태 조회
 
 ```kotlin
-val state: LeaderGroupState = election.state("parallel-batch")
-println(state.activeCount)  // 현재 리더 수
-println(state.maxLeaders)   // 옵션의 maxLeaders 값
+val single: LeaderState = LocalLeaderElector(
+    LeaderElectionOptions(nodeId = "node-a")
+).state("daily-job")
+println(single.status)        // Empty 또는 Occupied
+println(single.leader?.leaderId)
+
+val group: LeaderGroupState = election.state("parallel-batch")
+println(group.activeCount)    // 현재 리더 수
+println(group.maxLeaders)     // 옵션의 maxLeaders 값
+println(group.leaders.map { it.leaderId })
 ```
+
+상태 조회는 진단과 메트릭을 위한 best-effort 스냅샷입니다. 락 획득을 대체하는 API가 아닙니다.
 
 ## 의존성 추가
 

--- a/leader-core/README.md
+++ b/leader-core/README.md
@@ -283,10 +283,19 @@ println(election.availableSlots("parallel-batch")) // 3 - activeCount
 ### State inspection
 
 ```kotlin
-val state: LeaderGroupState = election.state("parallel-batch")
-println(state.activeCount)    // current leader count
-println(state.maxLeaders)     // maxLeaders from options
+val single: LeaderState = LocalLeaderElector(
+    LeaderElectionOptions(nodeId = "node-a")
+).state("daily-job")
+println(single.status)        // Empty or Occupied
+println(single.leader?.leaderId)
+
+val group: LeaderGroupState = election.state("parallel-batch")
+println(group.activeCount)    // current leader count
+println(group.maxLeaders)     // maxLeaders from options
+println(group.leaders.map { it.leaderId })
 ```
+
+State inspection is a best-effort snapshot for diagnostics and metrics. It is not a lock acquisition primitive.
 
 ## Dependency
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderElector.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.Executor
  * // future.join() == "ok"
  * ```
  */
-interface AsyncLeaderElector {
+interface AsyncLeaderElector: LeaderElectionState {
 
     /**
      * 리더 획득 성공 시 비동기 [action]을 실행합니다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionOptions.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionOptions.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader
 
 import io.bluetape4k.support.requireGe
 import io.bluetape4k.support.requireGt
+import io.bluetape4k.support.requireNotBlank
 import java.io.Serializable
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -21,14 +22,17 @@ import kotlin.time.Duration.Companion.seconds
  *
  * @property waitTime 리더 획득 대기 최대 시간. 기본값 5초
  * @property leaseTime 리더 보유(임대) 최대 시간. 기본값 60초
+ * @property nodeId 상태 조회에 노출할 노드 식별자. 기본값은 JVM 프로세스 단위 stable id
  */
 data class LeaderElectionOptions(
     val waitTime: Duration = DefaultWaitTime,
     val leaseTime: Duration = DefaultLeaseTime,
+    val nodeId: String = LeaderNodeId.Default,
 ): Serializable {
     init {
         waitTime.requireGe(Duration.ZERO, "waitTime")
         leaseTime.requireGt(Duration.ZERO, "leaseTime")
+        nodeId.requireNotBlank("nodeId")
     }
 
     companion object {

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionState.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionState.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.leader
+
+/**
+ * 단일 리더 선출의 상태 조회 메서드를 정의하는 공통 인터페이스입니다.
+ *
+ * ## 계약
+ * [state]는 조회 시점의 best-effort 스냅샷입니다. 상태 조회 결과를 보고 작업 실행 여부를
+ * 직접 결정하지 말고, 기존 `runIfLeader` 계열의 원자적 lock 획득 경로를 사용해야 합니다.
+ *
+ * ```kotlin
+ * val state = election.state("daily-job")
+ * println(state.status)
+ * ```
+ */
+interface LeaderElectionState {
+
+    /**
+     * [lockName]에 대한 현재 단일 리더 상태 스냅샷을 반환합니다.
+     *
+     * 기본 구현은 외부 구현체의 소스 호환성을 위해 빈 스냅샷을 반환합니다. backend가 실제
+     * owner metadata를 제공할 수 있다면 이 메서드를 override해야 합니다.
+     *
+     * @param lockName 조회할 락 이름
+     * @return 현재 리더 상태 스냅샷
+     */
+    fun state(lockName: String): LeaderState =
+        LeaderState.empty(lockName)
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupElectionOptions.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupElectionOptions.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader
 
 import io.bluetape4k.support.requireGe
 import io.bluetape4k.support.requireGt
+import io.bluetape4k.support.requireNotBlank
 import java.io.Serializable
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -23,17 +24,20 @@ import kotlin.time.Duration.Companion.seconds
  * @property maxLeaders 허용하는 최대 동시 리더 수. 기본값 2
  * @property waitTime 리더 획득 대기 최대 시간. 기본값 5초
  * @property leaseTime 리더 보유(임대) 최대 시간. 기본값 60초
+ * @property nodeId 상태 조회에 노출할 노드 식별자. 기본값은 JVM 프로세스 단위 stable id
  */
 data class LeaderGroupElectionOptions(
     val maxLeaders: Int = DefaultMaxLeaders,
     val waitTime: Duration = DefaultWaitTime,
     val leaseTime: Duration = DefaultLeaseTime,
+    val nodeId: String = LeaderNodeId.Default,
 ): Serializable {
 
     init {
         maxLeaders.requireGe(1, "maxLeaders")
         waitTime.requireGe(Duration.ZERO, "waitTime")
         leaseTime.requireGt(Duration.ZERO, "leaseTime")
+        nodeId.requireNotBlank("nodeId")
     }
 
     companion object {

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupState.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupState.kt
@@ -19,11 +19,13 @@ import java.io.Serializable
  * @property lockName 리더 그룹 식별에 사용하는 락 이름
  * @property maxLeaders 허용하는 최대 동시 리더 수
  * @property activeCount 현재 활성(실행 중인) 리더 수
+ * @property leaders 현재 리더로 선출된 노드/슬롯 lease 목록. backend에 따라 빈 목록일 수 있습니다.
  */
 data class LeaderGroupState(
     val lockName: String,
     val maxLeaders: Int,
     val activeCount: Int,
+    val leaders: List<LeaderLease> = emptyList(),
 ): Serializable {
 
     companion object {
@@ -34,6 +36,7 @@ data class LeaderGroupState(
         lockName.requireNotBlank("lockName")
         maxLeaders.requireGe(1, "maxLeaders")
         activeCount.requireInRange(0, maxLeaders, "activeCount")
+        leaders.size.requireInRange(0, maxLeaders, "leaders.size")
     }
 
     /**

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLease.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLease.kt
@@ -1,0 +1,43 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.support.requireNotBlank
+import java.io.Serializable
+import java.time.Instant
+
+/**
+ * 리더로 선출된 노드 또는 슬롯 점유자의 lease 스냅샷입니다.
+ *
+ * ## 계약
+ * - [leaderId]는 가능한 경우 노드 식별자이며, backend가 노드 식별자를 별도로 저장하지 않으면
+ *   fencing token 또는 backend holder id가 들어갈 수 있습니다.
+ * - [electedAt]과 [leaseUntil]은 backend가 제공하는 범위에서 채워지는 best-effort 값입니다.
+ * - [slot]은 그룹 리더 선출에서만 사용하며, 단일 리더 선출에서는 `null`입니다.
+ *
+ * ```kotlin
+ * val lease = LeaderLease(
+ *     leaderId = "node-a",
+ *     electedAt = Instant.now(),
+ * )
+ * ```
+ */
+data class LeaderLease(
+    val leaderId: String,
+    val electedAt: Instant? = null,
+    val leaseUntil: Instant? = null,
+    val slot: Int? = null,
+) : Serializable {
+
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+
+    init {
+        leaderId.requireNotBlank("leaderId")
+        require(slot == null || slot >= 0) { "slot must be null or non-negative: $slot" }
+        if (electedAt != null && leaseUntil != null) {
+            require(!leaseUntil.isBefore(electedAt)) {
+                "leaseUntil must not be before electedAt: electedAt=$electedAt, leaseUntil=$leaseUntil"
+            }
+        }
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderNodeId.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderNodeId.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.leader
+
+import java.lang.management.ManagementFactory
+import java.net.InetAddress
+
+/**
+ * 기본 리더 노드 식별자를 제공합니다.
+ *
+ * ## 계약
+ * [Default]는 JVM 프로세스 단위로 한 번 계산되는 stable id입니다. 옵션 기본값에서 매번
+ * 랜덤 id를 생성하면 동일 설정 간 equality/cache key가 흔들리므로, 기본값은 프로세스 수명 동안
+ * 일정해야 합니다.
+ */
+object LeaderNodeId {
+
+    /**
+     * 현재 JVM 프로세스의 기본 노드 식별자입니다.
+     *
+     * 형식은 `host:pid`이며, host 조회가 실패하면 `localhost`를 사용합니다.
+     */
+    @JvmField
+    val Default: String = "${hostname()}:${ProcessHandle.current().pid()}"
+
+    private fun hostname(): String =
+        runCatching { InetAddress.getLocalHost().hostName }
+            .recoverCatching { ManagementFactory.getRuntimeMXBean().name.substringBefore('@') }
+            .getOrDefault("localhost")
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderState.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderState.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.support.requireNotBlank
+import java.io.Serializable
+
+/**
+ * 단일 리더 선출의 현재 상태 스냅샷입니다.
+ *
+ * ## 계약
+ * - 이 값은 조회 시점의 best-effort 스냅샷입니다.
+ * - lock 획득 가능 여부 판단에는 [state] 대신 각 elector의 원자적 acquire 경로를 사용해야 합니다.
+ * - [status]가 [LeaderStatus.Empty]이면 [leader]는 `null`입니다.
+ * - [status]가 [LeaderStatus.Occupied]이면 [leader]는 `null`이 아닙니다.
+ *
+ * ```kotlin
+ * val state = election.state("batch-lock")
+ * if (state.isOccupied) {
+ *     println("leader=${state.leader?.leaderId}")
+ * }
+ * ```
+ */
+data class LeaderState(
+    val lockName: String,
+    val status: LeaderStatus,
+    val leader: LeaderLease? = null,
+) : Serializable {
+
+    companion object {
+        private const val serialVersionUID = 1L
+
+        /**
+         * 리더가 없는 상태 스냅샷을 생성합니다.
+         */
+        fun empty(lockName: String): LeaderState =
+            LeaderState(lockName, LeaderStatus.Empty)
+
+        /**
+         * 리더가 점유 중인 상태 스냅샷을 생성합니다.
+         */
+        fun occupied(lockName: String, leader: LeaderLease): LeaderState =
+            LeaderState(lockName, LeaderStatus.Occupied, leader)
+    }
+
+    init {
+        lockName.requireNotBlank("lockName")
+        when (status) {
+            LeaderStatus.Empty -> require(leader == null) { "leader must be null when status is Empty" }
+            LeaderStatus.Occupied -> require(leader != null) { "leader must not be null when status is Occupied" }
+        }
+    }
+
+    /** 현재 리더가 없는지 여부입니다. */
+    val isEmpty: Boolean get() = status == LeaderStatus.Empty
+
+    /** 현재 리더가 선출되어 있는지 여부입니다. */
+    val isOccupied: Boolean get() = status == LeaderStatus.Occupied
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderStatus.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderStatus.kt
@@ -1,0 +1,23 @@
+package io.bluetape4k.leader
+
+/**
+ * 단일 리더 선출의 현재 점유 상태를 표현합니다.
+ *
+ * ## 계약
+ * - [Empty]는 현재 리더가 없음을 의미합니다.
+ * - [Occupied]는 현재 리더가 선출되어 lease를 보유 중임을 의미합니다.
+ *
+ * ```kotlin
+ * val state = election.state("daily-job")
+ * if (state.status == LeaderStatus.Occupied) {
+ *     println(state.leader?.leaderId)
+ * }
+ * ```
+ */
+enum class LeaderStatus {
+    /** 현재 리더가 없습니다. */
+    Empty,
+
+    /** 현재 리더가 선출되어 있습니다. */
+    Occupied,
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/ListeningLeaderElectors.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/ListeningLeaderElectors.kt
@@ -21,6 +21,9 @@ class ListeningLeaderElector(
     override fun removeListener(listener: LeaderElectionListener): Boolean =
         listeners.removeListener(listener)
 
+    override fun state(lockName: String): LeaderState =
+        delegate.state(lockName)
+
     override fun <T> runIfLeader(lockName: String, action: () -> T): T? {
         var elected = false
         val result = delegate.runIfLeader(lockName) {

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/VirtualThreadLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/VirtualThreadLeaderElector.kt
@@ -21,7 +21,7 @@ import io.bluetape4k.concurrent.virtualthread.VirtualFuture
  * val result = future.await()  // "ok"
  * ```
  */
-interface VirtualThreadLeaderElector {
+interface VirtualThreadLeaderElector: LeaderElectionState {
 
     /**
      * 리더 획득 성공 시 [action]을 Virtual Thread에서 비동기로 실행합니다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/ListeningSuspendLeaderElectors.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/ListeningSuspendLeaderElectors.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.leader.LeaderElectionListener
 import io.bluetape4k.leader.LeaderElectionListenerRegistry
 import io.bluetape4k.leader.LeaderElectionListenerSupport
 import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.LeaderState
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -26,6 +27,9 @@ class ListeningSuspendLeaderElector(
 
     override fun removeListener(listener: LeaderElectionListener): Boolean =
         listeners.removeListener(listener)
+
+    override fun state(lockName: String): LeaderState =
+        delegate.state(lockName)
 
     override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? {
         var elected = false

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElector.kt
@@ -7,6 +7,8 @@ import io.bluetape4k.leader.LeaderElectionListener
 import io.bluetape4k.leader.LeaderElectionListenerRegistry
 import io.bluetape4k.leader.LeaderElectionListenerSupport
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderState
+import io.bluetape4k.leader.local.LocalLeaderStateRegistry
 import io.bluetape4k.support.requireNotBlank
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.sync.Mutex
@@ -39,6 +41,7 @@ class LocalSuspendLeaderElector(
     private val mutexes = ConcurrentHashMap<String, Mutex>()
     private val listeners = LeaderElectionListenerSupport()
     private val eventSubject = PublishSubject<LeaderElectionEvent>()
+    private val states = LocalLeaderStateRegistry()
 
     override val events: Flow<LeaderElectionEvent> = eventSubject
 
@@ -79,14 +82,19 @@ class LocalSuspendLeaderElector(
             eventSubject.emit(LeaderElectionEvent.Skipped(lockName))
             return null
         }
+        states.acquireSingle(lockName, options.nodeId, options.leaseTime)
         listeners.notifyElected(lockName)
         eventSubject.emit(LeaderElectionEvent.Elected(lockName))
         return try {
             action()
         } finally {
+            states.releaseSingle(lockName)
             if (acquired) mutex.unlock()
             listeners.notifyRevoked(lockName)
             eventSubject.emit(LeaderElectionEvent.Revoked(lockName))
         }
     }
+
+    override fun state(lockName: String): LeaderState =
+        states.singleState(lockName)
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElector.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.leader.LeaderElectionListenerRegistry
 import io.bluetape4k.leader.LeaderElectionListenerSupport
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.local.LocalLeaderStateRegistry
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requirePositiveNumber
@@ -69,6 +70,7 @@ class LocalSuspendLeaderGroupElector private constructor(
     private val semaphores = ConcurrentHashMap<String, Semaphore>()
     private val listeners = LeaderElectionListenerSupport()
     private val eventSubject = PublishSubject<LeaderElectionEvent>()
+    private val states = LocalLeaderStateRegistry()
 
     override val events: Flow<LeaderElectionEvent> = eventSubject
 
@@ -132,7 +134,7 @@ class LocalSuspendLeaderGroupElector private constructor(
      * @return 현재 리더 그룹 상태 스냅샷
      */
     override fun state(lockName: String): LeaderGroupState =
-        LeaderGroupState(lockName, maxLeaders, activeCount(lockName))
+        states.groupState(lockName, maxLeaders, activeCount(lockName))
 
     /**
      * [lockName]의 [Semaphore] 슬롯을 획득하고 suspend [action]을 실행합니다.
@@ -161,11 +163,13 @@ class LocalSuspendLeaderGroupElector private constructor(
             eventSubject.emit(LeaderElectionEvent.Skipped(lockName))
             return null
         }
+        val lease = states.acquireGroup(lockName, options.nodeId, options.leaseTime, maxLeaders)
         listeners.notifyElected(lockName)
         eventSubject.emit(LeaderElectionEvent.Elected(lockName))
         return try {
             action()
         } finally {
+            states.releaseGroup(lockName, lease)
             if (acquired) semaphore.release()
             listeners.notifyRevoked(lockName)
             eventSubject.emit(LeaderElectionEvent.Revoked(lockName))

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderElector.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.leader.coroutines
 
+import io.bluetape4k.leader.LeaderElectionState
+
 /**
  * 코루틴 기반 리더 선출 실행 계약을 정의합니다.
  *
@@ -15,7 +17,7 @@ package io.bluetape4k.leader.coroutines
  * // result == "ok"
  * ```
  */
-interface SuspendLeaderElector {
+interface SuspendLeaderElector: LeaderElectionState {
 
     /**
      * 리더 획득 성공 시 suspend [action]을 실행합니다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderElector.kt
@@ -1,9 +1,11 @@
 package io.bluetape4k.leader.local
 
-import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderElectionListener
 import io.bluetape4k.leader.LeaderElectionListenerRegistry
 import io.bluetape4k.leader.LeaderElectionListenerSupport
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderElectionState
+import io.bluetape4k.leader.LeaderState
 import io.bluetape4k.support.requireNotBlank
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
@@ -25,10 +27,11 @@ import kotlin.time.Duration
  */
 abstract class AbstractLocalLeaderElector(
     protected val options: LeaderElectionOptions = LeaderElectionOptions.Default,
-) : LeaderElectionListenerRegistry {
+) : LeaderElectionListenerRegistry, LeaderElectionState {
 
     private val locks = ConcurrentHashMap<String, ReentrantLock>()
     private val listeners = LeaderElectionListenerSupport()
+    private val states = LocalLeaderStateRegistry()
 
     override fun addListener(listener: LeaderElectionListener): AutoCloseable =
         listeners.addListener(listener)
@@ -87,12 +90,17 @@ abstract class AbstractLocalLeaderElector(
             listeners.notifySkipped(lockName)
             return null
         }
+        states.acquireSingle(lockName, options.nodeId, options.leaseTime)
         listeners.notifyElected(lockName)
         return try {
             action()
         } finally {
+            states.releaseSingle(lockName)
             lock.unlock()
             listeners.notifyRevoked(lockName)
         }
     }
+
+    override fun state(lockName: String): LeaderState =
+        states.singleState(lockName)
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderGroupElector.kt
@@ -39,6 +39,7 @@ abstract class AbstractLocalLeaderGroupElector(
 
     private val semaphores = ConcurrentHashMap<String, Semaphore>()
     private val listeners = LeaderElectionListenerSupport()
+    private val states = LocalLeaderStateRegistry()
 
     override fun addListener(listener: LeaderElectionListener): AutoCloseable =
         listeners.addListener(listener)
@@ -104,10 +105,12 @@ abstract class AbstractLocalLeaderGroupElector(
             listeners.notifySkipped(lockName)
             return null
         }
+        val lease = states.acquireGroup(lockName, options.nodeId, options.leaseTime, maxLeaders)
         listeners.notifyElected(lockName)
         return try {
             action()
         } finally {
+            states.releaseGroup(lockName, lease)
             semaphore.release()
             listeners.notifyRevoked(lockName)
         }
@@ -155,5 +158,5 @@ abstract class AbstractLocalLeaderGroupElector(
      * @return 현재 리더 그룹 상태 스냅샷
      */
     override fun state(lockName: String): LeaderGroupState =
-        LeaderGroupState(lockName, maxLeaders, activeCount(lockName))
+        states.groupState(lockName, maxLeaders, activeCount(lockName))
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderStateRegistry.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderStateRegistry.kt
@@ -1,0 +1,101 @@
+package io.bluetape4k.leader.local
+
+import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.LeaderLease
+import io.bluetape4k.leader.LeaderState
+import io.bluetape4k.support.requireNotBlank
+import java.time.Instant
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import kotlin.time.Duration
+
+/**
+ * 로컬 elector 구현체에서 사용하는 in-memory 리더 상태 registry입니다.
+ *
+ * `ReentrantLock`과 semaphore 자체는 현재 owner metadata를 노출하지 않으므로, acquire/release 경로에서
+ * 별도의 lease 스냅샷을 기록합니다.
+ */
+internal class LocalLeaderStateRegistry {
+
+    private val lock = ReentrantLock()
+    private val singleLeases = HashMap<String, LeaseRef>()
+    private val groupLeases = HashMap<String, MutableMap<Int, LeaderLease>>()
+
+    fun acquireSingle(lockName: String, nodeId: String, leaseTime: Duration): LeaderLease =
+        lock.withLock {
+            val lease = newLease(nodeId, leaseTime)
+            val current = singleLeases[lockName]
+            if (current == null) {
+                singleLeases[lockName] = LeaseRef(lease)
+            } else {
+                current.holdCount += 1
+            }
+            singleLeases.getValue(lockName).lease
+        }
+
+    fun releaseSingle(lockName: String) {
+        lock.withLock {
+            val current = singleLeases[lockName] ?: return
+            current.holdCount -= 1
+            if (current.holdCount <= 0) {
+                singleLeases.remove(lockName)
+            }
+        }
+    }
+
+    fun singleState(lockName: String): LeaderState {
+        lockName.requireNotBlank("lockName")
+        return lock.withLock {
+            singleLeases[lockName]?.lease
+                ?.let { LeaderState.occupied(lockName, it) }
+                ?: LeaderState.empty(lockName)
+        }
+    }
+
+    fun acquireGroup(lockName: String, nodeId: String, leaseTime: Duration, maxLeaders: Int): LeaderLease =
+        lock.withLock {
+            val leases = groupLeases.getOrPut(lockName) { HashMap() }
+            val slot = (0 until maxLeaders).firstOrNull { it !in leases }
+                ?: leases.size
+            val lease = newLease(nodeId, leaseTime, slot)
+            leases[slot] = lease
+            lease
+        }
+
+    fun releaseGroup(lockName: String, lease: LeaderLease) {
+        lock.withLock {
+            val slot = lease.slot ?: return
+            val leases = groupLeases[lockName] ?: return
+            leases.remove(slot)
+            if (leases.isEmpty()) {
+                groupLeases.remove(lockName)
+            }
+        }
+    }
+
+    fun groupState(lockName: String, maxLeaders: Int, activeCount: Int): LeaderGroupState {
+        lockName.requireNotBlank("lockName")
+        return lock.withLock {
+            val leaders = groupLeases[lockName]
+                ?.values
+                ?.sortedBy { it.slot }
+                ?: emptyList()
+            LeaderGroupState(lockName, maxLeaders, activeCount, leaders)
+        }
+    }
+
+    private fun newLease(nodeId: String, leaseTime: Duration, slot: Int? = null): LeaderLease {
+        val electedAt = Instant.now()
+        return LeaderLease(
+            leaderId = nodeId,
+            electedAt = electedAt,
+            leaseUntil = electedAt.plusMillis(leaseTime.inWholeMilliseconds),
+            slot = slot,
+        )
+    }
+
+    private data class LeaseRef(
+        val lease: LeaderLease,
+        var holdCount: Int = 1,
+    )
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionListenerTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionListenerTest.kt
@@ -239,6 +239,9 @@ class LeaderElectionListenerTest {
         private val elected: Boolean,
     ) : LeaderElector {
 
+        override fun state(lockName: String): LeaderState =
+            LeaderState.empty(lockName)
+
         override fun <T> runIfLeader(lockName: String, action: () -> T): T? =
             if (elected) action() else null
 

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderStateTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderStateTest.kt
@@ -1,0 +1,54 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class LeaderStateTest {
+
+    @Test
+    fun `empty - leader 없이 빈 상태를 생성한다`() {
+        val state = LeaderState.empty("job-lock")
+
+        state.status shouldBeEqualTo LeaderStatus.Empty
+        state.isEmpty.shouldBeTrue()
+        state.isOccupied.shouldBeFalse()
+        state.leader shouldBeEqualTo null
+    }
+
+    @Test
+    fun `occupied - leader lease 를 포함한 점유 상태를 생성한다`() {
+        val lease = LeaderLease("node-a", electedAt = Instant.now())
+        val state = LeaderState.occupied("job-lock", lease)
+
+        state.status shouldBeEqualTo LeaderStatus.Occupied
+        state.isOccupied.shouldBeTrue()
+        state.leader shouldBeEqualTo lease
+    }
+
+    @Test
+    fun `empty 상태에 leader 가 있으면 실패한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            LeaderState("job-lock", LeaderStatus.Empty, LeaderLease("node-a"))
+        }
+    }
+
+    @Test
+    fun `occupied 상태에 leader 가 없으면 실패한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            LeaderState("job-lock", LeaderStatus.Occupied)
+        }
+    }
+
+    @Test
+    fun `leaseUntil 이 electedAt 보다 이전이면 실패한다`() {
+        val now = Instant.now()
+
+        assertFailsWith<IllegalArgumentException> {
+            LeaderLease("node-a", electedAt = now, leaseUntil = now.minusSeconds(1))
+        }
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalLeaderElectionTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalLeaderElectionTest.kt
@@ -4,10 +4,12 @@ import io.bluetape4k.codec.Base58
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.leader.LeaderElectionException
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderStatus
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import io.bluetape4k.assertions.assertFailsWith
 import kotlin.time.Duration
@@ -39,6 +41,42 @@ class LocalLeaderElectionTest {
 
         result1 shouldBeEqualTo "a"
         result2 shouldBeEqualTo "b"
+    }
+
+    @Test
+    fun `state - 실행 중에는 occupied 이고 완료 후 empty 로 돌아간다`() {
+        val nodeId = "local-node-a"
+        val stateElection = LocalLeaderElector(
+            LeaderElectionOptions(nodeId = nodeId)
+        )
+        val lockName = randomLockName()
+        val started = java.util.concurrent.CountDownLatch(1)
+        val release = java.util.concurrent.CountDownLatch(1)
+
+        val holder = Thread {
+            stateElection.runIfLeader(lockName) {
+                started.countDown()
+                release.await()
+            }
+        }.apply { start() }
+
+        started.await()
+
+        val occupied = stateElection.state(lockName)
+        occupied.status shouldBeEqualTo LeaderStatus.Occupied
+        occupied.isOccupied shouldBeEqualTo true
+        val leader = occupied.leader.shouldNotBeNull()
+        leader.leaderId shouldBeEqualTo nodeId
+        leader.electedAt.shouldNotBeNull()
+        leader.leaseUntil.shouldNotBeNull()
+
+        release.countDown()
+        holder.join()
+
+        val empty = stateElection.state(lockName)
+        empty.status shouldBeEqualTo LeaderStatus.Empty
+        empty.isEmpty shouldBeEqualTo true
+        empty.leader.shouldBeNull()
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalLeaderGroupElectionTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalLeaderGroupElectionTest.kt
@@ -181,6 +181,9 @@ class LocalLeaderGroupElectionTest {
         val activeState = election.state(lockName)
         activeState.activeCount shouldBeEqualTo 2
         activeState.availableSlots shouldBeEqualTo maxLeaders - 2
+        activeState.leaders.size shouldBeEqualTo 2
+        activeState.leaders.map { it.leaderId }.all { it == options.nodeId }.shouldBeTrue()
+        activeState.leaders.mapNotNull { it.slot }.toSet().size shouldBeEqualTo 2
         activeState.isEmpty.shouldBeFalse()
         activeState.isFull.shouldBeFalse()
 
@@ -191,6 +194,7 @@ class LocalLeaderGroupElectionTest {
         // 모두 완료 후 초기 상태로 복귀
         election.activeCount(lockName) shouldBeEqualTo 0
         election.availableSlots(lockName) shouldBeEqualTo maxLeaders
+        election.state(lockName).leaders shouldBeEqualTo emptyList()
     }
 
     @Test


### PR DESCRIPTION
## Summary

PR #148의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: Leader state snapshot API 추가`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 요약

Refs #68.

Leader Election을 실행하기 전에 현재 상태를 조회할 수 있도록 core state snapshot API와 local 구현을 추가했습니다.

- `LeaderElectionState`, `LeaderState`, `LeaderLease`, `LeaderStatus` 공개 API 추가
- single elector 계열에서 `state(lockName)` 조회 지원
- `LeaderGroupState`에 현재 leader 목록을 담는 `leaders` 추가
- local blocking/async/virtual-thread/suspend 구현에 in-memory lease registry 추가
- README와 `leader-core` README에 best-effort snapshot 계약과 사용 예시 추가

## 검토 포인트

- 이 API는 lock 획득 판단용이 아니라 관측용 best-effort snapshot입니다. 실제 실행 가능 여부는 기존 atomic acquire path가 authoritative source입니다.
- 이 PR은 core/local 정확성을 우선 제공합니다. Redis/Mongo/Hazelcast/ZooKeeper/Exposed single backend의 정확한 occupied metadata는 후속 backend별 작업에서 확장할 수 있습니다.

## 6-Tier 리뷰

- `docs/superpowers/notes/2026-05-09-issue-68-6-tier-review.md`

## 검증

- `git diff --check`
- `./gradlew compileKotlin --continue`
- `./gradlew :leader-core:test`
- `./gradlew :leader-core:koverXmlReport`
  - `leader-core`: 288 passing
  - Kover line coverage: 88.0%

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #148, head `5513ba49a3bf454ab98b2ef92d4a5f146a78a3b8`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
