### PR TITLE
feat(examples): E5 멀티테넌트 집계 (Exposed-R2DBC) — closes #158

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
       examples-migration-gate: ${{ steps.filter.outputs.examples-migration-gate }}
       examples-webhook-poller: ${{ steps.filter.outputs.examples-webhook-poller }}
       examples-cache-warmer: ${{ steps.filter.outputs.examples-cache-warmer }}
+      examples-tenant-aggregator: ${{ steps.filter.outputs.examples-tenant-aggregator }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -132,6 +133,11 @@ jobs:
             examples-cache-warmer:
               - 'examples/cache-warmer/**'
               - 'leader-hazelcast/**'
+              - 'leader-core/**'
+            examples-tenant-aggregator:
+              - 'examples/tenant-aggregator/**'
+              - 'leader-exposed-r2dbc/**'
+              - 'leader-exposed-core/**'
               - 'leader-core/**'
 
   # ── 3. 전체 빌드 (테스트 제외) ───────────────────────────────────────────
@@ -628,6 +634,42 @@ jobs:
           path: '**/build/test-results/test/*.xml'
           retention-days: 7
 
+  # ── examples-tenant-aggregator (Testcontainers PostgreSQL + H2) ─────────────
+  test-examples-tenant-aggregator:
+    name: Test / examples-tenant-aggregator
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['examples-tenant-aggregator'] == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Test examples-tenant-aggregator
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :examples:tenant-aggregator:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-examples-tenant-aggregator
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 7
+
   # ── examples-batch-scheduler (Testcontainers Redis) ─────────────────────────
   test-examples-batch-scheduler:
     name: Test / examples-batch-scheduler
@@ -873,6 +915,7 @@ jobs:
       - test-examples-migration-gate
       - test-examples-webhook-poller
       - test-examples-cache-warmer
+      - test-examples-tenant-aggregator
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -921,6 +964,7 @@ jobs:
       - test-examples-migration-gate
       - test-examples-webhook-poller
       - test-examples-cache-warmer
+      - test-examples-tenant-aggregator
       - coverage-report
     if: always()
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -757,6 +757,41 @@ jobs:
           path: '**/build/test-results/test/*.xml'
           retention-days: 14
 
+  # tenant-aggregator (Testcontainers PostgreSQL + H2)
+  test-examples-tenant-aggregator:
+    name: Test / examples-tenant-aggregator (Testcontainers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Test examples-tenant-aggregator
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :examples:tenant-aggregator:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-examples-tenant-aggregator
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 14
+
   # ── examples-batch-scheduler (Testcontainers Redis) ─────────────────────────
   test-examples-batch-scheduler:
     name: Test / examples-batch-scheduler (Testcontainers)
@@ -861,6 +896,7 @@ jobs:
       - test-examples-migration-gate
       - test-examples-webhook-poller
       - test-examples-cache-warmer
+      - test-examples-tenant-aggregator
     if: always()
     steps:
       - uses: actions/checkout@v4
@@ -909,6 +945,7 @@ jobs:
       - test-examples-migration-gate
       - test-examples-webhook-poller
       - test-examples-cache-warmer
+      - test-examples-tenant-aggregator
       - coverage-report
     if: always()
     steps:

--- a/docs/lessons/2026-05-10-e5-tenant-aggregator.md
+++ b/docs/lessons/2026-05-10-e5-tenant-aggregator.md
@@ -1,0 +1,90 @@
+# Lessons — E5 examples/tenant-aggregator
+
+날짜: 2026-05-10
+범위: Issue #158 — examples/tenant-aggregator (Exposed R2DBC + multi-tenant leader election)
+
+## 컨텍스트
+
+E5는 Epic #36 examples 시리즈의 다섯 번째 모듈로, **멀티테넌트 환경에서 테넌트별로 독립된 집계 작업**을 실행해야 하는 상황을 시연한다. 사용자 시나리오:
+
+- 테넌트 N개 (예: tenant-A, tenant-B, tenant-C)
+- 인스턴스 M개 (Kubernetes pod 등)
+- 각 테넌트의 집계 코루틴은 동시에 정확히 1 인스턴스에서만 실행되어야 함
+- 집계는 long-running polling loop (E1 batch-scheduler 의 1회 실행과 다름)
+
+기술 스택은 leader-exposed-r2dbc (suspend coroutine + R2DBC 비동기 I/O).
+
+## L1 — 테넌트별 독립 lockName + LeaderGroup 미사용 (E4 와 동일)
+
+`SuspendLeaderGroupElector` 는 단일 lockName 의 maxLeaders 슬롯을 공유한다. "tenant T 가 슬롯 k 에 배정되도록" 호출자가 강제할 수 없으므로, 테넌트 ↔ 슬롯 매핑이 불확정이고 결국 **둘 다 슬롯을 받지 못해 테넌트 T 가 영영 polling 안 되는** 시나리오가 가능하다.
+
+해결: 테넌트마다 별도 lockName (`"${lockNamePrefix}-${tenantId}"`)으로 단일 leader-election 을 N 번 수행한다. "tenant T 에 대해서는 정확히 1 인스턴스" 계약을 직접 표현 가능. E4 cache-warmer 와 동일한 결론이며, 본 모듈은 long-running coroutine 으로 확장한 형태.
+
+## L2 — 테넌트별 child coroutine + supervisorScope
+
+테넌트 N개 polling 을 단일 루프에서 순차 처리하면 한 테넌트의 락 획득 대기가 다른 테넌트의 polling 주기를 좁힌다. 해결: `supervisorScope { tenants.forEach { launch { tenantLoop(it) } } }` 으로 테넌트마다 독립 child coroutine 을 띄운다.
+
+`coroutineScope` 가 아닌 `supervisorScope` 를 쓰는 이유는 한 테넌트의 예기치 못한 예외 (electorFactory throw 등) 가 다른 테넌트 루프를 죽이지 않게 하기 위함이다. coroutine cancellation 자체는 여전히 부모 → 자식 전파된다.
+
+## L3 — Aggregate 함수 예외 격리 (poison 방지)
+
+`aggregateFunction` 에서 발생한 예외가 polling 루프 자체를 종료시키면, 일시적 실패가 영구 정지로 이어진다 (poison loop). 해결: `runAggregate(tenantId)` 헬퍼에서 예외를 catch 하고 log warn 후 swallow — 단 `CancellationException` 은 즉시 re-throw 하여 cancellation 무결성 유지.
+
+`runIfLeader` 자체 (백엔드 장애로 인한 R2DBC 예외 등) 도 동일 정책: log warn 후 다음 사이클 재시도. 결국 두 단계 격리:
+1. `runAggregate` — 사용자 함수 예외
+2. tenantLoop 의 catch — 락 인프라 예외
+
+두 경우 모두 다음 사이클로 진행한다.
+
+## L4 — Elector 1회 생성 + suspend factory
+
+각 사이클마다 elector 를 새로 만들면 `ExposedR2DbcSuspendLeaderElector(db, options)` 의 `ensureSchema` 등 무거운 초기화가 매번 반복된다. 해결: `tenantLoop` 진입 시 elector 1회 생성 후 동일 instance 의 `runIfLeader` 를 사이클마다 재호출.
+
+`electorFactory` 시그니처는 suspend (Mongo 의 `MongoSuspendLeaderElector` 도 suspend factory 패턴) — 테스트 fake 주입성을 위해 `(lockName, LeaderElectionOptions) -> SuspendLeaderElector` 로 단순화.
+
+## L5 — stopGracefully 패턴 (E3 webhook-poller 동일)
+
+`rootJob.cancelAndJoin()` 을 `withTimeoutOrNull(timeout)` 로 감싸서, timeout 초과 시 강제 cancel 하여 호출자가 무한 대기하지 않도록 보장. `pollerJob = null` finally 처리는 두 번 호출 시 idempotent.
+
+진행 중인 `aggregateFunction` 호출은 cancel 되며, `runIfLeader` 가 보유한 락은 elector 의 finally 블록에서 자동 해제 → 락 lease 만료 후 차순위 인스턴스가 인계 (at-least-once 보장).
+
+## L6 — `ExposedR2dbcSchemaInitializer` 가 internal
+
+테스트 베이스 작성 시 `ExposedR2dbcSchemaInitializer.ensureSchema(db)` 를 직접 호출하려 했으나 `internal` 가시성으로 인해 다른 모듈에서 접근 불가. 해결: throwaway `ExposedR2DbcSuspendLeaderElector(...)` 를 1회 생성하여 companion `suspend operator fun invoke` 가 호출하는 ensureSchema 를 간접 트리거.
+
+향후 leader-exposed-r2dbc 가 `ensureSchema` 를 public 으로 승격시키면 더 깔끔해진다.
+
+## L7 — H2 R2DBC + Testcontainers PostgreSQL 병행 테스트
+
+`AbstractTenantAggregatorTest.enableDialects()` 가 `LEADER_TEST_DB` 환경 변수에 따라 dialect 를 필터링. 미설정이면 H2 + PostgreSQL 모두 실행. CI 에서는 환경 변수 미설정으로 두 dialect 모두 검증.
+
+H2 in-memory R2DBC URL 은 `r2dbc:h2:mem:///<unique>;MODE=MySQL;DB_CLOSE_DELAY=-1` — `MODE=MySQL` 는 `insertIgnore` 등 lock SQL 호환을 위해 필수, `DB_CLOSE_DELAY=-1` 은 connection close 시 in-memory DB 가 사라지지 않도록.
+
+## L8 — Workflow 누락 방지 체크리스트 (E4 lesson L4 강화)
+
+E4 cache-warmer 작업에서 settings.gradle.kts / ci.yml / nightly.yml 등록을 빠뜨려 PR review 단계에서 발견됐다. 본 작업에서는 미리 체크리스트로 점검:
+
+- [x] `settings.gradle.kts` — `"examples:tenant-aggregator"` 추가
+- [x] `ci.yml` — `changes.outputs` + `paths-filter` + 신규 `test-examples-tenant-aggregator` job + `coverage-report.needs` + `ci-status.needs`
+- [x] `nightly.yml` — 신규 `test-examples-tenant-aggregator` job + `coverage-report.needs` + `nightly-status.needs`
+- [x] `src/test/resources/junit-platform.properties`
+- [x] `src/test/resources/logback-test.xml`
+- [x] `README.md` + `README.ko.md`
+
+`grep -n "tenant-aggregator" .github/workflows/*.yml settings.gradle.kts` 로 마지막에 일괄 검증.
+
+## 검증 결과
+
+| Dialect | Pass | 소요 시간 |
+|---------|------|----------|
+| H2 | 10/10 | 5.4s |
+| PostgreSQL | 10/10 | 7.9s |
+
+테스트 커버:
+1. 단일 인스턴스 — 모든 테넌트 polling 시작
+2. 3 인스턴스 동시 — 테넌트당 정확히 1 인스턴스 (concurrent runners == 0 violations)
+3. aggregate 예외 — 다음 사이클 계속 (poison 방지)
+4. 리더 stop — 차순위 인계
+5. start 후 cancelAndJoin — CancellationException 재throw 로 정상 종료
+6. Options 검증 (blank nodeId / blank lockNamePrefix / 빈 tenants / blank 항목)
+7. start 두 번 호출 — IllegalStateException

--- a/examples/tenant-aggregator/README.ko.md
+++ b/examples/tenant-aggregator/README.ko.md
@@ -1,0 +1,130 @@
+# examples-tenant-aggregator
+
+한국어 | [English](./README.md)
+
+Exposed R2DBC 리더 선출 기반 멀티테넌트 집계기. N개 인스턴스 환경에서 **테넌트별 독립 lockName** 으로 각 테넌트는 정확히 1 인스턴스만 polling 한다. long-running coroutine 워커, graceful stop, 테넌트별 예외 격리를 시연.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant N1 as node-1
+    participant N2 as node-2
+    participant N3 as node-3
+    participant LockA as lock(tenant-A)
+    participant LockB as lock(tenant-B)
+    participant LockC as lock(tenant-C)
+
+    par tenant-A
+        N1->>LockA: runIfLeader
+        N2->>LockA: runIfLeader
+        N3->>LockA: runIfLeader
+        LockA-->>N1: granted -> aggregate(tenant-A)
+        LockA-->>N2: null
+        LockA-->>N3: null
+    and tenant-B
+        N1->>LockB: runIfLeader
+        N2->>LockB: runIfLeader
+        N3->>LockB: runIfLeader
+        LockB-->>N2: granted -> aggregate(tenant-B)
+        LockB-->>N1: null
+        LockB-->>N3: null
+    and tenant-C
+        N1->>LockC: runIfLeader
+        N2->>LockC: runIfLeader
+        N3->>LockC: runIfLeader
+        LockC-->>N3: granted -> aggregate(tenant-C)
+        LockC-->>N1: null
+        LockC-->>N2: null
+    end
+
+    Note over N1,N3: delay(pollInterval) 후 각 테넌트마다 재선출
+```
+
+## Core Features
+
+- 테넌트별 독립 leader-election — `lockName = "${lockNamePrefix}-${tenantId}"`
+- Long-running coroutine 워커 — 테넌트마다 supervised child coroutine 1개
+- Aggregate 예외 격리 — `aggregateFunction` 예외는 다음 사이클에 영향 없음 (poison 방지)
+- Graceful stop — `stopGracefully(timeout)` 가 모든 테넌트 코루틴 협력적 cancel
+- 모든 catch 에서 `CancellationException` 재throw — coroutine cancellation 무결성 유지
+- `ExposedR2DbcSuspendLeaderElector` (PostgreSQL / H2 / MySQL R2DBC) 백엔드
+
+## LeaderGroup 미사용 이유
+
+`LeaderGroupElector` 는 단일 lockName 의 `maxLeaders` 슬롯을 공유하는데 "테넌트 T -> 슬롯 k" 매핑을 호출자가 강제할 수 없다. 테넌트별 독립 lockName 으로 leader-election 하면 "테넌트 T 에 대해서는 정확히 1 인스턴스" 계약을 직접 표현 가능 (E4 cache-warmer 와 동일 결정).
+
+## Usage Example
+
+```kotlin
+val aggregator = TenantAggregator(
+    electorFactory = { _, options ->
+        ExposedR2DbcSuspendLeaderElector(
+            db,
+            ExposedR2dbcLeaderElectionOptions(leaderOptions = options),
+        )
+    },
+    options = TenantAggregatorOptions(
+        nodeId = System.getenv("HOSTNAME") ?: "node-local",
+        lockNamePrefix = "tenant-aggregator:metrics",
+        tenants = listOf("tenant-A", "tenant-B", "tenant-C"),
+        pollInterval = 5.seconds,
+        waitTime = 1.seconds,
+        leaseTime = 60.seconds,
+    ),
+    aggregateFunction = { tenantId -> metricsService.aggregate(tenantId) },
+)
+
+val job = aggregator.start(applicationScope)
+// ... shutdown ...
+aggregator.stopGracefully(timeout = 30.seconds)
+```
+
+## Demo
+
+```bash
+./gradlew :examples:tenant-aggregator:run
+```
+
+H2 R2DBC in-memory DB 를 공유하는 3개 in-process 집계기를 6초간 polling 후, 테넌트별 집계 호출 횟수 + 동시 실행 위반 0 을 출력.
+
+## Configuration Options
+
+| 파라미터 | 기본값 | 설명 |
+|---------|--------|------|
+| `nodeId` | required | Pod 식별자 — 로그/lock owner 노출 |
+| `tenants` | required | 독립 polling 할 테넌트 식별자 — 빈 목록·blank 항목 금지 |
+| `lockNamePrefix` | `"tenant-aggregator"` | 락 prefix — 최종 이름은 `"${prefix}-${tenantId}"` |
+| `pollInterval` | `5.seconds` | 테넌트별 사이클 간 휴지 |
+| `waitTime` | `1.seconds` | 락 획득 대기 (짧게 = 빠른 skip) |
+| `leaseTime` | `60.seconds` | 락 TTL — 최대 aggregate 실행 시간보다 길게 |
+
+## Failure Semantics
+
+- `aggregateFunction` throw -> log warn + 격리, 다음 사이클 계속 (poison 방지)
+- 리더 pod crash -> elector lease 만료 -> 차순위 인스턴스가 락 획득 -> aggregation 인계 (at-least-once)
+- `electorFactory` 가 테넌트 초기화에서 throw -> 해당 테넌트 루프 종료 (다른 테넌트는 `supervisorScope` 덕에 계속)
+- `start(scope)` 두 번 호출 -> `IllegalStateException`
+
+## Dependency
+
+```kotlin
+dependencies {
+    implementation(project(":leader-exposed-r2dbc"))
+    implementation(project(":examples:tenant-aggregator"))
+
+    // R2DBC 드라이버 (택일)
+    runtimeOnly(libs.r2dbc.h2)         // demo / tests
+    runtimeOnly(libs.r2dbc.postgresql) // production
+}
+```
+
+## Testing
+
+```bash
+LEADER_TEST_DB=H2 ./gradlew :examples:tenant-aggregator:test
+LEADER_TEST_DB=POSTGRESQL ./gradlew :examples:tenant-aggregator:test  # Testcontainers PostgreSQL
+./gradlew :examples:tenant-aggregator:test                            # 둘 다
+```
+
+`@ParameterizedTest @MethodSource("enableDialects")` 로 H2 in-memory + PostgreSQL Testcontainers 모두 지원.

--- a/examples/tenant-aggregator/README.md
+++ b/examples/tenant-aggregator/README.md
@@ -1,0 +1,130 @@
+# examples-tenant-aggregator
+
+[한국어](./README.ko.md) | English
+
+Multi-tenant aggregator backed by Exposed R2DBC leader election. Each tenant is polled by exactly one instance across N pods using independent per-tenant lock names. Demonstrates long-running coroutine workers with graceful stop and per-tenant exception isolation.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant N1 as node-1
+    participant N2 as node-2
+    participant N3 as node-3
+    participant LockA as lock(tenant-A)
+    participant LockB as lock(tenant-B)
+    participant LockC as lock(tenant-C)
+
+    par tenant-A
+        N1->>LockA: runIfLeader
+        N2->>LockA: runIfLeader
+        N3->>LockA: runIfLeader
+        LockA-->>N1: granted -> aggregate(tenant-A)
+        LockA-->>N2: null
+        LockA-->>N3: null
+    and tenant-B
+        N1->>LockB: runIfLeader
+        N2->>LockB: runIfLeader
+        N3->>LockB: runIfLeader
+        LockB-->>N2: granted -> aggregate(tenant-B)
+        LockB-->>N1: null
+        LockB-->>N3: null
+    and tenant-C
+        N1->>LockC: runIfLeader
+        N2->>LockC: runIfLeader
+        N3->>LockC: runIfLeader
+        LockC-->>N3: granted -> aggregate(tenant-C)
+        LockC-->>N1: null
+        LockC-->>N2: null
+    end
+
+    Note over N1,N3: delay(pollInterval), then re-elect for each tenant independently
+```
+
+## Core Features
+
+- Per-tenant independent leader election — `lockName = "${lockNamePrefix}-${tenantId}"`
+- Long-running coroutine workers — one supervised child coroutine per tenant
+- Aggregate exception isolation — a throwing aggregate function does NOT poison the loop, next cycle continues
+- Graceful stop — `stopGracefully(timeout)` cancels all tenant loops cooperatively
+- `CancellationException` rethrown in every catch — coroutine cancellation integrity preserved
+- Backed by `ExposedR2DbcSuspendLeaderElector` (PostgreSQL / H2 / MySQL R2DBC)
+
+## Why per-tenant locks (not LeaderGroup)
+
+`LeaderGroupElector` holds a single lockName with `maxLeaders` slots — but the caller cannot pin "tenant T -> slot k". A per-tenant lockName directly expresses "exactly one instance polls tenant T", which is the contract this example needs (same decision as E4 cache-warmer).
+
+## Usage Example
+
+```kotlin
+val aggregator = TenantAggregator(
+    electorFactory = { _, options ->
+        ExposedR2DbcSuspendLeaderElector(
+            db,
+            ExposedR2dbcLeaderElectionOptions(leaderOptions = options),
+        )
+    },
+    options = TenantAggregatorOptions(
+        nodeId = System.getenv("HOSTNAME") ?: "node-local",
+        lockNamePrefix = "tenant-aggregator:metrics",
+        tenants = listOf("tenant-A", "tenant-B", "tenant-C"),
+        pollInterval = 5.seconds,
+        waitTime = 1.seconds,
+        leaseTime = 60.seconds,
+    ),
+    aggregateFunction = { tenantId -> metricsService.aggregate(tenantId) },
+)
+
+val job = aggregator.start(applicationScope)
+// ... shutdown ...
+aggregator.stopGracefully(timeout = 30.seconds)
+```
+
+## Demo
+
+```bash
+./gradlew :examples:tenant-aggregator:run
+```
+
+Spins up 3 in-process aggregator instances against a shared H2 R2DBC database, polls 3 tenants for 6 seconds, then prints per-tenant aggregation counts and confirms zero concurrent-execution violations.
+
+## Configuration Options
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `nodeId` | required | Pod identifier — surfaces in logs and lock owner |
+| `tenants` | required | Tenant ids to poll independently — non-empty, no blanks |
+| `lockNamePrefix` | `"tenant-aggregator"` | Lock name prefix — final name is `"${prefix}-${tenantId}"` |
+| `pollInterval` | `5.seconds` | Sleep between cycles per tenant |
+| `waitTime` | `1.seconds` | Leader-lock acquisition timeout (short = fast skip) |
+| `leaseTime` | `60.seconds` | Leader-lock TTL — should exceed worst-case aggregate runtime |
+
+## Failure Semantics
+
+- `aggregateFunction` throws -> log warn, isolate, next cycle continues (no poison loop)
+- Leader pod crashes mid-aggregate -> elector lease expires -> next instance acquires lock -> aggregation resumes (at-least-once)
+- `electorFactory` throws on tenant init -> that tenant loop terminates (others continue thanks to `supervisorScope`)
+- Calling `start(scope)` twice -> `IllegalStateException`
+
+## Dependency
+
+```kotlin
+dependencies {
+    implementation(project(":leader-exposed-r2dbc"))
+    implementation(project(":examples:tenant-aggregator"))
+
+    // R2DBC driver (pick one)
+    runtimeOnly(libs.r2dbc.h2)         // demo / tests
+    runtimeOnly(libs.r2dbc.postgresql) // production
+}
+```
+
+## Testing
+
+```bash
+LEADER_TEST_DB=H2 ./gradlew :examples:tenant-aggregator:test
+LEADER_TEST_DB=POSTGRESQL ./gradlew :examples:tenant-aggregator:test  # Testcontainers PostgreSQL
+./gradlew :examples:tenant-aggregator:test                            # both
+```
+
+Both H2 in-memory and PostgreSQL Testcontainers are supported via `@ParameterizedTest @MethodSource("enableDialects")`.

--- a/examples/tenant-aggregator/build.gradle.kts
+++ b/examples/tenant-aggregator/build.gradle.kts
@@ -1,0 +1,37 @@
+plugins {
+    application
+}
+
+application {
+    mainClass.set("io.bluetape4k.leader.examples.tenant.TenantAggregatorDemo")
+}
+
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencies {
+    implementation(project(":leader-exposed-r2dbc"))
+
+    implementation(libs.exposed.core)
+    implementation(libs.exposed.r2dbc)
+
+    // R2DBC drivers (compileOnly — 사용자가 선택, demo 는 H2 사용)
+    compileOnly(libs.r2dbc.postgresql)
+
+    runtimeOnly(libs.r2dbc.h2)
+    runtimeOnly(libs.h2.v2)
+
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.bluetape4k.exposed.r2dbc.tests)
+    testImplementation(libs.kotlinx.coroutines.test)
+
+    testImplementation(libs.r2dbc.postgresql)
+    testImplementation(libs.r2dbc.h2)
+
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.junit.jupiter)
+    testImplementation(libs.testcontainers.postgresql)
+    testImplementation(libs.postgresql)
+}

--- a/examples/tenant-aggregator/src/main/kotlin/io/bluetape4k/leader/examples/tenant/TenantAggregator.kt
+++ b/examples/tenant-aggregator/src/main/kotlin/io/bluetape4k/leader/examples/tenant/TenantAggregator.kt
@@ -1,0 +1,198 @@
+package io.bluetape4k.leader.examples.tenant
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * 테넌트별 독립 leader-election 으로 멀티테넌트 집계를 수행하는 long-running 워커.
+ *
+ * ## 동작/계약
+ *
+ * - 다중 인스턴스 환경에서 동일 [TenantAggregatorOptions.lockNamePrefix] / [TenantAggregatorOptions.tenants] 를
+ *   공유하는 N 개 인스턴스가 [start] 를 호출하면, **각 테넌트마다 정확히 1 인스턴스의 코루틴만**
+ *   `aggregateFunction` 을 polling 한다.
+ * - 락 이름은 `"${lockNamePrefix}-${tenantId}"` 으로 조립된다 (테넌트 단위 독립).
+ * - 각 테넌트는 [start] 시점에 [electorFactory] 로 elector 를 1회 생성하고, 사이클마다 동일 elector 의
+ *   `runIfLeader(lockName)` 를 재호출하여 `aggregateFunction` 을 실행한다 (elector 재생성 비용 회피).
+ * - `aggregateFunction` 예외는 격리되어 다음 사이클은 계속 실행된다 (poison 방지).
+ * - [CancellationException] 은 모든 catch 에서 즉시 re-throw 한다.
+ *
+ * ### LeaderGroup 미사용 이유
+ *
+ * `LeaderGroupElector` 는 단일 lockName 의 maxLeaders 슬롯을 공유하므로
+ * "테넌트 T 가 어느 슬롯에 배정될지" 를 호출자가 제어할 수 없다. 본 집계기는
+ * **테넌트별 독립 lockName** 으로 leader-election 을 수행한다 (E4 cache-warmer 와 동일 결정).
+ *
+ * ### Graceful Stop
+ *
+ * [stopGracefully] 는 모든 테넌트 코루틴을 cancel 하고 timeout 안에 join 한다.
+ * 진행 중인 `aggregateFunction` 호출은 [CancellationException] 으로 인터럽트되며,
+ * `runIfLeader` 가 보유한 락은 elector 가 finally 블록에서 자동 해제한다 (lease 만료 후 차순위 인수).
+ *
+ * ```kotlin
+ * val aggregator = TenantAggregator(
+ *     electorFactory = { _, options -> ExposedR2DbcSuspendLeaderElector(db, /* ... */ options) },
+ *     options = TenantAggregatorOptions(
+ *         nodeId = "node-A",
+ *         lockNamePrefix = "tenant-aggregator:metrics",
+ *         tenants = listOf("tenant-A", "tenant-B", "tenant-C"),
+ *     ),
+ *     aggregateFunction = { tenantId -> metricsService.aggregate(tenantId) },
+ * )
+ * val job = aggregator.start(applicationScope)
+ * // ... shutdown ...
+ * aggregator.stopGracefully()
+ * ```
+ *
+ * @param electorFactory 락 이름 + 옵션을 받아 [SuspendLeaderElector] 를 생성하는 suspend 팩토리.
+ *                       Exposed R2DBC / Mongo / Redis 등 백엔드 교체 가능 + 테스트 fake 주입.
+ * @param options 집계기 동작 설정
+ * @param aggregateFunction 테넌트별 polling 콜백. 예외는 격리되어 다음 사이클로 진행.
+ */
+class TenantAggregator(
+    private val electorFactory: suspend (lockName: String, options: LeaderElectionOptions) -> SuspendLeaderElector,
+    val options: TenantAggregatorOptions,
+    private val aggregateFunction: suspend (tenantId: String) -> Unit,
+) {
+
+    companion object: KLogging()
+
+    /**
+     * [start] / [stopGracefully] 의 동시 호출을 직렬화하기 위한 락.
+     *
+     * 가상 스레드 환경에서도 안전하도록 `synchronized` 가 아닌 [ReentrantLock] 을 사용한다.
+     * (워크스페이스 정책: `@Synchronized` / `synchronized {}` 사용 금지).
+     */
+    private val lifecycleLock = ReentrantLock()
+
+    @Volatile
+    private var rootJob: Job? = null
+
+    /**
+     * 모든 [TenantAggregatorOptions.tenants] 에 대해 별도 child coroutine 을 launch 하여 polling 시작.
+     *
+     * - 동일 인스턴스에서 두 번 호출 금지 (이미 실행 중이면 [IllegalStateException]).
+     *   여러 호출자가 거의 동시에 호출해도 [lifecycleLock] 으로 직렬화되어 단 하나의 호출만 성공한다 (thread-safe).
+     * - [scope] 가 cancel 되면 모든 테넌트 코루틴이 자동 종료.
+     * - 한 테넌트 코루틴의 예외는 다른 테넌트 코루틴에 영향을 주지 않는다 ([supervisorScope] 사용).
+     */
+    fun start(scope: CoroutineScope): Job = lifecycleLock.withLock {
+        check(rootJob == null || rootJob?.isActive != true) {
+            "TenantAggregator(nodeId=${options.nodeId}) is already running"
+        }
+        val job = scope.launch {
+            try {
+                supervisorScope {
+                    options.tenants.forEach { tenantId ->
+                        launch { tenantLoop(tenantId) }
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log.warn(e) { "[${options.nodeId}] tenant aggregator root terminated unexpectedly" }
+                throw e
+            }
+        }
+        rootJob = job
+        job
+    }
+
+    /**
+     * 모든 테넌트 polling 을 정상 종료한다. [timeout] 안에 종료되지 않으면 강제 cancel 후 반환.
+     *
+     * [start] 와 동일한 [lifecycleLock] 으로 보호되어 동시 호출에도 안전하다.
+     */
+    suspend fun stopGracefully(timeout: Duration = 30.seconds) {
+        val job = lifecycleLock.withLock { rootJob } ?: return
+        try {
+            withTimeoutOrNull(timeout) { job.cancelAndJoin() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "[${options.nodeId}] stopGracefully encountered error" }
+        } finally {
+            lifecycleLock.withLock {
+                if (rootJob === job) rootJob = null
+            }
+        }
+    }
+
+    /**
+     * 단일 테넌트 polling 루프.
+     *
+     * 1. [start] 시점에 elector 1회 생성 — 매 사이클 재생성 시 schema-init 등 무거운 작업 반복 방지.
+     * 2. `runIfLeader(lockName)` 로 본 인스턴스가 리더면 [aggregateFunction] 실행, 아니면 null.
+     * 3. 사이클 종료 후 [TenantAggregatorOptions.pollInterval] 만큼 대기.
+     */
+    private suspend fun tenantLoop(tenantId: String) {
+        val lockName = "${options.lockNamePrefix}-$tenantId"
+        val electionOptions = LeaderElectionOptions(
+            waitTime = options.waitTime,
+            leaseTime = options.leaseTime,
+            nodeId = options.nodeId,
+        )
+
+        val elector: SuspendLeaderElector = try {
+            electorFactory(lockName, electionOptions)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "[${options.nodeId}] tenant=$tenantId elector 생성 실패 — 루프 종료" }
+            return
+        }
+
+        log.info { "[${options.nodeId}] tenant=$tenantId polling 시작 (lockName=$lockName)" }
+
+        while (currentCoroutineContext().isActive) {
+            try {
+                val ran = elector.runIfLeader(lockName) {
+                    log.debug { "[${options.nodeId}] tenant=$tenantId 리더 선출 — aggregate 실행" }
+                    runAggregate(tenantId)
+                }
+                if (ran == null) {
+                    log.debug { "[${options.nodeId}] tenant=$tenantId 비리더 — 다음 사이클 대기" }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // runIfLeader 자체 예외 (백엔드 장애 등) — 다음 사이클 재시도
+                log.warn(e) { "[${options.nodeId}] tenant=$tenantId 리더 선출 사이클 예외 — 다음 사이클 재시도" }
+            }
+            delay(options.pollInterval)
+        }
+
+        log.info { "[${options.nodeId}] tenant=$tenantId polling 종료" }
+    }
+
+    /**
+     * `aggregateFunction` 실행 — 예외 격리 (poison 방지).
+     */
+    private suspend fun runAggregate(tenantId: String) {
+        try {
+            aggregateFunction(tenantId)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "[${options.nodeId}] tenant=$tenantId aggregate 예외 격리 — 다음 사이클 계속" }
+        }
+    }
+}

--- a/examples/tenant-aggregator/src/main/kotlin/io/bluetape4k/leader/examples/tenant/TenantAggregatorDemo.kt
+++ b/examples/tenant-aggregator/src/main/kotlin/io/bluetape4k/leader/examples/tenant/TenantAggregatorDemo.kt
@@ -1,0 +1,100 @@
+package io.bluetape4k.leader.examples.tenant
+
+import io.bluetape4k.leader.exposed.r2dbc.ExposedR2DbcSuspendLeaderElector
+import io.bluetape4k.leader.exposed.r2dbc.ExposedR2dbcLeaderElectionOptions
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
+
+/**
+ * 3 인스턴스 × 3 테넌트 멀티테넌트 집계 데모.
+ *
+ * H2 in-memory R2DBC 데이터베이스를 공유하며 3개의 [TenantAggregator] 인스턴스가 동일한
+ * `lockNamePrefix` + `tenants` 를 polling 한다. 각 테넌트마다 정확히 1 인스턴스만 집계 실행되는지
+ * `ConcurrentHashMap` 카운트로 검증한다.
+ */
+object TenantAggregatorDemo: KLogging() {
+
+    private const val DEMO_LOCK_PREFIX = "tenant-aggregator:demo"
+    private val DEMO_TENANTS = listOf("tenant-A", "tenant-B", "tenant-C")
+    private const val DEMO_INSTANCE_COUNT = 3
+    private const val DEMO_DURATION_SECONDS = 6L
+
+    @JvmStatic
+    fun main(args: Array<String>): Unit = runBlocking {
+        // 모든 인스턴스가 공유하는 H2 in-memory database (동일 URL 로 같은 DB 참조)
+        val r2dbcUrl = "r2dbc:h2:mem:///tenant_aggregator_demo;MODE=MySQL;DB_CLOSE_DELAY=-1"
+        val db = R2dbcDatabase.connect(r2dbcUrl, user = "", password = "")
+
+        val aggregateCounts = ConcurrentHashMap<String, AtomicInteger>()
+        DEMO_TENANTS.forEach { aggregateCounts[it] = AtomicInteger(0) }
+
+        // tenant 별 동시 실행 인스턴스 수를 추적 (1을 초과하면 격리 실패)
+        val concurrentRunners = ConcurrentHashMap<String, AtomicInteger>()
+        DEMO_TENANTS.forEach { concurrentRunners[it] = AtomicInteger(0) }
+        val violations = AtomicInteger(0)
+
+        log.info { "=== 멀티테넌트 집계 데모 시작 ===" }
+        log.info { "$DEMO_INSTANCE_COUNT 인스턴스 × ${DEMO_TENANTS.size} 테넌트, ${DEMO_DURATION_SECONDS}s 동안 polling" }
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val aggregators = (1..DEMO_INSTANCE_COUNT).map { idx ->
+            val nodeId = "node-$idx"
+            TenantAggregator(
+                electorFactory = { _, options ->
+                    ExposedR2DbcSuspendLeaderElector(
+                        db,
+                        ExposedR2dbcLeaderElectionOptions(leaderOptions = options),
+                    )
+                },
+                options = TenantAggregatorOptions(
+                    nodeId = nodeId,
+                    lockNamePrefix = DEMO_LOCK_PREFIX,
+                    tenants = DEMO_TENANTS,
+                    pollInterval = 300.milliseconds,
+                    waitTime = 200.milliseconds,
+                    leaseTime = 5.seconds,
+                ),
+                aggregateFunction = { tenantId ->
+                    val now = concurrentRunners.getValue(tenantId).incrementAndGet()
+                    if (now > 1) {
+                        violations.incrementAndGet()
+                        log.warn { "[$nodeId] tenant=$tenantId 동시 실행 위반 (concurrent=$now)" }
+                    }
+                    try {
+                        aggregateCounts.getValue(tenantId).incrementAndGet()
+                        log.info { "[$nodeId] tenant=$tenantId 집계 실행" }
+                        delay(150.milliseconds)
+                    } finally {
+                        concurrentRunners.getValue(tenantId).decrementAndGet()
+                    }
+                },
+            )
+        }
+
+        try {
+            aggregators.forEach { it.start(scope) }
+            delay(DEMO_DURATION_SECONDS.seconds)
+        } finally {
+            aggregators.forEach { it.stopGracefully(2.seconds) }
+            scope.coroutineContext[kotlinx.coroutines.Job]?.cancelAndJoin()
+        }
+
+        log.info { "=== 결과 ===" }
+        DEMO_TENANTS.forEach { tenantId ->
+            log.info { "tenant=$tenantId 집계 호출 횟수=${aggregateCounts.getValue(tenantId).get()}" }
+        }
+        log.info { "동시 실행 위반 횟수=${violations.get()} (기대값=0)" }
+    }
+}

--- a/examples/tenant-aggregator/src/main/kotlin/io/bluetape4k/leader/examples/tenant/TenantAggregatorOptions.kt
+++ b/examples/tenant-aggregator/src/main/kotlin/io/bluetape4k/leader/examples/tenant/TenantAggregatorOptions.kt
@@ -1,0 +1,61 @@
+package io.bluetape4k.leader.examples.tenant
+
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requireNotEmpty
+import io.bluetape4k.support.requirePositiveNumber
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * [TenantAggregator] 설정.
+ *
+ * ## 동작/계약
+ *
+ * - [nodeId]: 본 집계 인스턴스 식별자. 로그/락 owner 기록 용도.
+ * - [lockNamePrefix]: 테넌트별 분산 락 이름 prefix. 실제 락 이름은
+ *   `"${lockNamePrefix}-${tenantId}"` 로 조립된다 (테넌트 단위 독립 leader-election).
+ * - [tenants]: 집계 대상 테넌트 식별자 목록. 각 테넌트는 서로 독립적으로 leader-election 수행.
+ *   - 빈 목록 금지
+ *   - blank 항목 금지
+ *   - 중복 항목 허용 (호출자 책임 — 같은 락에 두 번 시도해도 두 번째는 미선출)
+ * - [pollInterval]: 사이클 간 휴지 시간. 리더 action 종료 후 다음 사이클까지의 대기,
+ *   비리더가 락 미획득 후 재시도 전 대기에도 동일하게 적용된다.
+ * - [waitTime]: 테넌트별 leader 락 획득 대기 시간. 짧게 설정하면 비리더가 빠르게 skip.
+ * - [leaseTime]: 테넌트별 leader lease (락 TTL). aggregate 평균 실행 시간 + 안전 여유 (예: 2배) 권장.
+ *
+ * ### LeaderGroup 미사용 이유
+ *
+ * `LeaderGroupElector` 는 단일 lockName 의 maxLeaders 슬롯을 공유하므로
+ * 어느 테넌트가 어느 슬롯에 배정될지 호출자가 제어하지 못한다. 본 집계기는
+ * **테넌트별 독립 lockName** 으로 leader-election 을 수행하여
+ * "테넌트 T 에 대해서는 정확히 1 인스턴스만 집계 코루틴 실행" 계약을 직접 만족시킨다 (E4 cache-warmer 와 동일).
+ *
+ * ```kotlin
+ * TenantAggregatorOptions(
+ *     nodeId = System.getenv("HOSTNAME") ?: "node-local",
+ *     lockNamePrefix = "tenant-aggregator:metrics",
+ *     tenants = listOf("tenant-A", "tenant-B", "tenant-C"),
+ *     pollInterval = 5.seconds,
+ *     waitTime = 1.seconds,
+ *     leaseTime = 60.seconds,
+ * )
+ * ```
+ */
+data class TenantAggregatorOptions(
+    val nodeId: String,
+    val tenants: List<String>,
+    val lockNamePrefix: String = "tenant-aggregator",
+    val pollInterval: Duration = 5.seconds,
+    val waitTime: Duration = 1.seconds,
+    val leaseTime: Duration = 60.seconds,
+) {
+    init {
+        nodeId.requireNotBlank("nodeId")
+        lockNamePrefix.requireNotBlank("lockNamePrefix")
+        tenants.requireNotEmpty("tenants")
+        tenants.forEachIndexed { idx, t -> t.requireNotBlank("tenants[$idx]") }
+        pollInterval.inWholeMilliseconds.requirePositiveNumber("pollInterval")
+        waitTime.inWholeMilliseconds.requirePositiveNumber("waitTime")
+        leaseTime.inWholeMilliseconds.requirePositiveNumber("leaseTime")
+    }
+}

--- a/examples/tenant-aggregator/src/test/kotlin/io/bluetape4k/leader/examples/tenant/AbstractTenantAggregatorTest.kt
+++ b/examples/tenant-aggregator/src/test/kotlin/io/bluetape4k/leader/examples/tenant/AbstractTenantAggregatorTest.kt
@@ -1,0 +1,115 @@
+package io.bluetape4k.leader.examples.tenant
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.exposed.r2dbc.ExposedR2DbcSuspendLeaderElector
+import io.bluetape4k.leader.exposed.r2dbc.ExposedR2dbcLeaderElectionOptions
+import io.bluetape4k.leader.exposed.tables.LeaderGroupLockTable
+import io.bluetape4k.leader.exposed.tables.LeaderLockHistoryTable
+import io.bluetape4k.leader.exposed.tables.LeaderLockTable
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.database.PostgreSQLServer
+import kotlin.time.Duration.Companion.seconds
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
+import org.jetbrains.exposed.v1.r2dbc.deleteAll
+import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
+import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * tenant-aggregator 멀티 DB 테스트의 공통 베이스.
+ *
+ * H2 / PostgreSQL 두 가지 DB 를 대상으로 파라미터화 테스트를 실행한다.
+ * `LEADER_TEST_DB` 환경 변수로 단일 DB 를 강제할 수 있다 (CI 에서 H2 만 실행 등).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractTenantAggregatorTest {
+
+    companion object: KLogging() {
+
+        private val postgreSQLServer: PostgreSQLServer by lazy {
+            PostgreSQLServer.Launcher.postgres
+        }
+
+        private val dbCache = ConcurrentHashMap<TestTenantDB, R2dbcDatabase>()
+
+        /**
+         * `LEADER_TEST_DB` 환경 변수로 단일 DB 선택. 미설정 시 H2 + PostgreSQL.
+         * 허용 값: `H2`, `POSTGRESQL` (또는 `POSTGRES`).
+         */
+        @JvmStatic
+        fun enableDialects(): List<TestTenantDB> {
+            val filter = System.getenv("LEADER_TEST_DB")?.uppercase()
+                ?: return listOf(TestTenantDB.H2, TestTenantDB.POSTGRESQL)
+            return when (filter) {
+                "H2" -> listOf(TestTenantDB.H2)
+                "POSTGRESQL", "POSTGRES" -> listOf(TestTenantDB.POSTGRESQL)
+                "MYSQL_V8", "MYSQL" -> listOf(TestTenantDB.H2)  // 본 모듈은 MySQL 미지원 — H2 로 대체
+                else -> listOf(TestTenantDB.H2, TestTenantDB.POSTGRESQL)
+            }
+        }
+
+        fun r2dbcUrl(testDB: TestTenantDB): String = when (testDB) {
+            TestTenantDB.H2 -> "r2dbc:h2:mem:///tenant_${Base58.randomString(6)};MODE=MySQL;DB_CLOSE_DELAY=-1"
+            TestTenantDB.POSTGRESQL -> {
+                val c = postgreSQLServer
+                "r2dbc:postgresql://${c.host}:${c.getMappedPort(5432)}/${c.databaseName}"
+            }
+        }
+
+        fun r2dbcCredentials(testDB: TestTenantDB): Pair<String?, String?> = when (testDB) {
+            TestTenantDB.H2 -> "" to ""
+            TestTenantDB.POSTGRESQL -> postgreSQLServer.username to postgreSQLServer.password
+        }
+    }
+
+    /**
+     * testDB 에 대한 R2DBC 연결. PostgreSQL 은 캐시 재사용, H2 는 매번 새 in-memory DB
+     * (테스트 격리를 위해).
+     */
+    protected fun connectDb(testDB: TestTenantDB): R2dbcDatabase = when (testDB) {
+        TestTenantDB.H2 -> {
+            val url = r2dbcUrl(testDB)
+            val (user, password) = r2dbcCredentials(testDB)
+            R2dbcDatabase.connect(url, user = user ?: "", password = password ?: "")
+        }
+        TestTenantDB.POSTGRESQL -> dbCache.getOrPut(testDB) {
+            val url = r2dbcUrl(testDB)
+            val (user, password) = r2dbcCredentials(testDB)
+            R2dbcDatabase.connect(url, user = user ?: "", password = password ?: "")
+        }
+    }
+
+    protected fun setupDb(testDB: TestTenantDB): R2dbcDatabase = connectDb(testDB).also { db ->
+        // ExposedR2dbcSchemaInitializer 는 internal — companion invoke 가 ensureSchema 를 호출하므로
+        // throwaway elector 를 한 번 만들어 스키마 보장
+        runSuspendIO {
+            ExposedR2DbcSuspendLeaderElector(
+                db,
+                ExposedR2dbcLeaderElectionOptions(
+                    leaderOptions = LeaderElectionOptions(
+                        waitTime = 1.seconds,
+                        leaseTime = 5.seconds,
+                    ),
+                ),
+            )
+        }
+    }
+
+    protected suspend fun cleanTables(db: R2dbcDatabase) {
+        suspendTransaction(db) {
+            LeaderLockHistoryTable.deleteAll()
+            LeaderLockTable.deleteAll()
+            LeaderGroupLockTable.deleteAll()
+        }
+    }
+
+    protected fun randomPrefix(): String = "tenant-test-${Base58.randomString(8)}"
+}
+
+/** 테스트 대상 R2DBC DB 종류 (tenant-aggregator 는 H2 + PostgreSQL 만 지원). */
+enum class TestTenantDB {
+    H2,
+    POSTGRESQL,
+}

--- a/examples/tenant-aggregator/src/test/kotlin/io/bluetape4k/leader/examples/tenant/TenantAggregatorTest.kt
+++ b/examples/tenant-aggregator/src/test/kotlin/io/bluetape4k/leader/examples/tenant/TenantAggregatorTest.kt
@@ -1,0 +1,379 @@
+package io.bluetape4k.leader.examples.tenant
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.leader.exposed.r2dbc.ExposedR2DbcSuspendLeaderElector
+import io.bluetape4k.leader.exposed.r2dbc.ExposedR2dbcLeaderElectionOptions
+import io.bluetape4k.logging.KLogging
+import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+/**
+ * [TenantAggregator] 통합 테스트 — Exposed R2DBC + H2/PostgreSQL Testcontainers 기반.
+ */
+class TenantAggregatorTest: AbstractTenantAggregatorTest() {
+
+    companion object: KLogging() {
+        private val DEFAULT_TENANTS = listOf("tenant-A", "tenant-B", "tenant-C")
+        private val INSTANCE_TIMEOUT = 30.seconds
+    }
+
+    private fun fastOptions(
+        nodeId: String,
+        lockNamePrefix: String,
+        tenants: List<String> = DEFAULT_TENANTS,
+        pollInterval: Duration = 100.milliseconds,
+        waitTime: Duration = 200.milliseconds,
+        leaseTime: Duration = 5.seconds,
+    ) = TenantAggregatorOptions(
+        nodeId = nodeId,
+        lockNamePrefix = lockNamePrefix,
+        tenants = tenants,
+        pollInterval = pollInterval,
+        waitTime = waitTime,
+        leaseTime = leaseTime,
+    )
+
+    private fun electorFactory(
+        db: R2dbcDatabase,
+    ): suspend (String, LeaderElectionOptions) -> SuspendLeaderElector = { _, options ->
+        ExposedR2DbcSuspendLeaderElector(
+            db,
+            ExposedR2dbcLeaderElectionOptions(leaderOptions = options),
+        )
+    }
+
+    private suspend fun waitUntil(
+        timeout: Duration = 10.seconds,
+        condition: suspend () -> Boolean,
+    ): Boolean {
+        val deadline = System.currentTimeMillis() + timeout.inWholeMilliseconds
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return true
+            delay(50.milliseconds)
+        }
+        return false
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    fun `단일 인스턴스 - 모든 테넌트가 polling 시작`(testDB: TestTenantDB) = runSuspendIO {
+        val db = setupDb(testDB)
+        cleanTables(db)
+        val lockPrefix = randomPrefix()
+
+        val seen = ConcurrentHashMap.newKeySet<String>()
+        val aggregator = TenantAggregator(
+            electorFactory = electorFactory(db),
+            options = fastOptions("solo", lockPrefix),
+            aggregateFunction = { tenantId -> seen.add(tenantId) },
+        )
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            aggregator.start(scope)
+            val ok = waitUntil(INSTANCE_TIMEOUT) { seen.size == DEFAULT_TENANTS.size }
+            ok.shouldBeTrue()
+            DEFAULT_TENANTS.forEach { seen.contains(it).shouldBeTrue() }
+        } finally {
+            aggregator.stopGracefully(2.seconds)
+            scope.coroutineContext[kotlinx.coroutines.Job]?.cancelAndJoin()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    @Timeout(value = 90, unit = TimeUnit.SECONDS)
+    fun `3 인스턴스 동시 - 각 테넌트는 정확히 1 인스턴스만 polling`(testDB: TestTenantDB) = runSuspendIO {
+        val db = setupDb(testDB)
+        cleanTables(db)
+        val lockPrefix = randomPrefix()
+
+        // 각 tenant 의 동시 실행 인스턴스 수 추적 (1을 초과하면 위반)
+        val concurrentRunners = ConcurrentHashMap<String, AtomicInteger>()
+        DEFAULT_TENANTS.forEach { concurrentRunners[it] = AtomicInteger(0) }
+        val aggregateCounts = ConcurrentHashMap<String, AtomicInteger>()
+        DEFAULT_TENANTS.forEach { aggregateCounts[it] = AtomicInteger(0) }
+        val violations = AtomicInteger(0)
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val aggregators = (1..3).map { idx ->
+            TenantAggregator(
+                electorFactory = electorFactory(db),
+                options = fastOptions("node-$idx", lockPrefix, leaseTime = 3.seconds),
+                aggregateFunction = { tenantId ->
+                    val now = concurrentRunners.getValue(tenantId).incrementAndGet()
+                    if (now > 1) violations.incrementAndGet()
+                    try {
+                        aggregateCounts.getValue(tenantId).incrementAndGet()
+                        delay(150.milliseconds)
+                    } finally {
+                        concurrentRunners.getValue(tenantId).decrementAndGet()
+                    }
+                },
+            )
+        }
+
+        try {
+            aggregators.forEach { it.start(scope) }
+            // 모든 테넌트가 최소 1번 이상 집계되도록 기다림
+            val ok = waitUntil(INSTANCE_TIMEOUT) {
+                DEFAULT_TENANTS.all { aggregateCounts.getValue(it).get() >= 1 }
+            }
+            ok.shouldBeTrue()
+            // 추가 사이클 — 위반이 있다면 발생할 시간 확보
+            delay(2.seconds)
+
+            // 동시 실행 위반 0
+            violations.get() shouldBeEqualTo 0
+            DEFAULT_TENANTS.forEach { aggregateCounts.getValue(it).get() shouldBeGreaterOrEqualTo 1 }
+        } finally {
+            aggregators.forEach { it.stopGracefully(2.seconds) }
+            scope.coroutineContext[kotlinx.coroutines.Job]?.cancelAndJoin()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    fun `aggregate 함수 예외 - 다음 사이클은 계속 실행`(testDB: TestTenantDB) = runSuspendIO {
+        val db = setupDb(testDB)
+        cleanTables(db)
+        val lockPrefix = randomPrefix()
+        val tenantId = "tenant-X"
+
+        val callCount = AtomicInteger(0)
+        val firstFailed = CompletableDeferred<Unit>()
+        val secondSucceeded = CompletableDeferred<Unit>()
+
+        val aggregator = TenantAggregator(
+            electorFactory = electorFactory(db),
+            options = fastOptions("retry-node", lockPrefix, tenants = listOf(tenantId)),
+            aggregateFunction = { _ ->
+                val n = callCount.incrementAndGet()
+                if (n == 1) {
+                    firstFailed.complete(Unit)
+                    throw IllegalStateException("first cycle fails")
+                }
+                if (n >= 2 && !secondSucceeded.isCompleted) secondSucceeded.complete(Unit)
+            },
+        )
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            aggregator.start(scope)
+            withTimeoutOrNull(INSTANCE_TIMEOUT) { firstFailed.await() }?.let { } ?: error("first cycle did not run")
+            withTimeoutOrNull(INSTANCE_TIMEOUT) { secondSucceeded.await() }?.let { } ?: error("second cycle did not run")
+            callCount.get() shouldBeGreaterOrEqualTo 2
+        } finally {
+            aggregator.stopGracefully(2.seconds)
+            scope.coroutineContext[kotlinx.coroutines.Job]?.cancelAndJoin()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    @Timeout(value = 90, unit = TimeUnit.SECONDS)
+    fun `리더 stop - 차순위 인스턴스가 인계하여 polling 계속`(testDB: TestTenantDB) = runSuspendIO {
+        val db = setupDb(testDB)
+        cleanTables(db)
+        val lockPrefix = randomPrefix()
+        val tenantId = "tenant-handover"
+
+        val countsByNode = ConcurrentHashMap<String, AtomicInteger>()
+        countsByNode["node-A"] = AtomicInteger(0)
+        countsByNode["node-B"] = AtomicInteger(0)
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val aggA = TenantAggregator(
+            electorFactory = electorFactory(db),
+            options = fastOptions("node-A", lockPrefix, tenants = listOf(tenantId), leaseTime = 2.seconds),
+            aggregateFunction = { _ -> countsByNode.getValue("node-A").incrementAndGet() },
+        )
+        val aggB = TenantAggregator(
+            electorFactory = electorFactory(db),
+            options = fastOptions("node-B", lockPrefix, tenants = listOf(tenantId), leaseTime = 2.seconds),
+            aggregateFunction = { _ -> countsByNode.getValue("node-B").incrementAndGet() },
+        )
+
+        try {
+            // node-A 를 먼저 시작하여 초기 리더로 선점 확보
+            aggA.start(scope)
+            // node-A 가 최소 1번 leader 로 aggregate 를 실행할 때까지 대기.
+            // 이 단계가 timeout 되면 handover 검증 자체가 의미 없으므로 명시적으로 assert.
+            val nodeAReady = waitUntil(INSTANCE_TIMEOUT) {
+                countsByNode.getValue("node-A").get() >= 1
+            }
+            nodeAReady.shouldBeTrue()
+
+            // 이후에 node-B 시작 — node-A 가 lock 보유 중이므로 대기 상태.
+            aggB.start(scope)
+
+            val countAtStop = countsByNode.getValue("node-A").get()
+            aggA.stopGracefully(2.seconds)
+
+            // 차순위 인계 — node-B 가 lease 만료 후 락 획득
+            val ok = waitUntil(INSTANCE_TIMEOUT) { countsByNode.getValue("node-B").get() >= 1 }
+            ok.shouldBeTrue()
+            // node-A 는 stop 이후 더 이상 증가하면 안 됨 (관대하게 +1 정도 허용 — 사이클 race)
+            (countsByNode.getValue("node-A").get() <= countAtStop + 1).shouldBeTrue()
+        } finally {
+            aggB.stopGracefully(2.seconds)
+            scope.coroutineContext[kotlinx.coroutines.Job]?.cancelAndJoin()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    fun `start 후 cancelAndJoin - CancellationException 재throw 로 정상 종료`(testDB: TestTenantDB) = runSuspendIO {
+        val db = setupDb(testDB)
+        cleanTables(db)
+        val lockPrefix = randomPrefix()
+
+        val aggregator = TenantAggregator(
+            electorFactory = electorFactory(db),
+            options = fastOptions("node-cancel", lockPrefix, tenants = listOf("only")),
+            aggregateFunction = { delay(50.milliseconds) },
+        )
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val job = aggregator.start(scope)
+        delay(300.milliseconds)
+        job.cancelAndJoin()
+        job.isCancelled.shouldBeTrue()
+        // CancellationException 이 정상 전파되어 join 후 회수되었는지 확인
+        job.isCompleted.shouldBeTrue()
+    }
+
+    @Test
+    fun `blank nodeId - IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            TenantAggregatorOptions(nodeId = "  ", tenants = DEFAULT_TENANTS)
+        }
+    }
+
+    @Test
+    fun `blank lockNamePrefix - IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            TenantAggregatorOptions(nodeId = "ok", tenants = DEFAULT_TENANTS, lockNamePrefix = "")
+        }
+    }
+
+    @Test
+    fun `tenants 빈 목록 - IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            TenantAggregatorOptions(nodeId = "ok", tenants = emptyList())
+        }
+    }
+
+    @Test
+    fun `tenants 항목 blank - IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            TenantAggregatorOptions(nodeId = "ok", tenants = listOf("ok-1", " ", "ok-2"))
+        }
+    }
+
+    @Test
+    fun `start 두번 호출 - IllegalStateException`(): Unit = runBlocking {
+        // factory 를 영원히 suspend 시켜 첫 번째 start 의 tenantLoop 가 elector 생성 단계에서 멈추도록 한다.
+        // 이렇게 하면 factory throw / loop 종료로 인한 race 없이 두 번째 start 호출을 동기적으로 검증할 수 있다.
+        val blockingFactory: suspend (String, LeaderElectionOptions) -> SuspendLeaderElector = { _, _ ->
+            awaitCancellation()
+        }
+        val aggregator = TenantAggregator(
+            electorFactory = blockingFactory,
+            options = TenantAggregatorOptions(
+                nodeId = "n",
+                tenants = listOf("t"),
+                pollInterval = 100.milliseconds,
+                waitTime = 100.milliseconds,
+                leaseTime = 1.seconds,
+            ),
+            aggregateFunction = { },
+        )
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        try {
+            aggregator.start(scope)
+            assertFailsWith<IllegalStateException> { aggregator.start(scope) }
+        } finally {
+            aggregator.stopGracefully(2.seconds)
+            scope.coroutineContext[kotlinx.coroutines.Job]?.cancelAndJoin()
+        }
+    }
+
+    @Test
+    fun `start 동시 호출 - 정확히 하나만 성공하고 나머지는 IllegalStateException`(): Unit = runBlocking {
+        // P2-1 회귀 테스트: 두 개 이상의 호출자가 거의 동시에 start() 를 호출해도
+        // ReentrantLock 으로 직렬화되어 단 하나의 호출만 성공해야 한다.
+        repeat(20) { iteration ->
+            // factory 는 awaitCancellation 으로 무기한 suspend — start 후에도 root job 이 active 상태 유지
+            val blockingFactory: suspend (String, LeaderElectionOptions) -> SuspendLeaderElector = { _, _ ->
+                awaitCancellation()
+            }
+            val aggregator = TenantAggregator(
+                electorFactory = blockingFactory,
+                options = TenantAggregatorOptions(
+                    nodeId = "concurrent-$iteration",
+                    tenants = listOf("t"),
+                    pollInterval = 50.milliseconds,
+                    waitTime = 50.milliseconds,
+                    leaseTime = 1.seconds,
+                ),
+                aggregateFunction = { },
+            )
+            val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+            val gate = CompletableDeferred<Unit>()
+            val successCount = AtomicInteger(0)
+            val failureCount = AtomicInteger(0)
+            try {
+                val callerCount = 8
+                val callers = (1..callerCount).map {
+                    scope.launch {
+                        gate.await() // 동시 시작
+                        try {
+                            aggregator.start(scope)
+                            successCount.incrementAndGet()
+                        } catch (e: IllegalStateException) {
+                            failureCount.incrementAndGet()
+                        }
+                    }
+                }
+                gate.complete(Unit)
+                callers.forEach { it.join() }
+
+                // 정확히 하나의 호출만 성공해야 함
+                successCount.get() shouldBeEqualTo 1
+                failureCount.get() shouldBeEqualTo callerCount - 1
+            } finally {
+                aggregator.stopGracefully(2.seconds)
+                scope.coroutineContext[kotlinx.coroutines.Job]?.cancelAndJoin()
+            }
+        }
+    }
+}

--- a/examples/tenant-aggregator/src/test/resources/junit-platform.properties
+++ b/examples/tenant-aggregator/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/examples/tenant-aggregator/src/test/resources/logback-test.xml
+++ b/examples/tenant-aggregator/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%24.24t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+    <logger name="io.bluetape4k.leader.examples.tenant" level="DEBUG"/>
+    <logger name="io.bluetape4k.leader.exposed" level="INFO"/>
+    <logger name="org.testcontainers" level="WARN"/>
+    <logger name="org.jetbrains.exposed" level="WARN"/>
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+</configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,4 +28,5 @@ include(
     "examples:migration-gate",
     "examples:webhook-poller",
     "examples:cache-warmer",
+    "examples:tenant-aggregator",
 )


### PR DESCRIPTION
## Summary

Closes #158

PR #163의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat(examples): E5 멀티테넌트 집계 (Exposed-R2DBC) — closes #158`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 개요

Epic #36 의 E5 (마지막) — 멀티테넌트 환경에서 테넌트별 독립 리더 선출. 테넌트당 1개 집계 코루틴 동시 실행. Exposed-R2DBC 백엔드.

Closes #158
Refs #36

## API

```kotlin
val aggregator = TenantAggregator(
    electorFactory = { lockName, opts -> ExposedR2DbcSuspendLeaderElector(db, opts) },
    options = TenantAggregatorOptions(
        nodeId = HOSTNAME,
        lockNamePrefix = "tenant-aggregator",
        tenants = listOf("tenant-A", "tenant-B", "tenant-C"),
        pollInterval = 5.seconds,
        waitTime = 1.seconds,
        leaseTime = 60.seconds,
    ),
    aggregateFunction = { tenantId -> aggregateTenantData(tenantId) },
)

val job = aggregator.start(applicationScope)   // thread-safe
// graceful shutdown:
aggregator.stopGracefully(timeout = 30.seconds)
```

## 핵심 설계

- 테넌트별 독립 lockName (E4 와 동일 — LeaderGroup 미사용)
- `supervisorScope` + 테넌트마다 `launch` (한 테넌트 예외가 다른 테넌트 영향 X)
- 사용자 함수 예외 격리 + runIfLeader 자체 예외 격리 (poison 방지)
- start() thread-safe via `ReentrantLock` (워크스페이스 정책)
- stopGracefully via `withTimeoutOrNull(timeout) { rootJob.cancelAndJoin() }`

## 변경 사항

- `examples/tenant-aggregator/` 신규 모듈
- `settings.gradle.kts` + `.github/workflows/{ci,nightly}.yml`
- `docs/lessons/2026-05-10-e5-tenant-aggregator.md` (L1~L8)

## 테스트 결과

11 passing (H2 + PostgreSQL):
- 단일 인스턴스 → 모든 테넌트 polling 시작
- 3 인스턴스 동시 → 각 테넌트 정확히 1 인스턴스만 polling (분산)
- aggregate 함수 예외 → 다음 사이클 계속
- 리더 stop → 차순위 인스턴스 인계
- start 두 번 호출 → IllegalStateException
- start 동시 호출 → 정확히 1개만 성공 (P2-1 회귀 검증)
- start 후 cancelAndJoin → 정상 종료
- 옵션 검증 4종

## 코드 리뷰

- **code-reviewer agent** (Tier 4+5) 통과
- **Codex code review**: P2 2건 + P3 1건 반영
  - P2-1: start() race → `ReentrantLock` 으로 atomic check-and-set
  - P2-2: double-start 테스트 timing → `awaitCancellation` factory
  - P3-1: handover 테스트 → node-A leader 검증 추가

## Epic 완료

E1~E5 모두 머지 시 Epic #36 close.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #158, milestone `0.1.0`, assignee `debop`
- PR: #163, head `9de5203b87ddd8a53797a64f41d13434faf99103`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
