### PR TITLE
feat(leader-ktor): Ktor 3.x 통합 모듈 — closes #37

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       leader-hazelcast: ${{ steps.filter.outputs.leader-hazelcast }}
       leader-zookeeper: ${{ steps.filter.outputs.leader-zookeeper }}
       leader-spring-boot: ${{ steps.filter.outputs.leader-spring-boot }}
+      leader-ktor: ${{ steps.filter.outputs.leader-ktor }}
       leader-micrometer: ${{ steps.filter.outputs.leader-micrometer }}
       examples-batch-scheduler: ${{ steps.filter.outputs.examples-batch-scheduler }}
       examples-migration-gate: ${{ steps.filter.outputs.examples-migration-gate }}
@@ -116,6 +117,9 @@ jobs:
               - 'leader-zookeeper/**'
             leader-spring-boot:
               - 'leader-spring-boot/**'
+            leader-ktor:
+              - 'leader-ktor/**'
+              - 'leader-core/**'
             leader-micrometer:
               - 'leader-micrometer/**'
             examples-batch-scheduler:
@@ -753,6 +757,53 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 7
 
+  # ── leader-ktor 테스트 (Testcontainers: Redis) ─────────────────────────
+  test-leader-ktor:
+    name: Test / leader-ktor
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs['leader-ktor'] == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Test leader-ktor
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-ktor:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: '-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false'
+          TESTCONTAINERS_RYUK_DISABLED: 'true'
+          DOCKER_HOST: 'unix:///var/run/docker.sock'
+      - name: Generate Kover XML report
+        if: always()
+        run: ./gradlew :leader-ktor:koverXmlReport --no-daemon
+        continue-on-error: true
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-leader-ktor
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 7
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-leader-ktor
+          path: '**/build/reports/kover/'
+          retention-days: 7
+
   # ── leader-mongodb 테스트 (Testcontainers: MongoDB) ─────────────────────
   test-mongodb:
     name: Test / leader-mongodb
@@ -908,6 +959,7 @@ jobs:
       - test-exposed-jdbc-postgresql
       - test-exposed-jdbc-mysql
       - test-spring-boot
+      - test-leader-ktor
       - test-mongodb
       - test-hazelcast
       - test-zookeeper
@@ -957,6 +1009,7 @@ jobs:
       - test-exposed-jdbc-postgresql
       - test-exposed-jdbc-mysql
       - test-spring-boot
+      - test-leader-ktor
       - test-mongodb
       - test-hazelcast
       - test-zookeeper

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -873,6 +873,52 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
+  # ── leader-ktor (Testcontainers: Redis) ────────────────────────────────────
+  test-leader-ktor:
+    name: Test / leader-ktor (Testcontainers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Test leader-ktor
+        run: |
+          for attempt in 1 2 3; do
+            ./gradlew :leader-ktor:test --no-daemon && break
+            echo "Attempt $attempt failed"
+            [ $attempt -lt 3 ] && sleep 10 || exit 1
+          done
+        env:
+          GRADLE_OPTS: '-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false'
+          TESTCONTAINERS_RYUK_DISABLED: 'true'
+          DOCKER_HOST: 'unix:///var/run/docker.sock'
+      - name: Generate Kover XML report
+        if: always()
+        run: ./gradlew :leader-ktor:koverXmlReport --no-daemon
+        continue-on-error: true
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-leader-ktor
+          path: '**/build/test-results/test/*.xml'
+          retention-days: 14
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-leader-ktor
+          path: '**/build/reports/kover/'
+          retention-days: 14
+
   coverage-report:
     name: Coverage Report
     runs-on: ubuntu-latest
@@ -892,6 +938,7 @@ jobs:
       - test-zookeeper
       - test-micrometer
       - test-spring-boot
+      - test-leader-ktor
       - test-examples-batch-scheduler
       - test-examples-migration-gate
       - test-examples-webhook-poller
@@ -941,6 +988,7 @@ jobs:
       - test-zookeeper
       - test-micrometer
       - test-spring-boot
+      - test-leader-ktor
       - test-examples-batch-scheduler
       - test-examples-migration-gate
       - test-examples-webhook-poller

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`leader-ktor`**: Ktor 3.x 통합 모듈 (issue #37)
+  - `LeaderElectionPlugin` — `createApplicationPlugin` DSL, `SuspendLeaderElector` 기반
+  - `Application.leaderScheduled(lockName, period) { ... }` — Spring `@Scheduled` 스타일
+    리더 전용 주기 작업 헬퍼; `Application` 코루틴 스코프에서 launch 되어
+    `ApplicationStopped` 시 자동 취소, action 예외는 cycle 격리 후 다음 cycle 진행
+  - `Application.leaderElectionPluginConfig()` — 설치된 플러그인 설정 조회 확장
+  - Testcontainers Redis 기반 통합 테스트 (`testApplication` DSL + Redisson 백엔드)
+  - Ktor 버전: 3.4.3
 - **`leader-mongodb`**: MongoDB `findOneAndUpdate` + TTL index 기반 분산 락 백엔드 (issue #8, PR #46)
   - `MongoLock` — sync blocking, `findOneAndUpdate` upsert + `deleteOne(token)` 소유자 전용 해제
   - `MongoSuspendLock` — Kotlin coroutine driver 기반 suspend 분산 락

--- a/docs/lessons/2026-05-10-leader-ktor.md
+++ b/docs/lessons/2026-05-10-leader-ktor.md
@@ -1,0 +1,84 @@
+# Lessons Learned — leader-ktor 통합 모듈 (2026-05-10)
+
+**관련 PR**: TBD
+**관련 Issue**: #37
+**영향 모듈**: `leader-ktor/`, `leader-bom/`, `gradle/libs.versions.toml`, `.github/workflows/{ci,nightly}.yml`, `settings.gradle.kts`
+
+## L1: Ktor `createApplicationPlugin` 의 `pluginConfig` 노출 한계
+
+### 문제
+초기 spec 은 `Application.leaderScheduled(... plugin(LeaderElectionPlugin).pluginConfig.leaderElection!!)` 시그니처로 plugin config 직접 접근을 가정. 하지만 Ktor 의 `PluginInstance.builder` 가 `internal` — `pluginConfig` 는 `createApplicationPlugin { }` 블록 안에서만 접근 가능, 외부 호출자가 사용 불가.
+
+### 교훈
+**Application.attributes** 패턴 사용:
+
+```kotlin
+private val LeaderElectionConfigKey = AttributeKey<LeaderElectionPluginConfig>("leader-election-config")
+
+val LeaderElectionPlugin = createApplicationPlugin(...) {
+    val config = pluginConfig
+    requireNotNull(config.leaderElection) { "..." }
+    application.attributes.put(LeaderElectionConfigKey, config)
+    // ...
+}
+
+fun Application.leaderElectionPluginConfig(): LeaderElectionPluginConfig =
+    attributes.getOrNull(LeaderElectionConfigKey)
+        ?: error("LeaderElectionPlugin 미설치")
+```
+
+다른 Ktor plugin 작성 시 동일 패턴 적용 (외부 노출 필요한 설정).
+
+---
+
+## L2: `!!` 금지 (워크스페이스 규칙) — `requireNotNull` + `error()`
+
+### 교훈
+Ktor 예제 코드에 `!!` 흔히 등장하지만 워크스페이스 CLAUDE.md `!!` 절대 사용 금지. `requireNotNull(...)` 또는 `attributes.getOrNull(...) ?: error(...)` 사용.
+
+---
+
+## L3: Gradle build cache + Testcontainers — `--no-build-cache` 필요
+
+### 문제
+`./gradlew :leader-ktor:test --rerun` 후 재실행 시 Redis container 종료된 상태에서 첫 실패 → 그 이후 `cleanTest` + `test` 도 `FROM-CACHE` 로 통과 표시 (실제 실행 안 됨).
+
+### 교훈
+Testcontainers 기반 테스트의 fresh 검증 필요 시:
+```bash
+./gradlew :module:cleanTest :module:test --no-daemon --no-build-cache
+```
+
+`--no-build-cache` 빠지면 gradle 이 input/output 동일성 판단으로 cached 결과 반환.
+
+---
+
+## L4: testApplication { } DSL — `runSuspendIO` vs `runTest`
+
+### 문제
+Ktor `testApplication { ... }` 은 실제 코루틴 + 실시간 동작. `runTest` 의 가상 시간과 호환 안 됨.
+
+### 교훈
+Ktor 통합 테스트는:
+```kotlin
+@Test
+fun `xxx`() = runSuspendIO {
+    testApplication {
+        // ...
+    }
+}
+```
+
+또는 `runBlocking { ... }: Unit` (E3 lessons L5). `runTest` 는 사용 금지.
+
+---
+
+## L5: Ktor BOM 사용 + compileOnly 패턴
+
+### 교훈
+core 모듈에서 Ktor 의존성:
+- `compileOnly(libs.ktor.server.core)` — 사용자가 자체 Ktor 버전 선택 가능
+- `testImplementation` 으로 test 시 실제 의존성 주입
+- BOM (`io.ktor:ktor-bom`) import 로 모든 ktor-* artifact 버전 일관
+
+`gradle/libs.versions.toml` 에 ktor 버전 + 개별 library entry 추가.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,8 @@ curator = "5.9.0"  # https://mvnrepository.com/artifact/org.apache.curator/curat
 
 micrometer = "1.16.5"  # https://mvnrepository.com/artifact/io.micrometer/micrometer-bom
 
+ktor = "3.4.3"  # https://mvnrepository.com/artifact/io.ktor/ktor-bom
+
 slf4j = "2.0.17"  # https://mvnrepository.com/artifact/org.slf4j/slf4j-api
 logback = "1.5.32"  # https://mvnrepository.com/artifact/ch.qos.logback/logback-classic
 
@@ -187,3 +189,9 @@ testcontainers-mongodb = { module = "org.testcontainers:testcontainers-mongodb",
 testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql", version.ref = "testcontainers" }
 testcontainers-mysql = { module = "org.testcontainers:testcontainers-mysql", version.ref = "testcontainers" }
 testcontainers-toxiproxy = { module = "org.testcontainers:testcontainers-toxiproxy", version.ref = "testcontainers" }
+
+# Ktor
+ktor-bom = { module = "io.ktor:ktor-bom", version.ref = "ktor" }
+ktor-server-core = { module = "io.ktor:ktor-server-core" }
+ktor-server-cio = { module = "io.ktor:ktor-server-cio" }
+ktor-server-test-host = { module = "io.ktor:ktor-server-test-host" }

--- a/leader-bom/build.gradle.kts
+++ b/leader-bom/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
         api(project(":leader-hazelcast"))
         api(project(":leader-zookeeper"))
         api(project(":leader-spring-boot"))
+        api(project(":leader-ktor"))
         api(project(":leader-micrometer"))
     }
 }

--- a/leader-ktor/README.ko.md
+++ b/leader-ktor/README.ko.md
@@ -1,0 +1,124 @@
+# bluetape4k-leader-ktor
+
+한국어 | [English](./README.md)
+
+`bluetape4k-leader` 의 Ktor 3.x 통합 모듈입니다. Ktor 애플리케이션 플러그인 DSL 과
+Spring `@Scheduled` 스타일의 주기적 리더 전용 작업 헬퍼를 제공합니다.
+
+## Architecture
+
+`leader-ktor` 는 `leader-core` 위에 세 가지 통합 요소를 제공합니다:
+
+1. **`LeaderElectionPlugin`** — `createApplicationPlugin` DSL 로 정의된 플러그인.
+   `SuspendLeaderElector` (필요 시 `SuspendLeaderGroupElector`) 를 받아 `Application.attributes`
+   에 저장하여 확장 함수에서 재사용할 수 있게 합니다.
+2. **`leaderElectionPluginConfig()`** — `Application` 확장 함수. 저장된 설정을 조회합니다.
+3. **`Application.leaderScheduled(...)`** — 주기적으로 리더 전용 suspend 작업을 실행합니다.
+   `Application` 코루틴 스코프에서 `launch` 하여 `ApplicationStopped` 시 자동 취소됩니다.
+
+```mermaid
+sequenceDiagram
+    participant App as Application (Ktor)
+    participant Plugin as LeaderElectionPlugin
+    participant Helper as leaderScheduled
+    participant Elector as SuspendLeaderElector
+
+    App->>Plugin: install(LeaderElectionPlugin) { leaderElection = ... }
+    Plugin-->>App: attributes 에 설정 저장
+    App->>Helper: leaderScheduled("job", 1.minutes) { ... }
+    Helper-->>App: 백그라운드 Job launch
+    Note over Helper,Elector: 매 cycle 마다
+    Helper->>Elector: runIfLeader("job") { action() }
+    Elector-->>Helper: 결과 또는 null (skip)
+    Helper->>Helper: delay(period)
+    App->>Plugin: ApplicationStopped
+    Plugin-->>App: application scope 취소
+```
+
+## Core Features
+
+- Ktor 3.x 호환, coroutine-native (`SuspendLeaderElector` 기반)
+- `ApplicationStopped` 시 `Application` 코루틴 스코프가 자동 취소 처리
+- cycle 별 예외 격리 — `action` 예외는 로그만 남기고 다음 cycle 진행 (poison-pill 방지)
+- `CancellationException` 은 항상 재전파되어 구조적 동시성 보존
+- 입력 검증: `lockName` 은 blank 금지, `period` 는 양수 필수
+- 백엔드 자유 선택: `SuspendLeaderElector` 구현체
+  (`leader-redis-redisson`, `leader-redis-lettuce`, `leader-mongodb` 등)
+
+## Usage Examples
+
+```kotlin
+import io.bluetape4k.leader.ktor.LeaderElectionPlugin
+import io.bluetape4k.leader.ktor.leaderScheduled
+import io.bluetape4k.leader.redisson.RedissonSuspendLeaderElector
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import kotlin.time.Duration.Companion.minutes
+
+fun Application.module() {
+    val redisson = redissonClient()
+
+    install(LeaderElectionPlugin) {
+        leaderElection = RedissonSuspendLeaderElector(redisson)
+    }
+
+    leaderScheduled("daily-report", period = 1.minutes) {
+        reportService.generate()
+    }
+}
+```
+
+수동 취소:
+
+```kotlin
+val job = leaderScheduled("inventory-sync", 5.minutes) { syncInventory() }
+// ... 나중에
+job.cancel()
+```
+
+플러그인을 우회하여 elector 직접 주입 (advanced):
+
+```kotlin
+leaderScheduled(
+    lockName = "ad-hoc",
+    period = 30.seconds,
+    leaderElection = customElector,
+) {
+    doWork()
+}
+```
+
+## Configuration Options
+
+| 필드                  | 타입                          | 필수 | 설명                                       |
+|-----------------------|-------------------------------|------|--------------------------------------------|
+| `leaderElection`      | `SuspendLeaderElector?`       | 예   | 단일 리더 선출 백엔드                      |
+| `leaderGroupElection` | `SuspendLeaderGroupElector?`  | 아니오 | 그룹/멀티 리더 백엔드 (선택)             |
+
+`leaderScheduled` 파라미터:
+
+| 파라미터          | 타입                      | 기본값                           | 비고                                       |
+|-------------------|---------------------------|----------------------------------|--------------------------------------------|
+| `lockName`        | `String`                  | —                                | blank 금지                                 |
+| `period`          | `kotlin.time.Duration`    | —                                | 양수 필수                                  |
+| `leaderElection`  | `SuspendLeaderElector`    | 설치된 플러그인 설정에서 조회    | 미지정 시 플러그인 설정 사용               |
+| `action`          | `suspend () -> Unit`      | —                                | 리더로 선출되었을 때만 실행                |
+
+## Dependency
+
+Gradle (Kotlin DSL):
+
+```kotlin
+dependencies {
+    implementation("io.github.bluetape4k.leader:leader-ktor:$bluetape4kLeaderVersion")
+    implementation("io.github.bluetape4k.leader:leader-redis-redisson:$bluetape4kLeaderVersion") // 또는 다른 백엔드
+    implementation("io.ktor:ktor-server-core:3.4.3")
+}
+```
+
+`ktor-server-core` 는 본 모듈에서 `compileOnly` 로만 선언되므로, 사용 애플리케이션에서
+직접 의존성을 추가해야 합니다.
+
+## License
+
+Apache License 2.0

--- a/leader-ktor/README.md
+++ b/leader-ktor/README.md
@@ -1,0 +1,128 @@
+# bluetape4k-leader-ktor
+
+[한국어](./README.ko.md) | English
+
+Ktor 3.x integration module for `bluetape4k-leader`. Provides a Ktor application plugin
+DSL and a Spring-`@Scheduled`-style helper that runs leader-only tasks on a fixed period
+within the application coroutine scope.
+
+## Architecture
+
+`leader-ktor` adds three pieces of glue on top of `leader-core`:
+
+1. **`LeaderElectionPlugin`** — a `createApplicationPlugin` DSL that captures a
+   `SuspendLeaderElector` (and optionally a `SuspendLeaderGroupElector`) and stores it
+   in the `Application.attributes` map so it can be reused by extension functions.
+2. **`leaderElectionPluginConfig()`** — extension on `Application` to retrieve the
+   stored configuration.
+3. **`Application.leaderScheduled(...)`** — schedules a leader-only `suspend` action on
+   a fixed period, launched in the `Application` coroutine scope so it cancels
+   automatically on `ApplicationStopped`.
+
+```mermaid
+sequenceDiagram
+    participant App as Application (Ktor)
+    participant Plugin as LeaderElectionPlugin
+    participant Helper as leaderScheduled
+    participant Elector as SuspendLeaderElector
+
+    App->>Plugin: install(LeaderElectionPlugin) { leaderElection = ... }
+    Plugin-->>App: store config in attributes
+    App->>Helper: leaderScheduled("job", 1.minutes) { ... }
+    Helper-->>App: launch background Job
+    Note over Helper,Elector: every cycle
+    Helper->>Elector: runIfLeader("job") { action() }
+    Elector-->>Helper: result or null (skip)
+    Helper->>Helper: delay(period)
+    App->>Plugin: ApplicationStopped
+    Plugin-->>App: cancel application scope
+```
+
+## Core Features
+
+- Ktor 3.x compatible, coroutine-native (`SuspendLeaderElector` based)
+- Automatic cancellation on `ApplicationStopped` via `Application` coroutine scope
+- Per-cycle exception isolation — `action` exceptions are logged and the next cycle
+  continues (poison-pill prevention)
+- `CancellationException` is always re-thrown so structured concurrency works
+- Validation: `lockName` must be non-blank; `period` must be positive
+- Pluggable backend: any `SuspendLeaderElector` implementation
+  (`leader-redis-redisson`, `leader-redis-lettuce`, `leader-mongodb`, etc.)
+
+## Usage Examples
+
+```kotlin
+import io.bluetape4k.leader.ktor.LeaderElectionPlugin
+import io.bluetape4k.leader.ktor.leaderScheduled
+import io.bluetape4k.leader.redisson.RedissonSuspendLeaderElector
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import kotlin.time.Duration.Companion.minutes
+
+fun Application.module() {
+    val redisson = redissonClient()
+
+    install(LeaderElectionPlugin) {
+        leaderElection = RedissonSuspendLeaderElector(redisson)
+    }
+
+    leaderScheduled("daily-report", period = 1.minutes) {
+        reportService.generate()
+    }
+}
+```
+
+Manual cancellation:
+
+```kotlin
+val job = leaderScheduled("inventory-sync", 5.minutes) { syncInventory() }
+// ... later
+job.cancel()
+```
+
+Bypassing the plugin (advanced — pass the elector explicitly):
+
+```kotlin
+leaderScheduled(
+    lockName = "ad-hoc",
+    period = 30.seconds,
+    leaderElection = customElector,
+) {
+    doWork()
+}
+```
+
+## Configuration Options
+
+| Field                 | Type                          | Required | Description                              |
+|-----------------------|-------------------------------|----------|------------------------------------------|
+| `leaderElection`      | `SuspendLeaderElector?`       | Yes      | Single-leader elector backend            |
+| `leaderGroupElection` | `SuspendLeaderGroupElector?`  | No       | Group/multi-leader elector (optional)    |
+
+`leaderScheduled` parameters:
+
+| Parameter        | Type                       | Default                              | Notes                                       |
+|------------------|----------------------------|--------------------------------------|---------------------------------------------|
+| `lockName`       | `String`                   | —                                    | Must be non-blank                           |
+| `period`         | `kotlin.time.Duration`     | —                                    | Must be positive                            |
+| `leaderElection` | `SuspendLeaderElector`     | from installed plugin                | Falls back to plugin config if omitted      |
+| `action`         | `suspend () -> Unit`       | —                                    | Executed only when this node is leader      |
+
+## Dependency
+
+Gradle (Kotlin DSL):
+
+```kotlin
+dependencies {
+    implementation("io.github.bluetape4k.leader:leader-ktor:$bluetape4kLeaderVersion")
+    implementation("io.github.bluetape4k.leader:leader-redis-redisson:$bluetape4kLeaderVersion") // or another backend
+    implementation("io.ktor:ktor-server-core:3.4.3")
+}
+```
+
+The `ktor-server-core` artifact is `compileOnly` in this module — your application
+must declare it explicitly.
+
+## License
+
+Apache License 2.0

--- a/leader-ktor/build.gradle.kts
+++ b/leader-ktor/build.gradle.kts
@@ -1,0 +1,38 @@
+configurations {
+    testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
+}
+
+dependencyManagement {
+    imports {
+        mavenBom(libs.ktor.bom.get().toString())
+    }
+}
+
+dependencies {
+    api(project(":leader-core"))
+
+    api(libs.bluetape4k.coroutines)
+    implementation(libs.kotlinx.coroutines.core)
+
+    // Ktor 3.x — application/plugin DSL
+    compileOnly(libs.ktor.server.core)
+
+    // Logging
+    implementation(libs.bluetape4k.logging)
+
+    // Testing
+    testImplementation(libs.ktor.server.core)
+    testImplementation(libs.ktor.server.cio)
+    testImplementation(libs.ktor.server.test.host)
+
+    testImplementation(project(":leader-redis-redisson"))
+    testImplementation(libs.redisson)
+    testImplementation(libs.bluetape4k.redisson)
+
+    testImplementation(libs.bluetape4k.junit5)
+    testImplementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.testcontainers)
+    testImplementation(libs.testcontainers.junit.jupiter)
+    testImplementation(libs.awaitility.kotlin)
+}

--- a/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/ApplicationExt.kt
+++ b/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/ApplicationExt.kt
@@ -1,0 +1,93 @@
+package io.bluetape4k.leader.ktor
+
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+import io.ktor.server.application.Application
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration
+
+/**
+ * 주기적으로 리더 전용 작업을 실행하는 Ktor 확장 함수입니다.
+ *
+ * ## 동작/계약
+ * - [Application] 의 코루틴 스코프에서 [launch] 로 백그라운드 잡을 시작합니다 — `ApplicationStopped` 시 자동 취소됩니다.
+ * - 각 cycle 마다 [SuspendLeaderElector.runIfLeader] 를 호출해 [lockName] 으로 단일 인스턴스만 [action] 을 실행합니다.
+ * - [period] 간격으로 반복되며, [action] 예외는 WARN 로그 후 무시되고 다음 cycle 이 계속 진행됩니다 (poison-job 방지).
+ * - [CancellationException] 은 항상 호출자에게 재전파되어 정상 취소됩니다.
+ * - [leaderElection] 인자를 생략하면 [LeaderElectionPlugin] 의 설정에서 가져옵니다 — 플러그인 미설치 시 [IllegalStateException].
+ *
+ * ## 입력 검증
+ * - [lockName] 은 비어있지 않아야 합니다 (`IllegalArgumentException`).
+ * - [period] 는 양수여야 합니다 (`IllegalArgumentException`).
+ *
+ * ```kotlin
+ * fun Application.module() {
+ *     install(LeaderElectionPlugin) {
+ *         leaderElection = redissonElector
+ *     }
+ *     leaderScheduled("daily-report", period = 1.hours) {
+ *         reportService.generate()
+ *     }
+ * }
+ * ```
+ *
+ * @param lockName 리더 선출에 사용할 락 이름 (blank 금지)
+ * @param period 다음 실행까지 대기할 간격 (양수)
+ * @param leaderElection 사용할 [SuspendLeaderElector] — 미지정 시 플러그인 설정에서 조회
+ * @param action 리더로 선출되었을 때 실행할 suspend 작업
+ * @return 백그라운드 [Job] — 수동 취소 가능
+ * @throws IllegalArgumentException [lockName] blank 또는 [period] 가 양수가 아닐 때
+ * @throws IllegalStateException 인자 [leaderElection] 미지정 + 플러그인 미설치 시
+ */
+fun Application.leaderScheduled(
+    lockName: String,
+    period: Duration,
+    leaderElection: SuspendLeaderElector = resolveLeaderElection(),
+    action: suspend () -> Unit,
+): Job {
+    lockName.requireNotBlank("lockName")
+    period.inWholeMilliseconds.requirePositiveNumber("period")
+
+    LeaderScheduledLogger.log.debug {
+        "leaderScheduled 등록 — lockName=$lockName, period=$period"
+    }
+
+    return launch {
+        while (isActive) {
+            try {
+                leaderElection.runIfLeader(lockName) { action() }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                LeaderScheduledLogger.log.warn(e) {
+                    "leaderScheduled '$lockName' 실행 실패 — 다음 cycle 계속"
+                }
+            }
+            delay(period)
+        }
+    }
+}
+
+/**
+ * [LeaderElectionPlugin] 의 설정에서 [SuspendLeaderElector] 를 조회합니다.
+ *
+ * ## 동작/계약
+ * - 플러그인이 설치되지 않았거나 `leaderElection` 이 설정되지 않은 경우 [IllegalStateException] 을 던집니다.
+ */
+private fun Application.resolveLeaderElection(): SuspendLeaderElector {
+    val config = leaderElectionPluginConfig()
+    return requireNotNull(config.leaderElection) {
+        "LeaderElectionPlugin 의 leaderElection 이 설정되지 않았습니다."
+    }
+}
+
+/** 파일 단위 로거 보관용 internal object. */
+internal object LeaderScheduledLogger: KLogging()

--- a/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderElectionPlugin.kt
+++ b/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderElectionPlugin.kt
@@ -1,0 +1,91 @@
+package io.bluetape4k.leader.ktor
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.info
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationStarted
+import io.ktor.server.application.ApplicationStopped
+import io.ktor.server.application.createApplicationPlugin
+import io.ktor.server.application.hooks.MonitoringEvent
+import io.ktor.util.AttributeKey
+
+/**
+ * Ktor 3.x 애플리케이션에서 `bluetape4k-leader` 의 코루틴 기반 리더 선출 기능을
+ * 통합 사용할 수 있도록 제공하는 플러그인 진입점입니다.
+ *
+ * ## 동작/계약
+ * - `install(LeaderElectionPlugin) { leaderElection = ... }` 형태로 설치합니다.
+ * - [LeaderElectionPluginConfig.leaderElection] 미설정 시 `install()` 시점에
+ *   [IllegalArgumentException] 이 발생합니다 (`requireNotNull` 검증).
+ * - [ApplicationStarted] / [ApplicationStopped] 라이프사이클 이벤트를 구독하여 INFO 로그를 남깁니다.
+ * - 플러그인 자체는 백그라운드 잡을 시작하지 않습니다 — [Application.leaderScheduled] 확장 함수와 결합하여 사용합니다.
+ * - 종료 시 별도의 cleanup 동작은 없습니다 — `Application` CoroutineScope 가 자식 코루틴을 자동 취소합니다.
+ *
+ * ```kotlin
+ * fun Application.module() {
+ *     install(LeaderElectionPlugin) {
+ *         leaderElection = RedissonSuspendLeaderElector(redissonClient)
+ *     }
+ *
+ *     leaderScheduled("daily-report", 1.hours) {
+ *         reportService.generate()
+ *     }
+ * }
+ * ```
+ *
+ * @see LeaderElectionPluginConfig
+ * @see leaderScheduled
+ */
+val LeaderElectionPlugin = createApplicationPlugin(
+    name = LeaderElectionPluginInternals.NAME,
+    createConfiguration = ::LeaderElectionPluginConfig,
+) {
+    val config = pluginConfig
+    requireNotNull(config.leaderElection) {
+        "LeaderElectionPlugin 설치 전 leaderElection 을 반드시 설정해야 합니다."
+    }
+
+    // 외부 (예: leaderScheduled 확장) 에서 설정에 접근할 수 있도록 Application attributes 에 저장한다.
+    application.attributes.put(LeaderElectionConfigKey, config)
+
+    on(MonitoringEvent(ApplicationStarted)) { application ->
+        LeaderElectionPluginInternals.log.info {
+            "LeaderElectionPlugin 시작 — application=${application.javaClass.simpleName}"
+        }
+    }
+
+    on(MonitoringEvent(ApplicationStopped)) { application ->
+        LeaderElectionPluginInternals.log.info {
+            "LeaderElectionPlugin 종료 — application=${application.javaClass.simpleName}"
+        }
+    }
+}
+
+/**
+ * `Application` attributes 저장소에서 [LeaderElectionPluginConfig] 를 식별하는 키입니다.
+ * 동일 [Application] 내 단일 플러그인 인스턴스를 가정합니다.
+ */
+internal val LeaderElectionConfigKey: AttributeKey<LeaderElectionPluginConfig> =
+    AttributeKey("io.bluetape4k.leader.ktor.LeaderElectionPluginConfig")
+
+/**
+ * 현재 [Application] 에 설치된 [LeaderElectionPlugin] 의 [LeaderElectionPluginConfig] 를 조회합니다.
+ *
+ * ## 동작/계약
+ * - 플러그인이 설치되지 않은 경우 [IllegalStateException] 을 던집니다.
+ *
+ * @return 설치된 플러그인의 설정 객체
+ * @throws IllegalStateException 플러그인 미설치 시
+ */
+fun Application.leaderElectionPluginConfig(): LeaderElectionPluginConfig {
+    return attributes.getOrNull(LeaderElectionConfigKey)
+        ?: error("LeaderElectionPlugin 이 Application 에 설치되지 않았습니다.")
+}
+
+/**
+ * 플러그인 내부 상수와 로거를 담는 객체. 외부 노출이 필요 없으나,
+ * top-level 플러그인 정의에서 `KLogging` companion 패턴을 적용하기 위한 우회입니다.
+ */
+internal object LeaderElectionPluginInternals: KLogging() {
+    const val NAME: String = "LeaderElection"
+}

--- a/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderElectionPluginConfig.kt
+++ b/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderElectionPluginConfig.kt
@@ -1,0 +1,33 @@
+package io.bluetape4k.leader.ktor
+
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
+
+/**
+ * [LeaderElectionPlugin] 의 설정 클래스입니다.
+ *
+ * ## 동작/계약
+ * - [leaderElection] 은 필수 항목으로, `install(LeaderElectionPlugin) { ... }` 블록에서 반드시 설정해야 합니다.
+ * - [leaderGroupElection] 은 선택 항목으로, 멀티 리더(그룹 선출)가 필요한 애플리케이션에서만 설정합니다.
+ * - 미설정 시 플러그인 설치 시점에 [IllegalArgumentException] 이 발생합니다.
+ *
+ * ```kotlin
+ * fun Application.module() {
+ *     install(LeaderElectionPlugin) {
+ *         leaderElection = RedissonSuspendLeaderElector(redissonClient)
+ *         leaderGroupElection = RedissonSuspendLeaderGroupElector(redissonClient)
+ *     }
+ * }
+ * ```
+ *
+ * @property leaderElection 단일 리더 선출 구현체 (필수)
+ * @property leaderGroupElection 멀티 리더 선출 구현체 (선택)
+ */
+class LeaderElectionPluginConfig {
+
+    /** 단일 리더 선출 구현체. 플러그인 사용 전 반드시 설정해야 합니다. */
+    var leaderElection: SuspendLeaderElector? = null
+
+    /** 멀티 리더(그룹) 선출 구현체. 필요 시 설정합니다. */
+    var leaderGroupElection: SuspendLeaderGroupElector? = null
+}

--- a/leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/AbstractLeaderKtorTest.kt
+++ b/leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/AbstractLeaderKtorTest.kt
@@ -1,0 +1,40 @@
+package io.bluetape4k.leader.ktor
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.storage.RedisServer
+import io.bluetape4k.utils.ShutdownQueue
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.config.Config
+
+/**
+ * `leader-ktor` 통합 테스트의 공통 베이스 클래스입니다.
+ *
+ * ## 동작/계약
+ * - `bluetape4k-testcontainers` 의 [RedisServer.Launcher.redis] singleton 을 사용합니다.
+ * - [RedissonClient] 는 lazy 로 1회 생성되며, JVM 종료 시 [ShutdownQueue] 를 통해 정리됩니다.
+ * - 각 테스트는 [randomName] 으로 충돌하지 않는 고유 lock 이름을 발급받습니다.
+ */
+abstract class AbstractLeaderKtorTest {
+
+    companion object: KLogging() {
+        val redis = RedisServer.Launcher.redis
+
+        val redisUrl: String get() = redis.url
+
+        val redissonClient: RedissonClient by lazy {
+            val config = Config().apply {
+                useSingleServer()
+                    .setAddress(redisUrl)
+                    .setConnectionPoolSize(8)
+                    .setConnectionMinimumIdleSize(2)
+            }
+            Redisson.create(config).apply {
+                ShutdownQueue.register { shutdown() }
+            }
+        }
+    }
+
+    protected fun randomName(): String = "leader-ktor-test:${Base58.randomString(8)}"
+}

--- a/leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/ApplicationExtTest.kt
+++ b/leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/ApplicationExtTest.kt
@@ -1,0 +1,213 @@
+package io.bluetape4k.leader.ktor
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.leader.redisson.RedissonSuspendLeaderElector
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.ktor.server.application.install
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeoutOrNull
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.until
+import org.awaitility.kotlin.withPollInterval
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+class ApplicationExtTest: AbstractLeaderKtorTest() {
+
+    companion object: KLoggingChannel() {
+        private val SHORT_PERIOD = 50.milliseconds
+        private val POLL_INTERVAL = 50.milliseconds
+        private val AWAIT_TIMEOUT = 15.seconds
+    }
+
+    @Test
+    fun `lockName blank 인 경우 IllegalArgumentException`() = runSuspendIO {
+        val elector = RedissonSuspendLeaderElector(redissonClient)
+        testApplication {
+            application {
+                install(LeaderElectionPlugin) { leaderElection = elector }
+
+                assertFailsWith<IllegalArgumentException> {
+                    leaderScheduled(lockName = "  ", period = SHORT_PERIOD) { /* no-op */ }
+                }
+            }
+            startApplication()
+        }
+    }
+
+    @Test
+    fun `period 가 0 인 경우 IllegalArgumentException`() = runSuspendIO {
+        val elector = RedissonSuspendLeaderElector(redissonClient)
+        testApplication {
+            application {
+                install(LeaderElectionPlugin) { leaderElection = elector }
+
+                assertFailsWith<IllegalArgumentException> {
+                    leaderScheduled(lockName = "ok", period = Duration.ZERO) { /* no-op */ }
+                }
+            }
+            startApplication()
+        }
+    }
+
+    @Test
+    fun `period 가 음수인 경우 IllegalArgumentException`() = runSuspendIO {
+        val elector = RedissonSuspendLeaderElector(redissonClient)
+        testApplication {
+            application {
+                install(LeaderElectionPlugin) { leaderElection = elector }
+
+                assertFailsWith<IllegalArgumentException> {
+                    leaderScheduled(lockName = "ok", period = (-10).milliseconds) { /* no-op */ }
+                }
+            }
+            startApplication()
+        }
+    }
+
+    @Test
+    fun `리더 액션이 주기적으로 실행되며 단일 인스턴스로 동작한다`() = runSuspendIO {
+        val lockName = randomName()
+        val elector = RedissonSuspendLeaderElector(redissonClient)
+        val counter = AtomicInteger(0)
+
+        testApplication {
+            application {
+                install(LeaderElectionPlugin) { leaderElection = elector }
+
+                leaderScheduled(lockName, period = SHORT_PERIOD) {
+                    val current = counter.incrementAndGet()
+                    log.debug { "리더 작업 실행 #$current" }
+                }
+            }
+            startApplication()
+
+            await.atMost(AWAIT_TIMEOUT.toJavaDuration())
+                .withPollInterval(POLL_INTERVAL.toJavaDuration())
+                .until { counter.get() >= 3 }
+
+            counter.get() shouldBeGreaterOrEqualTo 3
+        }
+    }
+
+    @Test
+    fun `action 예외 발생 시에도 다음 cycle 이 계속 실행된다`() = runSuspendIO {
+        val lockName = randomName()
+        val elector = RedissonSuspendLeaderElector(redissonClient)
+        val cycles = AtomicInteger(0)
+        val firstCycleConsumed = AtomicBoolean(false)
+
+        testApplication {
+            application {
+                install(LeaderElectionPlugin) { leaderElection = elector }
+
+                leaderScheduled(lockName, period = SHORT_PERIOD) {
+                    val current = cycles.incrementAndGet()
+                    if (firstCycleConsumed.compareAndSet(false, true)) {
+                        log.debug { "첫 번째 cycle 에서 의도적으로 예외 발생" }
+                        error("의도된 실패 — poison-pill 방지 검증")
+                    }
+                    log.debug { "정상 cycle #$current" }
+                }
+            }
+            startApplication()
+
+            await.atMost(AWAIT_TIMEOUT.toJavaDuration())
+                .withPollInterval(POLL_INTERVAL.toJavaDuration())
+                .until { cycles.get() >= 3 }
+
+            cycles.get() shouldBeGreaterOrEqualTo 3
+            firstCycleConsumed.get().shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `명시 leaderElection 인자를 사용하면 plugin 미설치여도 동작한다`() = runSuspendIO {
+        val lockName = randomName()
+        val elector: SuspendLeaderElector = RedissonSuspendLeaderElector(redissonClient)
+        val counter = AtomicInteger(0)
+
+        testApplication {
+            application {
+                // 플러그인 install 생략
+                leaderScheduled(lockName, SHORT_PERIOD, leaderElection = elector) {
+                    counter.incrementAndGet()
+                }
+            }
+            startApplication()
+
+            await.atMost(AWAIT_TIMEOUT.toJavaDuration())
+                .withPollInterval(POLL_INTERVAL.toJavaDuration())
+                .until { counter.get() >= 2 }
+
+            counter.get() shouldBeGreaterOrEqualTo 2
+        }
+    }
+
+    @Test
+    fun `Application 종료 시 leaderScheduled job 이 자동 취소된다`() = runSuspendIO {
+        val lockName = randomName()
+        val elector = RedissonSuspendLeaderElector(redissonClient)
+        val counter = AtomicInteger(0)
+
+        testApplication {
+            application {
+                install(LeaderElectionPlugin) { leaderElection = elector }
+                leaderScheduled(lockName, SHORT_PERIOD) {
+                    counter.incrementAndGet()
+                }
+            }
+            startApplication()
+
+            await.atMost(AWAIT_TIMEOUT.toJavaDuration())
+                .withPollInterval(POLL_INTERVAL.toJavaDuration())
+                .until { counter.get() >= 2 }
+        } // testApplication 블록 종료 시 application 종료 + 스코프 취소
+
+        val countAtStop = counter.get()
+        delay(SHORT_PERIOD * 5)
+        // 종료 후에는 더 이상 실행되지 않아야 한다 — 어느 정도 시간이 지나도 거의 증가하지 않음
+        // 약간의 race 가 있을 수 있으므로 +2 까지 허용
+        (counter.get() <= countAtStop + 2).shouldBeTrue()
+    }
+
+    @Test
+    fun `leaderScheduled 는 즉시 Job 을 반환하며 수동 cancel 가능하다`() = runSuspendIO {
+        val lockName = randomName()
+        val elector = RedissonSuspendLeaderElector(redissonClient)
+        val counter = AtomicInteger(0)
+
+        testApplication {
+            application {
+                install(LeaderElectionPlugin) { leaderElection = elector }
+                val job = leaderScheduled(lockName, SHORT_PERIOD) {
+                    counter.incrementAndGet()
+                }
+
+                // 잠시 실행 후 수동 취소
+                withTimeoutOrNull(AWAIT_TIMEOUT) {
+                    while (counter.get() < 2) delay(SHORT_PERIOD)
+                }
+                job.cancel()
+                val countAtCancel = counter.get()
+                delay(SHORT_PERIOD * 5)
+                // cancel 이후 거의 증가하지 않음
+                (counter.get() <= countAtCancel + 2).shouldBeTrue()
+                countAtCancel shouldBeGreaterOrEqualTo 2
+            }
+            startApplication()
+        }
+    }
+}

--- a/leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/LeaderElectionPluginTest.kt
+++ b/leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/LeaderElectionPluginTest.kt
@@ -1,0 +1,60 @@
+package io.bluetape4k.leader.ktor
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.redisson.RedissonSuspendLeaderElector
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.ktor.server.application.install
+import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.Test
+
+class LeaderElectionPluginTest: AbstractLeaderKtorTest() {
+
+    companion object: KLoggingChannel()
+
+    @Test
+    fun `leaderElection 미설정 시 install 시점에 IllegalArgumentException 이 발생한다`() = runSuspendIO {
+        assertFailsWith<IllegalArgumentException> {
+            testApplication {
+                application {
+                    install(LeaderElectionPlugin) {
+                        // leaderElection 의도적으로 미설정
+                    }
+                }
+                startApplication()
+            }
+        }
+    }
+
+    @Test
+    fun `정상 설치 시 leaderElectionPluginConfig 로 설정에 접근할 수 있다`() = runSuspendIO {
+        val elector = RedissonSuspendLeaderElector(redissonClient)
+
+        testApplication {
+            application {
+                install(LeaderElectionPlugin) {
+                    leaderElection = elector
+                }
+
+                val cfg = leaderElectionPluginConfig()
+                cfg.leaderElection.shouldNotBeNull()
+                cfg.leaderElection shouldBeEqualTo elector
+            }
+            startApplication()
+        }
+    }
+
+    @Test
+    fun `플러그인 미설치 상태에서 leaderElectionPluginConfig 호출 시 IllegalStateException`() = runSuspendIO {
+        assertFailsWith<IllegalStateException> {
+            testApplication {
+                application {
+                    leaderElectionPluginConfig()
+                }
+                startApplication()
+            }
+        }
+    }
+}

--- a/leader-ktor/src/test/resources/junit-platform.properties
+++ b/leader-ktor/src/test/resources/junit-platform.properties
@@ -1,0 +1,6 @@
+junit.jupiter.extensions.autodetection.enabled=true
+junit.jupiter.testinstance.lifecycle.default=per_class
+
+junit.jupiter.execution.parallel.enabled=false
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=concurrent

--- a/leader-ktor/src/test/resources/logback-test.xml
+++ b/leader-ktor/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <immediateFlush>true</immediateFlush>
+        <encoder>
+            <!-- @formatter:off -->
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%blue(%32.32t)] %yellow(%logger{36}):%line: %msg%n%throwable</pattern>
+            <!-- @formatter:on -->
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <logger name="io.bluetape4k.leader" level="DEBUG"/>
+    <logger name="io.ktor" level="WARN"/>
+
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+    </root>
+
+</configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ include(
     "leader-hazelcast",
     "leader-zookeeper",
     "leader-spring-boot",
+    "leader-ktor",
     "leader-micrometer",
     "examples:batch-scheduler",
     "examples:migration-gate",


### PR DESCRIPTION
## Summary

Closes #37

PR #164의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat(leader-ktor): Ktor 3.x 통합 모듈 — closes #37`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 개요

Issue #37 — Ktor 3.x 애플리케이션에서 리더 선출을 사용할 수 있는 Plugin DSL + scheduling helper. Spring `@Scheduled` 부재를 `leaderScheduled()` 헬퍼로 보완.

Closes #37

## API

```kotlin
fun Application.module() {
    install(LeaderElectionPlugin) {
        leaderElection = redissonSuspendLeaderElection
    }

    leaderScheduled("daily-report", period = 1.hours) {
        reportService.generate()
    }
}
```

## 변경 사항

- `leader-ktor/` 신규 모듈 (publish 대상 — Maven Central)
  - `LeaderElectionPlugin` (createApplicationPlugin DSL)
  - `LeaderElectionPluginConfig` (leaderElection + leaderGroupElection 옵션)
  - `Application.leaderScheduled(...)` 확장
  - `Application.leaderElectionPluginConfig()` 외부 접근 헬퍼
- `gradle/libs.versions.toml` — ktor 3.4.3 BOM + 라이브러리 추가
- `settings.gradle.kts` + `leader-bom/build.gradle.kts` — 모듈 등록 + BOM 노출
- `.github/workflows/{ci,nightly}.yml` — test-leader-ktor job 추가
- `docs/lessons/2026-05-10-leader-ktor.md` (L1~L5)

## 핵심 설계 결정

- **Application.attributes 패턴**: Ktor `pluginConfig` 가 plugin 블록 외부에서 접근 불가 → `AttributeKey` 로 저장하고 `Application.leaderElectionPluginConfig()` 에서 조회
- **`!!` 금지**: 워크스페이스 규칙 — `requireNotNull` + `error()` 사용
- **`compileOnly` + BOM**: 사용자가 자체 Ktor 버전 선택 가능
- **`runSuspendIO` + `testApplication`**: Ktor 실시간 동작 — `runTest` 의 가상 시간 비호환

## 테스트 결과

11 passing:
- 플러그인 설정 검증 (3건):
  - leaderElection 미설정 시 install IllegalArgumentException
  - 정상 설치 시 leaderElectionPluginConfig 접근 가능
  - 미설치 상태에서 leaderElectionPluginConfig 호출 시 IllegalStateException
- leaderScheduled (8건):
  - lockName blank, period 0/음수 IllegalArgumentException
  - 단일 인스턴스 주기적 실행
  - action 예외 발생 시 다음 cycle 계속
  - 명시 leaderElection 인자로 plugin 미설치여도 동작
  - Application 종료 시 자동 취소
  - 즉시 Job 반환 + 수동 cancel

## 코드 리뷰

- **code-reviewer agent** (Tier 4+5) 통과
- **Codex code review**: "No blocking or actionable defects" — actionlint + workflow syntax 모두 통과

## 다음 작업

#37 머지 후 — Ktor 기반 examples 모듈 추가 (사용자 follow-up 요청).
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #37, milestone `0.1.0`, assignee `debop`
- PR: #164, head `6859ee4b1c040f51d392b0018ea71d0d75225081`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
