### PR TITLE
feat(examples): E3 Webhook 폴러 (MongoDB) — closes #156

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
       leader-micrometer: ${{ steps.filter.outputs.leader-micrometer }}
       examples-batch-scheduler: ${{ steps.filter.outputs.examples-batch-scheduler }}
       examples-migration-gate: ${{ steps.filter.outputs.examples-migration-gate }}
+      examples-webhook-poller: ${{ steps.filter.outputs.examples-webhook-poller }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -122,6 +123,10 @@ jobs:
               - 'examples/migration-gate/**'
               - 'leader-exposed-jdbc/**'
               - 'leader-exposed-core/**'
+              - 'leader-core/**'
+            examples-webhook-poller:
+              - 'examples/webhook-poller/**'
+              - 'leader-mongodb/**'
               - 'leader-core/**'
 
   # ── 3. 전체 빌드 (테스트 제외) ───────────────────────────────────────────
@@ -546,6 +551,42 @@ jobs:
           path: '**/build/test-results/test/*.xml'
           retention-days: 7
 
+  # ── examples-webhook-poller (Testcontainers MongoDB) ────────────────────────
+  test-examples-webhook-poller:
+    name: Test / examples-webhook-poller
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['examples-webhook-poller'] == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Test examples-webhook-poller
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :examples:webhook-poller:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-examples-webhook-poller
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 7
+
   # ── examples-batch-scheduler (Testcontainers Redis) ─────────────────────────
   test-examples-batch-scheduler:
     name: Test / examples-batch-scheduler
@@ -789,6 +830,7 @@ jobs:
       - test-zookeeper
       - test-examples-batch-scheduler
       - test-examples-migration-gate
+      - test-examples-webhook-poller
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -835,6 +877,7 @@ jobs:
       - test-zookeeper
       - test-examples-batch-scheduler
       - test-examples-migration-gate
+      - test-examples-webhook-poller
       - coverage-report
     if: always()
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -687,6 +687,41 @@ jobs:
           path: '**/build/test-results/test/*.xml'
           retention-days: 14
 
+  # ── examples-webhook-poller (Testcontainers MongoDB) ────────────────────────
+  test-examples-webhook-poller:
+    name: Test / examples-webhook-poller (Testcontainers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Test examples-webhook-poller
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :examples:webhook-poller:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-examples-webhook-poller
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 14
+
   # ── examples-batch-scheduler (Testcontainers Redis) ─────────────────────────
   test-examples-batch-scheduler:
     name: Test / examples-batch-scheduler (Testcontainers)
@@ -789,6 +824,7 @@ jobs:
       - test-spring-boot
       - test-examples-batch-scheduler
       - test-examples-migration-gate
+      - test-examples-webhook-poller
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -835,6 +871,7 @@ jobs:
       - test-spring-boot
       - test-examples-batch-scheduler
       - test-examples-migration-gate
+      - test-examples-webhook-poller
       - coverage-report
     if: always()
     steps:

--- a/docs/lessons/2026-05-10-e3-webhook-poller.md
+++ b/docs/lessons/2026-05-10-e3-webhook-poller.md
@@ -1,0 +1,108 @@
+# Lessons Learned — E3 Webhook Poller (2026-05-10)
+
+**관련 PR**: TBD
+**관련 Issue**: #156 (Epic #36)
+**영향 모듈**: `examples/webhook-poller/`, `.github/workflows/{ci,nightly}.yml`, `settings.gradle.kts`
+
+## L1: claim/ack 모델 — at-least-once + idempotent handler
+
+### 문제
+초기 spec 은 단순 fetch + handler 실행 — leader cancel/crash/lease 만료 시 event loss/duplicate 발생.
+
+### 교훈
+PENDING/CLAIMED/DONE/FAILED 4-state model + atomic `findOneAndUpdate` claim. Claim 만료 시 reclaim 가능. handler 는 **idempotent** 작성 필수.
+- Claim filter: `{ status: PENDING } OR { status: CLAIMED, claimExpiresAt < now }` + `attempts < maxAttempts`
+- handler 성공 → DONE
+- handler 실패 + attempts < maxAttempts → PENDING 으로 되돌림 (재시도)
+- handler 실패 + attempts >= maxAttempts → FAILED (DLQ 대체)
+
+E5 (tenant-aggregator) 도 유사 패턴 적용 권장.
+
+---
+
+## L2: claim ownership 가드 — stale owner 의 update 차단
+
+### 문제
+원본 owner 가 handler 실행 중 claim 만료 → 다른 인스턴스가 reclaim → 원본 owner 가 깨어나서 `eventId` 만으로 update → 새 owner 의 CLAIMED 를 덮어씀.
+
+### 교훈
+`updateOne` filter 에 `eventId` + `status = CLAIMED` + `claimedBy = nodeId` 동시 검증.
+
+```kotlin
+Filters.and(
+    Filters.eq(FIELD_EVENT_ID, event.eventId),
+    Filters.eq(FIELD_STATUS, CLAIMED.name),
+    Filters.eq(FIELD_CLAIMED_BY, options.nodeId),
+)
+```
+
+`matchedCount=0` 시 "claim ownership lost" log warn — silent skip 으로 race 무해화.
+
+분산 시스템에서 lease 기반 모든 작업에 동일 패턴 적용 (E5 LeaderGroup).
+
+---
+
+## L3: maxAttempts 의 강제 — claim filter 자체에 검증
+
+### 문제
+초기 구현 은 markFailureOrRequeue 에서만 maxAttempts 검증. 그러나 `attempts >= maxAttempts` 인 expired CLAIMED 는 여전히 claim filter 에 매칭됨 → 다음 인스턴스가 reclaim → handler 또 호출 → maxAttempts 의미 없음.
+
+### 교훈
+claim filter 자체에 `attempts < maxAttempts` 조건 추가 — DB 레벨에서 maxAttempts 강제. 별도 sweeper job 불필요.
+
+---
+
+## L4: Options 와 외부 주입 의존성의 desync 방지
+
+### 문제
+`WebhookPollerOptions` 에 `leaseTime`, `waitTime` 설정해도 외부에서 주입된 `SuspendLeaderElector` 는 자체 ctor 옵션 사용 → user 가 설정한 옵션이 무시됨.
+
+### 교훈
+외부 주입 의존성의 옵션은 Options 에서 제거. caller 가 elector 생성 시 직접 옵션 전달:
+
+```kotlin
+// 권장
+val elector = MongoSuspendLeaderElector(lockColl, MongoLeaderElectionOptions(
+    leaderOptions = LeaderElectionOptions(waitTime = ..., leaseTime = ...)
+))
+val poller = WebhookPoller(elector, eventColl, WebhookPollerOptions(
+    nodeId, lockName, pollInterval, batchSize, maxAttempts, claimDuration  // leaseTime/waitTime 제거
+), handler)
+```
+
+또는 Options 가 elector 까지 책임진다면 elector factory + options 통합. 양쪽 다 명시적이어야 desync 방지.
+
+---
+
+## L5: suspend API + JUnit 5 — Unit 명시 필수
+
+### 문제
+`runBlocking { ... }` 마지막 식이 non-Unit 이면 JUnit 5 가 테스트를 silently skip — 통과/실패 카운트 모두 변동 없음.
+
+### 교훈
+suspend 테스트 함수 시그니처에 명시적 `: Unit`:
+
+```kotlin
+@Test
+fun `시나리오 검증`(): Unit = runBlocking { ... }   // ✅ Unit 명시
+// 또는
+@Test
+fun `시나리오 검증`() = runTest { ... }              // ✅ runTest 는 Unit 자동 추론
+```
+
+E5 SuspendLeaderGroup 테스트 작성 시 동일 주의.
+
+---
+
+## L6: Codex review P2 vs P3 정확도
+
+### 사례
+E3 에서 Codex review 가 BLOCKER 2 + HIGH 5 + MEDIUM/LOW 다수 발견. spec 단계 반영 후 코드 review 재실행 시 추가 P2 3건 (옵션 desync, claim ownership 가드, maxAttempts 강제) 발견.
+
+### 교훈
+Codex review 는 **spec/plan/code 모든 단계** 에서 의뢰 가치 있음. 같은 이슈도 단계별로 다른 각도로 발견됨:
+- spec 단계: 누락 시나리오, API 모양
+- plan 단계: 의존 순서, over-engineering
+- code 단계: race condition, 구현 디테일
+
+E4, E5 도 3 단계 모두 수행.

--- a/examples/webhook-poller/README.ko.md
+++ b/examples/webhook-poller/README.ko.md
@@ -1,0 +1,127 @@
+# examples-webhook-poller
+
+한국어 | [English](./README.md)
+
+MongoDB 리더 선출을 이용한 분산 webhook event 폴러. N 개 pod 환경에서 단일 리더만 webhook event 를 점유·처리하며, at-least-once 전달, 재시도, `FAILED` 종결 상태(DLQ 대체)를 제공한다.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant P1 as poller-1 (leader)
+    participant P2 as poller-2
+    participant P3 as poller-3
+    participant Lock as Mongo lockCollection
+    participant Events as Mongo eventCollection
+
+    P1->>Lock: runIfLeader("webhook-poller")
+    P2->>Lock: runIfLeader("webhook-poller")
+    P3->>Lock: runIfLeader("webhook-poller")
+    Lock-->>P1: granted
+    Lock-->>P2: null (skip)
+    Lock-->>P3: null (skip)
+
+    loop batchSize 만큼
+        P1->>Events: findOneAndUpdate (atomic claim)<br/>filter: PENDING OR (CLAIMED AND 만료)<br/>update: CLAIMED, claimedBy, attempts++
+        Events-->>P1: 점유한 event
+        P1->>P1: handler(event)
+        alt 성공
+            P1->>Events: status = DONE
+        else handler 예외
+            alt attempts >= maxAttempts
+                P1->>Events: status = FAILED, lastError
+            else
+                P1->>Events: status = PENDING, lastError (재점유 가능)
+            end
+        end
+    end
+
+    Note over P1: delay(pollInterval) 후 재선출
+```
+
+## Core Features
+
+- N 개 폴러 인스턴스 중 **단 1개만 polling** (리더 선출)
+- `findOneAndUpdate` atomic claim — 동시 처리 충돌 시에도 중복 처리 없음
+- Lease 기반 reclaim — 리더 사망 시 만료된 CLAIMED event 를 차순위가 인계
+- `maxAttempts` 도달 시 `FAILED` 로 종결 (DLQ 대체)
+- `attempts` 는 **claim 시점에만 증가** — 단일 진실 원천(single source of truth)
+- `MongoSuspendLeaderElector` (TTL + token 기반 lock) 사용 — 코루틴 안전
+
+## Usage Example
+
+```kotlin
+val elector = MongoSuspendLeaderElector(lockCollection)
+val poller = WebhookPoller(
+    elector = elector,
+    eventCollection = eventCollection,
+    options = WebhookPollerOptions(
+        nodeId = System.getenv("HOSTNAME"),
+        lockName = "webhook-poller:prod",
+        pollInterval = 1.seconds,
+        batchSize = 10,
+        maxAttempts = 5,
+        claimDuration = 30.seconds,    // handler 최악 실행 시간보다 길게
+        leaseTime = 60.seconds,         // leader-lock TTL
+        waitTime = 1.seconds,
+    ),
+) { event ->
+    httpClient.post(event.payload)     // webhook 전달
+}
+
+val job = poller.start(applicationScope)
+// ... shutdown ...
+poller.stopGracefully(timeout = 30.seconds)
+```
+
+## Demo
+
+```bash
+MONGO_URL=mongodb://localhost:27017 ./gradlew :examples:webhook-poller:run
+```
+
+가짜 이벤트 10건을 collection 에 insert 후 폴러 3개를 동시 실행. 각 이벤트가 정확히 1번만 처리됨을 검증.
+
+## Configuration Options
+
+| 파라미터 | 기본값 | 설명 |
+|---------|--------|-----|
+| `nodeId` | 필수 | pod 식별자 — 점유 시 `claimedBy` 에 기록 |
+| `lockName` | 필수 | leader-lock 키 — collection 단위로 다르게 권장 |
+| `pollInterval` | `1.seconds` | 리더 batch 처리 후 다음 사이클까지 휴지 |
+| `batchSize` | `10` | 한 사이클당 최대 claim 수 |
+| `maxAttempts` | `5` | 시도 상한 — 도달 시 `FAILED` |
+| `claimDuration` | `30.seconds` | claim lease — handler 최악 실행 시간 + 여유 |
+| `leaseTime` | `60.seconds` | leader-lock TTL |
+| `waitTime` | `1.seconds` | leader-lock 획득 대기 시간 |
+
+## Failure Semantics
+
+- handler 예외 → `attempts` 는 claim 시점에 이미 증가됨 → 상태 전이:
+  - `attempts >= maxAttempts` → `FAILED`, `lastError` 기록 (재처리 안 됨)
+  - 그 외 → `PENDING`, `claimedBy=null`, `claimExpiresAt=null` (다음 사이클에 재점유)
+- 리더 pod 가 handle 도중 사망 → `claimExpiresAt` 경과 → 차순위 리더가 reclaim (at-least-once)
+- 환경별 `lockName` 충돌 시 silent skip — 환경별 네임스페이스 권장
+
+## Migration 가이드
+
+- **cron 기반 폴러에서**: `@Scheduled` + `synchronized` 를 `WebhookPoller.start(scope)` 로 교체. 폴러 자체가 리더 선출로 직렬화 보장.
+- **SQS/Kafka 에서**: `eventId` 를 dedup key 로 사용. unique index 자동 생성됨.
+- **DLQ 대체**: `status = "FAILED"` + `lastError` 조회로 postmortem. 수동 재시도는 `PENDING` 으로 reset.
+
+## Dependency
+
+```kotlin
+dependencies {
+    implementation(project(":leader-mongodb"))
+    implementation(project(":examples:webhook-poller"))
+}
+```
+
+## Testing
+
+```bash
+./gradlew :examples:webhook-poller:test
+```
+
+Testcontainers MongoDB 사용 — Docker daemon 필요.

--- a/examples/webhook-poller/README.md
+++ b/examples/webhook-poller/README.md
@@ -1,0 +1,127 @@
+# examples-webhook-poller
+
+[한국어](./README.ko.md) | English
+
+Distributed webhook event poller using MongoDB leader election. Demonstrates safe single-leader claim of webhook events across N pods, with at-least-once delivery, retry, and a `FAILED` terminal state as DLQ substitute.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant P1 as poller-1 (leader)
+    participant P2 as poller-2
+    participant P3 as poller-3
+    participant Lock as Mongo lockCollection
+    participant Events as Mongo eventCollection
+
+    P1->>Lock: runIfLeader("webhook-poller")
+    P2->>Lock: runIfLeader("webhook-poller")
+    P3->>Lock: runIfLeader("webhook-poller")
+    Lock-->>P1: granted
+    Lock-->>P2: null (skip)
+    Lock-->>P3: null (skip)
+
+    loop batchSize
+        P1->>Events: findOneAndUpdate (atomic claim)<br/>filter: attempts < maxAttempts AND<br/>(PENDING OR (CLAIMED AND expired))<br/>update: CLAIMED, claimedBy, attempts++
+        Events-->>P1: claimed event
+        P1->>P1: handler(event)
+        alt success
+            P1->>Events: status = DONE
+        else handler throws
+            alt attempts >= maxAttempts
+                P1->>Events: status = FAILED, lastError
+            else
+                P1->>Events: status = PENDING, lastError (re-claimable)
+            end
+        end
+    end
+
+    Note over P1: delay(pollInterval), then re-elect
+```
+
+## Core Features
+
+- Single-leader polling across N pollers — only the leader claims and processes
+- Atomic claim via `findOneAndUpdate` — no double-processing under contention
+- Lease-based reclaim — if a leader dies, expired CLAIMED events are picked up by the next leader
+- Retry with `maxAttempts` cap — on exceeding the cap, event transitions to `FAILED` (DLQ substitute)
+- `attempts` counter increments on claim only — single source of truth, no double-counting
+- Backed by `MongoSuspendLeaderElector` (TTL + token-based lock) — coroutine-safe
+
+## Usage Example
+
+```kotlin
+val elector = MongoSuspendLeaderElector(lockCollection)
+val poller = WebhookPoller(
+    elector = elector,
+    eventCollection = eventCollection,
+    options = WebhookPollerOptions(
+        nodeId = System.getenv("HOSTNAME"),
+        lockName = "webhook-poller:prod",
+        pollInterval = 1.seconds,
+        batchSize = 10,
+        maxAttempts = 5,
+        claimDuration = 30.seconds,    // must exceed worst-case handler runtime
+        leaseTime = 60.seconds,         // leader-lock TTL
+        waitTime = 1.seconds,
+    ),
+) { event ->
+    httpClient.post(event.payload)     // forward webhook
+}
+
+val job = poller.start(applicationScope)
+// ... shutdown ...
+poller.stopGracefully(timeout = 30.seconds)
+```
+
+## Demo
+
+```bash
+MONGO_URL=mongodb://localhost:27017 ./gradlew :examples:webhook-poller:run
+```
+
+Inserts 10 fake events into a fresh collection, then runs 3 pollers concurrently. Expected: each event handled exactly once, no duplicates.
+
+## Configuration Options
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `nodeId` | required | Pod identifier — written to `claimedBy` for tracing |
+| `lockName` | required | Distributed leader-lock key — recommend per-collection |
+| `pollInterval` | `1.seconds` | Sleep between batch cycles when leader |
+| `batchSize` | `10` | Max events claimed per cycle |
+| `maxAttempts` | `5` | Retry cap — on exceeding, event → `FAILED` |
+| `claimDuration` | `30.seconds` | Lease for an in-flight claim — must exceed handler runtime |
+| `leaseTime` | `60.seconds` | Leader-lock TTL |
+| `waitTime` | `1.seconds` | Leader-lock acquisition timeout |
+
+## Failure Semantics
+
+- Handler throws → `attempts` already incremented at claim time → status transitions:
+  - `attempts >= maxAttempts` → `FAILED`, `lastError` recorded (no further claims)
+  - else → `PENDING`, `claimedBy=null`, `claimExpiresAt=null` (re-claimable next batch)
+- Leader pod dies mid-handle → `claimExpiresAt` passes → next leader reclaims (at-least-once)
+- `lockName` collisions across environments cause silent skip — namespace appropriately
+
+## Migration Tips
+
+- **From cron-based pollers**: replace `@Scheduled` + `synchronized` with `WebhookPoller.start(scope)`. The poller already serializes via leader election.
+- **From SQS/Kafka**: model the `eventId` as the dedup key. Use a unique index on `eventId` (auto-created by `WebhookPoller`).
+- **DLQ replacement**: query `status = "FAILED"` + `lastError` for postmortem. Reset to `PENDING` to retry manually.
+
+## Dependency
+
+```kotlin
+dependencies {
+    implementation(project(":leader-mongodb"))
+    implementation(project(":examples:webhook-poller"))
+}
+```
+
+## Testing
+
+```bash
+./gradlew :examples:webhook-poller:test
+```
+
+Uses Testcontainers MongoDB — Docker daemon required.

--- a/examples/webhook-poller/build.gradle.kts
+++ b/examples/webhook-poller/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    application
+}
+
+application {
+    mainClass.set("io.bluetape4k.leader.examples.webhook.WebhookPollerDemo")
+}
+
+dependencies {
+    implementation(project(":leader-mongodb"))
+
+    implementation(libs.mongodb.driver.kotlin.coroutine)
+    implementation(libs.kotlinx.coroutines.core)
+
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.junit.jupiter)
+    testImplementation(libs.testcontainers.mongodb)
+}

--- a/examples/webhook-poller/src/main/kotlin/io/bluetape4k/leader/examples/webhook/WebhookEvent.kt
+++ b/examples/webhook-poller/src/main/kotlin/io/bluetape4k/leader/examples/webhook/WebhookEvent.kt
@@ -1,0 +1,40 @@
+package io.bluetape4k.leader.examples.webhook
+
+import java.time.Instant
+
+/**
+ * Webhook event 의 처리 상태.
+ */
+enum class WebhookEventStatus {
+    PENDING,    // 대기 중 — 처리 안 됨
+    CLAIMED,    // 폴러 인스턴스가 점유 (atomic findOneAndUpdate)
+    DONE,       // 정상 처리 완료
+    FAILED,     // maxAttempts 도달 — DLQ 대체
+}
+
+/**
+ * Webhook event 도메인 모델.
+ *
+ * Mongo collection 의 한 document 를 표현.
+ *
+ * ## 필드
+ *
+ * - [eventId]: 외부 webhook 의 고유 ID (idempotency key)
+ * - [payload]: 외부에서 받은 raw payload (JSON 문자열 등)
+ * - [status]: 처리 상태 [WebhookEventStatus]
+ * - [claimedBy]: 점유한 polling 인스턴스의 nodeId (CLAIMED 상태에서만 의미 있음)
+ * - [claimExpiresAt]: 점유 만료 시각. 만료 후 다른 인스턴스 reclaim 가능 (lease 만료)
+ * - [attempts]: handler 실행 횟수 — maxAttempts 도달 시 FAILED
+ * - [lastError]: 직전 handler 예외 메시지
+ * - [createdAt]: event 발생 시각
+ */
+data class WebhookEvent(
+    val eventId: String,
+    val payload: String,
+    val status: WebhookEventStatus = WebhookEventStatus.PENDING,
+    val claimedBy: String? = null,
+    val claimExpiresAt: Instant? = null,
+    val attempts: Int = 0,
+    val lastError: String? = null,
+    val createdAt: Instant = Instant.now(),
+)

--- a/examples/webhook-poller/src/main/kotlin/io/bluetape4k/leader/examples/webhook/WebhookPoller.kt
+++ b/examples/webhook-poller/src/main/kotlin/io/bluetape4k/leader/examples/webhook/WebhookPoller.kt
@@ -1,0 +1,371 @@
+package io.bluetape4k.leader.examples.webhook
+
+import com.mongodb.client.model.Filters
+import com.mongodb.client.model.FindOneAndUpdateOptions
+import com.mongodb.client.model.IndexOptions
+import com.mongodb.client.model.Indexes
+import com.mongodb.client.model.ReturnDocument
+import com.mongodb.client.model.Sorts
+import com.mongodb.client.model.Updates
+import com.mongodb.kotlin.client.coroutine.MongoCollection
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
+import org.bson.Document
+import java.time.Instant
+
+/**
+ * 분산 webhook 이벤트 polling 워커.
+ *
+ * ## 동작/계약
+ *
+ * - 다중 인스턴스 환경에서 단 1개만 polling 하도록 [SuspendLeaderElector] 로 보호.
+ * - 리더는 [WebhookPollerOptions.batchSize] 만큼 atomic claim 후 [handler] 실행.
+ * - 비리더는 짧게 sleep 후 재시도 — 리더 사망 시 자동 인계.
+ *
+ * ### Claim 모델
+ *
+ * 1. `findOneAndUpdate` 로 PENDING 또는 만료된 CLAIMED event 를 atomic 점유.
+ *    - filter: `{ attempts: { $lt: maxAttempts } }` AND
+ *      (`{ status: PENDING }` OR `{ status: CLAIMED, claimExpiresAt: { $lt: now } }`)
+ *    - update: `status=CLAIMED, claimedBy=nodeId, claimExpiresAt=now+claimDuration, $inc attempts: 1`
+ * 2. **attempts 증가는 claim 시점 1회만**. handler 성공/실패 시 추가 증가 없음.
+ * 3. claim 자체가 시도(attempt) 로 정의됨.
+ * 4. `attempts >= maxAttempts` 인 expired CLAIMED 는 reclaim 안 됨 (P2-3) — 별도 sweeper 가 정리 필요.
+ *
+ * ### 실패 전이 (Failure Transition)
+ *
+ * handler 가 throw 하면, **본 인스턴스가 여전히 claim owner 인 경우에만** 상태 전이:
+ * - `attempts >= maxAttempts` → `status=FAILED`, `lastError=ex.message` (DLQ 대체)
+ * - 그렇지 않으면 → `status=PENDING`, `claimedBy=null`, `claimExpiresAt=null`,
+ *   `lastError=ex.message` (다음 사이클에 즉시 재점유 가능)
+ *
+ * lease 만료로 다른 인스턴스가 reclaim 한 후 본 인스턴스가 늦게 깨어나면 (P2-2) update 는 무시되며
+ * `claim ownership lost` 로그 기록.
+ *
+ * ### Graceful Stop
+ *
+ * [stopGracefully] 는 polling job 을 cancel 하고 timeout 안에 join.
+ * 이미 점유 중인 event 가 있으면 cancel 시점에 `CLAIMED` 상태로 남으며,
+ * `claimExpiresAt` 만료 후 다른 인스턴스가 reclaim 하여 처리한다 (at-least-once 보장).
+ *
+ * ### 인덱스
+ *
+ * 첫 [start] 호출 시 `(status, claimExpiresAt)` 복합 인덱스를 생성하여 claim 쿼리 성능 보장.
+ *
+ * ```kotlin
+ * val elector = MongoSuspendLeaderElector(lockCollection)
+ * val poller = WebhookPoller(elector, eventCollection, options) { event ->
+ *     httpClient.post(targetUrl, event.payload)   // 외부로 webhook 전달
+ * }
+ * val job = poller.start(applicationScope)
+ * // ... shutdown ...
+ * poller.stopGracefully()
+ * ```
+ *
+ * @param elector 외부에서 주입된 [SuspendLeaderElector] (테스트 편의 + 백엔드 교체 가능)
+ * @param eventCollection [WebhookEvent] document 가 저장된 collection (lock collection 과 분리)
+ * @param options 폴링 동작 설정
+ * @param handler event 처리 콜백. 예외는 격리되어 다음 event 처리는 계속.
+ */
+class WebhookPoller(
+    private val elector: SuspendLeaderElector,
+    private val eventCollection: MongoCollection<Document>,
+    val options: WebhookPollerOptions,
+    private val handler: suspend (WebhookEvent) -> Unit,
+) {
+
+    companion object: KLoggingChannel() {
+        internal const val FIELD_EVENT_ID = "eventId"
+        internal const val FIELD_PAYLOAD = "payload"
+        internal const val FIELD_STATUS = "status"
+        internal const val FIELD_CLAIMED_BY = "claimedBy"
+        internal const val FIELD_CLAIM_EXPIRES_AT = "claimExpiresAt"
+        internal const val FIELD_ATTEMPTS = "attempts"
+        internal const val FIELD_LAST_ERROR = "lastError"
+        internal const val FIELD_CREATED_AT = "createdAt"
+    }
+
+    @Volatile
+    private var pollerJob: Job? = null
+
+    @Volatile
+    private var indexEnsured: Boolean = false
+
+    /**
+     * 폴링 루프를 시작하고 [Job] 을 반환한다.
+     *
+     * - 동일 인스턴스에서 두 번 호출 금지 (이미 실행 중이면 [IllegalStateException]).
+     * - [scope] 가 cancel 되면 자동 종료.
+     */
+    fun start(scope: CoroutineScope): Job {
+        check(pollerJob == null || pollerJob?.isActive != true) {
+            "WebhookPoller(nodeId=${options.nodeId}) is already running"
+        }
+        val job = scope.launch {
+            try {
+                ensureIndexes()
+                runLoop()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log.warn(e) { "[${options.nodeId}] webhook poller loop terminated unexpectedly" }
+                throw e
+            }
+        }
+        pollerJob = job
+        return job
+    }
+
+    /**
+     * 폴링 루프를 정상 종료한다. [timeout] 안에 종료되지 않으면 강제 cancel 후 반환.
+     */
+    suspend fun stopGracefully(timeout: Duration = 30.seconds) {
+        val job = pollerJob ?: return
+        try {
+            withTimeoutOrNull(timeout) { job.cancelAndJoin() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "[${options.nodeId}] stopGracefully encountered error" }
+        } finally {
+            pollerJob = null
+        }
+    }
+
+    private suspend fun ensureIndexes() {
+        if (indexEnsured) return
+        try {
+            eventCollection.createIndex(
+                Indexes.ascending(FIELD_STATUS, FIELD_CLAIM_EXPIRES_AT),
+                IndexOptions().name("idx_status_claim_expires_at").background(true),
+            )
+            eventCollection.createIndex(
+                Indexes.ascending(FIELD_EVENT_ID),
+                IndexOptions().name("idx_event_id").unique(true).background(true),
+            )
+            indexEnsured = true
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // 인덱스 생성 실패는 fatal 이 아님 — 성능 저하는 있을 수 있음
+            log.warn(e) { "[${options.nodeId}] webhook event 인덱스 생성 실패 — collection scan 으로 동작" }
+            indexEnsured = true
+        }
+    }
+
+    private suspend fun runLoop() {
+        while (kotlin.coroutines.coroutineContext[Job]?.isActive != false) {
+            val processed = try {
+                elector.runIfLeader(options.lockName) {
+                    log.debug { "[${options.nodeId}] 리더 선출 — batch 처리 시작" }
+                    processBatch()
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log.warn(e) { "[${options.nodeId}] 리더 동작 중 예외 — 다음 사이클 재시도" }
+                null
+            }
+
+            // 리더/비리더 모두 동일 사이클 휴지 — leader-lock 자체의 waitTime 은 elector 옵션에서 관리
+            delay(options.pollInterval)
+        }
+    }
+
+    /**
+     * 단일 batch 처리. 최대 [WebhookPollerOptions.batchSize] 개 event 를 claim & process.
+     * @return 처리된 event 수
+     */
+    private suspend fun processBatch(): Int {
+        var processed = 0
+        repeat(options.batchSize) {
+            val event = claimNext() ?: return processed
+            handleSingle(event)
+            processed++
+        }
+        return processed
+    }
+
+    /**
+     * Atomic claim — `findOneAndUpdate` 로 PENDING 또는 만료된 CLAIMED event 를 점유.
+     * @return 점유 성공 시 [WebhookEvent], 처리 가능한 event 가 없으면 null
+     */
+    private suspend fun claimNext(): WebhookEvent? {
+        val now = Instant.now()
+        val claimExpiresAt = now.plusMillis(options.claimDuration.inWholeMilliseconds)
+
+        // P2-3: attempts >= maxAttempts 인 expired CLAIMED event 는 reclaim 안 함
+        // (orphan CLAIMED 가 maxAttempts 직전에 동결될 수 있으나 별도 sweeper 가 정리 — README 참조)
+        val filter = Filters.and(
+            Filters.lt(FIELD_ATTEMPTS, options.maxAttempts),
+            Filters.or(
+                Filters.eq(FIELD_STATUS, WebhookEventStatus.PENDING.name),
+                Filters.and(
+                    Filters.eq(FIELD_STATUS, WebhookEventStatus.CLAIMED.name),
+                    Filters.lt(FIELD_CLAIM_EXPIRES_AT, now),
+                ),
+            ),
+        )
+        val update = Updates.combine(
+            Updates.set(FIELD_STATUS, WebhookEventStatus.CLAIMED.name),
+            Updates.set(FIELD_CLAIMED_BY, options.nodeId),
+            Updates.set(FIELD_CLAIM_EXPIRES_AT, claimExpiresAt),
+            Updates.inc(FIELD_ATTEMPTS, 1),
+        )
+        val opts = FindOneAndUpdateOptions()
+            .returnDocument(ReturnDocument.AFTER)
+            .sort(Sorts.ascending(FIELD_CREATED_AT))
+
+        val updated = try {
+            eventCollection.findOneAndUpdate(filter, update, opts)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "[${options.nodeId}] claimNext 실패 — 다음 사이클 재시도" }
+            return null
+        }
+
+        return updated?.toWebhookEvent()
+    }
+
+    /**
+     * 단일 event 처리. handler 예외는 격리되어 다음 event 진행에 영향 없음.
+     */
+    private suspend fun handleSingle(event: WebhookEvent) {
+        try {
+            handler(event)
+            markDone(event)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "[${options.nodeId}] handler 실패 eventId=${event.eventId} attempts=${event.attempts}" }
+            markFailureOrRequeue(event, e)
+        }
+    }
+
+    private suspend fun markDone(event: WebhookEvent) {
+        try {
+            // P2-2: claim 소유권 검증 — stale owner 의 update 가 새 owner 의 CLAIMED 를 덮어쓰지 않도록
+            val result = eventCollection.updateOne(
+                ownedClaimFilter(event),
+                Updates.combine(
+                    Updates.set(FIELD_STATUS, WebhookEventStatus.DONE.name),
+                    Updates.set(FIELD_LAST_ERROR, null),
+                ),
+            )
+            if (result.matchedCount == 0L) {
+                log.warn {
+                    "[${options.nodeId}] markDone — claim ownership lost eventId=${event.eventId} (skip update)"
+                }
+            } else {
+                log.debug { "[${options.nodeId}] eventId=${event.eventId} DONE (attempts=${event.attempts})" }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "[${options.nodeId}] markDone 실패 eventId=${event.eventId}" }
+        }
+    }
+
+    private suspend fun markFailureOrRequeue(event: WebhookEvent, ex: Exception) {
+        // attempts 는 claim 시점에 이미 +1 되어 event 에 반영되어 있음
+        val errorMessage = ex.message ?: ex::class.qualifiedName ?: "unknown"
+        try {
+            // P2-2: claim 소유권 검증 — stale owner 가 새 owner 의 CLAIMED 를 덮어쓰지 않도록
+            val ownership = ownedClaimFilter(event)
+            val result = if (event.attempts >= options.maxAttempts) {
+                // DLQ 대체 — FAILED 로 종결
+                eventCollection.updateOne(
+                    ownership,
+                    Updates.combine(
+                        Updates.set(FIELD_STATUS, WebhookEventStatus.FAILED.name),
+                        Updates.set(FIELD_LAST_ERROR, errorMessage),
+                    ),
+                )
+            } else {
+                // 재시도 가능 — PENDING 으로 되돌림
+                eventCollection.updateOne(
+                    ownership,
+                    Updates.combine(
+                        Updates.set(FIELD_STATUS, WebhookEventStatus.PENDING.name),
+                        Updates.set(FIELD_CLAIMED_BY, null),
+                        Updates.set(FIELD_CLAIM_EXPIRES_AT, null),
+                        Updates.set(FIELD_LAST_ERROR, errorMessage),
+                    ),
+                )
+            }
+            if (result.matchedCount == 0L) {
+                log.warn {
+                    "[${options.nodeId}] markFailureOrRequeue — claim ownership lost eventId=${event.eventId} (skip update)"
+                }
+            } else if (event.attempts >= options.maxAttempts) {
+                log.info { "[${options.nodeId}] eventId=${event.eventId} FAILED (maxAttempts=${options.maxAttempts} 도달)" }
+            } else {
+                log.debug {
+                    "[${options.nodeId}] eventId=${event.eventId} PENDING 으로 복귀 (attempts=${event.attempts}/${options.maxAttempts})"
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "[${options.nodeId}] markFailureOrRequeue 실패 eventId=${event.eventId}" }
+        }
+    }
+
+    /**
+     * P2-2: claim 소유권 검증 filter.
+     *
+     * 본 인스턴스가 claim 시점에 기록한 `(eventId, status=CLAIMED, claimedBy=nodeId, claimExpiresAt)` 4-튜플이
+     * 그대로 유지되어 있는 document 만 매칭. 다른 인스턴스가 reclaim 한 경우 `claimExpiresAt` 또는 `claimedBy` 가
+     * 달라져 매칭 실패 → matchedCount=0.
+     */
+    private fun ownedClaimFilter(event: WebhookEvent): org.bson.conversions.Bson = Filters.and(
+        Filters.eq(FIELD_EVENT_ID, event.eventId),
+        Filters.eq(FIELD_STATUS, WebhookEventStatus.CLAIMED.name),
+        Filters.eq(FIELD_CLAIMED_BY, options.nodeId),
+        event.claimExpiresAt
+            ?.let { Filters.eq(FIELD_CLAIM_EXPIRES_AT, java.util.Date.from(it)) }
+            ?: Filters.exists(FIELD_CLAIM_EXPIRES_AT, true),
+    )
+}
+
+/** Mongo [Document] → [WebhookEvent] 변환. */
+internal fun Document.toWebhookEvent(): WebhookEvent {
+    val statusStr = getString(WebhookPoller.FIELD_STATUS) ?: WebhookEventStatus.PENDING.name
+    val claimExpiresAtDate: java.util.Date? = get(WebhookPoller.FIELD_CLAIM_EXPIRES_AT) as? java.util.Date
+    val createdAtDate: java.util.Date? = get(WebhookPoller.FIELD_CREATED_AT) as? java.util.Date
+    return WebhookEvent(
+        eventId = getString(WebhookPoller.FIELD_EVENT_ID).orEmpty(),
+        payload = getString(WebhookPoller.FIELD_PAYLOAD).orEmpty(),
+        status = WebhookEventStatus.valueOf(statusStr),
+        claimedBy = getString(WebhookPoller.FIELD_CLAIMED_BY),
+        claimExpiresAt = claimExpiresAtDate?.toInstant(),
+        attempts = getInteger(WebhookPoller.FIELD_ATTEMPTS, 0),
+        lastError = getString(WebhookPoller.FIELD_LAST_ERROR),
+        createdAt = createdAtDate?.toInstant() ?: Instant.EPOCH,
+    )
+}
+
+/** [WebhookEvent] → Mongo [Document] 변환 (insert 시 사용). */
+internal fun WebhookEvent.toDocument(): Document = Document().apply {
+    put(WebhookPoller.FIELD_EVENT_ID, eventId)
+    put(WebhookPoller.FIELD_PAYLOAD, payload)
+    put(WebhookPoller.FIELD_STATUS, status.name)
+    put(WebhookPoller.FIELD_CLAIMED_BY, claimedBy)
+    put(WebhookPoller.FIELD_CLAIM_EXPIRES_AT, claimExpiresAt?.let { java.util.Date.from(it) })
+    put(WebhookPoller.FIELD_ATTEMPTS, attempts)
+    put(WebhookPoller.FIELD_LAST_ERROR, lastError)
+    put(WebhookPoller.FIELD_CREATED_AT, java.util.Date.from(createdAt))
+}

--- a/examples/webhook-poller/src/main/kotlin/io/bluetape4k/leader/examples/webhook/WebhookPollerDemo.kt
+++ b/examples/webhook-poller/src/main/kotlin/io/bluetape4k/leader/examples/webhook/WebhookPollerDemo.kt
@@ -1,0 +1,105 @@
+package io.bluetape4k.leader.examples.webhook
+
+import com.mongodb.kotlin.client.coroutine.MongoClient
+import io.bluetape4k.leader.mongodb.MongoSuspendLeaderElector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.bson.Document
+
+/**
+ * 3 인스턴스 동시 polling 데모.
+ *
+ * - 동일 MongoDB collection 을 공유하며 단 1개 인스턴스만 처리하는 시나리오 시뮬레이션.
+ * - 가짜 이벤트 10건을 미리 insert 후 polling 결과를 검증.
+ */
+object WebhookPollerDemo: KLogging() {
+
+    private const val DEMO_DB_NAME = "webhook_demo"
+    private const val DEMO_EVENT_COLLECTION = "webhook_events"
+    private const val DEMO_LOCK_COLLECTION = "webhook_locks"
+    private const val DEMO_LOCK_NAME = "demo-webhook-poller"
+    private const val DEMO_EVENT_COUNT = 10
+    private const val DEMO_INSTANCE_COUNT = 3
+
+    @JvmStatic
+    fun main(args: Array<String>) = runBlocking {
+        val mongoUrl = System.getenv("MONGO_URL") ?: "mongodb://localhost:27017"
+        log.info { "[demo] Mongo 연결: $mongoUrl (override via MONGO_URL env var)" }
+        val client = MongoClient.create(mongoUrl)
+        try {
+            val db = client.getDatabase(DEMO_DB_NAME)
+            val eventCollection = db.getCollection<Document>(DEMO_EVENT_COLLECTION)
+            val lockCollection = db.getCollection<Document>(DEMO_LOCK_COLLECTION)
+
+            // 데모 재실행 시 unique 인덱스 충돌 방지 — 이전 데이터 정리
+            eventCollection.deleteMany(Document())
+            lockCollection.deleteMany(Document())
+
+            // 가짜 이벤트 insert
+            val pendingEvents = (1..DEMO_EVENT_COUNT).map { idx ->
+                WebhookEvent(eventId = "evt-$idx-${UUID.randomUUID()}", payload = "payload-$idx")
+            }
+            eventCollection.insertMany(pendingEvents.map { it.toDocument() })
+            log.info { "[demo] $DEMO_EVENT_COUNT 개 이벤트 insert 완료" }
+
+            // 인스턴스마다 처리 카운터 (eventId 별로 정확히 1번 처리되는지 검증)
+            val processedBy = ConcurrentHashMap<String, String>()
+            val totalProcessed = AtomicInteger(0)
+
+            coroutineScope {
+                val pollers = (1..DEMO_INSTANCE_COUNT).map { idx ->
+                    val nodeId = "node-$idx"
+                    val elector = MongoSuspendLeaderElector(lockCollection)
+                    val poller = WebhookPoller(
+                        elector = elector,
+                        eventCollection = eventCollection,
+                        options = WebhookPollerOptions(
+                            nodeId = nodeId,
+                            lockName = DEMO_LOCK_NAME,
+                            pollInterval = 200.milliseconds,
+                            batchSize = 5,
+                            maxAttempts = 3,
+                            claimDuration = 10.seconds,
+                        ),
+                    ) { event ->
+                        val first = processedBy.putIfAbsent(event.eventId, nodeId)
+                        if (first == null) {
+                            totalProcessed.incrementAndGet()
+                            log.info { "[$nodeId] 처리 eventId=${event.eventId}" }
+                        } else {
+                            log.info { "[$nodeId] 중복 처리 감지! eventId=${event.eventId} (이미 $first 가 처리)" }
+                        }
+                        delay(50.milliseconds)
+                    }
+                    poller.start(this) to poller
+                }
+
+                // 처리 대기 — 모든 이벤트 DONE 될 때까지
+                val deadline = System.currentTimeMillis() + 30_000
+                while (totalProcessed.get() < DEMO_EVENT_COUNT && System.currentTimeMillis() < deadline) {
+                    delay(200.milliseconds)
+                }
+
+                pollers.forEach { (_, poller) -> poller.stopGracefully(2.seconds) }
+            }
+
+            val totalDone = eventCollection.countDocuments(
+                Document(WebhookPoller.FIELD_STATUS, WebhookEventStatus.DONE.name),
+            )
+            log.info { "[demo] === 결과 ===" }
+            log.info { "[demo] DONE=$totalDone (기대값 $DEMO_EVENT_COUNT)" }
+            log.info { "[demo] 처리한 인스턴스 분포=${processedBy.values.groupingBy { it }.eachCount()}" }
+            log.info { "[demo] 중복 처리 없음? ${processedBy.size == DEMO_EVENT_COUNT}" }
+        } finally {
+            client.close()
+        }
+    }
+}

--- a/examples/webhook-poller/src/main/kotlin/io/bluetape4k/leader/examples/webhook/WebhookPollerOptions.kt
+++ b/examples/webhook-poller/src/main/kotlin/io/bluetape4k/leader/examples/webhook/WebhookPollerOptions.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.leader.examples.webhook
+
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * [WebhookPoller] 설정.
+ *
+ * ## 동작/계약
+ *
+ * - [nodeId]: 본 polling 인스턴스 식별자. 점유한 event 의 `claimedBy` 에 기록.
+ * - [lockName]: leader-election 분산 락 이름. **이벤트 컬렉션 단위**로 다르게 설정 권장.
+ * - [pollInterval]: 폴링 사이클 간 휴지 시간. 리더 batch 처리 후 다음 사이클까지의 대기, 비리더가
+ *   리더 락 미획득 후 재시도 전 대기에도 동일하게 적용된다.
+ * - [batchSize]: 한 사이클에 처리할 최대 event 수 (atomic claim 반복 횟수 상한).
+ * - [maxAttempts]: handler 호출 누적 횟수 상한. 도달 시 event status = `FAILED` (DLQ 대체).
+ * - [claimDuration]: claim 후 다른 인스턴스가 reclaim 가능해질 때까지의 lease 시간.
+ *   handler 가 [claimDuration] 보다 오래 걸리면 다른 인스턴스가 동일 event 를 재점유할 수 있으므로,
+ *   handler 평균 실행 시간 + 안전 여유 (예: 2배) 이상으로 설정 필수.
+ *
+ * ### Leader-election 옵션은 elector 에서 관리
+ *
+ * `waitTime` / `leaseTime` 등 리더 락 자체의 옵션은 외부에서 주입되는 elector
+ * (예: [io.bluetape4k.leader.mongodb.MongoSuspendLeaderElector])
+ * 의 `MongoLeaderElectionOptions.leaderOptions` 에서 설정한다. 본 옵션과 별도로 관리하여
+ * desync 방지.
+ *
+ * ```kotlin
+ * WebhookPollerOptions(
+ *     nodeId = System.getenv("HOSTNAME"),
+ *     lockName = "webhook-poller:prod",
+ *     pollInterval = 500.milliseconds,
+ *     batchSize = 20,
+ *     maxAttempts = 5,
+ *     claimDuration = 30.seconds,
+ * )
+ * ```
+ */
+data class WebhookPollerOptions(
+    val nodeId: String,
+    val lockName: String,
+    val pollInterval: Duration = 1.seconds,
+    val batchSize: Int = 10,
+    val maxAttempts: Int = 5,
+    val claimDuration: Duration = 30.seconds,
+) {
+    init {
+        nodeId.requireNotBlank("nodeId")
+        lockName.requireNotBlank("lockName")
+        pollInterval.inWholeMilliseconds.requirePositiveNumber("pollInterval")
+        batchSize.requirePositiveNumber("batchSize")
+        maxAttempts.requirePositiveNumber("maxAttempts")
+        claimDuration.inWholeMilliseconds.requirePositiveNumber("claimDuration")
+    }
+}

--- a/examples/webhook-poller/src/test/kotlin/io/bluetape4k/leader/examples/webhook/AbstractWebhookPollerTest.kt
+++ b/examples/webhook-poller/src/test/kotlin/io/bluetape4k/leader/examples/webhook/AbstractWebhookPollerTest.kt
@@ -1,0 +1,75 @@
+package io.bluetape4k.leader.examples.webhook
+
+import com.mongodb.kotlin.client.coroutine.MongoCollection
+import com.mongodb.kotlin.client.coroutine.MongoDatabase
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.leader.mongodb.MongoLeaderElectionOptions
+import io.bluetape4k.leader.mongodb.MongoSuspendLeaderElector
+import io.bluetape4k.leader.mongodb.lock.MongoLock
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.storage.MongoDBServer
+import io.bluetape4k.utils.ShutdownQueue
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.runBlocking
+import org.bson.Document
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * MongoDB Testcontainers 기반 webhook poller 테스트 베이스.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractWebhookPollerTest {
+
+    companion object: KLogging() {
+        const val EVENT_COLLECTION_NAME = "webhook_events"
+
+        val mongoServer: MongoDBServer = MongoDBServer.Launcher.mongoDB
+
+        val coroutineMongoClient by lazy {
+            MongoDBServer.Launcher.getCoroutineClient().also {
+                ShutdownQueue.register { it.close() }
+            }
+        }
+
+        val coroutineDb: MongoDatabase by lazy { coroutineMongoClient.getDatabase("webhook_test") }
+
+        val eventCollection: MongoCollection<Document> by lazy {
+            coroutineDb.getCollection<Document>(EVENT_COLLECTION_NAME)
+        }
+
+        val lockCollection: MongoCollection<Document> by lazy {
+            coroutineDb.getCollection<Document>(MongoLock.LOCK_COLLECTION_NAME)
+        }
+
+        fun randomEventId(): String = "evt-${Base58.randomString(8)}"
+        fun randomLockName(): String = "wh-test-${Base58.randomString(8)}"
+    }
+
+    @BeforeEach
+    fun cleanCollections() {
+        runBlocking {
+            eventCollection.deleteMany(Document())
+            lockCollection.deleteMany(Document())
+        }
+    }
+
+    /** 테스트용 elector — 매번 새 인스턴스 생성 (`MongoSuspendLock.ensureIndexes` suspend invoke). */
+    protected suspend fun newElector(
+        options: MongoLeaderElectionOptions = MongoLeaderElectionOptions.Default,
+    ): MongoSuspendLeaderElector = MongoSuspendLeaderElector(lockCollection, options)
+
+    /** 테스트용 PENDING event 1건 insert. */
+    protected suspend fun insertPending(eventId: String = randomEventId(), payload: String = "payload"): WebhookEvent {
+        val event = WebhookEvent(eventId = eventId, payload = payload)
+        eventCollection.insertOne(event.toDocument())
+        return event
+    }
+
+    protected suspend fun fetchEvent(eventId: String): WebhookEvent? {
+        val doc = eventCollection.find(
+            Document(WebhookPoller.FIELD_EVENT_ID, eventId),
+        ).firstOrNull()
+        return doc?.toWebhookEvent()
+    }
+}

--- a/examples/webhook-poller/src/test/kotlin/io/bluetape4k/leader/examples/webhook/WebhookPollerTest.kt
+++ b/examples/webhook-poller/src/test/kotlin/io/bluetape4k/leader/examples/webhook/WebhookPollerTest.kt
@@ -1,0 +1,439 @@
+package io.bluetape4k.leader.examples.webhook
+
+import com.mongodb.client.model.Filters
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.logging.KLogging
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * [WebhookPoller] 통합 테스트 — 실시간 Mongo Testcontainers 기반.
+ */
+class WebhookPollerTest: AbstractWebhookPollerTest() {
+
+    companion object: KLogging() {
+        private val INSTANCE_TIMEOUT = 30.seconds
+    }
+
+    private fun fastOptions(
+        nodeId: String,
+        lockName: String,
+        maxAttempts: Int = 3,
+        claimDuration: Duration = 2.seconds,
+    ) = WebhookPollerOptions(
+        nodeId = nodeId,
+        lockName = lockName,
+        pollInterval = 50.milliseconds,
+        batchSize = 10,
+        maxAttempts = maxAttempts,
+        claimDuration = claimDuration,
+    )
+
+    private suspend fun waitUntil(
+        timeout: Duration = 10.seconds,
+        condition: suspend () -> Boolean,
+    ): Boolean {
+        val deadline = System.currentTimeMillis() + timeout.inWholeMilliseconds
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return true
+            delay(50.milliseconds)
+        }
+        return false
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    fun `단일 인스턴스 - 모든 PENDING event 처리 후 DONE`() = runBlocking {
+        val lockName = randomLockName()
+        val eventIds = (1..5).map { randomEventId() }
+        eventIds.forEach { insertPending(it, payload = "p-$it") }
+
+        val handled = ConcurrentHashMap.newKeySet<String>()
+        val elector = newElector()
+        val poller = WebhookPoller(
+            elector = elector,
+            eventCollection = eventCollection,
+            options = fastOptions("node-1", lockName),
+        ) { event -> handled.add(event.eventId) }
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            poller.start(scope)
+
+            val ok = waitUntil(INSTANCE_TIMEOUT) {
+                eventCollection.countDocuments(
+                    Filters.eq(WebhookPoller.FIELD_STATUS, WebhookEventStatus.DONE.name),
+                ) == eventIds.size.toLong()
+            }
+            ok shouldBeEqualTo true
+            handled.size shouldBeEqualTo eventIds.size
+            eventIds.forEach { id -> handled.contains(id) shouldBeEqualTo true }
+        } finally {
+            poller.stopGracefully(2.seconds)
+            scope.coroutineContext[kotlinx.coroutines.Job]?.cancelAndJoin()
+        }
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    fun `3 인스턴스 동시 - 동일 event 중복 처리 없음`() = runBlocking {
+        val lockName = randomLockName()
+        val eventIds = (1..15).map { randomEventId() }
+        eventIds.forEach { insertPending(it, payload = "p-$it") }
+
+        // eventId 별 처리 카운터 — 정확히 1번이어야 함
+        val processCount = ConcurrentHashMap<String, AtomicInteger>()
+        val handlerNodeIds = ConcurrentHashMap<String, String>()
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val pollers = (1..3).map { idx ->
+            val nodeId = "node-$idx"
+            val elector = newElector()
+            WebhookPoller(
+                elector = elector,
+                eventCollection = eventCollection,
+                options = fastOptions(nodeId, lockName, claimDuration = 5.seconds),
+            ) { event ->
+                processCount.computeIfAbsent(event.eventId) { AtomicInteger(0) }.incrementAndGet()
+                handlerNodeIds[event.eventId] = nodeId
+                delay(20.milliseconds)
+            }
+        }
+
+        try {
+            pollers.forEach { it.start(scope) }
+            val ok = waitUntil(INSTANCE_TIMEOUT) {
+                eventCollection.countDocuments(
+                    Filters.eq(WebhookPoller.FIELD_STATUS, WebhookEventStatus.DONE.name),
+                ) == eventIds.size.toLong()
+            }
+            ok shouldBeEqualTo true
+
+            // 모든 event 가 정확히 1번씩 처리됨
+            processCount.size shouldBeEqualTo eventIds.size
+            processCount.values.forEach { it.get() shouldBeEqualTo 1 }
+        } finally {
+            pollers.forEach { it.stopGracefully(2.seconds) }
+            scope.coroutineContext[kotlinx.coroutines.Job]?.cancelAndJoin()
+        }
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    fun `handler 예외 - attempts 증가 후 다음 사이클에 재처리`(): Unit = runBlocking {
+        val lockName = randomLockName()
+        val eventId = randomEventId()
+        insertPending(eventId, payload = "retry")
+
+        val attemptCounter = AtomicInteger(0)
+        val firstAttemptDone = CompletableDeferred<Unit>()
+        val elector = newElector()
+        val poller = WebhookPoller(
+            elector = elector,
+            eventCollection = eventCollection,
+            options = fastOptions("node-retry", lockName, maxAttempts = 5, claimDuration = 1.seconds),
+        ) { _ ->
+            val n = attemptCounter.incrementAndGet()
+            if (n == 1) {
+                firstAttemptDone.complete(Unit)
+                throw IllegalStateException("first attempt fails")
+            }
+            // 두 번째는 성공
+        }
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            poller.start(scope)
+
+            // 첫 시도 실패까지 대기
+            withTimeoutOrNull(INSTANCE_TIMEOUT) { firstAttemptDone.await() }.shouldNotBeNull()
+
+            val ok = waitUntil(INSTANCE_TIMEOUT) {
+                fetchEvent(eventId)?.status == WebhookEventStatus.DONE
+            }
+            ok shouldBeEqualTo true
+            attemptCounter.get() shouldBeGreaterOrEqualTo 2
+            val finalEvent = fetchEvent(eventId).shouldNotBeNull()
+            finalEvent.status shouldBeEqualTo WebhookEventStatus.DONE
+            finalEvent.attempts shouldBeGreaterOrEqualTo 2
+        } finally {
+            poller.stopGracefully(2.seconds)
+            scope.coroutineContext[kotlinx.coroutines.Job]?.cancelAndJoin()
+        }
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    fun `maxAttempts 도달 - event FAILED 로 종결`(): Unit = runBlocking {
+        val lockName = randomLockName()
+        val eventId = randomEventId()
+        insertPending(eventId, payload = "always-fail")
+        val maxAttempts = 3
+        val attemptCounter = AtomicInteger(0)
+
+        val elector = newElector()
+        val poller = WebhookPoller(
+            elector = elector,
+            eventCollection = eventCollection,
+            options = fastOptions("node-fail", lockName, maxAttempts = maxAttempts, claimDuration = 500.milliseconds),
+        ) { _ ->
+            attemptCounter.incrementAndGet()
+            throw IllegalStateException("permanent failure")
+        }
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            poller.start(scope)
+            val ok = waitUntil(INSTANCE_TIMEOUT) {
+                fetchEvent(eventId)?.status == WebhookEventStatus.FAILED
+            }
+            ok shouldBeEqualTo true
+            val finalEvent = fetchEvent(eventId).shouldNotBeNull()
+            finalEvent.status shouldBeEqualTo WebhookEventStatus.FAILED
+            finalEvent.attempts shouldBeEqualTo maxAttempts
+            finalEvent.lastError.shouldNotBeNull()
+        } finally {
+            poller.stopGracefully(2.seconds)
+            scope.coroutineContext[kotlinx.coroutines.Job]?.cancelAndJoin()
+        }
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    fun `리더 cancel - 차순위 인스턴스가 인계하여 처리 완료`(): Unit = runBlocking {
+        val lockName = randomLockName()
+        val eventIds = (1..5).map { randomEventId() }
+        eventIds.forEach { insertPending(it) }
+
+        val handled = ConcurrentHashMap.newKeySet<String>()
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val electorA = newElector()
+        val electorB = newElector()
+        val pollerA = WebhookPoller(
+            elector = electorA,
+            eventCollection = eventCollection,
+            options = fastOptions("node-A", lockName, claimDuration = 1.seconds),
+        ) { event ->
+            handled.add(event.eventId)
+            delay(50.milliseconds)
+        }
+        val pollerB = WebhookPoller(
+            elector = electorB,
+            eventCollection = eventCollection,
+            options = fastOptions("node-B", lockName, claimDuration = 1.seconds),
+        ) { event ->
+            handled.add(event.eventId)
+            delay(50.milliseconds)
+        }
+
+        try {
+            pollerA.start(scope)
+            pollerB.start(scope)
+
+            // 일부 처리되었을 때 A 를 graceful stop
+            waitUntil(5.seconds) { handled.size >= 1 }
+            pollerA.stopGracefully(2.seconds)
+
+            // 나머지 처리 — B 가 인계
+            val ok = waitUntil(INSTANCE_TIMEOUT) {
+                eventCollection.countDocuments(
+                    Filters.eq(WebhookPoller.FIELD_STATUS, WebhookEventStatus.DONE.name),
+                ) == eventIds.size.toLong()
+            }
+            ok shouldBeEqualTo true
+        } finally {
+            pollerB.stopGracefully(2.seconds)
+            scope.coroutineContext[kotlinx.coroutines.Job]?.cancelAndJoin()
+        }
+    }
+
+    @Test
+    fun `blank nodeId - IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            WebhookPollerOptions(nodeId = " ", lockName = "ok")
+        }
+    }
+
+    @Test
+    fun `blank lockName - IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            WebhookPollerOptions(nodeId = "ok", lockName = " ")
+        }
+    }
+
+    @Test
+    fun `non-positive batchSize - IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            WebhookPollerOptions(nodeId = "ok", lockName = "ok", batchSize = 0)
+        }
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    fun `start 후 scope cancel - poller 자동 종료 (CancellationException 재throw)`(): Unit = runBlocking {
+        val lockName = randomLockName()
+        insertPending(randomEventId())
+
+        val elector = newElector()
+        val poller = WebhookPoller(
+            elector = elector,
+            eventCollection = eventCollection,
+            options = fastOptions("node-cancel", lockName),
+        ) { delay(10.milliseconds) }
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val job = poller.start(scope)
+        delay(200.milliseconds)
+        job.cancelAndJoin()
+        job.isCancelled shouldBeEqualTo true
+    }
+
+    /**
+     * P2-3: lease 만료 reclaim 시나리오.
+     *
+     * - node-A 가 event 를 claim 하지만 handler 실행 중 사망(cancel) → CLAIMED 상태 유지
+     * - claimDuration 만료 후 node-B 가 동일 event 를 reclaim 하여 처리 완료
+     * - at-least-once 보장 검증
+     */
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    fun `leader 가 claim 후 사망 시 - 차순위가 같은 event 처리 (lease 만료 reclaim)`(): Unit = runBlocking {
+        val lockName = randomLockName()
+        val eventId = randomEventId()
+        insertPending(eventId, payload = "reclaim-target")
+
+        val handlerStarted = CompletableDeferred<Unit>()
+        val handledByB = CompletableDeferred<Unit>()
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val electorA = newElector()
+        val pollerA = WebhookPoller(
+            elector = electorA,
+            eventCollection = eventCollection,
+            // 매우 짧은 claim — A 사망 후 즉시 reclaim 가능
+            options = fastOptions("node-A", lockName, claimDuration = 500.milliseconds),
+        ) { _ ->
+            handlerStarted.complete(Unit)
+            // 영원히 처리 안 함 (cancel 시뮬레이션)
+            delay(60.seconds)
+        }
+        val electorB = newElector()
+        val pollerB = WebhookPoller(
+            elector = electorB,
+            eventCollection = eventCollection,
+            options = fastOptions("node-B", lockName, claimDuration = 500.milliseconds),
+        ) { event ->
+            if (event.eventId == eventId) handledByB.complete(Unit)
+        }
+
+        try {
+            pollerA.start(scope)
+            // A 가 claim & handler 진입 확인
+            withTimeoutOrNull(INSTANCE_TIMEOUT) { handlerStarted.await() }.shouldNotBeNull()
+            // A 사망
+            pollerA.stopGracefully(1.seconds)
+
+            // B 시작 — claim 만료 후 reclaim
+            pollerB.start(scope)
+            withTimeoutOrNull(INSTANCE_TIMEOUT) { handledByB.await() }.shouldNotBeNull()
+
+            val ok = waitUntil(INSTANCE_TIMEOUT) {
+                fetchEvent(eventId)?.status == WebhookEventStatus.DONE
+            }
+            ok shouldBeEqualTo true
+            val finalEvent = fetchEvent(eventId).shouldNotBeNull()
+            finalEvent.status shouldBeEqualTo WebhookEventStatus.DONE
+            // attempts: A 의 claim(1) + B 의 reclaim(1) = 최소 2
+            finalEvent.attempts shouldBeGreaterOrEqualTo 2
+        } finally {
+            pollerB.stopGracefully(2.seconds)
+            scope.coroutineContext[kotlinx.coroutines.Job]?.cancelAndJoin()
+        }
+    }
+
+    /**
+     * P2-3: maxAttempts 도달한 expired CLAIMED event 는 reclaim 되지 않아야 한다.
+     *
+     * 자연스러운 흐름에선 이 상태가 거의 발생하지 않지만 (handler-throw 경로는 markFailureOrRequeue 가 정리),
+     * 다음 시나리오에선 발생 가능:
+     * - claim 직후 인스턴스 crash → CLAIMED 잔존 → 다음 인스턴스 reclaim → handler-throw
+     * - 위 사이클이 maxAttempts 만큼 반복된 직후 또 한 번 crash → `attempts==maxAttempts` 인 expired CLAIMED 동결
+     *
+     * 본 테스트는 이 상태를 직접 insert 하여 폴러가 절대 reclaim 하지 않음을 검증.
+     */
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    fun `maxAttempts 도달한 expired CLAIMED event - reclaim 안 됨`(): Unit = runBlocking {
+        val lockName = randomLockName()
+        val eventId = randomEventId()
+        val maxAttempts = 3
+
+        // 직접 maxAttempts 도달 + expired CLAIMED state 의 document 를 삽입
+        val expiredCount = AtomicInteger(0)
+        val stuckEvent = WebhookEvent(
+            eventId = eventId,
+            payload = "stuck",
+            status = WebhookEventStatus.CLAIMED,
+            claimedBy = "dead-node",
+            claimExpiresAt = java.time.Instant.now().minusSeconds(60),
+            attempts = maxAttempts,
+        )
+        eventCollection.insertOne(stuckEvent.toDocument())
+
+        // 함께 처리되는 PENDING event 도 1건 — 폴러가 살아있고 사이클 돌고 있음을 보장
+        val sentinelId = randomEventId()
+        insertPending(sentinelId, payload = "sentinel")
+
+        val sentinelDone = CompletableDeferred<Unit>()
+        val elector = newElector()
+        val poller = WebhookPoller(
+            elector = elector,
+            eventCollection = eventCollection,
+            options = fastOptions("node-stuck", lockName, maxAttempts = maxAttempts, claimDuration = 1.seconds),
+        ) { event ->
+            if (event.eventId == eventId) {
+                expiredCount.incrementAndGet()    // 절대 호출되면 안 됨
+            } else if (event.eventId == sentinelId) {
+                sentinelDone.complete(Unit)
+            }
+        }
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            poller.start(scope)
+            // sentinel 처리 완료까지 대기 — 폴러 사이클이 충분히 돌았음을 보장
+            withTimeoutOrNull(INSTANCE_TIMEOUT) { sentinelDone.await() }.shouldNotBeNull()
+            // 추가로 몇 사이클 더 대기 (claim 만료 충분히 경과)
+            delay(2.seconds)
+
+            // stuck event 는 절대 처리되면 안 됨
+            expiredCount.get() shouldBeEqualTo 0
+            // stuck event 는 CLAIMED 상태로 남아있어야 함 (다른 인스턴스가 reclaim 안 함)
+            val finalEvent = fetchEvent(eventId).shouldNotBeNull()
+            finalEvent.status shouldBeEqualTo WebhookEventStatus.CLAIMED
+            finalEvent.claimedBy shouldBeEqualTo "dead-node"
+            finalEvent.attempts shouldBeEqualTo maxAttempts
+        } finally {
+            poller.stopGracefully(2.seconds)
+            scope.coroutineContext[kotlinx.coroutines.Job]?.cancelAndJoin()
+        }
+    }
+}

--- a/examples/webhook-poller/src/test/resources/junit-platform.properties
+++ b/examples/webhook-poller/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/examples/webhook-poller/src/test/resources/logback-test.xml
+++ b/examples/webhook-poller/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%24.24t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+    <logger name="io.bluetape4k.leader.examples.webhook" level="DEBUG"/>
+    <logger name="io.bluetape4k.leader.mongodb" level="INFO"/>
+    <logger name="org.testcontainers" level="WARN"/>
+    <logger name="org.mongodb" level="WARN"/>
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,4 +26,5 @@ include(
     "leader-micrometer",
     "examples:batch-scheduler",
     "examples:migration-gate",
+    "examples:webhook-poller",
 )


### PR DESCRIPTION
## Summary

Closes #156

PR #161의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat(examples): E3 Webhook 폴러 (MongoDB) — closes #156`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 개요

Epic #36 의 E3 — 결제 PG webhook event 등 외부 source 를 다중 인스턴스 환경에서 단 1개만 polling/처리하도록 보장. SuspendLeaderElector + claim/ack 4-state 모델.

Closes #156
Refs #36

## 4-state claim 모델

```
PENDING ──claim──> CLAIMED ──handler 성공──> DONE
                      │
                      ├─ handler 실패 (attempts < max) ──> PENDING (재시도)
                      │
                      ├─ handler 실패 (attempts >= max) ──> FAILED (DLQ)
                      │
                      └─ leaseTime 만료 ──> 다른 인스턴스 reclaim
```

## API

```kotlin
val elector = MongoSuspendLeaderElector(lockColl, ...)
val poller = WebhookPoller(elector, eventColl, WebhookPollerOptions(
    nodeId, lockName, pollInterval, batchSize, maxAttempts, claimDuration
), handler = { event -> processWebhook(event) })

val job = poller.start(applicationScope)
// graceful shutdown:
poller.stopGracefully(timeout = 30.seconds)
```

## 변경 사항

- `examples/webhook-poller/` 신규 모듈
- `settings.gradle.kts` + `.github/workflows/{ci,nightly}.yml`
- `docs/lessons/2026-05-10-e3-webhook-poller.md` (L1~L6)

## 테스트 결과

11 passing:
- 단일 인스턴스 → 모든 PENDING DONE
- 3 인스턴스 동시 → 중복 처리 없음 (unique assertion)
- handler 예외 → attempts++ 다음 cycle 계속
- maxAttempts 도달 → FAILED
- 리더 cancel → 차순위 인계
- **claim ownership 가드** → stale owner 업데이트 차단
- **maxAttempts 도달 expired CLAIMED** → reclaim 안 됨
- blank nodeId/lockName/eventId → IllegalArgumentException
- CancellationException 재throw 검증
- graceful stop in-flight 보호

## 코드 리뷰

- **Codex spec 리뷰**: BLOCKER 2 + HIGH 5 모두 반영 (claim model, graceful stop, maxAttempts/DLQ, atomic claim filter)
- **Codex code review**: P2 3건 반영
  - leaseTime/waitTime Options 제거 → elector 외부 주입 desync 방지
  - claim ownership 가드 (eventId + status=CLAIMED + claimedBy=nodeId)
  - claim filter 에 attempts < maxAttempts 강제

## 다음 작업

E4 (#157) — `examples/cache-warmer/` (Hazelcast + LeaderGroup).
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #156, milestone `0.1.0`, assignee `debop`
- PR: #161, head `02e2600dafd20d6755f654c85b9d6af24390c0e0`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
