### PR TITLE
feat: 단일 리더 lease autoExtend 지원

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -166,12 +166,15 @@ val options = LeaderElectionOptions(
     waitTime = 3.seconds,   // 락 획득 최대 대기 시간
     leaseTime = 30.seconds, // 락 보유(임대) 최대 시간
     nodeId = "worker-a",    // 상태 스냅샷에 노출할 노드 식별자
-    minLeaseTime = 0.seconds // lockAtLeastFor 방식의 최소 lease 보존 시간
+    minLeaseTime = 0.seconds, // lockAtLeastFor 방식의 최소 lease 보존 시간
+    autoExtend = true // action 실행 중 단일 리더 lease를 갱신
 )
 val election = RedissonLeaderElector(client, options)
 ```
 
 `minLeaseTime`은 ShedLock `lockAtLeastFor` 대응 옵션입니다. 로컬 elector는 release 전 대기하고, 지원되는 분산 backend는 남은 최소 lease를 storage TTL에 위임하므로 caller는 즉시 반환됩니다.
+
+`autoExtend`는 단일 리더 선출에서 opt-in으로 동작합니다. Local, Lettuce, MongoDB, Redisson은 action 실행 중 lease를 유지하며, Redisson은 자체 watchdog에 위임합니다. `@LeaderGroupElection`은 아직 auto-extension을 지원하지 않습니다. Redisson은 watchdog release semantics가 모호하므로 `autoExtend=true`와 `minLeaseTime > 0` 조합을 거부합니다.
 
 ### 상태 스냅샷
 

--- a/README.md
+++ b/README.md
@@ -166,12 +166,15 @@ val options = LeaderElectionOptions(
     waitTime = 3.seconds,   // how long to wait for the lock
     leaseTime = 30.seconds, // how long to hold the lock
     nodeId = "worker-a",    // id exposed by state snapshots
-    minLeaseTime = 0.seconds // lockAtLeastFor-style minimum lease retention
+    minLeaseTime = 0.seconds, // lockAtLeastFor-style minimum lease retention
+    autoExtend = true // renew single-leader leases while the action is running
 )
 val election = RedissonLeaderElector(client, options)
 ```
 
 `minLeaseTime` is the `lockAtLeastFor` equivalent. Local electors wait before releasing; supported distributed backends delegate the remaining minimum lease to storage TTL so callers can return immediately.
+
+`autoExtend` is opt-in for single-leader elections. Local, Lettuce, MongoDB, and Redisson keep the lease alive while the action is running; Redisson delegates to its native watchdog. `@LeaderGroupElection` does not support auto-extension yet. Redisson rejects `autoExtend=true` with `minLeaseTime > 0` because watchdog release semantics would be ambiguous.
 
 ### State snapshots
 

--- a/docs/superpowers/plans/2026-05-10-leader-auto-extend-plan.md
+++ b/docs/superpowers/plans/2026-05-10-leader-auto-extend-plan.md
@@ -1,0 +1,78 @@
+# Leader autoExtend 구현 계획
+
+## Task 1. Core option and tests
+
+- complexity: medium
+- files: `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionOptions.kt`, `leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionOptionsTest.kt`
+- work: `autoExtend: Boolean = false` 추가, KDoc/serialization 유지, 기본/커스텀 option test 갱신
+- verification: `./gradlew :leader-core:test --tests "*LeaderElectionOptionsTest"`
+- rollback point: option 추가 전으로 revert 가능
+
+## Task 2. Annotation and aspect mapping
+
+- complexity: medium
+- files: `LeaderElection.kt`, `LeaderElectionAnnotationTest.kt`, `LeaderElectionAspect.kt`, `LeaderElectionAspectTest.kt`
+- work: `@LeaderElection(autoExtend=false)` 추가, aspect metadata에서 `LeaderElectionOptions.autoExtend` 전달, mapping test 추가
+- verification: `./gradlew :leader-core:test --tests "*LeaderElectionAnnotationTest" && ./gradlew :leader-spring-boot:test --tests "*LeaderElectionAspectTest"`
+- docs impact: public annotation KDoc/README 갱신 필요
+
+## Task 3. Common watchdog helper
+
+- complexity: high
+- files: `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt`, focused unit test
+- work: daemon scheduled executor 기반 `start(enabled, leaseTime, extend)` helper 추가. close 시 future cancel. 실패 시 반복 중단.
+- verification: `./gradlew :leader-core:test --tests "*LeaderLeaseAutoExtenderTest"`
+- risk: leaked scheduled task. 테스트에서 close 후 추가 호출이 없는지 검증한다.
+
+## Task 4. Local backend support
+
+- complexity: medium
+- files: `AbstractLocalLeaderElector.kt`, `LocalSuspendLeaderElector.kt`, local tests
+- work: action 실행 중 state leaseUntil을 갱신하도록 autoExtend helper 연결. 실제 mutual exclusion은 기존 JVM lock이 담당.
+- verification: `./gradlew :leader-core:test --tests "*LocalLeaderElectionTest" --tests "*LocalSuspendLeaderElectorTest"`
+
+## Task 5. Lettuce backend support
+
+- complexity: high
+- files: `LettuceLock.kt`, `LettuceSuspendLock.kt`, `LettuceLeaderElector.kt`, `LettuceSuspendLeaderElector.kt`, Lettuce tests
+- work: token-conditional extend Lua 추가, sync/async/suspend elector watchdog lifecycle 연결
+- verification: `./gradlew :leader-redis-lettuce:test --tests "*LettuceLeaderElectionTest" --tests "*LettuceSuspendLeaderElectorTest"`
+- risk: Redis RTT와 짧은 TTL. 테스트는 200ms+ lease로 둔다.
+
+## Task 6. Mongo backend support
+
+- complexity: high
+- files: `MongoLock.kt`, `MongoSuspendLock.kt`, `MongoLeaderElector.kt`, `MongoSuspendLeaderElector.kt`, Mongo tests
+- work: token-conditional `expireAt` update extension 추가, sync/async/suspend elector watchdog lifecycle 연결
+- verification: `./gradlew :leader-mongodb:test --tests "*MongoLeaderElectionTest" --tests "*MongoSuspendLeaderElectorTest"`
+- risk: TTL monitor delete timing은 비결정적이므로 takeover가 아니라 contender skip으로 검증한다.
+
+## Task 7. Redisson backend support
+
+- complexity: high
+- files: `RedissonLeaderElector.kt`, `RedissonSuspendLeaderElector.kt`, Redisson tests
+- work: `autoExtend=true`이면 `tryLock(waitTime, TimeUnit)` / async overload로 Redisson watchdog 사용. `minLeaseTime > 0` fail-fast.
+- verification: `./gradlew :leader-redis-redisson:test --tests "*RedissonLeaderElectionTest" --tests "*RedissonSuspendLeaderElectorTest"`
+- risk: Redisson thread/lockId ownership. 기존 sync/async/suspend ownership path를 유지한다.
+
+## Task 8. Documentation and final verification
+
+- complexity: low
+- files: `README.md`, `README.ko.md`, relevant module READMEs if compact update is needed
+- work: single-leader `autoExtend` usage and backend support matrix 추가
+- verification: targeted module tests, `./gradlew :leader-core:build :leader-spring-boot:test :leader-redis-lettuce:test :leader-mongodb:test :leader-redis-redisson:test`
+- not in scope: Exposed/Hazelcast/ZooKeeper autoExtend behavior except compile fixes
+
+## Review notes
+
+- Spec review local perspectives:
+  - developer: option propagation and backend ownership are aligned with current factory model.
+  - security: extension must be token-conditional; no lock revival without ownership.
+  - ops: watchdog failure is logged but cannot cancel running action with current API.
+  - caller: default false preserves existing fixed TTL behavior.
+- Plan review local perspectives:
+  - implementer: tasks are ordered by shared API first, backend support second.
+  - test engineer: each backend has a focused long-running contention test.
+  - architect: no AOP-only timer; backend lifecycle owns renewal.
+  - delivery: group autoExtend is explicitly excluded.
+- Claude advisor: attempted with `claude-opus-4-7` at `.omx/artifacts/claude-leader-auto-extend-spec-plan-20260510-114935.md`; CLI produced no output for ~2 minutes and was terminated. Proceeding with local multi-perspective review to avoid blocking implementation.

--- a/docs/superpowers/specs/2026-05-10-leader-auto-extend-design.md
+++ b/docs/superpowers/specs/2026-05-10-leader-auto-extend-design.md
@@ -1,0 +1,89 @@
+# Leader autoExtend 설계
+
+## 문제
+
+Issue #73은 `@LeaderElection(leaseTime = "PT5M")` 본문이 lease를 초과 실행할 때 기존 backend TTL이 만료되고 다른 노드가 같은 lock을 획득하는 split-brain 위험을 줄이기 위해 `autoExtend` 옵션을 요구한다.
+
+현재 코드 근거:
+
+- `LeaderElectionOptions`는 `waitTime`, `leaseTime`, `nodeId`, `minLeaseTime`만 가진다.
+- `@LeaderElection`은 `waitTime`, `leaseTime`, `minLeaseTime`, `bean`, `failureMode`만 노출한다.
+- `LeaderElectionAspect`는 annotation duration을 `LeaderElectionOptions`로 변환해 factory에 넘긴다.
+- Lettuce/Mongo lock은 token을 저장하고 unlock 시 token 조건을 확인하므로 owner-conditional TTL 연장이 가능하다.
+- Redisson `RLock.tryLock(waitTime, TimeUnit)`은 Redisson 내부 watchdog을 사용한다. Redisson 공식 문서는 watchdog이 holder Redisson instance가 살아 있는 동안 lock expiration을 연장하며 기본 timeout이 30초라고 설명한다.
+- MongoDB TTL index 공식 문서는 date field 기반 TTL index가 문서를 자동 제거한다고 설명한다. 현재 Mongo backend는 `expireAt` TTL index를 사용한다.
+- Redis `PEXPIRE` 공식 문서는 key expiration을 millisecond 단위로 설정한다고 설명한다. Lettuce backend는 Lua unlock script가 이미 token 조건부 `PEXPIRE`를 사용한다.
+
+Primary references:
+
+- GitHub issue: https://github.com/bluetape4k/bluetape4k-leader/issues/73
+- Redisson locks: https://redisson.pro/docs/data-and-services/locks-and-synchronizers/
+- Redis PEXPIRE: https://redis.io/docs/latest/commands/pexpire/
+- MongoDB TTL indexes: https://www.mongodb.com/docs/v8.0/core/index-ttl/
+
+## 목표
+
+- `LeaderElectionOptions.autoExtend: Boolean = false`를 추가한다.
+- `@LeaderElection(autoExtend = true)`를 추가하고 `LeaderElectionAspect`가 core option으로 전달한다.
+- Single-leader path에서 lock/elector가 auto-extend lifecycle을 소유한다.
+- v1 production slice는 Redisson, Lettuce, MongoDB, Local single-leader backend를 지원한다.
+- `@LeaderGroupElection` autoExtend는 이번 PR 범위 밖이다.
+
+## 비목표
+
+- Group/semaphore backend autoExtend 구현.
+- Fencing token 도입.
+- AOP-only timer 구현.
+- 모든 backend(Exposed/Hazelcast/ZooKeeper)의 완전한 autoExtend 구현. 단, common option 추가로 compile 영향이 있으면 수정한다.
+
+## 설계
+
+### Core option
+
+`LeaderElectionOptions`에 `autoExtend`를 추가한다. 기본값은 false이므로 기존 호출자는 fixed TTL 동작을 유지한다.
+
+Validation은 기존 `minLeaseTime <= leaseTime` 규칙을 유지한다. `autoExtend + minLeaseTime`은 backend별 release semantics가 다르므로 core에서 금지하지 않고, Redisson single lock에서만 fail-fast 한다.
+
+### AOP
+
+`@LeaderElection`에 `autoExtend: Boolean = false`를 추가한다. `LeaderElectionAspect.resolveMetadata()`는 annotation 값을 `LeaderElectionOptions(autoExtend = ann.autoExtend)`로 전달한다.
+
+Aspect는 timer를 만들지 않는다. sync/suspend/Mono 모두 factory cache key에 포함된 option으로 backend elector를 선택한다.
+
+### Common watchdog helper
+
+Core에 `LeaderLeaseAutoExtender`를 둔다. Backend는 lock 획득 직후 `start(autoExtend, leaseTime) { extend(leaseTime) }`를 호출하고, action 종료/예외/취소 release path에서 close한다.
+
+Watchdog은 leaseTime의 약 1/3 주기로 실행하며, `extend()`가 false를 반환하거나 예외를 던지면 반복을 중단하고 warn log를 남긴다. 이미 소유권을 잃은 lock을 되살리지 않기 위해 extension 함수는 반드시 owner-token 조건부여야 한다.
+
+### Backend
+
+- Redisson: `autoExtend=true`이면 명시 leaseTime 대신 `tryLock(waitTime, TimeUnit)` / `tryLockAsync(waitTime, TimeUnit, lockId)`를 사용해 Redisson watchdog에 위임한다. `minLeaseTime > 0`과 조합하면 현재 key TTL 조작 release semantics가 watchdog과 충돌할 수 있어 fail-fast 한다.
+- Lettuce: `LettuceLock.extend(leaseTime): Boolean`과 suspend variant를 추가한다. Lua script는 `GET key == token`일 때만 `PEXPIRE key leaseMs`를 수행한다.
+- MongoDB: `MongoLock.extend(leaseTime): Boolean`과 suspend variant를 추가한다. `updateOne(_id, token, $set expireAt=now+leaseTime)`의 matched count로 성공 여부를 판단한다.
+- Local: JVM-local lock은 action 실행 동안 `ReentrantLock`/`Mutex`가 이미 유지되므로 split-brain 위험이 없다. `autoExtend`는 state registry `leaseUntil` 관측값 갱신만 수행한다.
+
+## 접근 비교
+
+1. AOP timer only
+   - Rejected: issue #73의 split-brain 원인은 backend TTL이고, AOP는 lock token을 알 수 없다. owner-conditional 연장을 보장할 수 없다.
+2. Common lock interface에 `extend()` 추가
+   - Rejected for v1: 모든 backend lock abstraction을 한 번에 바꾸면 Exposed/Hazelcast/group까지 scope가 넓어진다.
+3. Backend-local extension plus small common scheduler
+   - Accepted: lifecycle ownership을 elector/lock에 두면서 issue가 요구한 4 backend slice를 작게 구현한다.
+
+## 위험과 완화
+
+- Watchdog thread가 action 종료 후 살아남는 위험: `AutoCloseable` close를 finally/whenComplete/NonCancellable에 둔다.
+- Token이 만료된 뒤 다른 node가 획득한 lock을 연장하는 위험: Lettuce/Mongo extension은 token 조건부 Lua/update만 사용한다.
+- Redisson `minLeaseTime + autoExtend` release 모호성: Redisson elector constructor에서 fail-fast하고 테스트한다.
+- 짧은 leaseTime에서 scheduler jitter로 갱신이 늦는 위험: 테스트 lease는 200ms 이상으로 두고, production에서는 leaseTime을 backend RTT보다 충분히 크게 문서화한다.
+- Watchdog 연장 실패 후 action은 이미 실행 중이다. 현재 API는 실행 중 action 취소를 강제할 수 없으므로 warn 후 반복 중단으로 제한한다.
+
+## Acceptance Criteria
+
+- `LeaderElectionOptions.Default.autoExtend == false`.
+- `@LeaderElection(autoExtend = true)` 값을 aspect가 factory option으로 전달한다.
+- Local/Lettuce/Mongo long-running test에서 `leaseTime`을 초과해도 contender가 lock을 획득하지 못한다.
+- Redisson autoExtend는 watchdog acquisition path를 사용하고 `minLeaseTime > 0` 조합은 fail-fast 한다.
+- `@LeaderGroupElection`에는 autoExtend API를 추가하지 않는다.

--- a/leader-core/README.ko.md
+++ b/leader-core/README.ko.md
@@ -105,7 +105,8 @@ election.runIfLeader("nightly-sync") { syncToRemote() }
 LeaderElectionOptions(
     waitTime: Duration = 5.seconds,   // 락 획득 최대 대기 시간
     leaseTime: Duration = 60.seconds, // 락 보유(임대) 최대 시간
-    minLeaseTime: Duration = Duration.ZERO // 로컬 최소 보유 시간
+    minLeaseTime: Duration = Duration.ZERO, // 로컬 최소 보유 시간
+    autoExtend: Boolean = false // action 실행 중 단일 리더 lease 갱신
 )
 
 LeaderGroupElectionOptions(
@@ -117,6 +118,8 @@ LeaderGroupElectionOptions(
 ```
 
 `minLeaseTime`은 lockAtLeastFor 대응 옵션입니다. 로컬 elector는 최소 보유 시간이 지날 때까지 락 또는 슬롯을 유지합니다. 지원되는 분산 backend는 release 시 남은 최소 lease를 storage TTL에 위임합니다.
+
+`autoExtend`는 단일 리더 옵션입니다. 로컬 elector는 JVM lock으로 상호 배제를 유지하고 상태 스냅샷을 갱신하며, 분산 backend는 owner 조건부 lease 갱신을 구현합니다.
 
 ## 시퀀스 다이어그램
 

--- a/leader-core/README.md
+++ b/leader-core/README.md
@@ -105,7 +105,8 @@ election.runIfLeader("nightly-sync") { syncToRemote() }
 LeaderElectionOptions(
     waitTime: Duration = 5.seconds,   // max wait for lock acquisition
     leaseTime: Duration = 60.seconds, // max lock hold time
-    minLeaseTime: Duration = Duration.ZERO // minimum local hold time
+    minLeaseTime: Duration = Duration.ZERO, // minimum local hold time
+    autoExtend: Boolean = false // renew a single-leader lease while action runs
 )
 
 LeaderGroupElectionOptions(
@@ -117,6 +118,8 @@ LeaderGroupElectionOptions(
 ```
 
 `minLeaseTime` is the lockAtLeastFor equivalent. Local electors keep the lock or slot until the minimum hold time has elapsed. Supported distributed backends delegate the remaining minimum lease to their storage TTL on release.
+
+`autoExtend` is a single-leader option. Local electors keep mutual exclusion with the JVM lock and refresh state snapshots while distributed backends implement owner-conditional lease renewal.
 
 ## Sequence Diagrams
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionOptions.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionOptions.kt
@@ -24,12 +24,14 @@ import kotlin.time.Duration.Companion.seconds
  * @property leaseTime 리더 보유(임대) 최대 시간. 기본값 60초
  * @property nodeId 상태 조회에 노출할 노드 식별자. 기본값은 JVM 프로세스 단위 stable id
  * @property minLeaseTime 작업이 빨리 끝나도 리더 lease를 최소로 보유할 시간. 기본값 0초
+ * @property autoExtend 작업 실행 중 lease를 주기적으로 연장할지 여부. 기본값 false
  */
 data class LeaderElectionOptions(
     val waitTime: Duration = DefaultWaitTime,
     val leaseTime: Duration = DefaultLeaseTime,
     val nodeId: String = LeaderNodeId.Default,
     val minLeaseTime: Duration = Duration.ZERO,
+    val autoExtend: Boolean = false,
 ): Serializable {
     init {
         waitTime.requireGe(Duration.ZERO, "waitTime")

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt
@@ -1,0 +1,99 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * 리더 lease를 백엔드 소유권 조건으로 주기 연장하는 공통 watchdog helper입니다.
+ *
+ * ## 계약
+ * - [extend]는 반드시 현재 owner token/thread/instance 조건을 확인해야 합니다.
+ * - [extend]가 `false`를 반환하거나 예외를 던지면 watchdog은 반복을 중단합니다.
+ * - 호출자는 action 종료/예외/취소 release path에서 반환된 [AutoCloseable]을 닫아야 합니다.
+ *
+ * ```kotlin
+ * val watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime) {
+ *     lock.extend(options.leaseTime)
+ * }
+ * try {
+ *     action()
+ * } finally {
+ *     watchdog.close()
+ * }
+ * ```
+ */
+object LeaderLeaseAutoExtender : KLogging() {
+
+    private val threadSeq = AtomicInteger()
+    private val scheduler = Executors.newScheduledThreadPool(DEFAULT_WATCHDOG_THREADS) { runnable ->
+        Thread(runnable, "bluetape4k-leader-lease-watchdog-${threadSeq.incrementAndGet()}").apply {
+            isDaemon = true
+        }
+    }
+
+    /**
+     * [enabled]가 true이면 lease 연장 watchdog을 시작하고, false이면 no-op closeable을 반환합니다.
+     */
+    fun start(
+        enabled: Boolean,
+        leaseTime: Duration,
+        extend: () -> Boolean,
+    ): AutoCloseable {
+        if (!enabled) {
+            return NoopCloseable
+        }
+
+        val closed = AtomicBoolean(false)
+        val period = renewalPeriod(leaseTime)
+        lateinit var future: ScheduledFuture<*>
+
+        future = scheduler.scheduleWithFixedDelay(
+            {
+                if (closed.get()) {
+                    future.cancel(false)
+                    return@scheduleWithFixedDelay
+                }
+
+                val extended = runCatching { extend() }
+                    .onFailure { log.warn(it) { "leader.lease.auto-extend.failed" } }
+                    .getOrDefault(false)
+
+                if (!extended && closed.compareAndSet(false, true)) {
+                    log.warn { "leader.lease.auto-extend.stopped reason=NOT_OWNER" }
+                    future.cancel(false)
+                }
+            },
+            period.inWholeMilliseconds,
+            period.inWholeMilliseconds,
+            TimeUnit.MILLISECONDS,
+        )
+
+        return AutoCloseable {
+            if (closed.compareAndSet(false, true)) {
+                future.cancel(false)
+            }
+        }
+    }
+
+    /**
+     * [leaseTime] 기준 watchdog 반복 주기를 계산합니다.
+     */
+    fun renewalPeriod(leaseTime: Duration): Duration {
+        val third = leaseTime / 3
+        return if (third > MIN_RENEWAL_PERIOD) third else MIN_RENEWAL_PERIOD
+    }
+
+    private object NoopCloseable : AutoCloseable {
+        override fun close() = Unit
+    }
+
+    private const val DEFAULT_WATCHDOG_THREADS = 2
+    private val MIN_RENEWAL_PERIOD = 25.milliseconds
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/annotation/LeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/annotation/LeaderElection.kt
@@ -41,6 +41,7 @@ package io.bluetape4k.leader.annotation
  * @property waitTime 리더 획득 대기 시간 — 빈 문자열 시 property 또는 코어 default 폴백
  * @property leaseTime 리더 보유 시간 — 빈 문자열 시 property 또는 코어 default 폴백
  * @property minLeaseTime 최소 리더 보유 시간. `PT0S`이면 빠른 종료 시 즉시 해제
+ * @property autoExtend 작업 실행 중 단일 리더 lease를 backend watchdog으로 주기 연장할지 여부
  * @property bean 사용할 [io.bluetape4k.leader.LeaderElectorFactory] 빈 이름 (literal only). 빈 문자열 시 default factory
  * @property failureMode 백엔드 예외 처리 정책. default `RETHROW`
  *
@@ -55,6 +56,7 @@ annotation class LeaderElection(
     val waitTime: String = "",
     val leaseTime: String = "",
     val minLeaseTime: String = "PT0S",
+    val autoExtend: Boolean = false,
     val bean: String = "",
     val failureMode: LeaderAspectFailureMode = LeaderAspectFailureMode.INHERIT,
 )

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElector.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.leader.LeaderElectionListener
 import io.bluetape4k.leader.LeaderElectionListenerRegistry
 import io.bluetape4k.leader.LeaderElectionListenerSupport
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
 import io.bluetape4k.leader.LeaderState
 import io.bluetape4k.leader.local.LocalLeaderStateRegistry
 import io.bluetape4k.leader.remainingMinLeaseTime
@@ -88,12 +89,16 @@ class LocalSuspendLeaderElector(
         }
         val startedAtNanos = System.nanoTime()
         states.acquireSingle(lockName, options.nodeId, options.leaseTime)
+        val watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime) {
+            states.extendSingle(lockName, options.leaseTime)
+        }
         listeners.notifyElected(lockName)
         eventSubject.emit(LeaderElectionEvent.Elected(lockName))
         return try {
             action()
         } finally {
             withContext(NonCancellable) {
+                watchdog.close()
                 delayRemainingMinLeaseTime(startedAtNanos)
                 states.releaseSingle(lockName)
                 if (acquired) mutex.unlock()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderElector.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.leader.LeaderElectionListenerRegistry
 import io.bluetape4k.leader.LeaderElectionListenerSupport
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderElectionState
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
 import io.bluetape4k.leader.LeaderState
 import io.bluetape4k.leader.parkRemainingMinLeaseTime
 import io.bluetape4k.support.requireNotBlank
@@ -93,10 +94,14 @@ abstract class AbstractLocalLeaderElector(
         }
         val startedAtNanos = System.nanoTime()
         states.acquireSingle(lockName, options.nodeId, options.leaseTime)
+        val watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime) {
+            states.extendSingle(lockName, options.leaseTime)
+        }
         listeners.notifyElected(lockName)
         return try {
             action()
         } finally {
+            watchdog.close()
             parkRemainingMinLeaseTime(startedAtNanos, options.minLeaseTime)
             states.releaseSingle(lockName)
             lock.unlock()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderStateRegistry.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderStateRegistry.kt
@@ -43,6 +43,15 @@ internal class LocalLeaderStateRegistry {
         }
     }
 
+    fun extendSingle(lockName: String, leaseTime: Duration): Boolean =
+        lock.withLock {
+            val current = singleLeases[lockName] ?: return false
+            current.lease = current.lease.copy(
+                leaseUntil = Instant.now().plusMillis(leaseTime.inWholeMilliseconds),
+            )
+            true
+        }
+
     fun singleState(lockName: String): LeaderState {
         lockName.requireNotBlank("lockName")
         return lock.withLock {
@@ -95,7 +104,7 @@ internal class LocalLeaderStateRegistry {
     }
 
     private data class LeaseRef(
-        val lease: LeaderLease,
+        var lease: LeaderLease,
         var holdCount: Int = 1,
     )
 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionOptionsTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionOptionsTest.kt
@@ -18,6 +18,7 @@ class LeaderElectionOptionsTest {
         options.waitTime shouldBeEqualTo LeaderElectionOptions.DefaultWaitTime
         options.leaseTime shouldBeEqualTo LeaderElectionOptions.DefaultLeaseTime
         options.minLeaseTime shouldBeEqualTo Duration.ZERO
+        options.autoExtend shouldBeEqualTo false
     }
 
     @Test
@@ -26,10 +27,12 @@ class LeaderElectionOptionsTest {
             waitTime = 10.seconds,
             leaseTime = 120.seconds,
             minLeaseTime = 5.seconds,
+            autoExtend = true,
         )
         options.waitTime shouldBeEqualTo 10.seconds
         options.leaseTime shouldBeEqualTo 120.seconds
         options.minLeaseTime shouldBeEqualTo 5.seconds
+        options.autoExtend shouldBeEqualTo true
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtenderTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtenderTest.kt
@@ -1,0 +1,43 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import kotlinx.coroutines.delay
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+
+class LeaderLeaseAutoExtenderTest {
+
+    @Test
+    fun `disabled watchdog does not call extender`() = runSuspendIO {
+        val calls = AtomicInteger(0)
+
+        val watchdog = LeaderLeaseAutoExtender.start(false, 100.milliseconds) {
+            calls.incrementAndGet()
+            true
+        }
+
+        delay(120.milliseconds)
+        watchdog.close()
+
+        calls.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `watchdog stops after close`() = runSuspendIO {
+        val calls = AtomicInteger(0)
+
+        val watchdog = LeaderLeaseAutoExtender.start(true, 90.milliseconds) {
+            calls.incrementAndGet()
+            true
+        }
+
+        delay(120.milliseconds)
+        watchdog.close()
+        val afterClose = calls.get()
+        delay(120.milliseconds)
+
+        calls.get() shouldBeEqualTo afterClose
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/annotation/LeaderElectionAnnotationTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/annotation/LeaderElectionAnnotationTest.kt
@@ -20,6 +20,7 @@ class LeaderElectionAnnotationTest {
         waitTime = "PT5S",
         leaseTime = "PT60S",
         minLeaseTime = "PT10S",
+        autoExtend = true,
         bean = "redissonLeaderElectionFactory",
         failureMode = LeaderAspectFailureMode.SKIP,
     )
@@ -32,6 +33,7 @@ class LeaderElectionAnnotationTest {
         annotation.waitTime shouldBeEqualTo ""
         annotation.leaseTime shouldBeEqualTo ""
         annotation.minLeaseTime shouldBeEqualTo "PT0S"
+        annotation.autoExtend shouldBeEqualTo false
         annotation.bean shouldBeEqualTo ""
         annotation.failureMode shouldBeEqualTo LeaderAspectFailureMode.INHERIT
     }
@@ -43,6 +45,7 @@ class LeaderElectionAnnotationTest {
         annotation.waitTime shouldBeEqualTo "PT5S"
         annotation.leaseTime shouldBeEqualTo "PT60S"
         annotation.minLeaseTime shouldBeEqualTo "PT10S"
+        annotation.autoExtend shouldBeEqualTo true
         annotation.bean shouldBeEqualTo "redissonLeaderElectionFactory"
         annotation.failureMode shouldBeEqualTo LeaderAspectFailureMode.SKIP
     }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalLeaderElectionTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalLeaderElectionTest.kt
@@ -80,6 +80,36 @@ class LocalLeaderElectionTest {
     }
 
     @Test
+    fun `autoExtend - 실행 중 state leaseUntil 을 갱신한다`() {
+        val stateElection = LocalLeaderElector(
+            LeaderElectionOptions(
+                leaseTime = 120.milliseconds,
+                autoExtend = true,
+            )
+        )
+        val lockName = randomLockName()
+        val started = java.util.concurrent.CountDownLatch(1)
+        val release = java.util.concurrent.CountDownLatch(1)
+
+        val holder = Thread {
+            stateElection.runIfLeader(lockName) {
+                started.countDown()
+                release.await()
+            }
+        }.apply { start() }
+
+        started.await()
+        val initialLeaseUntil = stateElection.state(lockName).leader.shouldNotBeNull().leaseUntil.shouldNotBeNull()
+        Thread.sleep(180)
+        val extendedLeaseUntil = stateElection.state(lockName).leader.shouldNotBeNull().leaseUntil.shouldNotBeNull()
+
+        release.countDown()
+        holder.join()
+
+        extendedLeaseUntil.isAfter(initialLeaseUntil) shouldBeEqualTo true
+    }
+
+    @Test
     fun `runIfLeader - action 예외 발생 시 예외가 호출자에게 전파된다`() {
         assertFailsWith<LeaderElectionException> {
             election.runIfLeader(randomLockName()) {

--- a/leader-mongodb/README.ko.md
+++ b/leader-mongodb/README.ko.md
@@ -10,7 +10,7 @@
 
 `leader-mongodb`는 `leader-core` 인터페이스를 MongoDB의 `findOneAndUpdate` (`upsert=true`)를 원자적 락 기본 연산으로 구현합니다. `expireAt` 필드의 TTL 인덱스가 자동 만료를 담당합니다. 락 소유권은 인스턴스 별 UUID 토큰으로 추적하여 코루틴 스레드 전환에 무관하게 안전합니다.
 
-`minLeaseTime` 설정 시 unlock은 문서를 즉시 삭제하지 않고 남은 최소 lease만큼 `expireAt`을 갱신합니다. caller를 블로킹하지 않으면서 ShedLock `lockAtLeastFor`와 같은 동작을 제공합니다.
+`minLeaseTime` 설정 시 unlock은 문서를 즉시 삭제하지 않고 남은 최소 lease만큼 `expireAt`을 갱신합니다. caller를 블로킹하지 않으면서 ShedLock `lockAtLeastFor`와 같은 동작을 제공합니다. `LeaderElectionOptions(autoExtend = true)`를 사용하면 단일 리더 elector가 저장된 token이 현재 owner와 일치할 때만 `expireAt`을 주기적으로 갱신합니다.
 
 락 전략:
 - **획득**: `findOneAndUpdate(filter: {_id, expireAt < 현재}, update: {token, expireAt}, upsert=true, returnDocument=AFTER)` — 반환된 token이 일치하면 성공; `E11000`은 유효한 락이 이미 존재함을 의미 → 재시도.
@@ -225,7 +225,7 @@ MongoSuspendLeaderGroupElector(
 
 ## 주의사항
 
-- `leaseTime`은 action의 최대 실행 시간보다 충분히 커야 합니다 (자동 갱신 없음).
+- 단일 리더 선출은 `autoExtend=true`로 action 실행 중 `expireAt`을 갱신할 수 있습니다. 그룹 선출은 여전히 `leaseTime`이 예상 action 시간을 충분히 덮어야 합니다.
 - MongoDB TTL 인덱스는 최대 60초 주기로 실행 — 만료 문서가 잠시 잔류할 수 있습니다.
 - `activeCount()` / `availableSlots()`는 TTL 만료 주기로 인해 근사치입니다.
 - Replica Set 환경: 강한 일관성을 위해 `WriteConcern.MAJORITY` 권장.

--- a/leader-mongodb/README.md
+++ b/leader-mongodb/README.md
@@ -10,7 +10,7 @@ MongoDB-backed leader election using `findOneAndUpdate` + TTL index — blocking
 
 `leader-mongodb` implements `leader-core` interfaces using MongoDB's `findOneAndUpdate` with `upsert=true` as the atomic lock primitive. A TTL index on `expireAt` handles automatic expiry. Lock ownership is tracked by a per-instance UUID token, making it safe across coroutine thread switches.
 
-When `minLeaseTime` is configured, unlock updates `expireAt` to the remaining minimum lease instead of deleting the document, matching ShedLock `lockAtLeastFor` behavior without blocking the caller.
+When `minLeaseTime` is configured, unlock updates `expireAt` to the remaining minimum lease instead of deleting the document, matching ShedLock `lockAtLeastFor` behavior without blocking the caller. With `LeaderElectionOptions(autoExtend = true)`, single-leader electors periodically update `expireAt` only when the stored token still matches the owner.
 
 Lock strategy:
 - **Acquire**: `findOneAndUpdate(filter: {_id, expireAt < now}, update: {token, expireAt}, upsert=true, returnDocument=AFTER)` — succeeds if the returned token matches; `E11000` means a live lock exists → retry.
@@ -225,7 +225,7 @@ MongoSuspendLeaderGroupElector(
 
 ## Notes
 
-- `leaseTime` must be longer than the expected action duration (no automatic renewal).
+- For single-leader elections, `autoExtend=true` can renew `expireAt` while the action runs. Group elections still require `leaseTime` to cover the expected action duration.
 - MongoDB TTL index fires at most every 60 seconds — expired documents may linger briefly.
 - `activeCount()` / `availableSlots()` are approximate due to the TTL expiry window.
 - Replica Set environments: `WriteConcern.MAJORITY` is recommended for strong consistency.

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElector.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElector.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.leader.mongodb
 import com.mongodb.client.MongoCollection
 import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
 import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
 import io.bluetape4k.leader.mongodb.lock.MongoLock
 import io.bluetape4k.leader.mongodb.lock.validateMongoLockName
 import io.bluetape4k.logging.KLogging
@@ -58,10 +59,17 @@ class MongoLeaderElector private constructor(
         }
 
         val acquiredAtNanos = System.nanoTime()
+        val watchdog = LeaderLeaseAutoExtender.start(
+            options.leaderOptions.autoExtend,
+            options.leaderOptions.leaseTime,
+        ) {
+            lock.extend(options.leaderOptions.leaseTime)
+        }
         log.debug { "리더로 승격하여 작업을 수행합니다. lockName=$lockName" }
         try {
             return action()
         } finally {
+            watchdog.close()
             runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos) }
                 .onSuccess { log.debug { "리더 권한을 반납했습니다. lockName=$lockName" } }
                 .onFailure { e -> log.warn(e) { "락 해제 실패. lockName=$lockName" } }
@@ -84,14 +92,22 @@ class MongoLeaderElector private constructor(
                     CompletableFuture.completedFuture(null)
                 } else {
                     val acquiredAtNanos = System.nanoTime()
+                    val watchdog = LeaderLeaseAutoExtender.start(
+                        options.leaderOptions.autoExtend,
+                        options.leaderOptions.leaseTime,
+                    ) {
+                        lock.extend(options.leaderOptions.leaseTime)
+                    }
                     log.debug { "리더로 승격하여 비동기 작업을 수행합니다. lockName=$lockName" }
                     val actionFuture = runCatching { action() }
                         .getOrElse { e ->
+                            watchdog.close()
                             runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos) }
                                 .onFailure { ex -> log.warn(ex) { "락 해제 실패 (action 오류 경로). lockName=$lockName" } }
                             return@thenComposeAsync CompletableFuture.failedFuture(e)
                         }
                     actionFuture.whenCompleteAsync({ _, _ ->
+                        watchdog.close()
                         runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos) }
                             .onSuccess { log.debug { "비동기 리더 권한을 반납했습니다. lockName=$lockName" } }
                             .onFailure { e -> log.warn(e) { "비동기 락 해제 실패. lockName=$lockName" } }

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderElector.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderElector.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.mongodb
 
 import com.mongodb.kotlin.client.coroutine.MongoCollection
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
 import io.bluetape4k.leader.coroutines.SuspendLeaderElector
 import io.bluetape4k.leader.mongodb.lock.MongoSuspendLock
 import io.bluetape4k.leader.mongodb.lock.validateMongoLockName
@@ -9,6 +10,11 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.bson.Document
 
@@ -56,19 +62,44 @@ class MongoSuspendLeaderElector private constructor(
             return null
         }
 
-        val acquiredAtNanos = System.nanoTime()
-        log.debug { "리더로 승격하여 suspend 작업을 수행합니다. lockName=$lockName" }
-        try {
-            return action()
-        } finally {
-            withContext(NonCancellable) {
-                try {
-                    lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos)
-                    log.debug { "리더 권한을 반납했습니다 (suspend). lockName=$lockName" }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    log.warn(e) { "락 해제 실패 (suspend). lockName=$lockName" }
+        return coroutineScope {
+            val acquiredAtNanos = System.nanoTime()
+            val watchdog = if (options.leaderOptions.autoExtend) {
+                launch {
+                    val period = LeaderLeaseAutoExtender.renewalPeriod(options.leaderOptions.leaseTime)
+                    while (isActive) {
+                        delay(period)
+                        val extended = try {
+                            lock.extend(options.leaderOptions.leaseTime)
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            log.warn(e) { "leader.lease.auto-extend.failed lockName=$lockName" }
+                            false
+                        }
+                        if (!extended) {
+                            log.warn { "leader.lease.auto-extend.stopped lockName=$lockName reason=NOT_OWNER" }
+                            break
+                        }
+                    }
+                }
+            } else {
+                null
+            }
+            log.debug { "리더로 승격하여 suspend 작업을 수행합니다. lockName=$lockName" }
+            try {
+                action()
+            } finally {
+                withContext(NonCancellable) {
+                    watchdog?.cancelAndJoin()
+                    try {
+                        lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos)
+                        log.debug { "리더 권한을 반납했습니다 (suspend). lockName=$lockName" }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log.warn(e) { "락 해제 실패 (suspend). lockName=$lockName" }
+                    }
                 }
             }
         }

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/lock/MongoLock.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/lock/MongoLock.kt
@@ -205,6 +205,15 @@ class MongoLock private constructor(
             log.debug { "락 해제 성공: lockKey=$lockKey" }
         }
     }
+
+    fun extend(leaseTime: Duration): Boolean {
+        val matched = collection.updateOne(
+            Filters.and(Filters.eq("_id", lockKey), Filters.eq("token", token)),
+            Updates.set("expireAt", Date(System.currentTimeMillis() + leaseTime.inWholeMilliseconds))
+        ).matchedCount
+
+        return matched > 0L
+    }
 }
 
 internal fun validateMongoLockName(lockName: String) {

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/lock/MongoSuspendLock.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/lock/MongoSuspendLock.kt
@@ -23,7 +23,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import org.bson.Document
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
@@ -208,5 +207,14 @@ class MongoSuspendLock private constructor(
         } else {
             log.debug { "락 해제 성공 (suspend): lockKey=$lockKey" }
         }
+    }
+
+    suspend fun extend(leaseTime: Duration): Boolean {
+        val matched = collection.updateOne(
+            Filters.and(Filters.eq("_id", lockKey), Filters.eq("token", token)),
+            Updates.set("expireAt", Date(System.currentTimeMillis() + leaseTime.inWholeMilliseconds))
+        ).matchedCount
+
+        return matched > 0L
     }
 }

--- a/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElectionTest.kt
+++ b/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElectionTest.kt
@@ -138,6 +138,46 @@ class MongoLeaderElectionTest: AbstractMongoLeaderTest() {
     }
 
     @Test
+    fun `runIfLeader - autoExtend 가 leaseTime 초과 action 의 takeover 를 막는다`() {
+        val lockName = randomName()
+        val election = MongoLeaderElector(
+            lockCollection,
+            MongoLeaderElectionOptions(
+                leaderOptions = LeaderElectionOptions(
+                    waitTime = 100.milliseconds,
+                    leaseTime = 250.milliseconds,
+                    autoExtend = true,
+                )
+            )
+        )
+        val started = java.util.concurrent.CountDownLatch(1)
+        val release = java.util.concurrent.CountDownLatch(1)
+        val executor = java.util.concurrent.Executors.newSingleThreadExecutor()
+
+        try {
+            val holder = executor.submit<String?> {
+                election.runIfLeader(lockName) {
+                    started.countDown()
+                    release.await(1, TimeUnit.SECONDS)
+                    "holder"
+                }
+            }
+
+            started.await(1, TimeUnit.SECONDS)
+            Thread.sleep(450)
+
+            election.runIfLeader(lockName) { "contender" }.shouldBeNull()
+
+            release.countDown()
+            holder.get(2, TimeUnit.SECONDS) shouldBeEqualTo "holder"
+            election.runIfLeader(lockName) { "after-release" } shouldBeEqualTo "after-release"
+        } finally {
+            release.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
     fun `runIfLeader - 락 보유 중 짧은 waitTime으로 호출하면 null을 반환한다`() {
         val lockName = randomName()
         val holderLock = MongoLock(lockCollection, lockName)

--- a/leader-redis-lettuce/README.ko.md
+++ b/leader-redis-lettuce/README.ko.md
@@ -10,7 +10,7 @@
 
 `leader-redis-lettuce`는 Lettuce 리액티브 Redis 클라이언트를 사용하여 `leader-core` 인터페이스를 구현합니다. 락 프리미티브(`LettuceLock`, `LettuceSemaphore`)는 이 모듈에 직접 이식되어 있어 `bluetape4k-lettuce`에 대한 런타임 의존이 없습니다.
 
-락 전략: Redis `SET key value NX PX ttl` (원자적 compare-and-set). 자동 갱신(renewal)은 지원하지 않으므로 `leaseTime`은 예상 작업 시간보다 길게 설정해야 합니다.
+락 전략: Redis `SET key value NX PX ttl` (원자적 compare-and-set). `LeaderElectionOptions(autoExtend = true)`를 사용하면 단일 리더 elector가 action 실행 중 token 조건부 `PEXPIRE`로 TTL을 갱신합니다. 그룹/세마포어 갱신은 자동으로 수행하지 않습니다.
 
 ## 아키텍처
 

--- a/leader-redis-lettuce/README.md
+++ b/leader-redis-lettuce/README.md
@@ -10,7 +10,7 @@ Redis-backed leader election using [Lettuce](https://lettuce.io/) — blocking a
 
 `leader-redis-lettuce` implements `leader-core` interfaces using Lettuce's reactive Redis client. Lock primitives (`LettuceLock`, `LettuceSemaphore`) are ported directly into this module — no runtime dependency on `bluetape4k-lettuce`.
 
-Lock strategy: Redis `SET key value NX PX ttl` (atomic compare-and-set). Renewal is not automatic; the caller must ensure `leaseTime` is longer than the expected action duration.
+Lock strategy: Redis `SET key value NX PX ttl` (atomic compare-and-set). With `LeaderElectionOptions(autoExtend = true)`, single-leader electors renew the TTL with a token-conditional `PEXPIRE` while the action is running. Group/semaphore renewal is not automatic.
 
 ## Architecture
 

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElector.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.lettuce
 
 import io.bluetape4k.leader.LeaderElector
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
@@ -58,10 +59,14 @@ class LettuceLeaderElector(
             return null
         }
         val acquiredAtNanos = System.nanoTime()
+        val watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime) {
+            lock.extend(options.leaseTime)
+        }
         log.debug { "리더 선출 성공: lockName=$lockName" }
         try {
             return action()
         } finally {
+            watchdog.close()
             runCatching {
                 if (lock.isHeldByCurrentInstance()) {
                     lock.unlock(options.minLeaseTime, acquiredAtNanos)
@@ -90,9 +95,13 @@ class LettuceLeaderElector(
                 CompletableFuture.completedFuture(null)
             } else {
                 val acquiredAtNanos = System.nanoTime()
+                val watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime) {
+                    lock.extend(options.leaseTime)
+                }
                 log.debug { "리더 선출 성공 (async): lockName=$lockName" }
                 try {
                     action().whenComplete { _, _ ->
+                        watchdog.close()
                         runCatching {
                             if (lock.isHeldByCurrentInstance()) {
                                 lock.unlock(options.minLeaseTime, acquiredAtNanos)
@@ -101,6 +110,7 @@ class LettuceLeaderElector(
                             .onFailure { log.warn(it) { "Fail to release lock. lockName=$lockName" } }
                     }
                 } catch (e: Throwable) {
+                    watchdog.close()
                     runCatching {
                         if (lock.isHeldByCurrentInstance()) {
                             lock.unlock(options.minLeaseTime, acquiredAtNanos)

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElector.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.lettuce
 
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
 import io.bluetape4k.leader.coroutines.SuspendLeaderElector
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
@@ -10,6 +11,11 @@ import io.bluetape4k.support.requireNotBlank
 import io.lettuce.core.api.StatefulRedisConnection
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
@@ -58,22 +64,47 @@ class LettuceSuspendLeaderElector(
             log.debug { "리더 선출 실패 (슬롯 없음, suspend): lockName=$lockName" }
             return null
         }
-        val acquiredAtNanos = System.nanoTime()
-        log.debug { "리더 선출 성공 (suspend): lockName=$lockName" }
-        try {
-            return action()
-        } finally {
-            // NonCancellable: 코루틴 취소 시에도 락 해제가 중단되지 않도록 보호
-            withContext(NonCancellable) {
-                runCatching {
-                    if (lock.isHeldByCurrentInstance()) {
-                        lock.unlock(options.minLeaseTime, acquiredAtNanos)
+        return coroutineScope {
+            val acquiredAtNanos = System.nanoTime()
+            val watchdog = if (options.autoExtend) {
+                launch {
+                    val period = LeaderLeaseAutoExtender.renewalPeriod(options.leaseTime)
+                    while (isActive) {
+                        delay(period)
+                        val extended = try {
+                            lock.extend(options.leaseTime)
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            log.warn(e) { "leader.lease.auto-extend.failed lockName=$lockName" }
+                            false
+                        }
+                        if (!extended) {
+                            log.warn { "leader.lease.auto-extend.stopped lockName=$lockName reason=NOT_OWNER" }
+                            break
+                        }
                     }
                 }
-                    .onFailure { error ->
-                        if (error is CancellationException) throw error
-                        log.warn(error) { "Fail to release lock. lockName=$lockName" }
+            } else {
+                null
+            }
+            log.debug { "리더 선출 성공 (suspend): lockName=$lockName" }
+            try {
+                action()
+            } finally {
+                // NonCancellable: 코루틴 취소 시에도 락 해제가 중단되지 않도록 보호
+                withContext(NonCancellable) {
+                    watchdog?.cancelAndJoin()
+                    try {
+                        if (lock.isHeldByCurrentInstance()) {
+                            lock.unlock(options.minLeaseTime, acquiredAtNanos)
+                        }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log.warn(e) { "Fail to release lock. lockName=$lockName" }
                     }
+                }
             }
         }
     }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/lock/LettuceLock.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/lock/LettuceLock.kt
@@ -59,6 +59,15 @@ else
   return 0
 end"""
         )
+
+        private val EXTEND_SCRIPT = RedisScript(
+            """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+  return redis.call('pexpire', KEYS[1], ARGV[2])
+else
+  return 0
+end"""
+        )
     }
 
     private val tokenRef = atomic<String?>(null)
@@ -137,6 +146,16 @@ end"""
             "Lock 해제 실패 (토큰 불일치 또는 만료): lockKey=$lockKey"
         }
         log.debug { "Lock 해제 성공: lockKey=$lockKey" }
+    }
+
+    fun extend(leaseTime: Duration = defaultLeaseTime): Boolean {
+        val token = tokenRef.value ?: return false
+        val leaseMs = leaseTime.inWholeMilliseconds
+
+        val extended = RedisScriptRunner.run<Long>(
+            syncCommands, EXTEND_SCRIPT, ScriptOutputType.INTEGER, arrayOf(lockKey), token, leaseMs.toString()
+        )
+        return extended > 0L
     }
 
     // =========================================================================
@@ -220,5 +239,14 @@ end"""
             }
             log.debug { "Lock 해제 성공 (async): lockKey=$lockKey" }
         }
+    }
+
+    fun extendAsync(leaseTime: Duration = defaultLeaseTime): CompletableFuture<Boolean> {
+        val token = tokenRef.value ?: return CompletableFuture.completedFuture(false)
+        val leaseMs = leaseTime.inWholeMilliseconds
+
+        return RedisScriptRunner.runAsync<Long>(
+            asyncCommands, EXTEND_SCRIPT, ScriptOutputType.INTEGER, arrayOf(lockKey), token, leaseMs.toString()
+        ).thenApply { it > 0L }
     }
 }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/lock/LettuceSuspendLock.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/lock/LettuceSuspendLock.kt
@@ -56,6 +56,15 @@ else
   return 0
 end"""
         )
+
+        private val EXTEND_SCRIPT = RedisScript(
+            """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+  return redis.call('pexpire', KEYS[1], ARGV[2])
+else
+  return 0
+end"""
+        )
     }
 
     private val tokenRef = atomic<String?>(null)
@@ -134,5 +143,15 @@ end"""
             "Lock 해제 실패 (토큰 불일치 또는 만료, suspend): lockKey=$lockKey"
         }
         log.debug { "Lock 해제 성공 (suspend): lockKey=$lockKey" }
+    }
+
+    suspend fun extend(leaseTime: Duration = defaultLeaseTime): Boolean {
+        val token = tokenRef.value ?: return false
+        val leaseMs = leaseTime.inWholeMilliseconds
+
+        val extended = RedisScriptRunner.runSuspending<Long>(
+            asyncCommands, EXTEND_SCRIPT, ScriptOutputType.INTEGER, arrayOf(lockKey), token, leaseMs.toString()
+        )
+        return extended > 0L
     }
 }

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElectionTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElectionTest.kt
@@ -70,6 +70,43 @@ class LettuceLeaderElectionTest: AbstractLettuceLeaderTest() {
     }
 
     @Test
+    fun `autoExtend - leaseTime 을 초과하는 action 실행 중 contender 는 획득하지 못한다`() {
+        val el = LettuceLeaderElector(
+            connection,
+            LeaderElectionOptions(
+                waitTime = 100.milliseconds,
+                leaseTime = 250.milliseconds,
+                autoExtend = true,
+            )
+        )
+        val started = java.util.concurrent.CountDownLatch(1)
+        val release = java.util.concurrent.CountDownLatch(1)
+        val executor = java.util.concurrent.Executors.newSingleThreadExecutor()
+
+        try {
+            val holder = executor.submit<String?> {
+                el.runIfLeader(lockName) {
+                    started.countDown()
+                    release.await(1, java.util.concurrent.TimeUnit.SECONDS)
+                    "holder"
+                }
+            }
+
+            started.await(1, java.util.concurrent.TimeUnit.SECONDS)
+            Thread.sleep(450)
+
+            el.runIfLeader(lockName) { "contender" }.shouldBeNull()
+
+            release.countDown()
+            holder.get(2, java.util.concurrent.TimeUnit.SECONDS) shouldBeEqualTo "holder"
+            el.runIfLeader(lockName) { "after-release" } shouldBeEqualTo "after-release"
+        } finally {
+            release.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
     fun `리더 선출 - action 예외 발생 시 예외 전파`() {
         assertFailsWith<LeaderElectionException> {
             election.runIfLeader(lockName) { throw LeaderElectionException("오류") }

--- a/leader-redis-redisson/README.ko.md
+++ b/leader-redis-redisson/README.ko.md
@@ -10,6 +10,8 @@
 
 `leader-redis-redisson`은 Redisson의 `RLock`과 `RSemaphore`를 사용하여 `leader-core` 인터페이스를 구현합니다. 블로킹, 비동기, 코루틴, 가상 스레드 실행 모델을 모두 지원합니다.
 
+단일 리더 선출에서 `LeaderElectionOptions(autoExtend = true)`를 사용하면 명시적 lease timeout 없이 `RLock`을 획득해 Redisson 자체 watchdog에 위임합니다. watchdog release semantics가 모호하므로 `autoExtend=true`와 `minLeaseTime > 0` 조합은 거부합니다. 그룹/세마포어 auto-extension은 구현하지 않았습니다.
+
 코루틴 구현체는 PID 시드 기반의 미니 Snowflake ID 생성기를 사용하여 Redis 라운드트립 없이 코루틴별 고유 락 ID를 생성합니다. HA(다중 JVM) 환경에서 안전하게 동작합니다.
 
 ## 아키텍처

--- a/leader-redis-redisson/README.md
+++ b/leader-redis-redisson/README.md
@@ -10,6 +10,8 @@ Redis-backed leader election using [Redisson](https://redisson.org/) — blockin
 
 `leader-redis-redisson` implements `leader-core` interfaces using Redisson's `RLock` and `RSemaphore`. It supports blocking, async, coroutine, and virtual-thread execution models.
 
+For single-leader elections, `LeaderElectionOptions(autoExtend = true)` uses Redisson's native lock watchdog by acquiring `RLock` without an explicit lease timeout. `minLeaseTime > 0` is rejected with `autoExtend=true` because watchdog release semantics would be ambiguous. Group/semaphore auto-extension is not implemented.
+
 The coroutine implementation uses a PID-seeded mini-Snowflake ID generator to produce unique per-coroutine lock IDs without Redis round-trips, ensuring safety in HA (multi-JVM) deployments.
 
 ## Architecture

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElector.kt
@@ -55,6 +55,13 @@ class RedissonLeaderElector private constructor(
     private val waitTimeMills = options.waitTime.inWholeMilliseconds
     private val leaseTimeMills = options.leaseTime.inWholeMilliseconds
     private val minLeaseTime = options.minLeaseTime
+    private val autoExtend = options.autoExtend
+
+    init {
+        require(!(autoExtend && minLeaseTime > kotlin.time.Duration.ZERO)) {
+            "Redisson autoExtend does not support minLeaseTime because watchdog release semantics are ambiguous"
+        }
+    }
 
     /**
      * Redisson Lock을 이용하여, 리더로 선출되면 [action]을 수행하고, 그렇지 않다면 수행하지 않습니다.
@@ -72,7 +79,11 @@ class RedissonLeaderElector private constructor(
         log.debug { "Leader 승격을 요청합니다 ..." }
 
         try {
-            val acquired = lock.tryLock(waitTimeMills, leaseTimeMills, TimeUnit.MILLISECONDS)
+            val acquired = if (autoExtend) {
+                lock.tryLock(waitTimeMills, TimeUnit.MILLISECONDS)
+            } else {
+                lock.tryLock(waitTimeMills, leaseTimeMills, TimeUnit.MILLISECONDS)
+            }
             if (acquired) {
                 val acquiredAtNanos = System.nanoTime()
                 log.debug { "Leader로 승격하여 작업을 수행합니다. lock=$lockName" }
@@ -119,7 +130,12 @@ class RedissonLeaderElector private constructor(
             log.debug { "Leader 승격을 요청합니다 ... lock=$lockName, currentThreadId=$currentThreadId" }
 
             return lock
-                .tryLockAsync(waitTimeMills, leaseTimeMills, TimeUnit.MILLISECONDS, currentThreadId)
+                .tryLockAsync(
+                    waitTimeMills,
+                    if (autoExtend) -1L else leaseTimeMills,
+                    TimeUnit.MILLISECONDS,
+                    currentThreadId,
+                )
                 .thenComposeAsync({ acquired ->
                     if (acquired) {
                         executeActionAsync(lock, currentThreadId, executor, System.nanoTime(), action)

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElector.kt
@@ -108,6 +108,13 @@ class RedissonSuspendLeaderElector private constructor(
     private val waitTimeMills = options.waitTime.inWholeMilliseconds
     private val leaseTimeMills = options.leaseTime.inWholeMilliseconds
     private val minLeaseTime = options.minLeaseTime
+    private val autoExtend = options.autoExtend
+
+    init {
+        require(!(autoExtend && minLeaseTime > kotlin.time.Duration.ZERO)) {
+            "Redisson autoExtend does not support minLeaseTime because watchdog release semantics are ambiguous"
+        }
+    }
 
     /**
      * Redisson Lock을 이용하여, 리더로 선출되면 [action]을 수행하고, 그렇지 않다면 수행하지 않습니다.
@@ -137,7 +144,7 @@ class RedissonSuspendLeaderElector private constructor(
             val acquired = lock
                 .tryLockAsync(
                     waitTimeMills,
-                    leaseTimeMills,
+                    if (autoExtend) -1L else leaseTimeMills,
                     TimeUnit.MILLISECONDS,
                     lockId
                 )
@@ -152,14 +159,14 @@ class RedissonSuspendLeaderElector private constructor(
                     if (lock.isHeldByThread(lockId)) {
                         // NonCancellable: 코루틴 취소 시에도 락 해제가 중단되지 않도록 보호
                         withContext(NonCancellable) {
-                            runCatching { releaseLock(lock, lockId, acquiredAtNanos) }
-                                .onSuccess {
-                                    log.debug { "작업이 완료되어 Leader 권한을 반납했습니다. lock=$lockName, lockId=$lockId" }
-                                }
-                                .onFailure { error ->
-                                    if (error is CancellationException) throw error
-                                    log.warn(error) { "Fail to release lock. lock=$lockName, lockId=$lockId" }
-                                }
+                            try {
+                                releaseLock(lock, lockId, acquiredAtNanos)
+                                log.debug { "작업이 완료되어 Leader 권한을 반납했습니다. lock=$lockName, lockId=$lockId" }
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Exception) {
+                                log.warn(e) { "Fail to release lock. lock=$lockName, lockId=$lockId" }
+                            }
                         }
                     }
                 }

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElectionTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElectionTest.kt
@@ -118,6 +118,58 @@ class RedissonLeaderElectionTest: AbstractRedissonLeaderTest() {
     }
 
     @Test
+    fun `autoExtend with minLeaseTime fails fast`() {
+        assertFailsWith<IllegalArgumentException> {
+            RedissonLeaderElector(
+                redissonClient,
+                LeaderElectionOptions(
+                    leaseTime = 1.seconds,
+                    minLeaseTime = 100.milliseconds,
+                    autoExtend = true,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `autoExtend uses Redisson watchdog while action exceeds explicit leaseTime`() {
+        val lockName = randomName()
+        val leaderElection = RedissonLeaderElector(
+            redissonClient,
+            LeaderElectionOptions(
+                waitTime = 100.milliseconds,
+                leaseTime = 250.milliseconds,
+                autoExtend = true,
+            )
+        )
+        val started = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+
+        try {
+            val holder = executor.submit<String?> {
+                leaderElection.runIfLeader(lockName) {
+                    started.countDown()
+                    release.await(1, TimeUnit.SECONDS)
+                    "holder"
+                }
+            }
+
+            started.await(1, TimeUnit.SECONDS)
+            Thread.sleep(450)
+
+            leaderElection.runIfLeader(lockName) { "contender" }.shouldBeNull()
+
+            release.countDown()
+            holder.get(2, TimeUnit.SECONDS) shouldBeEqualTo "holder"
+            leaderElection.runIfLeader(lockName) { "after-release" } shouldBeEqualTo "after-release"
+        } finally {
+            release.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
     fun `run action should keep Redis TTL until minLeaseTime after fast return`() {
         val lockName = randomName()
         val leaderElection = RedissonLeaderElector(

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -458,7 +458,12 @@ class LeaderElectionAspect(
             java.time.Duration.ZERO,
         ).toKotlinDuration()
 
-        val opts = LeaderElectionOptions(waitTime = waitTime, leaseTime = leaseTime, minLeaseTime = minLeaseTime)
+        val opts = LeaderElectionOptions(
+            waitTime = waitTime,
+            leaseTime = leaseTime,
+            minLeaseTime = minLeaseTime,
+            autoExtend = ann.autoExtend,
+        )
         val selected = beanSelector.selectElectionFactory(ann.bean, method)
         val literal = if (LITERAL_PATTERN.matches(ann.name)) ann.name else null
 

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectTest.kt
@@ -53,6 +53,7 @@ class LeaderElectionAspectTest {
         fun runSync(): String?
         fun runWithArg(region: String): String?
         fun runWithMinLease(): String?
+        fun runWithAutoExtend(): String?
     }
 
     private class SampleServiceImpl: SampleService {
@@ -64,6 +65,9 @@ class LeaderElectionAspectTest {
 
         @LeaderElection(name = "min-job", leaseTime = "PT30S", minLeaseTime = "PT10S")
         override fun runWithMinLease(): String? = SAMPLE_RESULT
+
+        @LeaderElection(name = "auto-job", leaseTime = "PT30S", autoExtend = true)
+        override fun runWithAutoExtend(): String? = SAMPLE_RESULT
     }
 
     // Class-level mocks — reused across all tests, cleared in @BeforeEach
@@ -156,6 +160,28 @@ class LeaderElectionAspectTest {
         result shouldBeEqualTo SAMPLE_RESULT
         optionsSlot.captured.leaseTime shouldBeEqualTo 30.seconds
         optionsSlot.captured.minLeaseTime shouldBeEqualTo 10.seconds
+    }
+
+    @Test
+    fun `autoExtend - 어노테이션 값을 core options 로 전달한다`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("runWithAutoExtend")
+        configureJoinPoint(method, target, emptyArray())
+        every { pjp.proceed() } returns SAMPLE_RESULT
+
+        val actionSlot = slot<() -> Any?>()
+        every { election.runIfLeaderResult<Any?>(any(), capture(actionSlot)) } answers {
+            LeaderRunResult.Elected(actionSlot.captured.invoke())
+        }
+        val optionsSlot = slot<LeaderElectionOptions>()
+
+        val aspect = newAspect()
+        every { factoryMock.create(capture(optionsSlot)) } returns election
+
+        val result = aspect.aroundLeader(pjp)
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        optionsSlot.captured.autoExtend shouldBeEqualTo true
     }
 
     @Test

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/cache/FactoryCacheKeyTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/cache/FactoryCacheKeyTest.kt
@@ -52,6 +52,13 @@ class FactoryCacheKeyTest {
     }
 
     @Test
+    fun `같은 factory bean - 다른 autoExtend = 다른 key`() {
+        val a = FactoryCacheKey("X", LeaderElectionOptions(autoExtend = false))
+        val b = FactoryCacheKey("X", LeaderElectionOptions(autoExtend = true))
+        a shouldNotBeEqualTo b
+    }
+
+    @Test
     fun `Group key - 같은 factory bean - 다른 maxLeaders = 다른 key`() {
         val a = GroupFactoryCacheKey("X", LeaderGroupElectionOptions(maxLeaders = 2))
         val b = GroupFactoryCacheKey("X", LeaderGroupElectionOptions(maxLeaders = 3))


### PR DESCRIPTION
## Summary

Closes #73

PR #153의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: 단일 리더 lease autoExtend 지원`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 요약
- `LeaderElectionOptions.autoExtend`와 `@LeaderElection(autoExtend = true)`를 추가했습니다.
- Local/Lettuce/Mongo/Redisson single-leader lease renewal을 구현했습니다.
- Lettuce/Mongo는 owner token 조건부 TTL 연장, Redisson은 native watchdog을 사용합니다.
- `@LeaderGroupElection` autoExtend는 이번 slice에서 제외했습니다.
- Parent review에서 suspend watchdog/release 경로의 `runCatching { suspendCall }`을 제거해 cancellation 전파를 보강했습니다.

## 6-Tier Code Review
| Tier | 결과 | 요약 |
|---|---|---|
| Tier 1 Security | PASS | token 조건부 갱신만 수행, 무조건 TTL 연장 없음 |
| Tier 2 Ops/SRE | PASS | watchdog thread는 daemon scheduler, suspend 경로는 cancellation 전파 보존 |
| Tier 3 Structural | PASS | AOP가 아니라 `LeaderElectionOptions -> elector/lock` ownership 경로에서 renewal 소유 |
| Tier 4 Kotlin/Quality | PASS | touched suspend paths에서 `runCatching { suspendCall }` 제거, `!!`/synchronized 추가 없음 |
| Tier 5 Tests/Types | PASS | core/spring/Lettuce/Mongo/Redisson targeted + affected module tests 통과 |
| Tier 6 Performance/Stability | PASS | renewal period 기반 주기 연장, Redisson `autoExtend + minLeaseTime` ambiguous 조합 fail-fast |

## Advisor / Review Notes
- Architect subagent: AOP-only timer 금지, backend token/thread ownership 경로 구현 권고
- Executor subagent: initial implementation + tests + PR 생성
- Parent review: coroutine cancellation swallowing risk 수정 후 재검증
- Claude advisor CLI는 실행했지만 약 2분간 출력이 없어 중단했고, spec/plan에 gap을 기록했습니다.

## 검증
- `./gradlew :leader-core:test --tests '*LeaderElectionOptionsTest' --tests '*LeaderElectionAnnotationTest' --tests '*LeaderLeaseAutoExtenderTest' --tests '*LocalLeaderElectionTest'`
- `./gradlew :leader-spring-boot:test --tests '*LeaderElectionAspectTest'`
- `./gradlew :leader-redis-lettuce:test --tests '*LettuceLeaderElectionTest'`
- `./gradlew :leader-mongodb:test --tests '*MongoLeaderElectionTest'`
- `./gradlew :leader-redis-redisson:test --tests '*RedissonLeaderElectionTest'`
- `./gradlew :leader-core:test :leader-spring-boot:test :leader-redis-lettuce:test :leader-mongodb:test :leader-redis-redisson:test`
- `./gradlew :leader-core:test --tests '*LeaderLeaseAutoExtenderTest' :leader-spring-boot:test --tests '*FactoryCacheKeyTest'`
- `./gradlew :leader-redis-lettuce:compileKotlin :leader-mongodb:compileKotlin :leader-redis-redisson:compileKotlin :leader-redis-lettuce:test --tests '*LettuceLeaderElectionTest' :leader-mongodb:test --tests '*MongoLeaderElectionTest' :leader-redis-redisson:test --tests '*RedissonLeaderElectionTest' --no-configuration-cache`
- `git diff --check`

## 참고
- Exposed/Hazelcast/ZooKeeper autoExtend 구현은 의도적으로 제외했습니다.
- 전체 affected-module 테스트 중 기존 background logging/Mongo monitor thread 예외가 stdout에 출력됐지만 Gradle 결과는 BUILD SUCCESSFUL이었습니다.

Closes #73

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #73, milestone `0.1.0`, assignee `debop`
- PR: #153, head `b0ebbe7fae775f8b2ab41e8c122b9bee98c90247`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
