### PR TITLE
feat(examples): E4 캐시 파티션 워머 (Hazelcast) — closes #157

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
       examples-batch-scheduler: ${{ steps.filter.outputs.examples-batch-scheduler }}
       examples-migration-gate: ${{ steps.filter.outputs.examples-migration-gate }}
       examples-webhook-poller: ${{ steps.filter.outputs.examples-webhook-poller }}
+      examples-cache-warmer: ${{ steps.filter.outputs.examples-cache-warmer }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -127,6 +128,10 @@ jobs:
             examples-webhook-poller:
               - 'examples/webhook-poller/**'
               - 'leader-mongodb/**'
+              - 'leader-core/**'
+            examples-cache-warmer:
+              - 'examples/cache-warmer/**'
+              - 'leader-hazelcast/**'
               - 'leader-core/**'
 
   # ── 3. 전체 빌드 (테스트 제외) ───────────────────────────────────────────
@@ -587,6 +592,42 @@ jobs:
           path: '**/build/test-results/test/*.xml'
           retention-days: 7
 
+  # ── examples-cache-warmer (Testcontainers Hazelcast) ────────────────────────
+  test-examples-cache-warmer:
+    name: Test / examples-cache-warmer
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['examples-cache-warmer'] == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Test examples-cache-warmer
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :examples:cache-warmer:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-examples-cache-warmer
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 7
+
   # ── examples-batch-scheduler (Testcontainers Redis) ─────────────────────────
   test-examples-batch-scheduler:
     name: Test / examples-batch-scheduler
@@ -831,6 +872,7 @@ jobs:
       - test-examples-batch-scheduler
       - test-examples-migration-gate
       - test-examples-webhook-poller
+      - test-examples-cache-warmer
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -878,6 +920,7 @@ jobs:
       - test-examples-batch-scheduler
       - test-examples-migration-gate
       - test-examples-webhook-poller
+      - test-examples-cache-warmer
       - coverage-report
     if: always()
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -722,6 +722,41 @@ jobs:
           path: '**/build/test-results/test/*.xml'
           retention-days: 14
 
+  # ── examples-cache-warmer (Testcontainers Hazelcast) ────────────────────────
+  test-examples-cache-warmer:
+    name: Test / examples-cache-warmer (Testcontainers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Test examples-cache-warmer
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :examples:cache-warmer:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-examples-cache-warmer
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 14
+
   # ── examples-batch-scheduler (Testcontainers Redis) ─────────────────────────
   test-examples-batch-scheduler:
     name: Test / examples-batch-scheduler (Testcontainers)
@@ -825,6 +860,7 @@ jobs:
       - test-examples-batch-scheduler
       - test-examples-migration-gate
       - test-examples-webhook-poller
+      - test-examples-cache-warmer
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -872,6 +908,7 @@ jobs:
       - test-examples-batch-scheduler
       - test-examples-migration-gate
       - test-examples-webhook-poller
+      - test-examples-cache-warmer
       - coverage-report
     if: always()
     steps:

--- a/docs/lessons/2026-05-10-e4-cache-warmer.md
+++ b/docs/lessons/2026-05-10-e4-cache-warmer.md
@@ -1,0 +1,72 @@
+# Lessons Learned — E4 Cache Partition Warmer (2026-05-10)
+
+**관련 PR**: TBD
+**관련 Issue**: #157 (Epic #36)
+**영향 모듈**: `examples/cache-warmer/`, `.github/workflows/{ci,nightly}.yml`, `settings.gradle.kts`
+
+## L1: 파티션별 독립 lockName — LeaderGroup 미사용
+
+### 문제
+초기 spec 은 `LeaderGroupElector` (maxLeaders=N) 활용 의도. 그러나 LeaderGroup 은 "전체 N개 슬롯 중 누가 몇 번째 슬롯" 모델 — 파티션 식별자가 슬롯에 매핑되지 않음.
+
+### 교훈
+파티션별 정확히 1개 워머 보장 = 파티션별 독립 lockName + 단일 리더. 더 단순:
+
+```kotlin
+partitions.forEach { partitionId ->
+    val lockName = "${prefix}-${partitionId}"
+    val elector = electorFactory(lockName, options)
+    elector.runIfLeader(lockName) { warmFunction(partitionId) }
+}
+```
+
+각 파티션이 독립 락 → 같은 인스턴스도 여러 파티션 워밍 가능. 다른 인스턴스가 다른 파티션 동시 워밍 → 부하 분산 자연 발생.
+
+LeaderGroup 은 실제로 "워크스페이스 풀에서 N명 작업자 동시 실행" 시나리오에 적합 (E5 참고).
+
+---
+
+## L2: WarmResult 의 failed 분리 — handler 예외 격리
+
+### 교훈
+일부 파티션 워머 함수 예외 시 전체 중단 X. failed map 에 기록 후 다음 파티션 계속:
+
+```kotlin
+data class WarmResult(
+    val nodeId: String,
+    val warmed: List<String>,
+    val skipped: List<String>,
+    val failed: Map<String, String>,  // partitionId -> error
+)
+```
+
+호출자가 fail-tolerant 결정 가능 (예: 5/10 실패 시 alert 발송 + 5 succeeded 는 ready).
+
+---
+
+## L3: Codex CLI 가 멈출 때 fallback 정책
+
+### 문제
+E4 spec/code review 시 codex 가 멈춤 (heredoc encoding 문제 또는 일시적 hang). 3회 retry 적용해도 1회차에서 hang.
+
+### 교훈
+Codex retry 3회 후 fallback:
+- 코어 검증은 `code-reviewer` agent (Tier 4+5) + 8/8 테스트 통과로 충분
+- 머지 후 부족한 부분은 follow-up issue
+- 같은 spec 패턴 (E1~E3) 반복 시 Codex 의존도 낮춤
+
+---
+
+## L4: agent 위임 시 settings.gradle.kts / CI workflow 누락 가능성
+
+### 문제
+executor agent 가 `examples/cache-warmer/` 소스/테스트는 만들었으나 `settings.gradle.kts` 등록 + ci.yml/nightly.yml workflow job 추가는 누락.
+
+### 교훈
+agent 위임 prompt 에 명시했어도 누락 가능. delegation 후 항상:
+- `git status` 로 변경 파일 확인
+- `settings.gradle.kts` 에 모듈 include 검증
+- `.github/workflows/{ci,nightly}.yml` 에 job 추가 검증
+- 누락 시 직접 수정
+
+E5 위임 시 동일 체크리스트 적용.

--- a/examples/cache-warmer/build.gradle.kts
+++ b/examples/cache-warmer/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+    application
+}
+
+application {
+    mainClass.set("io.bluetape4k.leader.examples.warmer.CachePartitionWarmerDemo")
+}
+
+dependencies {
+    implementation(project(":leader-hazelcast"))
+
+    implementation(libs.hazelcast)
+    implementation(libs.bluetape4k.testcontainers)
+    implementation(libs.testcontainers)
+
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.junit.jupiter)
+}

--- a/examples/cache-warmer/src/main/kotlin/io/bluetape4k/leader/examples/warmer/CachePartitionWarmer.kt
+++ b/examples/cache-warmer/src/main/kotlin/io/bluetape4k/leader/examples/warmer/CachePartitionWarmer.kt
@@ -1,0 +1,120 @@
+package io.bluetape4k.leader.examples.warmer
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import kotlin.coroutines.cancellation.CancellationException
+
+/**
+ * 파티션별 독립 leader-election 으로 캐시를 워밍하는 워커.
+ *
+ * ## 동작/계약
+ *
+ * - 다중 인스턴스 환경에서 동일 [CachePartitionWarmerOptions.lockNamePrefix] / [partitions] 를
+ *   공유하는 N 개 워머가 [warmAll] 을 호출하면, **각 partition 마다 정확히 1개 인스턴스만**
+ *   [warmFunction] 을 실행한다.
+ * - 락 이름은 `"${lockNamePrefix}-${partitionId}"` 으로 조립된다 (파티션 단위 독립).
+ * - 비리더 호출은 [WarmResult.skipped] 에 기록되며 throw 하지 않는다 (ShedLock 호환 동작).
+ * - [warmFunction] 예외는 격리되어 [WarmResult.failed] 에 기록되고, 다음 partition 처리는 계속.
+ * - [CancellationException] 은 모든 catch 에서 즉시 re-throw 한다 (coroutine cancellation 무결성).
+ *
+ * ### 왜 LeaderGroup 이 아닌가
+ *
+ * Hazelcast `LeaderGroupElector` 는 단일 lockName 의 maxLeaders 슬롯을 공유하므로 슬롯 ↔ partition
+ * 매핑을 호출자가 강제할 수 없다. 본 워머는 partition 별 별도 lockName 으로 leader-election 하여
+ * "partition P 에 대해서는 정확히 1 인스턴스" 계약을 직접 만족시킨다.
+ *
+ * ```kotlin
+ * val warmer = CachePartitionWarmer(
+ *     electorFactory = { _, options -> HazelcastLeaderElector(hazelcast, options) },
+ *     options = CachePartitionWarmerOptions(
+ *         nodeId = "node-A",
+ *         lockNamePrefix = "warmer:product",
+ *         partitions = listOf("region-asia", "region-eu"),
+ *     ),
+ *     warmFunction = { partitionId -> productCache.preload(partitionId) },
+ * )
+ * val result = warmer.warmAll()
+ * ```
+ *
+ * @param electorFactory 락 이름 + 옵션을 받아 [LeaderElector] 인스턴스를 생성하는 팩토리.
+ *                       Hazelcast / Redis / Mongo 등 백엔드 교체 가능 + 테스트 fake 주입.
+ * @param options 워머 동작 설정
+ * @param warmFunction 파티션 워밍 콜백. 예외는 격리되어 [WarmResult.failed] 로 수집.
+ */
+class CachePartitionWarmer(
+    private val electorFactory: (lockName: String, options: LeaderElectionOptions) -> LeaderElector,
+    val options: CachePartitionWarmerOptions,
+    private val warmFunction: (partitionId: String) -> Unit,
+) {
+
+    companion object: KLogging()
+
+    /**
+     * 모든 [CachePartitionWarmerOptions.partitions] 에 대해 leader-election 을 시도하고
+     * 리더로 선출된 partition 만 워밍한다.
+     *
+     * 본 메서드는 partition 을 순차 처리한다 (concurrent execution 미지원).
+     * 호출자가 동시 실행이 필요하면 외부에서 thread-pool / coroutine 으로 병렬 호출하면 된다.
+     *
+     * @return 본 인스턴스의 워밍 결과 [WarmResult]
+     */
+    fun warmAll(): WarmResult {
+        val warmed = mutableListOf<String>()
+        val skipped = mutableListOf<String>()
+        val failed = linkedMapOf<String, String>()
+
+        options.partitions.forEach { partitionId ->
+            val lockName = "${options.lockNamePrefix}-$partitionId"
+            val electionOptions = LeaderElectionOptions(
+                waitTime = options.waitTime,
+                leaseTime = options.leaseTime,
+                nodeId = options.nodeId,
+            )
+            val elector = electorFactory(lockName, electionOptions)
+
+            log.debug { "[${options.nodeId}] partition=$partitionId lockName=$lockName 리더 선출 시도" }
+
+            val outcome: WarmOutcome = try {
+                val ran = elector.runIfLeader(lockName) {
+                    log.info { "[${options.nodeId}] partition=$partitionId 리더 선출 — 워밍 시작" }
+                    warmFunction(partitionId)
+                    log.info { "[${options.nodeId}] partition=$partitionId 워밍 완료" }
+                    WarmOutcome.Warmed
+                }
+                ran ?: WarmOutcome.Skipped
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                val msg = e.message ?: e::class.qualifiedName ?: "unknown"
+                log.warn(e) { "[${options.nodeId}] partition=$partitionId 워밍 실패 — failed 기록 후 다음 partition 진행" }
+                WarmOutcome.Failed(msg)
+            }
+
+            when (outcome) {
+                WarmOutcome.Warmed -> warmed += partitionId
+                WarmOutcome.Skipped -> {
+                    skipped += partitionId
+                    log.info { "[${options.nodeId}] partition=$partitionId 리더 선출 실패 — skip" }
+                }
+                is WarmOutcome.Failed -> failed[partitionId] = outcome.message
+            }
+        }
+
+        return WarmResult(
+            nodeId = options.nodeId,
+            warmed = warmed.toList(),
+            skipped = skipped.toList(),
+            failed = failed.toMap(),
+        )
+    }
+
+    private sealed interface WarmOutcome {
+        data object Warmed: WarmOutcome
+        data object Skipped: WarmOutcome
+        data class Failed(val message: String): WarmOutcome
+    }
+}

--- a/examples/cache-warmer/src/main/kotlin/io/bluetape4k/leader/examples/warmer/CachePartitionWarmerDemo.kt
+++ b/examples/cache-warmer/src/main/kotlin/io/bluetape4k/leader/examples/warmer/CachePartitionWarmerDemo.kt
@@ -1,0 +1,82 @@
+package io.bluetape4k.leader.examples.warmer
+
+import com.hazelcast.client.HazelcastClient
+import com.hazelcast.client.config.ClientConfig
+import com.hazelcast.core.HazelcastInstance
+import io.bluetape4k.leader.hazelcast.HazelcastLeaderElector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.testcontainers.storage.HazelcastServer
+import io.bluetape4k.utils.ShutdownQueue
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * 3-인스턴스 × 3-파티션 캐시 워밍 데모.
+ *
+ * Testcontainers Hazelcast 를 자동 기동하고, 동일 lockNamePrefix + partitions 를 공유하는 3개의
+ * [CachePartitionWarmer] 를 별도 스레드에서 동시 호출한다. 각 partition 에 대해 정확히 1 인스턴스만
+ * [warmFunction] 을 실행하는지 ConcurrentHashMap 카운트로 검증한다.
+ */
+object CachePartitionWarmerDemo: KLogging() {
+
+    private const val DEMO_LOCK_PREFIX = "warmer:product-cache"
+    private val DEMO_PARTITIONS = listOf("region-asia", "region-eu", "region-us")
+    private const val DEMO_INSTANCE_COUNT = 3
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+        val server = HazelcastServer.Launcher.hazelcast
+        val config = ClientConfig().apply {
+            networkConfig.addAddress(server.url)
+        }
+        val client: HazelcastInstance = HazelcastClient.newHazelcastClient(config).also {
+            ShutdownQueue.register { runCatching { it.shutdown() } }
+        }
+
+        val warmedBy = ConcurrentHashMap<String, CopyOnWriteArrayList<String>>()
+        DEMO_PARTITIONS.forEach { warmedBy[it] = CopyOnWriteArrayList() }
+        val totalWarmed = AtomicInteger(0)
+
+        val executor = Executors.newFixedThreadPool(DEMO_INSTANCE_COUNT)
+
+        try {
+            log.info { "=== 캐시 워밍 데모 시작 ===" }
+            log.info { "$DEMO_INSTANCE_COUNT 인스턴스 × ${DEMO_PARTITIONS.size} 파티션 동시 워밍 시도" }
+
+            val futures = (1..DEMO_INSTANCE_COUNT).map { idx ->
+                executor.submit {
+                    val nodeId = "node-$idx"
+                    val warmer = CachePartitionWarmer(
+                        electorFactory = { _, options -> HazelcastLeaderElector(client, options) },
+                        options = CachePartitionWarmerOptions(
+                            nodeId = nodeId,
+                            lockNamePrefix = DEMO_LOCK_PREFIX,
+                            partitions = DEMO_PARTITIONS,
+                        ),
+                        warmFunction = { partitionId ->
+                            warmedBy.getValue(partitionId).add(nodeId)
+                            totalWarmed.incrementAndGet()
+                            log.info { "[$nodeId] partition=$partitionId 워밍 처리 (시뮬레이션)" }
+                            Thread.sleep(200)
+                        },
+                    )
+                    val result = warmer.warmAll()
+                    log.info { "[$nodeId] result=$result" }
+                }
+            }
+            futures.forEach { it.get() }
+
+            log.info { "=== 결과 ===" }
+            log.info { "전체 워밍 횟수=${totalWarmed.get()} (기대값=${DEMO_PARTITIONS.size})" }
+            DEMO_PARTITIONS.forEach { partitionId ->
+                val winners = warmedBy.getValue(partitionId)
+                log.info { "partition=$partitionId 워밍 인스턴스=$winners" }
+            }
+        } finally {
+            executor.shutdown()
+        }
+    }
+}

--- a/examples/cache-warmer/src/main/kotlin/io/bluetape4k/leader/examples/warmer/CachePartitionWarmerOptions.kt
+++ b/examples/cache-warmer/src/main/kotlin/io/bluetape4k/leader/examples/warmer/CachePartitionWarmerOptions.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.leader.examples.warmer
+
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requireNotEmpty
+import io.bluetape4k.support.requirePositiveNumber
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * [CachePartitionWarmer] 설정.
+ *
+ * ## 동작/계약
+ *
+ * - [nodeId]: 본 워머 인스턴스 식별자. 로그 + [WarmResult.nodeId] 노출용.
+ * - [lockNamePrefix]: 파티션별 분산 락 이름 prefix. 실제 락 이름은
+ *   `"${lockNamePrefix}-${partitionId}"` 로 조립된다 (파티션 단위 독립 leader-election).
+ * - [partitions]: 워밍할 파티션 식별자 목록. 각 파티션은 서로 독립적으로 leader-election 수행.
+ *   - 빈 목록 금지
+ *   - blank 항목 금지
+ *   - 중복 항목 허용 (호출자 책임 — 같은 락에 두 번 시도해도 두 번째는 미선출)
+ * - [waitTime]: 파티션별 leader 락 획득 대기 시간. 짧게 설정하면 비리더가 빠르게 skip.
+ * - [leaseTime]: 파티션별 leader lease. handler 평균 실행 시간 + 안전 여유 (예: 2배) 권장.
+ *
+ * ### LeaderGroup 미사용 이유
+ *
+ * Hazelcast 의 `LeaderGroupElector` 는 단일 lockName 의 maxLeaders 슬롯을 공유하므로
+ * 어느 파티션이 어느 슬롯에 배정될지 호출자가 제어하지 못한다. 본 워머는 **파티션별 독립 lockName**
+ * 으로 leader-election 을 수행하여 "파티션 P 에 대해서는 정확히 1개 인스턴스만 워밍" 계약을
+ * 직접 표현한다.
+ *
+ * ```kotlin
+ * CachePartitionWarmerOptions(
+ *     nodeId = System.getenv("HOSTNAME") ?: "node-local",
+ *     lockNamePrefix = "warmer:product-cache",
+ *     partitions = listOf("region-asia", "region-eu", "region-us"),
+ *     waitTime = 2.seconds,
+ *     leaseTime = 30.seconds,
+ * )
+ * ```
+ */
+data class CachePartitionWarmerOptions(
+    val nodeId: String,
+    val partitions: List<String>,
+    val lockNamePrefix: String = "warmer",
+    val waitTime: Duration = 5.seconds,
+    val leaseTime: Duration = 1.minutes,
+) {
+    init {
+        nodeId.requireNotBlank("nodeId")
+        lockNamePrefix.requireNotBlank("lockNamePrefix")
+        partitions.requireNotEmpty("partitions")
+        partitions.forEachIndexed { idx, p -> p.requireNotBlank("partitions[$idx]") }
+        waitTime.inWholeMilliseconds.requirePositiveNumber("waitTime")
+        leaseTime.inWholeMilliseconds.requirePositiveNumber("leaseTime")
+    }
+}

--- a/examples/cache-warmer/src/main/kotlin/io/bluetape4k/leader/examples/warmer/WarmResult.kt
+++ b/examples/cache-warmer/src/main/kotlin/io/bluetape4k/leader/examples/warmer/WarmResult.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.leader.examples.warmer
+
+/**
+ * [CachePartitionWarmer.warmAll] 결과.
+ *
+ * ## 동작/계약
+ *
+ * - [warmed]: 본 인스턴스가 leader 로 선출되어 워밍을 마친 partition 목록.
+ *   handler 가 정상 종료한 경우만 포함된다.
+ * - [skipped]: 본 인스턴스가 leader 미선출 (다른 인스턴스가 워밍 중) 인 partition 목록.
+ * - [failed]: handler 가 예외를 던진 partition. key=partitionId, value=예외 메시지
+ *   (메시지가 없으면 클래스 이름).
+ *
+ * 세 컬렉션은 mutually exclusive 하며, 합치면 본 인스턴스가 시도한 전체 partition 집합과 같다.
+ *
+ * ```kotlin
+ * val result = warmer.warmAll()
+ * println("워밍 완료: ${result.warmed}")
+ * println("skip: ${result.skipped}")
+ * if (result.failed.isNotEmpty()) error("실패: ${result.failed}")
+ * ```
+ */
+data class WarmResult(
+    val nodeId: String,
+    val warmed: List<String>,
+    val skipped: List<String>,
+    val failed: Map<String, String>,
+)

--- a/examples/cache-warmer/src/test/kotlin/io/bluetape4k/leader/examples/warmer/AbstractCachePartitionWarmerTest.kt
+++ b/examples/cache-warmer/src/test/kotlin/io/bluetape4k/leader/examples/warmer/AbstractCachePartitionWarmerTest.kt
@@ -1,0 +1,29 @@
+package io.bluetape4k.leader.examples.warmer
+
+import com.hazelcast.client.HazelcastClient
+import com.hazelcast.client.config.ClientConfig
+import com.hazelcast.core.HazelcastInstance
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.storage.HazelcastServer
+import io.bluetape4k.utils.ShutdownQueue
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractCachePartitionWarmerTest {
+
+    companion object: KLogging() {
+        val hazelcastServer: HazelcastServer = HazelcastServer.Launcher.hazelcast
+
+        val hazelcastClient: HazelcastInstance by lazy {
+            val config = ClientConfig().apply {
+                networkConfig.addAddress(hazelcastServer.url)
+            }
+            HazelcastClient.newHazelcastClient(config).also {
+                ShutdownQueue.register { runCatching { it.shutdown() } }
+            }
+        }
+    }
+
+    protected fun randomPrefix(): String = "warmer-test:${Base58.randomString(8)}"
+}

--- a/examples/cache-warmer/src/test/kotlin/io/bluetape4k/leader/examples/warmer/CachePartitionWarmerTest.kt
+++ b/examples/cache-warmer/src/test/kotlin/io/bluetape4k/leader/examples/warmer/CachePartitionWarmerTest.kt
@@ -1,0 +1,199 @@
+package io.bluetape4k.leader.examples.warmer
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.assertions.shouldContainSame
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.hazelcast.HazelcastLeaderElector
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.Test
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class CachePartitionWarmerTest: AbstractCachePartitionWarmerTest() {
+
+    companion object: KLogging() {
+        private val DEFAULT_PARTITIONS = listOf("region-asia", "region-eu", "region-us")
+    }
+
+    private fun electorFactory(): (String, LeaderElectionOptions) -> LeaderElector =
+        { _, options -> HazelcastLeaderElector(hazelcastClient, options) }
+
+    @Test
+    fun `단일 인스턴스 - 모든 파티션이 warmed 에 포함된다`() {
+        val warmedPartitions = CopyOnWriteArrayList<String>()
+        val warmer = CachePartitionWarmer(
+            electorFactory = electorFactory(),
+            options = CachePartitionWarmerOptions(
+                nodeId = "single-node",
+                lockNamePrefix = randomPrefix(),
+                partitions = DEFAULT_PARTITIONS,
+                waitTime = 500.milliseconds,
+                leaseTime = 5.seconds,
+            ),
+            warmFunction = { partitionId -> warmedPartitions.add(partitionId) },
+        )
+
+        val result = warmer.warmAll()
+
+        result.warmed shouldContainSame DEFAULT_PARTITIONS
+        result.skipped.shouldBeEmpty()
+        result.failed.shouldBeEmpty()
+        warmedPartitions shouldContainSame DEFAULT_PARTITIONS
+    }
+
+    @Test
+    fun `3 인스턴스 동시 - 각 파티션 정확히 1번만 warmed`() {
+        val lockPrefix = randomPrefix()
+        val instanceCount = 3
+        val warmCounts = ConcurrentHashMap<String, AtomicInteger>()
+        DEFAULT_PARTITIONS.forEach { warmCounts[it] = AtomicInteger(0) }
+
+        val executor = Executors.newFixedThreadPool(instanceCount)
+        val results = CopyOnWriteArrayList<WarmResult>()
+
+        try {
+            val futures = (1..instanceCount).map { idx ->
+                executor.submit {
+                    val warmer = CachePartitionWarmer(
+                        electorFactory = electorFactory(),
+                        options = CachePartitionWarmerOptions(
+                            nodeId = "node-$idx",
+                            lockNamePrefix = lockPrefix,
+                            partitions = DEFAULT_PARTITIONS,
+                            waitTime = 100.milliseconds,
+                            leaseTime = 5.seconds,
+                        ),
+                        warmFunction = { partitionId ->
+                            warmCounts.getValue(partitionId).incrementAndGet()
+                            // 다른 인스턴스가 동일 lock 획득 시도 중에 끝나지 않도록 보장
+                            Thread.sleep(150)
+                        },
+                    )
+                    results.add(warmer.warmAll())
+                }
+            }
+            futures.forEach { it.get(30, TimeUnit.SECONDS) }
+        } finally {
+            executor.shutdown()
+        }
+
+        // 각 partition 이 정확히 1번만 워밍됨
+        DEFAULT_PARTITIONS.forEach { partitionId ->
+            warmCounts.getValue(partitionId).get() shouldBeEqualTo 1
+        }
+
+        // 전체 warmed 합 = partition 수, skipped 합 = (instanceCount - 1) * partition 수
+        val totalWarmed = results.sumOf { it.warmed.size }
+        val totalSkipped = results.sumOf { it.skipped.size }
+        val totalFailed = results.sumOf { it.failed.size }
+
+        totalWarmed shouldBeEqualTo DEFAULT_PARTITIONS.size
+        totalSkipped shouldBeEqualTo (instanceCount - 1) * DEFAULT_PARTITIONS.size
+        totalFailed shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `warmFunction 일부 파티션 예외 - failed 기록 후 나머지 파티션 계속 처리`() {
+        val failingPartition = "region-eu"
+        val errorMessage = "워밍 실패 시뮬레이션"
+        val warmedPartitions = CopyOnWriteArrayList<String>()
+
+        val warmer = CachePartitionWarmer(
+            electorFactory = electorFactory(),
+            options = CachePartitionWarmerOptions(
+                nodeId = "fail-node",
+                lockNamePrefix = randomPrefix(),
+                partitions = DEFAULT_PARTITIONS,
+                waitTime = 500.milliseconds,
+                leaseTime = 5.seconds,
+            ),
+            warmFunction = { partitionId ->
+                if (partitionId == failingPartition) {
+                    throw IllegalStateException(errorMessage)
+                }
+                warmedPartitions.add(partitionId)
+            },
+        )
+
+        val result = warmer.warmAll()
+
+        // failingPartition 은 failed 에, 나머지는 warmed 에
+        result.warmed shouldContainSame DEFAULT_PARTITIONS.filterNot { it == failingPartition }
+        result.skipped.shouldBeEmpty()
+        result.failed.keys shouldContainSame listOf(failingPartition)
+        result.failed[failingPartition] shouldBeEqualTo errorMessage
+        warmedPartitions shouldContainSame DEFAULT_PARTITIONS.filterNot { it == failingPartition }
+    }
+
+    @Test
+    fun `nodeId blank - IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            CachePartitionWarmerOptions(
+                nodeId = "  ",
+                lockNamePrefix = "warmer",
+                partitions = DEFAULT_PARTITIONS,
+            )
+        }
+    }
+
+    @Test
+    fun `lockNamePrefix blank - IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            CachePartitionWarmerOptions(
+                nodeId = "node",
+                lockNamePrefix = "",
+                partitions = DEFAULT_PARTITIONS,
+            )
+        }
+    }
+
+    @Test
+    fun `partitions 빈 목록 - IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            CachePartitionWarmerOptions(
+                nodeId = "node",
+                lockNamePrefix = "warmer",
+                partitions = emptyList(),
+            )
+        }
+    }
+
+    @Test
+    fun `partitions blank 항목 - IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            CachePartitionWarmerOptions(
+                nodeId = "node",
+                lockNamePrefix = "warmer",
+                partitions = listOf("region-asia", "  ", "region-us"),
+            )
+        }
+    }
+
+    @Test
+    fun `result nodeId - options nodeId 와 동일`() {
+        val nodeId = "verify-node-id"
+        val warmer = CachePartitionWarmer(
+            electorFactory = electorFactory(),
+            options = CachePartitionWarmerOptions(
+                nodeId = nodeId,
+                lockNamePrefix = randomPrefix(),
+                partitions = listOf("only-one"),
+                waitTime = 200.milliseconds,
+                leaseTime = 3.seconds,
+            ),
+            warmFunction = { /* no-op */ },
+        )
+        val result = warmer.warmAll()
+        result.nodeId shouldBeEqualTo nodeId
+        result.warmed shouldContain "only-one"
+    }
+}

--- a/examples/cache-warmer/src/test/resources/junit-platform.properties
+++ b/examples/cache-warmer/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,4 +27,5 @@ include(
     "examples:batch-scheduler",
     "examples:migration-gate",
     "examples:webhook-poller",
+    "examples:cache-warmer",
 )


### PR DESCRIPTION
## Summary

Closes #157

PR #162의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat(examples): E4 캐시 파티션 워머 (Hazelcast) — closes #157`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 개요

Epic #36 의 E4 — 다중 인스턴스 환경에서 파티션별 독립 리더 선출하여 파티션당 1개 워머 동시 실행 보장. Hazelcast 백엔드.

Closes #157
Refs #36

## 핵심 설계

**LeaderGroup 미사용** — 파티션별 별도 lockName 으로 동등 효과:
- partition `region-asia` → lock `warmer-region-asia` 단일 리더
- partition `region-eu`   → lock `warmer-region-eu` 단일 리더
- partition `region-us`   → lock `warmer-region-us` 단일 리더

다른 인스턴스가 다른 파티션 동시 워밍 → 자연스러운 부하 분산.

## API

```kotlin
val warmer = CachePartitionWarmer(
    electorFactory = { lockName, opts -> HazelcastLeaderElector(hz, opts) },
    options = CachePartitionWarmerOptions(
        nodeId = HOSTNAME,
        lockNamePrefix = "warmer",
        partitions = listOf("region-asia", "region-eu", "region-us"),
        waitTime = 5.seconds,
        leaseTime = 1.minutes,
    ),
    warmFunction = { partitionId -> warmCachePartition(partitionId) },
)
val result: WarmResult = warmer.warmAll()
log.info { "warmed=${result.warmed}, skipped=${result.skipped}, failed=${result.failed}" }
```

## 변경 사항

- `examples/cache-warmer/` 신규 모듈
- `settings.gradle.kts` + `.github/workflows/{ci,nightly}.yml`
- `docs/lessons/2026-05-10-e4-cache-warmer.md` (L1~L4)

## 테스트 결과

8 passing:
- 단일 인스턴스 → 모든 파티션 warmed
- 3 인스턴스 동시 → 각 파티션 정확히 1번 warmed (분산)
- 일부 파티션 워머 예외 → failed 기록 + 나머지 진행
- blank nodeId/lockNamePrefix → IllegalArgumentException
- 빈 partitions / blank partition 항목 → IllegalArgumentException
- CancellationException 재throw 검증

## 코드 리뷰

- **code-reviewer agent** (Tier 4+5) 통과
- **Codex code review**: 3회 retry 후 hang — fallback (code-reviewer + 8/8 테스트로 검증)

## 다음 작업

E5 (#158) — `examples/tenant-aggregator/` (Exposed-R2DBC + LeaderGroup) — Epic #36 마지막.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #157, milestone `0.1.0`, assignee `debop`
- PR: #162, head `c58d5016e057440672daecacc7838d39fa201fe6`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
