### PR TITLE
feat(examples): E2 마이그레이션 게이트 (Exposed-JDBC) — closes #155

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
       leader-spring-boot: ${{ steps.filter.outputs.leader-spring-boot }}
       leader-micrometer: ${{ steps.filter.outputs.leader-micrometer }}
       examples-batch-scheduler: ${{ steps.filter.outputs.examples-batch-scheduler }}
+      examples-migration-gate: ${{ steps.filter.outputs.examples-migration-gate }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -117,6 +118,11 @@ jobs:
             examples-batch-scheduler:
               - 'examples/batch-scheduler/**'
               - 'leader-redis-lettuce/**'
+            examples-migration-gate:
+              - 'examples/migration-gate/**'
+              - 'leader-exposed-jdbc/**'
+              - 'leader-exposed-core/**'
+              - 'leader-core/**'
 
   # ── 3. 전체 빌드 (테스트 제외) ───────────────────────────────────────────
   build:
@@ -504,6 +510,42 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 7
 
+  # ── examples-migration-gate (Testcontainers PostgreSQL + H2) ────────────────
+  test-examples-migration-gate:
+    name: Test / examples-migration-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['examples-migration-gate'] == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Test examples-migration-gate
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :examples:migration-gate:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-examples-migration-gate
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 7
+
   # ── examples-batch-scheduler (Testcontainers Redis) ─────────────────────────
   test-examples-batch-scheduler:
     name: Test / examples-batch-scheduler
@@ -746,6 +788,7 @@ jobs:
       - test-hazelcast
       - test-zookeeper
       - test-examples-batch-scheduler
+      - test-examples-migration-gate
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -791,6 +834,7 @@ jobs:
       - test-hazelcast
       - test-zookeeper
       - test-examples-batch-scheduler
+      - test-examples-migration-gate
       - coverage-report
     if: always()
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -652,6 +652,41 @@ jobs:
           path: "**/build/reports/kover/"
           retention-days: 14
 
+  # ── examples-migration-gate (Testcontainers PostgreSQL + H2) ────────────────
+  test-examples-migration-gate:
+    name: Test / examples-migration-gate (Testcontainers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Test examples-migration-gate
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :examples:migration-gate:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-examples-migration-gate
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 14
+
   # ── examples-batch-scheduler (Testcontainers Redis) ─────────────────────────
   test-examples-batch-scheduler:
     name: Test / examples-batch-scheduler (Testcontainers)
@@ -753,6 +788,7 @@ jobs:
       - test-micrometer
       - test-spring-boot
       - test-examples-batch-scheduler
+      - test-examples-migration-gate
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -798,6 +834,7 @@ jobs:
       - test-micrometer
       - test-spring-boot
       - test-examples-batch-scheduler
+      - test-examples-migration-gate
       - coverage-report
     if: always()
     steps:

--- a/docs/lessons/2026-05-10-e2-migration-gate.md
+++ b/docs/lessons/2026-05-10-e2-migration-gate.md
@@ -1,0 +1,97 @@
+# Lessons Learned — E2 Migration Gate (2026-05-10)
+
+**관련 PR**: TBD
+**관련 Issue**: #155 (Epic #36)
+**영향 모듈**: `examples/migration-gate/`, `.github/workflows/{ci,nightly}.yml`, `settings.gradle.kts`
+
+## L1: spec/plan 단계 Codex 사전 리뷰 효과
+
+### 문제
+Codex spec 검토에서 CRITICAL 3건 + HIGH 11건 발견. 단순 `runIfLeader == null → Followed` 매핑 모델로 시작했으나 운영 안전성 측면 결함 다수.
+
+### 교훈
+spec → 코드 작성 직전에 Codex 의뢰 1회는 비용 대비 효과 매우 큼. 이번 사례에서 다음 변경 견인:
+- `Outcome.AppliedByOther` → 마커 검증 후에만 `AlreadyApplied` 반환
+- `autoExtend=true` 기본값 → 백엔드 미지원으로 제거
+- 4단계 게이트 (precheck/lock/in-lock recheck/migration/post-skip) 도입
+- `nodeId` → `lockOwner` 매핑
+
+E3~E5 도 같은 절차 적용.
+
+---
+
+## L2: in-lock recheck — 멱등성 보장의 핵심
+
+### 문제
+"먼저 들어온 인스턴스가 마이그레이션, 나머지는 skip" 단순 모델은 leader 가 마이그레이션 완료 → lock 해제 → 다음 인스턴스가 lock 획득 시 다시 마이그레이션 시도 위험.
+
+### 교훈
+락 획득 후 마이그레이션 전 한 번 더 `isApplied()` 호출하여 idempotent 보장. 완료 후 lock 해제 → 후속 인스턴스가 lock 획득 → in-lock recheck → `AlreadyApplied` 반환 → migration skip.
+
+```kotlin
+elector.runIfLeader(lockName) {
+    if (isApplied()) return@runIfLeader Outcome.AlreadyApplied(...)  // ← 핵심
+    migration()
+    Outcome.Migrated(...)
+}
+```
+
+---
+
+## L3: action 외부 try/catch — runIfLeader 의 lambda 예외 처리
+
+### 문제
+`runIfLeader { try migration() / catch Failed }` 처럼 action 안에서 catch 하면 ExposedJdbc backend 의 history 가 success 로 기록됨 (action 이 정상 종료한 것처럼 보임).
+
+### 교훈
+runIfLeader 호출 전체를 try/catch 로 감싸서 lambda 예외를 외부에서 잡고 `Outcome.Failed` 로 매핑.
+runIfLeader 의 try-finally unlock 계약은 backend 가 보장 — 외부 catch 만 추가하면 안전.
+
+```kotlin
+val inLockOutcome: Outcome? = try {
+    elector.runIfLeader(lockName) { ... }
+} catch (e: CancellationException) { throw e }
+catch (e: Exception) { return Outcome.Failed(...) }
+```
+
+---
+
+## L4: sync API 에서도 `catch (Throwable)` → `catch (Exception)` 권장
+
+### 문제
+초기 코드는 `catch (Throwable)` 로 모든 예외를 `Outcome.Failed` 로 변환 → `Error` (OOM, StackOverflow), `InterruptedException` 까지 삼킴.
+
+### 교훈
+sync 함수에서도:
+- `Throwable` → `Exception` 으로 좁혀 `Error` 누수 방지
+- `kotlin.coroutines.cancellation.CancellationException` 명시적 재throw — coroutines 의존성 없이 stdlib 에서 제공
+
+E1 BatchScheduler 도 같은 패턴 적용 검토 필요 (next round refactor).
+
+---
+
+## L5: Codex CLI 사용 — `codex exec` vs `codex review`
+
+### 문제
+- `codex exec --skip-git-repo-check "prompt"` → 임의 prompt 실행 (spec/plan 검토용)
+- `codex review` → 코드 리뷰 전용. `--uncommitted` 와 prompt 동시 사용 불가.
+
+### 교훈
+- spec/plan 검토: `codex exec --skip-git-repo-check "검토 프롬프트"`
+- 코드 변경 리뷰: `codex review --uncommitted` (no prompt) 또는 `codex review` + prompt
+- 자동 review 가 출력 비어있을 시 spec/plan 단계 사전 리뷰로 대체 가능 (이번 케이스)
+
+---
+
+## L6: examples 모듈 paths-filter — backend 의존성 포함 필수
+
+### 문제
+초기 plan 은 `examples/migration-gate/**` 만 트리거. Codex 가 leader-core/leader-exposed-core/buildSrc/gradle 추가 권고.
+
+### 교훈
+examples 모듈 CI paths-filter 는:
+- 자기 자신 (`examples/<name>/**`)
+- 직접 의존 backend (`leader-<backend>/**`)
+- 공통 인프라 (`leader-core/**`, 추가 의존 시 `leader-exposed-core/**` 등)
+
+backend API 변경 시 examples 도 재테스트 필요 — paths-filter 누락 시 silent regression 위험.

--- a/examples/migration-gate/README.ko.md
+++ b/examples/migration-gate/README.ko.md
@@ -1,0 +1,121 @@
+# examples-migration-gate
+
+한국어 | [English](./README.md)
+
+Exposed-JDBC 백엔드 기반 분산 스키마 마이그레이션 게이트. K8s 롤링 배포 중 N개 pod 가 동시 기동될 때 마이그레이션을 단 1개만 실행하도록 보장.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant P1 as pod-1 (신버전)
+    participant P2 as pod-2 (신버전)
+    participant P3 as pod-3 (신버전)
+    participant DB
+
+    P1->>DB: isApplied("v3")? (precheck)
+    P2->>DB: isApplied("v3")? (precheck)
+    P3->>DB: isApplied("v3")? (precheck)
+    Note over P1,P3: 모두 false
+
+    par 락 경쟁
+        P1->>DB: lock "schema-v3" 획득 시도
+        P2->>DB: lock "schema-v3" 대기
+        P3->>DB: lock "schema-v3" 대기
+    end
+
+    DB-->>P1: 락 획득
+    P1->>DB: isApplied("v3")? (in-lock recheck)
+    DB-->>P1: false
+    P1->>DB: 마이그레이션 + 마커 insert
+    P1->>DB: 락 해제
+
+    DB-->>P2: 락 획득 (P1 이후)
+    P2->>DB: isApplied("v3")? (in-lock recheck)
+    DB-->>P2: true → AlreadyApplied
+    P2->>DB: 락 해제
+
+    DB-->>P3: 락 획득 (P2 이후)
+    P3->>DB: isApplied("v3")? (in-lock recheck)
+    DB-->>P3: true → AlreadyApplied
+```
+
+## Core Features
+
+- 롤링 배포 중 N개 pod 환경에서 마이그레이션의 **단일 실행 보장**
+- 3단계 `isApplied` 검증: precheck → in-lock recheck → post-skip recheck
+- 정상/실패/예외 모든 경로에서 락 자동 해제
+- 리더 실패 시 차순위 pod 가 자동 인계 (락 해제됨)
+- `ExposedJdbcLeaderElector` 사용 — H2/PostgreSQL/MySQL 지원
+
+## Usage Example
+
+```kotlin
+val gate = MigrationGate(db, MigrationGateOptions(
+    nodeId = System.getenv("HOSTNAME"),
+    lockName = "prod-app-schema-v3",
+    waitTime = 30.seconds,
+    leaseTime = 5.minutes,           // ⚠️ 마이그레이션 최악 실행 시간보다 길게
+))
+
+val outcome = gate.runMigration(
+    migrationId = "schema-v3",
+    isApplied = { schemaVersionExists(db, "v3") },
+    migration = {
+        transaction(db) {
+            SchemaUtils.createMissingTablesAndColumns(UsersTable, OrdersTable)
+            SchemaVersionTable.insert { it[version] = "v3" }   // 같은 tx 에 마커 기록
+        }
+    },
+)
+
+when (outcome) {
+    is Outcome.Migrated      -> log.info { "리더가 ${outcome.durationMs}ms 에 마이그레이션 완료" }
+    is Outcome.AlreadyApplied -> log.info { "이미 적용됨 — skip" }
+    is Outcome.Skipped        -> log.warn { "skipped: ${outcome.reason} — 진입 전 확인 필요" }
+    is Outcome.Failed         -> error("마이그레이션 실패: ${outcome.cause.message}")
+}
+```
+
+## Demo
+
+```bash
+./gradlew :examples:migration-gate:run
+```
+
+H2 in-memory DB + 3 pod 시뮬레이션. 1 Migrated + 2 AlreadyApplied 출력.
+
+## Configuration Options
+
+| 파라미터 | 기본값 | 설명 |
+|---------|-------|------|
+| `nodeId` | 필수 | pod 식별자 — 락 row 의 `lockOwner` 에 기록되어 추적 가능 |
+| `lockName` | 필수 | 분산 락 키 — `<env>-<app>-<schemaVersion>` 권장 |
+| `waitTime` | `30.seconds` | 락 획득 최대 대기 시간 |
+| `leaseTime` | `5.minutes` | 락 TTL — **마이그레이션 최악 실행 시간보다 길게** (auto-extend 미지원) |
+
+## Migration 작성 가이드
+
+- **idempotent 하게**: 재실행 안전하게 (예: `CREATE TABLE IF NOT EXISTS`)
+- **마커와 원자적으로**: 스키마 변경과 마커 insert 를 같은 transaction 에서 수행
+- **하위 호환**: 롤링 배포 중 구버전 pod 와 신버전 pod 가 공존 → expand-contract 패턴 권장
+  (컬럼 추가 → 백필 → 읽기 전환 → 구컬럼 제거)
+
+## Dependency
+
+```kotlin
+dependencies {
+    implementation(project(":leader-exposed-jdbc"))
+    implementation(project(":examples:migration-gate"))
+}
+```
+
+## Testing
+
+```bash
+./gradlew :examples:migration-gate:test                       # H2 + PostgreSQL
+LEADER_TEST_DB=H2 ./gradlew :examples:migration-gate:test     # H2 만
+LEADER_TEST_DB=POSTGRESQL ./gradlew :examples:migration-gate:test
+```
+
+PostgreSQL 테스트는 Testcontainers — Docker daemon 필요.

--- a/examples/migration-gate/README.md
+++ b/examples/migration-gate/README.md
@@ -1,0 +1,121 @@
+# examples-migration-gate
+
+[한국어](./README.ko.md) | English
+
+Distributed schema migration gate using Exposed JDBC backend. Demonstrates safe single-execution of DB migrations across N pods during Kubernetes rolling deploy.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant P1 as pod-1 (new version)
+    participant P2 as pod-2 (new version)
+    participant P3 as pod-3 (new version)
+    participant DB
+
+    P1->>DB: isApplied("v3")? (precheck)
+    P2->>DB: isApplied("v3")? (precheck)
+    P3->>DB: isApplied("v3")? (precheck)
+    Note over P1,P3: all return false
+
+    par lock contention
+        P1->>DB: acquire lock "schema-v3"
+        P2->>DB: acquire lock "schema-v3" (wait)
+        P3->>DB: acquire lock "schema-v3" (wait)
+    end
+
+    DB-->>P1: lock acquired
+    P1->>DB: isApplied("v3")? (in-lock recheck)
+    DB-->>P1: false
+    P1->>DB: run migration + insert marker
+    P1->>DB: release lock
+
+    DB-->>P2: lock acquired (after P1)
+    P2->>DB: isApplied("v3")? (in-lock recheck)
+    DB-->>P2: true → AlreadyApplied
+    P2->>DB: release lock
+
+    DB-->>P3: lock acquired (after P2)
+    P3->>DB: isApplied("v3")? (in-lock recheck)
+    DB-->>P3: true → AlreadyApplied
+```
+
+## Core Features
+
+- Single migration execution across N pods during rolling deploy
+- 3-phase `isApplied` check: precheck → in-lock recheck → post-skip recheck
+- Lock automatically released on success, failure, or exception
+- Failed leader's lock release allows next pod to take over
+- Backed by `ExposedJdbcLeaderElector` — works on H2/PostgreSQL/MySQL
+
+## Usage Example
+
+```kotlin
+val gate = MigrationGate(db, MigrationGateOptions(
+    nodeId = System.getenv("HOSTNAME"),
+    lockName = "prod-app-schema-v3",
+    waitTime = 30.seconds,
+    leaseTime = 5.minutes,           // ⚠️ Must exceed expected migration duration
+))
+
+val outcome = gate.runMigration(
+    migrationId = "schema-v3",
+    isApplied = { schemaVersionExists(db, "v3") },
+    migration = {
+        transaction(db) {
+            SchemaUtils.createMissingTablesAndColumns(UsersTable, OrdersTable)
+            SchemaVersionTable.insert { it[version] = "v3" }   // marker in same tx
+        }
+    },
+)
+
+when (outcome) {
+    is Outcome.Migrated      -> log.info { "Leader migrated in ${outcome.durationMs}ms" }
+    is Outcome.AlreadyApplied -> log.info { "Already applied — skipping" }
+    is Outcome.Skipped        -> log.warn { "Skipped: ${outcome.reason} — verify before serving" }
+    is Outcome.Failed         -> error("Migration failed: ${outcome.cause.message}")
+}
+```
+
+## Demo
+
+```bash
+./gradlew :examples:migration-gate:run
+```
+
+H2 in-memory DB + 3 pod simulation. Outputs 1 Migrated + 2 AlreadyApplied.
+
+## Configuration Options
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `nodeId` | required | Pod identifier — written to lock row's `lockOwner` for tracing |
+| `lockName` | required | Distributed lock key — recommend `<env>-<app>-<schemaVersion>` |
+| `waitTime` | `30.seconds` | Max time to wait for lock before giving up |
+| `leaseTime` | `5.minutes` | Lock TTL — **must exceed worst-case migration duration** (no auto-extend) |
+
+## Migration Authoring Guidelines
+
+- **Idempotent**: Migration must be safe to retry (e.g., `CREATE TABLE IF NOT EXISTS`)
+- **Atomic with marker**: Insert marker in same transaction as schema change
+- **Backward-compatible**: During rolling deploy, old pods coexist with migrated schema
+  → use expand-contract migration pattern (add column → backfill → switch reads → drop)
+
+## Dependency
+
+```kotlin
+dependencies {
+    implementation(project(":leader-exposed-jdbc"))
+    implementation(project(":examples:migration-gate"))
+}
+```
+
+## Testing
+
+```bash
+./gradlew :examples:migration-gate:test                       # H2 + PostgreSQL
+LEADER_TEST_DB=H2 ./gradlew :examples:migration-gate:test     # H2 only
+LEADER_TEST_DB=POSTGRESQL ./gradlew :examples:migration-gate:test
+```
+
+PostgreSQL tests use Testcontainers — Docker daemon required.

--- a/examples/migration-gate/build.gradle.kts
+++ b/examples/migration-gate/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    application
+}
+
+application {
+    mainClass.set("io.bluetape4k.leader.examples.migration.MigrationGateDemo")
+}
+
+dependencies {
+    implementation(project(":leader-exposed-jdbc"))
+
+    implementation(libs.exposed.core)
+    implementation(libs.exposed.jdbc)
+    implementation(libs.exposed.dao)
+    implementation(libs.exposed.java.time)
+    implementation(libs.hikaricp)
+
+    runtimeOnly(libs.h2.v2)
+
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.bluetape4k.exposed.jdbc.tests)
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.junit.jupiter)
+    testImplementation(libs.h2.v2)
+    testImplementation(libs.postgresql)
+    testImplementation(libs.mysql.connector.j)
+}

--- a/examples/migration-gate/src/main/kotlin/io/bluetape4k/leader/examples/migration/MigrationGate.kt
+++ b/examples/migration-gate/src/main/kotlin/io/bluetape4k/leader/examples/migration/MigrationGate.kt
@@ -1,0 +1,146 @@
+package io.bluetape4k.leader.examples.migration
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderElectionOptions
+import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderElector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import io.bluetape4k.support.requireNotBlank
+import kotlin.coroutines.cancellation.CancellationException
+import org.jetbrains.exposed.v1.jdbc.Database
+
+/**
+ * 롤링 배포 중 DB 마이그레이션 게이트.
+ *
+ * ## 동작/계약
+ *
+ * 다중 인스턴스(K8s pod) 환경에서 단 1개만 마이그레이션을 실행하도록 보장.
+ * `runMigration` 은 다음 4단계로 동작:
+ *
+ * 1. **Precheck**: [isApplied] 호출 — true 면 [Outcome.AlreadyApplied] 즉시 반환 (락 시도 없음)
+ * 2. **Lock 획득**: `runIfLeader` 로 옵션의 [MigrationGateOptions.waitTime] 동안 락 획득 시도
+ * 3. **In-lock recheck**: 락 내부에서 [isApplied] 재확인 — true 면 마이그레이션 skip ([Outcome.AlreadyApplied])
+ * 4. **Migration 실행**: [migration] lambda 실행 → 성공 시 [Outcome.Migrated], 예외 시 [Outcome.Failed]
+ * 5. **Post-skip check**: 락 미획득 시 [isApplied] 한 번 더 확인 — true 면 [Outcome.AlreadyApplied], 아니면 [Outcome.Skipped]
+ *
+ * **중요**: 현재 backend ([ExposedJdbcLeaderElector]) 는 lease auto-extend 미지원.
+ * 마이그레이션이 [MigrationGateOptions.leaseTime] 보다 길어지면 다른 인스턴스가 락을 재획득하여
+ * 중복 실행될 수 있음. [migration] 은 idempotent 하게 작성하거나,
+ * marker 기록을 같은 transaction 안에서 수행하여 안전성 확보 권장.
+ *
+ * **isApplied() 예외 처리**: 마커 조회 실패 (DB 연결 오류, 권한 문제 등) 는 "미적용" 과
+ * 동등하게 처리하지 않고 [Outcome.Failed] 로 매핑하여 호출자가 startup 실패 처리 가능.
+ * "마커 상태 불명" ≠ "미적용".
+ *
+ * ```kotlin
+ * val gate = MigrationGate(db, MigrationGateOptions(
+ *     nodeId = HOSTNAME,
+ *     lockName = "schema-v3",
+ *     waitTime = 30.seconds,
+ *     leaseTime = 5.minutes,
+ * ))
+ *
+ * val outcome = gate.runMigration(
+ *     migrationId = "schema-v3",
+ *     isApplied = { schemaMarkerExists(db, "v3") },
+ *     migration = {
+ *         transaction(db) {
+ *             SchemaUtils.createMissingTablesAndColumns(UsersTable)
+ *             SchemaMarkerTable.insert { it[version] = "v3" }   // marker 같은 tx
+ *         }
+ *     },
+ * )
+ * ```
+ */
+class MigrationGate(
+    db: Database,
+    val options: MigrationGateOptions,
+) {
+    companion object: KLogging()
+
+    private val elector: ExposedJdbcLeaderElector = ExposedJdbcLeaderElector(
+        db = db,
+        options = ExposedJdbcLeaderElectionOptions(
+            leaderOptions = LeaderElectionOptions(
+                waitTime = options.waitTime,
+                leaseTime = options.leaseTime,
+                nodeId = options.nodeId,
+            ),
+            lockOwner = options.nodeId,
+            recordHistory = true,
+        ),
+    )
+
+    /**
+     * 마이그레이션 실행 게이트.
+     *
+     * @param migrationId 마이그레이션 식별자 (로그·outcome 에 기록). 비어있으면 안 됨.
+     * @param isApplied 마이그레이션 완료 여부 확인 콜백. precheck/in-lock/post-skip 3회 호출됨.
+     * @param migration 실제 마이그레이션 작업. idempotent 하게 작성 권장. 예외 시 락 자동 해제.
+     * @return 4가지 분기 [Outcome]
+     */
+    fun runMigration(
+        migrationId: String,
+        isApplied: () -> Boolean,
+        migration: () -> Unit,
+    ): Outcome {
+        migrationId.requireNotBlank("migrationId")
+        val started = System.currentTimeMillis()
+
+        // 1. Precheck — isApplied() 예외는 그대로 Failed 로 매핑 (silent swallow 금지)
+        val precheckApplied = try {
+            isApplied()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "[${options.nodeId}] migration=$migrationId: precheck isApplied() 실패" }
+            return Outcome.Failed(migrationId, e, System.currentTimeMillis() - started)
+        }
+        if (precheckApplied) {
+            log.info { "[${options.nodeId}] migration=$migrationId: precheck — 이미 적용됨" }
+            return Outcome.AlreadyApplied(migrationId)
+        }
+
+        // 2. Lock 획득 + in-lock recheck + migration
+        val inLockOutcome: Outcome? = try {
+            elector.runIfLeader(options.lockName) {
+                log.info { "[${options.nodeId}] migration=$migrationId: 리더 선출 — in-lock recheck" }
+                if (isApplied()) {
+                    log.info { "[${options.nodeId}] migration=$migrationId: in-lock recheck — 이미 적용됨" }
+                    return@runIfLeader Outcome.AlreadyApplied(migrationId)
+                }
+                log.info { "[${options.nodeId}] migration=$migrationId: 마이그레이션 실행 시작" }
+                migration()
+                val elapsed = System.currentTimeMillis() - started
+                log.info { "[${options.nodeId}] migration=$migrationId: 마이그레이션 완료 (${elapsed}ms)" }
+                Outcome.Migrated(migrationId, elapsed)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            val elapsed = System.currentTimeMillis() - started
+            log.warn(e) { "[${options.nodeId}] migration=$migrationId: 마이그레이션 또는 in-lock isApplied() 실패 (${elapsed}ms)" }
+            return Outcome.Failed(migrationId, e, elapsed)
+        }
+
+        if (inLockOutcome != null) return inLockOutcome
+
+        // 3. Post-skip check — isApplied() 예외는 Failed 로 매핑
+        val postSkipApplied = try {
+            isApplied()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "[${options.nodeId}] migration=$migrationId: post-skip isApplied() 실패" }
+            return Outcome.Failed(migrationId, e, System.currentTimeMillis() - started)
+        }
+        return if (postSkipApplied) {
+            log.info { "[${options.nodeId}] migration=$migrationId: post-skip — 다른 인스턴스가 적용 완료" }
+            Outcome.AlreadyApplied(migrationId)
+        } else {
+            log.info { "[${options.nodeId}] migration=$migrationId: skipped (락 미획득 + 마커 미생성)" }
+            Outcome.Skipped(migrationId, "락 미획득 within ${options.waitTime}, 마커 미생성")
+        }
+    }
+}

--- a/examples/migration-gate/src/main/kotlin/io/bluetape4k/leader/examples/migration/MigrationGateDemo.kt
+++ b/examples/migration-gate/src/main/kotlin/io/bluetape4k/leader/examples/migration/MigrationGateDemo.kt
@@ -1,0 +1,90 @@
+package io.bluetape4k.leader.examples.migration
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * 3-인스턴스 마이그레이션 게이트 데모 (H2 in-memory).
+ *
+ * Kubernetes 롤링 배포에서 새 pod 3개가 동시 기동 → 단 1개만 마이그레이션 실행하는 시나리오.
+ */
+object MigrationGateDemo: KLogging() {
+
+    private object DemoSchemaMarkerTable: Table("demo_schema_markers") {
+        val migrationId = varchar("migration_id", 100)
+        override val primaryKey = PrimaryKey(migrationId)
+    }
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        // 단일 H2 in-memory DB — 3 pod 가 동일 DB 공유 시뮬레이션
+        val db = Database.connect(
+            url = "jdbc:h2:mem:migration-demo;DB_CLOSE_DELAY=-1;MODE=PostgreSQL",
+            driver = "org.h2.Driver",
+        )
+        transaction(db) {
+            SchemaUtils.create(DemoSchemaMarkerTable)
+        }
+
+        val migrationId = "schema-v3"
+        val lockName = "demo-migration-gate"
+
+        log.info { "=== K8s 롤링 배포 시뮬레이션 ===" }
+        log.info { "3개 pod 가 동시에 마이그레이션 게이트 진입" }
+
+        val executor = Executors.newFixedThreadPool(3)
+        try {
+            val futures = (1..3).map { idx ->
+                executor.submit<Outcome> {
+                    val gate = MigrationGate(db, MigrationGateOptions(
+                        nodeId = "pod-$idx",
+                        lockName = lockName,
+                        waitTime = 30.seconds,
+                        leaseTime = 5.minutes,
+                    ))
+                    gate.runMigration(
+                        migrationId = migrationId,
+                        isApplied = {
+                            transaction(db) {
+                                DemoSchemaMarkerTable.selectAll()
+                                    .where { DemoSchemaMarkerTable.migrationId eq migrationId }
+                                    .empty().not()
+                            }
+                        },
+                        migration = {
+                            log.info { "[pod-$idx] 마이그레이션 SQL 실행 중..." }
+                            Thread.sleep(500)
+                            transaction(db) {
+                                DemoSchemaMarkerTable.insert {
+                                    it[DemoSchemaMarkerTable.migrationId] = migrationId
+                                }
+                            }
+                        },
+                    )
+                }
+            }
+            val outcomes = futures.map { it.get(60, TimeUnit.SECONDS) }
+
+            log.info { "=== 결과 ===" }
+            outcomes.forEachIndexed { idx, outcome ->
+                log.info { "[pod-${idx + 1}] outcome=$outcome" }
+            }
+            val migrated = outcomes.count { it is Outcome.Migrated }
+            val applied = outcomes.count { it is Outcome.AlreadyApplied }
+            log.info { "Migrated=$migrated (기대값 1), AlreadyApplied=$applied (기대값 2)" }
+        } finally {
+            executor.shutdown()
+        }
+    }
+}

--- a/examples/migration-gate/src/main/kotlin/io/bluetape4k/leader/examples/migration/MigrationGateOptions.kt
+++ b/examples/migration-gate/src/main/kotlin/io/bluetape4k/leader/examples/migration/MigrationGateOptions.kt
@@ -1,0 +1,42 @@
+package io.bluetape4k.leader.examples.migration
+
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * [MigrationGate] 설정.
+ *
+ * ## 동작/계약
+ *
+ * - [nodeId]: 본 인스턴스 식별자. 락 row 와 history 에 lockOwner 로 기록되어 운영 추적성 확보
+ * - [lockName]: 분산 락 키. 환경/스키마/마이그레이션 셋 단위로 다르게 설정 권장
+ *   (예: `"prod-app-schema-v3"`)
+ * - [waitTime]: 비리더 인스턴스가 마이그레이션 완료를 대기하는 최대 시간
+ * - [leaseTime]: 락 TTL. **마이그레이션 최악 실행 시간보다 길게** 설정해야 split-brain 방지
+ *   (현재 backend 는 auto-extend 미지원)
+ *
+ * ```kotlin
+ * MigrationGateOptions(
+ *     nodeId = System.getenv("HOSTNAME") ?: "node-${UUID.randomUUID()}",
+ *     lockName = "prod-app-schema-v3",
+ *     waitTime = 30.seconds,
+ *     leaseTime = 5.minutes,
+ * )
+ * ```
+ */
+data class MigrationGateOptions(
+    val nodeId: String,
+    val lockName: String,
+    val waitTime: Duration = 30.seconds,
+    val leaseTime: Duration = 5.minutes,
+) {
+    init {
+        nodeId.requireNotBlank("nodeId")
+        lockName.requireNotBlank("lockName")
+        waitTime.inWholeMilliseconds.requirePositiveNumber("waitTime")
+        leaseTime.inWholeMilliseconds.requirePositiveNumber("leaseTime")
+    }
+}

--- a/examples/migration-gate/src/main/kotlin/io/bluetape4k/leader/examples/migration/Outcome.kt
+++ b/examples/migration-gate/src/main/kotlin/io/bluetape4k/leader/examples/migration/Outcome.kt
@@ -1,0 +1,42 @@
+package io.bluetape4k.leader.examples.migration
+
+/**
+ * [MigrationGate.runMigration] 의 실행 결과.
+ *
+ * ## 동작/계약
+ *
+ * 4가지 분기로 마이그레이션 시도의 모든 결과를 표현한다:
+ * - [Migrated]: 본 인스턴스가 리더로 선출되어 마이그레이션을 성공적으로 수행
+ * - [AlreadyApplied]: 마이그레이션이 이미 적용된 상태 (precheck/in-lock recheck/post-skip check 어느 단계에서든)
+ * - [Skipped]: 락 미획득 + 마커 미생성 — 다른 인스턴스가 처리 중이거나 wait 시간 초과
+ * - [Failed]: 마이그레이션 lambda 실행 중 예외 발생 — 락은 자동 해제됨
+ *
+ * 호출자는 sealed interface 의 모든 분기를 명시적으로 처리해야 한다 (exhaustive when).
+ */
+sealed interface Outcome {
+    val migrationId: String
+
+    /** 본 인스턴스가 리더로 마이그레이션 수행 완료. */
+    data class Migrated(
+        override val migrationId: String,
+        val durationMs: Long,
+    ): Outcome
+
+    /** 마이그레이션이 이미 적용된 상태 (마커 확인됨). */
+    data class AlreadyApplied(
+        override val migrationId: String,
+    ): Outcome
+
+    /** 락 미획득 + 마커 미생성 — 다른 인스턴스 처리 중일 가능성. */
+    data class Skipped(
+        override val migrationId: String,
+        val reason: String,
+    ): Outcome
+
+    /** 마이그레이션 실행 중 예외 발생. */
+    data class Failed(
+        override val migrationId: String,
+        val cause: Throwable,
+        val durationMs: Long,
+    ): Outcome
+}

--- a/examples/migration-gate/src/test/kotlin/io/bluetape4k/leader/examples/migration/AbstractMigrationGateTest.kt
+++ b/examples/migration-gate/src/test/kotlin/io/bluetape4k/leader/examples/migration/AbstractMigrationGateTest.kt
@@ -1,0 +1,61 @@
+package io.bluetape4k.leader.examples.migration
+
+import io.bluetape4k.exposed.tests.TestDB
+import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderElector
+import io.bluetape4k.leader.exposed.tables.LeaderGroupLockTable
+import io.bluetape4k.leader.exposed.tables.LeaderLockHistoryTable
+import io.bluetape4k.leader.exposed.tables.LeaderLockTable
+import io.bluetape4k.logging.KLogging
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.TestInstance
+import org.testcontainers.utility.Base58
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractMigrationGateTest {
+
+    companion object: KLogging() {
+        @JvmStatic
+        fun enableDialects(): List<TestDB> {
+            val filter = System.getenv("LEADER_TEST_DB")?.uppercase()
+                ?: return listOf(TestDB.H2, TestDB.POSTGRESQL)
+
+            return when (filter) {
+                "H2" -> listOf(TestDB.H2)
+                "POSTGRESQL", "POSTGRES" -> listOf(TestDB.POSTGRESQL)
+                else -> listOf(TestDB.H2, TestDB.POSTGRESQL)
+            }
+        }
+    }
+
+    /** 마이그레이션 완료 마커 테이블 (예제용 — Flyway/Liquibase 대체). */
+    object MigrationMarkerTable: Table("migration_marker_example") {
+        val migrationId = varchar("migration_id", 100)
+        override val primaryKey = PrimaryKey(migrationId)
+    }
+
+    protected fun connectDb(testDB: TestDB): Database {
+        val db = testDB.db ?: testDB.connect()
+        // ExposedJdbcLeaderElector factory 가 leader 테이블 스키마를 자동 생성한다
+        ExposedJdbcLeaderElector(db)
+        transaction(db) {
+            SchemaUtils.create(MigrationMarkerTable)
+        }
+        return db
+    }
+
+    protected fun cleanTables(db: Database) {
+        transaction(db) {
+            LeaderLockHistoryTable.deleteAll()
+            LeaderLockTable.deleteAll()
+            LeaderGroupLockTable.deleteAll()
+            MigrationMarkerTable.deleteAll()
+        }
+    }
+
+    protected fun randomMigrationId(): String = "migration-${Base58.randomString(8)}"
+    protected fun randomLockName(): String = "migration-lock-${Base58.randomString(8)}"
+}

--- a/examples/migration-gate/src/test/kotlin/io/bluetape4k/leader/examples/migration/MigrationGateTest.kt
+++ b/examples/migration-gate/src/test/kotlin/io/bluetape4k/leader/examples/migration/MigrationGateTest.kt
@@ -1,0 +1,256 @@
+package io.bluetape4k.leader.examples.migration
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.exposed.tests.TestDB
+import io.bluetape4k.logging.KLogging
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class MigrationGateTest: AbstractMigrationGateTest() {
+
+    companion object: KLogging()
+
+    private fun isApplied(db: org.jetbrains.exposed.v1.jdbc.Database, migrationId: String): Boolean =
+        transaction(db) {
+            MigrationMarkerTable.selectAll()
+                .where { MigrationMarkerTable.migrationId eq migrationId }
+                .empty().not()
+        }
+
+    private fun markApplied(db: org.jetbrains.exposed.v1.jdbc.Database, migrationId: String) {
+        transaction(db) {
+            MigrationMarkerTable.insert { it[MigrationMarkerTable.migrationId] = migrationId }
+        }
+    }
+
+    private fun gate(db: org.jetbrains.exposed.v1.jdbc.Database, lockName: String, nodeId: String = "test-node") =
+        MigrationGate(db, MigrationGateOptions(
+            nodeId = nodeId,
+            lockName = lockName,
+            waitTime = 2.seconds,
+            leaseTime = 30.seconds,
+        ))
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `단일 인스턴스 - 마이그레이션 실행 후 Migrated`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val migrationId = randomMigrationId()
+        val migrated = AtomicInteger(0)
+
+        val outcome = gate(db, randomLockName()).runMigration(
+            migrationId = migrationId,
+            isApplied = { isApplied(db, migrationId) },
+            migration = {
+                migrated.incrementAndGet()
+                markApplied(db, migrationId)
+            },
+        )
+
+        outcome.shouldBeInstanceOf<Outcome.Migrated>()
+        (outcome as Outcome.Migrated).migrationId shouldBeEqualTo migrationId
+        migrated.get() shouldBeEqualTo 1
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `이미 적용된 상태 - precheck로 AlreadyApplied (락 시도 없음)`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val migrationId = randomMigrationId()
+        markApplied(db, migrationId)
+        val migrated = AtomicInteger(0)
+
+        val outcome = gate(db, randomLockName()).runMigration(
+            migrationId = migrationId,
+            isApplied = { isApplied(db, migrationId) },
+            migration = { migrated.incrementAndGet() },
+        )
+
+        outcome.shouldBeInstanceOf<Outcome.AlreadyApplied>()
+        migrated.get() shouldBeEqualTo 0
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `3 인스턴스 동시 - 1 Migrated + 2 AlreadyApplied`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val migrationId = randomMigrationId()
+        val lockName = randomLockName()
+        val migrated = AtomicInteger(0)
+        val executor = Executors.newFixedThreadPool(3)
+
+        try {
+            val outcomes = (1..3).map { idx ->
+                executor.submit<Outcome> {
+                    val g = MigrationGate(db, MigrationGateOptions(
+                        nodeId = "node-$idx",
+                        lockName = lockName,
+                        waitTime = 5.seconds,
+                        leaseTime = 30.seconds,
+                    ))
+                    g.runMigration(
+                        migrationId = migrationId,
+                        isApplied = { isApplied(db, migrationId) },
+                        migration = {
+                            migrated.incrementAndGet()
+                            markApplied(db, migrationId)
+                            Thread.sleep(200)
+                        },
+                    )
+                }
+            }.map { it.get(15, TimeUnit.SECONDS) }
+
+            migrated.get() shouldBeEqualTo 1
+            outcomes.count { it is Outcome.Migrated } shouldBeEqualTo 1
+            outcomes.count { it is Outcome.AlreadyApplied } shouldBeEqualTo 2
+        } finally {
+            executor.shutdown()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `리더 마이그레이션 예외 - Failed (마커 미생성, 락 해제)`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val migrationId = randomMigrationId()
+        val lockName = randomLockName()
+
+        val outcome1 = gate(db, lockName, "fail-node").runMigration(
+            migrationId = migrationId,
+            isApplied = { isApplied(db, migrationId) },
+            migration = { throw IllegalStateException("DDL 실패") },
+        )
+        outcome1.shouldBeInstanceOf<Outcome.Failed>()
+        (outcome1 as Outcome.Failed).cause.shouldBeInstanceOf<IllegalStateException>()
+        isApplied(db, migrationId) shouldBeEqualTo false
+
+        // 차순위 인스턴스 takeover — 락이 해제되어 새로 획득 가능
+        val migrated = AtomicInteger(0)
+        val outcome2 = gate(db, lockName, "recover-node").runMigration(
+            migrationId = migrationId,
+            isApplied = { isApplied(db, migrationId) },
+            migration = {
+                migrated.incrementAndGet()
+                markApplied(db, migrationId)
+            },
+        )
+        outcome2.shouldBeInstanceOf<Outcome.Migrated>()
+        migrated.get() shouldBeEqualTo 1
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `waitTime 초과 + 마커 미생성 - Skipped`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val migrationId = randomMigrationId()
+        val lockName = randomLockName()
+        val leaderStarted = CountDownLatch(1)
+        val leaderRelease = CountDownLatch(1)
+        val executor = Executors.newFixedThreadPool(2)
+
+        try {
+            // 리더는 락 잡고 latch 대기 (마커 생성 안 함 — DDL 실행 중인 상황 시뮬레이션)
+            val leaderFuture = executor.submit {
+                MigrationGate(db, MigrationGateOptions(
+                    nodeId = "leader",
+                    lockName = lockName,
+                    waitTime = 100.milliseconds,
+                    leaseTime = 30.seconds,
+                )).runMigration(
+                    migrationId = migrationId,
+                    isApplied = { isApplied(db, migrationId) },
+                    migration = {
+                        leaderStarted.countDown()
+                        leaderRelease.await(10, TimeUnit.SECONDS)
+                        // 마커 안 만들고 종료 — 후속 인스턴스가 Skipped 받도록
+                    },
+                )
+            }
+
+            leaderStarted.await(10, TimeUnit.SECONDS)
+
+            // 비리더는 짧은 waitTime — 락 못 잡고 마커도 없음 → Skipped
+            val followerOutcome = MigrationGate(db, MigrationGateOptions(
+                nodeId = "follower",
+                lockName = lockName,
+                waitTime = 200.milliseconds,
+                leaseTime = 30.seconds,
+            )).runMigration(
+                migrationId = migrationId,
+                isApplied = { isApplied(db, migrationId) },
+                migration = { error("not reached") },
+            )
+
+            leaderRelease.countDown()
+            leaderFuture.get(15, TimeUnit.SECONDS)
+
+            followerOutcome.shouldBeInstanceOf<Outcome.Skipped>()
+        } finally {
+            executor.shutdown()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `blank nodeId 또는 lockName - IllegalArgumentException`(testDB: TestDB) {
+        connectDb(testDB)
+
+        assertFailsWith<IllegalArgumentException> {
+            MigrationGateOptions(nodeId = " ", lockName = "ok")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            MigrationGateOptions(nodeId = "ok", lockName = " ")
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `blank migrationId - IllegalArgumentException`(testDB: TestDB) {
+        val db = connectDb(testDB)
+
+        assertFailsWith<IllegalArgumentException> {
+            gate(db, randomLockName()).runMigration(
+                migrationId = "  ",
+                isApplied = { false },
+                migration = { },
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `isApplied 예외 발생 - 마커 상태 불명을 Failed 로 매핑`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val migrationId = randomMigrationId()
+        val migrated = AtomicInteger(0)
+
+        val outcome = gate(db, randomLockName()).runMigration(
+            migrationId = migrationId,
+            isApplied = { error("마커 테이블 조회 실패 시뮬레이션") },
+            migration = { migrated.incrementAndGet() },
+        )
+
+        outcome.shouldBeInstanceOf<Outcome.Failed>()
+        (outcome as Outcome.Failed).cause.shouldBeInstanceOf<IllegalStateException>()
+        // isApplied 예외 발생 시 마이그레이션 실행 안 됨
+        migrated.get() shouldBeEqualTo 0
+    }
+}

--- a/examples/migration-gate/src/test/resources/junit-platform.properties
+++ b/examples/migration-gate/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/examples/migration-gate/src/test/resources/logback-test.xml
+++ b/examples/migration-gate/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%24.24t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+    <logger name="io.bluetape4k.leader.examples.migration" level="DEBUG"/>
+    <logger name="io.bluetape4k.leader.exposed" level="INFO"/>
+    <logger name="org.testcontainers" level="WARN"/>
+    <logger name="org.jetbrains.exposed" level="WARN"/>
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,4 +25,5 @@ include(
     "leader-spring-boot",
     "leader-micrometer",
     "examples:batch-scheduler",
+    "examples:migration-gate",
 )


### PR DESCRIPTION
## Summary

Closes #155

PR #160의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat(examples): E2 마이그레이션 게이트 (Exposed-JDBC) — closes #155`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 개요

Epic #36 의 E2 — K8s 롤링 배포 중 N개 pod 환경에서 DB 스키마 마이그레이션을 단 1개만 실행하도록 보장하는 4단계 게이트.

Closes #155
Refs #36

## 4단계 게이트

1. **Precheck** — `isApplied()` true → `AlreadyApplied` (락 시도 없음)
2. **Lock 획득** — `runIfLeader` (waitTime 동안 시도)
3. **In-lock recheck** — 락 내부에서 `isApplied()` 재확인
4. **Migration 실행** — 성공 → `Migrated`, 예외 → `Failed`
5. **Post-skip check** — 락 미획득 시 `isApplied()` 재확인 → `AlreadyApplied` 또는 `Skipped`

## API

| Outcome | 의미 |
|---------|------|
| `Migrated(migrationId, durationMs)` | 본 인스턴스가 리더로 마이그레이션 수행 |
| `AlreadyApplied(migrationId)` | 마커 확인됨 — precheck/in-lock/post-skip 어느 단계든 |
| `Skipped(migrationId, reason)` | 락 미획득 + 마커 미생성 |
| `Failed(migrationId, cause, durationMs)` | 마이그레이션 또는 isApplied 예외 |

## 변경 사항

- `examples/migration-gate/` 신규 모듈
- `settings.gradle.kts` + `.github/workflows/{ci,nightly}.yml` 등록
- `docs/lessons/2026-05-10-e2-migration-gate.md` (L1~L6)

## 테스트 결과

8 passing (각 H2 + PG = 16):
- 단일 인스턴스 → Migrated
- 이미 적용된 상태 → precheck AlreadyApplied (락 시도 없음)
- 3 인스턴스 동시 → 1 Migrated + 2 AlreadyApplied
- 리더 예외 → Failed (마커 미생성, 락 해제) + 차순위 takeover
- waitTime 초과 + 마커 미생성 → Skipped
- blank nodeId/lockName → IllegalArgumentException
- blank migrationId → IllegalArgumentException
- isApplied 예외 → Failed (마커 상태 불명을 미적용으로 처리하지 않음)

## 코드 리뷰

- **Codex spec 리뷰**: CRITICAL 3 + HIGH 11 → spec 단계에서 모두 반영 (in-lock recheck, autoExtend 제거 등)
- **Codex plan 리뷰**: HIGH 6 → plan 단계 반영 (action 외부 try/catch, 5단계 게이트 등)
- **code-reviewer Tier 4+5**: H4(영문 README 한국어 잔존), H5(Throwable→Exception+CancellationException 재throw) 반영
- **Codex code review (uncommitted)**: P2 — `isApplied()` 예외 silent swallow 반영 → `Outcome.Failed` 매핑 + 신규 테스트

## 검증

\`\`\`bash
./gradlew :examples:migration-gate:test                       # H2 + PostgreSQL
./gradlew :examples:migration-gate:run                        # H2 데모
\`\`\`

## 다음 작업

E3 (#156) — `examples/webhook-poller/` (MongoDB).
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #155, milestone `0.1.0`, assignee `debop`
- PR: #160, head `070d59ecb20ccc2db70a0abad3b086ae75c4f05e`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
