### PR TITLE
feat(examples): E1 분산 배치 스케줄러 예제 (Redis-Lettuce) — closes #154

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
       leader-zookeeper: ${{ steps.filter.outputs.leader-zookeeper }}
       leader-spring-boot: ${{ steps.filter.outputs.leader-spring-boot }}
       leader-micrometer: ${{ steps.filter.outputs.leader-micrometer }}
+      examples-batch-scheduler: ${{ steps.filter.outputs.examples-batch-scheduler }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -113,6 +114,9 @@ jobs:
               - 'leader-spring-boot/**'
             leader-micrometer:
               - 'leader-micrometer/**'
+            examples-batch-scheduler:
+              - 'examples/batch-scheduler/**'
+              - 'leader-redis-lettuce/**'
 
   # ── 3. 전체 빌드 (테스트 제외) ───────────────────────────────────────────
   build:
@@ -500,6 +504,42 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 7
 
+  # ── examples-batch-scheduler (Testcontainers Redis) ─────────────────────────
+  test-examples-batch-scheduler:
+    name: Test / examples-batch-scheduler
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['examples-batch-scheduler'] == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Test examples-batch-scheduler
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :examples:batch-scheduler:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-examples-batch-scheduler
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 7
+
   # ── leader-spring-boot 테스트 (Testcontainers: Redis + MongoDB + H2) ────────
   test-spring-boot:
     name: Test / leader-spring-boot (Testcontainers)
@@ -705,6 +745,7 @@ jobs:
       - test-mongodb
       - test-hazelcast
       - test-zookeeper
+      - test-examples-batch-scheduler
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -749,6 +790,7 @@ jobs:
       - test-mongodb
       - test-hazelcast
       - test-zookeeper
+      - test-examples-batch-scheduler
       - coverage-report
     if: always()
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -652,6 +652,41 @@ jobs:
           path: "**/build/reports/kover/"
           retention-days: 14
 
+  # ── examples-batch-scheduler (Testcontainers Redis) ─────────────────────────
+  test-examples-batch-scheduler:
+    name: Test / examples-batch-scheduler (Testcontainers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Test examples-batch-scheduler
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :examples:batch-scheduler:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-examples-batch-scheduler
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 14
+
   # ── leader-spring-boot (Testcontainers: Redis + MongoDB + H2) ───────────────
   test-spring-boot:
     name: Test / leader-spring-boot (Testcontainers)
@@ -717,6 +752,7 @@ jobs:
       - test-zookeeper
       - test-micrometer
       - test-spring-boot
+      - test-examples-batch-scheduler
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -761,6 +797,7 @@ jobs:
       - test-zookeeper
       - test-micrometer
       - test-spring-boot
+      - test-examples-batch-scheduler
       - coverage-report
     if: always()
     steps:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,9 @@ allprojects {
 }
 
 subprojects {
+    if (path.startsWith(":examples:")) {
+        return@subprojects
+    }
     apply(plugin = "com.gradleup.nmcp")
 
     configurations.matching { it.name.startsWith("nmcp") }.configureEach {
@@ -91,13 +94,17 @@ subprojects {
         return@subprojects
     }
 
+    val isExample = path.startsWith(":examples:")
+
     apply {
         plugin<JavaLibraryPlugin>()
         plugin("org.jetbrains.kotlin.jvm")
         plugin("org.jetbrains.kotlinx.atomicfu")
         plugin("org.jetbrains.kotlinx.kover")
-        plugin("maven-publish")
-        plugin("signing")
+        if (!isExample) {
+            plugin("maven-publish")
+            plugin("signing")
+        }
         plugin("io.spring.dependency-management")
         plugin("org.jetbrains.dokka")
         plugin("com.adarshr.test-logger")
@@ -268,6 +275,10 @@ subprojects {
         testImplementation(rootLibs.mockk)
     }
 
+    if (isExample) {
+        return@subprojects
+    }
+
     publishing {
         publications {
             create<MavenPublication>("BluetapeLeader") {
@@ -331,11 +342,12 @@ extensions.configure<NmcpAggregationExtension>("nmcpAggregation") {
 
 dependencies {
     subprojects
+        .filter { !it.path.startsWith(":examples:") }
         .forEach { add("nmcpAggregation", project(it.path)) }
 }
 
 dependencies {
     subprojects
-        .filter { it.name != "leader-bom" }
+        .filter { it.name != "leader-bom" && !it.path.startsWith(":examples:") }
         .forEach { sub -> kover(project(sub.path)) }
 }

--- a/docs/lessons/2026-05-10-e1-batch-scheduler.md
+++ b/docs/lessons/2026-05-10-e1-batch-scheduler.md
@@ -1,0 +1,158 @@
+# Lessons Learned — E1 Batch Scheduler Example (2026-05-10)
+
+**관련 PR**: TBD (feat/examples-batch-scheduler → develop)
+**관련 Issue**: #154 (Epic #36)
+**영향 모듈**: `examples/batch-scheduler/`, root `build.gradle.kts`, `settings.gradle.kts`, `.github/workflows/{ci,nightly}.yml`
+
+## L1: bluetape4k KLogging — lambda 형태 호출은 별도 extension import 필요
+
+### 문제
+`KLogging` companion 의 `log` 객체는 SLF4J 호환 메서드(`info(String)`)만 노출.
+`log.info { "..." }` (lambda) 호출은 `io.bluetape4k.logging.info`/`debug`/`warn` extension function 을 별도 import 해야 컴파일됨.
+
+### 교훈
+신규 모듈에서 KLogging companion 사용 시 lambda-style logging extension import 누락하지 말 것:
+
+```kotlin
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info       // ✅ lambda overload
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
+```
+
+E2~E5 모두 동일 패턴 적용.
+
+---
+
+## L2: `executor.submit { lambda }` Kotlin 추론 — Future<*> vs Future<T?>
+
+### 문제
+`Executors.newFixedThreadPool(N).submit { lambda }` — Kotlin이 lambda 마지막 표현식의 반환 타입에 따라 `Callable<T>` vs `Runnable` overload 선택.
+runnable로 추론되면 `Future.get()` 결과는 항상 `null`. 이를 `filterNotNull()` 검증에 쓰면 false negative.
+
+### 교훈
+multi-instance race 테스트에서 결과 검증은 Future 반환값에 의존하지 말고 `AtomicInteger` 카운터로 lambda 내부에서 직접 누적할 것:
+
+```kotlin
+val successCount = AtomicInteger(0)
+executor.submit {
+    val result = scheduler.run { ... }
+    if (result != null) successCount.incrementAndGet()
+}
+```
+
+E2~E5 동시 실행 검증에 동일 패턴 권장.
+
+---
+
+## L3: 다중 인스턴스 동시 실행 테스트 — `Thread.sleep` 의존 race 회피
+
+### 문제
+초기 테스트는 리더 job 안에서 `Thread.sleep(N)` 으로 패자들의 `tryLock(waitTime=M)` 만료를 기다림.
+빠른 머신/CI 변동성에서 실패 가능. 시간 기반 race condition.
+
+### 교훈
+`CountDownLatch(loserCount)` 로 명시적 동기화:
+
+```kotlin
+val losersFinished = CountDownLatch(N - 1)
+
+scheduler.run {
+    losersFinished.await(timeout, SECONDS)  // 패자 완료까지 대기
+    // ... do work
+}
+// 패자 경로
+if (result == null) losersFinished.countDown()
+```
+
+E2~E5 의 contention 테스트는 모두 latch 기반으로 작성.
+
+---
+
+## L4: examples 모듈은 root `build.gradle.kts` 에서 publishing/signing/kover/nmcp 제외 필수
+
+### 문제
+bluetape4k-leader 의 `subprojects {}` 블록은 모든 모듈에 자동으로 `maven-publish`, `signing`, `nmcp`, kover aggregation 적용.
+examples 는 외부 배포 대상이 아님. 그대로 두면 Maven Central 에 example artifacts 가 published 됨.
+
+### 교훈
+`examples/` 경로 기반 일괄 제외 패턴:
+
+```kotlin
+val isExample = path.startsWith(":examples:")
+
+subprojects {
+    if (isExample) {
+        // skip publishing/signing setup
+    }
+    // ... rest
+}
+
+dependencies {
+    subprojects
+        .filter { !it.path.startsWith(":examples:") }
+        .forEach { add("nmcpAggregation", project(it.path)) }
+}
+```
+
+E2~E5 추가 시 root build 수정 불필요 — 자동 제외.
+
+---
+
+## L5: examples 모듈 README 의 `:run` 명령은 `application` 플러그인 필요
+
+### 문제
+README 에 `./gradlew :examples:batch-scheduler:run` 안내했으나 `application` 플러그인 미적용 시 `Task 'run' not found` 발생.
+
+### 교훈
+examples 모듈 build.gradle.kts 에 항상:
+
+```kotlin
+plugins {
+    application
+}
+
+application {
+    mainClass.set("io.bluetape4k.leader.examples.<pkg>.<DemoObject>")
+}
+```
+
+`mainClass` 는 정확한 FQN. Demo 는 `object: KLogging()` + `@JvmStatic fun main(args: Array<String>)` 패턴 사용 (top-level `fun main()` 보다 logger 사용 일관성 좋음).
+
+---
+
+## L6: CI/CD — examples 모듈은 별도 job 분리, paths-filter 트리거 추가
+
+### 문제
+nightly.yml + ci.yml 의 `coverage-report`, `ci-status`, `nightly-status` 가 모든 test job 의 needs 배열을 명시 — 새 examples job 누락 시 status check 가 통과해도 실제 실행 안 됨.
+
+### 교훈
+새 examples 모듈 추가 시 체크리스트:
+
+1. `nightly.yml`: 새 `test-examples-<name>` job + `nightly-status.needs` 추가
+2. `ci.yml`:
+   - `changes` job 의 `outputs` + `paths-filter` 에 모듈 등록
+   - 새 `test-examples-<name>` job + `coverage-report.needs` + `ci-status.needs` 추가
+   - paths-filter 에는 examples 자체 + 의존하는 leader-* 모듈 모두 등록 (의존성 변경 시 examples 도 재테스트)
+
+E2~E5 각각 4곳 (ci.yml outputs/filter + ci.yml job + nightly.yml job + nightly-status needs) 업데이트.
+
+---
+
+## L7: 워크스페이스 CLAUDE.md `assertFailsWith` 표준 패턴
+
+### 문제
+초기 테스트에서 `try { ... } catch (_: T) { }` 빈 catch 로 예외 검증 — silent swallow 룰 위반 + 표준 패턴 미사용.
+
+### 교훈
+bluetape4k 표준은 `io.bluetape4k.assertions.assertFailsWith<T> { ... }`.
+- JUnit `assertThrows`, `kotlin.test.assertFailsWith`, `invoking { } shouldThrow` 모두 금지.
+- suspend 함수 검증은 `coInvoking { } shouldThrow T::class`.
+
+```kotlin
+import io.bluetape4k.assertions.assertFailsWith
+
+assertFailsWith<IllegalStateException> {
+    s1.run<Unit> { throw IllegalStateException("...") }
+}
+```

--- a/examples/batch-scheduler/README.ko.md
+++ b/examples/batch-scheduler/README.ko.md
@@ -1,0 +1,96 @@
+# examples-batch-scheduler
+
+한국어 | [English](./README.md)
+
+Lettuce-Redis 백엔드를 사용한 분산 배치 스케줄러 예제. 야간 정산 등 주기 배치 Job 을 다중 인스턴스 환경에서 단 1개만 실행되도록 보장.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant Cron
+    participant N1 as Node-1
+    participant N2 as Node-2
+    participant N3 as Node-3
+    participant R as Redis
+
+    Cron->>N1: 02:00 트리거
+    Cron->>N2: 02:00 트리거
+    Cron->>N3: 02:00 트리거
+    par
+        N1->>R: SET nightly-settlement (NX EX 30s)
+    and
+        N2->>R: SET nightly-settlement (NX EX 30s)
+    and
+        N3->>R: SET nightly-settlement (NX EX 30s)
+    end
+    R-->>N1: OK (락 획득)
+    R-->>N2: nil (skip)
+    R-->>N3: nil (skip)
+    N1->>N1: 정산 Job 실행
+    N1->>R: DEL nightly-settlement
+```
+
+## Core Features
+
+- N 인스턴스 환경에서 주기 배치의 **단일 실행 보장**
+- 경쟁 발생 시 자동 skip — 예외 throw 없이 `null` 반환 (ShedLock 호환 동작)
+- 정상/실패/예외 모든 경로에서 락 자동 해제
+- Lease TTL 로 리더 사망 시에도 락 leak 방지
+
+## Usage Example
+
+```kotlin
+val redisConnection: StatefulRedisConnection<String, String> = client.connect(StringCodec.UTF8)
+
+val scheduler = BatchScheduler(
+    nodeId = "node-${System.getenv("HOSTNAME")}",
+    connection = redisConnection,
+    lockName = "nightly-settlement",
+    waitTime = 2.seconds,
+    leaseTime = 30.seconds,
+)
+
+// cron / Spring @Scheduled / Quartz 등에서 호출
+val result: Unit? = scheduler.run {
+    settlementService.processYesterday()
+}
+
+if (result == null) {
+    log.info { "다른 인스턴스가 실행 중 — skip" }
+}
+```
+
+## Demo
+
+```bash
+./gradlew :examples:batch-scheduler:run
+```
+
+또는 IDE 에서 `BatchSchedulerDemo.main()` 직접 실행. 3 인스턴스 시뮬레이션 후 1개만 Job 실행.
+
+## Configuration Options
+
+| 파라미터 | 기본값 | 설명 |
+|---------|-------|------|
+| `nodeId` | 필수 | 인스턴스별 고유 식별자 — 로그에 사용 |
+| `lockName` | 필수 | 분산 락 키 (같은 Job 의 모든 인스턴스가 동일 값 사용) |
+| `waitTime` | `2.seconds` | 락 획득 대기 시간 — 초과 시 즉시 skip |
+| `leaseTime` | `30.seconds` | 락 TTL — Job 예상 실행 시간보다 길게 |
+
+## Dependency
+
+```kotlin
+dependencies {
+    implementation(project(":leader-redis-lettuce"))
+    implementation(project(":examples:batch-scheduler"))
+}
+```
+
+## Testing
+
+```bash
+./gradlew :examples:batch-scheduler:test
+```
+
+테스트는 Testcontainers Redis singleton 사용 — Docker daemon 필요.

--- a/examples/batch-scheduler/README.md
+++ b/examples/batch-scheduler/README.md
@@ -1,0 +1,96 @@
+# examples-batch-scheduler
+
+[한국어](./README.ko.md) | English
+
+Distributed batch scheduler example using Lettuce-Redis backend. Demonstrates safe single execution of a periodic batch job (e.g. nightly settlement) across multiple deployed instances.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant Cron
+    participant N1 as Node-1
+    participant N2 as Node-2
+    participant N3 as Node-3
+    participant R as Redis
+
+    Cron->>N1: 02:00 trigger
+    Cron->>N2: 02:00 trigger
+    Cron->>N3: 02:00 trigger
+    par
+        N1->>R: SET nightly-settlement (NX EX 30s)
+    and
+        N2->>R: SET nightly-settlement (NX EX 30s)
+    and
+        N3->>R: SET nightly-settlement (NX EX 30s)
+    end
+    R-->>N1: OK (lock acquired)
+    R-->>N2: nil (skip)
+    R-->>N3: nil (skip)
+    N1->>N1: run settlement job
+    N1->>R: DEL nightly-settlement
+```
+
+## Core Features
+
+- Single-execution guarantee for periodic batch jobs across N replicas
+- Automatic skip on contention (no exception thrown — `null` return like ShedLock)
+- Lock release on success, failure, or exception
+- Lease TTL prevents lock leak if leader crashes mid-job
+
+## Usage Example
+
+```kotlin
+val redisConnection: StatefulRedisConnection<String, String> = client.connect(StringCodec.UTF8)
+
+val scheduler = BatchScheduler(
+    nodeId = "node-${System.getenv("HOSTNAME")}",
+    connection = redisConnection,
+    lockName = "nightly-settlement",
+    waitTime = 2.seconds,
+    leaseTime = 30.seconds,
+)
+
+// Called by cron / Spring @Scheduled / Quartz
+val result: Unit? = scheduler.run {
+    settlementService.processYesterday()
+}
+
+if (result == null) {
+    log.info { "Another instance is processing — skipping" }
+}
+```
+
+## Demo
+
+```bash
+./gradlew :examples:batch-scheduler:run
+```
+
+Or directly: run `BatchSchedulerDemo.main()` from your IDE. Spawns 3 simulated instances; only 1 runs the job.
+
+## Configuration Options
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `nodeId` | required | Unique identifier per instance — used in logs |
+| `lockName` | required | Distributed lock key (same across all instances of the job) |
+| `waitTime` | `2.seconds` | Time to wait for the lock before giving up |
+| `leaseTime` | `30.seconds` | Lock TTL — prevents leak on crash; should exceed expected job duration |
+
+## Dependency
+
+```kotlin
+dependencies {
+    implementation(project(":leader-redis-lettuce"))
+    implementation(project(":examples:batch-scheduler"))
+}
+```
+
+## Testing
+
+```bash
+./gradlew :examples:batch-scheduler:test
+```
+
+Tests use Testcontainers Redis singleton — Docker daemon required.

--- a/examples/batch-scheduler/build.gradle.kts
+++ b/examples/batch-scheduler/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    application
+}
+
+application {
+    mainClass.set("io.bluetape4k.leader.examples.batch.BatchSchedulerDemo")
+}
+
+dependencies {
+    implementation(project(":leader-redis-lettuce"))
+
+    implementation(libs.bluetape4k.lettuce)
+    implementation(libs.lettuce.core)
+    implementation(libs.bluetape4k.testcontainers)
+    implementation(libs.testcontainers)
+
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.junit.jupiter)
+}

--- a/examples/batch-scheduler/src/main/kotlin/io/bluetape4k/leader/examples/batch/BatchScheduler.kt
+++ b/examples/batch-scheduler/src/main/kotlin/io/bluetape4k/leader/examples/batch/BatchScheduler.kt
@@ -1,0 +1,72 @@
+package io.bluetape4k.leader.examples.batch
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.lettuce.LettuceLeaderElector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.requireNotBlank
+import io.lettuce.core.api.StatefulRedisConnection
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * 배치 스케줄러 예제.
+ *
+ * ## 동작/계약
+ *
+ * 다중 인스턴스 배포 환경에서 동일 lock 이름으로 [LettuceLeaderElector] 를 공유하면,
+ * 매 실행 시점에 단 한 인스턴스만 [run] 의 action 을 수행한다.
+ *
+ * - 리더 선출 실패 시 [run] 은 `null` 반환 — throw 하지 않음 (ShedLock 호환 동작)
+ * - [waitTime] 동안 락 획득 시도 후 실패하면 즉시 skip
+ * - [leaseTime] 동안 다른 인스턴스의 락 획득을 차단
+ * - [nodeId] 는 로그 식별 용도 — 락 키나 락 소유자 식별에는 사용되지 않음
+ *   (락 소유자 ID 는 [LettuceLeaderElector] 가 자체 발급)
+ *
+ * ```kotlin
+ * val scheduler = BatchScheduler(
+ *     nodeId = "node-A",
+ *     connection = redisConnection,
+ *     lockName = "nightly-settlement",
+ * )
+ * val executed = scheduler.run { settlementJob.execute() }
+ * if (executed != null) println("리더로 실행 완료") else println("다른 인스턴스 실행 중")
+ * ```
+ */
+class BatchScheduler(
+    val nodeId: String,
+    connection: StatefulRedisConnection<String, String>,
+    private val lockName: String,
+    waitTime: Duration = 2.seconds,
+    leaseTime: Duration = 30.seconds,
+) {
+    init {
+        nodeId.requireNotBlank("nodeId")
+        lockName.requireNotBlank("lockName")
+    }
+
+    companion object: KLogging()
+
+    private val elector = LettuceLeaderElector(
+        connection,
+        LeaderElectionOptions(waitTime = waitTime, leaseTime = leaseTime),
+    )
+
+    /**
+     * 리더 선출 성공 시 [job] 을 1회 실행하고 반환값을 돌려준다.
+     *
+     * @return 리더로 실행 시 [job] 의 반환값, 실패 시 `null`
+     */
+    fun <T> run(job: () -> T): T? {
+        return elector.runIfLeader(lockName) {
+            log.info { "[$nodeId] 리더 선출 성공 — Job 실행 시작" }
+            val result = job()
+            log.info { "[$nodeId] Job 실행 완료" }
+            result
+        }.also {
+            if (it == null) {
+                log.info { "[$nodeId] 리더 선출 실패 — 다른 인스턴스가 실행 중. skip." }
+            }
+        }
+    }
+}

--- a/examples/batch-scheduler/src/main/kotlin/io/bluetape4k/leader/examples/batch/BatchSchedulerDemo.kt
+++ b/examples/batch-scheduler/src/main/kotlin/io/bluetape4k/leader/examples/batch/BatchSchedulerDemo.kt
@@ -1,0 +1,66 @@
+package io.bluetape4k.leader.examples.batch
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.support.closeSafe
+import io.bluetape4k.testcontainers.storage.RedisServer
+import io.bluetape4k.utils.ShutdownQueue
+import io.lettuce.core.RedisClient
+import io.lettuce.core.codec.StringCodec
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * 3-인스턴스 배치 스케줄러 데모.
+ *
+ * 동일 lock 이름을 공유하는 3개의 [BatchScheduler] 인스턴스를 동시 실행하여,
+ * 단 1개만 정산 Job 을 수행하는 모습을 시연한다.
+ *
+ * Testcontainers Redis 를 자동 기동.
+ */
+object BatchSchedulerDemo: KLogging() {
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val redis = RedisServer.Launcher.redis
+        val client = RedisClient.create(redis.url).also {
+            ShutdownQueue.register { runCatching { it.shutdown() } }
+        }
+
+        val executions = AtomicInteger(0)
+        val executor = Executors.newFixedThreadPool(3)
+
+        try {
+            log.info { "=== 야간 정산 배치 데모 시작 ===" }
+            log.info { "3개 인스턴스가 동시에 'nightly-settlement' lock 획득 시도" }
+
+            val futures = (1..3).map { idx ->
+                executor.submit {
+                    val connection = client.connect(StringCodec.UTF8)
+                    try {
+                        val scheduler = BatchScheduler(
+                            nodeId = "node-$idx",
+                            connection = connection,
+                            lockName = "nightly-settlement",
+                        )
+                        val outcome = scheduler.run {
+                            log.info { "[node-$idx] 정산 처리 시작" }
+                            Thread.sleep(500)
+                            executions.incrementAndGet()
+                            log.info { "[node-$idx] 정산 처리 완료" }
+                        }
+                        log.info { "[node-$idx] outcome=${if (outcome != null) "LEADER" else "SKIPPED"}" }
+                    } finally {
+                        connection.closeSafe()
+                    }
+                }
+            }
+            futures.forEach { it.get() }
+
+            log.info { "=== 결과 ===" }
+            log.info { "실제 실행된 인스턴스 수: ${executions.get()} (기대값: 1)" }
+        } finally {
+            executor.shutdown()
+        }
+    }
+}

--- a/examples/batch-scheduler/src/test/kotlin/io/bluetape4k/leader/examples/batch/AbstractBatchSchedulerTest.kt
+++ b/examples/batch-scheduler/src/test/kotlin/io/bluetape4k/leader/examples/batch/AbstractBatchSchedulerTest.kt
@@ -1,0 +1,30 @@
+package io.bluetape4k.leader.examples.batch
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.closeSafe
+import io.bluetape4k.testcontainers.storage.RedisServer
+import io.bluetape4k.utils.ShutdownQueue
+import io.lettuce.core.RedisClient
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.codec.StringCodec
+
+abstract class AbstractBatchSchedulerTest {
+
+    companion object: KLogging() {
+        val redis = RedisServer.Launcher.redis
+
+        val client: RedisClient by lazy {
+            RedisClient.create(redis.url).also {
+                ShutdownQueue.register { runCatching { it.shutdown() } }
+            }
+        }
+
+        fun newConnection(): StatefulRedisConnection<String, String> =
+            client.connect(StringCodec.UTF8).also {
+                ShutdownQueue.register { it.closeSafe() }
+            }
+    }
+
+    protected fun randomLockName(): String = "batch-test:${Base58.randomString(8)}"
+}

--- a/examples/batch-scheduler/src/test/kotlin/io/bluetape4k/leader/examples/batch/BatchSchedulerTest.kt
+++ b/examples/batch-scheduler/src/test/kotlin/io/bluetape4k/leader/examples/batch/BatchSchedulerTest.kt
@@ -1,0 +1,134 @@
+package io.bluetape4k.leader.examples.batch
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.closeSafe
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class BatchSchedulerTest: AbstractBatchSchedulerTest() {
+
+    companion object: KLogging()
+
+    @Test
+    fun `단일 인스턴스 - run 호출 시 Job 실행 후 결과 반환`() {
+        val connection = newConnection()
+        try {
+            val scheduler = BatchScheduler(
+                nodeId = "single-node",
+                connection = connection,
+                lockName = randomLockName(),
+            )
+            val result = scheduler.run { 42 }
+            result.shouldNotBeNull() shouldBeEqualTo 42
+        } finally {
+            connection.closeSafe()
+        }
+    }
+
+    @Test
+    fun `3 인스턴스 동시 실행 - 단 1개만 Job 실행 보장`() {
+        val lockName = randomLockName()
+        val executions = AtomicInteger(0)
+        val successCount = AtomicInteger(0)
+        val losersFinished = CountDownLatch(2)
+        val executor = Executors.newFixedThreadPool(3)
+        val connections = (1..3).map { newConnection() }
+
+        try {
+            val futures = connections.mapIndexed { idx, conn ->
+                executor.submit {
+                    val scheduler = BatchScheduler(
+                        nodeId = "node-${idx + 1}",
+                        connection = conn,
+                        lockName = lockName,
+                        waitTime = 500.milliseconds,
+                        leaseTime = 10.seconds,
+                    )
+                    val result = scheduler.run {
+                        executions.incrementAndGet()
+                        // 리더는 두 패자가 락 획득 시도를 마칠 때까지 대기 (race-free)
+                        losersFinished.await(5, TimeUnit.SECONDS)
+                        "executed-by-node-${idx + 1}"
+                    }
+                    if (result != null) {
+                        successCount.incrementAndGet()
+                    } else {
+                        losersFinished.countDown()
+                    }
+                }
+            }
+
+            futures.forEach { it.get(15, TimeUnit.SECONDS) }
+
+            executions.get() shouldBeEqualTo 1
+            successCount.get() shouldBeEqualTo 1
+        } finally {
+            executor.shutdown()
+            connections.forEach { it.closeSafe() }
+        }
+    }
+
+    @Test
+    fun `리더 작업 완료 후 - 다음 호출도 새로 선출 가능`() {
+        val connection = newConnection()
+        try {
+            val scheduler = BatchScheduler(
+                nodeId = "seq-node",
+                connection = connection,
+                lockName = randomLockName(),
+                waitTime = 100.milliseconds,
+                leaseTime = 500.milliseconds,
+            )
+
+            val r1 = scheduler.run { "first" }
+            val r2 = scheduler.run { "second" }
+
+            r1.shouldNotBeNull() shouldBeEqualTo "first"
+            r2.shouldNotBeNull() shouldBeEqualTo "second"
+        } finally {
+            connection.closeSafe()
+        }
+    }
+
+    @Test
+    fun `Job 예외 발생 시 - 예외가 호출자에게 전달되고 락 해제됨`() {
+        val lockName = randomLockName()
+        val conn1 = newConnection()
+        val conn2 = newConnection()
+
+        try {
+            val s1 = BatchScheduler(
+                nodeId = "fail-node",
+                connection = conn1,
+                lockName = lockName,
+                waitTime = 100.milliseconds,
+                leaseTime = 30.seconds,
+            )
+
+            assertFailsWith<IllegalStateException> {
+                s1.run<Unit> { throw IllegalStateException("정산 중 오류") }
+            }
+
+            val s2 = BatchScheduler(
+                nodeId = "recover-node",
+                connection = conn2,
+                lockName = lockName,
+                waitTime = 2.seconds,
+                leaseTime = 5.seconds,
+            )
+            val recovered = s2.run { "recovered" }
+            recovered.shouldNotBeNull() shouldBeEqualTo "recovered"
+        } finally {
+            conn1.closeSafe()
+            conn2.closeSafe()
+        }
+    }
+}

--- a/examples/batch-scheduler/src/test/resources/junit-platform.properties
+++ b/examples/batch-scheduler/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/examples/batch-scheduler/src/test/resources/logback-test.xml
+++ b/examples/batch-scheduler/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%24.24t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+    <logger name="io.bluetape4k.leader.examples.batch" level="DEBUG"/>
+    <logger name="io.bluetape4k.leader.lettuce" level="INFO"/>
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,4 +24,5 @@ include(
     "leader-zookeeper",
     "leader-spring-boot",
     "leader-micrometer",
+    "examples:batch-scheduler",
 )


### PR DESCRIPTION
## Summary

Closes #154

PR #159의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat(examples): E1 분산 배치 스케줄러 예제 (Redis-Lettuce) — closes #154`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 개요

Epic #36 의 E1 — 다중 인스턴스 환경에서 야간 정산 등 주기 배치 Job 을 단 1개만 실행하도록 `LettuceLeaderElector.runIfLeader` 활용 예제.

Closes #154
Refs #36

## 변경 사항

| 항목 | 내용 |
|------|------|
| **신규 모듈** | `examples/batch-scheduler/` (Lettuce-Redis backend) |
| **소스** | `BatchScheduler.kt`, `BatchSchedulerDemo.kt` |
| **테스트** | 4건 (단일, 3인스턴스 contention, 순차, 예외 복구) |
| **README** | `README.md` + `README.ko.md` (이중언어, Mermaid 다이어그램) |
| **빌드** | root `build.gradle.kts` 의 examples 모듈 publishing/signing/nmcp/kover 제외 |
| **CI** | `ci.yml` + `nightly.yml` 에 examples-batch-scheduler 테스트 job 추가 |
| **Lessons** | `docs/lessons/2026-05-10-e1-batch-scheduler.md` (L1~L7) |

## 테스트 결과

```
./gradlew :examples:batch-scheduler:test
```

✅ 4 passing
- 단일 인스턴스 - run 호출 시 Job 실행 후 결과 반환
- 3 인스턴스 동시 실행 - 단 1개만 Job 실행 보장 (CountDownLatch race-free)
- 리더 작업 완료 후 - 다음 호출도 새로 선출 가능
- Job 예외 발생 시 - 예외가 호출자에게 전달되고 락 해제됨

## 검증

```bash
./gradlew :examples:batch-scheduler:test
./gradlew build -x test -x koverVerify
./gradlew :examples:batch-scheduler:run    # Demo 실행
```

## 체크리스트

- [x] 모듈 추가 + settings.gradle.kts 등록
- [x] 실행 가능 main 함수 + 시연 시나리오
- [x] Testcontainers 기반 통합 테스트 (3 인스턴스 시뮬레이션)
- [x] 모듈 README.md + README.ko.md
- [x] CI/Nightly workflow 에 examples job 추가
- [x] Code Review (Tier 4 + 5) — HIGH/MEDIUM 모두 반영
- [x] Lessons doc 작성 (L1~L7)
- [ ] Epic #36 체크박스 업데이트 (머지 후)

## 다음 작업

E2 (#155) — `examples/migration-gate/` (Exposed-JDBC).
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #154, milestone `0.1.0`, assignee `debop`
- PR: #159, head `3ebcbf5040a60390a321545a1cb9dfc6a1407b26`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
