### PR TITLE
feat(leader-redis): #151 Redis group minLeaseTime slot-token TTL 재설계

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,26 @@ LeaderGroupElectionOptions(maxLeaders = 3, waitTime = 5.seconds, leaseTime = 60.
 // Default constants: LeaderElectionOptions.Default, LeaderGroupElectionOptions.Default
 ```
 
+### Group elector — Redis backends (slot-token TTL model)
+
+`leader-redis-lettuce` / `leader-redis-redisson` 의 group elector 는 모두 **slot-token TTL 모델** 로 동작.
+
+| 항목 | Lettuce (`LettuceSlotTokenGroup`) | Redisson (`RPermitExpirableSemaphore`) |
+|---|---|---|
+| Key | `lg:{lockName}` ZSET | `lg:{lockName}` permit semaphore |
+| Slot 식별자 | `Base58 token (8자)` | Redisson 발급 `permitId` |
+| 시간 기준 | Lua `redis.call('TIME')` (server-side) | Redisson 내부 |
+| 초기화 | 첫 acquire 시 `ZREMRANGEBYSCORE` 만료 정리 | 첫 access 시 `trySetPermits(maxLeaders)` 멱등 호출 |
+| `minLeaseTime > 0` | RELEASE 시 `ZADD XX` 로 score 갱신 | `updateLeaseTime` / `updateLeaseTimeAsync` |
+| Crash recovery | `leaseTime` 만료 후 다음 acquire 시 자동 회수 | `leaseTime` 만료 후 Redisson 자동 회수 |
+
+**핵심 계약**:
+
+- `minLeaseTime` 은 backend TTL 에 위임 — caller-park 없음. `runIfLeader` 는 `action` 종료 직후 즉시 반환.
+- 외부 reaper / cleanup 작업 불필요 — 두 backend 모두 만료 슬롯 자동 회수.
+- `lg:{lockName}` key prefix 는 의도적으로 분리 — 구버전 (`LettuceSemaphore`, `RSemaphore`) 키와 충돌 회피, 롤링 배포 호환.
+- Lettuce 측 구버전 `LettuceSemaphore` / `LettuceSuspendSemaphore` 는 `@Deprecated` (소스에 잔존, 새 elector 와 미연결).
+
 ## AOP Annotation Guide (`leader-spring-boot`)
 
 `@LeaderElection` / `@LeaderGroupElection` — `leader-core` 선언, AspectJ CTW (Freefair post-compile weaving) 적용.

--- a/docs/lessons/2026-05-10-redis-group-slot-token.md
+++ b/docs/lessons/2026-05-10-redis-group-slot-token.md
@@ -1,0 +1,161 @@
+# Lessons Learned — Redis Group slot-token TTL 재설계 (2026-05-10)
+
+**관련 PR**: TBD
+**관련 Issue**: #151
+**영향 모듈**: `leader-redis-lettuce/`, `leader-redis-redisson/`
+
+## L1: Lua server-side TIME — 클라이언트 clock skew 차단
+
+### 문제
+초기 spec 은 ACQUIRE Lua 가 client `nowMs` 인자 사용. Codex P1 — 클라이언트 clock skew 시 fast client 가 valid slot 제거 / slow client 가 overlong lease 생성 가능 → maxLeaders 위반.
+
+### 교훈
+모든 시간 비교는 Redis 서버 시간 기준 (`redis.call('TIME')`):
+
+```lua
+local t = redis.call('TIME')
+local nowMs = tonumber(t[1]) * 1000 + math.floor(tonumber(t[2]) / 1000)
+```
+
+ACQUIRE/RELEASE/STATUS 모든 script 에 적용. score (expiryAt) 도 server-side time 으로 계산.
+
+다른 distributed lock 에서도 multi-client 비교는 server-side time 기본.
+
+---
+
+## L2: RPermitExpirableSemaphore — `trySetPermits(maxLeaders)` 멱등 호출 필수
+
+### 문제
+새 `lg:{lockName}` 키에 `getPermitExpirableSemaphore(name)` 만 호출 시 0 permits 로 시작 → 모든 `tryAcquire` null 반환 → group election 영구 실패.
+
+### 교훈
+RPermitExpirableSemaphore 는 RSemaphore 와 달리 자동 max permits 초기화 없음. 사용 전 반드시:
+
+```kotlin
+val semaphore = redissonClient.getPermitExpirableSemaphore("lg:{$lockName}")
+semaphore.trySetPermits(maxLeaders)  // 멱등, 이미 설정됐으면 no-op
+```
+
+Suspend 버전도 `trySetPermitsAsync(maxLeaders).await()` 로 동등 처리.
+
+---
+
+## L3: Redisson 4.3.1 API — `updateLeaseTime` (not `tryUpdateLeaseTime`)
+
+### 문제
+spec 초안에 `tryUpdateLeaseTime` 사용 — Redisson 4.3.1 에 미존재. 컴파일 에러.
+
+### 교훈
+Redisson 4.3.1 `RPermitExpirableSemaphore`:
+- **sync**: `updateLeaseTime(permitId, leaseTime, unit): Unit`
+- **async**: `updateLeaseTimeAsync(permitId, leaseTime, unit): RFuture<Boolean>`
+
+`tryUpdateLeaseTime` 는 4.x 어느 버전에서도 본 적 없음 — 항상 `updateLeaseTime` 으로 시작.
+
+다른 lib API 사용 시 spec 작성 단계에서 정확한 시그니처 검증 필수 (예: `gh search` 로 actual 코드 확인).
+
+---
+
+## L4: `startedAtNanos` 캡처 — acquire 성공 후
+
+### 문제
+spec 초안: `startedAtNanos = System.nanoTime()` 을 `tryAcquire` 호출 전 캡처. waitTime 이 non-zero 이고 caller 가 대기한 후 acquire 성공하면, waitTime 이 minLeaseTime 에서 차감 → fast action 후 release 시 minLease 가 음수로 되어 즉시 release.
+
+### 교훈
+acquire 가 성공한 후, action 실행 직전에 캡처:
+
+```kotlin
+val token = slotGroup.tryAcquire(waitTime) ?: return null
+val startedAtNanos = System.nanoTime()  // ⭐ 여기
+try { return action() } finally {
+    val remainingMs = remainingMinLeaseTime(startedAtNanos, options.minLeaseTime).inWholeMilliseconds
+    slotGroup.release(token, remainingMs)
+}
+```
+
+기존 backend-TTL 구현 (Lettuce single lock, Redisson single lock 등) 도 동일 패턴.
+
+---
+
+## L5: ZADD XX 가드 — expired token 부활 방지
+
+### 문제
+초기 RELEASE_SCRIPT: `if remainingMs > 0 then ZADD XX score=(now+remaining) token`. caller 가 release 호출 시점에 token 이 이미 만료되어 ZREM 됐다면 XX 는 no-op (좋음). 하지만 ZSET 에 잔존하지만 score 가 이미 nowMs 이하 (= expired but not yet purged) 면 XX 가 silent 하게 lease 연장 → caller 가 잃은 slot 의 lease 부적절 연장.
+
+### 교훈
+RELEASE_SCRIPT 에서 `ZSCORE` 로 현재 score 확인 후 nowMs 보다 큰 경우만 갱신:
+
+```lua
+local cur = redis.call('ZSCORE', KEYS[1], ARGV[1])
+if cur and tonumber(cur) > nowMs then
+  return redis.call('ZADD', KEYS[1], 'XX', nowMs + tonumber(ARGV[2]), ARGV[1])
+end
+return 0
+```
+
+distributed TTL extend 시 항상 "여전히 살아있는지" 확인 후 연장 (CAS 패턴).
+
+---
+
+## L6: tryAcquireAsync — backend error 보존 + retry
+
+### 문제
+async retry handler 가 backend error (Redis connection/auth/script) 를 `null` 로 변환 → contention 과 구분 불가. Redis outage 시 silent skip — sync/suspend path 와 불일치.
+
+### 교훈
+Async retry 에서 backend error 는 보존, deadline 도달 시 last error 로 future fail:
+
+```kotlin
+val lastError = AtomicReference<Throwable?>(null)
+fun attempt(): CompletableFuture<String?> {
+    return RedisScriptRunner.runAsync(...).handle { result, error ->
+        if (error != null) { lastError.set(error); null }
+        else result
+    }.thenCompose { result ->
+        when {
+            !result.isNullOrEmpty() -> CompletableFuture.completedFuture(result)
+            System.nanoTime() < deadlineNanos -> CompletableFuture.runAsync({}, delayed).thenCompose { attempt() }
+            lastError.get() != null -> CompletableFuture.failedFuture(lastError.get()!!)
+            else -> CompletableFuture.completedFuture(null)
+        }
+    }
+}
+```
+
+contention 만 `null` 로 노출. 단순 `null` 변환은 핵심 계약 (acquire 실패 = lock 없음) 위반.
+
+---
+
+## L7: runAsyncIfLeader — release 완료 후 outer future complete
+
+### 문제
+`actionFuture.handle { ... releaseAsync().whenComplete { ... } ...; if (error) throw else value }` — release 는 fire-and-forget. outer future 가 release 완료 전에 complete → caller 가 chained 호출 시 slot 이 still occupied 로 보임.
+
+### 교훈
+`thenCompose` 로 release future 까지 await:
+
+```kotlin
+actionFuture.handle<Pair<T?, Throwable?>> { v, e -> Pair(v, e) }
+    .thenCompose { (value, error) ->
+        slotGroup.releaseAsync(token, remainingMs)
+            .exceptionally { releaseError -> log.warn(releaseError) { "..." }; Unit }
+            .thenApply { if (error != null) throw error else value }
+    }
+```
+
+async semaphore/lock 의 release 는 항상 outer future 에 chain — sequential ordering 보장.
+
+---
+
+## L8: untracked 파일 staging 검증 — agent 결과 수정 시 매번
+
+### 문제
+agent 가 신규 파일 (LettuceSlotTokenGroup.kt + Test) 생성 후 git add 안 함 → `git status` untracked. 테스트는 working tree 기준 통과, 그러나 commit 후 PR 은 컴파일 실패.
+
+### 교훈
+agent delegate 후 항상:
+- `git status -uall` 로 untracked 파일 검증
+- `git add -A` 로 일괄 staging
+- 실수로 commit 안 한 신규 파일이 PR 에 누락되지 않도록
+
+E4 lessons L4 ("agent 위임 후 settings.gradle.kts/CI workflow 누락") 와 동일 교훈 — 위임 후 검증 단계 필수.

--- a/docs/superpowers/plans/2026-05-10-redis-group-slot-token-plan.md
+++ b/docs/superpowers/plans/2026-05-10-redis-group-slot-token-plan.md
@@ -1,0 +1,225 @@
+# Plan — Redis Group slot-token TTL 재설계
+
+**Spec**: `docs/superpowers/specs/2026-05-10-redis-group-slot-token-design.md`
+**Issue**: #151
+**작성일**: 2026-05-10
+
+---
+
+## Phase 1 — Lettuce primitive (단독 구현, 기존 코드 영향 X)
+
+### T1: `LettuceSlotTokenGroup.kt` 신규 작성
+**complexity: high**
+**파일**: `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/semaphore/LettuceSlotTokenGroup.kt`
+
+내용:
+- `class LettuceSlotTokenGroup(connection, lockName, maxLeaders)`
+- 3 Lua scripts (`ACQUIRE_SCRIPT`, `RELEASE_SCRIPT`, `STATUS_SCRIPT`) — **server-side `redis.call('TIME')` 사용**
+- key prefix: `lg:{lockName}`
+- API:
+  - `tryAcquire(waitTime: Duration): String?` (sync, spin-poll 50ms)
+  - `tryAcquireAsync(waitTime): CompletableFuture<String?>` (recursive delay chain)
+  - `tryAcquireSuspending(waitTime): String?` (delay 50ms loop)
+  - `release(token, remainingMinLeaseMs: Long)` (sync)
+  - `releaseAsync(token, remainingMinLeaseMs): CompletableFuture<Unit>`
+  - `releaseSuspending(token, remainingMinLeaseMs)`
+  - `availableSlots(): Int`, `activeCount(): Int`
+- token = `Base58.randomString(8)`
+- `requireNotBlank("lockName")`, `KLogging` companion
+- KDoc 한국어 + `## 동작/계약`
+
+### T2: `LettuceSlotTokenGroupTest.kt` 신규
+**complexity: medium**
+**파일**: `leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/semaphore/LettuceSlotTokenGroupTest.kt`
+
+시나리오:
+- 단일 acquire → token 반환
+- maxLeaders=N 동시 acquire 모두 success
+- maxLeaders+1 번째 acquire null
+- token 으로 release → 즉시 해제
+- minLeaseRemaining > 0 release → ZADD XX 로 score 갱신, slot 유지
+- expired entry 자동 회수 (`leaseTime` 만료 후 새 acquire 성공)
+
+`AbstractLettuceLeaderTest` 베이스 사용.
+
+---
+
+## Phase 2 — Deprecate `LettuceSemaphore`
+
+### T3: `LettuceSemaphore` / `LettuceSuspendSemaphore` `@Deprecated`
+**complexity: low**
+**파일**:
+- `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/semaphore/LettuceSemaphore.kt`
+- `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/semaphore/LettuceSuspendSemaphore.kt`
+
+`@Deprecated("Replaced by LettuceSlotTokenGroup ...", level = DeprecationLevel.WARNING)`
+
+---
+
+## Phase 3 — Lettuce group elector 교체
+
+### T4: `LettuceLeaderGroupElector` 수정
+**complexity: high**
+**파일**: `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElector.kt`
+
+변경:
+- `ConcurrentHashMap<String, LettuceSemaphore>` → `ConcurrentHashMap<String, LettuceSlotTokenGroup>`
+- `runIfLeader` / `runAsyncIfLeader`:
+  - `tryAcquire(waitTime)` → `String?`
+  - `null` → return null
+  - **`startedAtNanos = System.nanoTime()` — acquire 성공 후 캡처** (Codex P2)
+    - 근거: acquire 전 캡처 시 waitTime 이 minLeaseTime 에서 차감 → fast action 즉시 release 위험
+  - try { action() } finally:
+    - `remainingMs = remainingMinLeaseTime(startedAtNanos, options.minLeaseTime).inWholeMilliseconds`
+    - `release(token, remainingMs)`
+- `activeCount(name)` / `availableSlots(name)` → group 의 동일 함수 위임
+- 기존 `LettuceSemaphore` import 제거
+
+### T5: `LettuceSuspendLeaderGroupElector` 수정
+**complexity: high**
+**파일**: `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElector.kt`
+
+T4 와 동일 + suspend 패턴:
+```kotlin
+withContext(NonCancellable) {
+    try {
+        val remainingMs = remainingMinLeaseTime(...).inWholeMilliseconds
+        slotGroup.releaseSuspending(token, remainingMs)
+    } catch (e: CancellationException) { throw e }
+    catch (e: Exception) { log.warn(e) { "..." } }
+}
+```
+
+기존 `runCatching { semaphore.releaseAsync().await() }` (CancellationException 삼킴 버그) 동시 제거.
+
+### T6: Lettuce group 테스트 minLeaseTime + crash recovery 추가
+**complexity: medium**
+**파일**:
+- `leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElectionTest.kt`
+- `leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElectorTest.kt`
+
+신규 시나리오 (각 test 클래스):
+- minLeaseTime > runtime: caller 즉시 반환 + 다른 client 즉시 acquire 실패
+- minLeaseTime 만료 후 다음 acquire 성공
+- minLeaseTime == 0 회귀 (즉시 release)
+- maxLeaders 동시 점유 + minLease 모두 보유 → maxLeaders+1 실패
+- crash recovery: release 미호출 → leaseTime 만료 후 다른 client acquire 성공
+- (suspend) 코루틴 취소 + minLeaseTime > 0 → NonCancellable 으로 score 갱신 정확
+
+---
+
+## Phase 4 — Redisson group elector 교체
+
+### T7: `RedissonLeaderGroupElector` 수정
+**complexity: high**
+**파일**: `leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElector.kt`
+
+변경:
+- `RSemaphore` → `RPermitExpirableSemaphore`
+- key prefix `lg:{lockName}` (충돌 회피)
+- `getPermitSemaphore(lockName)`:
+  - `redissonClient.getPermitExpirableSemaphore("lg:{$lockName}")`
+  - **`semaphore.trySetPermits(maxLeaders)` 멱등 초기화** (Codex P1 — 누락 시 acquire 영구 실패)
+- acquire: `tryAcquire(waitTimeMs, leaseTimeMs, MILLISECONDS): String?` (permitId 반환)
+- **acquire 성공 후 `startedAtNanos = System.nanoTime()` 캡처** (Codex P2 — waitTime 이 minLease 에서 차감되지 않게)
+- release in finally:
+  ```kotlin
+  val remainingMs = remainingMinLeaseTime(startedAtNanos, options.minLeaseTime).inWholeMilliseconds
+  if (remainingMs > 0) {
+      semaphore.updateLeaseTime(permitId, remainingMs, TimeUnit.MILLISECONDS)
+  } else {
+      semaphore.release(permitId)
+  }
+  ```
+  - **API 명: `updateLeaseTime`** (Codex P2 — `tryUpdateLeaseTime` 미존재)
+- `activeCount` / `availableSlots`: `availablePermits()` 사용 (RPermitExpirableSemaphore 도 RSemaphore 상속)
+
+### T8: `RedissonSuspendLeaderGroupElector` 수정
+**complexity: high**
+**파일**: `leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElector.kt`
+
+T7 동일 + suspend:
+- `tryAcquireAsync(waitMs, leaseMs, MILLISECONDS).await(): String?`
+- `withContext(NonCancellable) { try { ... `updateLeaseTimeAsync(permitId, ...).await()` ... } catch (CancellationException) { throw } catch (Exception) { log.warn } }`
+- 기존 `runCatching { ... releaseAsync().await() }` (CancellationException 삼킴) 제거
+
+### T9: Redisson group 테스트 minLeaseTime + crash recovery 추가
+**complexity: medium**
+**파일**:
+- `leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElectionTest.kt`
+- `leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElectorTest.kt`
+
+T6 와 동일 시나리오 6종.
+
+---
+
+## Phase 5 — Verification
+
+### T10: 전체 빌드 + 테스트
+**complexity: low**
+
+```bash
+./gradlew :leader-redis-lettuce:test :leader-redis-redisson:test --no-daemon --no-build-cache
+./gradlew build -x test -x koverVerify
+./gradlew detekt
+```
+
+기존 group 테스트 회귀 0 + 새 시나리오 전부 통과.
+
+### T11: README + CLAUDE.md 갱신 (Codex P3)
+**complexity: low**
+**파일**:
+- `leader-redis-lettuce/README.md` + `README.ko.md`
+- `leader-redis-redisson/README.md` + `README.ko.md`
+- **`CLAUDE.md` (root)** — group 백엔드 모델 변경 (slot-token TTL 위임) 반영
+
+slot-token 모델 + crash recovery + minLeaseTime backend TTL 위임 명시.
+
+### T12: lessons doc
+**complexity: low**
+**파일**: `docs/lessons/2026-05-10-redis-group-slot-token.md`
+
+L1+: Lua server-side TIME, RPermitExpirableSemaphore 초기화, updateLeaseTime API 명, ZSET sorted set 패턴, 등.
+
+---
+
+## 의존 그래프
+
+```
+T1 (Lettuce primitive)
+  ↓
+T2 (primitive 단위 테스트)
+  ↓
+T3 (Deprecate old)
+  ↓
+T4 + T5 (Lettuce electors)
+  ↓
+T6 (Lettuce group 통합 테스트)
+  ↓
+T7 + T8 (Redisson electors) — T1~T6 와 독립 (병렬 가능)
+  ↓
+T9 (Redisson 통합 테스트)
+  ↓
+T10 + T11 + T12 (검증 + 문서)
+```
+
+T1~T6 (Lettuce) 와 T7~T9 (Redisson) 는 **독립 병렬** 가능 (서로 영향 없음).
+
+---
+
+## Task DoD
+
+| ID | 설명 | complexity | 의존 |
+|----|------|------------|------|
+| T1 | LettuceSlotTokenGroup.kt 신규 | high | - |
+| T2 | LettuceSlotTokenGroupTest.kt 신규 | medium | T1 |
+| T3 | LettuceSemaphore @Deprecated | low | T1 |
+| T4 | LettuceLeaderGroupElector 수정 | high | T1 |
+| T5 | LettuceSuspendLeaderGroupElector 수정 | high | T1 |
+| T6 | Lettuce group 테스트 추가 | medium | T4 + T5 |
+| T7 | RedissonLeaderGroupElector 수정 | high | - |
+| T8 | RedissonSuspendLeaderGroupElector 수정 | high | - |
+| T9 | Redisson group 테스트 추가 | medium | T7 + T8 |
+| T10 | 전체 빌드 + 테스트 | low | T6 + T9 |
+| T11 | README 갱신 | low | T10 |
+| T12 | lessons doc | low | T10 |

--- a/docs/superpowers/specs/2026-05-10-redis-group-slot-token-design.md
+++ b/docs/superpowers/specs/2026-05-10-redis-group-slot-token-design.md
@@ -1,0 +1,200 @@
+# Spec — Redis Group minLeaseTime slot-token TTL 재설계
+
+**Issue**: #151
+**관련 PR (참조)**: #149 (core/local minLeaseTime), #150 (single lock backend TTL 위임)
+**작성일**: 2026-05-10
+**영향 모듈**: `leader-redis-lettuce/`, `leader-redis-redisson/`
+
+---
+
+## 1. 배경 / 문제
+
+PR #150 머지로 single lock backend 들 (Lettuce/Redisson 단일 락, MongoDB, Hazelcast, Exposed JDBC/R2DBC) 의 `minLeaseTime` 은 backend TTL 위임 방식으로 통일됨. 그러나 Redis group elector (Lettuce + Redisson) 는 구조적 한계로 위임 불가능했음:
+
+- **Lettuce**: `LettuceSemaphore` 가 단일 INTEGER 카운터 — slot 식별자 없음, TTL 없음
+- **Redisson**: 표준 `RSemaphore` — clientId/slot 추적 안 됨
+
+결과: group 의 `minLeaseTime` 시맨틱 구현 불가. 또한 클라이언트 비정상 종료 시 슬롯 영구 누수.
+
+---
+
+## 2. 목표
+
+Redis group elector 모델을 **slot-token 기반**으로 재설계하여:
+
+1. 각 acquired slot 이 **고유 token + expiry score** 를 가짐
+2. 빠른 action 완료 시 token 의 score 만 갱신하여 **minLeaseTime 동안 slot 점유 유지** (caller-park 없이 backend TTL 위임)
+3. 클라이언트 crash 시 **다음 acquire 시점에 자동 회수** (외부 reaper 불필요)
+4. Lettuce / Redisson 양쪽 backend 의 동작 의미 통일
+5. 기존 `maxLeaders`, `waitTime`, `leaseTime` semantic backward compatibility 유지
+
+---
+
+## 3. 채택 모델
+
+### 3.1 Lettuce — Sorted Set + Lua atomic script
+
+`lg:{lockName}` ZSET. score = expiryAt (epoch milliseconds). member = token (Base58.randomString(8)).
+
+**ACQUIRE Lua** (server-side clock으로 클럭 skew 차단):
+```lua
+-- KEYS[1] = slotKey, ARGV[1] = maxLeaders, ARGV[2] = token, ARGV[3] = leaseTimeMs
+local t = redis.call('TIME')
+local nowMs = tonumber(t[1]) * 1000 + math.floor(tonumber(t[2]) / 1000)
+redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, nowMs)
+if redis.call('ZCARD', KEYS[1]) < tonumber(ARGV[1]) then
+  redis.call('ZADD', KEYS[1], nowMs + tonumber(ARGV[3]), ARGV[2])
+  redis.call('PEXPIRE', KEYS[1], tonumber(ARGV[3]) + 5000)
+  return ARGV[2]
+end
+return ''
+```
+
+**RELEASE Lua** (server-side clock):
+```lua
+-- KEYS[1] = slotKey, ARGV[1] = token, ARGV[2] = remainingMinLeaseMs
+if tonumber(ARGV[2]) > 0 then
+  local t = redis.call('TIME')
+  local nowMs = tonumber(t[1]) * 1000 + math.floor(tonumber(t[2]) / 1000)
+  return redis.call('ZADD', KEYS[1], 'XX', nowMs + tonumber(ARGV[2]), ARGV[1])
+else
+  return redis.call('ZREM', KEYS[1], ARGV[1])
+end
+```
+
+**STATUS Lua** (server-side clock):
+```lua
+-- KEYS[1] = slotKey, ARGV[1] = maxLeaders
+local t = redis.call('TIME')
+local nowMs = tonumber(t[1]) * 1000 + math.floor(tonumber(t[2]) / 1000)
+redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, nowMs)
+local active = redis.call('ZCARD', KEYS[1])
+return { active, tonumber(ARGV[1]) - active }
+```
+
+**근거 (Codex P1)**: 클라이언트 clock skew 시 `nowMs` 클라이언트 사용은 fast client 가 valid slot 제거 / slow client 가 overlong lease 생성 가능. **모든 시간 비교는 Redis 서버 시간 기준** (`redis.call('TIME')`).
+
+### 3.2 Redisson — RPermitExpirableSemaphore
+
+`lg:{lockName}` RPermitExpirableSemaphore. Redisson 표준 API (Redisson 4.3.1):
+- `trySetPermits(maxLeaders): Boolean` — **첫 사용 전 반드시 호출** (멱등). 안 하면 0 permits 로 시작하여 acquire 영구 실패.
+- `tryAcquire(waitTime, leaseTime, unit): String?` — permitId 반환 (null = 획득 실패)
+- `updateLeaseTime(permitId, leaseTime, unit): Unit` (sync) / `updateLeaseTimeAsync(permitId, leaseTime, unit): RFuture<Void>` (async) — minLease 위임
+  - 주의: `tryUpdateLeaseTime` 은 Redisson 4.3.1 에 없음. `updateLeaseTime` 만 존재.
+- `release(permitId)` — 즉시 해제
+
+자체 Lua script 불필요. Redisson watchdog 자연 결합.
+
+**근거 (Codex P1+P2)**:
+- 새 `lg:{lockName}` 키에 `trySetPermits(maxLeaders)` 멱등 초기화 누락 시 모든 acquire 실패 → group election 영구 안 됨
+- API 명칭 정확: `updateLeaseTime` / `updateLeaseTimeAsync` (Redisson 4.3.1)
+
+### 3.3 키 prefix `lg:{lockName}` 도입 (backward compat)
+
+기존 `lockName` (string counter / RSemaphore Hash) 와 충돌 회피 — 롤링 배포 중 구버전 클라이언트와 새 버전 클라이언트가 다른 키 사용 → WRONGTYPE 에러 방지.
+
+**Trade-off**: 롤링 배포 중 일시적으로 maxLeaders 의 효과가 2배가 될 수 있음 (구/신 그룹 분리). 완화책: 구버전 pod drain 후 신버전 배포.
+
+---
+
+## 4. 인터페이스 변경
+
+`LeaderGroupElector` 인터페이스 자체 변경 없음. Token 은 내부 구현 디테일 — caller 에 노출하지 않음.
+
+`LeaderGroupElectionOptions` 변경 없음 (`minLeaseTime` 이미 존재).
+
+---
+
+## 5. 동작 / 계약
+
+### 5.1 acquire
+
+```
+client → elector.runIfLeader(lockName, action)
+  startedAtNanos = System.nanoTime()
+  token = backend.tryAcquire(lockName, waitTime, leaseTime)
+  token == null → return null   (ShedLock skip-on-contention)
+  try { result = action() }
+  finally {
+    remainingMs = remainingMinLeaseTime(startedAtNanos, options.minLeaseTime).inWholeMilliseconds
+    backend.release(lockName, token, remainingMs)   // remainingMs > 0 → score 갱신, else → 즉시 해제
+  }
+  return result
+```
+
+### 5.2 minLeaseTime 시맨틱
+
+- `minLeaseTime == 0` (default): action 종료 즉시 slot 해제 (기존 동작 동일)
+- `minLeaseTime > 0`: action 이 minLeaseTime 보다 빨리 끝나도 slot 은 minLeaseTime 만료 까지 유지 (다른 client 가 같은 slot 못 잡음)
+- `minLeaseTime > leaseTime`: `IllegalArgumentException` (기존 init 검증, 변경 없음)
+- `minLeaseTime` 만료 후 자동으로 다음 client 가 acquire 가능
+
+### 5.3 leak recovery
+
+클라이언트 crash 시:
+- Lettuce: 다음 acquire 시 `ZREMRANGEBYSCORE 0 nowMs` 가 만료 entry 자동 정리
+- Redisson: `RPermitExpirableSemaphore` 가 backend TTL 로 permit 자동 회수
+
+외부 reaper 불필요. `leaseTime` 만료 후 다음 acquire 가 success.
+
+### 5.4 split-brain 방지
+
+`leaseTime` 이 action 실제 시간보다 짧으면:
+- backend 가 slot 자동 만료 → 다른 client acquire → 동시 실행 (split-brain)
+- watchdog auto-extension 미구현 (이번 issue scope 외)
+- caller 책임: `leaseTime > worst-case action duration` 보장
+
+---
+
+## 6. DoD
+
+### Lettuce
+
+- [ ] `LettuceSlotTokenGroup` 신규 — ZSET + 3 Lua scripts (ACQUIRE/RELEASE/STATUS)
+- [ ] sync/async/suspend API 모두 (tryAcquire / release / availableSlots / activeCount)
+- [ ] `LettuceLeaderGroupElector` — `LettuceSemaphore` → `LettuceSlotTokenGroup` 교체 + minLeaseTime release
+- [ ] `LettuceSuspendLeaderGroupElector` — 동일 + CancellationException 재throw 패턴 적용
+- [ ] `LettuceSemaphore` / `LettuceSuspendSemaphore` `@Deprecated`
+- [ ] `LettuceSlotTokenGroupTest` 신규 — primitive 단위 테스트
+- [ ] `LettuceLeaderGroupElectionTest` + `LettuceSuspendLeaderGroupElectorTest` minLeaseTime 시나리오 + crash recovery 추가
+
+### Redisson
+
+- [ ] `RedissonLeaderGroupElector` — `RSemaphore` → `RPermitExpirableSemaphore`, minLeaseTime → `updateLeaseTime` (sync) / `updateLeaseTimeAsync` (async)
+- [ ] `RedissonSuspendLeaderGroupElector` — 동일 + CancellationException 재throw 적용
+- [ ] `RedissonLeaderGroupElectionTest` + `RedissonSuspendLeaderGroupElectorTest` minLeaseTime 시나리오 + crash recovery
+
+### 공통
+
+- [ ] 기존 group 테스트 회귀 0
+- [ ] `./gradlew :leader-redis-lettuce:test :leader-redis-redisson:test` 모두 통과
+- [ ] `./gradlew detekt` 새 violation 0
+- [ ] README.md / README.ko.md 양 모듈 동기화 (slot-token 모델 + crash recovery 명시)
+- [ ] CLAUDE.md 갱신 (group 백엔드 모델 변경 반영)
+- [ ] `docs/lessons/2026-05-10-redis-group-slot-token.md` lesson doc
+
+---
+
+## 7. 테스트 시나리오 (필수)
+
+각 backend × blocking/suspend 4종 모두에 적용:
+
+1. **빠른 action + minLeaseTime > runtime**: caller 즉시 반환 확인 + 다른 client 가 minLeaseTime 만료 전 acquire 실패 확인
+2. **minLeaseTime 만료 후**: 다음 client acquire 성공
+3. **`minLeaseTime == 0`**: 즉시 release 회귀 방지
+4. **maxLeaders 동시 점유 + 모두 minLeaseTime 보유**: maxLeaders+1 번째 client 는 waitTime 내 실패
+5. **slot 누수 회수**: client crash 시뮬레이션 (release 호출 없음) → leaseTime 만료 후 다른 client acquire 성공
+6. **Suspend 코루틴 취소 + minLeaseTime > 0**: NonCancellable release 가 minLease score 갱신 정확히 적용
+7. **autoExtend + minLeaseTime > 0** (group autoExtend 도입 시): IllegalArgumentException — 이번 PR scope 외, group autoExtend 미구현이므로 N/A
+
+---
+
+## 8. 위험 / 완화
+
+| 위험 | 완화 |
+|------|------|
+| 키 자료구조 변경 → 롤링 배포 중 WRONGTYPE | `lg:{lockName}` prefix 도입 |
+| maxLeaders 일시 2배 (구/신 분리) | 구 pod drain 후 신 배포 명시 (CHANGELOG) |
+| Lua script 에러 → 락 누수 | release try-catch + 어차피 leaseTime TTL 로 자동 회수 |
+| `updateLeaseTime` race (minLease 가 release 시점 직전 만료) | RFuture<Boolean> false 반환 시 warn log 만, 던지지 않음 — 이미 자동 만료된 정상 결과 |
+| backward compat (행동 변경) | `minLeaseTime` semantic 자체는 동일 — caller-park → backend-TTL, 외부 관찰 동일 |

--- a/leader-redis-lettuce/README.ko.md
+++ b/leader-redis-lettuce/README.ko.md
@@ -8,9 +8,13 @@
 
 ## 개요
 
-`leader-redis-lettuce`는 Lettuce 리액티브 Redis 클라이언트를 사용하여 `leader-core` 인터페이스를 구현합니다. 락 프리미티브(`LettuceLock`, `LettuceSemaphore`)는 이 모듈에 직접 이식되어 있어 `bluetape4k-lettuce`에 대한 런타임 의존이 없습니다.
+`leader-redis-lettuce`는 Lettuce 리액티브 Redis 클라이언트를 사용하여 `leader-core` 인터페이스를 구현합니다. 락 프리미티브(`LettuceLock`, `LettuceSlotTokenGroup`)는 이 모듈에 직접 이식되어 있어 `bluetape4k-lettuce`에 대한 런타임 의존이 없습니다.
 
-락 전략: Redis `SET key value NX PX ttl` (원자적 compare-and-set). `LeaderElectionOptions(autoExtend = true)`를 사용하면 단일 리더 elector가 action 실행 중 token 조건부 `PEXPIRE`로 TTL을 갱신합니다. 그룹/세마포어 갱신은 자동으로 수행하지 않습니다.
+단일 리더 전략: Redis `SET key value NX PX ttl` (원자적 compare-and-set). `LeaderElectionOptions(autoExtend = true)`를 사용하면 단일 리더 elector가 action 실행 중 token 조건부 `PEXPIRE`로 TTL을 갱신합니다.
+
+그룹 전략 (slot-token TTL 모델): 단일 ZSET 키 `lg:{lockName}` 의 member 는 슬롯별 token (`Base58.randomString(8)`) 이고 score 는 `expiryAtMs` 입니다. ACQUIRE / RELEASE / STATUS Lua 스크립트는 모두 `redis.call('TIME')` 으로 Redis 서버 시간을 읽어 사용하므로 클라이언트 clock skew 영향이 없으며, ACQUIRE 시점에 `ZREMRANGEBYSCORE` 로 만료된 entry 를 자동 회수합니다. 클라이언트 crash 시 (release 미호출) 다음 acquire 시 자동 정리되므로 외부 reaper 가 필요 없습니다.
+
+> 기존 `LettuceSemaphore` / `LettuceSuspendSemaphore` 는 `LettuceSlotTokenGroup` 으로 대체되며 `@Deprecated` 처리되었습니다. 새 `lg:{lockName}` 키 prefix 는 롤링 배포 시 구버전 키와의 충돌을 피하기 위해 의도적으로 분리되었습니다.
 
 ## 아키텍처
 
@@ -33,17 +37,14 @@ classDiagram
         +tryLock(key, value, ttl) Boolean
         +unlock(key, value)
     }
-    class LettuceSemaphore {
-        +acquire(key, permits, ttl) Boolean
-        +release(key, permits)
+    class LettuceSlotTokenGroup {
+        +tryAcquire(waitTime, leaseTime) String?
+        +release(token, remainingMinLeaseMs)
+        +activeCount() Int
     }
     class LettuceSuspendLock {
         +tryLock(key, value, ttl) Boolean
         +unlock(key, value)
-    }
-    class LettuceSuspendSemaphore {
-        +acquire(key, permits, ttl) Boolean
-        +release(key, permits)
     }
 
     LettuceLeaderElector ..|> LeaderElector
@@ -52,9 +53,75 @@ classDiagram
     LettuceSuspendLeaderGroupElector ..|> SuspendLeaderGroupElector
 
     LettuceLeaderElector --> LettuceLock
-    LettuceLeaderGroupElector --> LettuceSemaphore
+    LettuceLeaderGroupElector --> LettuceSlotTokenGroup
     LettuceSuspendLeaderElector --> LettuceSuspendLock
-    LettuceSuspendLeaderGroupElector --> LettuceSuspendSemaphore
+    LettuceSuspendLeaderGroupElector --> LettuceSlotTokenGroup
+```
+
+## 그룹 락 흐름
+
+slot-token TTL 모델은 두 시나리오로 가장 잘 이해할 수 있습니다: 정상 acquire/release 와 crash recovery, 그리고 `minLeaseTime` 의 backend ZSET score 위임.
+
+### 시나리오 1 — 정상 acquire/release 와 crash recovery
+
+```mermaid
+sequenceDiagram
+    participant ClientA
+    participant ClientB
+    participant Redis as "Redis (lg:{lockName} ZSET)"
+
+    Note over ClientA,Redis: 정상 흐름 — slot-token TTL
+    ClientA->>Redis: EVALSHA ACQUIRE (maxLeaders=2, token=A1, leaseMs=10s)
+    Redis->>Redis: TIME -> nowMs<br/>ZREMRANGEBYSCORE 0 nowMs<br/>ZCARD < maxLeaders<br/>ZADD score=(nowMs+10s) member=A1<br/>PEXPIRE key (15s)
+    Redis-->>ClientA: token A1
+    ClientA->>ClientA: action() 실행
+
+    Note over ClientB,Redis: ClientA 작업 중
+    ClientB->>Redis: EVALSHA ACQUIRE (token=B1)
+    Redis-->>ClientB: token B1 (slot 2)
+
+    ClientA->>Redis: EVALSHA RELEASE (A1, remainingMinLeaseMs=0)
+    Redis->>Redis: ZREM lg:{lockName} A1
+    Redis-->>ClientA: 1
+
+    Note over ClientA,Redis: ClientA crash 시뮬레이션 (release 호출 안 됨)
+    ClientA->>Redis: EVALSHA ACQUIRE (token=A2, leaseMs=2s)
+    Redis-->>ClientA: token A2
+    ClientA->>ClientA: release 전 crash
+
+    Note over ClientB,Redis: 2초 후 leaseTime 만료
+    ClientB->>Redis: EVALSHA ACQUIRE (token=B3)
+    Redis->>Redis: ZREMRANGEBYSCORE -> A2 자동 정리<br/>ZADD B3
+    Redis-->>ClientB: token B3 (자동 회수)
+```
+
+### 시나리오 2 — `minLeaseTime` 의 backend TTL 위임
+
+```mermaid
+sequenceDiagram
+    participant ClientA
+    participant ClientB
+    participant Redis as "Redis (lg:{lockName} ZSET)"
+
+    Note over ClientA,Redis: minLeaseTime=300ms, action 빨리 종료 (50ms)
+
+    ClientA->>Redis: ACQUIRE token=A1
+    Redis-->>ClientA: token A1
+    ClientA->>ClientA: action() 50ms 실행
+    ClientA->>Redis: RELEASE (A1, remainingMinLeaseMs=250)
+    Redis->>Redis: TIME -> nowMs<br/>ZADD XX score=(nowMs+250) A1
+    Redis-->>ClientA: 1
+    Note over ClientA: caller 즉시 반환 (park 없음)
+
+    Note over ClientB,Redis: 250ms 이내
+    ClientB->>Redis: ACQUIRE (waitTime=100ms)
+    Redis->>Redis: ZREMRANGEBYSCORE -> A1 미만료<br/>ZCARD == maxLeaders
+    Redis-->>ClientB: '' (실패)
+
+    Note over ClientB,Redis: 250ms 후
+    ClientB->>Redis: ACQUIRE
+    Redis->>Redis: ZREMRANGEBYSCORE -> A1 만료 정리
+    Redis-->>ClientB: token B1 (성공)
 ```
 
 ## 구현체 목록
@@ -62,9 +129,9 @@ classDiagram
 | 클래스 | 구현 인터페이스 | 설명 |
 |-------|--------------|------|
 | `LettuceLeaderElector` | `LeaderElector` | `LettuceLock` 기반 블로킹 단일 리더 |
-| `LettuceLeaderGroupElector` | `LeaderGroupElector` | `LettuceSemaphore` 기반 블로킹 복수 리더 |
+| `LettuceLeaderGroupElector` | `LeaderGroupElector` | `LettuceSlotTokenGroup` (slot-token TTL) 기반 블로킹 복수 리더 |
 | `LettuceSuspendLeaderElector` | `SuspendLeaderElector` | `LettuceSuspendLock` 기반 코루틴 단일 리더 |
-| `LettuceSuspendLeaderGroupElector` | `SuspendLeaderGroupElector` | `LettuceSuspendSemaphore` 기반 코루틴 복수 리더 |
+| `LettuceSuspendLeaderGroupElector` | `SuspendLeaderGroupElector` | `LettuceSlotTokenGroup` 기반 코루틴 복수 리더 |
 | `LettuceSuspendLeaderElectorFactory` | `SuspendLeaderElectorFactory` | 팩토리: 호출마다 `LettuceSuspendLeaderElector` 생성 |
 | `LettuceSuspendLeaderGroupElectorFactory` | `SuspendLeaderGroupElectorFactory` | 팩토리: 호출마다 `LettuceSuspendLeaderGroupElector` 생성 |
 
@@ -139,6 +206,19 @@ val options = LeaderElectionOptions(
 val election = LettuceLeaderElector(connection, options)
 ```
 
+### 그룹 옵션 — `minLeaseTime` 은 backend TTL 에 위임
+
+복수 리더 그룹에서 `LeaderGroupElectionOptions(minLeaseTime = ...)` 는 슬롯이 최소 그 시간만큼 점유 상태로 유지되도록 합니다. 구현은 caller 를 park 하지 않고 release 시점에 슬롯 ZSET score (서버 측 TTL) 만 연장하므로, `runIfLeader` 는 `action` 종료 직후 즉시 반환합니다:
+
+```kotlin
+val options = LeaderGroupElectionOptions(
+    maxLeaders = 3,
+    leaseTime = 30.seconds,
+    minLeaseTime = 1.seconds, // 빠른 action 종료 시에도 최소 1초 슬롯 유지
+)
+val election = LettuceLeaderGroupElector(connection, options)
+```
+
 ### SPI 팩토리 사용
 
 ```kotlin
@@ -171,7 +251,18 @@ else
 end
 ```
 
-`LettuceSemaphore`는 Redis 리스트에 permit 토큰을 관리합니다. 획득 시 토큰 추가, 반환 시 토큰 제거.
+### `LettuceSlotTokenGroup` — slot-token TTL 모델
+
+`LettuceLeaderGroupElector` / `LettuceSuspendLeaderGroupElector` 가 사용하는 그룹 프리미티브:
+
+- 단일 ZSET 키 `lg:{lockName}` — `member = Base58 token (8자)`, `score = expiryAtMs`.
+- ACQUIRE / RELEASE / STATUS Lua 스크립트는 `redis.call('TIME')` 으로 시간을 읽어 클라이언트 clock skew 영향 없음.
+- ACQUIRE 시점에 `ZREMRANGEBYSCORE 0 nowMs` 로 만료된 entry 를 자동 회수 — 외부 reaper 불필요, crash recovery 자동.
+- RELEASE 시 `remainingMinLeaseMs > 0` 이면 `ZADD XX` 로 score 를 갱신하여 슬롯을 유지 (`minLeaseTime` 을 backend TTL 에 위임). 그렇지 않으면 member 를 제거.
+- 슬롯 미획득 시 `null` 반환 (waitTime 초과) — `IllegalStateException` 미발생.
+- `lg:{lockName}` prefix 는 구버전 `LettuceSemaphore` 키와의 충돌을 방지하기 위해 의도적으로 분리되었습니다.
+
+> 기존 `LettuceSemaphore` / `LettuceSuspendSemaphore` (Redis 카운터 + permit 토큰 리스트) 는 소스 트리에 `@Deprecated` 로 남아 있으며, 그룹 elector 와 더 이상 연결되지 않습니다.
 
 ## 의존성 추가
 

--- a/leader-redis-lettuce/README.md
+++ b/leader-redis-lettuce/README.md
@@ -8,9 +8,13 @@ Redis-backed leader election using [Lettuce](https://lettuce.io/) — blocking a
 
 ## Overview
 
-`leader-redis-lettuce` implements `leader-core` interfaces using Lettuce's reactive Redis client. Lock primitives (`LettuceLock`, `LettuceSemaphore`) are ported directly into this module — no runtime dependency on `bluetape4k-lettuce`.
+`leader-redis-lettuce` implements `leader-core` interfaces using Lettuce's reactive Redis client. Lock primitives (`LettuceLock`, `LettuceSlotTokenGroup`) are ported directly into this module — no runtime dependency on `bluetape4k-lettuce`.
 
-Lock strategy: Redis `SET key value NX PX ttl` (atomic compare-and-set). With `LeaderElectionOptions(autoExtend = true)`, single-leader electors renew the TTL with a token-conditional `PEXPIRE` while the action is running. Group/semaphore renewal is not automatic.
+Single-leader strategy: Redis `SET key value NX PX ttl` (atomic compare-and-set). With `LeaderElectionOptions(autoExtend = true)`, single-leader electors renew the TTL with a token-conditional `PEXPIRE` while the action is running.
+
+Group strategy (slot-token TTL model): a single ZSET key `lg:{lockName}` whose members are per-slot tokens (`Base58.randomString(8)`) and whose `score = expiryAtMs`. ACQUIRE/RELEASE/STATUS Lua scripts use Redis server-side `TIME` so client clock skew is irrelevant, and ACQUIRE auto-evicts expired members via `ZREMRANGEBYSCORE`. Crash recovery is automatic (no external reaper required) — if a holder dies without releasing, the slot is reclaimed on the next acquire after `leaseTime`.
+
+> The legacy `LettuceSemaphore` / `LettuceSuspendSemaphore` primitives are `@Deprecated` in favor of `LettuceSlotTokenGroup`. The new `lg:{lockName}` key prefix avoids collisions with any pre-existing keys during rolling deployment.
 
 ## Architecture
 
@@ -33,17 +37,14 @@ classDiagram
         +tryLock(key, value, ttl) Boolean
         +unlock(key, value)
     }
-    class LettuceSemaphore {
-        +acquire(key, permits, ttl) Boolean
-        +release(key, permits)
+    class LettuceSlotTokenGroup {
+        +tryAcquire(waitTime, leaseTime) String?
+        +release(token, remainingMinLeaseMs)
+        +activeCount() Int
     }
     class LettuceSuspendLock {
         +tryLock(key, value, ttl) Boolean
         +unlock(key, value)
-    }
-    class LettuceSuspendSemaphore {
-        +acquire(key, permits, ttl) Boolean
-        +release(key, permits)
     }
 
     LettuceLeaderElector ..|> LeaderElector
@@ -52,9 +53,75 @@ classDiagram
     LettuceSuspendLeaderGroupElector ..|> SuspendLeaderGroupElector
 
     LettuceLeaderElector --> LettuceLock
-    LettuceLeaderGroupElector --> LettuceSemaphore
+    LettuceLeaderGroupElector --> LettuceSlotTokenGroup
     LettuceSuspendLeaderElector --> LettuceSuspendLock
-    LettuceSuspendLeaderGroupElector --> LettuceSuspendSemaphore
+    LettuceSuspendLeaderGroupElector --> LettuceSlotTokenGroup
+```
+
+## Group Lock Flow
+
+The slot-token TTL model is best understood through two scenarios: a normal acquire/release cycle with crash recovery, and `minLeaseTime` delegation to the backend ZSET score.
+
+### Scenario 1 — Normal acquire/release plus crash recovery
+
+```mermaid
+sequenceDiagram
+    participant ClientA
+    participant ClientB
+    participant Redis as "Redis (lg:{lockName} ZSET)"
+
+    Note over ClientA,Redis: Normal flow — slot-token TTL
+    ClientA->>Redis: EVALSHA ACQUIRE (maxLeaders=2, token=A1, leaseMs=10s)
+    Redis->>Redis: TIME -> nowMs<br/>ZREMRANGEBYSCORE 0 nowMs<br/>ZCARD < maxLeaders<br/>ZADD score=(nowMs+10s) member=A1<br/>PEXPIRE key (15s)
+    Redis-->>ClientA: token A1
+    ClientA->>ClientA: action() running
+
+    Note over ClientB,Redis: ClientA still working
+    ClientB->>Redis: EVALSHA ACQUIRE (token=B1)
+    Redis-->>ClientB: token B1 (slot 2)
+
+    ClientA->>Redis: EVALSHA RELEASE (A1, remainingMinLeaseMs=0)
+    Redis->>Redis: ZREM lg:{lockName} A1
+    Redis-->>ClientA: 1
+
+    Note over ClientA,Redis: ClientA crash simulation (release never called)
+    ClientA->>Redis: EVALSHA ACQUIRE (token=A2, leaseMs=2s)
+    Redis-->>ClientA: token A2
+    ClientA->>ClientA: crash before release
+
+    Note over ClientB,Redis: 2s later — leaseTime expired
+    ClientB->>Redis: EVALSHA ACQUIRE (token=B3)
+    Redis->>Redis: ZREMRANGEBYSCORE -> A2 evicted<br/>ZADD B3
+    Redis-->>ClientB: token B3 (auto-recovered)
+```
+
+### Scenario 2 — `minLeaseTime` delegated to backend TTL
+
+```mermaid
+sequenceDiagram
+    participant ClientA
+    participant ClientB
+    participant Redis as "Redis (lg:{lockName} ZSET)"
+
+    Note over ClientA,Redis: minLeaseTime=300ms, action finishes fast (50ms)
+
+    ClientA->>Redis: ACQUIRE token=A1
+    Redis-->>ClientA: token A1
+    ClientA->>ClientA: action() runs 50ms
+    ClientA->>Redis: RELEASE (A1, remainingMinLeaseMs=250)
+    Redis->>Redis: TIME -> nowMs<br/>ZADD XX score=(nowMs+250) A1
+    Redis-->>ClientA: 1
+    Note over ClientA: caller returns immediately (no parking)
+
+    Note over ClientB,Redis: within 250ms window
+    ClientB->>Redis: ACQUIRE (waitTime=100ms)
+    Redis->>Redis: ZREMRANGEBYSCORE -> A1 not yet expired<br/>ZCARD == maxLeaders
+    Redis-->>ClientB: '' (failed)
+
+    Note over ClientB,Redis: after 250ms
+    ClientB->>Redis: ACQUIRE
+    Redis->>Redis: ZREMRANGEBYSCORE -> A1 evicted
+    Redis-->>ClientB: token B1 (success)
 ```
 
 ## Implementations
@@ -62,9 +129,9 @@ classDiagram
 | Class | Interface | Description |
 |-------|-----------|-------------|
 | `LettuceLeaderElector` | `LeaderElector` | Blocking single-leader via `LettuceLock` |
-| `LettuceLeaderGroupElector` | `LeaderGroupElector` | Blocking multi-leader via `LettuceSemaphore` |
+| `LettuceLeaderGroupElector` | `LeaderGroupElector` | Blocking multi-leader via `LettuceSlotTokenGroup` (slot-token TTL) |
 | `LettuceSuspendLeaderElector` | `SuspendLeaderElector` | Coroutine single-leader via `LettuceSuspendLock` |
-| `LettuceSuspendLeaderGroupElector` | `SuspendLeaderGroupElector` | Coroutine multi-leader via `LettuceSuspendSemaphore` |
+| `LettuceSuspendLeaderGroupElector` | `SuspendLeaderGroupElector` | Coroutine multi-leader via `LettuceSlotTokenGroup` |
 | `LettuceSuspendLeaderElectorFactory` | `SuspendLeaderElectorFactory` | Factory: creates `LettuceSuspendLeaderElector` per call |
 | `LettuceSuspendLeaderGroupElectorFactory` | `SuspendLeaderGroupElectorFactory` | Factory: creates `LettuceSuspendLeaderGroupElector` per call |
 
@@ -139,6 +206,19 @@ val options = LeaderElectionOptions(
 val election = LettuceLeaderElector(connection, options)
 ```
 
+### Group options — `minLeaseTime` is delegated to the backend TTL
+
+For multi-leader groups, `LeaderGroupElectionOptions(minLeaseTime = ...)` keeps a slot occupied for at least that duration. Implementation extends the slot's ZSET score (server-side TTL) on release rather than parking the caller, so `runIfLeader` returns as soon as `action` finishes:
+
+```kotlin
+val options = LeaderGroupElectionOptions(
+    maxLeaders = 3,
+    leaseTime = 30.seconds,
+    minLeaseTime = 1.seconds, // slot stays at least 1s after a fast action
+)
+val election = LettuceLeaderGroupElector(connection, options)
+```
+
 ### Using factories
 
 ```kotlin
@@ -171,7 +251,18 @@ else
 end
 ```
 
-`LettuceSemaphore` maintains a Redis list of permit tokens. Acquire appends a token; release removes one.
+### `LettuceSlotTokenGroup` — slot-token TTL model
+
+The group primitive backing `LettuceLeaderGroupElector` and `LettuceSuspendLeaderGroupElector`:
+
+- Single ZSET key `lg:{lockName}` — `member = Base58 token (8 chars)`, `score = expiryAtMs`.
+- ACQUIRE / RELEASE / STATUS Lua scripts read the timestamp via `redis.call('TIME')` so client clock skew has no effect.
+- ACQUIRE first runs `ZREMRANGEBYSCORE 0 nowMs` to evict expired members — crash recovery is automatic, no external reaper required.
+- RELEASE with `remainingMinLeaseMs > 0` does `ZADD XX` to extend the slot's score (delegating `minLeaseTime` to backend TTL); otherwise it removes the member.
+- Failed acquire returns `null` (waitTime exhausted) — no `IllegalStateException`.
+- The `lg:{lockName}` prefix is intentionally distinct from the legacy `LettuceSemaphore` keys to avoid collisions during rolling upgrades.
+
+> The legacy `LettuceSemaphore` / `LettuceSuspendSemaphore` (Redis counter + permit tokens) remain in the source tree marked `@Deprecated` and are no longer wired into the group electors.
 
 ## Dependency
 

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElector.kt
@@ -3,10 +3,11 @@ package io.bluetape4k.leader.lettuce
 import io.bluetape4k.leader.LeaderGroupElector
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.lettuce.semaphore.LettuceSlotTokenGroup
+import io.bluetape4k.leader.remainingMinLeaseTime
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
-import io.bluetape4k.leader.lettuce.semaphore.LettuceSemaphore
 import io.bluetape4k.support.requireNotBlank
 import io.lettuce.core.api.StatefulRedisConnection
 import java.util.concurrent.CompletableFuture
@@ -32,20 +33,27 @@ fun StatefulRedisConnection<String, String>.leaderGroupElection(
 
 
 /**
- * Lettuce Redis 클라이언트를 이용한 복수 리더 선출 구현체입니다.
+ * Lettuce Redis 클라이언트 기반의 복수 리더 선출 구현체입니다.
  *
- * [LettuceSemaphore]를 사용하여 분산 환경에서 최대 [maxLeaders]개의 리더를 동시에 허용합니다.
- * 동기([runIfLeader])와 비동기([runAsyncIfLeader]) 방식을 모두 지원합니다.
+ * ## 동작/계약
+ *
+ * - 내부적으로 [LettuceSlotTokenGroup] (ZSET + Lua) 을 사용하여 slot-token 모델로 동작합니다.
+ * - 각 acquire 는 고유 token 을 반환하며, release 시 token 으로 정확한 슬롯을 식별합니다.
+ * - `options.minLeaseTime > 0` 이면 빠른 action 종료 시 slot 의 score 만 갱신하여
+ *   `minLeaseTime` 동안 backend TTL 로 슬롯을 유지합니다 (caller-park 없음).
+ * - 클라이언트 crash 시 (release 미호출) leaseTime 만료 후 다음 acquire 시 자동 회수됩니다.
+ * - `runAsyncIfLeader` 가 반환한 [CompletableFuture] 는 action 완료 + slot release 가 모두 끝난 후에만
+ *   complete 됩니다. 따라서 chained `runAsyncIfLeader` 호출은 slot 이 freed 된 이후 시점에 acquire 를 시도합니다.
+ *   release 자체의 실패는 warn log 로 남기되 outer future 의 결과에는 영향을 주지 않습니다.
  *
  * ```kotlin
- * val options = LeaderGroupElectionOptions(maxLeaders = 3)
+ * val options = LeaderGroupElectionOptions(maxLeaders = 3, minLeaseTime = 1.seconds)
  * val election = LettuceLeaderGroupElector(connection, options)
  * val result = election.runIfLeader("batch-job") { processChunk() }
- * println(election.state("batch-job"))
  * ```
  *
  * @param connection Lettuce [StatefulRedisConnection] (StringCodec 기반)
- * @param options    리더 선출 옵션 (maxLeaders, waitTime, leaseTime)
+ * @param options    리더 선출 옵션 (maxLeaders, waitTime, leaseTime, minLeaseTime)
  */
 class LettuceLeaderGroupElector(
     private val connection: StatefulRedisConnection<String, String>,
@@ -54,53 +62,45 @@ class LettuceLeaderGroupElector(
 
     companion object: KLogging()
 
-    // 개선: LettuceSemaphore 인스턴스를 lockName 별로 1회만 생성/초기화 하여 재사용합니다.
-    //       이전엔 매 호출마다 `new + initialize()` 로 SET NX 라운드트립을 반복했습니다.
-    //       ConcurrentHashMap.computeIfAbsent 로 원자적 캐싱을 보장합니다.
-    private val semaphores = ConcurrentHashMap<String, LettuceSemaphore>()
-
-    private fun getSemaphore(lockName: String): LettuceSemaphore {
-        lockName.requireNotBlank("lockName")
-        return semaphores.computeIfAbsent(lockName) {
-            LettuceSemaphore(connection, it, maxLeaders).apply { initialize() }
-        }
-    }
-
     override val maxLeaders: Int = options.maxLeaders
 
-    override fun activeCount(lockName: String): Int {
-        val semaphore = getSemaphore(lockName)
-        return maxLeaders - semaphore.availablePermits()
+    // lockName 별 slot-token group 을 1회만 생성하여 재사용합니다.
+    private val slotGroups = ConcurrentHashMap<String, LettuceSlotTokenGroup>()
+
+    private fun getSlotGroup(lockName: String): LettuceSlotTokenGroup {
+        lockName.requireNotBlank("lockName")
+        return slotGroups.computeIfAbsent(lockName) {
+            LettuceSlotTokenGroup(connection, it, maxLeaders)
+        }
     }
 
-    override fun availableSlots(lockName: String): Int {
-        val semaphore = getSemaphore(lockName)
-        return semaphore.availablePermits()
-    }
+    override fun activeCount(lockName: String): Int = getSlotGroup(lockName).activeCount()
 
-    override fun state(lockName: String): LeaderGroupState {
-        val active = activeCount(lockName)
-        return LeaderGroupState(lockName, maxLeaders, active)
-    }
+    override fun availableSlots(lockName: String): Int = getSlotGroup(lockName).availableSlots()
+
+    override fun state(lockName: String): LeaderGroupState =
+        LeaderGroupState(lockName, maxLeaders, activeCount(lockName))
 
     override fun <T> runIfLeader(lockName: String, action: () -> T): T? {
-        val semaphore = getSemaphore(lockName)
+        val slotGroup = getSlotGroup(lockName)
 
-        val acquired = try {
-            semaphore.acquire(waitTime = options.waitTime)
-            true
-        } catch (e: IllegalStateException) {
+        val token = slotGroup.tryAcquire(options.waitTime, options.leaseTime)
+        if (token == null) {
             log.debug { "리더 선출 실패 (슬롯 없음): lockName=$lockName" }
-            false
+            return null
         }
-        if (!acquired) return null
-
-        log.debug { "리더 선출 성공: lockName=$lockName" }
+        // Codex P2: acquire 성공 후 startedAtNanos 캡처. acquire 전 캡처 시 waitTime 이 minLease 에서 차감.
+        val startedAtNanos = System.nanoTime()
+        log.debug { "리더 선출 성공: lockName=$lockName, token=$token" }
         try {
             return action()
         } finally {
-            runCatching { semaphore.release() }
-                .onFailure { log.warn(it) { "Fail to release semaphore slot. lockName=$lockName" } }
+            val remainingMs = remainingMinLeaseTime(startedAtNanos, options.minLeaseTime).inWholeMilliseconds
+            try {
+                slotGroup.release(token, remainingMs)
+            } catch (e: Throwable) {
+                log.warn(e) { "Failed to release slot. lockName=$lockName, token=$token" }
+            }
         }
     }
 
@@ -109,32 +109,62 @@ class LettuceLeaderGroupElector(
         executor: Executor,
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
-        val semaphore = getSemaphore(lockName)
+        val slotGroup = getSlotGroup(lockName)
 
-        return CompletableFuture.supplyAsync({
-            try {
-                semaphore.acquire(waitTime = options.waitTime)
-                true
-            } catch (e: IllegalStateException) {
+        return slotGroup.tryAcquireAsync(options.waitTime, options.leaseTime).thenComposeAsync({ token ->
+            if (token == null) {
                 log.debug { "리더 선출 실패 (슬롯 없음, async): lockName=$lockName" }
-                false
-            }
-        }, executor).thenCompose { acquired ->
-            if (!acquired) {
-                CompletableFuture.completedFuture(null)
+                CompletableFuture.completedFuture<T?>(null)
             } else {
-                log.debug { "리더 선출 성공 (async): lockName=$lockName" }
-                try {
-                    action().whenComplete { _, _ ->
-                        runCatching { semaphore.release() }
-                .onFailure { log.warn(it) { "Fail to release semaphore slot. lockName=$lockName" } }
-                    }
+                // Codex P2: acquire 성공 후 startedAtNanos 캡처
+                val startedAtNanos = System.nanoTime()
+                log.debug { "리더 선출 성공 (async): lockName=$lockName, token=$token" }
+
+                // Codex P2-2: action 결과(성공/실패)와 무관하게 release 완료까지 대기한 뒤 outer future 를 complete.
+                // 기존 구현은 release 를 fire-and-forget 으로 trigger 하여 chained 호출이 slot 이 아직 점유된 채로 보일 수 있었음.
+                val actionFuture: CompletableFuture<T> = try {
+                    action()
                 } catch (e: Throwable) {
-                    runCatching { semaphore.release() }
-                .onFailure { log.warn(it) { "Fail to release semaphore slot. lockName=$lockName" } }
-                    CompletableFuture.failedFuture(e)
+                    // action 자체가 sync throw 한 경우에도 release 를 sequential 하게 chain.
+                    return@thenComposeAsync releaseAndPropagate<T>(slotGroup, lockName, token, startedAtNanos, e, null)
+                }
+
+                actionFuture.handle<Pair<T?, Throwable?>> { value, error ->
+                    Pair(value, error)
+                }.thenCompose { (value, error) ->
+                    releaseAndPropagate<T>(slotGroup, lockName, token, startedAtNanos, error, value)
                 }
             }
-        }
+        }, executor)
+    }
+
+    /**
+     * action 종료 후 slot 을 release 하고, release 완료 시점에 결과(value 또는 error)로 future 를 complete 합니다.
+     *
+     * release 자체의 실패는 warn log 로만 남기고 outer future 의 결과에 영향을 주지 않습니다 — caller 는 action
+     * 의 성공/실패만 알면 충분하기 때문입니다. release 완료 전에는 outer future 가 complete 되지 않으므로
+     * 동일 elector 에 대한 chained `runAsyncIfLeader` 호출은 slot 이 정확히 freed 된 이후에만 acquire 를 시도합니다.
+     */
+    private fun <T> releaseAndPropagate(
+        slotGroup: LettuceSlotTokenGroup,
+        lockName: String,
+        token: String,
+        startedAtNanos: Long,
+        error: Throwable?,
+        value: T?,
+    ): CompletableFuture<T?> {
+        val remainingMs = remainingMinLeaseTime(startedAtNanos, options.minLeaseTime).inWholeMilliseconds
+        return slotGroup.releaseAsync(token, remainingMs)
+            .exceptionally { releaseError ->
+                log.warn(releaseError) { "Failed to release slot. lockName=$lockName, token=$token" }
+                Unit
+            }
+            .thenCompose {
+                if (error != null) {
+                    CompletableFuture.failedFuture(error)
+                } else {
+                    CompletableFuture.completedFuture<T?>(value)
+                }
+            }
     }
 }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElector.kt
@@ -3,15 +3,14 @@ package io.bluetape4k.leader.lettuce
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderGroupState
 import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
+import io.bluetape4k.leader.lettuce.semaphore.LettuceSlotTokenGroup
+import io.bluetape4k.leader.remainingMinLeaseTime
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
-import io.bluetape4k.leader.lettuce.semaphore.LettuceSemaphore
 import io.bluetape4k.support.requireNotBlank
 import io.lettuce.core.api.StatefulRedisConnection
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.future.await
 import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
 
@@ -33,19 +32,24 @@ fun StatefulRedisConnection<String, String>.suspendLeaderGroupElector(
 
 
 /**
- * Lettuce Redis 클라이언트를 이용한 코루틴 기반 복수 리더 선출 구현체입니다.
+ * Lettuce Redis 기반의 코루틴 복수 리더 선출 구현체입니다.
  *
- * [LettuceSemaphore]의 suspend 메서드를 사용하여 최대 [maxLeaders]개의 리더를 동시에 허용합니다.
+ * ## 동작/계약
+ *
+ * - 내부적으로 [LettuceSlotTokenGroup] (ZSET + Lua) 을 사용합니다.
+ * - 슬롯 획득 실패 시 `null` 을 반환합니다 (ShedLock skip-on-contention).
+ * - `options.minLeaseTime > 0` 이면 빠른 action 종료 시 score 만 갱신하여 minLeaseTime 동안 슬롯 유지.
+ * - 코루틴 취소 시에도 `withContext(NonCancellable)` 안에서 release 가 보장됩니다.
+ * - `CancellationException` 은 항상 re-throw 합니다.
  *
  * ```kotlin
- * val options = LeaderGroupElectionOptions(maxLeaders = 3)
+ * val options = LeaderGroupElectionOptions(maxLeaders = 3, minLeaseTime = 1.seconds)
  * val election = LettuceSuspendLeaderGroupElector(connection, options)
  * val result = election.runIfLeader("batch-job") { processChunk() }
- * println(election.state("batch-job"))
  * ```
  *
  * @param connection Lettuce [StatefulRedisConnection] (StringCodec 기반)
- * @param options    리더 선출 옵션 (maxLeaders, waitTime, leaseTime)
+ * @param options    리더 선출 옵션 (maxLeaders, waitTime, leaseTime, minLeaseTime)
  */
 class LettuceSuspendLeaderGroupElector(
     private val connection: StatefulRedisConnection<String, String>,
@@ -56,54 +60,47 @@ class LettuceSuspendLeaderGroupElector(
 
     override val maxLeaders: Int = options.maxLeaders
 
-    // 개선: LettuceSemaphore 인스턴스를 lockName 별로 1회만 생성/초기화 하여 재사용합니다.
-    //       ConcurrentHashMap.computeIfAbsent 로 원자적 캐싱을 보장합니다.
-    private val semaphores = ConcurrentHashMap<String, LettuceSemaphore>()
+    private val slotGroups = ConcurrentHashMap<String, LettuceSlotTokenGroup>()
 
-    private fun getSemaphore(lockName: String): LettuceSemaphore {
+    private fun getSlotGroup(lockName: String): LettuceSlotTokenGroup {
         lockName.requireNotBlank("lockName")
-        return semaphores.computeIfAbsent(lockName) {
-            LettuceSemaphore(connection, it, maxLeaders).apply { initialize() }
+        return slotGroups.computeIfAbsent(lockName) {
+            LettuceSlotTokenGroup(connection, it, maxLeaders)
         }
     }
 
-    override fun activeCount(lockName: String): Int {
-        val semaphore = getSemaphore(lockName)
-        return maxLeaders - semaphore.availablePermits()
-    }
+    override fun activeCount(lockName: String): Int = getSlotGroup(lockName).activeCount()
 
-    override fun availableSlots(lockName: String): Int {
-        val semaphore = getSemaphore(lockName)
-        return semaphore.availablePermits()
-    }
+    override fun availableSlots(lockName: String): Int = getSlotGroup(lockName).availableSlots()
 
-    override fun state(lockName: String): LeaderGroupState {
-        val active = activeCount(lockName)
-        return LeaderGroupState(lockName, maxLeaders, active)
-    }
+    override fun state(lockName: String): LeaderGroupState =
+        LeaderGroupState(lockName, maxLeaders, activeCount(lockName))
 
     override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? {
-        val semaphore = getSemaphore(lockName)
-        val acquired = try {
-            semaphore.acquireAsync(waitTime = options.waitTime).await()
-            true
-        } catch (e: IllegalStateException) {
-            log.debug { "리더 선출 실패 (슬롯 없음, suspend): lockName=$lockName" }
-            false
-        }
-        if (!acquired) return null
+        val slotGroup = getSlotGroup(lockName)
 
-        log.debug { "리더 선출 성공 (suspend): lockName=$lockName" }
+        val token = slotGroup.tryAcquireSuspending(options.waitTime, options.leaseTime)
+        if (token == null) {
+            log.debug { "리더 선출 실패 (슬롯 없음, suspend): lockName=$lockName" }
+            return null
+        }
+        // Codex P2: acquire 성공 후 startedAtNanos 캡처
+        val startedAtNanos = System.nanoTime()
+        log.debug { "리더 선출 성공 (suspend): lockName=$lockName, token=$token" }
+
         try {
             return action()
         } finally {
             // NonCancellable: 코루틴 취소 시에도 슬롯 반납이 중단되지 않도록 보호
             withContext(NonCancellable) {
-                runCatching { semaphore.releaseAsync().await() }
-                    .onFailure { error ->
-                        if (error is CancellationException) throw error
-                        log.warn(error) { "Fail to release semaphore slot. lockName=$lockName" }
-                    }
+                try {
+                    val remainingMs = remainingMinLeaseTime(startedAtNanos, options.minLeaseTime).inWholeMilliseconds
+                    slotGroup.releaseSuspending(token, remainingMs)
+                } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    log.warn(e) { "Failed to release slot. lockName=$lockName, token=$token" }
+                }
             }
         }
     }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/semaphore/LettuceSemaphore.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/semaphore/LettuceSemaphore.kt
@@ -36,6 +36,10 @@ import java.util.concurrent.locks.LockSupport
  * @param semaphoreKey Redis에 저장될 세마포어 키
  * @param totalPermits 전체 허가 수
  */
+@Deprecated(
+    "Replaced by LettuceSlotTokenGroup which supports slot-token TTL and crash recovery",
+    level = DeprecationLevel.WARNING,
+)
 class LettuceSemaphore(
     private val connection: StatefulRedisConnection<String, String>,
     val semaphoreKey: String,

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/semaphore/LettuceSlotTokenGroup.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/semaphore/LettuceSlotTokenGroup.kt
@@ -1,0 +1,339 @@
+package io.bluetape4k.leader.lettuce.semaphore
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.leader.lettuce.script.RedisScript
+import io.bluetape4k.leader.lettuce.script.RedisScriptRunner
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
+import io.lettuce.core.ScriptOutputType
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.async.RedisAsyncCommands
+import io.lettuce.core.api.sync.RedisCommands
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.future.await
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.locks.LockSupport
+import kotlin.time.Duration
+
+/**
+ * Lettuce 기반 Redis ZSET + Lua 스크립트로 동작하는 slot-token group primitive 입니다.
+ *
+ * ## 동작/계약
+ *
+ * - 단일 키 `lg:{lockName}` 의 ZSET 에 `token = Base58.randomString(8)` 멤버를
+ *   `score = expiryAtMs` 로 추가하여 슬롯을 표현합니다.
+ * - ACQUIRE / RELEASE / STATUS 3개의 Lua 스크립트가 모두 `redis.call('TIME')` 을 사용해
+ *   **Redis 서버 시간** 만으로 만료를 판정하므로 클라이언트 clock skew 영향이 없습니다.
+ * - ACQUIRE 시점에 `ZREMRANGEBYSCORE 0 nowMs` 로 만료된 entry 를 자동 회수합니다.
+ *   클라이언트 crash 시 release 가 호출되지 않더라도 다음 acquire 시 자동 정리됩니다.
+ * - RELEASE 는 `remainingMinLeaseMs > 0` 이면 ZADD XX 로 score 를 갱신하여 슬롯을 유지합니다.
+ *   minLeaseTime 시맨틱을 backend TTL 에 위임하는 방식입니다 (caller-park 없음).
+ * - 슬롯 획득 spin-poll 은 50ms 간격이며, deadline 초과 시 `null` 을 반환합니다.
+ *   기존 `LettuceSemaphore` 와 달리 `IllegalStateException` 을 던지지 않습니다.
+ * - token 은 caller stack 이 보유하므로 동일 인스턴스가 여러 슬롯을 동시에 잡아도 안전합니다.
+ *
+ * ## 사용 예
+ *
+ * ```kotlin
+ * val group = LettuceSlotTokenGroup(connection, "batch-job", maxLeaders = 3)
+ * val token = group.tryAcquire(5.seconds) ?: return
+ * try {
+ *     doWork()
+ * } finally {
+ *     group.release(token, remainingMinLeaseMs = 0)
+ * }
+ * ```
+ *
+ * @param connection Lettuce [StatefulRedisConnection] (StringCodec 기반)
+ * @param lockName   slot 식별 이름 (`lg:{lockName}` 으로 prefix 됨)
+ * @param maxLeaders 최대 동시 점유 슬롯 수 (>= 1)
+ */
+class LettuceSlotTokenGroup(
+    private val connection: StatefulRedisConnection<String, String>,
+    val lockName: String,
+    val maxLeaders: Int,
+) {
+    companion object: KLogging() {
+        private const val SPIN_DELAY_MS = 50L
+        private const val SPIN_DELAY_NANOS = SPIN_DELAY_MS * 1_000_000L
+        private const val SLOT_KEY_TTL_MARGIN_MS = 5_000L
+        private const val TOKEN_LENGTH = 8
+        private const val KEY_PREFIX = "lg:{"
+        private const val KEY_SUFFIX = "}"
+
+        /**
+         * ACQUIRE 스크립트.
+         *
+         * KEYS[1] = slotKey
+         * ARGV[1] = maxLeaders
+         * ARGV[2] = token (Base58 8자)
+         * ARGV[3] = leaseTimeMs
+         *
+         * 반환: token (성공) 또는 빈 문자열 (실패)
+         */
+        private val ACQUIRE_SCRIPT = RedisScript(
+            """
+redis.replicate_commands()
+local t = redis.call('TIME')
+local nowMs = tonumber(t[1]) * 1000 + math.floor(tonumber(t[2]) / 1000)
+redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, nowMs)
+if redis.call('ZCARD', KEYS[1]) < tonumber(ARGV[1]) then
+  redis.call('ZADD', KEYS[1], nowMs + tonumber(ARGV[3]), ARGV[2])
+  redis.call('PEXPIRE', KEYS[1], tonumber(ARGV[3]) + $SLOT_KEY_TTL_MARGIN_MS)
+  return ARGV[2]
+end
+return ''
+"""
+        )
+
+        /**
+         * RELEASE 스크립트.
+         *
+         * KEYS[1] = slotKey
+         * ARGV[1] = token
+         * ARGV[2] = remainingMinLeaseMs
+         *
+         * remainingMinLeaseMs > 0 → 현재 score 가 nowMs 보다 큰 경우(아직 살아있는 token)에만
+         *                            ZADD XX 로 score 갱신 (slot 유지). expired token 부활 방지.
+         * 그 외 → ZREM 으로 즉시 해제
+         */
+        private val RELEASE_SCRIPT = RedisScript(
+            """
+redis.replicate_commands()
+if tonumber(ARGV[2]) > 0 then
+  local t = redis.call('TIME')
+  local nowMs = tonumber(t[1]) * 1000 + math.floor(tonumber(t[2]) / 1000)
+  local cur = redis.call('ZSCORE', KEYS[1], ARGV[1])
+  if cur and tonumber(cur) > nowMs then
+    return redis.call('ZADD', KEYS[1], 'XX', nowMs + tonumber(ARGV[2]), ARGV[1])
+  end
+  return 0
+else
+  return redis.call('ZREM', KEYS[1], ARGV[1])
+end
+"""
+        )
+
+        /**
+         * STATUS 스크립트.
+         *
+         * KEYS[1] = slotKey
+         * ARGV[1] = maxLeaders
+         *
+         * 반환: { active, available }
+         */
+        private val STATUS_SCRIPT = RedisScript(
+            """
+redis.replicate_commands()
+local t = redis.call('TIME')
+local nowMs = tonumber(t[1]) * 1000 + math.floor(tonumber(t[2]) / 1000)
+redis.call('ZREMRANGEBYSCORE', KEYS[1], 0, nowMs)
+local active = redis.call('ZCARD', KEYS[1])
+return { active, tonumber(ARGV[1]) - active }
+"""
+        )
+    }
+
+    init {
+        lockName.requireNotBlank("lockName")
+        maxLeaders.requirePositiveNumber("maxLeaders")
+    }
+
+    val slotKey: String = "$KEY_PREFIX$lockName$KEY_SUFFIX"
+
+    private val syncCommands: RedisCommands<String, String> = connection.sync()
+    private val asyncCommands: RedisAsyncCommands<String, String> = connection.async()
+
+    // =========================================================================
+    // 동기 API
+    // =========================================================================
+
+    /**
+     * 슬롯을 동기 방식으로 획득합니다.
+     *
+     * @param waitTime 슬롯 대기 최대 시간
+     * @return 획득 성공 시 token, 실패 시 `null`
+     */
+    fun tryAcquire(waitTime: Duration, leaseTime: Duration): String? {
+        val token = Base58.randomString(TOKEN_LENGTH)
+        val deadline = System.currentTimeMillis() + waitTime.inWholeMilliseconds
+        val leaseMs = leaseTime.inWholeMilliseconds.toString()
+        while (true) {
+            val result = RedisScriptRunner.run<String>(
+                syncCommands, ACQUIRE_SCRIPT, ScriptOutputType.VALUE,
+                arrayOf(slotKey), maxLeaders.toString(), token, leaseMs
+            )
+            if (!result.isNullOrEmpty()) {
+                log.debug { "슬롯 획득 성공. slotKey=$slotKey, token=$token" }
+                return result
+            }
+            if (System.currentTimeMillis() >= deadline) {
+                log.debug { "슬롯 획득 타임아웃. slotKey=$slotKey, waitTime=$waitTime" }
+                return null
+            }
+            LockSupport.parkNanos(SPIN_DELAY_NANOS)
+        }
+    }
+
+    /**
+     * 슬롯을 즉시 해제합니다 (`remainingMinLeaseMs <= 0`) 또는 score 만 갱신하여 유지합니다.
+     */
+    fun release(token: String, remainingMinLeaseMs: Long) {
+        token.requireNotBlank("token")
+        val ret = RedisScriptRunner.run<Long>(
+            syncCommands, RELEASE_SCRIPT, ScriptOutputType.INTEGER,
+            arrayOf(slotKey), token, remainingMinLeaseMs.toString()
+        )
+        log.debug {
+            "슬롯 해제. slotKey=$slotKey, token=$token, remainingMinLeaseMs=$remainingMinLeaseMs, ret=$ret"
+        }
+    }
+
+    fun activeCount(): Int = status().first
+    fun availableSlots(): Int = status().second
+
+    private fun status(): Pair<Int, Int> {
+        @Suppress("UNCHECKED_CAST")
+        val list = RedisScriptRunner.run<List<Long>>(
+            syncCommands, STATUS_SCRIPT, ScriptOutputType.MULTI,
+            arrayOf(slotKey), maxLeaders.toString()
+        )
+        val active = list.getOrNull(0)?.toInt() ?: 0
+        val available = list.getOrNull(1)?.toInt() ?: maxLeaders
+        return active to available
+    }
+
+    // =========================================================================
+    // 비동기 API (CompletableFuture)
+    // =========================================================================
+
+    /**
+     * 슬롯을 비동기 방식으로 획득합니다.
+     *
+     * @param waitTime  슬롯 대기 최대 시간
+     * @param leaseTime 슬롯 점유 시간 (만료 시 자동 회수)
+     * @return 획득 성공 시 token, contention 으로 deadline 도달 시 `null` 을 담은 [CompletableFuture].
+     *         backend error (Redis connection/auth/script 오류) 가 retry deadline 까지 해소되지 않으면
+     *         마지막 error 로 future 가 실패합니다.
+     *
+     * ### Caveats
+     *
+     * - 재시도 사이 지연은 [CompletableFuture.delayedExecutor] 의 글로벌 단일 스케줄러 thread 를
+     *   사용합니다. 다수의 동시 acquire 가 spin-poll 중이라면 이 스케줄러가 병목이 될 수 있습니다.
+     * - 일시적 script error (예: 일시적 connection failure) 는 retry 안에서 swallow 되며 다음 시도까지
+     *   대기합니다. 그러나 deadline 도달 시점까지 error 가 해소되지 않으면 (그리고 contention 도 아니면)
+     *   마지막 error 가 caller 에게 전달됩니다. sync / suspend path 와 동일하게 backend outage 를
+     *   silent 하게 무시하지 않습니다.
+     * - token 은 attempt() 외부에서 1회만 생성합니다. ACQUIRE 스크립트가 ZADD 로 token 을 멤버로
+     *   사용하므로 retry 시 동일 token 을 재사용해야 ghost entry 가 발생하지 않습니다.
+     */
+    fun tryAcquireAsync(waitTime: Duration, leaseTime: Duration): CompletableFuture<String?> {
+        val token = Base58.randomString(TOKEN_LENGTH)
+        val deadline = System.currentTimeMillis() + waitTime.inWholeMilliseconds
+        val leaseMs = leaseTime.inWholeMilliseconds.toString()
+        val lastError = AtomicReference<Throwable?>(null)
+
+        fun attempt(): CompletableFuture<String?> {
+            return RedisScriptRunner.runAsync<String>(
+                asyncCommands, ACQUIRE_SCRIPT, ScriptOutputType.VALUE,
+                arrayOf(slotKey), maxLeaders.toString(), token, leaseMs
+            ).handle { result, error ->
+                if (error != null) {
+                    log.warn(error) { "ACQUIRE 스크립트 오류 (async retry). slotKey=$slotKey" }
+                    lastError.set(error)
+                    null
+                } else {
+                    lastError.set(null)
+                    result
+                }
+            }.thenCompose { result ->
+                when {
+                    !result.isNullOrEmpty() -> CompletableFuture.completedFuture<String?>(result)
+                    System.currentTimeMillis() < deadline -> {
+                        val delayed = CompletableFuture.delayedExecutor(SPIN_DELAY_MS, TimeUnit.MILLISECONDS)
+                        CompletableFuture.runAsync({}, delayed).thenCompose { attempt() }
+                    }
+                    else -> {
+                        // deadline 도달 시점에 마지막 error 가 있으면 backend outage 로 간주하여 surface.
+                        // contention (script 정상 실행 + 빈 문자열 반환) 만 null 로 반환.
+                        val terminalError = lastError.get()
+                        if (terminalError != null) {
+                            CompletableFuture.failedFuture(terminalError)
+                        } else {
+                            CompletableFuture.completedFuture<String?>(null)
+                        }
+                    }
+                }
+            }
+        }
+        return attempt()
+    }
+
+    fun releaseAsync(token: String, remainingMinLeaseMs: Long): CompletableFuture<Unit> {
+        token.requireNotBlank("token")
+        return RedisScriptRunner.runAsync<Long>(
+            asyncCommands, RELEASE_SCRIPT, ScriptOutputType.INTEGER,
+            arrayOf(slotKey), token, remainingMinLeaseMs.toString()
+        ).thenApply {
+            log.debug {
+                "슬롯 해제 (async). slotKey=$slotKey, token=$token, remainingMinLeaseMs=$remainingMinLeaseMs"
+            }
+            Unit
+        }
+    }
+
+    // =========================================================================
+    // 코루틴 API (suspend)
+    // =========================================================================
+
+    suspend fun tryAcquireSuspending(waitTime: Duration, leaseTime: Duration): String? {
+        val token = Base58.randomString(TOKEN_LENGTH)
+        val deadline = System.currentTimeMillis() + waitTime.inWholeMilliseconds
+        val leaseMs = leaseTime.inWholeMilliseconds.toString()
+        while (true) {
+            val result = RedisScriptRunner.runSuspending<String>(
+                asyncCommands, ACQUIRE_SCRIPT, ScriptOutputType.VALUE,
+                arrayOf(slotKey), maxLeaders.toString(), token, leaseMs
+            )
+            if (!result.isNullOrEmpty()) {
+                log.debug { "슬롯 획득 성공 (suspend). slotKey=$slotKey, token=$token" }
+                return result
+            }
+            if (System.currentTimeMillis() >= deadline) {
+                log.debug { "슬롯 획득 타임아웃 (suspend). slotKey=$slotKey, waitTime=$waitTime" }
+                return null
+            }
+            delay(SPIN_DELAY_MS)
+        }
+    }
+
+    suspend fun releaseSuspending(token: String, remainingMinLeaseMs: Long) {
+        token.requireNotBlank("token")
+        val ret = RedisScriptRunner.runSuspending<Long>(
+            asyncCommands, RELEASE_SCRIPT, ScriptOutputType.INTEGER,
+            arrayOf(slotKey), token, remainingMinLeaseMs.toString()
+        )
+        log.debug {
+            "슬롯 해제 (suspend). slotKey=$slotKey, token=$token, remainingMinLeaseMs=$remainingMinLeaseMs, ret=$ret"
+        }
+    }
+
+    suspend fun activeCountSuspending(): Int = statusSuspending().first
+    suspend fun availableSlotsSuspending(): Int = statusSuspending().second
+
+    private suspend fun statusSuspending(): Pair<Int, Int> {
+        @Suppress("UNCHECKED_CAST")
+        val list = RedisScriptRunner.runSuspending<List<Long>>(
+            asyncCommands, STATUS_SCRIPT, ScriptOutputType.MULTI,
+            arrayOf(slotKey), maxLeaders.toString()
+        )
+        val active = list.getOrNull(0)?.toInt() ?: 0
+        val available = list.getOrNull(1)?.toInt() ?: maxLeaders
+        return active to available
+    }
+}

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/semaphore/LettuceSuspendSemaphore.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/semaphore/LettuceSuspendSemaphore.kt
@@ -34,6 +34,10 @@ import kotlin.time.Duration.Companion.milliseconds
  * @param semaphoreKey Redis에 저장될 세마포어 키
  * @param totalPermits 전체 허가 수
  */
+@Deprecated(
+    "Replaced by LettuceSlotTokenGroup which supports slot-token TTL and crash recovery",
+    level = DeprecationLevel.WARNING,
+)
 class LettuceSuspendSemaphore(
     private val connection: StatefulRedisConnection<String, String>,
     val semaphoreKey: String,

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElectionTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElectionTest.kt
@@ -37,7 +37,7 @@ class LettuceLeaderGroupElectionTest: AbstractLettuceLeaderTest() {
 
     @AfterEach
     fun teardown() {
-        connection.sync().del(lockName)
+        connection.sync().del("lg:{$lockName}")
     }
 
     // =========================================================================
@@ -203,5 +203,158 @@ class LettuceLeaderGroupElectionTest: AbstractLettuceLeaderTest() {
 
         maxConcurrent.get() shouldBeInRange 1..maxLeaders
         executed.get() shouldBeGreaterOrEqualTo 1
+    }
+
+    // =========================================================================
+    // minLeaseTime 시맨틱 (slot-token TTL 모델)
+    // =========================================================================
+
+    @Test
+    fun `minLeaseTime 보유 - 빠른 action 종료 후에도 다른 client 는 즉시 acquire 실패한다`() {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 1,
+            waitTime = 100.milliseconds,
+            leaseTime = 10.seconds,
+            minLeaseTime = 800.milliseconds,
+        )
+        val el = LettuceLeaderGroupElector(connection, opts)
+
+        // 빠른 action — caller 즉시 반환
+        val result = el.runIfLeader(lockName) { "fast" }
+        result shouldBeEqualTo "fast"
+
+        // minLease 만료 전에 다른 client (동일 lockName) 는 acquire 실패해야 한다
+        val secondElector = LettuceLeaderGroupElector(connection, opts)
+        val blocked = secondElector.runIfLeader(lockName) { "should-not" }
+        blocked shouldBeEqualTo null
+    }
+
+    @Test
+    fun `minLeaseTime 만료 후 다음 acquire 가 성공한다`() {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 1,
+            waitTime = 100.milliseconds,
+            leaseTime = 10.seconds,
+            minLeaseTime = 300.milliseconds,
+        )
+        val el = LettuceLeaderGroupElector(connection, opts)
+
+        el.runIfLeader(lockName) { "first" } shouldBeEqualTo "first"
+
+        // minLease 만료 대기
+        Thread.sleep(400)
+
+        val secondElector = LettuceLeaderGroupElector(connection, opts)
+        secondElector.runIfLeader(lockName) { "second" } shouldBeEqualTo "second"
+    }
+
+    @Test
+    fun `minLeaseTime=0 회귀 - 즉시 release 가 정상 동작한다`() {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 1,
+            waitTime = 100.milliseconds,
+            leaseTime = 10.seconds,
+            minLeaseTime = Duration.ZERO,
+        )
+        val el = LettuceLeaderGroupElector(connection, opts)
+
+        el.runIfLeader(lockName) { "a" } shouldBeEqualTo "a"
+        // 즉시 release: 다음 client 가 곧바로 acquire 가능
+        val secondElector = LettuceLeaderGroupElector(connection, opts)
+        secondElector.runIfLeader(lockName) { "b" } shouldBeEqualTo "b"
+    }
+
+    @Test
+    fun `maxLeaders 동시 점유 + 모두 minLease 보유 - 추가 client 는 실패한다`() {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 2,
+            waitTime = 100.milliseconds,
+            leaseTime = 10.seconds,
+            minLeaseTime = 1.seconds,
+        )
+        val el = LettuceLeaderGroupElector(connection, opts)
+        repeat(opts.maxLeaders) {
+            el.runIfLeader(lockName) { "fast" } shouldBeEqualTo "fast"
+        }
+
+        // minLease 만료 전: 추가 client 는 실패
+        val third = LettuceLeaderGroupElector(connection, opts)
+        third.runIfLeader(lockName) { "third" } shouldBeEqualTo null
+    }
+
+    @Test
+    fun `crash recovery - release 미호출 시 leaseTime 만료 후 다른 client 가 acquire 한다`() {
+        // primitive 를 직접 사용하여 release 를 호출하지 않음 (crash 시뮬레이션)
+        val crashLockName = randomName()
+        val crashGroup = io.bluetape4k.leader.lettuce.semaphore.LettuceSlotTokenGroup(
+            connection, crashLockName, maxLeaders = 1
+        )
+        val token = crashGroup.tryAcquire(waitTime = 200.milliseconds, leaseTime = 400.milliseconds)
+        token shouldBeEqualTo token   // non-null
+
+        // 다른 elector (동일 키) — leaseTime 만료 대기 후 acquire 성공
+        val opts = LeaderGroupElectionOptions(maxLeaders = 1, waitTime = 1.seconds, leaseTime = 5.seconds)
+        val el = LettuceLeaderGroupElector(connection, opts)
+        Thread.sleep(500) // leaseTime(400ms) 만료 대기
+        val result = el.runIfLeader(crashLockName) { "recovered" }
+        result shouldBeEqualTo "recovered"
+
+        connection.sync().del("lg:{$crashLockName}")
+    }
+
+    // =========================================================================
+    // Codex P2-2: runAsyncIfLeader 가 release 완료 후 future complete 보장
+    // =========================================================================
+
+    @Test
+    fun `runAsyncIfLeader - 두 번째 chained 호출은 첫 번째 future complete 후 즉시 acquire 가능`() {
+        // maxLeaders=1, minLeaseTime=0 → 첫 번째 future 가 complete 되는 시점에 slot 이 freed 되어야
+        // 두 번째 호출이 즉시 acquire 가능. 기존 fire-and-forget release 였다면 race condition 으로
+        // 두 번째 호출이 contention 으로 fail 할 수 있다.
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 1,
+            waitTime = 50.milliseconds,         // 짧은 wait — race 시 immediate fail
+            leaseTime = 5.seconds,
+            minLeaseTime = Duration.ZERO,
+        )
+        val el = LettuceLeaderGroupElector(connection, opts)
+
+        repeat(20) {
+            val first = el.runAsyncIfLeader(lockName) {
+                CompletableFuture.completedFuture("first-$it")
+            }
+            first.get() shouldBeEqualTo "first-$it"
+
+            // first.get() 이 반환된 시점에 release 도 완료되어 있어야 함 → 즉시 acquire 가능
+            val second = el.runAsyncIfLeader(lockName) {
+                CompletableFuture.completedFuture("second-$it")
+            }
+            second.get() shouldBeEqualTo "second-$it"
+        }
+    }
+
+    @Test
+    fun `runAsyncIfLeader - action 이 sync throw 해도 release 가 완료된 후 future 가 fail 한다`() {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 1,
+            waitTime = 50.milliseconds,
+            leaseTime = 5.seconds,
+            minLeaseTime = Duration.ZERO,
+        )
+        val el = LettuceLeaderGroupElector(connection, opts)
+
+        // action 이 sync throw → outer future 가 fail
+        val failed = el.runAsyncIfLeader<String>(lockName) {
+            throw LeaderGroupElectionException("sync throw")
+        }
+        assertFailsWith<java.util.concurrent.ExecutionException> {
+            failed.get()
+        }
+
+        // future 가 fail 한 직후, slot 이 freed 되어 다음 호출 즉시 성공해야 함
+        val recovered = el.runAsyncIfLeader(lockName) {
+            CompletableFuture.completedFuture("recovered")
+        }
+        recovered.get() shouldBeEqualTo "recovered"
     }
 }

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElectorTest.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.logging.KLogging
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
@@ -38,7 +39,7 @@ class LettuceSuspendLeaderGroupElectorTest: AbstractLettuceLeaderTest() {
 
     @AfterEach
     fun teardown() {
-        connection.sync().del(lockName)
+        connection.sync().del("lg:{$lockName}")
     }
 
     @Test
@@ -134,5 +135,123 @@ class LettuceSuspendLeaderGroupElectorTest: AbstractLettuceLeaderTest() {
             .run()
 
         executed.get() shouldBeEqualTo rounds
+    }
+
+    // =========================================================================
+    // minLeaseTime 시맨틱 (slot-token TTL 모델)
+    // =========================================================================
+
+    @Test
+    fun `minLeaseTime 보유 - 빠른 action 종료 후에도 다른 client 는 즉시 acquire 실패한다`() = runSuspendIO {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 1,
+            waitTime = 100.milliseconds,
+            leaseTime = 10.seconds,
+            minLeaseTime = 800.milliseconds,
+        )
+        val el = LettuceSuspendLeaderGroupElector(connection, opts)
+        el.runIfLeader(lockName) { "fast" } shouldBeEqualTo "fast"
+
+        val secondElector = LettuceSuspendLeaderGroupElector(connection, opts)
+        secondElector.runIfLeader(lockName) { "should-not" } shouldBeEqualTo null
+    }
+
+    @Test
+    fun `minLeaseTime 만료 후 다음 acquire 가 성공한다 (suspend)`() = runSuspendIO {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 1,
+            waitTime = 100.milliseconds,
+            leaseTime = 10.seconds,
+            minLeaseTime = 300.milliseconds,
+        )
+        val el = LettuceSuspendLeaderGroupElector(connection, opts)
+        el.runIfLeader(lockName) { "first" } shouldBeEqualTo "first"
+
+        delay(400.milliseconds)
+
+        val secondElector = LettuceSuspendLeaderGroupElector(connection, opts)
+        secondElector.runIfLeader(lockName) { "second" } shouldBeEqualTo "second"
+    }
+
+    @Test
+    fun `minLeaseTime=0 회귀 - 즉시 release 가 정상 동작한다 (suspend)`() = runSuspendIO {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 1,
+            waitTime = 100.milliseconds,
+            leaseTime = 10.seconds,
+        )
+        val el = LettuceSuspendLeaderGroupElector(connection, opts)
+        el.runIfLeader(lockName) { "a" } shouldBeEqualTo "a"
+
+        val secondElector = LettuceSuspendLeaderGroupElector(connection, opts)
+        secondElector.runIfLeader(lockName) { "b" } shouldBeEqualTo "b"
+    }
+
+    @Test
+    fun `maxLeaders 동시 점유 + 모두 minLease 보유 - 추가 client 는 실패한다 (suspend)`() = runSuspendIO {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 2,
+            waitTime = 100.milliseconds,
+            leaseTime = 10.seconds,
+            minLeaseTime = 1.seconds,
+        )
+        val el = LettuceSuspendLeaderGroupElector(connection, opts)
+        repeat(opts.maxLeaders) {
+            el.runIfLeader(lockName) { "fast" } shouldBeEqualTo "fast"
+        }
+
+        val third = LettuceSuspendLeaderGroupElector(connection, opts)
+        third.runIfLeader(lockName) { "third" } shouldBeEqualTo null
+    }
+
+    @Test
+    fun `crash recovery - release 미호출 시 leaseTime 만료 후 다른 client 가 acquire 한다 (suspend)`() = runSuspendIO {
+        val crashLockName = randomName()
+        val crashGroup = io.bluetape4k.leader.lettuce.semaphore.LettuceSlotTokenGroup(
+            connection, crashLockName, maxLeaders = 1
+        )
+        crashGroup.tryAcquireSuspending(waitTime = 200.milliseconds, leaseTime = 400.milliseconds)
+
+        val opts = LeaderGroupElectionOptions(maxLeaders = 1, waitTime = 1.seconds, leaseTime = 5.seconds)
+        val el = LettuceSuspendLeaderGroupElector(connection, opts)
+        delay(500.milliseconds)
+        val result = el.runIfLeader(crashLockName) { "recovered" }
+        result shouldBeEqualTo "recovered"
+
+        connection.sync().del("lg:{$crashLockName}")
+    }
+
+    @Test
+    fun `코루틴 취소 + minLeaseTime 보유 - NonCancellable 로 score 갱신 보장`() = runSuspendIO {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 1,
+            waitTime = 200.milliseconds,
+            leaseTime = 10.seconds,
+            minLeaseTime = 800.milliseconds,
+        )
+        val el = LettuceSuspendLeaderGroupElector(connection, opts)
+        val cancelLock = randomName()
+
+        kotlinx.coroutines.coroutineScope {
+            val deferred = async {
+                el.runIfLeader(cancelLock) {
+                    delay(50.milliseconds)
+                    "cancelled-action"
+                }
+            }
+            // action 진입 직후 취소
+            delay(20.milliseconds)
+            deferred.cancelAndJoin()
+        }
+
+        // 취소 후에도 minLease 동안은 다른 client 가 진입 못 해야 함
+        val secondElector = LettuceSuspendLeaderGroupElector(connection, opts)
+        secondElector.runIfLeader(cancelLock) { "should-not" } shouldBeEqualTo null
+
+        // minLease 만료 후 정상 acquire
+        delay(900.milliseconds)
+        secondElector.runIfLeader(cancelLock) { "later" } shouldBeEqualTo "later"
+
+        connection.sync().del("lg:{$cancelLock}")
     }
 }

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/semaphore/LettuceSlotTokenGroupTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/semaphore/LettuceSlotTokenGroupTest.kt
@@ -1,0 +1,139 @@
+package io.bluetape4k.leader.lettuce.semaphore
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.leader.lettuce.AbstractLettuceLeaderTest
+import io.bluetape4k.logging.KLogging
+import io.lettuce.core.codec.StringCodec
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.ExecutionException
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LettuceSlotTokenGroupTest: AbstractLettuceLeaderTest() {
+
+    companion object: KLogging() {
+        private const val MAX_LEADERS = 3
+    }
+
+    private lateinit var group: LettuceSlotTokenGroup
+    private lateinit var lockName: String
+
+    @BeforeEach
+    fun setup() {
+        lockName = "slot-token:${Base58.randomString(8)}"
+        group = LettuceSlotTokenGroup(connection, lockName, MAX_LEADERS)
+    }
+
+    @AfterEach
+    fun teardown() {
+        connection.sync().del(group.slotKey)
+    }
+
+    @Test
+    fun `단일 acquire 시 token 을 반환한다`() {
+        val token = group.tryAcquire(waitTime = 1.seconds, leaseTime = 5.seconds)
+        token.shouldNotBeNull()
+        token.length shouldBeEqualTo 8
+
+        group.release(token, remainingMinLeaseMs = 0)
+    }
+
+    @Test
+    fun `maxLeaders 동시 acquire 모두 성공한다`() {
+        val tokens = (1..MAX_LEADERS).map {
+            group.tryAcquire(waitTime = 1.seconds, leaseTime = 5.seconds)
+        }
+        tokens.forEach { it.shouldNotBeNull() }
+        group.activeCount() shouldBeEqualTo MAX_LEADERS
+        group.availableSlots() shouldBeEqualTo 0
+
+        tokens.forEach { token -> group.release(token!!, remainingMinLeaseMs = 0) }
+        group.activeCount() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `maxLeaders+1 번째 acquire 는 null 을 반환한다`() {
+        val tokens = (1..MAX_LEADERS).map {
+            group.tryAcquire(waitTime = 1.seconds, leaseTime = 10.seconds)!!
+        }
+
+        val overflow = group.tryAcquire(waitTime = 200.milliseconds, leaseTime = 10.seconds)
+        overflow.shouldBeNull()
+
+        tokens.forEach { group.release(it, remainingMinLeaseMs = 0) }
+    }
+
+    @Test
+    fun `release 즉시 슬롯이 해제된다`() {
+        val token = group.tryAcquire(waitTime = 1.seconds, leaseTime = 10.seconds)!!
+        group.activeCount() shouldBeEqualTo 1
+
+        group.release(token, remainingMinLeaseMs = 0)
+        group.activeCount() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `remainingMinLeaseMs 가 양수이면 score 만 갱신되고 슬롯은 유지된다`() {
+        val token = group.tryAcquire(waitTime = 1.seconds, leaseTime = 10.seconds)!!
+        group.activeCount() shouldBeEqualTo 1
+
+        // minLease 가 남아있는 release: 슬롯은 유지되어야 한다
+        group.release(token, remainingMinLeaseMs = 800)
+        group.activeCount() shouldBeEqualTo 1
+
+        // 다른 client 가 동일 token 을 흉내내도 acquire 는 가능 (슬롯은 1개 점유 중, max 는 3)
+        val secondToken = group.tryAcquire(waitTime = 200.milliseconds, leaseTime = 5.seconds)
+        secondToken.shouldNotBeNull()
+        group.release(secondToken, remainingMinLeaseMs = 0)
+
+        // 원래 token 도 cleanup
+        group.release(token, remainingMinLeaseMs = 0)
+    }
+
+    @Test
+    fun `Codex P2-1 - tryAcquireAsync 는 backend error 가 deadline 까지 해소되지 않으면 future 가 fail 한다`() {
+        // 별도 connection 을 만든 뒤 즉시 close → 모든 async ACQUIRE script call 이 backend error 로 실패.
+        // 기존 구현은 error 를 null 로 변환 후 contention 으로 판단해 timeout 후 null 을 반환했지만,
+        // P2-1 fix 후에는 마지막 error 가 future 로 propagate 되어야 한다.
+        val deadConn = client.connect(StringCodec.UTF8)
+        deadConn.close()
+
+        val deadGroup = LettuceSlotTokenGroup(deadConn, "dead-test:${Base58.randomString(8)}", MAX_LEADERS)
+        val future = deadGroup.tryAcquireAsync(waitTime = 200.milliseconds, leaseTime = 5.seconds)
+        assertFailsWith<ExecutionException> {
+            future.get()
+        }
+    }
+
+    @Test
+    fun `expired entry 는 다음 acquire 시 자동 회수된다`() {
+        // 매우 짧은 leaseTime 으로 maxLeaders 만큼 잡고 release 호출 안 함 (crash simulation)
+        val shortLeaseGroup = LettuceSlotTokenGroup(connection, "expire-test:${Base58.randomString(8)}", MAX_LEADERS)
+        try {
+            repeat(MAX_LEADERS) {
+                val token = shortLeaseGroup.tryAcquire(waitTime = 500.milliseconds, leaseTime = 300.milliseconds)
+                token.shouldNotBeNull()
+                // intentional: release 호출 안 함
+            }
+            shortLeaseGroup.activeCount() shouldBeEqualTo MAX_LEADERS
+
+            // leaseTime 만료 대기
+            Thread.sleep(500)
+
+            // 다음 acquire 가 expired entry 를 정리하고 성공해야 함
+            val recovered = shortLeaseGroup.tryAcquire(waitTime = 500.milliseconds, leaseTime = 5.seconds)
+            recovered.shouldNotBeNull()
+            shortLeaseGroup.release(recovered, remainingMinLeaseMs = 0)
+        } finally {
+            connection.sync().del(shortLeaseGroup.slotKey)
+        }
+    }
+}

--- a/leader-redis-redisson/README.ko.md
+++ b/leader-redis-redisson/README.ko.md
@@ -8,11 +8,13 @@
 
 ## 개요
 
-`leader-redis-redisson`은 Redisson의 `RLock`과 `RSemaphore`를 사용하여 `leader-core` 인터페이스를 구현합니다. 블로킹, 비동기, 코루틴, 가상 스레드 실행 모델을 모두 지원합니다.
+`leader-redis-redisson`은 Redisson의 `RLock`과 `RPermitExpirableSemaphore` 를 사용하여 `leader-core` 인터페이스를 구현합니다. 블로킹, 비동기, 코루틴, 가상 스레드 실행 모델을 모두 지원합니다.
 
-단일 리더 선출에서 `LeaderElectionOptions(autoExtend = true)`를 사용하면 명시적 lease timeout 없이 `RLock`을 획득해 Redisson 자체 watchdog에 위임합니다. watchdog release semantics가 모호하므로 `autoExtend=true`와 `minLeaseTime > 0` 조합은 거부합니다. 그룹/세마포어 auto-extension은 구현하지 않았습니다.
+단일 리더 선출에서 `LeaderElectionOptions(autoExtend = true)`를 사용하면 명시적 lease timeout 없이 `RLock`을 획득해 Redisson 자체 watchdog에 위임합니다. watchdog release semantics가 모호하므로 `autoExtend=true`와 `minLeaseTime > 0` 조합은 거부합니다.
 
-코루틴 구현체는 PID 시드 기반의 미니 Snowflake ID 생성기를 사용하여 Redis 라운드트립 없이 코루틴별 고유 락 ID를 생성합니다. HA(다중 JVM) 환경에서 안전하게 동작합니다.
+복수 리더 그룹 elector 는 `lg:{lockName}` 키의 `RPermitExpirableSemaphore` 를 사용하며, 첫 접근 시 `trySetPermits(maxLeaders)` 를 멱등적으로 호출합니다 (호출하지 않으면 0 permits 로 시작하여 acquire 가 영구 실패). 각 acquire 는 Redisson 이 발급한 고유한 `permitId` 를 반환하며, release / 연장 시 정확히 그 슬롯을 식별합니다. `minLeaseTime` 은 `updateLeaseTime` (sync) / `updateLeaseTimeAsync` (async) 로 backend TTL 에 위임되어 — caller 를 park 하지 않고 `runIfLeader` 가 `action` 종료 직후 즉시 반환합니다. 클라이언트 crash 시 (release 미호출) `leaseTime` 만료 후 Redisson 이 자동으로 슬롯을 회수합니다. `lg:{lockName}` key prefix 는 롤링 배포 시 구버전 semaphore 키와의 충돌을 피하기 위해 의도적으로 분리되었습니다.
+
+코루틴 단일 리더 구현체는 PID 시드 기반의 미니 Snowflake ID 생성기를 사용하여 Redis 라운드트립 없이 코루틴별 고유 락 ID를 생성합니다. HA(다중 JVM) 환경에서 안전하게 동작합니다.
 
 ## 아키텍처
 
@@ -58,14 +60,77 @@ classDiagram
     RedissonSuspendLeaderGroupElector ..|> SuspendLeaderGroupElector
 ```
 
+## 그룹 락 흐름
+
+`RPermitExpirableSemaphore` 기반 그룹 elector 는 Lettuce slot-token TTL 모델과 동등하게 동작합니다. 두 시나리오로 계약을 설명합니다: 정상 acquire/release 와 crash recovery, 그리고 `updateLeaseTime` 을 통한 `minLeaseTime` 연장.
+
+### 시나리오 1 — 정상 acquire/release 와 crash recovery
+
+```mermaid
+sequenceDiagram
+    participant ClientA
+    participant ClientB
+    participant Redis as "Redis (RPermitExpirableSemaphore)"
+
+    Note over ClientA,Redis: 첫 사용 — trySetPermits 멱등 초기화
+    ClientA->>Redis: getPermitExpirableSemaphore(lg:{lockName})
+    ClientA->>Redis: trySetPermits(maxLeaders=2)
+    Redis-->>ClientA: ok
+
+    ClientA->>Redis: tryAcquire(waitMs, leaseMs)
+    Redis-->>ClientA: permitId A1
+    ClientA->>ClientA: action()
+
+    ClientB->>Redis: tryAcquire(...)
+    Redis-->>ClientB: permitId B1
+
+    ClientA->>Redis: release(A1)
+    Redis-->>ClientA: ok
+
+    Note over ClientA,Redis: ClientA crash 시뮬레이션
+    ClientA->>Redis: tryAcquire (lease=2s)
+    Redis-->>ClientA: permitId A2
+    ClientA->>ClientA: crash
+
+    Note over ClientB,Redis: 2초 후 lease 만료
+    ClientB->>Redis: tryAcquire
+    Redis-->>ClientB: permitId B3 (자동 회수)
+```
+
+### 시나리오 2 — `updateLeaseTime` 을 통한 `minLeaseTime`
+
+```mermaid
+sequenceDiagram
+    participant ClientA
+    participant ClientB
+    participant Redis
+
+    Note over ClientA: minLeaseTime=300ms, action 50ms
+
+    ClientA->>Redis: tryAcquire
+    Redis-->>ClientA: permitId A1
+    ClientA->>ClientA: action() 50ms
+
+    ClientA->>Redis: updateLeaseTime(A1, remaining=250ms)
+    Redis-->>ClientA: true
+    Note over ClientA: caller 즉시 반환
+
+    ClientB->>Redis: tryAcquire (waitMs=100)
+    Redis-->>ClientB: null (250ms 안에 만료 X)
+
+    Note over ClientB: 250ms 후
+    ClientB->>Redis: tryAcquire
+    Redis-->>ClientB: permitId B1 (성공)
+```
+
 ## 구현체 목록
 
 | 클래스 | 구현 인터페이스 | 설명 |
 |-------|--------------|------|
 | `RedissonLeaderElector` | `LeaderElector` | `RLock.tryLock()` 기반 블로킹 |
-| `RedissonLeaderGroupElector` | `LeaderGroupElector` | `RSemaphore` 기반 블로킹 복수 리더 |
+| `RedissonLeaderGroupElector` | `LeaderGroupElector` | `RPermitExpirableSemaphore` (`lg:{lockName}`) 기반 블로킹 복수 리더 |
 | `RedissonSuspendLeaderElector` | `SuspendLeaderElector` | 코루틴, PID 시드 Snowflake 락 ID |
-| `RedissonSuspendLeaderGroupElector` | `SuspendLeaderGroupElector` | `RSemaphoreAsync` 기반 코루틴 복수 리더 |
+| `RedissonSuspendLeaderGroupElector` | `SuspendLeaderGroupElector` | `RPermitExpirableSemaphoreAsync` 기반 코루틴 복수 리더 |
 | `RedissonSuspendLeaderElectorFactory` | `SuspendLeaderElectorFactory` | 팩토리: 호출마다 `RedissonSuspendLeaderElector` 생성 |
 | `RedissonSuspendLeaderGroupElectorFactory` | `SuspendLeaderGroupElectorFactory` | 팩토리: 호출마다 `RedissonSuspendLeaderGroupElector` 생성 |
 
@@ -82,6 +147,20 @@ timestamp(42비트) | pid%(2^10)(10비트) | seq(12비트)
 - `pid % 1024`를 머신 ID로 사용 — HA 환경에서 JVM 프로세스 간 충돌 최소화
 - 인스턴스 내 `AtomicLong` 시퀀스 카운터 (12비트, 4096 이후 순환)
 - Redis I/O 없음 — 순수 인메모리 연산
+
+## 그룹 내부 동작 — `RPermitExpirableSemaphore`
+
+`RedissonLeaderGroupElector` 와 `RedissonSuspendLeaderGroupElector` 는 `lg:{lockName}` 키의 `RPermitExpirableSemaphore` 를 사용합니다:
+
+- 각 `lockName` 의 첫 접근에서 `trySetPermits(maxLeaders)` 를 멱등적으로 호출. 호출하지 않으면 0 permits 로 시작해 `tryAcquire` 가 항상 `null` 을 반환합니다.
+- 각 `tryAcquire(waitTime, leaseTime, ms)` 는 고유한 `permitId: String?` 를 반환 (경합 시 `null`). 이 `permitId` 로 정확한 슬롯을 release / 연장하므로 동일 elector 인스턴스가 동시에 여러 슬롯을 보유해도 안전합니다.
+- `runIfLeader` finally 블록에서:
+  - `remainingMinLeaseTime > 0` → `updateLeaseTime(permitId, remainingMs, MILLISECONDS)` 로 backend TTL 연장 (async 경로는 `updateLeaseTimeAsync`).
+  - 그 외 → `release(permitId)` 로 즉시 슬롯 반납.
+- 클라이언트 crash 시 (release 미호출) `leaseTime` 만료 후 Redisson 이 자동으로 permit 을 회수합니다.
+- `minLeaseTime` 을 backend TTL 에 위임 (caller-park 없음) — `runIfLeader` 는 `action` 종료 직후 즉시 반환.
+
+> 이전 버전은 익명 permit 의 `RSemaphore` 를 사용했습니다. `RPermitExpirableSemaphore` 로의 전환과 새 `lg:{lockName}` key prefix 는 롤링 업그레이드 시 구버전 키와의 충돌을 방지합니다.
 
 ## 사용 예시
 
@@ -158,6 +237,17 @@ val options = LeaderElectionOptions(
     leaseTime = 30.seconds
 )
 val election = RedissonLeaderElector(client, options)
+```
+
+### 그룹 `minLeaseTime` — backend TTL 연장
+
+```kotlin
+val options = LeaderGroupElectionOptions(
+    maxLeaders = 3,
+    leaseTime = 30.seconds,
+    minLeaseTime = 1.seconds, // updateLeaseTime 으로 permit TTL 연장
+)
+val election = RedissonLeaderGroupElector(client, options)
 ```
 
 ### SPI 팩토리 사용

--- a/leader-redis-redisson/README.md
+++ b/leader-redis-redisson/README.md
@@ -8,11 +8,13 @@ Redis-backed leader election using [Redisson](https://redisson.org/) — blockin
 
 ## Overview
 
-`leader-redis-redisson` implements `leader-core` interfaces using Redisson's `RLock` and `RSemaphore`. It supports blocking, async, coroutine, and virtual-thread execution models.
+`leader-redis-redisson` implements `leader-core` interfaces using Redisson's `RLock` and `RPermitExpirableSemaphore`. It supports blocking, async, coroutine, and virtual-thread execution models.
 
-For single-leader elections, `LeaderElectionOptions(autoExtend = true)` uses Redisson's native lock watchdog by acquiring `RLock` without an explicit lease timeout. `minLeaseTime > 0` is rejected with `autoExtend=true` because watchdog release semantics would be ambiguous. Group/semaphore auto-extension is not implemented.
+For single-leader elections, `LeaderElectionOptions(autoExtend = true)` uses Redisson's native lock watchdog by acquiring `RLock` without an explicit lease timeout. `minLeaseTime > 0` is rejected with `autoExtend=true` because watchdog release semantics would be ambiguous.
 
-The coroutine implementation uses a PID-seeded mini-Snowflake ID generator to produce unique per-coroutine lock IDs without Redis round-trips, ensuring safety in HA (multi-JVM) deployments.
+For multi-leader groups, the elector binds to a `RPermitExpirableSemaphore` keyed `lg:{lockName}` and calls `trySetPermits(maxLeaders)` idempotently on first access (without it the semaphore would default to 0 permits and `tryAcquire` would deadlock). Each acquire returns a Redisson-issued `permitId` used to release or extend the slot. `minLeaseTime` is delegated to the backend TTL via `updateLeaseTime` (sync) / `updateLeaseTimeAsync` (async) — `runIfLeader` returns immediately when `action` finishes, with no caller-side parking. Crash recovery is automatic: a permit's TTL expires and the slot is reclaimed by Redisson on the next acquire. The `lg:{lockName}` key prefix is intentionally distinct from any pre-existing semaphore keys to avoid collisions during rolling deployment.
+
+The coroutine single-leader implementation uses a PID-seeded mini-Snowflake ID generator to produce unique per-coroutine lock IDs without Redis round-trips, ensuring safety in HA (multi-JVM) deployments.
 
 ## Architecture
 
@@ -58,14 +60,77 @@ classDiagram
     RedissonSuspendLeaderGroupElector ..|> SuspendLeaderGroupElector
 ```
 
+## Group Lock Flow
+
+The `RPermitExpirableSemaphore`-backed group elector behaves equivalently to the Lettuce slot-token TTL model. Two scenarios illustrate the contract: a normal acquire/release with crash recovery, and `minLeaseTime` extension via `updateLeaseTime`.
+
+### Scenario 1 — Normal acquire/release plus crash recovery
+
+```mermaid
+sequenceDiagram
+    participant ClientA
+    participant ClientB
+    participant Redis as "Redis (RPermitExpirableSemaphore)"
+
+    Note over ClientA,Redis: First use — trySetPermits idempotent init
+    ClientA->>Redis: getPermitExpirableSemaphore(lg:{lockName})
+    ClientA->>Redis: trySetPermits(maxLeaders=2)
+    Redis-->>ClientA: ok
+
+    ClientA->>Redis: tryAcquire(waitMs, leaseMs)
+    Redis-->>ClientA: permitId A1
+    ClientA->>ClientA: action()
+
+    ClientB->>Redis: tryAcquire(...)
+    Redis-->>ClientB: permitId B1
+
+    ClientA->>Redis: release(A1)
+    Redis-->>ClientA: ok
+
+    Note over ClientA,Redis: ClientA crash simulation
+    ClientA->>Redis: tryAcquire (lease=2s)
+    Redis-->>ClientA: permitId A2
+    ClientA->>ClientA: crash
+
+    Note over ClientB,Redis: 2s later — lease expired
+    ClientB->>Redis: tryAcquire
+    Redis-->>ClientB: permitId B3 (auto-recovered)
+```
+
+### Scenario 2 — `minLeaseTime` via `updateLeaseTime`
+
+```mermaid
+sequenceDiagram
+    participant ClientA
+    participant ClientB
+    participant Redis
+
+    Note over ClientA: minLeaseTime=300ms, action 50ms
+
+    ClientA->>Redis: tryAcquire
+    Redis-->>ClientA: permitId A1
+    ClientA->>ClientA: action() 50ms
+
+    ClientA->>Redis: updateLeaseTime(A1, remaining=250ms)
+    Redis-->>ClientA: true
+    Note over ClientA: caller returns immediately
+
+    ClientB->>Redis: tryAcquire (waitMs=100)
+    Redis-->>ClientB: null (not expired within 250ms)
+
+    Note over ClientB: after 250ms
+    ClientB->>Redis: tryAcquire
+    Redis-->>ClientB: permitId B1 (success)
+```
+
 ## Implementations
 
 | Class | Interface | Description |
 |-------|-----------|-------------|
 | `RedissonLeaderElector` | `LeaderElector` | Blocking via `RLock.tryLock()` |
-| `RedissonLeaderGroupElector` | `LeaderGroupElector` | Blocking multi-leader via `RSemaphore` |
+| `RedissonLeaderGroupElector` | `LeaderGroupElector` | Blocking multi-leader via `RPermitExpirableSemaphore` (`lg:{lockName}`) |
 | `RedissonSuspendLeaderElector` | `SuspendLeaderElector` | Coroutine, PID-seeded Snowflake lock ID |
-| `RedissonSuspendLeaderGroupElector` | `SuspendLeaderGroupElector` | Coroutine multi-leader via `RSemaphoreAsync` |
+| `RedissonSuspendLeaderGroupElector` | `SuspendLeaderGroupElector` | Coroutine multi-leader via `RPermitExpirableSemaphoreAsync` |
 | `RedissonSuspendLeaderElectorFactory` | `SuspendLeaderElectorFactory` | Factory: creates `RedissonSuspendLeaderElector` per call |
 | `RedissonSuspendLeaderGroupElectorFactory` | `SuspendLeaderGroupElectorFactory` | Factory: creates `RedissonSuspendLeaderGroupElector` per call |
 
@@ -82,6 +147,20 @@ timestamp(42 bits) | pid%(2^10)(10 bits) | seq(12 bits)
 - `pid % 1024` as machine ID — reasonably collision-resistant across JVM processes in HA
 - Per-instance `AtomicLong` sequence counter (12 bits, wraps after 4096)
 - Zero Redis I/O — pure in-memory computation
+
+## Group Internals — `RPermitExpirableSemaphore`
+
+`RedissonLeaderGroupElector` and `RedissonSuspendLeaderGroupElector` use `RPermitExpirableSemaphore` keyed `lg:{lockName}`:
+
+- `trySetPermits(maxLeaders)` is invoked idempotently on the first access for each `lockName`. Without this, the semaphore would default to 0 permits and `tryAcquire` would always return `null`.
+- Each `tryAcquire(waitTime, leaseTime, ms)` returns a unique `permitId: String?` (or `null` on contention). The `permitId` is used to release or extend the exact slot — no positional ambiguity even when one elector instance holds multiple slots concurrently.
+- On `runIfLeader` finally:
+  - if `remainingMinLeaseTime > 0` → `updateLeaseTime(permitId, remainingMs, MILLISECONDS)` extends the backend TTL (the async path uses `updateLeaseTimeAsync`).
+  - otherwise → `release(permitId)` returns the slot immediately.
+- Crash recovery is automatic: when a holder dies without releasing, Redisson reclaims the permit after `leaseTime` expires.
+- `minLeaseTime` is delegated to the backend TTL (no caller-side park) — `runIfLeader` returns as soon as `action` finishes.
+
+> Earlier versions used `RSemaphore` with anonymous permits. The shift to `RPermitExpirableSemaphore` plus the new `lg:{lockName}` key prefix avoids collisions with any legacy keys during rolling upgrades.
 
 ## Usage
 
@@ -158,6 +237,17 @@ val options = LeaderElectionOptions(
     leaseTime = 30.seconds
 )
 val election = RedissonLeaderElector(client, options)
+```
+
+### Group `minLeaseTime` — backend TTL extension
+
+```kotlin
+val options = LeaderGroupElectionOptions(
+    maxLeaders = 3,
+    leaseTime = 30.seconds,
+    minLeaseTime = 1.seconds, // extends the permit TTL via updateLeaseTime
+)
+val election = RedissonLeaderGroupElector(client, options)
 ```
 
 ### Using `invoke` factory

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElector.kt
@@ -4,91 +4,50 @@ import io.bluetape4k.concurrent.failedCompletableFutureOf
 import io.bluetape4k.leader.LeaderGroupElector
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.remainingMinLeaseTime
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.error
+import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requirePositiveNumber
-import org.redisson.api.RSemaphore
+import org.redisson.api.RPermitExpirableSemaphore
 import org.redisson.api.RedissonClient
 import org.redisson.client.RedisException
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
 
 /**
- * Redisson 분산 Semaphore를 이용하여 복수 리더 선출을 통한 작업을 수행합니다.
+ * Redisson 분산 [RPermitExpirableSemaphore] 를 이용한 복수 리더 선출 구현체입니다.
  *
- * ```kotlin
- * val client: RedissonClient = ...
- * val options = LeaderGroupElectionOptions(maxLeaders = 3)
- * val result: Int = client.runIfLeaderGroup("batch-job", options) {
- *     // 최대 3개 프로세스가 동시에 실행
- *     42
- * }
- * ```
+ * ## 동작/계약
  *
- * @param lockName 락 이름
- * @param options 리더 선출 옵션
- * @param action 리더 그룹 슬롯 획득 시 수행할 작업
- * @return 작업 결과
- */
-inline fun <T> RedissonClient.runIfLeaderGroup(
-    lockName: String,
-    options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
-    crossinline action: () -> T,
-): T? {
-    lockName.requireNotBlank("lockName")
-    return RedissonLeaderGroupElector(this, options).runIfLeader(lockName) { action() }
-}
-
-/**
- * Redisson 분산 [RSemaphore]를 이용한 복수 리더 선출 구현체입니다.
- *
- * ## 동작
- * - `lockName`별로 Redis 분산 `RSemaphore(maxLeaders)`를 생성하여 동시 실행 수를 제한합니다.
- * - 슬롯이 가득 찬 경우 [LeaderGroupElectionOptions.waitTime] 내에 슬롯을 획득하지 못하면 `null`을 반환합니다 (ShedLock skip 방식).
- * - 슬롯 대기 중 인터럽트가 발생하면 [RedisException]으로 래핑되어 전파됩니다.
- * - 슬롯 획득 성공 시 `action`을 실행하고, 완료(또는 예외) 후 반드시 슬롯을 반납합니다.
- * - 여러 JVM 프로세스에 걸친 분산 동시 실행 제한에 적합합니다.
+ * - `lockName` 별로 `lg:{lockName}` Redisson [RPermitExpirableSemaphore] 를 사용합니다.
+ * - 각 acquire 는 고유 permitId 를 반환하며, release 시 permitId 로 정확한 슬롯을 식별합니다.
+ * - `options.minLeaseTime > 0` 이면 빠른 action 종료 시 [RPermitExpirableSemaphore.updateLeaseTime] 으로
+ *   slot 의 TTL 을 minLeaseTime 만큼 연장하여 유지합니다 (caller-park 없음).
+ * - 클라이언트 crash 시 (release 미호출) leaseTime 만료 후 Redisson 이 자동 회수합니다.
+ * - 슬롯 미획득 시 `null` 반환 (ShedLock skip-on-contention).
  *
  * ## [io.bluetape4k.leader.local.LocalLeaderGroupElector] 과의 차이
- * - [io.bluetape4k.leader.local.LocalLeaderGroupElector]은 단일 JVM 내 `java.util.concurrent.Semaphore`를 사용합니다.
- * - 이 구현체는 Redis 기반 `RSemaphore`를 사용하므로 여러 프로세스에서 동작합니다.
+ * - 이 구현체는 Redis 기반이므로 여러 JVM 프로세스에 걸친 동시 실행 제한에 적합합니다.
  *
  * ```kotlin
- * val options = LeaderGroupElectionOptions(maxLeaders = 3)
+ * val options = LeaderGroupElectionOptions(maxLeaders = 3, minLeaseTime = 1.seconds)
  * val election = RedissonLeaderGroupElector(redissonClient, options)
- *
- * // 최대 3개 스레드/프로세스가 동시에 실행
  * val result = election.runIfLeader("batch-job") { processChunk() }
- *
- * // 비동기 실행
- * val future = election.runAsyncIfLeader("batch-job") { CompletableFuture.completedFuture(42) }
- *
- * // 상태 조회
- * println(election.state("batch-job"))
  * ```
  *
  * @param redissonClient Redisson 클라이언트
- * @param maxLeaders 허용하는 최대 동시 리더 수. 기본값 2
- * @param options 리더 선출 옵션 (waitTime 사용)
+ * @param options 리더 선출 옵션 (maxLeaders, waitTime, leaseTime, minLeaseTime)
  */
 class RedissonLeaderGroupElector private constructor(
     private val redissonClient: RedissonClient,
-    options: LeaderGroupElectionOptions,
+    val options: LeaderGroupElectionOptions,
 ): LeaderGroupElector {
     companion object: KLogging() {
-        /**
-         * [RedissonLeaderGroupElector] 인스턴스를 생성합니다.
-         *
-         * @param redissonClient Redisson 클라이언트
-         * @param maxLeaders 허용하는 최대 동시 리더 수. 기본값 2
-         * @param options 리더 선출 옵션
-         */
         @JvmStatic
         operator fun invoke(
             redissonClient: RedissonClient,
@@ -102,91 +61,64 @@ class RedissonLeaderGroupElector private constructor(
     override val maxLeaders: Int = options.maxLeaders
 
     private val waitTime: Duration = options.waitTime
+    private val leaseTime: Duration = options.leaseTime
 
     /**
-     * [lockName]에 해당하는 Redis [RSemaphore]를 가져오고, 허용 가능한 최대 슬롯 수를 [maxLeaders]로 초기화합니다.
+     * `lg:{lockName}` 키의 [RPermitExpirableSemaphore] 를 가져옵니다.
      *
-     * `trySetPermits`는 세마포어가 이미 초기화된 경우 아무 동작도 하지 않으므로 멱등적으로 호출할 수 있습니다.
-     *
-     * @param lockName 세마포어 키 이름
-     * @return [maxLeaders] permits로 초기화된 [RSemaphore]
+     * Codex P1: `trySetPermits(maxLeaders)` 멱등 호출 — 누락 시 0 permits 로 시작하여 acquire 영구 실패.
      */
-    private fun getSemaphore(lockName: String): RSemaphore {
+    private fun getPermitSemaphore(lockName: String): RPermitExpirableSemaphore {
         lockName.requireNotBlank("lockName")
-        val semaphore = redissonClient.getSemaphore(lockName)
+        val semaphore = redissonClient.getPermitExpirableSemaphore("lg:{$lockName}")
         semaphore.trySetPermits(maxLeaders)
         return semaphore
     }
 
-    /**
-     * [lockName]에 대해 현재 활성(실행 중인) 리더 수를 반환합니다.
-     *
-     * `maxLeaders - availablePermits()`로 계산하므로 근사값입니다.
-     */
-    override fun activeCount(lockName: String): Int = maxLeaders - getSemaphore(lockName).availablePermits()
+    override fun activeCount(lockName: String): Int =
+        maxLeaders - getPermitSemaphore(lockName).availablePermits()
 
-    /**
-     * [lockName]에 대해 새 리더를 수용할 수 있는 남은 슬롯 수를 반환합니다.
-     */
-    override fun availableSlots(lockName: String): Int = getSemaphore(lockName).availablePermits()
+    override fun availableSlots(lockName: String): Int =
+        getPermitSemaphore(lockName).availablePermits()
 
-    /**
-     * [lockName]에 대한 현재 [LeaderGroupState] 스냅샷을 반환합니다.
-     */
     override fun state(lockName: String): LeaderGroupState =
         LeaderGroupState(lockName, maxLeaders, activeCount(lockName))
 
-    /**
-     * [lockName]의 분산 [RSemaphore] 슬롯을 획득하고 [action]을 실행합니다.
-     *
-     * @param lockName 리더 그룹 선출에 사용할 락 이름
-     * @param action 슬롯 획득 성공 시 실행할 동기 작업
-     * @return [action] 실행 결과, 슬롯 획득 실패 시 `null`
-     * @throws RedisException 슬롯 대기 중 인터럽트가 발생한 경우
-     */
     override fun <T> runIfLeader(
         lockName: String,
         action: () -> T,
     ): T? {
         lockName.requireNotBlank("lockName")
+        val semaphore = getPermitSemaphore(lockName)
+        log.debug { "리더 그룹 슬롯 획득 요청. lockName=$lockName, maxLeaders=$maxLeaders" }
 
-        val semaphore = getSemaphore(lockName)
-        log.debug { "리더 그룹 슬롯 획득을 요청합니다. lockName=$lockName, maxLeaders=$maxLeaders" }
-
-        val acquired =
-            try {
-                semaphore.tryAcquire(waitTime.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-            } catch (e: InterruptedException) {
-                Thread.currentThread().interrupt()
-                log.error(e) { "슬롯 획득 대기 중 인터럽트가 발생했습니다. lockName=$lockName" }
-                throw RedisException("Interrupted while acquiring semaphore slot. lockName=$lockName", e)
-            }
-
-        if (!acquired) {
-            log.debug { "리더 그룹 슬롯 획득 실패 (슬롯 없음). lockName=$lockName" }
-            return null
+        val permitId: String? = try {
+            semaphore.tryAcquire(
+                waitTime.inWholeMilliseconds,
+                leaseTime.inWholeMilliseconds,
+                TimeUnit.MILLISECONDS,
+            )
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            log.error(e) { "슬롯 획득 대기 중 인터럽트. lockName=$lockName" }
+            throw RedisException("Interrupted while acquiring permit. lockName=$lockName", e)
         }
 
-        log.debug { "리더 그룹 슬롯을 획득하여 작업을 수행합니다. lockName=$lockName" }
+        if (permitId == null) {
+            log.debug { "슬롯 획득 실패. lockName=$lockName" }
+            return null
+        }
+        // Codex P2: acquire 성공 후 startedAtNanos 캡처
+        val startedAtNanos = System.nanoTime()
+        log.debug { "슬롯 획득 성공. lockName=$lockName, permitId=$permitId" }
+
         try {
             return action()
         } finally {
-            semaphore.release()
-            log.debug { "작업이 완료되어 슬롯을 반납했습니다. lockName=$lockName" }
+            releaseOrExtend(semaphore, permitId, startedAtNanos, lockName)
         }
     }
 
-    /**
-     * [lockName]의 분산 [RSemaphore] 슬롯을 [executor]에서 획득하고 비동기 [action]을 실행합니다.
-     *
-     * - 슬롯이 가득 찬 경우 [waitTime] 내 슬롯을 획득하지 못하면 `null`로 완료된 [CompletableFuture]를 반환합니다.
-     * - [action] 예외 발생 시에도 슬롯은 반드시 반환됩니다.
-     *
-     * @param lockName 리더 그룹 선출에 사용할 락 이름
-     * @param executor 비동기 실행에 사용할 [Executor]
-     * @param action 슬롯 획득 성공 시 실행할 비동기 작업
-     * @return [action] 실행 결과를 담은 [CompletableFuture]. 슬롯 획득 실패 시 `null`로 완료됨
-     */
     override fun <T> runAsyncIfLeader(
         lockName: String,
         executor: Executor,
@@ -194,18 +126,24 @@ class RedissonLeaderGroupElector private constructor(
     ): CompletableFuture<T?> {
         return try {
             lockName.requireNotBlank("lockName")
-            val semaphore = getSemaphore(lockName)
-            log.debug { "리더 그룹 슬롯 획득을 요청합니다 (비동기). lockName=$lockName, maxLeaders=$maxLeaders" }
+            val semaphore = getPermitSemaphore(lockName)
+            log.debug { "리더 그룹 슬롯 획득 요청 (async). lockName=$lockName" }
 
             semaphore
-                .tryAcquireAsync(waitTime.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+                .tryAcquireAsync(
+                    waitTime.inWholeMilliseconds,
+                    leaseTime.inWholeMilliseconds,
+                    TimeUnit.MILLISECONDS,
+                )
                 .toCompletableFuture()
-                .thenComposeAsync({ acquired ->
-                    if (!acquired) {
-                        log.debug { "리더 그룹 슬롯 획득 실패 (슬롯 없음, 비동기). lockName=$lockName" }
-                        CompletableFuture.completedFuture(null)
+                .thenComposeAsync({ permitId ->
+                    if (permitId == null) {
+                        log.debug { "슬롯 획득 실패 (async). lockName=$lockName" }
+                        CompletableFuture.completedFuture<T?>(null)
                     } else {
-                        executeGroupActionAsync(semaphore, lockName, action)
+                        // Codex P2: acquire 성공 후 startedAtNanos 캡처
+                        val startedAtNanos = System.nanoTime()
+                        executeAsync(semaphore, lockName, permitId, startedAtNanos, action)
                     }
                 }, executor)
         } catch (e: Throwable) {
@@ -214,37 +152,88 @@ class RedissonLeaderGroupElector private constructor(
         }
     }
 
-    /**
-     * 세마포어 슬롯을 보유한 상태에서 비동기 [action]을 실행하고, 완료(성공/실패) 후 슬롯을 반납합니다.
-     *
-     * [action] 호출 자체가 동기적으로 예외를 던져도 슬롯은 반드시 반납됩니다.
-     */
-    private inline fun <T> executeGroupActionAsync(
-        semaphore: RSemaphore,
+    private fun <T> executeAsync(
+        semaphore: RPermitExpirableSemaphore,
         lockName: String,
+        permitId: String,
+        startedAtNanos: Long,
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
-        log.debug { "리더 그룹 슬롯을 획득하여 비동기 작업을 수행합니다. lockName=$lockName" }
+        log.debug { "슬롯 획득 성공 (async). lockName=$lockName, permitId=$permitId" }
 
-        val actionFuture = runCatching { action() }
-            .getOrElse { error ->
-                // action() 이 동기적으로 예외를 던진 경우에도 슬롯은 반드시 반납해야 한다
-                releaseSlotAsync(semaphore, lockName)
-                return failedCompletableFutureOf(error)
-            }
+        val actionFuture: CompletableFuture<T> = try {
+            action()
+        } catch (e: Throwable) {
+            releaseOrExtendAsync(semaphore, permitId, startedAtNanos, lockName)
+            return failedCompletableFutureOf(e)
+        }
 
-        return actionFuture.whenComplete { _, _ ->
-            releaseSlotAsync(semaphore, lockName)
+        return actionFuture.handle<T?> { value, error ->
+            releaseOrExtendAsync(semaphore, permitId, startedAtNanos, lockName)
+            if (error != null) throw error else value
         }
     }
 
-    private fun releaseSlotAsync(semaphore: RSemaphore, lockName: String) {
-        semaphore.releaseAsync().whenComplete { _, error ->
-            if (error != null) {
-                log.error(error) { "Fail to release semaphore slot. lockName=$lockName" }
+    private fun releaseOrExtend(
+        semaphore: RPermitExpirableSemaphore,
+        permitId: String,
+        startedAtNanos: Long,
+        lockName: String,
+    ) {
+        try {
+            val remainingMs = remainingMinLeaseTime(startedAtNanos, options.minLeaseTime).inWholeMilliseconds
+            if (remainingMs > 0) {
+                // Codex P2: tryUpdateLeaseTime 미존재. updateLeaseTime 만 존재.
+                semaphore.updateLeaseTime(permitId, remainingMs, TimeUnit.MILLISECONDS)
+                log.debug {
+                    "minLease 유지를 위해 leaseTime 갱신. lockName=$lockName, permitId=$permitId, remainingMs=$remainingMs"
+                }
             } else {
-                log.debug { "비동기 작업이 완료되어 슬롯을 반납했습니다. lockName=$lockName" }
+                semaphore.release(permitId)
+                log.debug { "슬롯 즉시 반납. lockName=$lockName, permitId=$permitId" }
+            }
+        } catch (e: Throwable) {
+            log.warn(e) { "Failed to release/extend permit. lockName=$lockName, permitId=$permitId" }
+        }
+    }
+
+    private fun releaseOrExtendAsync(
+        semaphore: RPermitExpirableSemaphore,
+        permitId: String,
+        startedAtNanos: Long,
+        lockName: String,
+    ) {
+        val remainingMs = remainingMinLeaseTime(startedAtNanos, options.minLeaseTime).inWholeMilliseconds
+        val future = if (remainingMs > 0) {
+            semaphore.updateLeaseTimeAsync(permitId, remainingMs, TimeUnit.MILLISECONDS)
+        } else {
+            semaphore.releaseAsync(permitId)
+        }
+        future.whenComplete { _, error ->
+            if (error != null) {
+                log.warn(error) { "Failed to release/extend permit. lockName=$lockName, permitId=$permitId" }
             }
         }
     }
+}
+
+/**
+ * Redisson 분산 Semaphore를 이용하여 복수 리더 선출을 통한 작업을 수행합니다.
+ *
+ * ```kotlin
+ * val client: RedissonClient = ...
+ * val options = LeaderGroupElectionOptions(maxLeaders = 3)
+ * val result: Int = client.runIfLeaderGroup("batch-job", options) {
+ *     // 최대 3개 프로세스가 동시에 실행
+ *     42
+ * }
+ * ```
+ */
+inline fun <T> RedissonClient.runIfLeaderGroup(
+    lockName: String,
+    options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
+    crossinline action: () -> T,
+): T? {
+    lockName.requireNotBlank("lockName")
+    return RedissonLeaderGroupElector(this, options).runIfLeader(lockName) { action() }
 }

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElector.kt
@@ -3,93 +3,48 @@ package io.bluetape4k.leader.redisson
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderGroupState
 import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
+import io.bluetape4k.leader.remainingMinLeaseTime
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requirePositiveNumber
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.withContext
-import org.redisson.api.RSemaphore
+import org.redisson.api.RPermitExpirableSemaphore
 import org.redisson.api.RedissonClient
 import org.redisson.client.RedisException
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 
 /**
- * Redisson 분산 Semaphore를 이용하여 복수 리더 선출을 통한 suspend 작업을 수행합니다.
+ * Redisson 분산 [RPermitExpirableSemaphore]를 이용한 코루틴 복수 리더 선출 구현체입니다.
+ *
+ * ## 동작/계약
+ *
+ * - `lockName` 별로 `lg:{lockName}` Redisson [RPermitExpirableSemaphore] 를 사용합니다.
+ * - 슬롯 획득 실패 시 `null` 반환 (ShedLock skip-on-contention).
+ * - `options.minLeaseTime > 0` 이면 빠른 action 종료 시 `updateLeaseTimeAsync` 로
+ *   slot 의 TTL 을 minLeaseTime 만큼 연장하여 유지합니다 (caller-park 없음).
+ * - 코루틴 취소 시에도 `withContext(NonCancellable)` 안에서 release 가 보장됩니다.
+ * - `CancellationException` 은 항상 re-throw 합니다.
  *
  * ```kotlin
- * val client: RedissonClient = ...
- * val options = LeaderGroupElectionOptions(maxLeaders = 3)
- * val result: Int = client.runSuspendIfLeaderGroup("batch-job", options) {
- *     // 최대 3개 프로세스가 동시에 실행
- *     delay(100)
- *     42
- * }
- * ```
- *
- * @param lockName 락 이름
- * @param options 리더 선출 옵션
- * @param action 리더 그룹 슬롯 획득 시 수행할 suspend 작업
- * @return 작업 결과
- */
-suspend fun <T> RedissonClient.runSuspendIfLeaderGroup(
-    lockName: String,
-    options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
-    action: suspend () -> T,
-): T? {
-    lockName.requireNotBlank("lockName")
-    options.maxLeaders.requirePositiveNumber("maxLeaders")
-    return RedissonSuspendLeaderGroupElector(this, options).runIfLeader(lockName, action)
-}
-
-
-/**
- * Redisson 분산 [RSemaphore]를 이용한 코루틴 기반 복수 리더 선출 구현체입니다.
- *
- * ## 동작
- * - `lockName`별로 Redis 분산 `RSemaphore(maxLeaders)`를 생성하여 동시 실행 수를 제한합니다.
- * - 슬롯이 가득 찬 경우 [LeaderGroupElectionOptions.waitTime] 내에 슬롯을 획득하지 못하면 `null`을 반환합니다 (ShedLock skip 방식).
- * - 슬롯 대기 중 인터럽트가 발생하면 [RedisException]으로 래핑되어 전파됩니다.
- * - `tryAcquireAsync`/`releaseAsync`를 사용하여 호출 코루틴을 블로킹하지 않습니다.
- * - `action` 예외 발생 시에도 슬롯은 반드시 반환됩니다.
- * - 여러 JVM 프로세스에 걸친 분산 동시 실행 제한에 적합합니다.
- *
- * ## [RedissonLeaderGroupElector] 과의 차이
- * - [RedissonLeaderGroupElector]은 스레드를 블로킹합니다.
- * - 이 구현체는 `await()`으로 코루틴을 suspend합니다.
- *
- * ```kotlin
- * val options = LeaderGroupElectionOptions(maxLeaders = 3)
+ * val options = LeaderGroupElectionOptions(maxLeaders = 3, minLeaseTime = 1.seconds)
  * val election = RedissonSuspendLeaderGroupElector(redissonClient, options)
- *
- * // 최대 3개 코루틴/프로세스가 동시에 실행
  * val result = election.runIfLeader("batch-job") { processChunkSuspend() }
- *
- * // 상태 조회
- * println(election.state("batch-job"))
  * ```
  *
  * @param redissonClient Redisson 클라이언트
- * @param options 리더 선출 옵션 (maxLeader, waitTime, leaseTime)
+ * @param options 리더 선출 옵션 (maxLeaders, waitTime, leaseTime, minLeaseTime)
  */
 class RedissonSuspendLeaderGroupElector private constructor(
     private val redissonClient: RedissonClient,
-    options: LeaderGroupElectionOptions,
+    val options: LeaderGroupElectionOptions,
 ): SuspendLeaderGroupElector {
 
     companion object: KLoggingChannel() {
-        /**
-         * [RedissonSuspendLeaderGroupElector] 인스턴스를 생성합니다.
-         *
-         * @param redissonClient Redisson 클라이언트
-         * @param options 리더 선출 옵션 (maxLeader, waitTime, leaseTime)
-         */
         operator fun invoke(
             redissonClient: RedissonClient,
             options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
@@ -101,86 +56,104 @@ class RedissonSuspendLeaderGroupElector private constructor(
 
     override val maxLeaders: Int = options.maxLeaders
     private val waitTime: Duration = options.waitTime
+    private val leaseTime: Duration = options.leaseTime
 
-    private fun getInitializedSemaphore(lockName: String): RSemaphore {
+    /**
+     * Codex P1: `trySetPermits(maxLeaders)` 멱등 호출 — 누락 시 acquire 영구 실패.
+     */
+    private fun getInitializedPermitSemaphore(lockName: String): RPermitExpirableSemaphore {
         lockName.requireNotBlank("lockName")
-        val semaphore = redissonClient.getSemaphore(lockName)
+        val semaphore = redissonClient.getPermitExpirableSemaphore("lg:{$lockName}")
         semaphore.trySetPermits(maxLeaders)
         return semaphore
     }
 
-    private suspend fun getInitializedSemaphoreAsync(lockName: String): RSemaphore {
+    private suspend fun getInitializedPermitSemaphoreAsync(lockName: String): RPermitExpirableSemaphore {
         lockName.requireNotBlank("lockName")
-        val semaphore = redissonClient.getSemaphore(lockName)
+        val semaphore = redissonClient.getPermitExpirableSemaphore("lg:{$lockName}")
         semaphore.trySetPermitsAsync(maxLeaders).await()
         return semaphore
     }
 
-    /**
-     * [lockName]에 대해 현재 활성(실행 중인) 리더 수를 반환합니다.
-     *
-     * `maxLeaders - availablePermits()`로 계산하므로 근사값입니다.
-     */
     override fun activeCount(lockName: String): Int =
-        maxLeaders - getInitializedSemaphore(lockName).availablePermits()
+        maxLeaders - getInitializedPermitSemaphore(lockName).availablePermits()
 
-    /**
-     * [lockName]에 대해 새 리더를 수용할 수 있는 남은 슬롯 수를 반환합니다.
-     */
     override fun availableSlots(lockName: String): Int =
-        getInitializedSemaphore(lockName).availablePermits()
+        getInitializedPermitSemaphore(lockName).availablePermits()
 
-    /**
-     * [lockName]에 대한 현재 [LeaderGroupState] 스냅샷을 반환합니다.
-     */
     override fun state(lockName: String): LeaderGroupState =
         LeaderGroupState(lockName, maxLeaders, activeCount(lockName))
 
-    /**
-     * [lockName]의 분산 [RSemaphore] 슬롯을 비동기로 획득하고 suspend [action]을 실행합니다.
-     *
-     * - 슬롯이 가득 찬 경우 [waitTime] 내 슬롯을 획득하지 못하면 `null`을 반환합니다 (ShedLock skip 방식).
-     * - [action] 예외 발생 시에도 슬롯은 반드시 반환됩니다.
-     *
-     * @param lockName 리더 그룹 선출에 사용할 락 이름
-     * @param action 슬롯 획득 성공 시 실행할 suspend 작업
-     * @return [action] 실행 결과, 슬롯 획득 실패 시 `null`
-     * @throws RedisException 슬롯 대기 중 인터럽트가 발생한 경우
-     */
     override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? {
         lockName.requireNotBlank("lockName")
 
-        val semaphore = getInitializedSemaphoreAsync(lockName)
-        log.debug { "리더 그룹 슬롯 획득을 요청합니다. lockName=$lockName, maxLeaders=$maxLeaders" }
+        val semaphore = getInitializedPermitSemaphoreAsync(lockName)
+        log.debug { "슬롯 획득 요청. lockName=$lockName, maxLeaders=$maxLeaders" }
 
-        val acquired = try {
-            semaphore.tryAcquireAsync(waitTime.inWholeMilliseconds, TimeUnit.MILLISECONDS).await()
+        val permitId: String? = try {
+            semaphore.tryAcquireAsync(
+                waitTime.inWholeMilliseconds,
+                leaseTime.inWholeMilliseconds,
+                TimeUnit.MILLISECONDS,
+            ).await()
         } catch (e: InterruptedException) {
             Thread.currentThread().interrupt()
-            log.warn(e) { "슬롯 획득 대기 중 인터럽트가 발생했습니다. lockName=$lockName" }
-            throw RedisException("Interrupted while acquiring semaphore slot. lockName=$lockName", e)
+            log.warn(e) { "슬롯 획득 대기 중 인터럽트. lockName=$lockName" }
+            throw RedisException("Interrupted while acquiring permit. lockName=$lockName", e)
         }
 
-        if (!acquired) {
-            log.debug { "리더 그룹 슬롯 획득 실패 (슬롯 없음). lockName=$lockName" }
+        if (permitId == null) {
+            log.debug { "슬롯 획득 실패. lockName=$lockName" }
             return null
         }
+        // Codex P2: acquire 성공 후 startedAtNanos 캡처
+        val startedAtNanos = System.nanoTime()
+        log.debug { "슬롯 획득 성공. lockName=$lockName, permitId=$permitId" }
 
-        log.debug { "리더 그룹 슬롯을 획득하여 suspend 작업을 수행합니다. lockName=$lockName" }
         try {
             return action()
         } finally {
-            // NonCancellable: 코루틴 취소 시에도 세마포어 슬롯 반납이 중단되지 않도록 보호
+            // NonCancellable: 코루틴 취소 시에도 release/extend 가 중단되지 않도록 보호
             withContext(NonCancellable) {
-                runCatching { semaphore.releaseAsync().await() }
-                    .onSuccess {
-                        log.debug { "작업이 완료되어 슬롯을 반납했습니다. lockName=$lockName" }
+                try {
+                    val remainingMs = remainingMinLeaseTime(startedAtNanos, options.minLeaseTime).inWholeMilliseconds
+                    if (remainingMs > 0) {
+                        semaphore.updateLeaseTimeAsync(permitId, remainingMs, TimeUnit.MILLISECONDS).await()
+                        log.debug {
+                            "minLease 유지를 위해 leaseTime 갱신. lockName=$lockName, permitId=$permitId, remainingMs=$remainingMs"
+                        }
+                    } else {
+                        semaphore.releaseAsync(permitId).await()
+                        log.debug { "슬롯 즉시 반납. lockName=$lockName, permitId=$permitId" }
                     }
-                    .onFailure { error ->
-                        if (error is CancellationException) throw error
-                        log.warn(error) { "Fail to release semaphore slot. lockName=$lockName" }
-                    }
+                } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                    throw e
+                } catch (e: Throwable) {
+                    log.warn(e) { "Failed to release/extend permit. lockName=$lockName, permitId=$permitId" }
+                }
             }
         }
     }
+}
+
+/**
+ * Redisson 분산 [RPermitExpirableSemaphore] 를 이용하여 복수 리더 선출을 통한 suspend 작업을 수행합니다.
+ *
+ * ```kotlin
+ * val client: RedissonClient = ...
+ * val options = LeaderGroupElectionOptions(maxLeaders = 3)
+ * val result: Int = client.runSuspendIfLeaderGroup("batch-job", options) {
+ *     delay(100)
+ *     42
+ * }
+ * ```
+ */
+suspend fun <T> RedissonClient.runSuspendIfLeaderGroup(
+    lockName: String,
+    options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
+    action: suspend () -> T,
+): T? {
+    lockName.requireNotBlank("lockName")
+    options.maxLeaders.requirePositiveNumber("maxLeaders")
+    return RedissonSuspendLeaderGroupElector(this, options).runIfLeader(lockName, action)
 }

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElectionTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElectionTest.kt
@@ -480,4 +480,97 @@ class RedissonLeaderGroupElectionTest: AbstractRedissonLeaderTest() {
         task1.get() shouldBeEqualTo numThreads * roundsPerThread / 2
         task2.get() shouldBeEqualTo numThreads * roundsPerThread / 2
     }
+
+    // =========================================================================
+    // minLeaseTime 시맨틱 (slot-token TTL 모델)
+    // =========================================================================
+
+    @Test
+    fun `minLeaseTime 보유 - 빠른 action 종료 후에도 다른 client 는 즉시 acquire 실패한다`() {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 1,
+            waitTime = 100.milliseconds,
+            leaseTime = 10.seconds,
+            minLeaseTime = 800.milliseconds,
+        )
+        val el = RedissonLeaderGroupElector(redissonClient, opts)
+        val lockName = randomName()
+
+        el.runIfLeader(lockName) { "fast" } shouldBeEqualTo "fast"
+
+        val secondElector = RedissonLeaderGroupElector(redissonClient, opts)
+        secondElector.runIfLeader(lockName) { "should-not" } shouldBeEqualTo null
+    }
+
+    @Test
+    fun `minLeaseTime 만료 후 다음 acquire 가 성공한다`() {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 1,
+            waitTime = 100.milliseconds,
+            leaseTime = 10.seconds,
+            minLeaseTime = 300.milliseconds,
+        )
+        val el = RedissonLeaderGroupElector(redissonClient, opts)
+        val lockName = randomName()
+
+        el.runIfLeader(lockName) { "first" } shouldBeEqualTo "first"
+
+        Thread.sleep(400)
+
+        val secondElector = RedissonLeaderGroupElector(redissonClient, opts)
+        secondElector.runIfLeader(lockName) { "second" } shouldBeEqualTo "second"
+    }
+
+    @Test
+    fun `minLeaseTime=0 회귀 - 즉시 release 가 정상 동작한다`() {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 1,
+            waitTime = 100.milliseconds,
+            leaseTime = 10.seconds,
+        )
+        val el = RedissonLeaderGroupElector(redissonClient, opts)
+        val lockName = randomName()
+
+        el.runIfLeader(lockName) { "a" } shouldBeEqualTo "a"
+
+        val secondElector = RedissonLeaderGroupElector(redissonClient, opts)
+        secondElector.runIfLeader(lockName) { "b" } shouldBeEqualTo "b"
+    }
+
+    @Test
+    fun `maxLeaders 동시 점유 + 모두 minLease 보유 - 추가 client 는 실패한다`() {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 2,
+            waitTime = 100.milliseconds,
+            leaseTime = 10.seconds,
+            minLeaseTime = 1.seconds,
+        )
+        val el = RedissonLeaderGroupElector(redissonClient, opts)
+        val lockName = randomName()
+
+        repeat(opts.maxLeaders) {
+            el.runIfLeader(lockName) { "fast" } shouldBeEqualTo "fast"
+        }
+
+        val third = RedissonLeaderGroupElector(redissonClient, opts)
+        third.runIfLeader(lockName) { "third" } shouldBeEqualTo null
+    }
+
+    @Test
+    fun `crash recovery - release 미호출 시 leaseTime 만료 후 다른 client 가 acquire 한다`() {
+        val lockName = randomName()
+        // 짧은 leaseTime 으로 직접 permit 을 잡고 release 하지 않음
+        val crashSemaphore = redissonClient.getPermitExpirableSemaphore("lg:{$lockName}")
+        crashSemaphore.trySetPermits(1)
+        val crashedPermit = crashSemaphore.tryAcquire(
+            200, 400, java.util.concurrent.TimeUnit.MILLISECONDS
+        )
+        crashedPermit shouldBeEqualTo crashedPermit
+
+        val opts = LeaderGroupElectionOptions(maxLeaders = 1, waitTime = 1.seconds, leaseTime = 5.seconds)
+        val el = RedissonLeaderGroupElector(redissonClient, opts)
+        Thread.sleep(500) // leaseTime(400ms) 만료 대기
+
+        el.runIfLeader(lockName) { "recovered" } shouldBeEqualTo "recovered"
+    }
 }

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElectorTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElectorTest.kt
@@ -9,6 +9,7 @@ import io.bluetape4k.logging.debug
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import io.bluetape4k.assertions.shouldBeEqualTo
@@ -184,5 +185,119 @@ class RedissonSuspendLeaderGroupElectorTest: AbstractRedissonLeaderTest() {
 
         task1.get() shouldBeEqualTo numWorkers * roundsPerJob
         task2.get() shouldBeEqualTo numWorkers * roundsPerJob
+    }
+
+    // =========================================================================
+    // minLeaseTime 시맨틱 (slot-token TTL 모델)
+    // =========================================================================
+
+    @Test
+    fun `minLeaseTime 보유 - 빠른 action 종료 후에도 다른 client 는 즉시 acquire 실패한다`() = runSuspendIO {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 1,
+            waitTime = 100.milliseconds,
+            leaseTime = 10.seconds,
+            minLeaseTime = 800.milliseconds,
+        )
+        val el = RedissonSuspendLeaderGroupElector(redissonClient, opts)
+        val lockName = randomName()
+        el.runIfLeader(lockName) { "fast" } shouldBeEqualTo "fast"
+
+        val secondElector = RedissonSuspendLeaderGroupElector(redissonClient, opts)
+        secondElector.runIfLeader(lockName) { "should-not" } shouldBeEqualTo null
+    }
+
+    @Test
+    fun `minLeaseTime 만료 후 다음 acquire 가 성공한다 (suspend)`() = runSuspendIO {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 1,
+            waitTime = 100.milliseconds,
+            leaseTime = 10.seconds,
+            minLeaseTime = 300.milliseconds,
+        )
+        val el = RedissonSuspendLeaderGroupElector(redissonClient, opts)
+        val lockName = randomName()
+        el.runIfLeader(lockName) { "first" } shouldBeEqualTo "first"
+
+        delay(400.milliseconds)
+
+        val secondElector = RedissonSuspendLeaderGroupElector(redissonClient, opts)
+        secondElector.runIfLeader(lockName) { "second" } shouldBeEqualTo "second"
+    }
+
+    @Test
+    fun `minLeaseTime=0 회귀 - 즉시 release 가 정상 동작한다 (suspend)`() = runSuspendIO {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 1,
+            waitTime = 100.milliseconds,
+            leaseTime = 10.seconds,
+        )
+        val el = RedissonSuspendLeaderGroupElector(redissonClient, opts)
+        val lockName = randomName()
+        el.runIfLeader(lockName) { "a" } shouldBeEqualTo "a"
+
+        val secondElector = RedissonSuspendLeaderGroupElector(redissonClient, opts)
+        secondElector.runIfLeader(lockName) { "b" } shouldBeEqualTo "b"
+    }
+
+    @Test
+    fun `maxLeaders 동시 점유 + 모두 minLease 보유 - 추가 client 는 실패한다 (suspend)`() = runSuspendIO {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 2,
+            waitTime = 100.milliseconds,
+            leaseTime = 10.seconds,
+            minLeaseTime = 1.seconds,
+        )
+        val el = RedissonSuspendLeaderGroupElector(redissonClient, opts)
+        val lockName = randomName()
+        repeat(opts.maxLeaders) {
+            el.runIfLeader(lockName) { "fast" } shouldBeEqualTo "fast"
+        }
+
+        val third = RedissonSuspendLeaderGroupElector(redissonClient, opts)
+        third.runIfLeader(lockName) { "third" } shouldBeEqualTo null
+    }
+
+    @Test
+    fun `crash recovery - release 미호출 시 leaseTime 만료 후 다른 client 가 acquire 한다 (suspend)`() = runSuspendIO {
+        val lockName = randomName()
+        val crashSemaphore = redissonClient.getPermitExpirableSemaphore("lg:{$lockName}")
+        crashSemaphore.trySetPermits(1)
+        crashSemaphore.tryAcquire(200, 400, java.util.concurrent.TimeUnit.MILLISECONDS)
+
+        val opts = LeaderGroupElectionOptions(maxLeaders = 1, waitTime = 1.seconds, leaseTime = 5.seconds)
+        val el = RedissonSuspendLeaderGroupElector(redissonClient, opts)
+        delay(500.milliseconds)
+
+        el.runIfLeader(lockName) { "recovered" } shouldBeEqualTo "recovered"
+    }
+
+    @Test
+    fun `코루틴 취소 + minLeaseTime 보유 - NonCancellable 로 score 갱신 보장`() = runSuspendIO {
+        val opts = LeaderGroupElectionOptions(
+            maxLeaders = 1,
+            waitTime = 200.milliseconds,
+            leaseTime = 10.seconds,
+            minLeaseTime = 800.milliseconds,
+        )
+        val el = RedissonSuspendLeaderGroupElector(redissonClient, opts)
+        val cancelLock = randomName()
+
+        coroutineScope {
+            val deferred = async {
+                el.runIfLeader(cancelLock) {
+                    delay(50.milliseconds)
+                    "cancelled-action"
+                }
+            }
+            delay(20.milliseconds)
+            deferred.cancelAndJoin()
+        }
+
+        val secondElector = RedissonSuspendLeaderGroupElector(redissonClient, opts)
+        secondElector.runIfLeader(cancelLock) { "should-not" } shouldBeEqualTo null
+
+        delay(900.milliseconds)
+        secondElector.runIfLeader(cancelLock) { "later" } shouldBeEqualTo "later"
     }
 }


### PR DESCRIPTION
## Summary

Closes #151

PR #170의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat(leader-redis): #151 Redis group minLeaseTime slot-token TTL 재설계`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 개요

Issue #151 — Redis group elector (Lettuce + Redisson) 가 counter/semaphore 기반 → **slot-token TTL 모델** 재설계.

PR #149/#150 single lock minLeaseTime backend TTL 위임 패턴을 group 에도 적용. crash recovery 자동.

Closes #151

## 핵심 설계

| | Old | New |
|---|---|---|
| **Lettuce** | LettuceSemaphore (단일 INTEGER 카운터) | LettuceSlotTokenGroup (ZSET + Lua server-side TIME) |
| **Redisson** | 표준 RSemaphore | RPermitExpirableSemaphore + trySetPermits + updateLeaseTime |
| **slot 식별자** | 없음 | token (Base58 / permitId) |
| **slot 별 TTL** | 없음 (영구) | score=expiryAt (Lettuce) / Redis TTL (Redisson) |
| **minLeaseTime** | caller-park (행동만 흉내) | backend TTL 위임 (caller 즉시 반환) |
| **crash recovery** | 영구 누수 → 외부 reaper 필요 | 다음 acquire 시 자동 정리 |
| **key** | lockName | lg:{lockName} (충돌 회피) |

## 변경 사항

### 신규
- `LettuceSlotTokenGroup.kt` — ZSET 기반 group lock + 3 Lua scripts (server-side TIME)
- `LettuceSlotTokenGroupTest.kt` — 7 시나리오 (단일/N동시/N+1실패/release/score 갱신/expired 회수/backend error)

### 수정
- LettuceLeaderGroupElector + LettuceSuspendLeaderGroupElector — slot group 으로 교체, sequential async ordering
- RedissonLeaderGroupElector + RedissonSuspendLeaderGroupElector — RPermitExpirableSemaphore + updateLeaseTime
- LettuceSemaphore / LettuceSuspendSemaphore — @Deprecated
- 4 group elector 통합 테스트 — minLeaseTime + crash recovery 시나리오 추가

### 문서
- 4 README + 4 README.ko.md — Architecture + Mermaid sequenceDiagram (정상/crash + minLeaseTime delegation 2 시나리오 each)
- CLAUDE.md — Group elector slot-token 섹션
- docs/lessons/2026-05-10-redis-group-slot-token.md (L1~L8)

## 테스트 결과

| 모듈 | 결과 |
|------|------|
| `:leader-redis-lettuce:test` | **110 passing** (기존 107 + 회귀 3) |
| `:leader-redis-redisson:test` | **102 passing** |

신규 시나리오 (각 backend × blocking/suspend):
- minLeaseTime > runtime → 즉시 반환 + 다른 client minLease 만료 전 실패
- minLeaseTime 만료 후 acquire 성공
- minLeaseTime == 0 즉시 release 회귀
- crash recovery: release 미호출 → leaseTime 만료 후 acquire 성공
- maxLeaders 동시 점유 + 모두 minLease 보유 → maxLeaders+1 실패
- (suspend) 코루틴 취소 + minLease > 0 → NonCancellable score 갱신
- async sequential ordering (release 완료 후 outer future complete)

## 코드 리뷰

| Reviewer | 발견 | 조치 |
|----------|------|------|
| Codex spec review | P1×3 + P2×1 | ✅ 모두 spec 반영 (server-side TIME, trySetPermits, updateLeaseTime API) |
| Codex plan review | P2×2 + P3×1 | ✅ 모두 plan 반영 (startedAtNanos 시점, CLAUDE.md task) |
| code-reviewer Tier 4 | CRITICAL 1 + HIGH 3 | ✅ C1 staging, H1 ZSCORE 가드, H2 async retry 처리, H3 release logging 비대칭 |
| Codex code review | P2×2 | ✅ P2-1 backend error retain, P2-2 release sequential |
| Final | CRITICAL 0, HIGH 0 | ✅ ready |

## Backward Compatibility

key prefix `lg:{lockName}` 도입으로 구버전 키와 충돌 회피 → WRONGTYPE 에러 차단. 단, **rolling deploy 중 일시적으로 maxLeaders 효과 2배** 가능 (구/신 그룹 분리). 완화: 구 pod drain 후 신 배포 권장 (CHANGELOG breaking change 명시 권장).
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #151, milestone `0.1.0`, assignee `debop`
- PR: #170, head `9fd1b0e0457a85f1a03f24142723751fbb5e278c`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
