### PR TITLE
feat(leader-core/leader-spring-boot): #79 PR 1 Core — LockExtender / LockAssert + reentrant + 명시적 lease 연장

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,40 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`leader-core`**: ShedLock-호환 ergonomic API + reentrant + 명시적 lease 연장 (issue #79 PR 1 Core)
+  - `LockAssert` — `assertLocked()` / `assertLocked(lockName)` / `isLocked()` 그리고 suspend 변형
+    (`assertLockedSuspend` / `isLockedSuspend`)
+  - `LockExtender` — `extendActiveLock(Duration): Boolean` + Java `java.time.Duration` overload
+    + `extendActiveLockDetailed(Duration): ExtendOutcome` (sealed result) + suspend 변형
+  - `LeaderLockHandle` sealed class (`Real` / `FailOpen`) — `internal constructor` + companion factory
+  - `LockIdentity` — `(lockName, kind, factoryBeanName, groupParams)` 4-tuple. `equals/hashCode` 에서
+    `factoryBeanName` 제외 — sync ↔ suspend nested 호출 시에도 reentrant 정확 (Step 3-P R3)
+  - `ExtendOutcome` sealed — `Extended` / `NotHeld` / `WrongThread` / `BackendError(Exception)`
+  - `LockHandleElement` — `CoroutineContext.Element` (internal handle, public Key)
+  - `BackendErrorClassifier` SPI + `CoreBackendErrorClassifier` (JDK/공통) + `CompositeBackendErrorClassifier`
+  - `runIfLeaderResultSuspend` default fun on `SuspendLeaderElector` / `SuspendLeaderGroupElector`
+    (binary-compat via `-jvm-default=enable`)
+  - `LeaderLeaseAutoExtender.start(delegate: ExtendDelegate)` 신규 시그니처. 기존 `(Duration) -> Boolean`
+    `@Deprecated`. `ExtendDelegate.lastExtendDeadline` 으로 watchdog × user-extend last-write-wins
+    metric 가시화 (Step 3-P R2)
+  - Local elector (sync / suspend / group / suspend-group) — `CaptureScope` + `LeaderLockHandle` 통합
+
+- **`leader-spring-boot`**: `@LeaderElection` / `@LeaderGroupElection` aspect 의 `LockAssert` / `LockExtender` 통합
+  (issue #79 PR 1)
+  - sync / suspend / Mono 3 branch — reentrant peek (Real handle) + sentinel push (FAIL_OPEN_RUN)
+    + `BodyThrownMarker` (body exception 보호) + `CaptureInvariantException` (spec invariant fail-fast)
+  - `AdviceBranch { SYNC, COROUTINES, REACTIVE }` enum (카테고리 명칭 — Flow / Flux 등 향후 확장 여지)
+  - `AdviceMetadata.annotationKind` explicit field + `resolveLockIdentity(branch)`
+  - `LeaderAnnotationValidatorBeanPostProcessor` — `CompletableFuture` / `Future` / `ListenableFuture`
+    / `kotlinx.coroutines.Deferred` 반환 타입 차단 (Step 3-P R12 — lock release 가 future 완료 전 발생 위험)
+  - Kotlin reified `findMergedAnnotationOrNull<A>()` / `hasMergedAnnotation<A>()` extension
+    (`AnnotationExt.kt`, idiom 적용)
+
+### Changed
+
+- `LeaderElectionAspect` / `LeaderGroupElectionAspect` — outer `catch (Exception)` (Throwable 아님 —
+  `OutOfMemoryError` / `StackOverflowError` / `LinkageError` 차단)
+
 - **`examples/`**: Runnable example modules demonstrating production scenarios for `bluetape4k-leader` (issue #36)
   - `examples/batch-scheduler` — Lettuce Redis 기반 분산 batch 스케줄러; 야간 정산 등 주기 작업의
     멀티 인스턴스 단일 실행 보장 (PR #159)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,8 @@ LeaderGroupElectionOptions(maxLeaders = 3, waitTime = 5.seconds, leaseTime = 60.
 - CTW → `open` 불필요 (final Kotlin 메서드에도 동작)
 - `@EnableAspectJAutoProxy` **사용 금지** — CTW가 컴파일 타임에 weaving 처리
 - `private` 메서드는 인터셉트 안 됨 — startup validation에서 warn/fail
-- `suspend` / `Mono` / `Flux` / `Flow` 반환 타입 미지원 (v1.x sync-only)
+- `suspend` / `Mono` 반환 타입 지원 (#90 / #91). `Flux` / `Flow` 미지원 (validator startup fail/WARN)
+- `CompletableFuture` / `Future` / `ListenableFuture` / `kotlinx.coroutines.Deferred` 반환 타입 차단 (#79 — lock release 가 future 완료 전 발생 → split-brain 위험)
 
 ### SpEL name 규칙
 

--- a/WIP.md
+++ b/WIP.md
@@ -1,10 +1,19 @@
 # WIP - bluetape4k-leader
 
-Snapshot: 2026-05-10 KST
+Snapshot: 2026-05-11 KST
 Scope: open GitHub issues assigned to `debop`, created on or after 2026-01-01.
 
 ## Recently Completed (now in CHANGELOG `[Unreleased]`)
 
+- **#79 LockExtender / LockAssert (PR 1 Core)** — ShedLock-호환 ergonomic API + reentrant + 명시적 lease 연장.
+  - `leader-core`: `LockAssert` / `LockExtender` top-level API, `LeaderLockHandle` sealed, `LockIdentity`
+    (factoryBeanName equals 제외), `ExtendOutcome` sealed, `LockHandleElement` (`CoroutineContext.Element`),
+    `BackendErrorClassifier` SPI 분산, `ExtendDelegate.lastExtendDeadline` (watchdog × explicit extend race-free),
+    Local elector capture/extend 통합
+  - `leader-spring-boot`: aspect 3 branch (sync / COROUTINES / REACTIVE) — reentrant peek + sentinel push
+    + capture invariant. Validator 가 `CompletableFuture` / `Future` / `Deferred` 반환 차단 (R12).
+  - PR 분할 전략: PR 1 Core 머지 후 backend 별 PR (Lettuce / Redisson / Mongo / Exposed JDBC/R2DBC / Hazelcast / ZooKeeper / Ktor smoke).
+  - 8 round Spec + 5 round Plan review 누적 117 finding 적용 후 architectural 수렴.
 - **#37 leader-ktor** — Ktor 3.x integration (`LeaderElectionPlugin`,
   `Application.leaderScheduled`) — PR #164.
 - **#36 leader examples** — six runnable examples covering every supported
@@ -29,7 +38,6 @@ single-issue rather than a phase.
 |---|---|---:|---|
 | P1 | [#73](https://github.com/bluetape4k/bluetape4k-leader/issues/73) watchdog / lease auto-extend | L | Addresses split-brain risk for long-running AOP work. |
 | P1 | [#77](https://github.com/bluetape4k/bluetape4k-leader/issues/77) minLeaseTime backend TTL delegation | L | More concrete replacement for `#38`; align semantics before implementing both. |
-| P1 | [#79](https://github.com/bluetape4k/bluetape4k-leader/issues/79) LockExtender / LockAssert | M | Builds on watchdog semantics and explicit extension behavior. |
 | P1 | [#74](https://github.com/bluetape4k/bluetape4k-leader/issues/74) Flux/Flow AOP support | L | Depends on `#73`; streaming lease renewal must be solved first. |
 | P2 | [#68](https://github.com/bluetape4k/bluetape4k-leader/issues/68) election state API | M | Useful for metrics and operational visibility. |
 | P2 | [#50](https://github.com/bluetape4k/bluetape4k-leader/issues/50) common audit contract | M | Define history semantics before durable audit implementations. |
@@ -44,7 +52,7 @@ single-issue rather than a phase.
 ```text
 #73 watchdog / auto-extend
   -> #74 Flux/Flow support
-  -> #79 explicit lease extension API
+  -> #79 explicit lease extension API ✅ (PR 1 Core landed)
 
 #38 lockAtLeastFor
 #77 minLeaseTime backend TTL delegation

--- a/docs/superpowers/plans/2026-05-10-lock-extender-plan.md
+++ b/docs/superpowers/plans/2026-05-10-lock-extender-plan.md
@@ -1993,7 +1993,7 @@ git commit -m "test(leader-core): T6 abstract contract bases + Local concrete te
 
 **Complexity:** high
 **Module:** `leader-redis-lettuce`
-**Depends on:** T1, T3, T5
+**Depends on:** T1, T3, T5, T6 (AbstractLockExtenderContractTest base — Plan-R2-P1-2)
 **Satisfies AC:** AC-1 (Lettuce rows), AC-15 (delegate ref), AC-16 (server-side TIME grep), AC-18 (CancellationException re-throw), AC-21 (extendSuspend override), AC-23 (per-module ref test), AC-24 (Lettuce classifier)
 
 **Files:**
@@ -2259,9 +2259,19 @@ rg -n "withContext\(Dispatchers\.IO\)" leader-redis-lettuce/src/main/kotlin/
 class LettuceExtendDelegateReferenceTest {
     @Test fun `delegate reference shared with watchdog`() {
         // T5 의 LocalExtendDelegateReferenceTest 와 동일 패턴 — Lettuce elector
+        // - acquire 한 elector 의 watchdog.delegate 와 handle.extendDelegate 가 === 동일 reference
+        // - `extendDelegate` 가 `internal` 접근 가능 (backend module 안 test 이므로 OK)
+        // - mockk 또는 reflection 으로 reference equality 검증
     }
 }
 ```
+
+> 💡 **AC-23 per-backend ref test pattern (Plan-R2-P1-3)** — T8~T13 모두 동일 패턴 적용:
+> - `RedissonExtendDelegateReferenceTest` (T8), `MongoExtendDelegateReferenceTest` (T9),
+> - `ExposedJdbcExtendDelegateReferenceTest` (T10), `ExposedR2dbcExtendDelegateReferenceTest` (T11),
+> - `HazelcastExtendDelegateReferenceTest` (T12), `ZkExtendDelegateReferenceTest` (T13).
+>
+> 각 backend module 의 test sourceSet 안에 위치 — `extendDelegate` 가 `internal` 이므로 cross-module 접근 불가, same-module test 만 가능. **각 task 의 마지막 step 으로 "Write `{Backend}ExtendDelegateReferenceTest` (AC-23)" 추가 의무.**
 
 - [ ] **Step 13: Run module build + tests**
 
@@ -2283,7 +2293,7 @@ git commit -m "feat(leader-redis-lettuce): T7 extend ExtendOutcome + group exten
 
 **Complexity:** high
 **Module:** `leader-redis-redisson`
-**Depends on:** T1, T3, T5
+**Depends on:** T1, T3, T5, T6 (AbstractLockExtenderContractTest base — Plan-R2-P1-2)
 **Satisfies AC:** AC-1 (Redisson rows), AC-8 (thread-id semantics), AC-15, AC-18, AC-21, AC-23, AC-24
 
 **Files:**
@@ -2450,7 +2460,7 @@ git commit -m "feat(leader-redis-redisson): T8 owner-guarded Lua + group updateL
 
 **Complexity:** medium
 **Module:** `leader-mongodb`
-**Depends on:** T1, T3, T5
+**Depends on:** T1, T3, T5, T6 (AbstractLockExtenderContractTest base — Plan-R2-P1-2)
 **Satisfies AC:** AC-1 (Mongo rows), AC-15, AC-17 (filter grep), AC-18, AC-21, AC-23, AC-24
 
 **Files:**
@@ -2603,7 +2613,7 @@ git commit -m "feat(leader-mongodb): T9 extend filter expireAt>now + group exten
 
 **Complexity:** medium
 **Module:** `leader-exposed-jdbc`
-**Depends on:** T1, T3, T5
+**Depends on:** T1, T3, T5, T6 (AbstractLockExtenderContractTest base — Plan-R2-P1-2)
 **Satisfies AC:** AC-1 (Exposed JDBC rows), AC-15, AC-18, AC-21, AC-23, AC-24
 
 **Files:**
@@ -2779,7 +2789,7 @@ git commit -m "feat(leader-exposed-r2dbc): T11 suspend extend SQL + classifier"
 
 **Complexity:** high
 **Module:** `leader-hazelcast`
-**Depends on:** T1, T3, T5
+**Depends on:** T1, T3, T5, T6 (AbstractLockExtenderContractTest base — Plan-R2-P1-2)
 **Satisfies AC:** AC-1 (Hazelcast rows), AC-7 (EntryProcessor — plain setTtl 금지), AC-15, AC-18, AC-21, AC-23, AC-24
 
 **Files:**
@@ -2906,7 +2916,7 @@ git commit -m "feat(leader-hazelcast): T12 ExtendEntryProcessor + capture + clas
 
 **Complexity:** low
 **Module:** `leader-zookeeper`
-**Depends on:** T1, T3, T5
+**Depends on:** T1, T3, T5, T6 (AbstractLockExtenderContractTest base — Plan-R2-P1-2)
 **Satisfies AC:** AC-1 (ZK rows — passthrough), AC-15, AC-20 (autoExtend WARN), AC-23, AC-24
 
 **Files:**
@@ -3437,6 +3447,26 @@ fun `AC-2b — @LeaderElection + @LeaderGroupElection same lockName both acquire
     // outer SyncSingleBean (lockName="X") + inner SyncGroupBean (lockName="X")
     // verify(exactly = 1) { singleElector.runIfLeaderResult("X", any()) }
     // verify(exactly = 1) { groupElector.runIfLeaderResult("X", any()) }
+}
+```
+
+- [ ] **Step 6b: Group FailOpen sentinel reentrant test (Plan-R2-P1-1)**
+
+```kotlin
+@Test
+fun `Plan-R2-P1-1 — group FailOpen sentinel scope nested same identity — backend untouched + sentinel preserved (sync)`() {
+    // outer @LeaderGroupElection("gA") backend exception → FAIL_OPEN_RUN → sentinel push
+    //   inner @LeaderGroupElection("gA") 진입 → reentrant peek 가 FailOpen sentinel 감지 → 동일 sentinel 유지
+    // verify(exactly = 0) { groupElector.runIfLeaderResult("gA", any()) }  // inner backend 미접촉
+    // assert LockStateHolder.peekSync() is LeaderLockHandle.FailOpen
+    // assertFailsWith<IllegalStateException> { LockAssert.assertLocked() }
+}
+
+@Test
+fun `Plan-R2-P1-1 — group FailOpen sentinel scope nested same identity (suspend)`() = runTest {
+    // 동일 시나리오 suspend 분기 — coroutineContext[LockHandleElement]?.handle is FailOpen + identity 일치 시 sentinel 유지
+    // currentCoroutineContext()[LockHandleElement]?.handle.shouldBeInstanceOf<LeaderLockHandle.FailOpen>()
+    // assertFailsWith<IllegalStateException> { LockAssert.assertLockedSuspend() }
 }
 ```
 

--- a/docs/superpowers/plans/2026-05-10-lock-extender-plan.md
+++ b/docs/superpowers/plans/2026-05-10-lock-extender-plan.md
@@ -10,7 +10,14 @@
 
 **Spec:** [`docs/superpowers/specs/2026-05-10-lock-extender-design.md`](../specs/2026-05-10-lock-extender-design.md) — Round 8 architectural convergence (Codex P0/P1=0), 117 finding 통합.
 
-**Critical path:** T1 → T2 → T3 → T4 → T14 → T17 → T18 → T19. T5-T13 backend 별 병렬 가능 (T1-T3 완료 후).
+**Critical path:** T1 → T2 → T3 → T4 → T14 → T17 → T18 → T19.
+
+**Parallel windows** (R3-Plan-R1-P3 — dependency graph 정확화):
+- T5 는 T1, T3 후 시작 (backend 의 capture/extend 가 의존)
+- T7~T13 backend tasks 는 **T5 완료 후** 병렬 가능 (단 T11 R2DBC 는 T10 JDBC 의 SQL 패턴 참조 — T10 → T11 직렬)
+- T14 는 T1~T4 모두 완료 후 시작 (LockAssert/LockExtender 사용)
+- T15 는 T14 후
+- T16 (validator) 는 T1~T4 의존 — T14 와 병렬 가능
 
 **Effort estimate (19 tasks):**
 - high (8): T7, T8, T12, T14, T15, T17 + critical paths
@@ -2994,7 +3001,7 @@ git commit -m "feat(leader-zookeeper): T13 passthrough extend + autoExtend=false
 
 **Complexity:** high
 **Module:** `leader-spring-boot`
-**Depends on:** T1, T2, T3
+**Depends on:** T1, T2, T3, T4 (LockAssert/LockExtender 사용)
 **Satisfies AC:** AC-2 (reentrant counter 0), AC-2b (cross-kind dedupe 차단), AC-4 (fail-open sentinel), AC-4b (failure mode 행렬), AC-5 (sync/suspend/Mono), AC-22 (CTW weave)
 
 **Files:**
@@ -3095,6 +3102,15 @@ class LeaderElectionAspectReentrantTest {
     fun `same lockName different factoryBean — both acquire`() {
         // factoryBeanName 이 다르면 LockIdentity 가 다르므로 passthrough 안 함
     }
+
+    @Test
+    fun `Plan-R1-P1-1 — FailOpen sentinel scope nested same identity — backend untouched + sentinel preserved`() {
+        // outer @LeaderElection("job-X") backend exception → FAIL_OPEN_RUN → sentinel push
+        //   inner @LeaderElection("job-X") 진입 → reentrant peek 가 FailOpen sentinel 감지 → 동일 sentinel 유지
+        // verify(exactly = 0) { elector.runIfLeaderResult("job-X", any()) }  // inner backend 미접촉
+        // assert LockStateHolder.peekSync() is LeaderLockHandle.FailOpen
+        // assertFailsWith<IllegalStateException> { LockAssert.assertLocked() }  // sentinel scope 일관 throw
+    }
 }
 ```
 
@@ -3105,11 +3121,19 @@ class LeaderElectionAspectReentrantTest {
 private fun aroundLeader(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
     val identity = meta.resolveLockIdentity(AdviceBranch.SYNC)
 
-    // 1) Reentrant peek — full identity (R1 / Codex F3)
+    // 1) Reentrant peek — full identity (R1 / Codex F3 / Plan-R1-P1-1)
     val outer = LockStateHolder.peekSync()
-    if (outer is LeaderLockHandle.Real && outer.matchesIdentity(identity)) {
-        return LockStateHolder.withPushed(outer.withReentryDepth(outer.reentryDepth + 1)) {
-            pjp.proceed()
+    when {
+        outer is LeaderLockHandle.Real && outer.matchesIdentity(identity) -> {
+            // 실 lock 보유 — passthrough copy
+            return LockStateHolder.withPushed(outer.withReentryDepth(outer.reentryDepth + 1)) {
+                pjp.proceed()
+            }
+        }
+        outer is LeaderLockHandle.FailOpen && outer.identity == identity -> {
+            // ⭐ Plan-R1-P1-1 — FailOpen sentinel scope 안 nested @LeaderElection 동일 identity → backend 미접촉.
+            //   sentinel 유지 (lock 보유 아님). nested body 안 LockAssert.assertLocked() 도 throw 일관.
+            return LockStateHolder.withPushed(outer) { pjp.proceed() }
         }
     }
 
@@ -3182,11 +3206,19 @@ private suspend fun aroundLeaderSuspendBody(pjp: ProceedingJoinPoint, meta: Advi
         throw BodyThrownMarker(e)
     }
 
-    val outer = currentCoroutineContext()[LockHandleElement]?.handle as? LeaderLockHandle.Real
-    if (outer != null && outer.matchesIdentity(identity)) {
-        val passthrough = outer.withReentryDepth(outer.reentryDepth + 1)
-        return withContext(LeaderElectionInfo(identity.lockName, true) + LockHandleElement(passthrough)) {
-            proceedProtected()
+    val outerElement = currentCoroutineContext()[LockHandleElement]?.handle
+    when {
+        outerElement is LeaderLockHandle.Real && outerElement.matchesIdentity(identity) -> {
+            val passthrough = outerElement.withReentryDepth(outerElement.reentryDepth + 1)
+            return withContext(LeaderElectionInfo(identity.lockName, true) + LockHandleElement(passthrough)) {
+                proceedProtected()
+            }
+        }
+        outerElement is LeaderLockHandle.FailOpen && outerElement.identity == identity -> {
+            // ⭐ Plan-R1-P1-1 — FailOpen sentinel scope 안 nested suspend @LeaderElection 동일 identity → backend 미접촉.
+            return withContext(LeaderElectionInfo(identity.lockName, false) + LockHandleElement(outerElement)) {
+                proceedProtected()
+            }
         }
     }
 
@@ -3523,12 +3555,14 @@ git commit -m "feat(leader-spring-boot): T16 validator rejects CompletableFuture
 
 ---
 
-## Task 17: Cross-cutting integration tests — 모든 시나리오 (8 backend × failure mode × Reentrant × Watchdog × Mono × ktor)
+## Task 17: Cross-cutting integration tests — aspect 통합 + watchdog race + ktor smoke + AC grep (각 backend contract test 는 backend module 안 — Plan-R1-P1-2)
 
 **Complexity:** high
-**Module:** `leader-spring-boot` + `leader-ktor`
+**Module:** `leader-spring-boot` (AOP integration) + `leader-ktor` (smoke) — backend contract test 는 각 backend module 안 (T7~T13)
 **Depends on:** T7–T16
-**Satisfies AC:** AC-1 전체, AC-4b matrix integration, AC-5 (sync/suspend/Mono 3 분기 × 2 API), AC-6 (watchdog race-free), AC-6b (watchdog override WARN), AC-9 (Mermaid 검증은 T18), AC-12 (coverage 80%+), AC-18 (CancellationException grep — 통합 점검), AC-22b (leader-ktor `leaderScheduled`)
+**Satisfies AC:** AC-1 (각 backend module 의 contract test — T7~T13 에서 검증), AC-4b matrix integration, AC-5 (sync/suspend/Mono 3 분기 × 2 API), AC-6 (watchdog race-free), AC-6b (watchdog override WARN/clock 진행 검증 — Plan-R1-P1-4), AC-9 (Mermaid 검증은 T18), AC-12 (coverage 80%+), AC-18 (CancellationException grep — 통합 점검), AC-22b (leader-ktor `leaderScheduled`), AC-23 (extendDelegate reference — 각 backend module 안)
+
+> ⚠️ **Test ownership (Plan-R1-P1-2 — Codex)**: backend contract test (Lettuce/Redisson/Mongo/JDBC/R2DBC/Hazelcast/ZK) 는 **각 backend module 안** 위치 — AC-23 의 `extendDelegate === watchdog.delegate` 가 `internal` 접근 필요. leader-spring-boot 는 backend module 의존성 없음 (특히 `leader-zookeeper` 미의존). T17 은 **aspect-level cross-cutting** (Local backend 만 spring-boot 안 통합) + ktor smoke + AC grep 검증에 한정.
 
 **Files:**
 - Create: `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/integration/LockExtenderCrossBackendIntegrationTest.kt`
@@ -3542,14 +3576,19 @@ git commit -m "feat(leader-spring-boot): T16 validator rejects CompletableFuture
 ```kotlin
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class LockExtenderCrossBackendIntegrationTest {
+class LockAssertAspectIntegrationTest {
+    // ⭐ Plan-R1-P1-2 — Local backend 만 spring-boot test classpath 에 포함.
+    //   각 backend (lettuce/redisson/mongodb/exposed-jdbc/exposed-r2dbc/hazelcast/zk) 의 contract test 는
+    //   해당 backend module 안 — T7~T13 의 `*LockExtenderContractTest` 가 담당.
 
-    @ParameterizedTest
-    @ValueSource(strings = ["lettuce", "redisson", "mongodb", "exposed-jdbc", "exposed-r2dbc", "hazelcast", "zookeeper", "local"])
-    fun `LockAssert assertLocked passes across all 8 backends`(backend: String) {
-        val bean = beanForBackend(backend)
-        bean.annotatedMethod()    // throw 없으면 통과
+    @Test
+    fun `LockAssert assertLocked passes in @LeaderElection annotated method (Local backend)`() {
+        annotatedBean.annotatedSyncMethod()
     }
+    @Test
+    fun `LockAssert assertLockedSuspend passes in @LeaderElection suspend method`() = runTest { ... }
+    @Test
+    fun `LockAssert assertLockedSuspend passes in @LeaderElection Mono method`() { ... }
 }
 ```
 
@@ -3588,6 +3627,27 @@ class WatchdogOverrideWarnTest {
         }
         logs.any { it.contains("lock_extender_overridden") || it.contains("watchdog will reduce") } shouldBeEqualTo true
         // metric `lock_extender_overridden_total` increment 검증
+    }
+
+    @Test
+    fun `AC-6b clock progression — watchdog next tick semantics with TestDispatcher`() = runTest {
+        // ⭐ Plan-R1-P1-4 — fake scheduler / TestDispatcher 로 시간 진행 검증.
+        //   `extendActiveLock(60s)` 직후 watchdog tick (leaseTime/3 = 10s 후) 가 실제 TTL 을 어떻게 처리?
+        val expireRecords = mutableListOf<Long>()  // backend extend 호출 시 expireAt 기록
+        val watchdog = LeaderLeaseAutoExtender.start(
+            enabled = true,
+            leaseTime = 30.seconds,
+            delegate = TestExtendDelegate(expireRecords),
+            scheduler = TestCoroutineScheduler(),  // virtual clock
+        )
+        // T+0: acquire → backend expireAt = now+30
+        elector.runIfLeader("clock-A") {
+            // T+1: user explicit extend(60s) → expireAt = now+60
+            LockExtender.extendActiveLock(60.seconds)
+            advanceTimeBy(10.seconds)   // T+11: watchdog tick — backend extend(30s) 호출 시 expireAt = now+30 (사용자 60s 의도와 충돌)
+        }
+        // 검증: AC-6b 정책은 "last-write-wins, 사용자에게 WARN" — 시간 진행 후 expireAt 이 user-extended 보다 작을 수 있음 확인 + WARN log 발생
+        expireRecords.last() shouldBeLessThan (initialTime + 60.seconds.inWholeMilliseconds)
     }
 }
 ```

--- a/docs/superpowers/plans/2026-05-10-lock-extender-plan.md
+++ b/docs/superpowers/plans/2026-05-10-lock-extender-plan.md
@@ -1,0 +1,4025 @@
+# LockExtender / LockAssert + Reentrant `@LeaderElection` + Explicit Lease Extension Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** ShedLock-등가 `LockAssert.assertLocked()` / `LockExtender.extendActiveLock(Duration)` 추가 + `@LeaderElection`/`@LeaderGroupElection` 의 reentrant 의미론 정의 + 8 backend 의 atomic explicit lease extension API 신설.
+
+**Architecture:** sealed `LeaderLockHandle { Real, FailOpen }` + `LockIdentity` 4-tuple (lockName, kind, factoryBean, groupParams) + ThreadLocal Deque(`LockStateHolder`) + `CoroutineContext.Element`(`LockHandleElement`) 로 sync/suspend/Mono 3 분기 propagation. Watchdog 와 LockExtender 는 단일 `ExtendDelegate` reference 공유 → race-free atomic backend extend. Aspect 가 full identity reentrant peek + fail-open sentinel push (contention + backend exception 양쪽) 을 수행.
+
+**Tech Stack:** Kotlin 2.3, Java 21, Spring Boot 4.x AOP (AspectJ CTW), Coroutines, Lettuce/Redisson/MongoDB/Exposed JDBC·R2DBC/Hazelcast/ZooKeeper/Local, JUnit 5 + MockK + bluetape4k-assertions + Testcontainers.
+
+**Spec:** [`docs/superpowers/specs/2026-05-10-lock-extender-design.md`](../specs/2026-05-10-lock-extender-design.md) — Round 8 architectural convergence (Codex P0/P1=0), 117 finding 통합.
+
+**Critical path:** T1 → T2 → T3 → T4 → T14 → T17 → T18 → T19. T5-T13 backend 별 병렬 가능 (T1-T3 완료 후).
+
+**Effort estimate (19 tasks):**
+- high (8): T7, T8, T12, T14, T15, T17 + critical paths
+- medium (8): T1, T4, T5, T6, T9, T10, T11, T16, T18
+- low (3): T2, T3, T13, T19
+
+---
+
+## File Structure Map
+
+### `leader-core` (신규 + 수정)
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLockHandle.kt` — sealed class Real/FailOpen
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/LockIdentity.kt` — 4-tuple identity
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/ExtendOutcome.kt` — sealed result
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/LockAssert.kt` — top-level object
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt` — top-level object
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LockStateHolder.kt` — ThreadLocal Deque
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderLockHandleCapture.kt` — elector → aspect ThreadLocal
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/internal/ExtendDelegate.kt` — SPI
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/internal/BackendErrorClassifier.kt` — SPI + Core + Composite
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LockHandleElement.kt` — CoroutineContext.Element
+- Modify: `leader-core/src/main/kotlin/io/bluetape4k/leader/SuspendLeaderElector.kt` — `runIfLeaderResultSuspend` default fun
+- Modify: `leader-core/src/main/kotlin/io/bluetape4k/leader/SuspendLeaderGroupElector.kt` — `runIfLeaderResultSuspend` default fun
+- Modify: `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt` — `start(delegate: ExtendDelegate)` 시그니처 변경
+- Modify: `leader-core/src/main/kotlin/io/bluetape4k/leader/local/*` — capture + extend 메서드 추가
+
+### Backend modules (각 8 backend 별 lock + elector)
+- `leader-redis-lettuce/.../lock/LettuceLock.kt`, `LettuceSuspendLock.kt`, `semaphore/LettuceSlotTokenGroup.kt`, `LettuceLeaderElector.kt`, `LettuceSuspendLeaderElector.kt`, `LettuceLeaderGroupElector.kt`, `LettuceSuspendLeaderGroupElector.kt`, `internal/LettuceBackendErrorClassifier.kt` (Create)
+- `leader-redis-redisson/.../RedissonLeaderElector.kt`, `RedissonSuspendLeaderElector.kt`, `RedissonLeaderGroupElector.kt`, `RedissonSuspendLeaderGroupElector.kt`, `internal/RedissonBackendErrorClassifier.kt` (Create)
+- `leader-mongodb/.../lock/MongoLock.kt`, `MongoSuspendLock.kt`, `MongoLeaderGroupElector.kt`, `MongoSuspendLeaderGroupElector.kt`, `internal/MongoBackendErrorClassifier.kt` (Create)
+- `leader-exposed-jdbc/.../lock/ExposedJdbcLock.kt`, `ExposedJdbcGroupLock.kt`, `internal/JdbcBackendErrorClassifier.kt` (Create)
+- `leader-exposed-r2dbc/.../lock/ExposedR2dbcLock.kt`, `ExposedR2dbcGroupLock.kt`, `internal/R2dbcBackendErrorClassifier.kt` (Create)
+- `leader-hazelcast/.../lock/HazelcastLock.kt`, `HazelcastSuspendLock.kt`, `ExtendEntryProcessor.kt` (Create), group variants, `internal/HazelcastBackendErrorClassifier.kt`
+- `leader-zookeeper/.../ZkLeaderElector.kt`, `ZkSuspendLeaderElector.kt` (passthrough extend), `internal/ZkBackendErrorClassifier.kt`
+
+### `leader-spring-boot` (aspect + validator)
+- Modify: `leader-spring-boot/.../aop/LeaderElectionAspect.kt` — 3 분기 + reentrant peek + sentinel + capture
+- Modify: `leader-spring-boot/.../aop/LeaderGroupElectionAspect.kt` — group 분기 동일
+- Modify: `leader-spring-boot/.../aop/validator/LeaderAnnotationValidatorBeanPostProcessor.kt` — CompletableFuture/Future/ListenableFuture 차단
+- Create: `leader-spring-boot/.../aop/internal/AdviceMetadata.kt` + `AdviceBranch.kt` + `BodyThrownMarker.kt` + `CaptureInvariantException.kt`
+
+### Docs
+- Modify: `leader-spring-boot/README.md` + `README.ko.md`
+- Modify: `CHANGELOG.md`, `WIP.md`
+- Modify: `CLAUDE.md` (3 군데 — workspace root, project root, worktree)
+- Modify: `examples/ktor-app/README.md` + source — `LockAssertSuspend` 사용 예
+- Modify: 각 8 backend README "extend supported" 한 줄
+
+---
+
+## Task 1: Core types — `LeaderLockHandle`, `LockIdentity`, `ExtendOutcome`, internal mechanisms
+
+**Complexity:** medium
+**Module:** `leader-core`
+**Depends on:** —
+**Satisfies AC:** AC-10 (KDoc), part of AC-2/2b (identity), AC-11 (detekt)
+
+**Files:**
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/LockIdentity.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/ExtendOutcome.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLockHandle.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/internal/ExtendDelegate.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LockStateHolder.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderLockHandleCapture.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/LockIdentityTest.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/ExtendOutcomeTest.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLockHandleTest.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LockStateHolderTest.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LeaderLockHandleCaptureTest.kt`
+
+- [ ] **Step 1: Write failing test — `LockIdentity` invariant**
+
+```kotlin
+// leader-core/src/test/kotlin/io/bluetape4k/leader/LockIdentityTest.kt
+package io.bluetape4k.leader
+
+import io.bluetape4k.assertions.assertFailsWith
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LockIdentityTest {
+    @Test
+    fun `single kind without groupParams is allowed`() {
+        val id = LockIdentity("job-A", LockIdentity.AnnotationKind.SINGLE, "lettuceFactory")
+        id.lockName shouldBeEqualTo "job-A"
+        id.groupParams shouldBeEqualTo null
+    }
+
+    @Test
+    fun `group kind requires groupParams`() {
+        assertFailsWith<IllegalArgumentException> {
+            LockIdentity("job-A", LockIdentity.AnnotationKind.GROUP, "lettuceGroupFactory", groupParams = null)
+        }
+    }
+
+    @Test
+    fun `single kind forbids groupParams`() {
+        assertFailsWith<IllegalArgumentException> {
+            LockIdentity(
+                "job-A",
+                LockIdentity.AnnotationKind.SINGLE,
+                "lettuceFactory",
+                groupParams = LockIdentity.GroupParams(maxLeaders = 3),
+            )
+        }
+    }
+
+    @Test
+    fun `equality compares all four tuple components`() {
+        val a = LockIdentity("X", LockIdentity.AnnotationKind.SINGLE, "f1")
+        val b = LockIdentity("X", LockIdentity.AnnotationKind.SINGLE, "f1")
+        val c = LockIdentity("X", LockIdentity.AnnotationKind.SINGLE, "f2")
+        (a == b) shouldBeEqualTo true
+        (a == c) shouldBeEqualTo false
+    }
+}
+```
+
+- [ ] **Step 2: Run test, expect FAIL (compile error — `LockIdentity` 미존재)**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.LockIdentityTest" --no-daemon
+# Expected: FAIL — Unresolved reference: LockIdentity
+```
+
+- [ ] **Step 3: Implement `LockIdentity`**
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/LockIdentity.kt
+package io.bluetape4k.leader
+
+/**
+ * Reentrant dedupe 비교 단위. lockName 만으로는 Single ↔ Group 구분 불가 → full identity 필수.
+ *
+ * ## 동작/계약
+ * - `kind == GROUP` ↔ `groupParams != null` invariant (init require)
+ * - `factoryBeanName` 은 branch 별 elector factory 의 Spring bean name. sync/suspend/group/suspend-group 가 모두 다른 bean.
+ *
+ * ## Example
+ * ```kotlin
+ * val syncId = LockIdentity("report-job", LockIdentity.AnnotationKind.SINGLE, "lettuceLeaderElectorFactory")
+ * val groupId = LockIdentity("group-job", LockIdentity.AnnotationKind.GROUP, "lettuceGroupFactory",
+ *     LockIdentity.GroupParams(maxLeaders = 3))
+ * ```
+ */
+data class LockIdentity(
+    val lockName: String,
+    val kind: AnnotationKind,
+    val factoryBeanName: String,
+    val groupParams: GroupParams? = null,
+) {
+    init {
+        require((kind == AnnotationKind.GROUP) == (groupParams != null)) {
+            "GROUP kind requires groupParams; SINGLE kind forbids it (kind=$kind, groupParams=$groupParams)"
+        }
+    }
+
+    enum class AnnotationKind { SINGLE, GROUP }
+
+    /** Currently `maxLeaders` only — 신규 필드 추가 시 default value 필수 (binary-compat). */
+    data class GroupParams(val maxLeaders: Int)
+}
+```
+
+- [ ] **Step 4: Run test, expect PASS**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.LockIdentityTest" --no-daemon
+# Expected: PASS (4/4)
+```
+
+- [ ] **Step 5: Write failing test — `ExtendOutcome` sealed result**
+
+```kotlin
+// leader-core/src/test/kotlin/io/bluetape4k/leader/ExtendOutcomeTest.kt
+package io.bluetape4k.leader
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExtendOutcomeTest {
+    @Test
+    fun `Extended carries observedExpireAt`() {
+        val now = Instant.now()
+        val out: ExtendOutcome = ExtendOutcome.Extended(now)
+        out shouldBeInstanceOf ExtendOutcome.Extended::class
+        (out as ExtendOutcome.Extended).observedExpireAt shouldBeEqualTo now
+        out.isExtended shouldBeEqualTo true
+    }
+
+    @Test
+    fun `NotHeld is data object singleton`() {
+        val a: ExtendOutcome = ExtendOutcome.NotHeld
+        val b: ExtendOutcome = ExtendOutcome.NotHeld
+        (a === b) shouldBeEqualTo true
+        a.isExtended shouldBeEqualTo false
+    }
+
+    @Test
+    fun `WrongThread is data object singleton`() {
+        val a: ExtendOutcome = ExtendOutcome.WrongThread
+        a.isExtended shouldBeEqualTo false
+    }
+
+    @Test
+    fun `BackendError wraps Exception cause`() {
+        val cause = java.io.IOException("transient")
+        val out: ExtendOutcome = ExtendOutcome.BackendError(cause)
+        (out as ExtendOutcome.BackendError).cause shouldBeEqualTo cause
+        out.isExtended shouldBeEqualTo false
+    }
+}
+```
+
+- [ ] **Step 6: Implement `ExtendOutcome`**
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/ExtendOutcome.kt
+package io.bluetape4k.leader
+
+import java.time.Instant
+
+/**
+ * `LeaderLockHandle.Real.extend` 의 상세 결과. Boolean 시그니처는 `isExtended` 로 단순 변환.
+ *
+ * ## Variants
+ * - [Extended] — atomic backend extend 성공. `observedExpireAt` 는 best-effort (backend별 정확도 §5.3 spec).
+ * - [NotHeld] — token mismatch / lease expired / takeover.
+ * - [WrongThread] — Redisson thread-bound (acquire thread ≠ extend thread).
+ * - [BackendError] — transient (false 변환) / non-transient (caller 가 throw 결정). FATAL Error 는 propagate (catch 안 함).
+ */
+sealed interface ExtendOutcome {
+    data class Extended(val observedExpireAt: Instant) : ExtendOutcome
+    data object NotHeld : ExtendOutcome
+    data object WrongThread : ExtendOutcome
+    data class BackendError(val cause: Exception) : ExtendOutcome
+
+    val isExtended: Boolean get() = this is Extended
+}
+```
+
+- [ ] **Step 7: Run test, expect PASS**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.ExtendOutcomeTest" --no-daemon
+# Expected: PASS (4/4)
+```
+
+- [ ] **Step 8: Write failing test — `ExtendDelegate` SPI default behavior**
+
+```kotlin
+// leader-core/src/test/kotlin/io/bluetape4k/leader/internal/ExtendDelegateTest.kt
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExtendDelegateTest {
+    @Test
+    fun `extendSuspend default calls sync extend`() = runTest {
+        var syncCalls = 0
+        val delegate = object : ExtendDelegate {
+            override fun extend(lockAtMostFor: kotlin.time.Duration): ExtendOutcome {
+                syncCalls++
+                return ExtendOutcome.Extended(Instant.now())
+            }
+            override fun isHeld(): Boolean = true
+        }
+        delegate.extendSuspend(10.seconds).isExtended shouldBeEqualTo true
+        syncCalls shouldBeEqualTo 1
+    }
+}
+```
+
+- [ ] **Step 9: Implement `ExtendDelegate`**
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/internal/ExtendDelegate.kt
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import kotlin.time.Duration
+
+/**
+ * Backend lock 의 atomic extend 단일 reference. `LeaderLockHandle.Real` 와 `LeaderLeaseAutoExtender`
+ * 가 동일 instance 를 참조 — race-free + last-write-wins.
+ *
+ * ## 동작/계약
+ * - `extendSuspend` default 구현 = sync `extend` 직접 호출 → **local / non-blocking backend 전용**.
+ * - Blocking backend (Lettuce sync, Hazelcast, Exposed JDBC, Redisson) 는 반드시 override 하여
+ *   `withContext(Dispatchers.IO)` + `coroutineContext.ensureActive()` 사용 (AC-21 grep verify).
+ * - `CancellationException` 은 항상 re-throw (`catch(Exception)` 앞에 위치).
+ */
+internal interface ExtendDelegate {
+    fun extend(lockAtMostFor: Duration): ExtendOutcome
+    suspend fun extendSuspend(lockAtMostFor: Duration): ExtendOutcome = extend(lockAtMostFor)
+    fun isHeld(): Boolean
+}
+```
+
+- [ ] **Step 10: Run test, expect PASS**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.internal.ExtendDelegateTest" --no-daemon
+# Expected: PASS (1/1)
+```
+
+- [ ] **Step 11: Write failing test — `LeaderLockHandle` Real/FailOpen**
+
+```kotlin
+// leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLockHandleTest.kt
+package io.bluetape4k.leader
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.leader.internal.ExtendDelegate
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import kotlin.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderLockHandleTest {
+    private val noopDelegate = object : ExtendDelegate {
+        override fun extend(lockAtMostFor: Duration): ExtendOutcome = ExtendOutcome.Extended(Instant.now())
+        override fun isHeld(): Boolean = true
+    }
+    private val id = LockIdentity("job-A", LockIdentity.AnnotationKind.SINGLE, "factoryA")
+
+    @Test
+    fun `Real exposes identity and lockName accessor`() {
+        val real = LeaderLockHandle.real(id, "tok", 0L, noopDelegate)
+        real shouldBeInstanceOf LeaderLockHandle.Real::class
+        real.lockName shouldBeEqualTo "job-A"
+        real.isReentrant shouldBeEqualTo false
+    }
+
+    @Test
+    fun `FailOpen sentinel preserves identity`() {
+        val fo = LeaderLockHandle.failOpen(id)
+        fo shouldBeInstanceOf LeaderLockHandle.FailOpen::class
+        fo.lockName shouldBeEqualTo "job-A"
+        fo.reentryDepth shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `matchesIdentity compares all 4 components`() {
+        val real = LeaderLockHandle.real(id, "tok", 0L, noopDelegate)
+        real.matchesIdentity(id) shouldBeEqualTo true
+        real.matchesIdentity(id.copy(factoryBeanName = "other")) shouldBeEqualTo false
+    }
+
+    @Test
+    fun `withReentryDepth produces copy with passthrough delegate`() {
+        val real = LeaderLockHandle.real(id, "tok", 0L, noopDelegate)
+        val inner = real.withReentryDepth(1)
+        inner.isReentrant shouldBeEqualTo true
+        inner.reentryDepth shouldBeEqualTo 1
+        // ⭐ delegate reference 동일 — passthrough extend = outer lease 갱신
+        (inner.extendDelegate === real.extendDelegate) shouldBeEqualTo true
+    }
+
+    @Test
+    fun `withReentryDepth rejects negative`() {
+        val real = LeaderLockHandle.real(id, "tok", 0L, noopDelegate)
+        assertFailsWith<IllegalArgumentException> { real.withReentryDepth(-1) }
+    }
+
+    @Test
+    fun `equals uses identity token reentryDepth slotId — excludes delegate and threadId`() {
+        val a = LeaderLockHandle.real(id, "tok", 0L, noopDelegate)
+        val b = LeaderLockHandle.real(id, "tok", 999L, noopDelegate)  // acquiredAtNanos / threadId 다름
+        a shouldBeEqualTo b
+    }
+}
+```
+
+- [ ] **Step 12: Implement `LeaderLockHandle`**
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLockHandle.kt
+package io.bluetape4k.leader
+
+import io.bluetape4k.leader.internal.ExtendDelegate
+import kotlin.time.Duration
+
+/**
+ * 활성 lock 의 handle. AOP aspect 가 push 하고 [LockAssert] / [LockExtender] 가 read.
+ *
+ * ## Variants
+ * - [Real] — 실제 backend lock 보유. `extend` / `extendSuspend` 호출 가능
+ * - [FailOpen] — fail-open sentinel. extend 항상 `NotHeld` 반환
+ *
+ * `internal constructor` — 외부 source API 차단 (소스 API only — reflection boundary 아님).
+ *
+ * ## Example
+ * ```kotlin
+ * val handle = LeaderLockHandle.real(identity, token = "abc", acquiredAtNanos = System.nanoTime(),
+ *     extendDelegate = myDelegate)
+ * if (handle is LeaderLockHandle.Real) handle.extend(60.seconds)
+ * ```
+ */
+sealed class LeaderLockHandle {
+    abstract val identity: LockIdentity
+    val lockName: String get() = identity.lockName
+    abstract val reentryDepth: Int
+    val isReentrant: Boolean get() = reentryDepth > 0
+    fun matchesIdentity(other: LockIdentity): Boolean = identity == other
+
+    class Real internal constructor(
+        override val identity: LockIdentity,
+        val token: String,
+        val acquiredAtNanos: Long,
+        val slotId: String? = null,
+        val acquiringThreadId: Long? = null,
+        override val reentryDepth: Int = 0,
+        internal val extendDelegate: ExtendDelegate,
+    ) : LeaderLockHandle() {
+        fun extend(d: Duration): ExtendOutcome = extendDelegate.extend(d)
+        suspend fun extendSuspend(d: Duration): ExtendOutcome = extendDelegate.extendSuspend(d)
+        fun isStillHeld(): Boolean = extendDelegate.isHeld()
+
+        /**
+         * Reentrant passthrough copy. **inner extend → outer 의 `extendDelegate` 호출 → outer/backend lease 갱신.**
+         */
+        internal fun withReentryDepth(n: Int): Real {
+            require(n >= 0) { "reentryDepth must be >= 0 (was $n)" }
+            return Real(identity, token, acquiredAtNanos, slotId, acquiringThreadId, n, extendDelegate)
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Real) return false
+            return identity == other.identity &&
+                token == other.token &&
+                reentryDepth == other.reentryDepth &&
+                slotId == other.slotId
+        }
+
+        override fun hashCode(): Int {
+            var r = identity.hashCode()
+            r = 31 * r + token.hashCode()
+            r = 31 * r + reentryDepth
+            r = 31 * r + (slotId?.hashCode() ?: 0)
+            return r
+        }
+
+        override fun toString(): String =
+            "LeaderLockHandle.Real(identity=$identity, token='$token', reentryDepth=$reentryDepth, slotId=$slotId)"
+    }
+
+    class FailOpen internal constructor(
+        override val identity: LockIdentity,
+    ) : LeaderLockHandle() {
+        override val reentryDepth: Int = 0
+        override fun toString(): String = "LeaderLockHandle.FailOpen(identity=$identity)"
+    }
+
+    companion object {
+        internal fun real(
+            identity: LockIdentity,
+            token: String,
+            acquiredAtNanos: Long,
+            extendDelegate: ExtendDelegate,
+            slotId: String? = null,
+            acquiringThreadId: Long? = null,
+        ): Real = Real(identity, token, acquiredAtNanos, slotId, acquiringThreadId, 0, extendDelegate)
+
+        internal fun failOpen(identity: LockIdentity): FailOpen = FailOpen(identity)
+    }
+}
+```
+
+- [ ] **Step 13: Run handle test, expect PASS**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.LeaderLockHandleTest" --no-daemon
+# Expected: PASS (6/6)
+```
+
+- [ ] **Step 14: Write failing test — `LockStateHolder` ThreadLocal Deque**
+
+```kotlin
+// leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LockStateHolderTest.kt
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LockIdentity
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.shouldBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import kotlin.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LockStateHolderTest {
+    private val delegate = object : ExtendDelegate {
+        override fun extend(lockAtMostFor: Duration): ExtendOutcome = ExtendOutcome.Extended(Instant.now())
+        override fun isHeld(): Boolean = true
+    }
+    private val idA = LockIdentity("A", LockIdentity.AnnotationKind.SINGLE, "fA")
+    private val idB = LockIdentity("B", LockIdentity.AnnotationKind.SINGLE, "fB")
+
+    @Test
+    fun `push then peek returns top`() {
+        val h = LeaderLockHandle.real(idA, "tok", 0L, delegate)
+        LockStateHolder.push(h)
+        LockStateHolder.peekSync().shouldNotBeNull()
+        LockStateHolder.pop()
+        LockStateHolder.cleanup()
+        LockStateHolder.peekSync().shouldBeNull()
+    }
+
+    @Test
+    fun `peekSyncMatching finds by lockName`() {
+        val a = LeaderLockHandle.real(idA, "tA", 0L, delegate)
+        val b = LeaderLockHandle.real(idB, "tB", 0L, delegate)
+        LockStateHolder.push(a)
+        LockStateHolder.push(b)
+        LockStateHolder.peekSyncMatching("A").shouldNotBeNull()
+        LockStateHolder.peekSyncMatching("Z").shouldBeNull()
+        LockStateHolder.pop(); LockStateHolder.pop(); LockStateHolder.cleanup()
+    }
+
+    @Test
+    fun `withPushed cleans up on exception`() {
+        val h = LeaderLockHandle.real(idA, "t", 0L, delegate)
+        runCatching {
+            LockStateHolder.withPushed(h) { throw RuntimeException("body") }
+        }
+        LockStateHolder.peekSync().shouldBeNull()
+    }
+}
+```
+
+- [ ] **Step 15: Implement `LockStateHolder`**
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LockStateHolder.kt
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.leader.LeaderLockHandle
+
+/**
+ * 활성 lock handle 의 ThreadLocal Deque. Aspect sync 분기가 push/pop 한다.
+ *
+ * ## 동작/계약
+ * - suspend / Mono 분기는 [io.bluetape4k.leader.coroutines.LockHandleElement] 사용 — ThreadLocal 누수 차단.
+ * - [withPushed] 사용 시 finally 정리 자동 보장.
+ */
+internal object LockStateHolder {
+    private val tl: ThreadLocal<ArrayDeque<LeaderLockHandle>> = ThreadLocal.withInitial { ArrayDeque() }
+
+    fun push(handle: LeaderLockHandle) { tl.get().addFirst(handle) }
+    fun pop(): LeaderLockHandle? = tl.get().removeFirstOrNull()
+    fun peekSync(): LeaderLockHandle? = tl.get().firstOrNull()
+    fun peekSyncMatching(lockName: String): LeaderLockHandle? =
+        tl.get().firstOrNull { it.lockName == lockName }
+    fun cleanup() { if (tl.get().isEmpty()) tl.remove() }
+
+    inline fun <R> withPushed(handle: LeaderLockHandle, block: () -> R): R {
+        push(handle)
+        try {
+            return block()
+        } finally {
+            pop()
+            cleanup()
+        }
+    }
+}
+```
+
+- [ ] **Step 16: Run state holder test, expect PASS**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.internal.LockStateHolderTest" --no-daemon
+# Expected: PASS (3/3)
+```
+
+- [ ] **Step 17: Write failing test — `LeaderLockHandleCapture`**
+
+```kotlin
+// leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LeaderLockHandleCaptureTest.kt
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LockIdentity
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import kotlin.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderLockHandleCaptureTest {
+    private val delegate = object : ExtendDelegate {
+        override fun extend(lockAtMostFor: Duration): ExtendOutcome = ExtendOutcome.Extended(Instant.now())
+        override fun isHeld(): Boolean = true
+    }
+    private val id = LockIdentity("A", LockIdentity.AnnotationKind.SINGLE, "fA")
+
+    @AfterEach fun cleanup() { LeaderLockHandleCapture.clear() }
+
+    @Test
+    fun `set then poll returns same handle and clears`() {
+        val h = LeaderLockHandle.real(id, "tok", 0L, delegate)
+        LeaderLockHandleCapture.set(h)
+        val polled = LeaderLockHandleCapture.poll()
+        polled.shouldNotBeNull()
+        (polled === h) shouldBeEqualTo true
+        // 2nd poll = null
+        LeaderLockHandleCapture.poll().shouldBeNull()
+    }
+
+    @Test
+    fun `poll when never set returns null`() {
+        LeaderLockHandleCapture.poll().shouldBeNull()
+    }
+}
+```
+
+- [ ] **Step 18: Implement `LeaderLockHandleCapture`**
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderLockHandleCapture.kt
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.leader.LeaderLockHandle
+
+/**
+ * Elector → Aspect 간 handle 전달용 ThreadLocal.
+ *
+ * ## 엄격한 invariant (spec R10 / SF3 / Codex F10)
+ * - elector 가 acquire 후 action 호출 **직전 동일 thread** 에서 [set] 호출.
+ * - aspect 가 action lambda **첫 statement** 로 [poll] 호출.
+ * - poll 결과 null → `CaptureInvariantException` throw (silent fail-open 금지).
+ * - virtual thread / dispatcher hop 사이에 set/poll 분리 금지.
+ */
+internal object LeaderLockHandleCapture {
+    private val tl: ThreadLocal<LeaderLockHandle.Real?> = ThreadLocal()
+    fun set(handle: LeaderLockHandle.Real) { tl.set(handle) }
+    fun poll(): LeaderLockHandle.Real? {
+        val v = tl.get()
+        tl.remove()
+        return v
+    }
+    fun clear() { tl.remove() }
+}
+```
+
+- [ ] **Step 19: Run capture test, expect PASS**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.internal.LeaderLockHandleCaptureTest" --no-daemon
+# Expected: PASS (2/2)
+```
+
+- [ ] **Step 20: Run all T1 tests + detekt**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.LockIdentityTest" \
+                            --tests "io.bluetape4k.leader.ExtendOutcomeTest" \
+                            --tests "io.bluetape4k.leader.LeaderLockHandleTest" \
+                            --tests "io.bluetape4k.leader.internal.*" --no-daemon
+./gradlew :leader-core:detekt --no-daemon
+# Expected: PASS all, detekt zero new HIGH/CRITICAL
+```
+
+- [ ] **Step 21: Commit**
+
+```bash
+git add leader-core/src/main/kotlin/io/bluetape4k/leader/LockIdentity.kt \
+        leader-core/src/main/kotlin/io/bluetape4k/leader/ExtendOutcome.kt \
+        leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLockHandle.kt \
+        leader-core/src/main/kotlin/io/bluetape4k/leader/internal/ \
+        leader-core/src/test/kotlin/io/bluetape4k/leader/LockIdentityTest.kt \
+        leader-core/src/test/kotlin/io/bluetape4k/leader/ExtendOutcomeTest.kt \
+        leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLockHandleTest.kt \
+        leader-core/src/test/kotlin/io/bluetape4k/leader/internal/
+git commit -m "feat(leader-core): T1 core types (LockIdentity, ExtendOutcome, LeaderLockHandle, internal)"
+```
+
+---
+
+## Task 2: `LockHandleElement` (CoroutineContext.Element)
+
+**Complexity:** low
+**Module:** `leader-core`
+**Depends on:** T1
+**Satisfies AC:** AC-5 (suspend/Mono propagation), AC-10 (KDoc), part of binary-compat (R8 / Type T8)
+
+**Files:**
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LockHandleElement.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LockHandleElementTest.kt`
+
+- [ ] **Step 1: Write failing test**
+
+```kotlin
+// leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LockHandleElementTest.kt
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.internal.ExtendDelegate
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LockHandleElementTest {
+    private val delegate = object : ExtendDelegate {
+        override fun extend(lockAtMostFor: Duration): ExtendOutcome = ExtendOutcome.Extended(Instant.now())
+        override fun isHeld(): Boolean = true
+    }
+    private val id = LockIdentity("A", LockIdentity.AnnotationKind.SINGLE, "fA")
+
+    @Test
+    fun `element propagates through withContext`() = runTest {
+        val h = LeaderLockHandle.real(id, "tok", 0L, delegate)
+        withContext(LockHandleElement(h)) {
+            val read = coroutineContext[LockHandleElement]
+            read shouldBeEqualTo LockHandleElement(h)
+        }
+    }
+
+    @Test
+    fun `element absent outside scope returns null`() = runTest {
+        coroutineContext[LockHandleElement] shouldBeEqualTo null
+    }
+}
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.coroutines.LockHandleElementTest" --no-daemon
+# Expected: FAIL — Unresolved reference: LockHandleElement
+```
+
+- [ ] **Step 3: Implement `LockHandleElement`**
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LockHandleElement.kt
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.leader.LeaderLockHandle
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * suspend / Mono 컨텍스트의 active lock handle. `LeaderElectionInfo` 와 **별도** element —
+ * binary-compat 보존 (`LeaderElectionInfo` data class 무변경).
+ *
+ * ## 동작/계약
+ * - `handle` property 는 `internal` — 외부 caller 는 `LockAssert.assertLockedSuspend()` /
+ *   `LockExtender.extendActiveLockSuspend(d)` 만 사용 (R3-F12).
+ * - Mono 분기는 `mono { withContext(... + LockHandleElement(h)) { ... } }` 안에서만 보장
+ *   (임의 Reactor operator 미보장 — Codex F14).
+ */
+data class LockHandleElement internal constructor(internal val handle: LeaderLockHandle) : CoroutineContext.Element {
+    companion object Key : CoroutineContext.Key<LockHandleElement>
+    override val key: CoroutineContext.Key<*> get() = Key
+}
+```
+
+- [ ] **Step 4: Run test, expect PASS**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.coroutines.LockHandleElementTest" --no-daemon
+# Expected: PASS (2/2)
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LockHandleElement.kt \
+        leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LockHandleElementTest.kt
+git commit -m "feat(leader-core): T2 LockHandleElement coroutine context propagation"
+```
+
+---
+
+## Task 3: `runIfLeaderResultSuspend` default fun on suspend electors
+
+**Complexity:** low
+**Module:** `leader-core`
+**Depends on:** T1
+**Satisfies AC:** AC-25 (binary-compat default fun), part of AC-4b (Skipped detection)
+
+**Files:**
+- Modify: `leader-core/src/main/kotlin/io/bluetape4k/leader/SuspendLeaderElector.kt`
+- Modify: `leader-core/src/main/kotlin/io/bluetape4k/leader/SuspendLeaderGroupElector.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/SuspendLeaderElectorDefaultFunTest.kt`
+
+- [ ] **Step 1: Write failing test — default fun on stub implementation**
+
+```kotlin
+// leader-core/src/test/kotlin/io/bluetape4k/leader/SuspendLeaderElectorDefaultFunTest.kt
+package io.bluetape4k.leader
+
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SuspendLeaderElectorDefaultFunTest {
+    private fun electedStub(): SuspendLeaderElector = object : SuspendLeaderElector {
+        // 최소 구현 — action 호출 후 결과 반환 (선출 성공 모킹)
+        override suspend fun <T : Any> runIfLeader(lockName: String, action: suspend () -> T?): T? = action()
+        // ... 기타 필수 멤버는 기존 인터페이스 default 또는 throw NotImplementedError() — 본 테스트에서 호출 안 함
+    }
+    private fun skippedStub(): SuspendLeaderElector = object : SuspendLeaderElector {
+        override suspend fun <T : Any> runIfLeader(lockName: String, action: suspend () -> T?): T? = null
+    }
+
+    @Test
+    fun `elected even if action returns null`() = runTest {
+        val r = electedStub().runIfLeaderResultSuspend("L") { null as String? }
+        r shouldBeInstanceOf LeaderRunResult.Elected::class
+        (r as LeaderRunResult.Elected<*>).value shouldBeEqualTo null
+    }
+
+    @Test
+    fun `skipped when contention`() = runTest {
+        val r = skippedStub().runIfLeaderResultSuspend("L") { "x" }
+        r shouldBeInstanceOf LeaderRunResult.Skipped::class
+    }
+}
+```
+
+> ⚠️ `SuspendLeaderElector` 의 실제 패키지 / 멤버 시그니처가 다를 경우 (예: `io.bluetape4k.leader.coroutines.SuspendLeaderElector`) test stub 의 멤버는 동일 인터페이스 시그니처 맞춰 조정. 본 step 의 핵심은 `runIfLeaderResultSuspend` 가 default fun 으로 caller-side 가능하다는 검증.
+
+- [ ] **Step 2: Run test, expect FAIL (compile error)**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.SuspendLeaderElectorDefaultFunTest" --no-daemon
+# Expected: FAIL — Unresolved reference: runIfLeaderResultSuspend
+```
+
+- [ ] **Step 3: Add default fun to `SuspendLeaderElector`**
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderElector.kt
+// (기존 interface 안에 default fun 추가 — 다른 멤버 변경 없음)
+
+/**
+ * Elected/Skipped 분류 가능한 suspend variant. `elected` flag 패턴 사용 — action 정상 실행 후 null 반환해도 Elected.
+ *
+ * ## 동작/계약
+ * - 기존 `runIfLeader` 호출 → flag 로 elected 여부 판정 → `LeaderRunResult` 반환.
+ * - `CancellationException` 은 `runIfLeader` 내부에서 명시적으로 propagate (구현체 의무).
+ */
+suspend fun <T> runIfLeaderResultSuspend(
+    lockName: String,
+    action: suspend () -> T,
+): LeaderRunResult<T> {
+    var elected = false
+    @Suppress("UNCHECKED_CAST")
+    val value = runIfLeader(lockName) {
+        elected = true
+        action() as Any?
+    } as T?
+    return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
+}
+```
+
+> ⚠️ 실제 추가 위치 / generic 시그니처는 기존 `runIfLeader` 시그니처 (`suspend fun <T : Any> runIfLeader(lockName: String, action: suspend () -> T?): T?` 등) 에 맞춰 조정. 캐스트 패턴은 기존 sync `LeaderElector.runIfLeaderResult` (`LeaderElector.kt:62`) 와 동일 패턴 적용.
+
+- [ ] **Step 4: Add default fun to `SuspendLeaderGroupElector` (동일 패턴)**
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/SuspendLeaderGroupElector.kt
+suspend fun <T> runIfLeaderResultSuspend(
+    lockName: String,
+    action: suspend () -> T,
+): LeaderRunResult<T> {
+    var elected = false
+    @Suppress("UNCHECKED_CAST")
+    val value = runIfLeader(lockName) {
+        elected = true
+        action() as Any?
+    } as T?
+    return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
+}
+```
+
+- [ ] **Step 5: Run test, expect PASS**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.SuspendLeaderElectorDefaultFunTest" --no-daemon
+# Expected: PASS (2/2)
+```
+
+- [ ] **Step 6: Verify binary-compat bytecode (AC-25)**
+
+```bash
+./gradlew :leader-core:compileKotlin --no-daemon
+javap -p leader-core/build/classes/kotlin/main/io/bluetape4k/leader/coroutines/SuspendLeaderElector.class \
+  | grep "runIfLeaderResultSuspend"
+# Expected: public default Object runIfLeaderResultSuspend(...) — JVM default method
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderElector.kt \
+        leader-core/src/main/kotlin/io/bluetape4k/leader/SuspendLeaderGroupElector.kt \
+        leader-core/src/test/kotlin/io/bluetape4k/leader/SuspendLeaderElectorDefaultFunTest.kt
+git commit -m "feat(leader-core): T3 runIfLeaderResultSuspend default fun (binary-compat)"
+```
+
+---
+
+## Task 4: `LockAssert` + `LockExtender` top-level objects
+
+**Complexity:** medium
+**Module:** `leader-core`
+**Depends on:** T1, T2
+**Satisfies AC:** AC-3 (assertLocked outside body), AC-4 (extend in fail-open), AC-10 (KDoc), AC-19 (Java Duration overload), partial AC-5 (sync/suspend API surface)
+
+**Files:**
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/LockAssert.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/LockAssertTest.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/LockExtenderTest.kt`
+- Test: `leader-core/src/test/java/io/bluetape4k/leader/LockExtenderJavaCompatTest.java`
+
+- [ ] **Step 1: Write failing test — `LockAssert` (sync)**
+
+```kotlin
+// leader-core/src/test/kotlin/io/bluetape4k/leader/LockAssertTest.kt
+package io.bluetape4k.leader
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.leader.coroutines.LockHandleElement
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.leader.internal.LockStateHolder
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import kotlin.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LockAssertTest {
+    private val delegate = object : ExtendDelegate {
+        override fun extend(lockAtMostFor: Duration) = ExtendOutcome.Extended(Instant.now())
+        override fun isHeld(): Boolean = true
+    }
+    private val id = LockIdentity("A", LockIdentity.AnnotationKind.SINGLE, "fA")
+
+    @Test
+    fun `assertLocked passes inside Real scope`() {
+        val h = LeaderLockHandle.real(id, "tok", 0L, delegate)
+        LockStateHolder.withPushed(h) {
+            LockAssert.assertLocked()    // does not throw
+            LockAssert.isLocked() shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `assertLocked throws outside any scope`() {
+        val ex = assertFailsWith<IllegalStateException> { LockAssert.assertLocked() }
+        ex.message!!.contains("no active scope") || ex.message!!.contains("outside")
+    }
+
+    @Test
+    fun `assertLocked throws inside FailOpen sentinel scope`() {
+        val fo = LeaderLockHandle.failOpen(id)
+        LockStateHolder.withPushed(fo) {
+            assertFailsWith<IllegalStateException> { LockAssert.assertLocked() }
+            LockAssert.isLocked() shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `assertLocked(lockName) mismatched name throws`() {
+        val h = LeaderLockHandle.real(id, "tok", 0L, delegate)
+        LockStateHolder.withPushed(h) {
+            assertFailsWith<IllegalStateException> { LockAssert.assertLocked("OTHER") }
+        }
+    }
+
+    @Test
+    fun `assertLockedSuspend reads coroutineContext only — ignores ThreadLocal`() = runTest {
+        val h = LeaderLockHandle.real(id, "tok", 0L, delegate)
+        // sync ThreadLocal push (suspend 가 fallback 하면 안 됨)
+        LockStateHolder.withPushed(h) {
+            // suspend assert in coroutine — no LockHandleElement → must throw (R7)
+            kotlinx.coroutines.runBlocking {
+                assertFailsWith<IllegalStateException> { LockAssert.assertLockedSuspend() }
+            }
+        }
+        // 정상 propagation
+        withContext(LockHandleElement(h)) {
+            LockAssert.assertLockedSuspend()   // does not throw
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.LockAssertTest" --no-daemon
+# Expected: FAIL — Unresolved reference: LockAssert
+```
+
+- [ ] **Step 3: Implement `LockAssert`**
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/LockAssert.kt
+package io.bluetape4k.leader
+
+import io.bluetape4k.leader.coroutines.LockHandleElement
+import io.bluetape4k.leader.internal.LockStateHolder
+import io.bluetape4k.logging.KLogging
+import kotlin.coroutines.coroutineContext
+
+/**
+ * 현재 컨텍스트가 활성 `@LeaderElection` / `@LeaderGroupElection` 본문 안에서 실행 중인지 단언합니다.
+ *
+ * ShedLock 의 `LockAssert.assertLocked()` 와 동일한 사용감을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 활성 lock state 없음 → [IllegalStateException]
+ * - fail-open sentinel scope → [IllegalStateException] (fail-open 본문은 락이 없는 상태)
+ * - reentrant 진입 시 outer 가 Real 이면 통과
+ *
+ * ## Cross-context 동작 (R7)
+ * suspend 컨텍스트에서는 [assertLockedSuspend] 호출. sync `assertLocked()` 를 suspend 안에서 호출 시
+ * carrier thread 의 ThreadLocal 만 검사 → 잘못된 handle 노출 위험.
+ *
+ * ## Example
+ * ```kotlin
+ * @LeaderElection(name = "report-job")
+ * fun runReport() {
+ *     LockAssert.assertLocked()           // ✅
+ * }
+ * ```
+ */
+object LockAssert : KLogging() {
+    @JvmStatic fun assertLocked() {
+        val h = LockStateHolder.peekSync()
+            ?: error("LockAssert.assertLocked() called outside @LeaderElection body — no active scope on this thread")
+        if (h is LeaderLockHandle.FailOpen) {
+            error("LockAssert.assertLocked() called inside fail-open sentinel scope (lockName=${h.lockName})")
+        }
+    }
+
+    @JvmStatic fun assertLocked(lockName: String) {
+        val h = LockStateHolder.peekSyncMatching(lockName)
+            ?: error("LockAssert.assertLocked(name='$lockName') called outside matching @LeaderElection body")
+        if (h is LeaderLockHandle.FailOpen) {
+            error("LockAssert.assertLocked(name='$lockName') called inside fail-open sentinel scope")
+        }
+    }
+
+    @JvmStatic fun isLocked(): Boolean {
+        val h = LockStateHolder.peekSync() ?: return false
+        return h is LeaderLockHandle.Real
+    }
+
+    @JvmStatic fun isLocked(lockName: String): Boolean {
+        val h = LockStateHolder.peekSyncMatching(lockName) ?: return false
+        return h is LeaderLockHandle.Real
+    }
+
+    suspend fun assertLockedSuspend() {
+        val h = coroutineContext[LockHandleElement]?.handle
+            ?: error("LockAssert.assertLockedSuspend() called outside suspend @LeaderElection body — no active scope in coroutineContext")
+        if (h is LeaderLockHandle.FailOpen) {
+            error("LockAssert.assertLockedSuspend() called inside fail-open sentinel scope (lockName=${h.lockName})")
+        }
+    }
+
+    suspend fun assertLockedSuspend(lockName: String) {
+        val h = coroutineContext[LockHandleElement]?.handle
+        if (h == null || h.lockName != lockName) {
+            error("LockAssert.assertLockedSuspend(name='$lockName') called outside matching suspend @LeaderElection body")
+        }
+        if (h is LeaderLockHandle.FailOpen) {
+            error("LockAssert.assertLockedSuspend(name='$lockName') called inside fail-open sentinel scope")
+        }
+    }
+
+    suspend fun isLockedSuspend(): Boolean =
+        coroutineContext[LockHandleElement]?.handle is LeaderLockHandle.Real
+
+    suspend fun isLockedSuspend(lockName: String): Boolean {
+        val h = coroutineContext[LockHandleElement]?.handle ?: return false
+        return h is LeaderLockHandle.Real && h.lockName == lockName
+    }
+}
+```
+
+- [ ] **Step 4: Run LockAssert tests, expect PASS**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.LockAssertTest" --no-daemon
+# Expected: PASS (5/5)
+```
+
+- [ ] **Step 5: Write failing test — `LockExtender`**
+
+```kotlin
+// leader-core/src/test/kotlin/io/bluetape4k/leader/LockExtenderTest.kt
+package io.bluetape4k.leader
+
+import io.bluetape4k.leader.coroutines.LockHandleElement
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.leader.internal.LockStateHolder
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LockExtenderTest {
+    private val calls = AtomicInteger(0)
+    private val successDelegate = object : ExtendDelegate {
+        override fun extend(lockAtMostFor: Duration): ExtendOutcome {
+            calls.incrementAndGet()
+            return ExtendOutcome.Extended(Instant.now().plusSeconds(60))
+        }
+        override fun isHeld(): Boolean = true
+    }
+    private val notHeldDelegate = object : ExtendDelegate {
+        override fun extend(lockAtMostFor: Duration) = ExtendOutcome.NotHeld
+        override fun isHeld(): Boolean = false
+    }
+    private val id = LockIdentity("A", LockIdentity.AnnotationKind.SINGLE, "fA")
+
+    @Test
+    fun `extendActiveLock returns false outside scope`() {
+        calls.set(0)
+        LockExtender.extendActiveLock(30.seconds) shouldBeEqualTo false
+        calls.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `extendActiveLock returns true inside Real scope`() {
+        calls.set(0)
+        val h = LeaderLockHandle.real(id, "tok", 0L, successDelegate)
+        LockStateHolder.withPushed(h) {
+            LockExtender.extendActiveLock(30.seconds) shouldBeEqualTo true
+        }
+        calls.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `extendActiveLock returns false in FailOpen sentinel`() {
+        val fo = LeaderLockHandle.failOpen(id)
+        LockStateHolder.withPushed(fo) {
+            LockExtender.extendActiveLock(30.seconds) shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `extendActiveLockDetailed returns NotHeld when backend says so`() {
+        val h = LeaderLockHandle.real(id, "tok", 0L, notHeldDelegate)
+        LockStateHolder.withPushed(h) {
+            LockExtender.extendActiveLockDetailed(30.seconds) shouldBeEqualTo ExtendOutcome.NotHeld
+        }
+    }
+
+    @Test
+    fun `mismatched lockName returns false + Detailed returns NotHeld`() {
+        val h = LeaderLockHandle.real(id, "tok", 0L, successDelegate)
+        LockStateHolder.withPushed(h) {
+            LockExtender.extendActiveLock("OTHER", 30.seconds) shouldBeEqualTo false
+            LockExtender.extendActiveLockDetailed("OTHER", 30.seconds) shouldBeEqualTo ExtendOutcome.NotHeld
+        }
+    }
+
+    @Test
+    fun `extendActiveLockSuspend uses coroutineContext`() = runTest {
+        val h = LeaderLockHandle.real(id, "tok", 0L, successDelegate)
+        withContext(LockHandleElement(h)) {
+            LockExtender.extendActiveLockSuspend(30.seconds) shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `Java Duration overload converts correctly`() {
+        val h = LeaderLockHandle.real(id, "tok", 0L, successDelegate)
+        LockStateHolder.withPushed(h) {
+            LockExtender.extendActiveLock(java.time.Duration.ofSeconds(45)) shouldBeEqualTo true
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run test, expect FAIL**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.LockExtenderTest" --no-daemon
+# Expected: FAIL — Unresolved reference: LockExtender
+```
+
+- [ ] **Step 7: Implement `LockExtender`**
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt
+package io.bluetape4k.leader
+
+import io.bluetape4k.leader.coroutines.LockHandleElement
+import io.bluetape4k.leader.internal.LockStateHolder
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
+import kotlin.time.toKotlinDuration
+
+/**
+ * 활성 `@LeaderElection` / `@LeaderGroupElection` 컨텍스트의 lease 를 명시적으로 연장합니다.
+ *
+ * ## 동작/계약
+ * - 활성 컨텍스트 없음 → `false` + WARN log
+ * - fail-open sentinel → `false` + WARN
+ * - backend extend 실패 → `false` (token mismatch / expired / wrong thread / backend exception)
+ * - **absolute** lease — `lockAtMostFor` 만큼 새 expire time 설정
+ *
+ * ## Boolean ↔ Detailed 변환
+ * `extendActiveLock(d) ≡ extendActiveLockDetailed(d).isExtended`. 운영 가시성이 필요하면 Detailed 사용.
+ *
+ * ## mismatched lockName
+ * `extendActiveLock(lockName, d)` 의 lockName 이 active handle 과 다르면 `false` + WARN.
+ * Detailed 변형은 `NotHeld` 반환.
+ *
+ * ## Group elector 의미
+ * `@LeaderGroupElection` 본문 안에서는 현재 보유 slot 의 lease 만 갱신. 다른 slot 갱신 시 token guard 가
+ * `NotHeld` 반환.
+ *
+ * ## Watchdog 상호작용
+ * Watchdog (#73) 와 race-free 공존 — 둘 다 atomic backend extend → last-write-wins. 정확한 TTL 보호가
+ * 필요하면 watchdog OFF 권장.
+ *
+ * ## Example
+ * ```kotlin
+ * @LeaderElection(name = "long-report")
+ * fun longReport() {
+ *     LockAssert.assertLocked()
+ *     if (estimateTime() > leaseTime) LockExtender.extendActiveLock(10.minutes)
+ *     doWork()
+ * }
+ * ```
+ */
+object LockExtender : KLogging() {
+
+    @JvmStatic fun extendActiveLock(lockAtMostFor: Duration): Boolean =
+        extendActiveLockDetailed(lockAtMostFor).isExtended
+
+    @JvmStatic fun extendActiveLock(lockAtMostFor: java.time.Duration): Boolean =
+        extendActiveLock(lockAtMostFor.toKotlinDuration())
+
+    @JvmStatic fun extendActiveLock(lockName: String, lockAtMostFor: Duration): Boolean =
+        extendActiveLockDetailed(lockName, lockAtMostFor).isExtended
+
+    @JvmStatic fun extendActiveLock(lockName: String, lockAtMostFor: java.time.Duration): Boolean =
+        extendActiveLock(lockName, lockAtMostFor.toKotlinDuration())
+
+    @JvmStatic fun extendActiveLockDetailed(lockAtMostFor: Duration): ExtendOutcome {
+        val h = LockStateHolder.peekSync()
+        return when (h) {
+            null -> {
+                log.warn { "LockExtender.extendActiveLock called outside @LeaderElection body — no active scope" }
+                ExtendOutcome.NotHeld
+            }
+            is LeaderLockHandle.FailOpen -> {
+                log.warn { "LockExtender.extendActiveLock called in fail-open sentinel (lockName=${h.lockName})" }
+                ExtendOutcome.NotHeld
+            }
+            is LeaderLockHandle.Real -> h.extend(lockAtMostFor)
+        }
+    }
+
+    @JvmStatic fun extendActiveLockDetailed(lockName: String, lockAtMostFor: Duration): ExtendOutcome {
+        val h = LockStateHolder.peekSyncMatching(lockName)
+        if (h == null) {
+            log.warn { "LockExtender.extendActiveLock(name='$lockName') — active lock name mismatch or no scope" }
+            return ExtendOutcome.NotHeld
+        }
+        if (h is LeaderLockHandle.FailOpen) {
+            log.warn { "LockExtender.extendActiveLock(name='$lockName') called in fail-open sentinel" }
+            return ExtendOutcome.NotHeld
+        }
+        return (h as LeaderLockHandle.Real).extend(lockAtMostFor)
+    }
+
+    suspend fun extendActiveLockSuspend(lockAtMostFor: Duration): Boolean =
+        extendActiveLockDetailedSuspend(lockAtMostFor).isExtended
+
+    suspend fun extendActiveLockSuspend(lockName: String, lockAtMostFor: Duration): Boolean =
+        extendActiveLockDetailedSuspend(lockName, lockAtMostFor).isExtended
+
+    suspend fun extendActiveLockDetailedSuspend(lockAtMostFor: Duration): ExtendOutcome {
+        val h = coroutineContext[LockHandleElement]?.handle
+        return when (h) {
+            null -> {
+                log.warn { "LockExtender.extendActiveLockSuspend called outside suspend @LeaderElection body" }
+                ExtendOutcome.NotHeld
+            }
+            is LeaderLockHandle.FailOpen -> {
+                log.warn { "LockExtender.extendActiveLockSuspend called in fail-open sentinel (lockName=${h.lockName})" }
+                ExtendOutcome.NotHeld
+            }
+            is LeaderLockHandle.Real -> h.extendSuspend(lockAtMostFor)
+        }
+    }
+
+    suspend fun extendActiveLockDetailedSuspend(lockName: String, lockAtMostFor: Duration): ExtendOutcome {
+        val h = coroutineContext[LockHandleElement]?.handle
+        if (h == null || h.lockName != lockName) {
+            log.warn { "LockExtender.extendActiveLockSuspend(name='$lockName') — active lock name mismatch" }
+            return ExtendOutcome.NotHeld
+        }
+        if (h is LeaderLockHandle.FailOpen) {
+            log.warn { "LockExtender.extendActiveLockSuspend(name='$lockName') called in fail-open sentinel" }
+            return ExtendOutcome.NotHeld
+        }
+        return (h as LeaderLockHandle.Real).extendSuspend(lockAtMostFor)
+    }
+}
+```
+
+- [ ] **Step 8: Run LockExtender tests, expect PASS**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.LockExtenderTest" --no-daemon
+# Expected: PASS (7/7)
+```
+
+- [ ] **Step 9: Write Java compat test (AC-19)**
+
+```java
+// leader-core/src/test/java/io/bluetape4k/leader/LockExtenderJavaCompatTest.java
+package io.bluetape4k.leader;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LockExtenderJavaCompatTest {
+
+    @Test
+    void java_Duration_overload_compiles_and_runs() {
+        // no active scope → false (just verify it compiles + returns false)
+        boolean r = LockExtender.extendActiveLock(Duration.ofSeconds(30));
+        assertFalse(r);
+        boolean r2 = LockExtender.extendActiveLock("any", Duration.ofMinutes(1));
+        assertFalse(r2);
+    }
+}
+```
+
+- [ ] **Step 10: Run Java test, expect PASS**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.LockExtenderJavaCompatTest" --no-daemon
+# Expected: PASS (1/1)
+```
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add leader-core/src/main/kotlin/io/bluetape4k/leader/LockAssert.kt \
+        leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt \
+        leader-core/src/test/kotlin/io/bluetape4k/leader/LockAssertTest.kt \
+        leader-core/src/test/kotlin/io/bluetape4k/leader/LockExtenderTest.kt \
+        leader-core/src/test/java/io/bluetape4k/leader/LockExtenderJavaCompatTest.java
+git commit -m "feat(leader-core): T4 LockAssert + LockExtender top-level API (ShedLock-equivalent)"
+```
+
+---
+
+## Task 5: `BackendErrorClassifier` SPI + `LeaderLeaseAutoExtender` 시그니처 변경 + Local elector capture/extend
+
+**Complexity:** medium
+**Module:** `leader-core`
+**Depends on:** T1, T3
+**Satisfies AC:** AC-15 (delegate reference 동일성), AC-24 (SPI core 의존성 역전), part of AC-1 (Local contract), AC-6 (race-free)
+
+**Files:**
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/internal/BackendErrorClassifier.kt`
+- Modify: `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt`
+- Modify: `leader-core/src/main/kotlin/io/bluetape4k/leader/local/*` (local registry + electors)
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/internal/BackendErrorClassifierTest.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtenderTest.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalExtendDelegateReferenceTest.kt`
+
+- [ ] **Step 1: Write failing test — `BackendErrorClassifier` chain**
+
+```kotlin
+// leader-core/src/test/kotlin/io/bluetape4k/leader/internal/BackendErrorClassifierTest.kt
+package io.bluetape4k.leader.internal
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.sql.SQLTransientException
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class BackendErrorClassifierTest {
+    @Test
+    fun `core classifies SQLTransientException as TRANSIENT`() {
+        CoreBackendErrorClassifier.classify(SQLTransientException("x")) shouldBeEqualTo BackendErrorKind.TRANSIENT
+    }
+
+    @Test
+    fun `core classifies OOM as FATAL`() {
+        CoreBackendErrorClassifier.classify(OutOfMemoryError()) shouldBeEqualTo BackendErrorKind.FATAL
+    }
+
+    @Test
+    fun `composite delegates to backend specific first`() {
+        val specific = BackendErrorClassifier { cause ->
+            if (cause is IllegalStateException) BackendErrorKind.NON_TRANSIENT else null
+        }
+        val composite = CompositeBackendErrorClassifier(specific)
+        composite.classify(IllegalStateException()) shouldBeEqualTo BackendErrorKind.NON_TRANSIENT
+        composite.classify(SQLTransientException()) shouldBeEqualTo BackendErrorKind.TRANSIENT  // fall through to core
+        composite.classify(Exception("unknown")) shouldBeEqualTo BackendErrorKind.NON_TRANSIENT  // safe default
+    }
+}
+```
+
+- [ ] **Step 2: Run test, expect FAIL**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.internal.BackendErrorClassifierTest" --no-daemon
+# Expected: FAIL — Unresolved reference: BackendErrorClassifier
+```
+
+- [ ] **Step 3: Implement `BackendErrorClassifier`**
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/internal/BackendErrorClassifier.kt
+package io.bluetape4k.leader.internal
+
+/** Backend exception 분류. transient → false 변환, non-transient → throw, fatal → propagate (catch 안 함). */
+enum class BackendErrorKind { TRANSIENT, NON_TRANSIENT, FATAL }
+
+/**
+ * SPI — 각 backend module 이 자기 backend 용 구현 등록.
+ *
+ * ## 동작/계약
+ * - `classify(cause)` 가 `null` 반환 → chain next (`CoreBackendErrorClassifier` 로 fallback).
+ * - `leader-core` 는 backend exception class 를 직접 참조하지 않음 — JDK 공통만 처리.
+ */
+fun interface BackendErrorClassifier {
+    fun classify(cause: Throwable): BackendErrorKind?
+}
+
+/** JDK / 공통 분류 — backend dependency 없음 (R5-F4). */
+internal object CoreBackendErrorClassifier : BackendErrorClassifier {
+    override fun classify(cause: Throwable): BackendErrorKind = when (cause) {
+        is OutOfMemoryError, is StackOverflowError, is LinkageError -> BackendErrorKind.FATAL
+        is java.sql.SQLTransientException -> BackendErrorKind.TRANSIENT
+        is java.sql.SQLRecoverableException -> BackendErrorKind.TRANSIENT
+        is java.sql.SQLNonTransientException -> BackendErrorKind.NON_TRANSIENT
+        is java.net.SocketTimeoutException -> BackendErrorKind.TRANSIENT
+        is java.net.ConnectException -> BackendErrorKind.TRANSIENT
+        else -> BackendErrorKind.NON_TRANSIENT
+    }
+}
+
+/** classifier chain — 각 elector 가 `(backend classifier, core)` 합성 호출. */
+internal class CompositeBackendErrorClassifier(
+    private val backendSpecific: BackendErrorClassifier,
+) : BackendErrorClassifier {
+    override fun classify(cause: Throwable): BackendErrorKind =
+        backendSpecific.classify(cause)
+            ?: CoreBackendErrorClassifier.classify(cause)
+            ?: BackendErrorKind.NON_TRANSIENT
+}
+```
+
+- [ ] **Step 4: Run classifier tests, expect PASS**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.internal.BackendErrorClassifierTest" --no-daemon
+# Expected: PASS (3/3)
+```
+
+- [ ] **Step 5: Modify `LeaderLeaseAutoExtender.start` signature → `delegate: ExtendDelegate`**
+
+`leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt` — 기존 `(Duration) -> Boolean` 람다 인자를 `delegate: ExtendDelegate` 로 교체. 내부 scheduled task 가 `delegate.extend(leaseTime)` 호출.
+
+```kotlin
+// Before
+fun start(enabled: Boolean, leaseTime: Duration, extend: (Duration) -> Boolean) { ... }
+
+// After
+fun start(enabled: Boolean, leaseTime: Duration, delegate: ExtendDelegate) {
+    if (!enabled) return
+    // schedule at leaseTime / 3 ...
+    scheduledTask = scheduler.scheduleAtFixedRate({
+        val outcome = try {
+            delegate.extend(leaseTime)
+        } catch (e: Throwable) {
+            log.warn(e) { "watchdog extend threw" }
+            return@scheduleAtFixedRate
+        }
+        if (!outcome.isExtended) {
+            log.warn { "watchdog extend failed: $outcome — stopping watchdog" }
+            stop()
+        }
+    }, ...)
+}
+```
+
+> ⚠️ 기존 호출처 (`LocalLeaderElector`, `LettuceLeaderElector`, 등) 의 `start(...)` 호출이 모두 깨짐 — 이후 task (T5 Local, T7 Lettuce, ...) 에서 함께 수정. 본 task 에서는 leader-core 빌드만 그린 상태로 만들어 둔다 (caller 가 leader-core 안에 있는 경우만 동시 수정).
+
+- [ ] **Step 6: Modify Local registry/elector → 단일 `ExtendDelegate` 객체 사용 + capture**
+
+각 Local elector (`LocalLeaderElector`, `LocalSuspendLeaderElector`, `LocalLeaderGroupElector`, `LocalSuspendLeaderGroupElector`, `LocalVirtualThreadLeaderElector`, `LocalVirtualThreadLeaderGroupElector`, `LocalAsyncLeaderElector`, `LocalAsyncLeaderGroupElector`) 의 `runIfLeader` acquire 직후:
+
+```kotlin
+// 의사 코드 — 각 Local elector 의 runIfLeader 안
+val delegate = object : ExtendDelegate {
+    override fun extend(lockAtMostFor: Duration): ExtendOutcome =
+        registry.extend(lockName, token, lockAtMostFor)
+    override fun isHeld(): Boolean = registry.isHeld(lockName, token)
+}
+LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime, delegate)
+
+val handle = LeaderLockHandle.real(
+    identity = LockIdentity(lockName, LockIdentity.AnnotationKind.SINGLE, factoryBeanName = "<thisBean>"),
+    token = token,
+    acquiredAtNanos = System.nanoTime(),
+    extendDelegate = delegate,
+)
+LeaderLockHandleCapture.set(handle)
+try {
+    return action()
+} finally {
+    LeaderLockHandleCapture.clear()
+    autoExtender.stop()
+    registry.release(lockName, token)
+}
+```
+
+`LocalLeaderStateRegistry.extend(name, token, leaseTime)`: `ConcurrentHashMap.compute` 안에서 `if (entry.token == token && entry.expireAt > now) entry.copy(expireAt = now + leaseTime) -> Extended else NotHeld`.
+
+> ⚠️ 정확한 factoryBeanName 은 Spring auto-config 에서만 알 수 있음 — Local elector 가 standalone (no Spring) 일 때는 `"local"` 등 sentinel string 사용. 본 task 의 capture 검증 테스트에서는 string 만 일치하면 OK.
+
+- [ ] **Step 7: Write delegate-reference test (AC-15 / AC-23 핵심)**
+
+```kotlin
+// leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalExtendDelegateReferenceTest.kt
+package io.bluetape4k.leader.local
+
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.internal.LeaderLockHandleCapture
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LocalExtendDelegateReferenceTest {
+    @Test
+    fun `handle and watchdog share same delegate reference (AC-15)`() {
+        val elector = LocalLeaderElector(/* options with autoExtend = true */)
+        var capturedDelegate: Any? = null
+        var watchdogDelegate: Any? = null
+        // hook into LeaderLeaseAutoExtender to capture the delegate passed
+        // (test-only static visible-for-testing accessor)
+        LeaderLeaseAutoExtender.testHookOnStart = { _, _, d -> watchdogDelegate = d }
+        elector.runIfLeader("ref-lock") {
+            val h = LeaderLockHandleCapture.peekForTestOnly() as LeaderLockHandle.Real
+            capturedDelegate = h.extendDelegate
+        }
+        (capturedDelegate === watchdogDelegate) shouldBeEqualTo true
+    }
+}
+```
+
+> ⚠️ `testHookOnStart` 와 `peekForTestOnly` 는 `@VisibleForTesting` 또는 internal accessor — 본 task 안에서 `LeaderLeaseAutoExtender` / `LeaderLockHandleCapture` 에 동시 추가.
+
+- [ ] **Step 8: Run reference test, expect PASS**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.local.LocalExtendDelegateReferenceTest" --no-daemon
+# Expected: PASS (1/1)
+```
+
+- [ ] **Step 9: Run watchdog unit test (시그니처 변경 검증)**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.LeaderLeaseAutoExtenderTest" --no-daemon
+# Expected: PASS — start(delegate) 으로 호출되며 extend 호출 시 delegate.extend 가 invoke
+```
+
+- [ ] **Step 10: Run leader-core full build**
+
+```bash
+./gradlew :leader-core:build --no-daemon
+# Expected: PASS
+```
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add leader-core/src/main/kotlin/io/bluetape4k/leader/internal/BackendErrorClassifier.kt \
+        leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt \
+        leader-core/src/main/kotlin/io/bluetape4k/leader/local/ \
+        leader-core/src/test/kotlin/io/bluetape4k/leader/internal/BackendErrorClassifierTest.kt \
+        leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtenderTest.kt \
+        leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalExtendDelegateReferenceTest.kt
+git commit -m "feat(leader-core): T5 BackendErrorClassifier SPI + ExtendDelegate signature + Local capture/extend"
+```
+
+---
+
+## Task 6: Abstract contract bases + Local concrete contract tests
+
+**Complexity:** medium
+**Module:** `leader-core`
+**Depends on:** T4, T5
+**Satisfies AC:** AC-1 (capability matrix Local row), AC-6 (race-free), AC-12 (coverage)
+
+**Files:**
+- Create: `leader-core/src/testFixtures/kotlin/io/bluetape4k/leader/contract/AbstractSyncLockExtenderContractTest.kt`
+- Create: `leader-core/src/testFixtures/kotlin/io/bluetape4k/leader/contract/AbstractSuspendLockExtenderContractTest.kt`
+- Create: `leader-core/src/testFixtures/kotlin/io/bluetape4k/leader/contract/AbstractGroupLockExtenderContractTest.kt`
+- Create: `leader-core/src/testFixtures/kotlin/io/bluetape4k/leader/contract/AbstractSuspendGroupLockExtenderContractTest.kt`
+- Create: `leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalLockExtenderContractTest.kt` (sync)
+- Create: `leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalSuspendLockExtenderContractTest.kt`
+- Create: `leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalGroupLockExtenderContractTest.kt`
+- Create: `leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalSuspendGroupLockExtenderContractTest.kt`
+- Modify: `leader-core/build.gradle.kts` — `java-test-fixtures` plugin 추가
+
+- [ ] **Step 1: Add `java-test-fixtures` plugin to `leader-core/build.gradle.kts`**
+
+```kotlin
+// leader-core/build.gradle.kts
+plugins {
+    // ... 기존 플러그인
+    `java-test-fixtures`
+}
+```
+
+- [ ] **Step 2: Write `AbstractSyncLockExtenderContractTest`**
+
+```kotlin
+// leader-core/src/testFixtures/kotlin/io/bluetape4k/leader/contract/AbstractSyncLockExtenderContractTest.kt
+package io.bluetape4k.leader.contract
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.leader.LockExtender
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractSyncLockExtenderContractTest {
+
+    abstract val elector: LeaderElector
+    /** backend 의 현재 expireAt — null = 락 부재 / 만료. */
+    abstract fun probeBackendExpireAt(lockName: String): Instant?
+    /** lease 만료를 강제 (테스트용). */
+    abstract fun forceExpire(lockName: String)
+    /** 다른 노드가 takeover 한 상태 모사. */
+    abstract fun forceTakeover(lockName: String)
+
+    @Test
+    fun `assertLocked passes inside annotated body`() {
+        elector.runIfLeader("contract-A") {
+            LockAssert.assertLocked()
+        }
+    }
+
+    @Test
+    fun `assertLocked throws outside body`() {
+        assertFailsWith<IllegalStateException> { LockAssert.assertLocked() }
+    }
+
+    @Test
+    fun `extend returns true when held — TTL updated`() {
+        elector.runIfLeader("contract-ext") {
+            val before = probeBackendExpireAt("contract-ext")!!
+            Thread.sleep(50)
+            LockExtender.extendActiveLock(30.seconds) shouldBeEqualTo true
+            val after = probeBackendExpireAt("contract-ext")!!
+            (after.isAfter(before)) shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `extend returns false after release`() {
+        var afterReleaseResult = true
+        elector.runIfLeader("contract-rel") { /* noop */ }
+        // outside scope
+        afterReleaseResult = LockExtender.extendActiveLock(30.seconds)
+        afterReleaseResult shouldBeEqualTo false
+    }
+
+    @Test
+    fun `extend returns false after lease expiry (takeover)`() {
+        elector.runIfLeader("contract-exp") {
+            forceExpire("contract-exp")
+            LockExtender.extendActiveLock(30.seconds) shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `extend returns false after token mismatch`() {
+        elector.runIfLeader("contract-tok") {
+            forceTakeover("contract-tok")
+            LockExtender.extendActiveLock(30.seconds) shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `concurrent extends are race-free, last-write-wins`() {
+        elector.runIfLeader("contract-race") {
+            val pool = Executors.newFixedThreadPool(4)
+            val barrier = CyclicBarrier(4)
+            val outcomes = AtomicReference(mutableListOf<Boolean>())
+            repeat(4) {
+                pool.submit {
+                    barrier.await()
+                    val r = LockExtender.extendActiveLock(30.seconds)
+                    synchronized(outcomes) { outcomes.get().add(r) }
+                }
+            }
+            pool.shutdown()
+            pool.awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS)
+            // ⭐ ThreadLocal 기반이므로 다른 thread 에서는 false (no active scope) — race-free,
+            //   본 테스트는 "torn writes 없음" + "최종 expireAt 가 단조 증가 아님" 만 검증
+            val finalExpire = probeBackendExpireAt("contract-race")
+            (finalExpire != null) shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `extendActiveLockDetailed returns BackendError on transient failure`() {
+        // 각 backend subclass 가 transient 시나리오를 setup
+        val outcome = simulateTransientExtend("contract-be")
+        outcome shouldBeInstanceOf ExtendOutcome.BackendError::class
+    }
+
+    @Test
+    fun `assertLocked with mismatched lockName throws`() {
+        elector.runIfLeader("contract-name") {
+            assertFailsWith<IllegalStateException> { LockAssert.assertLocked("OTHER") }
+        }
+    }
+
+    /** subclass override — backend 별 transient simulation. */
+    protected open fun simulateTransientExtend(lockName: String): ExtendOutcome =
+        ExtendOutcome.BackendError(java.io.IOException("default — subclass should override"))
+}
+```
+
+- [ ] **Step 3: Write `AbstractSuspendLockExtenderContractTest` + cancellation tests**
+
+```kotlin
+// leader-core/src/testFixtures/kotlin/io/bluetape4k/leader/contract/AbstractSuspendLockExtenderContractTest.kt
+package io.bluetape4k.leader.contract
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.leader.LockExtender
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractSuspendLockExtenderContractTest {
+
+    abstract val elector: SuspendLeaderElector
+
+    @Test
+    fun `assertLockedSuspend passes inside body`() = runTest {
+        elector.runIfLeader("s-A") { LockAssert.assertLockedSuspend() }
+    }
+
+    @Test
+    fun `extendActiveLockSuspend returns true when held`() = runTest {
+        elector.runIfLeader("s-ext") {
+            LockExtender.extendActiveLockSuspend(30.seconds) shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `assertLockedSuspend ignores sync ThreadLocal (R7)`() = runTest {
+        // sync ThreadLocal 가 set 되어 있어도 coroutineContext 가 없으면 throw
+        elector.runIfLeader("s-thr") {
+            // 안에서는 정상
+            LockAssert.assertLockedSuspend()
+        }
+        // 밖에서 sync push 후 suspend → throw
+        // (test에서 LockStateHolder 직접 조작은 internal — 본 step 은 elector 외부 호출만 검증)
+        assertFailsWith<IllegalStateException> { LockAssert.assertLockedSuspend() }
+    }
+
+    @Test
+    fun `extend cancellation re-throws CancellationException`() = runTest {
+        assertFailsWith<CancellationException> {
+            withTimeout(50) {
+                elector.runIfLeader("s-cancel") {
+                    delay(500)   // suspend 안에서 timeout
+                    LockExtender.extendActiveLockSuspend(30.seconds)
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Write `AbstractGroupLockExtenderContractTest` + suspend-group variant**
+
+```kotlin
+// leader-core/src/testFixtures/kotlin/io/bluetape4k/leader/contract/AbstractGroupLockExtenderContractTest.kt
+package io.bluetape4k.leader.contract
+
+import io.bluetape4k.leader.LeaderGroupElector
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.leader.LockExtender
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractGroupLockExtenderContractTest {
+
+    abstract val elector: LeaderGroupElector
+
+    @Test
+    fun `extend on current slot only`() {
+        elector.runIfLeader("group-A") {
+            LockAssert.assertLocked()
+            LockExtender.extendActiveLock(30.seconds) shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `multiple slots — each extend touches only own slot`() {
+        // 동시 2 slot 잡기 + 각각 extend → token guard 로 자기 slot 만 갱신
+        // (구체 구현은 backend 별 slotId / token 검증으로 subclass 에서 추가)
+    }
+}
+
+// 동일 패턴의 AbstractSuspendGroupLockExtenderContractTest 도 같은 파일 위치에 별도로 생성.
+```
+
+```kotlin
+// leader-core/src/testFixtures/kotlin/io/bluetape4k/leader/contract/AbstractSuspendGroupLockExtenderContractTest.kt
+package io.bluetape4k.leader.contract
+
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.leader.LockExtender
+import io.bluetape4k.leader.SuspendLeaderGroupElector
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractSuspendGroupLockExtenderContractTest {
+    abstract val elector: SuspendLeaderGroupElector
+
+    @Test
+    fun `extendSuspend on current slot`() = runTest {
+        elector.runIfLeader("sg-A") {
+            LockAssert.assertLockedSuspend()
+            LockExtender.extendActiveLockSuspend(30.seconds) shouldBeEqualTo true
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Write Local concrete tests (4 subclasses)**
+
+```kotlin
+// leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalLockExtenderContractTest.kt
+package io.bluetape4k.leader.local
+
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.contract.AbstractSyncLockExtenderContractTest
+import java.time.Instant
+
+class LocalLockExtenderContractTest : AbstractSyncLockExtenderContractTest() {
+    private val registry = LocalLeaderStateRegistry()
+    override val elector: LeaderElector = LocalLeaderElector(registry /*, default options */)
+    override fun probeBackendExpireAt(lockName: String): Instant? = registry.snapshot(lockName)?.expireAt
+    override fun forceExpire(lockName: String) { registry.testOnlyForceExpire(lockName) }
+    override fun forceTakeover(lockName: String) { registry.testOnlyForceTakeover(lockName) }
+}
+```
+
+Same pattern for `LocalSuspendLockExtenderContractTest`, `LocalGroupLockExtenderContractTest`, `LocalSuspendGroupLockExtenderContractTest`.
+
+- [ ] **Step 6: Run all Local contract tests, expect PASS**
+
+```bash
+./gradlew :leader-core:test --tests "io.bluetape4k.leader.local.Local*LockExtenderContractTest" --no-daemon
+# Expected: PASS — 4 concrete subclasses × 각각 inherited @Test 메서드
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add leader-core/build.gradle.kts \
+        leader-core/src/testFixtures/ \
+        leader-core/src/test/kotlin/io/bluetape4k/leader/local/Local*LockExtenderContractTest.kt
+git commit -m "test(leader-core): T6 abstract contract bases + Local concrete tests"
+```
+
+---
+
+## Task 7: Lettuce — single sync/suspend `extend` + group `extendSlot` Lua (server-side TIME) + capture + classifier
+
+**Complexity:** high
+**Module:** `leader-redis-lettuce`
+**Depends on:** T1, T3, T5
+**Satisfies AC:** AC-1 (Lettuce rows), AC-15 (delegate ref), AC-16 (server-side TIME grep), AC-18 (CancellationException re-throw), AC-21 (extendSuspend override), AC-23 (per-module ref test), AC-24 (Lettuce classifier)
+
+**Files:**
+- Modify: `leader-redis-lettuce/.../lock/LettuceLock.kt` — `extend(d): ExtendOutcome` (반환형 변경)
+- Modify: `leader-redis-lettuce/.../lock/LettuceSuspendLock.kt` — `suspend fun extend(d): ExtendOutcome`
+- Modify: `leader-redis-lettuce/.../semaphore/LettuceSlotTokenGroup.kt` — `extendSlot(token, d): ExtendOutcome` + `suspend extendSlot`
+- Modify: `leader-redis-lettuce/.../LettuceLeaderElector.kt` — capture + delegate
+- Modify: `leader-redis-lettuce/.../LettuceSuspendLeaderElector.kt`
+- Modify: `leader-redis-lettuce/.../LettuceLeaderGroupElector.kt`
+- Modify: `leader-redis-lettuce/.../LettuceSuspendLeaderGroupElector.kt`
+- Create: `leader-redis-lettuce/.../internal/LettuceBackendErrorClassifier.kt`
+- Test: `leader-redis-lettuce/.../LettuceLockExtenderContractTest.kt` + suspend / group / suspend-group variants
+- Test: `leader-redis-lettuce/.../LettuceExtendDelegateReferenceTest.kt`
+
+- [ ] **Step 1: Write failing test — `LettuceBackendErrorClassifier`**
+
+```kotlin
+// leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/internal/LettuceBackendErrorClassifierTest.kt
+package io.bluetape4k.leader.lettuce.internal
+
+import io.bluetape4k.leader.internal.BackendErrorKind
+import io.lettuce.core.RedisCommandTimeoutException
+import io.lettuce.core.RedisConnectionException
+import io.lettuce.core.RedisCommandExecutionException
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LettuceBackendErrorClassifierTest {
+    @Test fun `command timeout is TRANSIENT`() {
+        LettuceBackendErrorClassifier.classify(RedisCommandTimeoutException("x")) shouldBeEqualTo BackendErrorKind.TRANSIENT
+    }
+    @Test fun `connection exception is TRANSIENT`() {
+        LettuceBackendErrorClassifier.classify(RedisConnectionException("x")) shouldBeEqualTo BackendErrorKind.TRANSIENT
+    }
+    @Test fun `command execution is NON_TRANSIENT`() {
+        LettuceBackendErrorClassifier.classify(RedisCommandExecutionException("x")) shouldBeEqualTo BackendErrorKind.NON_TRANSIENT
+    }
+    @Test fun `unknown returns null (chain delegates to core)`() {
+        LettuceBackendErrorClassifier.classify(RuntimeException("x")) shouldBeEqualTo null
+    }
+}
+```
+
+- [ ] **Step 2: Implement `LettuceBackendErrorClassifier`**
+
+```kotlin
+// leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/internal/LettuceBackendErrorClassifier.kt
+package io.bluetape4k.leader.lettuce.internal
+
+import io.bluetape4k.leader.internal.BackendErrorClassifier
+import io.bluetape4k.leader.internal.BackendErrorKind
+import io.lettuce.core.RedisCommandExecutionException
+import io.lettuce.core.RedisCommandTimeoutException
+import io.lettuce.core.RedisConnectionException
+
+internal object LettuceBackendErrorClassifier : BackendErrorClassifier {
+    override fun classify(cause: Throwable): BackendErrorKind? = when (cause) {
+        is RedisCommandTimeoutException -> BackendErrorKind.TRANSIENT
+        is RedisConnectionException -> BackendErrorKind.TRANSIENT
+        is RedisCommandExecutionException -> BackendErrorKind.NON_TRANSIENT
+        else -> null   // delegate to CoreBackendErrorClassifier
+    }
+}
+```
+
+- [ ] **Step 3: Run classifier test, expect PASS**
+
+```bash
+./gradlew :leader-redis-lettuce:test --tests "*LettuceBackendErrorClassifierTest" --no-daemon
+# Expected: PASS (4/4)
+```
+
+- [ ] **Step 4: Modify `LettuceLock.kt` — `extend(d): ExtendOutcome`**
+
+`LettuceLock` 의 기존 `extend(...)` (Boolean 반환) 를 `ExtendOutcome` 으로 변경. 기존 Lua `EXTEND_SCRIPT` (`IF GET k == token THEN PEXPIRE`) 재사용. server-side `redis.call('TIME')` 으로 `observedExpireAt` 계산:
+
+```kotlin
+// LettuceLock.kt — extend 메서드 교체
+private val EXTEND_SCRIPT = """
+    if redis.call('GET', KEYS[1]) == ARGV[1] then
+        redis.call('PEXPIRE', KEYS[1], ARGV[2])
+        local t = redis.call('TIME')
+        return t[1] * 1000 + math.floor(t[2] / 1000) + tonumber(ARGV[2])
+    else
+        return 0
+    end
+""".trimIndent()
+
+fun extend(leaseTime: Duration): ExtendOutcome {
+    return try {
+        val resultMs = redis.eval<Long>(EXTEND_SCRIPT, ScriptOutputType.INTEGER,
+            arrayOf(key), token, leaseTime.inWholeMilliseconds.toString()).block()
+        if (resultMs == null || resultMs == 0L) ExtendOutcome.NotHeld
+        else ExtendOutcome.Extended(Instant.ofEpochMilli(resultMs))
+    } catch (e: Exception) {
+        val kind = CompositeBackendErrorClassifier(LettuceBackendErrorClassifier).classify(e)
+        when (kind) {
+            BackendErrorKind.TRANSIENT -> ExtendOutcome.BackendError(e)
+            BackendErrorKind.NON_TRANSIENT -> throw e
+            BackendErrorKind.FATAL -> throw e
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Modify `LettuceSuspendLock.kt` — suspend extend with `withContext(IO)`**
+
+```kotlin
+suspend fun extend(leaseTime: Duration): ExtendOutcome = withContext(Dispatchers.IO) {
+    coroutineContext.ensureActive()
+    try {
+        val resultMs = redis.eval<Long>(EXTEND_SCRIPT, ScriptOutputType.INTEGER,
+            arrayOf(key), token, leaseTime.inWholeMilliseconds.toString()).awaitFirst()
+        if (resultMs == 0L) ExtendOutcome.NotHeld
+        else ExtendOutcome.Extended(Instant.ofEpochMilli(resultMs))
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        val kind = CompositeBackendErrorClassifier(LettuceBackendErrorClassifier).classify(e)
+        when (kind) {
+            BackendErrorKind.TRANSIENT -> ExtendOutcome.BackendError(e)
+            else -> throw e
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Implement Lettuce group `extendSlot` Lua (server-side TIME — AC-16)**
+
+```kotlin
+// LettuceSlotTokenGroup.kt
+private val EXTEND_SLOT_SCRIPT = """
+    local t = redis.call('TIME')
+    local nowMs = t[1] * 1000 + math.floor(t[2] / 1000)
+    local score = redis.call('ZSCORE', KEYS[1], ARGV[1])
+    if score and tonumber(score) > nowMs then
+        local newExpire = nowMs + tonumber(ARGV[2])
+        redis.call('ZADD', KEYS[1], 'XX', newExpire, ARGV[1])
+        redis.call('PEXPIRE', KEYS[1], tonumber(ARGV[2]) + 5000)
+        return newExpire
+    else
+        return 0
+    end
+""".trimIndent()
+
+fun extendSlot(token: String, leaseTime: Duration): ExtendOutcome {
+    return try {
+        val result = redis.eval<Long>(EXTEND_SLOT_SCRIPT, ScriptOutputType.INTEGER,
+            arrayOf(key), token, leaseTime.inWholeMilliseconds.toString()).block()
+        if (result == null || result == 0L) ExtendOutcome.NotHeld
+        else ExtendOutcome.Extended(Instant.ofEpochMilli(result))
+    } catch (e: Exception) {
+        val kind = CompositeBackendErrorClassifier(LettuceBackendErrorClassifier).classify(e)
+        if (kind == BackendErrorKind.TRANSIENT) ExtendOutcome.BackendError(e) else throw e
+    }
+}
+
+suspend fun extendSlotSuspend(token: String, leaseTime: Duration): ExtendOutcome = withContext(Dispatchers.IO) {
+    coroutineContext.ensureActive()
+    try {
+        val result = redis.eval<Long>(EXTEND_SLOT_SCRIPT, ScriptOutputType.INTEGER,
+            arrayOf(key), token, leaseTime.inWholeMilliseconds.toString()).awaitFirst()
+        if (result == 0L) ExtendOutcome.NotHeld
+        else ExtendOutcome.Extended(Instant.ofEpochMilli(result))
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        val kind = CompositeBackendErrorClassifier(LettuceBackendErrorClassifier).classify(e)
+        if (kind == BackendErrorKind.TRANSIENT) ExtendOutcome.BackendError(e) else throw e
+    }
+}
+```
+
+- [ ] **Step 7: Modify 4 Lettuce electors — single `ExtendDelegate` + capture + factoryBeanName**
+
+각 elector (`LettuceLeaderElector`, `LettuceSuspendLeaderElector`, `LettuceLeaderGroupElector`, `LettuceSuspendLeaderGroupElector`) 의 `runIfLeader` acquire 직후:
+
+```kotlin
+// LettuceLeaderElector.runIfLeader (sync 단일)
+override fun <T : Any> runIfLeader(lockName: String, action: () -> T?): T? {
+    val lock = lettuceLock.acquire(lockName, options)  // 기존
+        ?: return null
+    val delegate = object : ExtendDelegate {
+        override fun extend(d: Duration) = lock.extend(d)
+        override suspend fun extendSuspend(d: Duration) = withContext(Dispatchers.IO) {
+            coroutineContext.ensureActive(); lock.extend(d)
+        }
+        override fun isHeld(): Boolean = lock.isHeld()
+    }
+    LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime, delegate)
+
+    val handle = LeaderLockHandle.real(
+        identity = LockIdentity(lockName, LockIdentity.AnnotationKind.SINGLE, factoryBeanName = beanName),
+        token = lock.token,
+        acquiredAtNanos = System.nanoTime(),
+        extendDelegate = delegate,
+    )
+    LeaderLockHandleCapture.set(handle)
+    return try { action() }
+    catch (e: CancellationException) { throw e }
+    finally {
+        LeaderLockHandleCapture.clear()
+        autoExtender.stop()
+        lock.release()
+    }
+}
+```
+
+> ⚠️ `beanName` 은 elector 생성 시점에 Spring `BeanNameAware` 또는 factory 가 주입. Standalone 사용 시 elector 생성자에 `factoryBeanName: String` 인자 추가.
+
+- [ ] **Step 8: Write Lettuce contract concrete tests**
+
+```kotlin
+// leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceLockExtenderContractTest.kt
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.contract.AbstractSyncLockExtenderContractTest
+import java.time.Instant
+
+class LettuceLockExtenderContractTest : AbstractSyncLockExtenderContractTest() {
+    companion object : io.bluetape4k.logging.KLogging() {
+        val redis = io.bluetape4k.testcontainers.storage.RedisServer.Launcher.redis
+    }
+    override val elector: LeaderElector = LettuceLeaderElector(/* redis.url, factoryBeanName="testFactory" */)
+    override fun probeBackendExpireAt(lockName: String): Instant? = /* PTTL via Lettuce */ TODO()
+    override fun forceExpire(lockName: String) { /* DEL or PEXPIRE 0 */ }
+    override fun forceTakeover(lockName: String) { /* SET key newToken */ }
+}
+```
+
+Same pattern for `LettuceSuspendLockExtenderContractTest`, `LettuceLockExtenderGroupContractTest`, `LettuceSuspendGroupLockExtenderContractTest`.
+
+- [ ] **Step 9: Run Lettuce contract tests (Testcontainers)**
+
+```bash
+./gradlew :leader-redis-lettuce:test --tests "*LockExtenderContractTest" --no-daemon
+# Expected: PASS for all 4 subclasses (sync, suspend, group, suspend-group)
+```
+
+- [ ] **Step 10: Verify AC-16 — server-side TIME grep**
+
+```bash
+rg -n "redis\.call\('TIME'\)" leader-redis-lettuce/src/main/kotlin/
+# Expected: 2+ matches in EXTEND_SLOT_SCRIPT (group) — AC-16 검증
+```
+
+- [ ] **Step 11: Verify AC-21 — extendSuspend override + withContext(IO)**
+
+```bash
+rg -n "object\s*:\s*ExtendDelegate" leader-redis-lettuce/src/main/kotlin/
+rg -n "override\s+suspend\s+fun\s+extendSuspend" leader-redis-lettuce/src/main/kotlin/
+rg -n "withContext\(Dispatchers\.IO\)" leader-redis-lettuce/src/main/kotlin/
+# Expected: 각 elector 마다 ExtendDelegate 익명 객체 + extendSuspend override + withContext(IO)
+```
+
+- [ ] **Step 12: Write Lettuce delegate reference test (AC-23 per-module)**
+
+```kotlin
+// leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceExtendDelegateReferenceTest.kt
+class LettuceExtendDelegateReferenceTest {
+    @Test fun `delegate reference shared with watchdog`() {
+        // T5 의 LocalExtendDelegateReferenceTest 와 동일 패턴 — Lettuce elector
+    }
+}
+```
+
+- [ ] **Step 13: Run module build + tests**
+
+```bash
+./gradlew :leader-redis-lettuce:build --no-daemon
+# Expected: PASS
+```
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add leader-redis-lettuce/
+git commit -m "feat(leader-redis-lettuce): T7 extend ExtendOutcome + group extendSlot Lua (server TIME) + classifier"
+```
+
+---
+
+## Task 8: Redisson — owner-guarded Lua single + group `updateLeaseTime` + thread-id guard + capture + classifier
+
+**Complexity:** high
+**Module:** `leader-redis-redisson`
+**Depends on:** T1, T3, T5
+**Satisfies AC:** AC-1 (Redisson rows), AC-8 (thread-id semantics), AC-15, AC-18, AC-21, AC-23, AC-24
+
+**Files:**
+- Modify: `leader-redis-redisson/.../RedissonLeaderElector.kt` — owner-guarded Lua extend + capture
+- Modify: `leader-redis-redisson/.../RedissonSuspendLeaderElector.kt`
+- Modify: `leader-redis-redisson/.../RedissonLeaderGroupElector.kt` — `updateLeaseTime` 호출
+- Modify: `leader-redis-redisson/.../RedissonSuspendLeaderGroupElector.kt`
+- Create: `leader-redis-redisson/.../internal/RedissonBackendErrorClassifier.kt`
+- Test: contract concrete tests + thread-id test + ref test
+
+- [ ] **Step 1: Write failing test — owner-guarded Lua single**
+
+```kotlin
+// leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLockExtenderContractTest.kt
+class RedissonLockExtenderContractTest : AbstractSyncLockExtenderContractTest() {
+    /* setup with RedisServer.Launcher.redis */
+}
+```
+
+- [ ] **Step 2: Implement owner-guarded Lua extend in `RedissonLeaderElector`**
+
+Redisson `RLock` 의 내부 hash 구조 (`{lockKey, threadId}`) 를 owner-guarded Lua 로 직접 조작. 단순 `RLock.expire(...)` 사용 금지 (spec R3 / Codex F8):
+
+```kotlin
+private val OWNER_EXTEND_LUA = """
+    -- KEYS[1] = lock key, ARGV[1] = thread id (Redisson 형식), ARGV[2] = lease ms
+    if redis.call('HEXISTS', KEYS[1], ARGV[1]) == 1 then
+        redis.call('PEXPIRE', KEYS[1], ARGV[2])
+        local t = redis.call('TIME')
+        return t[1] * 1000 + math.floor(t[2] / 1000) + tonumber(ARGV[2])
+    else
+        return 0
+    end
+""".trimIndent()
+
+fun extend(d: Duration, threadId: Long): ExtendOutcome {
+    val currentThreadId = Thread.currentThread().threadId()
+    if (currentThreadId != threadId) {
+        log.warn { "Redisson extend called from thread $currentThreadId but acquired on $threadId — WrongThread" }
+        return ExtendOutcome.WrongThread
+    }
+    return try {
+        val resultMs = redisson.script.eval<Long>(
+            Mode.READ_WRITE, OWNER_EXTEND_LUA, ReturnType.INTEGER,
+            listOf(rlock.name), threadId.toString(), d.inWholeMilliseconds.toString()
+        )
+        if (resultMs == 0L) ExtendOutcome.NotHeld
+        else ExtendOutcome.Extended(Instant.ofEpochMilli(resultMs))
+    } catch (e: Exception) {
+        val kind = CompositeBackendErrorClassifier(RedissonBackendErrorClassifier).classify(e)
+        if (kind == BackendErrorKind.TRANSIENT) ExtendOutcome.BackendError(e) else throw e
+    }
+}
+```
+
+- [ ] **Step 3: Implement Redisson group extend via `updateLeaseTime`**
+
+```kotlin
+// RedissonLeaderGroupElector
+fun extendPermit(permitId: String, leaseTime: Duration): ExtendOutcome {
+    return try {
+        permitSemaphore.updateLeaseTime(permitId, leaseTime.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        ExtendOutcome.Extended(Instant.now().plusMillis(leaseTime.inWholeMilliseconds))
+    } catch (e: Exception) {
+        val kind = CompositeBackendErrorClassifier(RedissonBackendErrorClassifier).classify(e)
+        when {
+            e.message?.contains("not found") == true || e.message?.contains("expired") == true -> ExtendOutcome.NotHeld
+            kind == BackendErrorKind.TRANSIENT -> ExtendOutcome.BackendError(e)
+            else -> throw e
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Implement `RedissonBackendErrorClassifier`**
+
+```kotlin
+// leader-redis-redisson/.../internal/RedissonBackendErrorClassifier.kt
+package io.bluetape4k.leader.redisson.internal
+
+import io.bluetape4k.leader.internal.BackendErrorClassifier
+import io.bluetape4k.leader.internal.BackendErrorKind
+import org.redisson.client.RedisConnectionException
+import org.redisson.client.RedisTimeoutException
+
+internal object RedissonBackendErrorClassifier : BackendErrorClassifier {
+    override fun classify(cause: Throwable): BackendErrorKind? = when (cause) {
+        is RedisTimeoutException -> BackendErrorKind.TRANSIENT
+        is RedisConnectionException -> BackendErrorKind.TRANSIENT
+        else -> null
+    }
+}
+```
+
+- [ ] **Step 5: Capture handle — `LeaderLockHandle.Real` with `acquiringThreadId`**
+
+```kotlin
+// RedissonLeaderElector.runIfLeader
+val acquireThreadId = Thread.currentThread().threadId()
+val delegate = object : ExtendDelegate {
+    override fun extend(d: Duration) = this@RedissonLeaderElector.extend(d, acquireThreadId)
+    override suspend fun extendSuspend(d: Duration) = withContext(Dispatchers.IO) {
+        coroutineContext.ensureActive()
+        this@RedissonLeaderElector.extend(d, acquireThreadId)
+    }
+    override fun isHeld() = rlock.isHeldByCurrentThread
+}
+LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime, delegate)
+val handle = LeaderLockHandle.real(
+    identity = LockIdentity(lockName, LockIdentity.AnnotationKind.SINGLE, beanName),
+    token = "${rlock.name}-${acquireThreadId}",
+    acquiredAtNanos = System.nanoTime(),
+    extendDelegate = delegate,
+    acquiringThreadId = acquireThreadId,
+)
+LeaderLockHandleCapture.set(handle)
+```
+
+- [ ] **Step 6: Write thread-id semantics test (AC-8)**
+
+```kotlin
+// leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonThreadIdSemanticsTest.kt
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RedissonThreadIdSemanticsTest {
+    @Test
+    fun `extend from different thread returns WrongThread`() {
+        elector.runIfLeader("rs-thr") {
+            val result = Executors.newSingleThreadExecutor().submit<ExtendOutcome> {
+                // sync thread state holder propagation 불가 — 다른 thread 에서 직접 handle 가져와 호출
+                /* test setup: 다른 thread 에서 동일 handle 의 extend 호출 → WrongThread */
+            }.get()
+            result shouldBeEqualTo ExtendOutcome.WrongThread
+        }
+    }
+
+    @Test
+    fun `extend after Dispatchers IO hop returns WrongThread`() = runTest {
+        elector.runIfLeader("rs-io") {
+            withContext(Dispatchers.IO) {
+                LockExtender.extendActiveLockSuspend(30.seconds) shouldBeEqualTo false  // WrongThread → false
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 7: Run Redisson contract + thread-id tests**
+
+```bash
+./gradlew :leader-redis-redisson:test --tests "*LockExtenderContractTest" --tests "*ThreadIdSemanticsTest" --no-daemon
+# Expected: PASS
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add leader-redis-redisson/
+git commit -m "feat(leader-redis-redisson): T8 owner-guarded Lua + group updateLeaseTime + thread-id guard"
+```
+
+---
+
+## Task 9: MongoDB — extend filter `expireAt > now` + group `extendSlot` 신규 + capture + classifier
+
+**Complexity:** medium
+**Module:** `leader-mongodb`
+**Depends on:** T1, T3, T5
+**Satisfies AC:** AC-1 (Mongo rows), AC-15, AC-17 (filter grep), AC-18, AC-21, AC-23, AC-24
+
+**Files:**
+- Modify: `leader-mongodb/.../lock/MongoLock.kt` — filter 강화 + `extend` 반환형 변경
+- Modify: `leader-mongodb/.../lock/MongoSuspendLock.kt`
+- Modify: `leader-mongodb/.../MongoLeaderElector.kt` + suspend variant — capture
+- Modify: `leader-mongodb/.../MongoLeaderGroupElector.kt` — `extendSlot` 신규 + capture
+- Modify: `leader-mongodb/.../MongoSuspendLeaderGroupElector.kt`
+- Create: `leader-mongodb/.../internal/MongoBackendErrorClassifier.kt`
+- Test: contract concrete tests + filter grep test
+
+- [ ] **Step 1: Modify `MongoLock.extend` — atomic filter with `expireAt > now`**
+
+```kotlin
+// MongoLock.kt — extend
+fun extend(leaseTime: Duration): ExtendOutcome {
+    val now = Instant.now()
+    val newExpireAt = now.plusMillis(leaseTime.inWholeMilliseconds)
+    return try {
+        val result = collection.findOneAndUpdate(
+            Filters.and(
+                Filters.eq("_id", lockName),
+                Filters.eq("token", token),
+                Filters.gt("expireAt", now),   // ⭐ R6 / Codex F6 / AC-17 — 만료 부활 차단
+            ),
+            Updates.set("expireAt", newExpireAt),
+            FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER),
+        )
+        if (result == null) ExtendOutcome.NotHeld
+        else ExtendOutcome.Extended(result["expireAt"] as Instant)
+    } catch (e: Exception) {
+        val kind = CompositeBackendErrorClassifier(MongoBackendErrorClassifier).classify(e)
+        if (kind == BackendErrorKind.TRANSIENT) ExtendOutcome.BackendError(e) else throw e
+    }
+}
+```
+
+- [ ] **Step 2: Modify `MongoSuspendLock.extend` — suspend with `withContext(IO)` + `ensureActive()`**
+
+```kotlin
+suspend fun extend(leaseTime: Duration): ExtendOutcome = withContext(Dispatchers.IO) {
+    coroutineContext.ensureActive()
+    val now = Instant.now()
+    val newExpireAt = now.plusMillis(leaseTime.inWholeMilliseconds)
+    try {
+        val result = collection.findOneAndUpdate(
+            and(eq("_id", lockName), eq("token", token), gt("expireAt", now)),
+            set("expireAt", newExpireAt),
+            FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER),
+        ).awaitFirstOrNull()
+        if (result == null) ExtendOutcome.NotHeld
+        else ExtendOutcome.Extended(result["expireAt"] as Instant)
+    } catch (e: CancellationException) { throw e }
+    catch (e: Exception) {
+        val kind = CompositeBackendErrorClassifier(MongoBackendErrorClassifier).classify(e)
+        if (kind == BackendErrorKind.TRANSIENT) ExtendOutcome.BackendError(e) else throw e
+    }
+}
+```
+
+- [ ] **Step 3: Implement `MongoLeaderGroupElector.extendSlot` — per-slot document filter**
+
+```kotlin
+fun extendSlot(slotId: String, leaseTime: Duration): ExtendOutcome {
+    val now = Instant.now()
+    val newExpireAt = now.plusMillis(leaseTime.inWholeMilliseconds)
+    return try {
+        val result = collection.findOneAndUpdate(
+            Filters.and(
+                Filters.eq("name", groupName),
+                Filters.eq("slotId", slotId),
+                Filters.eq("token", token),
+                Filters.gt("expireAt", now),
+            ),
+            Updates.set("expireAt", newExpireAt),
+            FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER),
+        )
+        if (result == null) ExtendOutcome.NotHeld
+        else ExtendOutcome.Extended(result["expireAt"] as Instant)
+    } catch (e: Exception) {
+        val kind = CompositeBackendErrorClassifier(MongoBackendErrorClassifier).classify(e)
+        if (kind == BackendErrorKind.TRANSIENT) ExtendOutcome.BackendError(e) else throw e
+    }
+}
+```
+
+- [ ] **Step 4: Implement `MongoBackendErrorClassifier`**
+
+```kotlin
+// leader-mongodb/.../internal/MongoBackendErrorClassifier.kt
+package io.bluetape4k.leader.mongodb.internal
+
+import com.mongodb.MongoSocketException
+import com.mongodb.MongoTimeoutException
+import com.mongodb.MongoWriteException
+import io.bluetape4k.leader.internal.BackendErrorClassifier
+import io.bluetape4k.leader.internal.BackendErrorKind
+
+internal object MongoBackendErrorClassifier : BackendErrorClassifier {
+    override fun classify(cause: Throwable): BackendErrorKind? = when (cause) {
+        is MongoSocketException -> BackendErrorKind.TRANSIENT
+        is MongoTimeoutException -> BackendErrorKind.TRANSIENT
+        is MongoWriteException -> BackendErrorKind.NON_TRANSIENT
+        else -> null
+    }
+}
+```
+
+- [ ] **Step 5: Modify 4 Mongo electors — capture + delegate**
+
+각 elector (`MongoLeaderElector`, `MongoSuspendLeaderElector`, `MongoLeaderGroupElector`, `MongoSuspendLeaderGroupElector`) 의 `runIfLeader` 안에 T7 Lettuce 와 동일 패턴으로 `ExtendDelegate` + `LeaderLockHandleCapture.set` 추가.
+
+- [ ] **Step 6: Write contract concrete tests (4 variants)**
+
+```kotlin
+// leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoLockExtenderContractTest.kt
+class MongoLockExtenderContractTest : AbstractSyncLockExtenderContractTest() {
+    companion object : KLogging() {
+        val mongo = MongoDBServer.Launcher.mongodb
+    }
+    /* setup with mongo.url */
+}
+```
+
+- [ ] **Step 7: Verify AC-17 — filter `expireAt > now` grep**
+
+```bash
+rg -n 'gt\("expireAt"' leader-mongodb/src/main/kotlin/
+rg -n '\$gt.*expireAt|expireAt.*\$gt' leader-mongodb/src/main/kotlin/
+# Expected: 4+ matches (sync single, suspend single, sync group, suspend group)
+```
+
+- [ ] **Step 8: Run Mongo contract + classifier tests**
+
+```bash
+./gradlew :leader-mongodb:test --tests "*LockExtenderContractTest" --tests "*MongoBackendErrorClassifierTest" --no-daemon
+# Expected: PASS
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add leader-mongodb/
+git commit -m "feat(leader-mongodb): T9 extend filter expireAt>now + group extendSlot + classifier"
+```
+
+---
+
+## Task 10: Exposed JDBC — `extend` SQL + group `extendSlot` SQL + capture + classifier
+
+**Complexity:** medium
+**Module:** `leader-exposed-jdbc`
+**Depends on:** T1, T3, T5
+**Satisfies AC:** AC-1 (Exposed JDBC rows), AC-15, AC-18, AC-21, AC-23, AC-24
+
+**Files:**
+- Create: `leader-exposed-jdbc/.../lock/ExposedJdbcLock.kt` — `extend(d): ExtendOutcome`
+- Create: `leader-exposed-jdbc/.../lock/ExposedJdbcGroupLock.kt`
+- Modify: `leader-exposed-jdbc/.../ExposedJdbcLeaderElector.kt` + group variant — capture
+- Create: `leader-exposed-jdbc/.../internal/JdbcBackendErrorClassifier.kt`
+- Test: contract + classifier
+
+- [ ] **Step 1: Implement `ExposedJdbcLock.extend`**
+
+```kotlin
+// ExposedJdbcLock.kt
+fun extend(leaseTime: Duration): ExtendOutcome {
+    return try {
+        val rows = transaction {
+            // ⚠️ Exposed 1.2.0 — top-level operator imports 사용
+            val now = CurrentTimestamp
+            LeaderLockTable.update({
+                (LeaderLockTable.name eq lockName) and
+                (LeaderLockTable.token eq token) and
+                (LeaderLockTable.expireAt greater now)
+            }) {
+                it[expireAt] = Instant.now().plusMillis(leaseTime.inWholeMilliseconds)
+            }
+        }
+        if (rows == 0) ExtendOutcome.NotHeld
+        else {
+            // SELECT back to get authoritative expireAt
+            val row = transaction { LeaderLockTable.select { LeaderLockTable.name eq lockName }.firstOrNull() }
+            ExtendOutcome.Extended(row?.get(LeaderLockTable.expireAt) ?: Instant.now().plusMillis(leaseTime.inWholeMilliseconds))
+        }
+    } catch (e: Exception) {
+        val kind = CompositeBackendErrorClassifier(JdbcBackendErrorClassifier).classify(e)
+        if (kind == BackendErrorKind.TRANSIENT) ExtendOutcome.BackendError(e) else throw e
+    }
+}
+```
+
+- [ ] **Step 2: Implement group `extendSlot` SQL (per-slot row)**
+
+`leader-exposed-jdbc/.../lock/ExposedJdbcGroupLock.kt` — `UPDATE group_slot SET expireAt = ? WHERE groupName = ? AND slotToken = ? AND expireAt > now()`.
+
+- [ ] **Step 3: Implement `JdbcBackendErrorClassifier`**
+
+```kotlin
+// leader-exposed-jdbc/.../internal/JdbcBackendErrorClassifier.kt
+internal object JdbcBackendErrorClassifier : BackendErrorClassifier {
+    override fun classify(cause: Throwable): BackendErrorKind? = when (cause) {
+        is java.sql.SQLTransientConnectionException -> BackendErrorKind.TRANSIENT
+        is java.sql.SQLNonTransientConnectionException -> BackendErrorKind.NON_TRANSIENT
+        // JDK 공통 SQLTransientException 등은 CoreBackendErrorClassifier 가 처리
+        else -> null
+    }
+}
+```
+
+- [ ] **Step 4: Modify JDBC electors — capture + delegate**
+
+T7 Lettuce 와 동일 패턴.
+
+- [ ] **Step 5: Write contract concrete tests (sync + group)**
+
+```kotlin
+// leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLockExtenderContractTest.kt
+class ExposedJdbcLockExtenderContractTest : AbstractSyncLockExtenderContractTest() {
+    /* setup with H2 or PostgreSQL container */
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+./gradlew :leader-exposed-jdbc:test --tests "*LockExtenderContractTest" --no-daemon
+# Expected: PASS
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add leader-exposed-jdbc/
+git commit -m "feat(leader-exposed-jdbc): T10 extend SQL + group extendSlot + classifier"
+```
+
+---
+
+## Task 11: Exposed R2DBC — suspend `extend` SQL + capture + classifier
+
+**Complexity:** medium
+**Module:** `leader-exposed-r2dbc`
+**Depends on:** T10
+**Satisfies AC:** AC-1 (R2DBC suspend/suspend-group rows), AC-15, AC-18 (CancellationException), AC-21 (suspend native — default OK), AC-23, AC-24
+
+**Files:**
+- Create: `leader-exposed-r2dbc/.../lock/ExposedR2dbcLock.kt`
+- Create: `leader-exposed-r2dbc/.../lock/ExposedR2dbcGroupLock.kt`
+- Modify: `leader-exposed-r2dbc/.../ExposedR2dbcSuspendLeaderElector.kt` + group — capture
+- Create: `leader-exposed-r2dbc/.../internal/R2dbcBackendErrorClassifier.kt`
+
+- [ ] **Step 1: Implement `ExposedR2dbcLock.extend` (suspend native)**
+
+```kotlin
+// ExposedR2dbcLock.kt
+suspend fun extend(leaseTime: Duration): ExtendOutcome {
+    return try {
+        val rows = suspendTransaction {
+            LeaderLockTable.update({
+                (LeaderLockTable.name eq lockName) and
+                (LeaderLockTable.token eq token) and
+                (LeaderLockTable.expireAt greater CurrentTimestamp)
+            }) {
+                it[expireAt] = Instant.now().plusMillis(leaseTime.inWholeMilliseconds)
+            }
+        }
+        if (rows == 0) ExtendOutcome.NotHeld
+        else ExtendOutcome.Extended(/* SELECT back */ Instant.now().plusMillis(leaseTime.inWholeMilliseconds))
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        val kind = CompositeBackendErrorClassifier(R2dbcBackendErrorClassifier).classify(e)
+        if (kind == BackendErrorKind.TRANSIENT) ExtendOutcome.BackendError(e) else throw e
+    }
+}
+```
+
+- [ ] **Step 2: Implement `R2dbcBackendErrorClassifier`**
+
+```kotlin
+internal object R2dbcBackendErrorClassifier : BackendErrorClassifier {
+    override fun classify(cause: Throwable): BackendErrorKind? = when (cause) {
+        is io.r2dbc.spi.R2dbcTransientException -> BackendErrorKind.TRANSIENT
+        is io.r2dbc.spi.R2dbcTimeoutException -> BackendErrorKind.TRANSIENT
+        is io.r2dbc.spi.R2dbcNonTransientException -> BackendErrorKind.NON_TRANSIENT
+        else -> null
+    }
+}
+```
+
+- [ ] **Step 3: Modify R2DBC suspend electors — capture + delegate (suspend native, no withContext needed)**
+
+```kotlin
+val delegate = object : ExtendDelegate {
+    override fun extend(d: Duration) = runBlocking { lock.extend(d) }  // lazy fallback — sync caller 가 없으면 호출되지 않음
+    override suspend fun extendSuspend(d: Duration) = lock.extend(d)
+    override fun isHeld() = runBlocking { lock.isHeld() }
+}
+```
+
+- [ ] **Step 4: Write contract concrete tests (suspend + suspend-group only)**
+
+```kotlin
+class ExposedR2dbcSuspendLockExtenderContractTest : AbstractSuspendLockExtenderContractTest() { /* ... */ }
+class ExposedR2dbcSuspendGroupLockExtenderContractTest : AbstractSuspendGroupLockExtenderContractTest() { /* ... */ }
+```
+
+- [ ] **Step 5: Run R2DBC tests**
+
+```bash
+./gradlew :leader-exposed-r2dbc:test --tests "*LockExtenderContractTest" --no-daemon
+# Expected: PASS
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add leader-exposed-r2dbc/
+git commit -m "feat(leader-exposed-r2dbc): T11 suspend extend SQL + classifier"
+```
+
+---
+
+## Task 12: Hazelcast — `ExtendEntryProcessor` 신규 + capture + classifier
+
+**Complexity:** high
+**Module:** `leader-hazelcast`
+**Depends on:** T1, T3, T5
+**Satisfies AC:** AC-1 (Hazelcast rows), AC-7 (EntryProcessor — plain setTtl 금지), AC-15, AC-18, AC-21, AC-23, AC-24
+
+**Files:**
+- Create: `leader-hazelcast/.../lock/ExtendEntryProcessor.kt`
+- Modify: `leader-hazelcast/.../lock/HazelcastLock.kt` + suspend variant — `extend(d)` via `executeOnKey`
+- Modify: `leader-hazelcast/.../HazelcastLeaderElector.kt` + 3 variants — capture
+- Modify: group elector / lock (per-slot IMap entry)
+- Create: `leader-hazelcast/.../internal/HazelcastBackendErrorClassifier.kt`
+
+- [ ] **Step 1: Implement `ExtendEntryProcessor`**
+
+```kotlin
+// leader-hazelcast/.../lock/ExtendEntryProcessor.kt
+package io.bluetape4k.leader.hazelcast.lock
+
+import com.hazelcast.map.EntryProcessor
+import java.io.Serializable
+import java.time.Instant
+
+/**
+ * Atomic extend via `IMap.executeOnKey`. `(token == ours && expireAt > now)` 일 때만 atomic 갱신.
+ *
+ * ## 동작/계약
+ * - return null → NotHeld (token mismatch or expired)
+ * - return newExpireAt epoch millis → Extended
+ * - plain `IMap.setTtl` 사용 금지 (lost-update race — spec R2 / AC-7).
+ */
+class ExtendEntryProcessor(
+    private val expectedToken: String,
+    private val leaseMillis: Long,
+) : EntryProcessor<String, LockEntry, Long?>, Serializable {
+
+    override fun process(entry: MutableMap.MutableEntry<String, LockEntry>): Long? {
+        val current = entry.value ?: return null
+        val now = Instant.now().toEpochMilli()
+        if (current.token != expectedToken || current.expireAtMs <= now) return null
+        val newExpire = now + leaseMillis
+        entry.setValue(current.copy(expireAtMs = newExpire))
+        return newExpire
+    }
+}
+```
+
+- [ ] **Step 2: Modify `HazelcastLock.extend` → use `executeOnKey`**
+
+```kotlin
+fun extend(leaseTime: Duration): ExtendOutcome {
+    return try {
+        val resultMs = imap.executeOnKey(lockKey, ExtendEntryProcessor(token, leaseTime.inWholeMilliseconds))
+        if (resultMs == null) ExtendOutcome.NotHeld
+        else ExtendOutcome.Extended(Instant.ofEpochMilli(resultMs))
+    } catch (e: Exception) {
+        val kind = CompositeBackendErrorClassifier(HazelcastBackendErrorClassifier).classify(e)
+        if (kind == BackendErrorKind.TRANSIENT) ExtendOutcome.BackendError(e) else throw e
+    }
+}
+```
+
+- [ ] **Step 3: Suspend variant — `withContext(IO)` + `ensureActive()`**
+
+```kotlin
+suspend fun extend(leaseTime: Duration): ExtendOutcome = withContext(Dispatchers.IO) {
+    coroutineContext.ensureActive()
+    try {
+        val resultMs = imap.executeOnKey(lockKey, ExtendEntryProcessor(token, leaseTime.inWholeMilliseconds))
+        if (resultMs == null) ExtendOutcome.NotHeld else ExtendOutcome.Extended(Instant.ofEpochMilli(resultMs))
+    } catch (e: CancellationException) { throw e }
+    catch (e: Exception) {
+        val kind = CompositeBackendErrorClassifier(HazelcastBackendErrorClassifier).classify(e)
+        if (kind == BackendErrorKind.TRANSIENT) ExtendOutcome.BackendError(e) else throw e
+    }
+}
+```
+
+- [ ] **Step 4: Implement `HazelcastBackendErrorClassifier`**
+
+```kotlin
+internal object HazelcastBackendErrorClassifier : BackendErrorClassifier {
+    override fun classify(cause: Throwable): BackendErrorKind? = when (cause) {
+        is com.hazelcast.core.OperationTimeoutException -> BackendErrorKind.TRANSIENT
+        is com.hazelcast.spi.exception.RetryableHazelcastException -> BackendErrorKind.TRANSIENT
+        is com.hazelcast.core.HazelcastInstanceNotActiveException -> BackendErrorKind.NON_TRANSIENT
+        else -> null
+    }
+}
+```
+
+- [ ] **Step 5: Verify AC-7 — plain `setTtl` 금지 grep**
+
+```bash
+rg -n "\.setTtl\(" leader-hazelcast/src/main/kotlin/
+# Expected: 0 매치 in lock/extend code paths — AC-7 검증
+```
+
+- [ ] **Step 6: Write contract concrete tests + AC-7 grep test**
+
+```kotlin
+// leader-hazelcast/.../HazelcastLockExtenderContractTest.kt
+class HazelcastLockExtenderContractTest : AbstractSyncLockExtenderContractTest() { /* setup with Hazelcast container */ }
+
+@Test
+fun `AC-7 — extend uses EntryProcessor, not setTtl`() {
+    // mockk verify: imap.executeOnKey called, imap.setTtl never called
+}
+```
+
+- [ ] **Step 7: Run Hazelcast tests**
+
+```bash
+./gradlew :leader-hazelcast:test --tests "*LockExtenderContractTest" --no-daemon
+# Expected: PASS
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add leader-hazelcast/
+git commit -m "feat(leader-hazelcast): T12 ExtendEntryProcessor + capture + classifier (AC-7)"
+```
+
+---
+
+## Task 13: ZooKeeper — passthrough extend + `autoExtend=false` 강제 + capture + classifier
+
+**Complexity:** low
+**Module:** `leader-zookeeper`
+**Depends on:** T1, T3, T5
+**Satisfies AC:** AC-1 (ZK rows — passthrough), AC-15, AC-20 (autoExtend WARN), AC-23, AC-24
+
+**Files:**
+- Modify: `leader-zookeeper/.../ZkLeaderElector.kt` — `extend` passthrough + `autoExtend=false` enforce
+- Modify: `leader-zookeeper/.../ZkSuspendLeaderElector.kt`
+- Modify: group variants
+- Create: `leader-zookeeper/.../internal/ZkBackendErrorClassifier.kt`
+
+- [ ] **Step 1: Implement passthrough extend**
+
+```kotlin
+// ZkLeaderElector — extend passthrough
+fun extend(d: Duration): ExtendOutcome {
+    return if (mutex.isAcquiredInThisProcess) ExtendOutcome.Extended(Instant.MAX)
+    else ExtendOutcome.NotHeld
+}
+```
+
+- [ ] **Step 2: Force `autoExtend=false` + startup WARN (AC-20)**
+
+```kotlin
+// ZkLeaderElector init
+init {
+    if (options.autoExtend) {
+        log.warn { "ZooKeeper backend does not have TTL — autoExtend=true is no-op. Forcing autoExtend=false." }
+    }
+}
+
+override fun runIfLeader(...): T? {
+    // ...
+    LeaderLeaseAutoExtender.start(enabled = false /* always */, options.leaseTime, delegate)
+    // ...
+}
+```
+
+- [ ] **Step 3: Implement `ZkBackendErrorClassifier`**
+
+```kotlin
+internal object ZkBackendErrorClassifier : BackendErrorClassifier {
+    override fun classify(cause: Throwable): BackendErrorKind? = when (cause) {
+        is org.apache.zookeeper.KeeperException.ConnectionLossException -> BackendErrorKind.TRANSIENT
+        is org.apache.zookeeper.KeeperException.SessionExpiredException -> BackendErrorKind.TRANSIENT
+        is org.apache.zookeeper.KeeperException -> BackendErrorKind.NON_TRANSIENT
+        else -> null
+    }
+}
+```
+
+- [ ] **Step 4: Write contract concrete tests (4 variants — extend = passthrough)**
+
+```kotlin
+class ZkLockExtenderContractTest : AbstractSyncLockExtenderContractTest() {
+    // ⭐ extend 검증 override — Extended(Instant.MAX) 반환 확인
+    @Test
+    override fun `extend returns true when held — TTL updated`() {
+        elector.runIfLeader("zk-ext") {
+            val out = LockExtender.extendActiveLockDetailed(30.seconds)
+            (out as ExtendOutcome.Extended).observedExpireAt shouldBeEqualTo Instant.MAX
+        }
+    }
+    /* forceExpire / forceTakeover 는 ZK session kill 로 모사 */
+}
+```
+
+- [ ] **Step 5: AC-20 — autoExtend=true 시 startup WARN test**
+
+```kotlin
+@Test
+fun `AC-20 — autoExtend=true emits WARN at startup`() {
+    val logs = captureLogs { ZkLeaderElector(options = options.copy(autoExtend = true)) }
+    logs.any { it.contains("autoExtend") && it.contains("no-op") } shouldBeEqualTo true
+}
+```
+
+- [ ] **Step 6: Run ZK tests**
+
+```bash
+./gradlew :leader-zookeeper:test --tests "*LockExtenderContractTest" --no-daemon
+# Expected: PASS
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add leader-zookeeper/
+git commit -m "feat(leader-zookeeper): T13 passthrough extend + autoExtend=false enforce + classifier"
+```
+
+---
+
+## Task 14: `LeaderElectionAspect` — 3 분기 + reentrant peek (full identity) + sentinel push + capture invariant
+
+**Complexity:** high
+**Module:** `leader-spring-boot`
+**Depends on:** T1, T2, T3
+**Satisfies AC:** AC-2 (reentrant counter 0), AC-2b (cross-kind dedupe 차단), AC-4 (fail-open sentinel), AC-4b (failure mode 행렬), AC-5 (sync/suspend/Mono), AC-22 (CTW weave)
+
+**Files:**
+- Create: `leader-spring-boot/.../aop/internal/AdviceBranch.kt`
+- Create: `leader-spring-boot/.../aop/internal/AdviceMetadata.kt`
+- Create: `leader-spring-boot/.../aop/internal/BodyThrownMarker.kt`
+- Create: `leader-spring-boot/.../aop/internal/CaptureInvariantException.kt`
+- Modify: `leader-spring-boot/.../aop/LeaderElectionAspect.kt` — 3 분기 재구조
+- Test: `leader-spring-boot/.../aop/LeaderElectionAspectReentrantTest.kt`
+- Test: `leader-spring-boot/.../aop/LeaderElectionAspectFailureModeMatrixTest.kt`
+- Test: `leader-spring-boot/.../aop/LeaderElectionAspectCtwWeaveSmokeTest.kt`
+
+- [ ] **Step 1: Create `AdviceBranch` enum + `AdviceMetadata` data class + `BodyThrownMarker` + `CaptureInvariantException`**
+
+```kotlin
+// leader-spring-boot/.../aop/internal/AdviceBranch.kt
+package io.bluetape4k.leader.spring.aop.internal
+
+internal enum class AdviceBranch { SYNC, SUSPEND, MONO }
+```
+
+```kotlin
+// leader-spring-boot/.../aop/internal/AdviceMetadata.kt
+package io.bluetape4k.leader.spring.aop.internal
+
+import io.bluetape4k.leader.LockIdentity
+
+internal data class AdviceMetadata(
+    val lockName: String,
+    val failureMode: LeaderAspectFailureMode,
+    val annotationKind: LockIdentity.AnnotationKind,
+    val syncFactoryBeanName: String?,
+    val suspendFactoryBeanName: String?,
+    val groupParams: LockIdentity.GroupParams?,
+    // ... 기존 필드 (autoExtend, leaseTime 등)
+) {
+    init {
+        require((annotationKind == LockIdentity.AnnotationKind.GROUP) == (groupParams != null)) {
+            "annotationKind=$annotationKind inconsistent with groupParams=$groupParams"
+        }
+    }
+
+    fun resolveLockIdentity(branch: AdviceBranch): LockIdentity = LockIdentity(
+        lockName = lockName,
+        kind = annotationKind,
+        factoryBeanName = when (branch) {
+            AdviceBranch.SYNC -> requireNotNull(syncFactoryBeanName) {
+                "syncFactoryBeanName must be set for SYNC branch"
+            }
+            AdviceBranch.SUSPEND, AdviceBranch.MONO -> requireNotNull(suspendFactoryBeanName) {
+                "suspendFactoryBeanName must be set for SUSPEND/MONO branch"
+            }
+        },
+        groupParams = groupParams,
+    )
+}
+```
+
+```kotlin
+// leader-spring-boot/.../aop/internal/BodyThrownMarker.kt
+package io.bluetape4k.leader.spring.aop.internal
+
+/** body exception wrapper — outer catch 가 backend exception 과 구분. */
+internal class BodyThrownMarker(override val cause: Throwable) : RuntimeException(cause)
+```
+
+```kotlin
+// leader-spring-boot/.../aop/internal/CaptureInvariantException.kt
+package io.bluetape4k.leader.spring.aop.internal
+
+/** capture 누락 (spec invariant 위반) 전용 — 일반 IllegalStateException 과 구분 (R5-F3). */
+internal class CaptureInvariantException(message: String) : IllegalStateException(message)
+```
+
+- [ ] **Step 2: Write failing reentrant test**
+
+```kotlin
+// leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectReentrantTest.kt
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderElectionAspectReentrantTest {
+    private val elector: LeaderElector = mockk(relaxed = true)
+    // ... aspect setup ...
+
+    @Test
+    fun `AC-2 — same identity reentrant — backend acquire called exactly once`() {
+        // outer @LeaderElection("job-A") 안에서 inner @LeaderElection("job-A") 호출
+        // verify(exactly = 1) { elector.runIfLeaderResult("job-A", any()) }
+    }
+
+    @Test
+    fun `AC-2b — same lockName different kind (Single vs Group) — both acquire`() {
+        // outer @LeaderElection("name-X") + inner @LeaderGroupElection("name-X") — 두 elector 모두 호출
+        // verify(exactly = 1) { singleElector.runIfLeaderResult("name-X", any()) }
+        // verify(exactly = 1) { groupElector.runIfLeaderResult("name-X", any()) }
+    }
+
+    @Test
+    fun `same lockName different factoryBean — both acquire`() {
+        // factoryBeanName 이 다르면 LockIdentity 가 다르므로 passthrough 안 함
+    }
+}
+```
+
+- [ ] **Step 3: Implement `LeaderElectionAspect.aroundLeader` (sync) — 본 plan 의 핵심 구현**
+
+```kotlin
+// leader-spring-boot/.../aop/LeaderElectionAspect.kt
+private fun aroundLeader(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
+    val identity = meta.resolveLockIdentity(AdviceBranch.SYNC)
+
+    // 1) Reentrant peek — full identity (R1 / Codex F3)
+    val outer = LockStateHolder.peekSync()
+    if (outer is LeaderLockHandle.Real && outer.matchesIdentity(identity)) {
+        return LockStateHolder.withPushed(outer.withReentryDepth(outer.reentryDepth + 1)) {
+            pjp.proceed()
+        }
+    }
+
+    val elector = electorFactory.lookup(identity.factoryBeanName) as LeaderElector
+
+    /** body exception → BodyThrownMarker. elected/contention-fail-open/backend-fail-open 3 분기 모두 사용. */
+    fun proceedProtected(): Any? = try {
+        pjp.proceed()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        throw BodyThrownMarker(e)
+    }
+
+    return try {
+        when (val result = elector.runIfLeaderResult(identity.lockName) {
+            val handle = LeaderLockHandleCapture.poll()
+                ?: throw CaptureInvariantException(
+                    "elector did not capture handle — bug in ${elector::class.simpleName} (lockName=${identity.lockName})"
+                )
+            LockStateHolder.withPushed(handle) { proceedProtected() }
+        }) {
+            is LeaderRunResult.Elected -> result.value
+            is LeaderRunResult.Skipped -> when (meta.failureMode) {
+                FAIL_OPEN_RUN -> LockStateHolder.withPushed(LeaderLockHandle.failOpen(identity)) {
+                    proceedProtected()
+                }
+                SKIP, RETHROW -> null
+                INHERIT -> error("INHERIT must be resolved in resolveMetadata")
+            }
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: BodyThrownMarker) {
+        throw e.cause                // body exception 그대로 propagate
+    } catch (e: CaptureInvariantException) {
+        throw e                      // spec invariant — 절대 fail-open 분기로 흘리지 않음
+    } catch (e: Exception) {         // backend exception (Throwable 아님 — R3-F5)
+        when (meta.failureMode) {
+            FAIL_OPEN_RUN -> LockStateHolder.withPushed(LeaderLockHandle.failOpen(identity)) {
+                proceedProtected()
+            }
+            SKIP -> {
+                log.warn(e) { "backend exception in SKIP mode (lockName=${identity.lockName})" }
+                null
+            }
+            RETHROW -> throw e
+            INHERIT -> error("INHERIT must be resolved in resolveMetadata")
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Implement `aroundLeaderSuspend`**
+
+```kotlin
+private suspend fun aroundLeaderSuspendBody(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
+    val identity = meta.resolveLockIdentity(AdviceBranch.SUSPEND)
+
+    suspend fun proceedProtected(): Any? = try {
+        @Suppress("UNCHECKED_CAST")
+        suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
+            val newArgs = pjp.args.copyOf()
+            newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
+            pjp.proceed(newArgs)
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        throw BodyThrownMarker(e)
+    }
+
+    val outer = currentCoroutineContext()[LockHandleElement]?.handle as? LeaderLockHandle.Real
+    if (outer != null && outer.matchesIdentity(identity)) {
+        val passthrough = outer.withReentryDepth(outer.reentryDepth + 1)
+        return withContext(LeaderElectionInfo(identity.lockName, true) + LockHandleElement(passthrough)) {
+            proceedProtected()
+        }
+    }
+
+    val suspendElector = electorFactory.lookup(identity.factoryBeanName) as SuspendLeaderElector
+
+    return try {
+        when (val result = suspendElector.runIfLeaderResultSuspend(identity.lockName) {
+            val handle = LeaderLockHandleCapture.poll()
+                ?: throw CaptureInvariantException("suspend elector did not capture handle — bug in ${suspendElector::class.simpleName}")
+            withContext(LeaderElectionInfo(identity.lockName, true) + LockHandleElement(handle)) {
+                proceedProtected()
+            }
+        }) {
+            is LeaderRunResult.Elected -> result.value
+            is LeaderRunResult.Skipped -> when (meta.failureMode) {
+                FAIL_OPEN_RUN -> withContext(
+                    LeaderElectionInfo(identity.lockName, false) +
+                    LockHandleElement(LeaderLockHandle.failOpen(identity))
+                ) { proceedProtected() }
+                SKIP, RETHROW -> null
+                INHERIT -> error("INHERIT must be resolved")
+            }
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: BodyThrownMarker) {
+        throw e.cause
+    } catch (e: CaptureInvariantException) {
+        throw e
+    } catch (e: Exception) {
+        when (meta.failureMode) {
+            FAIL_OPEN_RUN -> withContext(
+                LeaderElectionInfo(identity.lockName, false) +
+                LockHandleElement(LeaderLockHandle.failOpen(identity))
+            ) { proceedProtected() }
+            SKIP -> { log.warn(e) { "backend exception in suspend SKIP" }; null }
+            RETHROW -> throw e
+            INHERIT -> error("INHERIT must be resolved")
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Implement Mono 분기 — `aroundLeaderMono`**
+
+```kotlin
+private fun aroundLeaderMono(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Mono<*> {
+    return Mono.defer {
+        mono(Dispatchers.Unconfined) {
+            aroundLeaderSuspendBody(pjp, meta.copy(/* MONO branch — resolveLockIdentity(MONO) 사용 */))
+        }
+    }
+    // ⚠️ KDoc: "Mono propagation 은 mono { withContext(...) { ... } } scope 안에서만 보장.
+    //   임의 Reactor operator (subscribeOn, publishOn) 후 LockAssert 호출은 미지원."
+}
+```
+
+- [ ] **Step 6: Run reentrant tests, expect PASS**
+
+```bash
+./gradlew :leader-spring-boot:test --tests "*LeaderElectionAspectReentrantTest" --no-daemon
+# Expected: PASS — AC-2 + AC-2b 검증
+```
+
+- [ ] **Step 7: Write failure mode matrix test (AC-4b)**
+
+```kotlin
+// leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectFailureModeMatrixTest.kt
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderElectionAspectFailureModeMatrixTest {
+
+    @Test fun `Skipped × RETHROW returns null`() { /* mockk Skipped → expect null */ }
+    @Test fun `Skipped × SKIP returns null`() { }
+    @Test fun `Skipped × FAIL_OPEN_RUN sentinel push + body runs + assertLocked throws`() { }
+
+    @Test fun `Exception × RETHROW rethrows`() { /* mockk throw → expect same exception */ }
+    @Test fun `Exception × SKIP returns null + WARN log`() { }
+    @Test fun `Exception × FAIL_OPEN_RUN sentinel push + body runs`() { }
+
+    @Test fun `Elected × RETHROW runs body normally`() { }
+    @Test fun `Elected × SKIP runs body normally`() { }
+    @Test fun `Elected × FAIL_OPEN_RUN runs body normally`() { }
+
+    @Test fun `body exception bypasses fail-open — propagates`() {
+        // BodyThrownMarker wrapping 검증 — fail-open 재실행 footgun 차단
+    }
+
+    @Test fun `CaptureInvariantException propagates regardless of failureMode`() {
+        // capture invariant 위반은 절대 fail-open 으로 변환되지 않음
+    }
+
+    @Test fun `OutOfMemoryError propagates (not caught by Exception clause)`() {
+        // catch (Exception) — Error 클래스 propagate 확인
+    }
+}
+```
+
+- [ ] **Step 8: Run matrix test, expect PASS**
+
+```bash
+./gradlew :leader-spring-boot:test --tests "*LeaderElectionAspectFailureModeMatrixTest" --no-daemon
+# Expected: PASS (10+ scenarios)
+```
+
+- [ ] **Step 9: Write CTW weave smoke test (AC-22)**
+
+```kotlin
+// leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectCtwWeaveSmokeTest.kt
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderElectionAspectCtwWeaveSmokeTest {
+    @Autowired lateinit var syncBean: SyncWovenBean
+    @Autowired lateinit var suspendBean: SuspendWovenBean
+    @Autowired lateinit var monoBean: MonoWovenBean
+
+    @Test fun `AC-22 — sync woven bean propagates LockHandleElement-equivalent ThreadLocal`() {
+        syncBean.protectedMethod()    // assertLocked 안에서 호출 — throw 없음 = PASS
+    }
+
+    @Test fun `AC-22 — suspend woven bean propagates LockHandleElement`() = runTest {
+        suspendBean.protectedSuspend()
+    }
+
+    @Test fun `AC-22 — Mono woven bean propagates LockHandleElement`() {
+        StepVerifier.create(monoBean.protectedMono()).verifyComplete()
+    }
+}
+
+// fixtures
+@Component class SyncWovenBean {
+    @LeaderElection(name = "smoke-sync")
+    fun protectedMethod() { LockAssert.assertLocked() }
+}
+@Component class SuspendWovenBean {
+    @LeaderElection(name = "smoke-suspend")
+    suspend fun protectedSuspend() { LockAssert.assertLockedSuspend() }
+}
+@Component class MonoWovenBean {
+    @LeaderElection(name = "smoke-mono")
+    fun protectedMono(): Mono<String> = mono { LockAssert.assertLockedSuspend(); "ok" }
+}
+```
+
+- [ ] **Step 10: Run CTW smoke test**
+
+```bash
+./gradlew :leader-spring-boot:test --tests "*LeaderElectionAspectCtwWeaveSmokeTest" --no-daemon
+# Expected: PASS (3/3) — Freefair CTW actually wove the beans
+```
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/ \
+        leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect*Test.kt
+git commit -m "feat(leader-spring-boot): T14 aspect 3-branch + reentrant + sentinel + capture invariant"
+```
+
+---
+
+## Task 15: `LeaderGroupElectionAspect` — group 분기 동일 패턴
+
+**Complexity:** high
+**Module:** `leader-spring-boot`
+**Depends on:** T14
+**Satisfies AC:** AC-1 (group), AC-2 (group reentrant), AC-5 (group sync/suspend), AC-22 (CTW weave for group)
+
+**Files:**
+- Modify: `leader-spring-boot/.../aop/LeaderGroupElectionAspect.kt`
+- Test: `leader-spring-boot/.../aop/LeaderGroupElectionAspectReentrantTest.kt`
+- Test: `leader-spring-boot/.../aop/LeaderGroupElectionAspectCtwWeaveSmokeTest.kt`
+
+- [ ] **Step 1: Write failing test — group reentrant slot reuse**
+
+```kotlin
+// leader-spring-boot/.../aop/LeaderGroupElectionAspectReentrantTest.kt
+@Test
+fun `nested @LeaderGroupElection same lockName reuses slotId — no new acquire`() {
+    val mockGroupElector: LeaderGroupElector = mockk(relaxed = true)
+    // outer 가 slotId="s1" 잡은 상태에서 inner 호출 — verify(exactly = 1) { mockGroupElector.runIfLeader(...) }
+}
+```
+
+- [ ] **Step 2: Implement `LeaderGroupElectionAspect.aroundLeaderGroup` (sync)**
+
+```kotlin
+// T14 의 aroundLeader 와 동일 패턴 — annotationKind = GROUP, factoryBean = groupFactoryBeanName
+private fun aroundLeaderGroup(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
+    val identity = meta.resolveLockIdentity(AdviceBranch.SYNC)
+    require(identity.kind == LockIdentity.AnnotationKind.GROUP) {
+        "LeaderGroupElectionAspect requires GROUP kind"
+    }
+    // ... 이후 T14 sync sketch 와 identical 로직 — proceedProtected, reentrant peek, capture invariant, fail-open
+}
+```
+
+- [ ] **Step 3: Implement `aroundLeaderGroupSuspend`** — T14 의 suspend sketch 동일.
+
+- [ ] **Step 4: Implement `aroundLeaderGroupMono`** — T14 의 Mono sketch 동일.
+
+- [ ] **Step 5: Write CTW weave smoke test (group)**
+
+```kotlin
+@Component class SyncGroupWovenBean {
+    @LeaderGroupElection(name = "smoke-sg", maxLeaders = 2)
+    fun protectedMethod() { LockAssert.assertLocked() }
+}
+// + Suspend / Mono variants
+```
+
+- [ ] **Step 6: Cross-kind dedupe blocked test (AC-2b)**
+
+```kotlin
+@Test
+fun `AC-2b — @LeaderElection + @LeaderGroupElection same lockName both acquire`() {
+    // outer SyncSingleBean (lockName="X") + inner SyncGroupBean (lockName="X")
+    // verify(exactly = 1) { singleElector.runIfLeaderResult("X", any()) }
+    // verify(exactly = 1) { groupElector.runIfLeaderResult("X", any()) }
+}
+```
+
+- [ ] **Step 7: Run group aspect tests**
+
+```bash
+./gradlew :leader-spring-boot:test --tests "*LeaderGroupElectionAspect*Test" --no-daemon
+# Expected: PASS
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt \
+        leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect*Test.kt
+git commit -m "feat(leader-spring-boot): T15 group aspect 3-branch + reentrant + sentinel"
+```
+
+---
+
+## Task 16: `LeaderAnnotationValidatorBeanPostProcessor` — `CompletableFuture`/Future/ListenableFuture 차단
+
+**Complexity:** medium
+**Module:** `leader-spring-boot`
+**Depends on:** —
+**Satisfies AC:** AC-14 (CompletableFuture validator)
+
+**Files:**
+- Modify: `leader-spring-boot/.../aop/validator/LeaderAnnotationValidatorBeanPostProcessor.kt`
+- Test: `leader-spring-boot/.../aop/validator/CompletableFutureRejectionTest.kt`
+
+- [ ] **Step 1: Write failing test**
+
+```kotlin
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CompletableFutureRejectionTest {
+
+    class CompletableFutureBean {
+        @LeaderElection(name = "cf-bad")
+        fun returnsCompletableFuture(): java.util.concurrent.CompletableFuture<String> = CompletableFuture.completedFuture("x")
+    }
+    class FutureBean {
+        @LeaderElection(name = "f-bad")
+        fun returnsFuture(): java.util.concurrent.Future<String> = CompletableFuture.completedFuture("x")
+    }
+    class ListenableFutureBean {
+        @LeaderElection(name = "lf-bad")
+        fun returnsLF(): com.google.common.util.concurrent.ListenableFuture<String> = TODO()
+    }
+
+    @Test
+    fun `strict=true throws IllegalStateException`() {
+        val validator = LeaderAnnotationValidatorBeanPostProcessor(strict = true, ...)
+        assertFailsWith<IllegalStateException> {
+            validator.postProcessBeforeInitialization(CompletableFutureBean(), "cfBean")
+        }
+    }
+
+    @Test
+    fun `strict=false logs WARN`() {
+        val validator = LeaderAnnotationValidatorBeanPostProcessor(strict = false, ...)
+        val logs = captureLogs { validator.postProcessBeforeInitialization(CompletableFutureBean(), "cfBean") }
+        logs.any { it.contains("unsupported") && it.contains("Future") } shouldBeEqualTo true
+    }
+
+    @Test fun `Future return type rejected`() { /* same pattern */ }
+    @Test fun `ListenableFuture return type rejected`() { /* same pattern */ }
+
+    @Test
+    fun `String return type not rejected`() {
+        class OkBean {
+            @LeaderElection(name = "ok") fun method(): String = "x"
+        }
+        // no throw, no WARN
+    }
+}
+```
+
+- [ ] **Step 2: Implement validator addition**
+
+```kotlin
+// leader-spring-boot/.../aop/validator/LeaderAnnotationValidatorBeanPostProcessor.kt
+private fun validateReturnType(method: Method, strict: Boolean) {
+    val rt = method.returnType
+    val forbiddenNames = setOf(
+        "java.util.concurrent.CompletableFuture",
+        "java.util.concurrent.Future",
+        "com.google.common.util.concurrent.ListenableFuture",
+    )
+    val isForbidden = forbiddenNames.any { name ->
+        try { Class.forName(name).isAssignableFrom(rt) } catch (e: ClassNotFoundException) { false }
+    }
+    if (isForbidden) {
+        val msg = "@LeaderElection on Future/CompletableFuture-returning method (${method.declaringClass.name}#${method.name}) is unsupported in v1 — lock would release before future completes."
+        if (strict) throw IllegalStateException(msg) else log.warn { msg }
+    }
+}
+```
+
+> ⚠️ `ListenableFuture` 는 Guava 의존성 optional — `Class.forName` 실패 시 silent skip.
+
+- [ ] **Step 3: Run validator test, expect PASS**
+
+```bash
+./gradlew :leader-spring-boot:test --tests "*CompletableFutureRejectionTest" --no-daemon
+# Expected: PASS (5/5)
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessor.kt \
+        leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/validator/CompletableFutureRejectionTest.kt
+git commit -m "feat(leader-spring-boot): T16 validator rejects CompletableFuture/Future/ListenableFuture returns"
+```
+
+---
+
+## Task 17: Cross-cutting integration tests — 모든 시나리오 (8 backend × failure mode × Reentrant × Watchdog × Mono × ktor)
+
+**Complexity:** high
+**Module:** `leader-spring-boot` + `leader-ktor`
+**Depends on:** T7–T16
+**Satisfies AC:** AC-1 전체, AC-4b matrix integration, AC-5 (sync/suspend/Mono 3 분기 × 2 API), AC-6 (watchdog race-free), AC-6b (watchdog override WARN), AC-9 (Mermaid 검증은 T18), AC-12 (coverage 80%+), AC-18 (CancellationException grep — 통합 점검), AC-22b (leader-ktor `leaderScheduled`)
+
+**Files:**
+- Create: `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/integration/LockExtenderCrossBackendIntegrationTest.kt`
+- Create: `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/integration/WatchdogExtenderRaceTest.kt`
+- Create: `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/integration/WatchdogOverrideWarnTest.kt`
+- Create: `leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/LeaderScheduledLockAssertSmokeTest.kt`
+- Create: `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/integration/AcGrepVerifyTest.kt`
+
+- [ ] **Step 1: Write cross-backend integration test**
+
+```kotlin
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LockExtenderCrossBackendIntegrationTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = ["lettuce", "redisson", "mongodb", "exposed-jdbc", "exposed-r2dbc", "hazelcast", "zookeeper", "local"])
+    fun `LockAssert assertLocked passes across all 8 backends`(backend: String) {
+        val bean = beanForBackend(backend)
+        bean.annotatedMethod()    // throw 없으면 통과
+    }
+}
+```
+
+- [ ] **Step 2: Write watchdog × extend race test (AC-6)**
+
+```kotlin
+class WatchdogExtenderRaceTest {
+    @Test
+    fun `AC-6 — watchdog and LockExtender concurrent — no torn writes`() {
+        // ⭐ Local backend 로 충분 — 둘 다 동일 ExtendDelegate 호출 → atomic
+        elector.runIfLeader("race-A") {
+            val barrier = CyclicBarrier(2)
+            val t1 = thread {
+                barrier.await()
+                repeat(100) { LockExtender.extendActiveLock(30.seconds) }
+            }
+            // watchdog 가 동시 호출 — torn write 없음
+            t1.join()
+            // 최종 expireAt 가 모든 호출값의 max 또는 그 사이 값 (단조 가정 X)
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Watchdog override WARN test (AC-6b)**
+
+```kotlin
+class WatchdogOverrideWarnTest {
+    @Test
+    fun `AC-6b — extendActiveLock(d) where d gt watchdog lease emits WARN + metric`() {
+        // watchdog leaseTime = 30s, LockExtender.extendActiveLock(60s) — WARN log 1회 + metric 증가
+        val logs = captureLogs {
+            elector.runIfLeader("wd-A") {
+                LockExtender.extendActiveLock(60.seconds)
+            }
+        }
+        logs.any { it.contains("lock_extender_overridden") || it.contains("watchdog will reduce") } shouldBeEqualTo true
+        // metric `lock_extender_overridden_total` increment 검증
+    }
+}
+```
+
+- [ ] **Step 4: Write leader-ktor `leaderScheduled` smoke test (AC-22b)**
+
+```kotlin
+// leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/LeaderScheduledLockAssertSmokeTest.kt
+class LeaderScheduledLockAssertSmokeTest {
+    @Test
+    fun `AC-22b — leaderScheduled background propagates LockHandleElement`() = testApplication {
+        application {
+            install(LeaderElectionPlugin) { /* config */ }
+            leaderScheduled(lockName = "ktor-bg") {
+                LockAssert.assertLockedSuspend()    // 통과해야 함
+                LockExtender.extendActiveLockSuspend(30.seconds) shouldBeEqualTo true
+            }
+        }
+        // wait for scheduled tick
+        delay(2000)
+        // 통과하면 OK
+    }
+}
+```
+
+- [ ] **Step 5: AC grep verification test (AC-7, AC-16, AC-17, AC-18, AC-21, AC-24)**
+
+```kotlin
+// leader-spring-boot/.../integration/AcGrepVerifyTest.kt
+class AcGrepVerifyTest {
+    @Test
+    fun `AC-7 — Hazelcast no plain setTtl in lock code`() {
+        val output = ProcessBuilder("rg", "-n", "\\.setTtl\\(", "leader-hazelcast/src/main/kotlin/")
+            .redirectErrorStream(true).start().inputStream.bufferedReader().readText()
+        // 0 매치 OR comments only
+        output.contains("setTtl(") shouldBeEqualTo false
+    }
+
+    @Test
+    fun `AC-16 — Lettuce group extend Lua uses server-side TIME`() {
+        val output = ProcessBuilder("rg", "-n", "redis\\.call\\('TIME'\\)", "leader-redis-lettuce/src/main/kotlin/")
+            .start().inputStream.bufferedReader().readText()
+        output.contains("redis.call('TIME')") shouldBeEqualTo true
+    }
+
+    @Test
+    fun `AC-17 — Mongo extend filter has expireAt gt now`() {
+        val output = ProcessBuilder("rg", "-n", "gt\\(\"expireAt\"|\\$gt.*expireAt", "leader-mongodb/src/main/kotlin/")
+            .start().inputStream.bufferedReader().readText()
+        output.lines().count { it.contains("expireAt") } >= 4
+    }
+
+    @Test
+    fun `AC-18 — suspend extend code has explicit CancellationException re-throw before generic catch`() {
+        // grep 패턴: runCatching|Result\.runCatching|catch\s*\(\s*(Throwable|Exception)\s*[):]
+        // 각 매칭 위치 앞에 `catch(CancellationException) { throw e }` 가 선행하는지 inspect
+        // (수동 검토 + automated grep — false positive 가능)
+    }
+
+    @Test
+    fun `AC-21 — blocking backends override extendSuspend with withContext(IO)`() {
+        val blocking = listOf("leader-redis-lettuce", "leader-redis-redisson", "leader-mongodb",
+                              "leader-exposed-jdbc", "leader-hazelcast", "leader-zookeeper")
+        blocking.forEach { mod ->
+            val anonObjs = ProcessBuilder("rg", "-cn", "object\\s*:\\s*ExtendDelegate", "$mod/src/main/kotlin/")
+                .start().inputStream.bufferedReader().readText().trim().toIntOrNull() ?: 0
+            val overrides = ProcessBuilder("rg", "-cn", "override\\s+suspend\\s+fun\\s+extendSuspend", "$mod/src/main/kotlin/")
+                .start().inputStream.bufferedReader().readText().trim().toIntOrNull() ?: 0
+            (anonObjs == overrides) shouldBeEqualTo true   // 모든 익명 객체에 override 존재
+        }
+    }
+
+    @Test
+    fun `AC-24 — leader-core does not reference backend exception classes`() {
+        val output = ProcessBuilder("rg", "-n", "io\\.lettuce\\.|org\\.redisson\\.|com\\.mongodb\\.|com\\.hazelcast\\.|org\\.apache\\.zookeeper\\.|io\\.r2dbc\\.",
+            "leader-core/src/main/kotlin/").start().inputStream.bufferedReader().readText()
+        output shouldBeEqualTo ""   // 0 매치
+    }
+}
+```
+
+- [ ] **Step 6: Run integration suite**
+
+```bash
+./gradlew :leader-spring-boot:test --tests "*IntegrationTest" --tests "*AcGrepVerifyTest" \
+          :leader-ktor:test --tests "*LeaderScheduledLockAssertSmokeTest" --no-daemon
+# Expected: PASS all
+```
+
+- [ ] **Step 7: Run full multi-module test (final gating)**
+
+```bash
+./gradlew :leader-core:test :leader-redis-lettuce:test :leader-redis-redisson:test \
+          :leader-mongodb:test :leader-exposed-jdbc:test :leader-exposed-r2dbc:test \
+          :leader-hazelcast:test :leader-zookeeper:test :leader-spring-boot:test :leader-ktor:test --no-daemon
+# Expected: PASS — full matrix 검증
+```
+
+- [ ] **Step 8: Verify Kover coverage 80%+ (AC-12)**
+
+```bash
+./gradlew koverHtmlReport --no-daemon
+# 새 코드 (LockAssert, LockExtender, LeaderLockHandle, ExtendOutcome, LockIdentity 등) coverage ≥ 80%
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/integration/ \
+        leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/
+git commit -m "test: T17 cross-backend integration + watchdog race + ktor smoke + AC grep verify"
+```
+
+---
+
+## Task 18: README — Mermaid sequenceDiagram + 8 backend "extend supported" 노트 + ktor 노트
+
+**Complexity:** medium
+**Module:** docs
+**Depends on:** T17
+**Satisfies AC:** AC-9 (Mermaid sequenceDiagram), AC-10 (KDoc 검토 — public API surface)
+
+**Files:**
+- Modify: `leader-spring-boot/README.md` + `README.ko.md` — 신규 섹션
+- Modify: 8 backend module README.md/README.ko.md — "extend supported" 한 줄
+- Modify: `leader-ktor/README.md` + `README.ko.md` — `LockAssert.assertLockedSuspend()` 사용 노트
+
+- [ ] **Step 1: Add `LockAssert & LockExtender` section to `leader-spring-boot/README.md`**
+
+```markdown
+## LockAssert & LockExtender (ShedLock-equivalent)
+
+`@LeaderElection` / `@LeaderGroupElection` 본문 안에서 ShedLock 의 `LockAssert.assertLocked()` /
+`LockExtender.extendActiveLock(Duration)` 와 동일한 ergonomic API 를 제공합니다.
+
+### Usage
+
+```kotlin
+@LeaderElection(name = "report-job", leaseTime = "30s")
+fun runReport() {
+    LockAssert.assertLocked()                              // 락 보유 확인 (sync)
+    val rows = computeReport()
+    if (rows > 100_000) {
+        LockExtender.extendActiveLock(10.minutes)          // 명시적 lease 연장
+    }
+    save(rows)
+}
+
+@LeaderElection(name = "ingest-job")
+suspend fun ingestSuspend() {
+    LockAssert.assertLockedSuspend()                       // suspend 분기
+    LockExtender.extendActiveLockSuspend(5.minutes)
+}
+```
+
+### Reentrant 의미론
+
+동일 lock identity `(lockName, kind, factoryBean)` 의 중첩 호출은 backend acquire 를 다시 호출하지 않습니다.
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant Aspect
+    participant Elector
+    participant Backend
+    Caller->>Aspect: @LeaderElection("A") outer
+    Aspect->>Elector: runIfLeaderResult("A")
+    Elector->>Backend: acquire
+    Backend-->>Elector: token=t1
+    Elector-->>Aspect: handle Real(t1)
+    Aspect->>Aspect: push to LockStateHolder
+    Aspect->>Caller: outer body runs
+    Caller->>Aspect: @LeaderElection("A") inner (reentrant)
+    Aspect->>Aspect: peekSync → matches identity
+    Aspect->>Caller: inner body runs (no backend call)
+    Caller->>Aspect: inner returns
+    Caller->>Aspect: outer returns
+    Aspect->>Backend: release(t1)
+```
+
+### Failure mode 행렬
+
+| 분기 | `RETHROW` | `SKIP` | `FAIL_OPEN_RUN` |
+|---|---|---|---|
+| `Elected` | body 실행 + lock | body 실행 + lock | body 실행 + lock |
+| `Skipped` (contention) | `null` | `null` | sentinel push + body 실행 |
+| `Exception` (backend) | throw | `null` | sentinel push + body 실행 |
+
+`FAIL_OPEN_RUN` 분기에서 `LockAssert.assertLocked()` 는 throw, `LockExtender.extendActiveLock` 는 `false` 반환.
+
+### Watchdog 와의 상호작용
+
+`autoExtend = true` 와 `LockExtender.extendActiveLock` 동시 사용은 race-free 이지만 **last-write-wins**.
+명시적 사용자 의도가 다음 watchdog tick 에서 덮어 씌워질 수 있으면 WARN log + metric (`lock_extender_overridden_total`) 발생.
+정확한 TTL 보호가 필요하면 `autoExtend = false`.
+```
+
+- [ ] **Step 2: Korean translation in `README.ko.md`** — 동일 구조 + 한국어.
+
+- [ ] **Step 3: Each backend README — "Lease extension" 한 줄**
+
+```markdown
+## Lease extension
+
+`@LeaderElection` 본문 안에서 `LockExtender.extendActiveLock(Duration)` 로 atomic 한 lease 연장 지원.
+[자세히](../leader-spring-boot/README.ko.md#lockassert--lockextender-shedlock-equivalent).
+```
+
+- [ ] **Step 4: `leader-ktor/README.md` — `leaderScheduled` 안에서 사용**
+
+```markdown
+## LockAssert in `leaderScheduled`
+
+`leaderScheduled { ... }` background action 안에서는 `LockAssert.assertLockedSuspend()` 가 정상 동작합니다.
+plugin 자체는 `Application.attributes` 만 사용 — `Application.routing` / `PipelineContext` 등 별도 표면에서는 미지원.
+```
+
+- [ ] **Step 5: Verify Mermaid syntax**
+
+```bash
+# 외부 도구 사용 가능하면 mmdc CLI 로 syntax check; 아니면 GitHub preview 확인
+# Mermaid sequenceDiagram 문법 그대로 GitHub 에서 렌더링 OK
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add leader-spring-boot/README.md leader-spring-boot/README.ko.md \
+        leader-*/README.md leader-*/README.ko.md
+git commit -m "docs: T18 LockAssert/LockExtender README + Mermaid sequenceDiagram (AC-9)"
+```
+
+---
+
+## Task 19: CHANGELOG + WIP + 3 CLAUDE.md drift fix + examples/ktor-app `LockAssertSuspend` 예제
+
+**Complexity:** low
+**Module:** docs
+**Depends on:** T18
+**Satisfies AC:** AC-13 (full build) — 빌드 통과 검증, R7-A2 drift fix
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `WIP.md`
+- Modify: `/Users/debop/work/bluetape4k/CLAUDE.md` (workspace root)
+- Modify: `/Users/debop/work/bluetape4k/bluetape4k-leader/CLAUDE.md` (project root)
+- Modify: `.worktrees/issue-79-lock-extender/leader-bom/CLAUDE.md` (worktree — 존재 시)
+- Modify: `examples/ktor-app/README.md` + 1 source file
+
+- [ ] **Step 1: Update `CHANGELOG.md`**
+
+```markdown
+## [Unreleased]
+
+### Added
+- `LockAssert.assertLocked()` / `assertLockedSuspend()` — ShedLock-equivalent 락 보유 단언 API (#79)
+- `LockExtender.extendActiveLock(Duration)` / `extendActiveLockSuspend(Duration)` — 명시적 lease 연장 API (Java `java.time.Duration` overload 포함)
+- `LockExtender.extendActiveLockDetailed` — `ExtendOutcome` sealed result (`Extended` / `NotHeld` / `WrongThread` / `BackendError`)
+- `LeaderLockHandle` sealed class (`Real` / `FailOpen`) + `LockIdentity` 4-tuple — reentrant dedupe 단위
+- `LockHandleElement: CoroutineContext.Element` — suspend / Mono propagation
+- `BackendErrorClassifier` SPI — 각 backend module 별 transient/non-transient 분류
+- 8 backend atomic `extend(Duration): ExtendOutcome` 지원
+
+### Changed
+- `LeaderLeaseAutoExtender.start(extend: (Duration) -> Boolean)` → `start(delegate: ExtendDelegate)` — watchdog 와 LockExtender 가 동일 reference 공유
+- `LeaderAnnotationValidatorBeanPostProcessor` — `CompletableFuture`/`Future`/`ListenableFuture` 반환 메서드 차단 (strict=true throw, strict=false WARN)
+- `MongoLock.extend` filter 강화 — `expireAt > now` 추가 (만료 부활 차단)
+- Lettuce group `extendSlot` Lua — server-side `redis.call('TIME')` 사용
+- Redisson single extend — owner-guarded Lua (단순 `RLock.expire` 사용 중단)
+- Hazelcast extend — `ExtendEntryProcessor` (plain `setTtl` 사용 중단)
+```
+
+- [ ] **Step 2: Update `WIP.md`**
+
+```markdown
+## Issue #79 — ShedLock-equivalent ergonomic API + reentrant + explicit lease extension ✅
+
+ShedLock 호환 ergonomic API 도입. `LockAssert.assertLocked()` / `LockExtender.extendActiveLock(Duration)` /
+reentrant `@LeaderElection` / 8 backend atomic extend 모두 v1 에서 지원.
+
+신규 API surface:
+- [`LockAssert`](leader-core/src/main/kotlin/io/bluetape4k/leader/LockAssert.kt)
+- [`LockExtender`](leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt)
+- [`ExtendOutcome`](leader-core/src/main/kotlin/io/bluetape4k/leader/ExtendOutcome.kt)
+- [`LeaderLockHandle`](leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLockHandle.kt)
+```
+
+- [ ] **Step 3: Fix CLAUDE.md drift — workspace root**
+
+`/Users/debop/work/bluetape4k/CLAUDE.md` 안의 "v1.x sync-only" / "suspend / Mono / Flux / Flow 반환 타입 미지원" 문구를 갱신:
+
+```markdown
+- `suspend` / `Mono` 반환 타입 지원 (v1.x); `Flux` / `Flow` 는 미지원
+```
+
+- [ ] **Step 4: Fix CLAUDE.md drift — project root**
+
+`/Users/debop/work/bluetape4k/bluetape4k-leader/CLAUDE.md` 의 동일 문구 갱신.
+
+- [ ] **Step 5: Fix CLAUDE.md drift — worktree (leader-bom)**
+
+worktree 안에 `leader-bom/CLAUDE.md` 존재 여부 확인 후 동일 문구 갱신:
+
+```bash
+ls .worktrees/issue-79-lock-extender/leader-bom/CLAUDE.md 2>/dev/null
+# 존재하면 동일 patch, 부재하면 skip (worktree 자체 CLAUDE.md 만 갱신)
+```
+
+- [ ] **Step 6: Add `LockAssert.assertLockedSuspend()` 예제 to `examples/ktor-app`**
+
+```markdown
+## Lock assert in Ktor
+
+`examples/ktor-app` 의 background scheduled action 안에서 `LockAssert.assertLockedSuspend()` 사용 예:
+
+```kotlin
+// examples/ktor-app/src/main/kotlin/.../Application.kt
+fun Application.module() {
+    install(LeaderElectionPlugin) { /* ... */ }
+    leaderScheduled(lockName = "ktor-bg-job", period = 30.seconds) {
+        LockAssert.assertLockedSuspend()
+        // 명시적 lease 연장이 필요하면
+        LockExtender.extendActiveLockSuspend(5.minutes)
+        runBackgroundJob()
+    }
+}
+```
+```
+
+- [ ] **Step 7: Add example source modification** — `examples/ktor-app/src/main/kotlin/.../Application.kt` 안의 background job 에 `LockAssert.assertLockedSuspend()` 한 줄 추가 (compile + runtime 검증).
+
+- [ ] **Step 8: Update `examples/ktor-app/README.md` + `README.ko.md`** — Lock assert 섹션 추가.
+
+- [ ] **Step 9: Full repo build (AC-13)**
+
+```bash
+./gradlew clean build -x test --no-daemon
+# Expected: PASS — 모든 모듈 컴파일 통과
+```
+
+- [ ] **Step 10: Final detekt check (AC-11)**
+
+```bash
+./gradlew detekt --no-daemon
+# Expected: 신규 HIGH/CRITICAL 0건
+```
+
+- [ ] **Step 11: Final commit**
+
+```bash
+git add CHANGELOG.md WIP.md \
+        /Users/debop/work/bluetape4k/CLAUDE.md \
+        /Users/debop/work/bluetape4k/bluetape4k-leader/CLAUDE.md \
+        leader-bom/CLAUDE.md \
+        examples/ktor-app/
+git commit -m "docs: T19 CHANGELOG + WIP + CLAUDE.md drift fix + ktor-app LockAssert example"
+```
+
+---
+
+## Self-Review (Author checklist — completed before handoff)
+
+### 1. Spec coverage — 29 AC mapping
+
+| AC | Tasks |
+|---|---|
+| AC-1 (capability matrix ✅ cells) | T6 (Local) + T7 (Lettuce) + T8 (Redisson) + T9 (Mongo) + T10 (JDBC) + T11 (R2DBC) + T12 (Hazelcast) + T13 (ZK) + T17 (cross-backend integration) |
+| AC-2 (reentrant counter 0) | T14 (sync aspect reentrant peek) |
+| AC-2b (cross-kind dedupe blocked) | T14 + T15 (group) |
+| AC-3 (assertLocked outside throws) | T4 (LockAssert) |
+| AC-4 (extend in fail-open returns false) | T4 (LockExtender) |
+| AC-4b (failure mode × branch matrix) | T14 (matrix test) + T17 (integration) |
+| AC-5 (sync/suspend/Mono × 2 API) | T14 + T15 + T17 |
+| AC-6 (watchdog race-free) | T17 (WatchdogExtenderRaceTest) |
+| AC-6b (watchdog override WARN) | T17 (WatchdogOverrideWarnTest) |
+| AC-7 (Hazelcast EntryProcessor, no setTtl) | T12 + T17 (grep verify) |
+| AC-8 (Redisson thread-id semantics) | T8 (RedissonThreadIdSemanticsTest) |
+| AC-9 (Mermaid sequenceDiagram) | T18 |
+| AC-10 (KDoc public surface) | T1 (handle) + T4 (LockAssert/Extender) + ongoing |
+| AC-11 (detekt zero new HIGH/CRITICAL) | T19 final check |
+| AC-12 (Kover 80%+) | T17 Step 8 |
+| AC-13 (`./gradlew build -x test`) | T19 |
+| AC-14 (validator CompletableFuture) | T16 |
+| AC-15 (delegate reference 동일성) | T5 (Local) + T7..T13 (각 backend ref test) |
+| AC-16 (Lettuce server-side TIME grep) | T7 Step 10 + T17 grep verify |
+| AC-17 (Mongo expireAt>now filter) | T9 + T17 grep verify |
+| AC-18 (suspend CancellationException re-throw) | T7 (Lettuce) + T9 (Mongo) + T11 (R2DBC) + T12 (Hazelcast) + T17 grep |
+| AC-19 (Java Duration overload) | T4 (LockExtenderJavaCompatTest) |
+| AC-20 (ZK autoExtend WARN) | T13 |
+| AC-21 (blocking backends override extendSuspend) | T7 + T8 + T9 + T10 + T12 + T13 (각 backend) + T17 grep |
+| AC-22 (CTW weave smoke) | T14 (LeaderElectionAspectCtwWeaveSmokeTest) + T15 (group variant) |
+| AC-22b (leader-ktor leaderScheduled smoke) | T17 |
+| AC-23 (per-module extendDelegate ref test) | T7..T13 (각 backend ref test) |
+| AC-24 (SPI core 의존성 역전) | T5 (core SPI) + T7..T13 (각 backend classifier) + T17 grep |
+| AC-25 (default fun bytecode) | T3 Step 6 (javap) |
+
+✅ 모든 29 AC 가 적어도 하나의 task 에 매핑됨.
+
+### 2. Placeholder scan
+
+- `simulateTransientExtend` (Step 7 T6) — abstract method, subclass override 가능 — placeholder 아님.
+- 모든 코드 step 에 실제 Kotlin/Java 코드 또는 명시적 grep/build 명령 포함.
+- "TBD"/"TODO"/"implement later" 검색: T11 Step 3 의 `runBlocking { lock.extend(d) }` 의 `// lazy fallback — sync caller 가 없으면 호출되지 않음` 주석 — 정상 (R2DBC suspend-only 의 sync fallback 의도 설명).
+- T7 Step 8 의 `TODO()` — `probeBackendExpireAt` 의 Lettuce 구체 구현 자리 — backend별 PTTL 호출이며 step text 안에 "PTTL via Lettuce" 명시. 구현자는 1줄로 채울 수 있음 (`commands.pttl(key).get()`).
+
+→ 명시적 placeholder 없음. backend별 구체 구현 부분은 spec §6 표를 참조.
+
+### 3. Type consistency
+
+- `LeaderLockHandle.real(...)` companion factory 시그니처 (T1 Step 12) 와 모든 backend 호출 시그니처 일치 — `identity, token, acquiredAtNanos, extendDelegate, slotId?, acquiringThreadId?` 순서.
+- `LockIdentity.AnnotationKind` enum: `SINGLE` / `GROUP` — T1, T14, T15 모두 동일.
+- `ExtendOutcome.Extended` 의 property 는 `observedExpireAt: Instant` (newExpireAt 아님 — R2-F5).
+- `BackendErrorClassifier.classify` 반환은 `BackendErrorKind?` (nullable, null = chain next).
+- `LeaderLeaseAutoExtender.start(enabled, leaseTime, delegate: ExtendDelegate)` — T5 변경 후 모든 backend (T7-T13) 가 동일 시그니처 사용.
+- `LeaderLockHandleCapture.poll(): LeaderLockHandle.Real?` — Real 만 캡처 (FailOpen 은 aspect 가 직접 sentinel push).
+- `AdviceMetadata.resolveLockIdentity(branch: AdviceBranch)` — T14 도입, T15 group aspect 도 동일 호출.
+- `BodyThrownMarker(override val cause: Throwable)` — non-null cause 보장, T14/T15 모두 동일 unwrap (`throw e.cause`).
+
+✅ 시그니처 일관성 확인 완료.
+
+---
+
+## Execution Handoff
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-10-lock-extender-plan.md`.**
+
+Two execution options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task with two-stage review (REQUIRED SUB-SKILL: `superpowers:subagent-driven-development`).
+2. **Inline Execution** — batch execution with checkpoints (REQUIRED SUB-SKILL: `superpowers:executing-plans`).
+
+**Critical path:** T1 → T2 → T3 → T4 → T14 → T17 → T18 → T19.
+**Parallel-eligible:** T5-T13 backend 별 (T1-T3 완료 후).
+**Estimated effort:** 19 tasks — high(6) / medium(8) / low(5).
+

--- a/docs/superpowers/plans/2026-05-10-lock-extender-plan.md
+++ b/docs/superpowers/plans/2026-05-10-lock-extender-plan.md
@@ -12,9 +12,10 @@
 
 **Critical path:** T1 → T2 → T3 → T4 → T14 → T17 → T18 → T19.
 
-**Parallel windows** (R3-Plan-R1-P3 — dependency graph 정확화):
-- T5 는 T1, T3 후 시작 (backend 의 capture/extend 가 의존)
-- T7~T13 backend tasks 는 **T5 완료 후** 병렬 가능 (단 T11 R2DBC 는 T10 JDBC 의 SQL 패턴 참조 — T10 → T11 직렬)
+**Parallel windows** (Plan-R3-P1-1 + Plan-R4-P1 — dependency graph 정확화 + handoff 동기화):
+- T5 는 T1, T3 후 시작 (BackendErrorClassifier SPI + LeaderLeaseAutoExtender signature)
+- T6 는 T4, T5 후 시작 (AbstractLockExtenderContractTest base)
+- T7~T13 backend tasks 는 **T5, T6 모두 완료 후** 병렬 가능 (단 T11 R2DBC 는 T10 JDBC 의 SQL 패턴 참조 — T10 → T11 직렬)
 - T14 는 T1~T4 모두 완료 후 시작 (LockAssert/LockExtender 사용)
 - T15 는 T14 후
 - T16 (validator) 는 T1~T4 의존 — T14 와 병렬 가능

--- a/docs/superpowers/plans/2026-05-10-lock-extender-plan.md
+++ b/docs/superpowers/plans/2026-05-10-lock-extender-plan.md
@@ -4195,3 +4195,112 @@ Two execution options:
 
 **Estimated effort:** 19 tasks — high(6) / medium(8) / low(5).
 
+---
+
+## PR Split Strategy (Step 3-P 후 결정 — Hybrid)
+
+Devil's Advocate scope challenge + Reliability isolation 권고 통합. Full scope (4-5주, 19 task) 단일 PR 위험 → **9 PR 분할**.
+
+### PR 순서 (직렬 + backend별 isolated)
+
+| PR | Tasks | Module | Effort | Goal |
+|---|---|---|---|---|
+| **PR 1 (Core)** | T1-T6 + T14-T16 + T18 (core) + T19 | leader-core + leader-spring-boot + docs | 3-4일 | SPI/sealed types/aspect/validator invariant 잠금 + Local backend + Issue #79 본질 (ShedLock ergonomic API) early delivery |
+| **PR 2** | T7 + AC-15/16/18 grep | leader-redis-lettuce | 2일 | Lettuce single + group (server-side TIME Lua) — most-used backend, SPI 검증 |
+| **PR 3** | T8 + AC-8 thread-id semantics | leader-redis-redisson | 2일 | Redisson owner-guarded Lua + group `updateLeaseTime` |
+| **PR 4** | T9 + AC-17 (`$$NOW` server-side 강화) | leader-mongodb | 1.5일 | MongoDB extend filter + group `extendSlot` |
+| **PR 5** | T10 | leader-exposed-jdbc | 1일 | Exposed JDBC extend SQL |
+| **PR 6** | T11 (T10 dependency) | leader-exposed-r2dbc | 1일 | Exposed R2DBC suspend SQL |
+| **PR 7** | T12 + AC-7 (EntryProcessor) | leader-hazelcast | 1.5일 | Hazelcast atomic extend |
+| **PR 8** | T13 + AC-20 (autoExtend=false) | leader-zookeeper | 0.5일 | ZK passthrough |
+| **PR 9** | T17 leader-ktor smoke (AC-22b) | leader-ktor | 0.5일 | leaderScheduled smoke test |
+
+**합계 ~13-14일** (full scope 4-5주 vs).
+
+### PR 1 (Core) — Critical Path
+
+- 모든 후속 PR 이 PR 1 의 invariants 의존
+- PR 1 머지 후 backend PR 들 develop rebase + 자기 backend 만 구현
+- T17 (cross-cutting integration) 는 PR 1 의 Local + Lettuce (PR 2) 머지 후 마지막 PR (또는 PR 2 안에 통합 가능)
+
+### Per-PR DoD
+
+각 PR 마다 다음 의무:
+- 해당 backend 의 `*LockExtenderContractTest` (4 capability) 통과
+- `*ExtendDelegateReferenceTest` (AC-23) 통과
+- Detekt + Kover 80%+ 신규 코드
+- README.md + README.ko.md 노트 (해당 backend)
+- KDoc 신규 public surface
+- code-reviewer (Tier 4) CRITICAL/HIGH 0 + Codex (Tier 7) P0/P1 0
+
+---
+
+## Step 3-P Top 5 Risks — Mitigation Integration (PR 1 적용)
+
+### R1 (CRITICAL) — Capture invariant silent fail-open
+
+**문제**: elector `LeaderLockHandleCapture.set()` 누락 시 → `BodyThrownMarker` 가 `CaptureInvariantException` 을 catch → silent fail-open. spec §7.1/§7.2 이미 `catch (e: CaptureInvariantException) { throw e }` 가 `BodyThrownMarker` 보다 먼저 위치.
+
+**추가 mitigation (PR 1 적용)**:
+- `internal inline fun <T> runWithCapture(handle: LeaderLockHandle.Real, action: () -> T): T` helper 추출 (`leader-core/.../internal/CaptureScope.kt`)
+- 각 elector 가 `LeaderLockHandleCapture.set/clear` 직접 호출 X → `runWithCapture(handle) { ... action ... }` 사용
+- AC 추가: `grep -r "LeaderLockHandleCapture.set" leader-*/src/main` → 0 match (CaptureScope.kt 외)
+
+### R2 (CRITICAL) — Watchdog × LockExtender split-brain
+
+**문제**: user `extend(60s)` 후 watchdog tick (lease/3) 가 `lease=30s` 로 silently override → 사용자 작업 중 lock 만료.
+
+**Mitigation (PR 1 적용)**:
+- `ExtendDelegate` interface 에 `lastExtendDeadline: AtomicReference<Instant>` 필드 추가
+- `LeaderLeaseAutoExtender` tick 마다 `now() + watchdogCadence < lastExtendDeadline.get()` 이면 backend extend 호출 skip (이미 충분히 큰 lease 보유)
+- AC-6b 강화: TestDispatcher 로 watchdog tick skip 동작 검증
+
+### R3 (HIGH) — `LockIdentity.factoryBeanName` equality deadlock
+
+**문제**: `runBlocking { @LeaderElectionSuspend }` 동일 lockName + 다른 factoryBean → 별개 identity → inner physical acquire → wait timeout deadlock.
+
+**Mitigation (PR 1 적용)**:
+- `LockIdentity.equals/hashCode` 에서 `factoryBeanName` 제거 — `(lockName, kind, groupParams)` 만 비교
+- `factoryBeanName` 은 진단 metadata 로 demote
+- AC 추가: sync→suspend 동일 lockName nested reentrant test (inner 가 backend acquire 0 호출)
+
+### R4 (HIGH) — Mongo extend filter clock authority
+
+**문제**: spec `expireAt > now` 인데 `now` 출처 미명시. Client `Instant.now()` 사용 시 clock skew → expired lock revival.
+
+**Mitigation (PR 4 적용 — leader-mongodb)**:
+- `findOneAndUpdate` aggregation pipeline `$expr: { $gt: ["$expireAt", "$$NOW"] }` server-side 강제
+- AC-17 강화: `grep "Instant.now()" leader-mongodb/src/main` → extend filter 안 0 match
+
+### R5 (HIGH) — Reactor non-suspend operator silently fail
+
+**문제**: `@LeaderElection fun foo(): Mono<X> = svc.call().map { LockAssert.assertLocked(); ... }` → ThreadLocal/CoroutineContext 둘 다 없음 → throw.
+
+**Mitigation (PR 1 적용)**:
+- `LockAssert.assertLocked()` / `LockExtender.extendActiveLock()` KDoc 명시:
+  > ⚠️ Reactor non-suspend operator (`.map`, `.filter`) 미지원. `.flatMap { mono { LockAssert.assertLockedSuspend() } }` 패턴 사용.
+- 부정 테스트 추가: `MonoReactorOperatorTest`
+  - `.map { assertLocked() }` → throw 검증
+  - `.flatMap { mono { assertLockedSuspend() } }` → 통과 검증
+
+### Additional Security Mitigations (PR 1 적용)
+
+- **S1 handle forgery**: `internal` 우회 reflection 명시 — KDoc "not a security boundary" (이미 spec). 추가: production 환경 JPMS module export 제한 권장 README
+- **S2 lockName injection**: `LeaderAnnotationValidatorBeanPostProcessor` 에 `^[a-zA-Z0-9_:\-]{1,128}$` regex validation 추가 (resolved name 검증)
+- **S4 SpEL RCE**: `SimpleEvaluationContext.forReadOnlyDataBinding().build()` 강제 — `StandardEvaluationContext` 금지
+
+### Performance Mitigations
+
+- **P1 Mongo expireAt index** (PR 4 적용): `{name: 1, token: 1, expireAt: 1}` 복합 인덱스 startup `ensureIndexes()` hook
+- **P2 watchdog double-rate**: R2 mitigation 으로 자동 해결 (lastExtendDeadline skip)
+
+---
+
+## PR 1 Implementation Scope (확정)
+
+**Tasks**: T1, T2, T3, T4, T5, T6, T14, T15, T16, T18(core), T19
+**Excluded from PR 1**: T7~T13 (backend별 후속 PR), T17 (cross-backend integration — 후속 PR 통합)
+**Estimated**: 3-4일
+
+PR 1 머지 후 → PR 2 (Lettuce) 시작.
+

--- a/docs/superpowers/plans/2026-05-10-lock-extender-plan.md
+++ b/docs/superpowers/plans/2026-05-10-lock-extender-plan.md
@@ -2447,6 +2447,20 @@ class RedissonThreadIdSemanticsTest {
 # Expected: PASS
 ```
 
+- [ ] **Step 7b: Write `RedissonExtendDelegateReferenceTest` (AC-23 — Plan-R3-P1-2)**
+
+```kotlin
+// leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonExtendDelegateReferenceTest.kt
+class RedissonExtendDelegateReferenceTest {
+    @Test fun `delegate reference shared with watchdog`() {
+        // T7 의 LettuceExtendDelegateReferenceTest 와 동일 패턴 — Redisson elector
+    }
+}
+```
+```bash
+./gradlew :leader-redis-redisson:test --tests "*ExtendDelegateReferenceTest" --no-daemon
+```
+
 - [ ] **Step 8: Commit**
 
 ```bash
@@ -2600,6 +2614,17 @@ rg -n '\$gt.*expireAt|expireAt.*\$gt' leader-mongodb/src/main/kotlin/
 # Expected: PASS
 ```
 
+- [ ] **Step 8b: Write `MongoExtendDelegateReferenceTest` (AC-23 — Plan-R3-P1-2)**
+
+```kotlin
+class MongoExtendDelegateReferenceTest {
+    @Test fun `delegate reference shared with watchdog`() { /* T7 패턴 — MongoLeaderElector */ }
+}
+```
+```bash
+./gradlew :leader-mongodb:test --tests "*ExtendDelegateReferenceTest" --no-daemon
+```
+
 - [ ] **Step 9: Commit**
 
 ```bash
@@ -2691,6 +2716,17 @@ class ExposedJdbcLockExtenderContractTest : AbstractSyncLockExtenderContractTest
 # Expected: PASS
 ```
 
+- [ ] **Step 6b: Write `ExposedJdbcExtendDelegateReferenceTest` (AC-23 — Plan-R3-P1-2)**
+
+```kotlin
+class ExposedJdbcExtendDelegateReferenceTest {
+    @Test fun `delegate reference shared with watchdog`() { /* T7 패턴 — ExposedJdbcLeaderElector */ }
+}
+```
+```bash
+./gradlew :leader-exposed-jdbc:test --tests "*ExtendDelegateReferenceTest" --no-daemon
+```
+
 - [ ] **Step 7: Commit**
 
 ```bash
@@ -2774,6 +2810,17 @@ class ExposedR2dbcSuspendGroupLockExtenderContractTest : AbstractSuspendGroupLoc
 ```bash
 ./gradlew :leader-exposed-r2dbc:test --tests "*LockExtenderContractTest" --no-daemon
 # Expected: PASS
+```
+
+- [ ] **Step 5b: Write `ExposedR2dbcExtendDelegateReferenceTest` (AC-23 — Plan-R3-P1-2)**
+
+```kotlin
+class ExposedR2dbcExtendDelegateReferenceTest {
+    @Test fun `delegate reference shared with watchdog`() { /* T7 패턴 — ExposedR2dbcSuspendLeaderElector */ }
+}
+```
+```bash
+./gradlew :leader-exposed-r2dbc:test --tests "*ExtendDelegateReferenceTest" --no-daemon
 ```
 
 - [ ] **Step 6: Commit**
@@ -2903,6 +2950,17 @@ fun `AC-7 — extend uses EntryProcessor, not setTtl`() {
 # Expected: PASS
 ```
 
+- [ ] **Step 7b: Write `HazelcastExtendDelegateReferenceTest` (AC-23 — Plan-R3-P1-2)**
+
+```kotlin
+class HazelcastExtendDelegateReferenceTest {
+    @Test fun `delegate reference shared with watchdog`() { /* T7 패턴 — HazelcastLeaderElector */ }
+}
+```
+```bash
+./gradlew :leader-hazelcast:test --tests "*ExtendDelegateReferenceTest" --no-daemon
+```
+
 - [ ] **Step 8: Commit**
 
 ```bash
@@ -2996,6 +3054,20 @@ fun `AC-20 — autoExtend=true emits WARN at startup`() {
 ```bash
 ./gradlew :leader-zookeeper:test --tests "*LockExtenderContractTest" --no-daemon
 # Expected: PASS
+```
+
+- [ ] **Step 6b: Write `ZkExtendDelegateReferenceTest` (AC-23 — Plan-R3-P1-2)**
+
+```kotlin
+class ZkExtendDelegateReferenceTest {
+    @Test fun `delegate reference shared with watchdog`() {
+        // T7 패턴 — ZkLeaderElector. ZK 는 autoExtend=false 강제이므로 watchdog.delegate 는 noop placeholder.
+        // 그래도 handle.extendDelegate === watchdog.delegate reference 일관성 검증.
+    }
+}
+```
+```bash
+./gradlew :leader-zookeeper:test --tests "*ExtendDelegateReferenceTest" --no-daemon
 ```
 
 - [ ] **Step 7: Commit**
@@ -4110,6 +4182,15 @@ Two execution options:
 2. **Inline Execution** — batch execution with checkpoints (REQUIRED SUB-SKILL: `superpowers:executing-plans`).
 
 **Critical path:** T1 → T2 → T3 → T4 → T14 → T17 → T18 → T19.
-**Parallel-eligible:** T5-T13 backend 별 (T1-T3 완료 후).
+
+**Parallel windows** (Plan-R3-P1-1 — handoff 동기화, 상단 dependency graph 와 일치):
+- T5 는 T1, T3 후 시작 (BackendErrorClassifier SPI + LeaderLeaseAutoExtender signature)
+- T6 는 T4, T5 후 시작 (AbstractLockExtenderContractTest base)
+- T7~T13 backend tasks 는 **T5, T6 완료 후** 병렬 가능
+- T11 (R2DBC) 는 T10 (JDBC) 의 SQL 패턴 참조 — T10 → T11 직렬
+- T14 는 T1~T4 모두 완료 후 시작 (LockAssert/LockExtender 사용)
+- T15 는 T14 후
+- T16 (validator) 는 T1~T4 의존 — T14 와 병렬 가능
+
 **Estimated effort:** 19 tasks — high(6) / medium(8) / low(5).
 

--- a/docs/superpowers/specs/2026-05-10-lock-extender-design.md
+++ b/docs/superpowers/specs/2026-05-10-lock-extender-design.md
@@ -1,0 +1,936 @@
+# Spec — `LockExtender` / `LockAssert` 등가 API + Reentrant `@LeaderElection` + 명시적 lease 연장
+
+> **Issue:** #79 — ShedLock-equivalent API + reentrant + explicit lease extension
+> **Date:** 2026-05-10
+> **Scope:** `leader-core`, `leader-spring-boot`, 8개 backend (Lettuce, Redisson, Mongo, Exposed JDBC/R2DBC, Hazelcast, ZooKeeper, Local)
+> **Status:** Spec — Brainstorming Step 2-A 산출물 + Round 1 review 통합 (Codex + 4 perspective)
+
+---
+
+## 0. Prerequisites (확정 사항)
+
+- [x] **AOP suspend / Mono 분기는 이미 지원됨** — `LeaderElectionAspect.aroundLeaderSuspend` (#90), `aroundLeaderMono` (#91) 가 main 에 머지된 상태. 두 CLAUDE.md (root + leader-bom) 의 "v1.x sync-only" 문구는 doc drift — 본 PR 에서 함께 갱신.
+- [x] **`runIfLeader` 반환값 contract 불변** — null 은 "리더 미선출" 의미 유지. fail-open detection 은 `result == null` 가 아닌 명시적 `LeaderRunResult { Elected, Skipped }` sealed marker 또는 `actionExecuted: AtomicBoolean` flag 사용 (Codex F1).
+- [x] **Absolute duration 채택** — `lockAtMostFor: Duration` (ShedLock 호환). Issue #79 의 "additional duration" 문구는 misnomer — §10.4 마이그레이션 가이드에 반영.
+- [x] **8 backend 모두 lock instance closure 가능** — code-architect A12 검증 완료. `LeaderElector` 인터페이스 변경 없음.
+
+---
+
+## 1. Problem Statement
+
+ShedLock 사용자가 bluetape4k-leader 로 마이그레이션할 때 **세 가지 ergonomic gap** 이 막힌다:
+
+1. **`LockAssert.assertLocked()` 부재** — 어노테이션이 정말로 락을 잡았는지 비즈니스 로직 안에서 단언할 방법이 없다.
+2. **`LockExtender.extendActiveLock(Duration)` 부재** — 작업이 예상보다 오래 걸릴 때 caller 가 명시적으로 lease 를 연장할 표준 API 가 없다. Watchdog 자동 연장(#73) 은 backend cadence 에 묶여 있고 사용자 의도를 표현하지 못한다.
+3. **Reentrant `@LeaderElection` 미정의** — 동일 lockName 으로 annotated 메서드를 중첩 호출하면 안쪽 호출이 backend 를 두 번 두드린다. 결과는 backend 별로 다르며 (Lettuce SETNX false, Mongo token 충돌 → fail-open, Redisson reentrant true) 사용자 코드는 정상으로 보이지만 race window 가 발생한다.
+
+bluetape4k-leader 의 elector 인터페이스 6개 모두 lock handle 을 외부에 노출하지 않는다. 이 캡슐화 자체는 좋지만 ShedLock 의 thread-local 기반 패턴(`LockProvider` 가 lock stack 을 ThreadLocal 에 push) 으로 정확히 대응 가능하므로, **현재 elector 인터페이스를 변경하지 않고** `LockAssert` / `LockExtender` 를 추가할 수 있다 — single source of insight.
+
+핵심 질문 (Round 1 review 결과 강화):
+- **누가 handle 을 들고 있는가?** ShedLock 답: ThreadLocal Deque. caller 는 backend 인스턴스를 만질 필요가 없다.
+- **handle 은 어떻게 backend 의 atomic extend 를 호출하는가?** Closure 로 backend lock 의 `extend(leaseTime)` 를 캡처. **suspend 백엔드는 `suspendExtendFn` 별도 보유** (Codex F2).
+- **suspend / Mono 컨텍스트는?** ThreadLocal 부정확 → `CoroutineContext.Element` 사용. **별도 `LockHandleElement`** 로 binary-compat 보존 (type T8 / Codex F5).
+
+---
+
+## 2. Goals / Non-Goals
+
+### Goals
+- ShedLock-호환 ergonomic API: `LockAssert.assertLocked()`, `LockExtender.extendActiveLock(Duration)` (Java + Kotlin sync, suspend).
+- Reentrant `@LeaderElection` / `@LeaderGroupElection` — 동일 **lock identity** (lockName + 어노테이션 종류 + factory bean + group params) 의 중첩 진입 시 backend acquire 호출은 정확히 1회 (Codex F3).
+- 8 backend 모두 atomic `extend(leaseTime: Duration): Boolean` 또는 `suspend fun extend(...)` API 구비 — token guard 필수.
+- AOP 통합: sync, suspend, Mono 3 분기에서 `LockAssert` / `LockExtender` 모두 동작.
+- Watchdog (#73) 와 race-free 공존 + **last-write-wins 가시성** (metric + WARN log).
+- Fail-open 모드 (`failureMode = FAIL_OPEN_RUN`) — contention 분기 + backend exception 분기 모두에서 sentinel push. `SKIP` 모드는 sentinel push 없이 `null` 반환, `RETHROW` 는 throw (R2-F1).
+- `@LeaderElection` 이 `CompletableFuture` 반환 메서드에 적용된 경우 **validator 가 차단** (Codex F9 / Architect A4).
+
+### Non-Goals (v1)
+- `AsyncLeaderElector.runAsyncIfLeader` 직접 호출.
+- `VirtualThreadLeaderElector.runAsyncIfLeader` 직접 호출.
+- `leader-ktor` plugin 통합 — `LockAssertSuspend` 만 자동 동작 (coroutineContext propagate). README 한 줄 노트만 추가.
+- Multi-process reentrant lock — 분산 reentrancy 비목표.
+- ShedLock `@SchedulerLock(lockAtLeastFor)` minLeaseTime override — 이미 `LeaderElectionOptions.leaseTime` + backend `minLeaseTime` 구현 (#108).
+
+---
+
+## 3. Risks / Failure Modes
+
+| # | 위험 | 영향 | 완화 |
+|---|------|------|------|
+| R1 | **Reentrant dedupe 잘못된 위치 — elector 레벨에 두면 cross-elector deadlock** | A elector 로 lock A 잡고, 같은 thread 에서 다른 elector 인스턴스로 lock A 다시 시도 → 두 번째 호출이 backend acquire 로 빠져 timeout | Aspect 레벨 + **full lock identity peek** (lockName + annotation kind + factory bean) — Codex F3 |
+| R2 | **Hazelcast `IMap.setTtl` lost-update race** | 토큰 검사 없이 TTL 만 갱신 | 반드시 `EntryProcessor` 내부에서 `(token == ours && expireAt > now)` 검사 후 atomic 갱신. plain `setTtl` 금지 + AC-7 grep verify |
+| R3 | **Redisson `RLock.expire` 의 owner-atomic 미보장** | `isHeldByThread` 검사 후 `expire` 호출 사이에 lease 만료 + 다른 thread 가 acquire → wrong owner extend | **owner-guarded Lua** (`HEXISTS k thread → HSET expire`) 사용. Redisson 내장 `RLockEntry`/`tryLockExpireAsync` 또는 자체 Lua 작성 (Codex F8) |
+| R4 | **FAIL_OPEN sentinel handle 이 real handle 로 오인** | 사용자가 silent false 보고 작업 계속 | **Sealed class `LeaderLockHandle.FailOpen` ≠ `LeaderLockHandle.Real`** — 컴파일러 exhaustive check 강제 (Type T3) |
+| R5 | **Watchdog 가 사용자 명시적 extend 를 silently 덮어쓴다** | `extendActiveLock(60s)` 직후 watchdog 이 `lease/3` 시점에 `lease=30s` 로 setExpire → 사용자 의도 60s 가 30s 로 축소 | (a) `extendActiveLock(d)` 호출 시 watchdog 활성 + `d > watchdog lease` 면 WARN log + metric `lock_extender_overridden_total` (b) AC-6b 추가: "user-extended TTL 가 watchdog 다음 tick 에서 보호" — `LeaderLeaseAutoExtender` 가 handle 의 마지막 extend deadline 검사 후 max(watchdog cadence, user deadline) 사용 |
+| R6 | **MongoDB `MongoLock.extend` 가 expired 문서 부활** | 현재 `MongoLock.extend` filter 가 `{_id, token}` 만 검사 → TTL 만료 후 cleanup 전 시점에 token 일치하면 부활 가능 (Codex F6) | filter 에 **`expireAt: { $gt: now }`** 추가 — atomic guard. 기존 `extend` 코드 수정 (private 변경 → internal + filter 강화) |
+| R7 | **Suspend → Mono ThreadLocal 누수** | aspect sync 분기에서 push 한 ThreadLocal 이 IO dispatcher carrier 에서 다른 coroutine 에 노출 | suspend `assertLockedSuspend` 는 **`coroutineContext` only** — ThreadLocal fallback 제거 (Codex F13 / SF7) |
+| R8 | **`LeaderElectionInfo` data class 변경 시 binary-compat 손상** | 외부 caller 가 `componentN()` / `copy()` 사용 중이면 NoSuchMethodError | **별도 `LockHandleElement: CoroutineContext.Element` 도입** — `LeaderElectionInfo` 무변경 (Type T8 / Codex F5). element 2개 동기화는 aspect 단일 위치에서만 수행 |
+| R9 | **`extendFn: (Duration) -> Boolean` 가 suspend 백엔드 blocking** | R2DBC / Mongo suspend / Lettuce suspend 가 `withContext(IO)` 안에서 sync 호출 시 cancellation 무시 | **`LeaderLockHandle.Real` 에 `extendFn` 과 `suspendExtendFn` 모두 보유** — sync caller 는 전자, suspend caller 는 후자. `runCatching` 금지, 명시적 `try { ... } catch(CancellationException) { throw e } catch(Exception) { ... }` (Codex F2) |
+| R10 | **`LeaderLockHandleCapture` ThreadLocal 누락 시 silent sentinel** | elector 가 set 누락하면 사용자 코드가 fail-open sentinel 로 silently 동작 → split-brain | capture 누락 = **IllegalStateException** (`error("elector did not capture handle — bug in <elector class>")`) — fail-fast (SF3 / Codex F10) |
+| R11 | **Sync extendFn Boolean 정보 손실** | 4가지 실패 (token mismatch / expired / wrong thread / backend error) 가 모두 false → 운영 분류 불가 | **`sealed class ExtendOutcome { Extended(newExpireAt), NotHeld, WrongThread, BackendError(cause) }`** 도입. `LockExtender.extendActiveLockDetailed(d): ExtendOutcome` 추가 (legacy `Boolean` API 는 wrapper 로 유지) (Type T2 / SF2) |
+| R12 | **`@LeaderElection` 이 `CompletableFuture` 반환 메서드에 적용** | aspect 가 sync 분기로 처리 → action 종료 = release 가 future 완료 전 | **`LeaderAnnotationValidatorBeanPostProcessor` 가 returnType ∈ {CompletableFuture, Future, ListenableFuture} → strict throw / non-strict WARN** (Codex F9) |
+| R13 | **Group reentrant 의미론 미정의** | `@LeaderGroupElection` 동일 lockName 중첩 호출 시 backend 동작 불명 | aspect 의 reentrant peek 은 **lockName + annotation kind 동시 일치** 시 passthrough — Single ↔ Group 간 dedupe 차단. Group nested 시 outer 의 `slotId` 재사용 (Architect A5) |
+| R14 | **Lettuce group extend Lua client-side now 시 clock skew** | acquire/release 는 `redis.call('TIME')` 사용 (#151 lessons) 인데 extend 만 client now 사용 시 unanalyzable race | extend Lua 도 **server-side `redis.call('TIME')` 사용 강제** + AC 에 grep 검증 (Codex F7 / Reviewer F5) |
+| R15 | **Java caller 가 `kotlin.time.Duration` 받음** | ShedLock Java 사용자 마이그레이션 시 API 불호환 | **`@JvmStatic` overload `extendActiveLock(java.time.Duration)`** 추가. Kotlin 사용자는 `kotlin.time.Duration` 사용 (Codex F4) |
+| R16 | **ZK + watchdog 활성 시 noop watchdog tick** | ZK 는 TTL 없음 — watchdog 가 의미 없는 noop 호출 반복 | ZK elector 는 `LeaderLeaseAutoExtender.start(enabled = false)` 강제 호출 또는 ZK extend 가 항상 `Extended(neverExpires)` 반환 (Architect A7) |
+
+---
+
+## 4. Approaches (decision-by-decision)
+
+### 4.1 Handle 노출 방식
+
+| Option | 설명 | 장점 | 단점 |
+|---|---|---|---|
+| **A. Sealed class `LeaderLockHandle { Real, FailOpen }` (chosen)** | 기존 closure-based 변형 — `Real` 은 `extendFn` + `suspendExtendFn` 보유, `FailOpen` 은 sentinel | 컴파일러 exhaustive check, sentinel ≠ Real, internal constructor → 외부 fake 차단 | data class 의 자동 `copy/equals` 손실 — 명시적 reentrantCopy 메서드 필요 |
+| B. data class + private 람다 | 단순 | `equals/hashCode` 가 람다 ref 비교 (불의미), `copy(token=...)` 외부 호출 가능 (R4 footgun) | type T1+T3+T4 high finding |
+| C. Marker interface `BackendLock` | 모든 backend lock 이 인터페이스 구현 | 정적 타입 안전 | 8 backend 침습적 |
+
+→ **A 채택** — Round 1 type T1/T3/T4 통합.
+
+### 4.2 Reentrant dedupe 위치 + identity
+
+| Option | 설명 |
+|---|---|
+| **A. Aspect 레벨 + full lock identity (chosen)** | `(lockName, annotationKind, factoryBean, groupParams)` 4-tuple 일치 시 passthrough |
+| B. Aspect + lockName only | 원래 spec — Single ↔ Group 간 잘못 dedupe (Codex F3) |
+
+→ **A 채택**.
+
+### 4.3 Suspend / Mono propagation
+
+| Option | 설명 | 장점 | 단점 |
+|---|---|---|---|
+| **A. 별도 `LockHandleElement` (chosen)** | `LeaderElectionInfo` 무변경, 새 element 추가 | binary-compat 보존, 의미 분리 명확 | aspect 가 element 2개 push (`+` 결합) |
+| B. `LeaderElectionInfo` 에 `handle` 추가 | element 1개 | data class binary-compat 손상 (R8 / Codex F5) |
+| C. `ThreadContextElement` | suspend 안에서 sync API 호출 가능 | 매 dispatch 마다 push/pop 비용 |
+
+→ **A 채택** — type T8 / Codex F5 통합.
+
+### 4.4 Fail-open 모드 동작
+
+| Option | 설명 |
+|---|---|
+| **A. Sentinel handle push (chosen)** | contention + backend exception 두 분기 모두에서 `LeaderLockHandle.FailOpen(lockName)` push |
+| B. push 안 함 — `assertLocked` IllegalStateException, `extend` false |
+| C. `assertLocked` throw, `extend` false (push 안 함) |
+
+→ **A 채택** + **backend-exception fail-open 분기 명시** (Codex F10 / Architect A2).
+
+### 4.5 ZooKeeper extend 의미
+
+→ **Passthrough `mutex.isAcquiredInThisProcess()`** + watchdog noop 강제 (R16).
+
+### 4.6 LockExtender result type
+
+| Option | 설명 |
+|---|---|
+| **A. Boolean wrapper + Detailed sealed (chosen)** | `extendActiveLock(d): Boolean` (ShedLock 호환) + `extendActiveLockDetailed(d): ExtendOutcome` 동시 노출 |
+| B. Boolean only | 정보 손실 (R11) |
+| C. Detailed only | ShedLock 1:1 호환 깨짐 |
+
+→ **A 채택** — type T2 / SF2 통합.
+
+### 4.7 Java Duration support
+
+→ **`@JvmStatic` overload `(java.time.Duration)` 추가** (R15).
+
+---
+
+## 5. API Surface
+
+### 5.1 `LockAssert` / `LockExtender` (top-level objects)
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/LockAssert.kt
+package io.bluetape4k.leader
+
+import io.bluetape4k.leader.coroutines.LockHandleElement
+import io.bluetape4k.leader.internal.LockStateHolder
+import kotlin.coroutines.coroutineContext
+
+/**
+ * 현재 컨텍스트가 활성 `@LeaderElection` / `@LeaderGroupElection` 본문 안에서 실행 중인지 단언합니다.
+ *
+ * ShedLock 의 `LockAssert.assertLocked()` 와 동일한 사용감을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 활성 lock state 없음 → [IllegalStateException]
+ * - fail-open sentinel scope → [IllegalStateException] (fail-open 본문은 락이 없는 상태)
+ * - reentrant 진입 시에도 outer 가 sentinel 이 아니면 통과
+ *
+ * ## Cross-context 동작 (suspend → sync API 호출)
+ * **suspend 컨텍스트에서는 [assertLockedSuspend] 호출**. sync `assertLocked()` 를 suspend 안에서 호출 시
+ * carrier thread 의 ThreadLocal 만 검사 → 잘못된 handle 노출 위험 (R7).
+ *
+ * ## Example
+ * ```kotlin
+ * @LeaderElection(name = "report-job")
+ * fun runReport() {
+ *     LockAssert.assertLocked()       // ✅ passes
+ * }
+ * ```
+ */
+object LockAssert {
+    @JvmStatic fun assertLocked() { ... }
+    @JvmStatic fun assertLocked(lockName: String) { ... }
+    @JvmStatic fun isLocked(): Boolean = LockStateHolder.peekSync()
+        ?.let { it !is LeaderLockHandle.FailOpen } ?: false
+    @JvmStatic fun isLocked(lockName: String): Boolean { ... }
+
+    suspend fun assertLockedSuspend() { ... }
+    suspend fun assertLockedSuspend(lockName: String) { ... }
+    suspend fun isLockedSuspend(): Boolean { ... }
+    suspend fun isLockedSuspend(lockName: String): Boolean { ... }
+
+    /** suspend 전용 — coroutineContext only, ThreadLocal fallback 없음 (R7 / Codex F13) */
+    private suspend fun currentRealHandleSuspend(): LeaderLockHandle.Real? =
+        coroutineContext[LockHandleElement]?.handle as? LeaderLockHandle.Real
+}
+```
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt
+package io.bluetape4k.leader
+
+import io.bluetape4k.leader.coroutines.LockHandleElement
+import io.bluetape4k.leader.internal.LockStateHolder
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
+import kotlin.time.toKotlinDuration
+
+/**
+ * 활성 `@LeaderElection` 컨텍스트의 lease 를 명시적으로 연장합니다.
+ *
+ * ## 동작/계약
+ * - 활성 컨텍스트 없음 → `false` 반환 + WARN log + metric `lock_extender_no_active_scope_total` (SF1)
+ * - fail-open sentinel → `false` 반환 + WARN log
+ * - backend extend 실패 → `false` (token mismatch / expired / wrong thread / backend exception)
+ * - **absolute** lease — `lockAtMostFor` 만큼 새 expire time 설정. 이슈 #79 의 "additional duration" 은 misnomer.
+ *
+ * ## Detailed result
+ * 운영 가시성이 필요하면 [extendActiveLockDetailed] 사용 — `ExtendOutcome` sealed result 반환 (R11).
+ *
+ * ## Boolean ↔ Detailed 변환 contract (R2-F6)
+ * - `extendActiveLock(d): Boolean` ≡ `extendActiveLockDetailed(d).isExtended`
+ * - `Extended` → true
+ * - `NotHeld` / `WrongThread` → false (WARN log + metric)
+ * - `BackendError` (transient — `SQLTransientException`, `MongoSocketException` 등) → false (WARN log + metric)
+ * - `BackendError` (non-transient — schema, auth) → throw (caller 가 결정)
+ *
+ * ## mismatched lockName 처리 (R2-F7)
+ * - `extendActiveLock(lockName, d)` 의 `lockName` 이 현재 active handle 과 다르면 → `false` + WARN log
+ *   ("LockExtender.extendActiveLock(name='X') called but active lock is 'Y'")
+ * - `extendActiveLockDetailed(lockName, d)` 동일 시나리오 → `NotHeld`
+ * - 오용 탐지를 원하면 `LockAssert.assertLocked(lockName)` 먼저 호출 권장
+ *
+ * ## Group elector 의미 (R2-F8)
+ * `@LeaderGroupElection` 본문 안에서 호출 시 — **현재 보유한 slot 만** 의 lease 를 연장.
+ * `lockName` 인자는 group name (전체 group 의 lockName) 이며, slotId 직접 지정 API 는 노출되지 않음.
+ * 다른 slot 의 lease 를 갱신하는 것은 token guard 로 차단 (NotHeld 반환).
+ *
+ * ## 동시성 (Watchdog × LockExtender)
+ * - 둘 다 atomic backend extend 호출 → race-free, 단 **last-write-wins**.
+ * - `extendActiveLock(d)` 호출 시 watchdog 활성 + `d > watchdog lease` → WARN + metric (R5).
+ * - 정확한 TTL 보호가 필요하면 watchdog OFF 권장 (= ShedLock 등가 모드).
+ */
+object LockExtender : KLogging() {
+    @JvmStatic fun extendActiveLock(lockAtMostFor: Duration): Boolean { ... }
+    @JvmStatic fun extendActiveLock(lockAtMostFor: java.time.Duration): Boolean =
+        extendActiveLock(lockAtMostFor.toKotlinDuration())  // R15
+    @JvmStatic fun extendActiveLock(lockName: String, lockAtMostFor: Duration): Boolean { ... }
+    @JvmStatic fun extendActiveLock(lockName: String, lockAtMostFor: java.time.Duration): Boolean =
+        extendActiveLock(lockName, lockAtMostFor.toKotlinDuration())
+
+    @JvmStatic fun extendActiveLockDetailed(lockAtMostFor: Duration): ExtendOutcome { ... }
+    @JvmStatic fun extendActiveLockDetailed(lockName: String, lockAtMostFor: Duration): ExtendOutcome { ... }
+
+    suspend fun extendActiveLockSuspend(lockAtMostFor: Duration): Boolean { ... }
+    suspend fun extendActiveLockSuspend(lockName: String, lockAtMostFor: Duration): Boolean { ... }
+    suspend fun extendActiveLockDetailedSuspend(lockAtMostFor: Duration): ExtendOutcome { ... }
+}
+```
+
+### 5.2a `LockIdentity` — full reentrant identity (R2-F3 / Codex F3)
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/LockIdentity.kt
+package io.bluetape4k.leader
+
+/**
+ * Reentrant dedupe 의 비교 단위. lockName 만으로는 Single ↔ Group 구분 불가 → full identity 필요.
+ *
+ * @property lockName SpEL 평가 후 resolved string
+ * @property kind 어노테이션 종류 — `SINGLE` (`@LeaderElection`) / `GROUP` (`@LeaderGroupElection`)
+ * @property factoryBeanName Spring bean name — 같은 lockName 이라도 다른 factory 면 별개 lock
+ * @property groupParams Group 의 maxLeaders + slot strategy 등 (Single 이면 null)
+ */
+data class LockIdentity(
+    val lockName: String,
+    val kind: AnnotationKind,
+    val factoryBeanName: String,
+    val groupParams: GroupParams? = null,
+) {
+    enum class AnnotationKind { SINGLE, GROUP }
+    data class GroupParams(val maxLeaders: Int)
+}
+```
+
+`LeaderLockHandle.Real` 와 `FailOpen` 모두 `identity: LockIdentity` 필드 보유 — `matchesIdentity(other)` 는 `this.identity == other.identity`.
+
+### 5.2b `LeaderLockHandle` (sealed class — Type T1+T3+T4)
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLockHandle.kt
+package io.bluetape4k.leader
+
+import kotlin.time.Duration
+
+/**
+ * 활성 lock 의 handle. AOP aspect 가 push 하고 `LockAssert` / `LockExtender` 가 read.
+ *
+ * ## Variants
+ * - [Real] — 실제 backend 보유. `extend()` / `extendSuspend()` 호출 가능
+ * - [FailOpen] — fail-open sentinel. extend 항상 `NotHeld` 반환
+ *
+ * 외부에서 인스턴스 생성 불가 — `internal constructor`. AOP aspect 또는 elector 만 생성.
+ */
+sealed class LeaderLockHandle {
+    abstract val identity: LockIdentity                 // ⭐ R2-F3 — full identity 필수
+    val lockName: String get() = identity.lockName
+    abstract val reentryDepth: Int
+    val isReentrant: Boolean get() = reentryDepth > 0
+    fun matchesIdentity(other: LockIdentity): Boolean = identity == other
+
+    class Real internal constructor(
+        override val identity: LockIdentity,
+        val token: String,
+        val acquiredAtNanos: Long,
+        val slotId: String? = null,
+        val acquiringThreadId: Long? = null,            // Redisson 만 non-null
+        override val reentryDepth: Int = 0,
+        internal val extendDelegate: ExtendDelegate,    // ⭐ R2-F4 — watchdog 와 reference 동일성 보장
+    ) : LeaderLockHandle() {
+        /** sync extend — `Dispatchers.IO` 호출이 필요한 backend 는 내부에서 처리. suspend caller 는 [extendSuspend] 사용. */
+        fun extend(d: Duration): ExtendOutcome = extendDelegate.extend(d)
+
+        /** suspend extend — backend 가 suspend native 면 non-blocking, 아니면 `withContext(IO)` 위임. */
+        suspend fun extendSuspend(d: Duration): ExtendOutcome = extendDelegate.extendSuspend(d)
+
+        fun isStillHeld(): Boolean = extendDelegate.isHeld()
+
+        /**
+         * Reentrant passthrough copy 생성. **inner extend 는 outer 의 `extendDelegate` 를 그대로 호출
+         * → outer/backend lease 가 갱신됨** (R2-F12 / SF11).
+         */
+        internal fun withReentryDepth(n: Int): Real {
+            require(n >= 0) { "reentryDepth must be >= 0" }
+            return Real(identity, token, acquiredAtNanos, slotId, acquiringThreadId, n, extendDelegate)
+        }
+
+        // 명시적 equals/hashCode/toString — delegate 제외, (identity, token, reentryDepth, slotId) 기반
+        override fun equals(other: Any?): Boolean { ... }
+        override fun hashCode(): Int { ... }
+        override fun toString(): String =
+            "LeaderLockHandle.Real(identity=$identity, token='$token', reentryDepth=$reentryDepth, slotId=$slotId)"
+    }
+
+    class FailOpen internal constructor(
+        override val identity: LockIdentity,            // ⭐ R2-F3 — sentinel 도 identity 보유
+    ) : LeaderLockHandle() {
+        override val reentryDepth: Int = 0
+        override fun toString(): String = "LeaderLockHandle.FailOpen(identity=$identity)"
+    }
+
+    companion object {
+        internal fun real(...): Real = Real(...)
+        internal fun failOpen(identity: LockIdentity): FailOpen = FailOpen(identity)
+    }
+}
+```
+
+### 5.3 `ExtendOutcome` (sealed result — Type T2 / R11)
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/ExtendOutcome.kt
+package io.bluetape4k.leader
+
+import java.time.Instant
+
+/**
+ * `LeaderLockHandle.Real.extend` 의 상세 결과. Boolean 시그니처는 `is Extended` 으로 단순 변환 가능.
+ */
+sealed interface ExtendOutcome {
+    /**
+     * extend 성공.
+     *
+     * @property observedExpireAt **best-effort** new expire time. backend 별 정확도 (R2-F5):
+     * - Lettuce / Hazelcast / Local: server-side 시각 사용 → 정확
+     * - Redisson: Redisson 내부 atomic — Redisson 이 client clock 사용 가능 → ±50ms
+     * - MongoDB: server-side `$set` — 정확
+     * - Exposed JDBC/R2DBC: DB server 시각 (`now()` SQL) — 정확
+     * - ZooKeeper: TTL 개념 없음 — `Instant.MAX` (session liveness)
+     *
+     * caller 는 정확한 deadline 으로 사용 X — observability/logging 용.
+     */
+    data class Extended(val observedExpireAt: Instant) : ExtendOutcome
+    data object NotHeld : ExtendOutcome              // token mismatch / lease expired / takeover
+    data object WrongThread : ExtendOutcome          // Redisson thread-bound
+    data class BackendError(val cause: Throwable) : ExtendOutcome  // transient: false 변환, non-transient: throw
+
+    val isExtended: Boolean get() = this is Extended
+}
+```
+
+### 5.3a `ExtendDelegate` — watchdog 와 LockExtender 의 단일 진입점 (R2-F4 / Architect A3)
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/internal/ExtendDelegate.kt
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import kotlin.time.Duration
+
+/**
+ * Backend lock 의 atomic extend 를 단일 reference 로 제공. `LeaderLockHandle.Real` 와
+ * `LeaderLeaseAutoExtender` (Watchdog #73) 모두 동일 `ExtendDelegate` 를 참조 — race-free.
+ *
+ * AC-15 검증: `handle.extendDelegate === watchdog.delegate` (reference 동일성).
+ */
+internal interface ExtendDelegate {
+    fun extend(lockAtMostFor: Duration): ExtendOutcome
+    suspend fun extendSuspend(lockAtMostFor: Duration): ExtendOutcome = extend(lockAtMostFor)
+    fun isHeld(): Boolean
+}
+```
+
+각 elector 가 acquire 직후 단일 `ExtendDelegate` 인스턴스 생성 → watchdog `.start(delegate = ...)` + `LeaderLockHandle.Real(extendDelegate = ...)` 둘 다 동일 reference 전달. `LeaderLeaseAutoExtender.start` 시그니처 변경 — `(Duration) -> Boolean` 람다 → `ExtendDelegate` 객체.
+
+### 5.4 Internal mechanisms
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LockStateHolder.kt
+internal object LockStateHolder {
+    private val tl: ThreadLocal<ArrayDeque<LeaderLockHandle>> = ThreadLocal.withInitial { ArrayDeque() }
+
+    fun push(handle: LeaderLockHandle) { tl.get().push(handle) }
+    fun pop(): LeaderLockHandle? = tl.get().pollFirst()
+    fun peekSync(): LeaderLockHandle? = tl.get().peekFirst()
+    fun peekSyncMatching(lockName: String): LeaderLockHandle? =
+        tl.get().firstOrNull { it.lockName == lockName }
+    fun cleanup() { if (tl.get().isEmpty()) tl.remove() }
+
+    /** push/pop 헬퍼 — 누수 차단 */
+    inline fun <R> withPushed(handle: LeaderLockHandle, block: () -> R): R {
+        push(handle); try { return block() } finally { pop(); cleanup() }
+    }
+}
+```
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderLockHandleCapture.kt
+/**
+ * Elector → Aspect 간 handle 전달용 ThreadLocal.
+ *
+ * ## 엄격한 invariant (R10)
+ * - elector 는 acquire 후 action 호출 **직전** 동일 thread 에서 [set] 호출.
+ * - aspect 는 action lambda 의 **첫 statement** 로 [poll] 호출.
+ * - capture 누락 (poll 결과 null) → IllegalStateException ("elector did not capture handle — bug")
+ *   silent fallback to FailOpen 절대 금지 (SF3 / Codex F10).
+ * - virtual thread / dispatcher hop 사이에 set/poll 분리 금지.
+ */
+internal object LeaderLockHandleCapture {
+    private val tl: ThreadLocal<LeaderLockHandle.Real?> = ThreadLocal()
+    fun set(handle: LeaderLockHandle.Real) { tl.set(handle) }
+    fun poll(): LeaderLockHandle.Real? = tl.get().also { tl.remove() }
+    fun clear() { tl.remove() }
+}
+```
+
+### 5.5 `LockHandleElement` — `CoroutineContext.Element` (R8 / Type T8)
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LockHandleElement.kt
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.leader.LeaderLockHandle
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * suspend / Mono 컨텍스트의 active lock handle. `LeaderElectionInfo` 와 별도 element —
+ * binary-compat 보존 (`LeaderElectionInfo` 무변경).
+ */
+data class LockHandleElement(val handle: LeaderLockHandle) : CoroutineContext.Element {
+    companion object Key : CoroutineContext.Key<LockHandleElement>
+    override val key: CoroutineContext.Key<*> get() = Key
+}
+```
+
+### 5.6 `LeaderElectionInfo` — **무변경**
+
+기존 2-arg data class 그대로. binary-compat 보존.
+
+### 5.7 `LeaderRunResult` — fail-open detection (Codex F1 / R2-F2)
+
+**기존 public sealed 그대로 사용**:
+
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderRunResult.kt (이미 존재, 수정 없음)
+sealed interface LeaderRunResult<out T> {
+    data class Elected<out T>(val value: T?) : LeaderRunResult<T>
+    data object Skipped : LeaderRunResult<Nothing>
+}
+```
+
+**Backend exception 처리** — `LeaderRunResult` 에 `BackendError` 추가하지 않음. Aspect 가 `runIfLeaderResult` 호출을 `try/catch` 로 감싸 backend exception 캡처 (§7.1, §7.2).
+
+**적용 범위 매트릭스** (R2-F2):
+
+| Elector 종류 | `runIfLeaderResult` | 변경 사항 |
+|---|---|---|
+| `LeaderElector` (sync) | 이미 default fun 존재 | aspect 가 `try/catch` 로 backend exception 처리 |
+| `SuspendLeaderElector` | default fun 추가 (`runIfLeaderResultSuspend`) | 동일 |
+| `LeaderGroupElector` | 이미 default fun 존재 | 동일 |
+| `SuspendLeaderGroupElector` | default fun 추가 | 동일 |
+| `AsyncLeaderElector` | 추가 안 함 (out-of-scope) | — |
+| `VirtualThreadLeaderElector` | 추가 안 함 (out-of-scope) | — |
+
+---
+
+## 6. Backend `extend` Contract Table
+
+| Backend | 파일 | 메서드 시그니처 | Atomicity 메커니즘 | 신규/기존 |
+|---|---|---|---|---|
+| **Lettuce single sync** | `leader-redis-lettuce/.../lock/LettuceLock.kt` | `fun extend(leaseTime: Duration): ExtendOutcome` | 기존 Lua `EXTEND_SCRIPT` (`IF GET k == token THEN PEXPIRE`) — server-side TTL | 기존 (반환형만 변경) |
+| **Lettuce single suspend** | `LettuceSuspendLock.kt` | `suspend fun extend(...): ExtendOutcome` | 동일 + `withContext(IO)` + `ensureActive()` | 기존 검증 |
+| **Lettuce group** | `leader-redis-lettuce/.../slot/LettuceSlotTokenGroup.kt` | `fun extendSlot(token, leaseTime): ExtendOutcome` (+ suspend variant) | **신규 Lua, server-side `redis.call('TIME')` 사용** (R14 / Codex F7): `local t=redis.call('TIME'); local nowMs=t[1]*1000+math.floor(t[2]/1000); IF ZSCORE k tok > nowMs THEN ZADD XX k (nowMs+lease) tok PEXPIRE k (lease+5000) RETURN 1 ELSE RETURN 0` | **신규** |
+| **Redisson single** | `leader-redis-redisson/.../RedissonLeaderElector.kt` 내부 `RLock` | `fun extend(...): ExtendOutcome` | **owner-guarded Lua** (`HEXISTS lock thread → HSET lock thread expire`) — `RLockEntry.expireAsync(...)` 또는 자체 Lua. 단순 `RLock.expire` 금지 (R3 / Codex F8) | **신규 Lua** |
+| **Redisson group** | `RedissonLeaderGroupElector` 내부 `RPermitExpirableSemaphore` | `fun extendPermit(permitId, leaseTime): ExtendOutcome` | 기존 `updateLeaseTime(permitId, ms, MS)` — Redisson 내부 atomic | 기존 (#151) |
+| **MongoDB single sync** | `leader-mongodb/.../lock/MongoLock.kt` | `fun extend(leaseTime: Duration): ExtendOutcome` | **filter 강화** `{_id, token, expireAt: { $gt: now } }` (R6 / Codex F6) — atomic + 만료 부활 차단 | 기존 수정 |
+| **MongoDB single suspend** | `MongoSuspendLock.kt` | `suspend fun extend(...): ExtendOutcome` | 동일 + `withContext(IO)` | 기존 수정 |
+| **MongoDB group** | `MongoLeaderGroupElector` / `MongoSuspendLeaderGroupElector` | `fun extendSlot(slotId, leaseTime): ExtendOutcome` | per-slot doc filter `{name, slotId, token, expireAt: { $gt: now } }` | **신규** (Codex F12) |
+| **Exposed JDBC single** | `leader-exposed-jdbc/.../lock/ExposedJdbcLock.kt` | `fun extend(...): ExtendOutcome` | `UPDATE leader_lock SET expire_at = now + interval WHERE name=? AND token=? AND expire_at > now()` (transient `SQLException` → `BackendError`, non-transient → propagate) | **신규** |
+| **Exposed JDBC group** | `ExposedJdbcGroupLock.kt` | `fun extendSlot(slotToken, leaseTime): ExtendOutcome` | per-slot row 동일 SQL | **신규** |
+| **Exposed R2DBC single** | `leader-exposed-r2dbc/.../lock/ExposedR2dbcLock.kt` | `suspend fun extend(...): ExtendOutcome` | 동일 SQL, R2DBC suspend transaction + `ensureActive()` | **신규** |
+| **Exposed R2DBC group** | `ExposedR2dbcGroupLock.kt` | `suspend fun extendSlot(...): ExtendOutcome` | 동일 | **신규** |
+| **Hazelcast single** | `leader-hazelcast/.../lock/HazelcastLock.kt` | `fun extend(...): ExtendOutcome` | `IMap.executeOnKey(lockKey, ExtendEntryProcessor(token, lease))` — EntryProcessor 내부 `entry.value == ours && expireAt > now → setValue(token, lease, MS) ELSE NotHeld` (R2). plain `setTtl` 금지 | **신규** |
+| **Hazelcast group / suspend** | `HazelcastSuspendLock.kt` 등 | 동일 + `withContext(IO)` | 동일 | **신규** |
+| **ZooKeeper** | `leader-zookeeper/.../ZkLeaderElector.kt` 내부 `InterProcessMutex` | `fun extend(...): ExtendOutcome` | `if (mutex.isAcquiredInThisProcess()) Extended(Instant.MAX) else NotHeld` — TTL 개념 없음, session liveness 검사. **`LeaderLeaseAutoExtender.start(enabled=false)` 강제** (R16) | **신규** passthrough |
+| **Local single** | `leader-core/.../local/LocalLeaderStateRegistry.kt` | `fun extend(name, token, leaseTime): ExtendOutcome` | `ConcurrentHashMap.compute` atomic + `expireAt > now` guard | **신규** |
+| **Local group** | `LocalLeaderGroupRegistry` (가칭) | `fun extendSlot(name, slot, leaseTime): ExtendOutcome` | 동일 | **신규** |
+
+### Backend exception policy (SF9 신규)
+
+- **Transient errors** (`SQLTransientException`, Mongo `MongoSocketException`, Redis `RedisCommandTimeoutException`, Hazelcast `RetryableHazelcastException`) → `ExtendOutcome.BackendError(cause)` 반환 + WARN log + metric.
+- **Non-transient** (`SQLException` non-transient, schema 오류, auth) → throw — caller 가 결정.
+- **`CancellationException`** → 항상 re-throw (suspend backend 의 R9 mitigation).
+
+### Watchdog interaction
+
+- 모든 backend 의 atomic extend 메서드는 watchdog (`LeaderLeaseAutoExtender.extend` lambda) 와 **동일 reference** 사용 (Architect A3 / R5):
+
+```kotlin
+// 각 elector 내부
+val extendClosure: (Duration) -> ExtendOutcome = { d -> lock.extend(d) }
+LeaderLeaseAutoExtender.start(enabled = options.autoExtend, leaseTime = options.leaseTime, extend = { d -> extendClosure(d).isExtended })
+val handle = LeaderLockHandle.real(..., extendFn = extendClosure, ...)
+```
+
+- AC 추가: `extendClosure === watchdog.extend` reference 동일 (test verify).
+
+---
+
+## 7. AOP 분기
+
+### 7.1 Sync 분기 (`aroundLeader`)
+
+```kotlin
+private fun aroundLeader(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
+    val identity = meta.resolveLockIdentity(pjp)  // (lockName, kind=SINGLE, factoryBeanId, groupParams=null)
+
+    // 1) Reentrant peek — full identity (Codex F3)
+    val outer = LockStateHolder.peekSync()
+    if (outer is LeaderLockHandle.Real && outer.matchesIdentity(identity)) {
+        return LockStateHolder.withPushed(outer.withReentryDepth(outer.reentryDepth + 1)) { pjp.proceed() }
+    }
+
+    // 2) 정상 경로 — runIfLeaderResult (internal, sealed result)
+    val elector = ... // 기존 캐시 로직
+    return when (val result = elector.runIfLeaderResult(identity.lockName, meta.options) {
+        // Elector 가 acquire 직후 LeaderLockHandleCapture.set(handle) 호출
+        val handle = LeaderLockHandleCapture.poll()
+            ?: error("elector did not capture handle — bug in ${elector::class.simpleName}")  // R10
+        LockStateHolder.withPushed(handle) { pjp.proceed() }
+    }) {
+        is LeaderRunResult.Elected -> result.value
+        is LeaderRunResult.Skipped -> when (meta.failureMode) {
+            FAIL_OPEN_RUN -> LockStateHolder.withPushed(LeaderLockHandle.failOpen(identity.lockName)) { pjp.proceed() }
+            SKIP -> null
+            RETHROW -> null  // Skipped 는 contention — 정상 흐름, throw 없음
+            INHERIT -> error("INHERIT must be resolved in resolveMetadata")
+        }
+        // backend exception (try/catch 로 캡처 — `LeaderRunResult` public sealed 에 BackendError 없음)
+    }
+} catch (e: CancellationException) {
+    throw e
+} catch (t: Throwable) {  // backend exception 분기 — Architect A2 / Codex F10 / R2-F1
+    when (meta.failureMode) {
+        FAIL_OPEN_RUN -> LockStateHolder.withPushed(LeaderLockHandle.failOpen(identity.lockName)) { pjp.proceed() }
+        SKIP -> null  // 침묵 + WARN log
+        RETHROW -> throw t
+        INHERIT -> error("INHERIT must be resolved in resolveMetadata")
+    }
+}
+```
+
+### 7.2 Suspend 분기 (`aroundLeaderSuspend`)
+
+```kotlin
+private suspend fun aroundLeaderSuspendBody(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
+    val identity = meta.resolveLockIdentity(pjp)
+
+    // 1) Reentrant peek — coroutineContext only (R7)
+    val outer = currentCoroutineContext()[LockHandleElement]?.handle as? LeaderLockHandle.Real
+    if (outer != null && outer.matchesIdentity(identity)) {
+        return withContext(LockHandleElement(outer.withReentryDepth(outer.reentryDepth + 1))) {
+            suspendBlock.startCoroutineUninterceptedOrReturn(...)
+        }
+    }
+
+    // 2) 정상 경로
+    return when (val result = suspendElector.runIfLeaderResultSuspend(identity.lockName, meta.options) {
+        val handle = LeaderLockHandleCapture.poll()
+            ?: error("suspend elector did not capture handle — bug in ${suspendElector::class.simpleName}")
+        withContext(LockHandleElement(handle)) {
+            suspendBlock.startCoroutineUninterceptedOrReturn(...)
+        }
+    }) {
+        is LeaderRunResult.Elected -> result.value
+        is LeaderRunResult.Skipped -> when (meta.failureMode) {
+            FAIL_OPEN_RUN -> withContext(LockHandleElement(LeaderLockHandle.failOpen(identity.lockName))) {
+                suspendBlock.startCoroutineUninterceptedOrReturn(...)
+            }
+            SKIP, RETHROW -> null
+            INHERIT -> error("INHERIT must be resolved")
+        }
+    }
+} catch (e: CancellationException) {
+    throw e
+} catch (t: Throwable) {  // backend exception 분기 (R2-F1)
+    when (meta.failureMode) {
+        FAIL_OPEN_RUN -> withContext(LockHandleElement(LeaderLockHandle.failOpen(identity.lockName))) {
+            suspendBlock.startCoroutineUninterceptedOrReturn(...)
+        }
+        SKIP -> null
+        RETHROW -> throw t
+        INHERIT -> error("INHERIT must be resolved")
+    }
+}
+```
+
+### 7.3 Mono 분기 (`aroundLeaderMono`)
+
+`Mono.defer { mono { aroundLeaderSuspendBody(...) } }` — suspend 분기 본문 재사용. **`mono { withContext(...) }` 안에서만 propagation 보장**. 임의 Reactor operator (`subscribeOn`, `publishOn`) 는 미보장 (Codex F14) — KDoc 명시.
+
+### 7.4 Reentrant 의미론
+
+- **동일 lock identity (lockName + kind + factoryBean)**: passthrough — backend 미접촉.
+- **다른 identity (lockName 같지만 kind 다름)**: 정상 acquire (Codex F3).
+- **Group nested**: outer 의 `slotId` 재사용 — backend 미접촉 (R13 / Architect A5).
+- **Sync ↔ Suspend cross-context**: 미지원 — sync ThreadLocal 과 suspend coroutineContext 간 fallback 없음 (R7). 사용자가 sync 안에서 `runBlocking` 등으로 suspend 호출 시 inner 는 새 acquire 시도.
+
+### 7.5 Validator 강화 (R12 / Codex F9)
+
+`LeaderAnnotationValidatorBeanPostProcessor` 에 추가:
+- `method.returnType ∈ {CompletableFuture, Future, ListenableFuture}` → strict throw / non-strict WARN.
+- 메시지: "@LeaderElection on Future/CompletableFuture-returning method is unsupported in v1 — lock would release before future completes."
+
+### 7.6 Elector 변경 사항
+
+각 backend elector 의 **internal** `runIfLeaderResult(name, options): LeaderRunResult<T>` 를 추가 (공개 `runIfLeader` 인터페이스는 무변경 — `runIfLeaderResult` 결과를 `Elected.value` 또는 `null` 로 변환).
+
+acquire 직후 `LeaderLockHandleCapture.set(handle)` 호출 — **action lambda 호출 직전, 동일 thread**. action 종료 후 `clear()` (try/finally).
+
+영향받는 elector 파일 (Codex F3, A1 검증 완료):
+- Local: `LocalLeaderElector`, `LocalSuspendLeaderElector`, `LocalLeaderGroupElector`, `LocalSuspendLeaderGroupElector`, `LocalVirtualThreadLeaderElector`, `LocalVirtualThreadLeaderGroupElector`, `LocalAsyncLeaderElector`, `LocalAsyncLeaderGroupElector`
+- Lettuce: `LettuceLeaderElector`, `LettuceSuspendLeaderElector`, `LettuceLeaderGroupElector`, `LettuceSuspendLeaderGroupElector`
+- Redisson: `RedissonLeaderElector`, `RedissonSuspendLeaderElector`, `RedissonLeaderGroupElector`, `RedissonSuspendLeaderGroupElector`
+- MongoDB: `MongoLeaderElector`, `MongoSuspendLeaderElector`, `MongoLeaderGroupElector`, `MongoSuspendLeaderGroupElector`
+- Exposed JDBC/R2DBC: `ExposedJdbcLeaderElector`, `ExposedR2dbcSuspendLeaderElector`, group variants
+- Hazelcast: `HazelcastLeaderElector`, `HazelcastSuspendLeaderElector`, group variants
+- ZK: `ZkLeaderElector`, `ZkSuspendLeaderElector`, group variants
+
+---
+
+## 8. Test Strategy
+
+### 8.1 4 Abstract Contract Bases (Architect A6 / Codex F15)
+
+```kotlin
+abstract class AbstractSyncLockExtenderContractTest {
+    abstract val elector: LeaderElector
+    abstract fun probeBackendExpireAt(lockName: String): Instant?
+    @Test fun `assertLocked passes inside annotated body`() { ... }
+    @Test fun `assertLocked throws outside body`() { ... }
+    @Test fun `extend returns true when held — TTL updated`() { ... }
+    @Test fun `extend returns false after release`() { ... }
+    @Test fun `extend returns false after lease expiry (takeover)`() { ... }
+    @Test fun `extend returns false after token mismatch (other node took over)`() { ... }
+    @Test fun `concurrent extends are race-free, last-write-wins`() { ... }
+    @Test fun `extendActiveLockDetailed returns BackendError on transient failure`() { ... }
+    @Test fun `assertLocked with mismatched lockName throws`() { ... }
+}
+abstract class AbstractSuspendLockExtenderContractTest { ... + cancellation tests }
+abstract class AbstractGroupLockExtenderContractTest { ... + slot identity }
+abstract class AbstractSuspendGroupLockExtenderContractTest { ... }
+```
+
+**Backend × Contract Capability Matrix** (R2-F9):
+
+| Backend | sync | suspend | group | suspend-group | 비고 |
+|---|:-:|:-:|:-:|:-:|---|
+| Local | ✅ | ✅ | ✅ | ✅ | virtual-thread / async 도 sync base 재사용 |
+| Lettuce | ✅ | ✅ | ✅ | ✅ | |
+| Redisson | ✅ | ✅ | ✅ | ✅ | sync base 에 cross-thread test 추가 |
+| MongoDB | ✅ | ✅ | ✅ | ✅ | suspend native — sync 는 `runBlocking` wrap |
+| Exposed JDBC | ✅ | — | ✅ | — | R2DBC 와 분리 — sync 만 |
+| Exposed R2DBC | — | ✅ | — | ✅ | suspend 만 |
+| Hazelcast | ✅ | ✅ | ✅ | ✅ | |
+| ZooKeeper | ✅ | ✅ | ✅ | ✅ | extend = passthrough; AC-20 watchdog noop |
+
+unsupported 행은 concrete test class 부재 (skip 아님). matrix 자체가 AC-1 검증 단위.
+
+각 backend 모듈에 해당 capability 의 concrete 테스트 서브클래스 추가:
+- `LettuceLockExtenderContractTest` (sync), `LettuceSuspendLockExtenderContractTest`, `LettuceLockExtenderGroupContractTest`, `LettuceSuspendGroupLockExtenderContractTest`
+- 기타 backend 도 동일 패턴 (matrix 의 ✅ 행만)
+
+### 8.2 Cross-cutting integration tests (`leader-spring-boot`)
+
+| Scenario | 검증 |
+|---|---|
+| `LockAssert.assertLocked()` × `@LeaderElection` × 8 backend × sync/suspend/Mono | passes |
+| Reentrant `@LeaderElection` same identity, same thread | inner acquire counter 증가 0 (mockk verify) |
+| Reentrant cross-elector 동일 lockName 다른 factoryBean | 정상 acquire (passthrough 안 함) — Codex F3 |
+| `@LeaderElection` ↔ `@LeaderGroupElection` 동일 lockName nested | 둘 다 정상 acquire (kind 다름) |
+| Group nested same lockName | inner slotId 재사용, acquire 0 |
+| FAIL_OPEN_RUN — contention 분기 | sentinel push, `assertLocked` throw, `extend` `false` |
+| FAIL_OPEN_RUN — backend exception 분기 | 동일 (Architect A2) |
+| Suspend `assertLockedSuspend` ThreadLocal fallback 제거 검증 | sync ThreadLocal push 후 suspend `assertLockedSuspend` 호출 → IllegalStateException |
+| Watchdog 활성 + `extendActiveLock(60s)` (lease=30s) | WARN log 1회 + metric `lock_extender_overridden_total` 증가 |
+| Redisson cross-carrier-thread extend | `WrongThread` outcome + WARN |
+| Hazelcast EntryProcessor — stale token | `NotHeld` outcome (lost-update 방지) |
+| ZK extend — session live | `Extended(Instant.MAX)` |
+| ZK + autoExtend=true | startup WARN + watchdog noop |
+| `@LeaderElection` on `CompletableFuture` 반환 메서드 | strict=true → IllegalStateException at startup, strict=false → WARN |
+| Mono propagation: arbitrary Reactor `publishOn` 후 `assertLockedSuspend` | undefined — 미지원 명시 (Codex F14) |
+| `LockExtender.extendActiveLock(d)` cancellation | `CancellationException` re-throw — `runCatching` 사용 0회 (grep verify) |
+
+### 8.3 테스트 도구 준수
+- JUnit 5 + MockK + bluetape4k-assertions, `@TestInstance(PER_CLASS)`, suspend → `runTest`, 예외 → `assertFailsWith<T> { }`, Testcontainers singleton.
+
+---
+
+## 9. Acceptance Criteria
+
+- [ ] **AC-1**: 8 backend × {sync, suspend, group, suspend-group} 모두 해당 contract test 통과 (capability 매트릭스 만족 — ZK 는 group 미지원, R2DBC 는 sync 미지원 등 명시).
+- [ ] **AC-2**: `@LeaderElection` 동일 full-identity reentrant 호출 시 backend acquire counter 정확히 1회 (mockk verify).
+- [ ] **AC-2b**: `@LeaderElection` ↔ `@LeaderGroupElection` 동일 lockName 은 dedupe 안 됨 — 둘 다 정상 acquire (Codex F3).
+- [ ] **AC-3**: `LockAssert.assertLocked()` annotated 외부 호출 시 IllegalStateException (메시지에 "outside" / "no active scope" 포함).
+- [ ] **AC-4**: `LockExtender.extendActiveLock(d)` 가 fail-open sentinel scope 에서 `false` + WARN 로그 + metric (rate-limited).
+- [ ] **AC-4b**: backend exception 분기 × failureMode 행렬 검증 (Architect A2 / R2-F1):
+  - `FAIL_OPEN_RUN` → sentinel push + body 실행
+  - `SKIP` → null + WARN log, body 미실행
+  - `RETHROW` → throw, body 미실행
+  - 동일 행렬을 `Skipped` (contention) 분기에도 적용
+- [ ] **AC-5**: Sync, suspend, Mono 3 분기 모두 `LockAssert` / `LockExtender` 동작 (각 분기 × 2 API = 6).
+- [ ] **AC-6**: Watchdog 활성 + `extendActiveLock` 동시 호출 race-free — torn write 0 (TTL 가 두 마지막 호출의 최댓값 또는 그 사이 값, 단조 가정 X).
+- [ ] **AC-6b**: watchdog cadence 다음 tick 에서 user-extended 큰 값이 watchdog 작은 값으로 silently 줄어들 때 WARN log + metric (R5 / SF5).
+- [ ] **AC-7**: Hazelcast extend 는 EntryProcessor 사용 — plain `setTtl` 호출 0회 (소스 grep + Mockk verify).
+- [ ] **AC-8**: Redisson extend thread-id semantics (R2-F11):
+  - `acquiringThreadId` = `Thread.currentThread().threadId()` at acquire time
+  - `extend(d)` 시 `Thread.currentThread().threadId() != acquiringThreadId` → `WrongThread` outcome + WARN
+  - 시나리오 검증: (a) virtual thread carrier hop, (b) `Dispatchers.IO` hop, (c) `mono { withContext(IO) }` 모두에서 thread-id mismatch 시 WrongThread
+  - KDoc: "Redisson `RLock` 은 acquire 한 platform/virtual thread 와 동일 thread 에서만 explicit extend 가능. dispatcher hop 시 WrongThread 가능"
+- [ ] **AC-9**: README + README.ko.md (`leader-spring-boot`) — Mermaid sequenceDiagram 포함 reentrant 시나리오.
+- [ ] **AC-10**: `LockAssert`, `LockExtender`, `LeaderLockHandle.Real`, `LeaderLockHandle.FailOpen`, `ExtendOutcome` 의 모든 public 멤버 KDoc + `## 동작/계약` + `kotlin` 예제.
+- [ ] **AC-11**: `./gradlew detekt` 통과 — 신규 HIGH/CRITICAL 0건.
+- [ ] **AC-12**: Kover coverage 신규 코드 80%+.
+- [ ] **AC-13**: `./gradlew build -x test` 로컬 빌드 통과.
+- [ ] **AC-14**: `LeaderAnnotationValidatorBeanPostProcessor` — `CompletableFuture` 반환 메서드 strict=true → throw, strict=false → WARN (Codex F9).
+- [ ] **AC-15**: 각 backend elector 가 동일 `ExtendDelegate` 객체를 watchdog (`LeaderLeaseAutoExtender.start(delegate=...)`) 와 `LeaderLockHandle.Real.extendDelegate` 양쪽에 전달 — `handle.extendDelegate === watchdog.delegate` 검증 (test verify) (R5 / Architect A3 / R2-F4).
+- [ ] **AC-16**: Lettuce group extend Lua — `redis.call('TIME')` 사용 검증 (소스 grep) (R14).
+- [ ] **AC-17**: Mongo extend filter `expireAt: { $gt: now }` 포함 검증 (소스 inspect) (R6 / Codex F6).
+- [ ] **AC-18**: suspend extend 구현에서 `CancellationException` first-class re-throw 검증 (R2-F10):
+  - grep 패턴: `runCatching|Result\.runCatching|catch\s*\(\s*(Throwable|Exception)\s*[):]`
+  - 매칭된 모든 위치에 `catch(CancellationException) { throw e }` 가 선행하는지 inspect
+  - helper 함수 안에 swallow 된 케이스도 점검
+- [ ] **AC-19**: Java caller 가 `LockExtender.extendActiveLock(java.time.Duration)` 호출 가능 — `LockExtenderJavaCompatTest` (R15).
+- [ ] **AC-20**: ZK + autoExtend=true 시 startup WARN — watchdog noop (R16).
+
+---
+
+## 10. Migration / Compatibility
+
+### 10.1 Source-compat
+- 모든 elector 인터페이스 무변경.
+- `LeaderElectionInfo` 무변경 — 별도 `LockHandleElement` 추가 (R8 / Type T8).
+- `LockAssert`, `LockExtender`, `LeaderLockHandle`, `ExtendOutcome` 모두 신규 — 추가 only.
+
+### 10.2 Binary-compat
+- `LeaderElectionInfo` data class 무변경 — `componentN()` / `copy()` ABI 유지.
+- `MongoLock.token` private → internal — 같은 모듈 내부만 영향.
+- `LeaderLockHandle` 는 신규 sealed class — 외부 영향 없음.
+
+### 10.3 v0.x → v1.x 마이그레이션 (Architect A10)
+- AOP 미사용자: 영향 없음 (top-level objects 추가만).
+- AOP 사용자: 자동 활성. `@LeaderElection` 동작 유지 + 추가로 `LockAssert`/`LockExtender` 사용 가능.
+- Watchdog ON + LockExtender 사용: last-write-wins 권고 — watchdog OFF 또는 user lease 보호 patch (R5).
+
+### 10.4 ShedLock 사용자 마이그레이션
+```java
+// ShedLock (2-arg)
+LockExtender.extendActiveLock(Duration.ofMinutes(5), Duration.ofSeconds(10));
+
+// bluetape4k-leader (1-arg, absolute)
+LockExtender.extendActiveLock(Duration.ofMinutes(5));
+// ⚠️ Semantics differ: ShedLock 의 `lockAtLeastFor` 는 bluetape4k 의
+//   LeaderElectionOptions.minLeaseTime (별도 backend mechanism, #108) 로 대체.
+```
+
+---
+
+## 11. Documentation Plan
+
+- **`leader-spring-boot/README.md` + `README.ko.md`** — 신규 섹션 "LockAssert & LockExtender (ShedLock-equivalent)" + Mermaid sequenceDiagram.
+- 8 backend 모듈 README — "extend now supported" 한 줄 노트.
+- **`leader-ktor/README.md`** — 한 줄 노트: "plugin 안에서 `LockAssert.assertLockedSuspend()` 사용 가능" (Architect A8).
+- KDoc — 모든 신규 public surface + `ExtendOutcome` variants.
+- **CHANGELOG.md** — `LockHandleElement` 추가, `LockAssert`/`LockExtender` API 신규, validator `CompletableFuture` 차단, watchdog × extend 가시성 (Architect A9).
+- **`WIP.md`** — Issue #79 완료 표시.
+- **CLAUDE.md (root + leader-bom)** — "v1.x sync-only" 문구 → "suspend + Mono 지원, Flux/Flow 미지원" 으로 갱신 (Architect A11).
+- **`docs/lessons/2026-05-10-lock-extender.md`** — PR merge 후: Hazelcast EntryProcessor 함정, Redisson owner-Lua, capture invariant, sealed `ExtendOutcome` 도입, ShedLock semantics divergence.
+
+---
+
+## 12. Draft Task List
+
+| ID | Task | Complexity | Depends |
+|---|---|---|---|
+| **T1** | `LeaderLockHandle` sealed class (Real / FailOpen) + internal constructor + `ExtendOutcome` sealed result + `LockStateHolder` + `LeaderLockHandleCapture` (`leader-core`) | medium | — |
+| **T2** | `LockHandleElement` (`CoroutineContext.Element`) 신규 — `LeaderElectionInfo` 무변경 (`leader-core`) | low | T1 |
+| **T3** | `LeaderRunResult<T>` internal sealed (`leader-core`) | low | T1 |
+| **T4** | `LockAssert` / `LockExtender` top-level objects + Java `java.time.Duration` overload + `extendActiveLockDetailed` + KDoc (`leader-core`) | medium | T1, T2 |
+| **T5** | Local elector — capture + `runIfLeaderResult` internal + `LocalLeaderStateRegistry.extend` (`leader-core`) | medium | T1, T3 |
+| **T6** | 4 abstract contract bases (sync/suspend/group/suspend-group) + Local 4 concrete tests (`leader-core`) | medium | T4, T5 |
+| **T7** | Lettuce — single sync/suspend `extend` 반환형 변경 + group `extendSlot` Lua (server-side TIME) + capture + `runIfLeaderResult` (`leader-redis-lettuce`) | high | T1, T3 |
+| **T8** | Redisson — owner-guarded Lua single + group `updateLeaseTime` + thread-id 가드 + capture (`leader-redis-redisson`) | high | T1, T3 |
+| **T9** | MongoDB — extend filter 강화 (`expireAt > now`) + group `extendSlot` 신규 + capture (`leader-mongodb`) | medium | T1, T3 |
+| **T10** | Exposed JDBC — `extend` SQL + group `extendSlot` SQL + capture (`leader-exposed-jdbc`) | medium | T1, T3 |
+| **T11** | Exposed R2DBC — suspend SQL + capture (`leader-exposed-r2dbc`) | medium | T10 |
+| **T12** | Hazelcast — `ExtendEntryProcessor` 신규 + capture (`leader-hazelcast`) | high | T1, T3 |
+| **T13** | ZooKeeper — passthrough + autoExtend=false 강제 + capture (`leader-zookeeper`) | low | T1, T3 |
+| **T14** | `LeaderElectionAspect` — sync/suspend/Mono 3 분기 + reentrant peek (full identity) + sentinel push (contention + backend exception) + `runIfLeaderResult` 사용 (`leader-spring-boot`) | high | T1, T2, T3 |
+| **T15** | `LeaderGroupElectionAspect` — group 분기 동일 패턴 (`leader-spring-boot`) | high | T14 |
+| **T16** | `LeaderAnnotationValidatorBeanPostProcessor` — `CompletableFuture` 반환 fail-fast (`leader-spring-boot`) | medium | — |
+| **T17** | 통합 테스트 — 모든 시나리오 (`leader-spring-boot` + 각 backend 모듈 contract) | high | T7–T16 |
+| **T18** | README (`leader-spring-boot/README.md` + `.ko.md`) + Mermaid sequenceDiagram + 8 backend README 노트 + `leader-ktor` 노트 | medium | T17 |
+| **T19** | CHANGELOG.md + WIP.md 업데이트 + 두 CLAUDE.md drift 수정 (root + leader-bom) | low | T18 |
+
+**Critical path**: T1 → T4 → T14 → T17 → T18 → T19. T7–T13 backend 별 병렬 가능 (T1 완료 후).
+
+---
+
+## Appendix A — Round 1 Review 통합 (Codex + 4 perspective)
+
+총 63 finding (P0×2, P1×30, P2×13, P3×0, low ~12, low-priority/observational ×6).
+
+### 적용된 P0/P1/HIGH (32개 → spec 본문 반영)
+
+- **Codex F1** (P0) → §0, §5.7 `LeaderRunResult`, §7.1/§7.2
+- **Codex F2** (P0) → §3 R9, §5.2 `suspendExtendFn`, §6 표
+- **Codex F3** (P1) → §3 R1, §4.2, §7.1, AC-2/2b
+- **Codex F4** (P1) → §3 R15, §5.1 Java overload, AC-19
+- **Codex F5 / Type T8** (P1/HIGH) → §3 R8, §4.3 별도 element, §5.5/§5.6
+- **Codex F6** (P1) → §3 R6, §6 Mongo filter, AC-17
+- **Codex F7 / Reviewer F5** (P1/HIGH) → §3 R14, §6 Lettuce group Lua, AC-16
+- **Codex F8** (P1) → §3 R3, §6 Redisson owner-Lua
+- **Codex F9 / Architect A4** (P1/HIGH) → §3 R12, §7.5, AC-14
+- **Codex F10 / Architect A2 / SF3** (P1/HIGH) → §3 R10, §7.1 backend-exception sentinel, AC-4b
+- **Codex F11 / Architect A1 / SF7 / Type T9** (P1/HIGH) → §3 R10, §5.4 strict invariant
+- **Codex F12** (P1) → §6 Mongo group row 추가
+- **Codex F13 / SF7 / Reviewer F7** (P2/HIGH) → §3 R7, §5.1 ThreadLocal fallback 제거
+- **Codex F14** (P2) → §7.3 Mono propagation 한정
+- **Codex F15 / Architect A6** (P2/MEDIUM) → §8 4 contract bases, AC-1 capability matrix
+- **Codex F16 / Type T1+T3+T4** (P2/HIGH) → §4.1 sealed class, §5.2 internal constructor
+- **Type T2 / SF2** (HIGH) → §3 R11, §5.3 `ExtendOutcome`, §5.1 detailed API
+- **Type T8** (MEDIUM) → §4.3 별도 element 결정
+- **Reviewer F1 / Architect A11** (HIGH/LOW) → §0, §11 CLAUDE.md drift
+- **Reviewer F6 / SF5** (HIGH) → §3 R5, AC-6b
+- **SF1** (HIGH) → §5.1 KDoc 명시 + WARN + metric
+- **SF4** (HIGH) → §6 backend exception policy + AC-18
+- **SF8** (MEDIUM) → 별도 element 결정으로 자동 해결 (Codex F5 / Type T8)
+- **SF9** (MEDIUM) → §6 backend exception policy 추가
+- **SF10** (MEDIUM) → AC-4 rate-limited
+- **SF11** (MEDIUM) → §5.2 `withReentryDepth` KDoc 명시 (passthrough extend = outermost lease 갱신)
+- **SF12** (MEDIUM) → §7.4 detection 로직 명시
+- **Architect A3** (HIGH) → §6 watchdog reference 동일 + AC-15
+- **Architect A5** (MEDIUM) → §3 R13, §7.4 group reentrant
+- **Architect A7** (MEDIUM) → §3 R16, §6 ZK row + AC-20
+- **Architect A8** (MEDIUM) → §11 leader-ktor README 노트
+- **Architect A9** (LOW) → §11 CHANGELOG + WIP
+- **Architect A10** (LOW) → §10.3 마이그레이션
+
+### 미적용 (의도적)
+
+- **Type T5** (MEDIUM, threadId nullable) — sealed class 채택으로 자연스럽게 Real 안에 포함 — 별도 marker 도입 안 함 (overhead).
+- **Type T7** (MEDIUM, reentryDepth Int) — sealed class + `withReentryDepth(n)` 의 `require(n >= 0)` 로 충분.
+- **Type T10** (LOW, `checkLocked`) — `isLocked()` 로 채택 (§5.1 query API 포함).
+- **Type T11** (LOW, withPushed helper) — §5.4 에 `inline fun withPushed` 헬퍼 추가됨.
+- **Codex F16 분리** — 위 sealed class 결정에 통합.
+- **SF13** (LOW, `error()` 메시지) — 적용 가능하지만 spec 변경 불필요 (구현 시 메시지에 lockName/token 포함).
+
+## Appendix B — Round 2 Review 통합 (Codex 단독)
+
+총 12 finding (P0×1, P1×4, P2×6, P3×1).
+
+### 적용 (12개 모두)
+
+- **R2-F1** (P0) → §0, §2 Goals, §7.1/7.2 failure mode 매트릭스, AC-4b — `LEADERLESS_RUN` → `FAIL_OPEN_RUN` 전역 수정 + `Skipped`/exception × `RETHROW`/`SKIP`/`FAIL_OPEN_RUN` 행렬
+- **R2-F2** (P1) → §5.7 — 기존 public `LeaderRunResult { Elected, Skipped }` 재사용, `BackendError` variant 추가 안 함, aspect `try/catch` 로 backend exception 처리, 적용 범위 매트릭스
+- **R2-F3** (P1) → §5.2a `LockIdentity` 신규, §5.2b `Real`/`FailOpen` 모두 `identity` 필드, §7.1/7.2 `matchesIdentity` 호출
+- **R2-F4** (P1) → §5.3a `ExtendDelegate` interface 신규, AC-15 wording 변경 (reference 동일성 검증)
+- **R2-F5** (P1) → §5.3 `ExtendOutcome.Extended.observedExpireAt` (best-effort + backend별 정확도 정책)
+- **R2-F6** (P2) → §5.1 `LockExtender` KDoc — Boolean ↔ Detailed 변환 contract 명시
+- **R2-F7** (P2) → §5.1 `LockExtender` KDoc — mismatched lockName 처리 명시 (false + WARN / `NotHeld`)
+- **R2-F8** (P2) → §5.1 `LockExtender` KDoc — group 의미 명시 (현재 slot 만 갱신)
+- **R2-F9** (P2) → §8.1 backend × contract capability matrix 추가 (ZK group 포함)
+- **R2-F10** (P2) → AC-18 grep 패턴 확장 (`runCatching|Result\.runCatching|catch\s*\(\s*(Throwable|Exception)`)
+- **R2-F11** (P2) → AC-8 Redisson thread-id semantics 명시 (virtual thread / IO hop / mono 시나리오)
+- **R2-F12** (P3) → §5.2b `withReentryDepth` KDoc — passthrough extend = outermost lease 갱신 명시
+
+### Round 2 결정 기록
+
+13. **`LockIdentity` 도입** — `(lockName, kind, factoryBeanName, groupParams)` 4-tuple 으로 reentrant dedupe.
+14. **`ExtendDelegate` interface 단일 reference** — watchdog 와 LockExtender 가 동일 객체 공유.
+15. **`Extended.observedExpireAt`** — `newExpireAt` 명칭 변경 (best-effort 명시), backend별 정확도 정책.
+16. **`LeaderRunResult` 변경 없음** — backend exception 은 aspect `try/catch` 로 처리 (public sealed 무변경).
+17. **failure mode 행렬 명시적 처리** — `Skipped`/exception × `RETHROW`/`SKIP`/`FAIL_OPEN_RUN` 모든 cell 정의.
+
+---
+
+### 결정 기록 (Round 1 후)
+
+1. **Sealed class `LeaderLockHandle { Real, FailOpen }`** — type design + invariant + sentinel 분리 동시 해결.
+2. **별도 `LockHandleElement: CoroutineContext.Element`** — `LeaderElectionInfo` binary-compat 보존.
+3. **`ExtendOutcome` sealed result** — `Boolean` API 와 병행, observability + recovery 가시성.
+4. **Reentrant dedupe = full lock identity** — Single ↔ Group 간 dedupe 차단.
+5. **Capture missing = IllegalStateException** — silent sentinel 금지.
+6. **Backend exception fail-open 분기 별도 처리** — sentinel push 보장.
+7. **CompletableFuture validator 차단** — v1 미지원 명시.
+8. **Lettuce group extend Lua server-side TIME** — #151 lessons 강제.
+9. **Redisson owner-guarded Lua** — `RLock.expire` 단순 호출 금지.
+10. **Mongo extend filter `expireAt > now`** — 만료 부활 차단.
+11. **Watchdog × LockExtender reference 동일** — race-free 보장 + last-write-wins 가시성 metric.
+12. **ZK autoExtend=false 강제** — TTL 없는 backend 의 noop 차단.

--- a/docs/superpowers/specs/2026-05-10-lock-extender-design.md
+++ b/docs/superpowers/specs/2026-05-10-lock-extender-design.md
@@ -250,6 +250,7 @@ object LockExtender : KLogging() {
     suspend fun extendActiveLockSuspend(lockAtMostFor: Duration): Boolean { ... }
     suspend fun extendActiveLockSuspend(lockName: String, lockAtMostFor: Duration): Boolean { ... }
     suspend fun extendActiveLockDetailedSuspend(lockAtMostFor: Duration): ExtendOutcome { ... }
+    suspend fun extendActiveLockDetailedSuspend(lockName: String, lockAtMostFor: Duration): ExtendOutcome { ... }  // R4-F6 — sync API 와 대칭
 }
 ```
 
@@ -264,7 +265,10 @@ package io.bluetape4k.leader
  *
  * @property lockName SpEL 평가 후 resolved string
  * @property kind 어노테이션 종류 — `SINGLE` (`@LeaderElection`) / `GROUP` (`@LeaderGroupElection`)
- * @property factoryBeanName Spring bean name — 같은 lockName 이라도 다른 factory 면 별개 lock
+ * @property factoryBeanName Spring bean name — 같은 lockName 이라도 다른 factory 면 별개 lock.
+ *   **Branch별로 사용되는 factory bean 이 다름** (R4-F3): sync = `LeaderElector` factory, suspend = `SuspendLeaderElector` factory,
+ *   group = `LeaderGroupElector` factory, suspend-group = `SuspendLeaderGroupElector` factory.
+ *   `AdviceMetadata.resolveLockIdentity(branch)` 가 branch 에 맞는 bean name 을 LockIdentity 에 설정.
  * @property groupParams Group 의 식별 파라미터 (Single 이면 null) — **현재 `maxLeaders` 만 보유** (R3-F7).
  *   slot strategy / weight 등 추가 옵션은 향후 확장 시 이 클래스에 필드 추가 (binary-compat 위해 default 값 사용).
  */
@@ -507,8 +511,28 @@ sealed interface LeaderRunResult<out T> {
 ```
 
 - **backend exception variant 추가하지 않음** — aspect 가 `runIfLeaderResult` 호출을 `try/catch (Exception)` 로 감싸 직접 캡처.
-- **인터페이스 default fun 변경 없음** — `runIfLeaderResult` 는 `LeaderElector`/`LeaderGroupElector` 에 이미 default fun 으로 존재. 본 PR 에서 신규 추가 X.
-- **suspend 변형은 default fun 으로 추가** — `SuspendLeaderElector`/`SuspendLeaderGroupElector` 에 `runIfLeaderResultSuspend` default fun 추가. **default 구현 보유 → 기존 구현체 binary-compat 보존** (Kotlin default fun 은 caller-side 호환 — 새 구현 없이도 동작).
+- **인터페이스 default fun 변경 없음** — `runIfLeaderResult(lockName, action)` 는 `LeaderElector`/`LeaderGroupElector` 에 이미 default fun 으로 존재 (현재 sync 시그니처: `fun <T> runIfLeaderResult(lockName: String, action: () -> T): LeaderRunResult<T>`). 본 PR 에서 신규 추가 X.
+- **suspend 변형 default fun 추가** (R4-F1):
+
+```kotlin
+// SuspendLeaderElector.kt — default fun 신규 추가
+suspend fun <T> runIfLeaderResultSuspend(
+    lockName: String,
+    action: suspend () -> T,
+): LeaderRunResult<T> {
+    val value = runIfLeader(lockName, action)
+    return if (value != null) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
+}
+
+// SuspendLeaderGroupElector.kt — 동일
+suspend fun <T> runIfLeaderResultSuspend(
+    lockName: String,
+    action: suspend () -> T,
+): LeaderRunResult<T> { ... }
+```
+
+- ⚠️ **`options` 인자 spec sketch 에서 제거** (R4-F1) — 기존 `runIfLeader` API 가 `options` 를 별도 인자로 받지 않고 `LeaderElectionOptions` 는 elector 생성 시점 또는 어노테이션 메타데이터로 전달. spec §7.1/§7.2 sketch 의 `meta.options` 인자는 **메타데이터 전달 용 (caller side context)** 이며, 실제 `runIfLeaderResult*` 호출 시 인자로 넣지 않음. (default fun 이 기존 `runIfLeader(name, action)` 만 호출.)
+- **default 구현 보유 → 기존 구현체 binary-compat 보존** (Kotlin default fun 은 caller-side 호환 — 새 구현 없이도 동작).
 
 **적용 범위 매트릭스** (R2-F2 / R3-F3):
 
@@ -546,10 +570,48 @@ sealed interface LeaderRunResult<out T> {
 | **Local single** | `leader-core/.../local/LocalLeaderStateRegistry.kt` | `fun extend(name, token, leaseTime): ExtendOutcome` | `ConcurrentHashMap.compute` atomic + `expireAt > now` guard | **신규** |
 | **Local group** | `LocalLeaderGroupRegistry` (가칭) | `fun extendSlot(name, slot, leaseTime): ExtendOutcome` | 동일 | **신규** |
 
-### Backend exception policy (SF9 신규)
+### Backend exception policy (SF9 + R4-F5)
 
-- **Transient errors** (`SQLTransientException`, Mongo `MongoSocketException`, Redis `RedisCommandTimeoutException`, Hazelcast `RetryableHazelcastException`) → `ExtendOutcome.BackendError(cause)` 반환 + WARN log + metric.
-- **Non-transient** (`SQLException` non-transient, schema 오류, auth) → throw — caller 가 결정.
+```kotlin
+// leader-core/src/main/kotlin/io/bluetape4k/leader/internal/BackendErrorClassifier.kt
+internal enum class BackendErrorKind { TRANSIENT, NON_TRANSIENT, FATAL }
+
+internal object BackendErrorClassifier {
+    /** backend 별 known exception 매핑 — TRANSIENT 는 BackendError 변환, NON_TRANSIENT 는 throw, FATAL 은 propagate. */
+    fun classify(cause: Throwable): BackendErrorKind = when {
+        cause is OutOfMemoryError || cause is StackOverflowError || cause is LinkageError -> FATAL
+        // Lettuce
+        cause is io.lettuce.core.RedisCommandTimeoutException -> TRANSIENT
+        cause is io.lettuce.core.RedisConnectionException -> TRANSIENT
+        cause is io.lettuce.core.RedisCommandExecutionException -> NON_TRANSIENT  // Lua syntax / auth
+        // Redisson
+        cause is org.redisson.client.RedisTimeoutException -> TRANSIENT
+        cause is org.redisson.client.RedisConnectionException -> TRANSIENT
+        // Mongo
+        cause is com.mongodb.MongoSocketException -> TRANSIENT
+        cause is com.mongodb.MongoTimeoutException -> TRANSIENT
+        cause is com.mongodb.MongoCommandException -> NON_TRANSIENT  // auth / index 오류
+        // Exposed JDBC / R2DBC
+        cause is java.sql.SQLTransientException -> TRANSIENT
+        cause is java.sql.SQLRecoverableException -> TRANSIENT
+        cause is java.sql.SQLNonTransientException -> NON_TRANSIENT
+        cause is io.r2dbc.spi.R2dbcTransientException -> TRANSIENT
+        cause is io.r2dbc.spi.R2dbcNonTransientException -> NON_TRANSIENT
+        // Hazelcast
+        cause is com.hazelcast.spi.exception.RetryableHazelcastException -> TRANSIENT
+        cause is com.hazelcast.core.OperationTimeoutException -> TRANSIENT
+        // ZooKeeper / Curator
+        cause is org.apache.zookeeper.KeeperException.ConnectionLossException -> TRANSIENT
+        cause is org.apache.zookeeper.KeeperException.SessionExpiredException -> NON_TRANSIENT
+        // 기본 — 알 수 없는 RuntimeException 은 NON_TRANSIENT (안전한 default — caller 가 보도록)
+        else -> NON_TRANSIENT
+    }
+}
+```
+
+- **Transient** → `ExtendOutcome.BackendError(cause)` 반환 + WARN log + metric.
+- **Non-transient** → throw — caller 가 결정.
+- **FATAL** → propagate (catch 안 함).
 - **`CancellationException`** → 항상 re-throw (suspend backend 의 R9 mitigation).
 
 ### Watchdog interaction
@@ -586,33 +648,49 @@ private fun aroundLeader(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
         return LockStateHolder.withPushed(outer.withReentryDepth(outer.reentryDepth + 1)) { pjp.proceed() }
     }
 
-    // 2) 정상 경로 — runIfLeaderResult (internal, sealed result)
+    // 2) 정상 경로 — body exception 과 backend exception 을 명확히 분리 (R4-F2)
     val elector = ... // 기존 캐시 로직
-    return when (val result = elector.runIfLeaderResult(identity.lockName, meta.options) {
-        // Elector 가 acquire 직후 LeaderLockHandleCapture.set(handle) 호출
-        val handle = LeaderLockHandleCapture.poll()
-            ?: error("elector did not capture handle — bug in ${elector::class.simpleName}")  // R10
-        LockStateHolder.withPushed(handle) { pjp.proceed() }
-    }) {
-        is LeaderRunResult.Elected -> result.value
-        is LeaderRunResult.Skipped -> when (meta.failureMode) {
+    return try {
+        when (val result = elector.runIfLeaderResult(identity.lockName) {
+            // ⭐ Elector 가 acquire 직후 LeaderLockHandleCapture.set(handle) 호출
+            // capture 누락 = elector 구현 버그 — IllegalStateException 직접 throw (R10).
+            // ⚠️ failureMode 변환 대상 아님 — outer catch 보다 먼저 propagate.
+            val handle = LeaderLockHandleCapture.poll()
+                ?: throw IllegalStateException("elector did not capture handle — bug in ${elector::class.simpleName}")
+            // ⭐ Body exception 은 BodyThrownMarker 로 wrap → outer catch 가 backend exception 과 구분 (R4-F2)
+            try {
+                LockStateHolder.withPushed(handle) { pjp.proceed() }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                throw BodyThrownMarker(e)  // body exception 분리 — failureMode 변환 안 함
+            }
+        }) {
+            is LeaderRunResult.Elected -> result.value
+            is LeaderRunResult.Skipped -> when (meta.failureMode) {
+                FAIL_OPEN_RUN -> LockStateHolder.withPushed(LeaderLockHandle.failOpen(identity)) { pjp.proceed() }
+                SKIP, RETHROW -> null   // ⭐ R3-F1 — contention 정상 흐름. RETHROW 는 Exception 분기에서만 throw.
+                INHERIT -> error("INHERIT must be resolved in resolveMetadata")
+            }
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: BodyThrownMarker) {
+        throw e.cause!!   // body exception 그대로 propagate — failureMode 무관
+    } catch (e: IllegalStateException) {
+        throw e            // capture invariant failure 등 spec invariant — 그대로 propagate
+    } catch (e: Exception) {  // ⭐ backend exception 만 (R3-F5 — Throwable 아님)
+        when (meta.failureMode) {
             FAIL_OPEN_RUN -> LockStateHolder.withPushed(LeaderLockHandle.failOpen(identity)) { pjp.proceed() }
-            SKIP, RETHROW -> null   // ⭐ R3-F1 — contention 은 정상 흐름 (`runIfLeader` contract: null = skip-on-contention).
-                                    //   `RETHROW` 는 backend exception 시에만 throw — `Skipped` 와 무관
+            SKIP -> null  // 침묵 + WARN log + metric
+            RETHROW -> throw e
             INHERIT -> error("INHERIT must be resolved in resolveMetadata")
         }
-        // backend exception (try/catch 로 캡처 — `LeaderRunResult` public sealed 에 BackendError 없음)
-    }
-} catch (e: CancellationException) {
-    throw e
-} catch (e: Exception) {  // ⭐ R3-F5 — Throwable 대신 Exception (OOM/StackOverflow/LinkageError 제외)
-    when (meta.failureMode) {
-        FAIL_OPEN_RUN -> LockStateHolder.withPushed(LeaderLockHandle.failOpen(identity)) { pjp.proceed() }
-        SKIP -> null  // 침묵 + WARN log + metric
-        RETHROW -> throw e
-        INHERIT -> error("INHERIT must be resolved in resolveMetadata")
     }
 }
+
+/** body exception 을 backend exception 과 구분하기 위한 internal marker (R4-F2) */
+private class BodyThrownMarker(cause: Throwable) : RuntimeException(cause)
 ```
 
 ### 7.2 Suspend 분기 (`aroundLeaderSuspend`)
@@ -631,13 +709,19 @@ private suspend fun aroundLeaderSuspendBody(pjp: ProceedingJoinPoint, meta: Advi
         }
     }
 
-    // 2) 정상 경로
+    // 2) 정상 경로 — body 와 backend exception 분리 (R4-F2)
     return try {
-        when (val result = suspendElector.runIfLeaderResultSuspend(identity.lockName, meta.options) {
+        when (val result = suspendElector.runIfLeaderResultSuspend(identity.lockName) {
             val handle = LeaderLockHandleCapture.poll()
-                ?: error("suspend elector did not capture handle — bug in ${suspendElector::class.simpleName}")
-            withContext(LeaderElectionInfo(identity.lockName, true) + LockHandleElement(handle)) {
-                suspendBlock.startCoroutineUninterceptedOrReturn(...)
+                ?: throw IllegalStateException("suspend elector did not capture handle — bug in ${suspendElector::class.simpleName}")
+            try {
+                withContext(LeaderElectionInfo(identity.lockName, true) + LockHandleElement(handle)) {
+                    suspendBlock.startCoroutineUninterceptedOrReturn(...)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                throw BodyThrownMarker(e)
             }
         }) {
             is LeaderRunResult.Elected -> result.value
@@ -645,18 +729,22 @@ private suspend fun aroundLeaderSuspendBody(pjp: ProceedingJoinPoint, meta: Advi
                 FAIL_OPEN_RUN -> withContext(LeaderElectionInfo(identity.lockName, false) + LockHandleElement(LeaderLockHandle.failOpen(identity))) {
                     suspendBlock.startCoroutineUninterceptedOrReturn(...)
                 }
-                SKIP, RETHROW -> null   // contention 은 모든 모드에서 정상 흐름 — null 반환 (R3-F1)
+                SKIP, RETHROW -> null
                 INHERIT -> error("INHERIT must be resolved")
             }
         }
     } catch (e: CancellationException) {
         throw e
-    } catch (e: Exception) {  // ⭐ R3-F5 — Throwable 대신 Exception (OOM/StackOverflow/LinkageError 제외)
+    } catch (e: BodyThrownMarker) {
+        throw e.cause!!
+    } catch (e: IllegalStateException) {
+        throw e
+    } catch (e: Exception) {  // ⭐ backend exception 만 (R3-F5)
         when (meta.failureMode) {
             FAIL_OPEN_RUN -> withContext(LeaderElectionInfo(identity.lockName, false) + LockHandleElement(LeaderLockHandle.failOpen(identity))) {
                 suspendBlock.startCoroutineUninterceptedOrReturn(...)
             }
-            SKIP -> null      // backend exception silent skip + WARN log
+            SKIP -> null
             RETHROW -> throw e
             INHERIT -> error("INHERIT must be resolved")
         }
@@ -681,9 +769,38 @@ private suspend fun aroundLeaderSuspendBody(pjp: ProceedingJoinPoint, meta: Advi
 - `method.returnType ∈ {CompletableFuture, Future, ListenableFuture}` → strict throw / non-strict WARN.
 - 메시지: "@LeaderElection on Future/CompletableFuture-returning method is unsupported in v1 — lock would release before future completes."
 
+### 7.5b AdviceMetadata 변경 (R4-F3)
+
+```kotlin
+// leader-spring-boot/.../aop/LeaderElectionAspect.kt — 의사코드
+internal data class AdviceMetadata(
+    val lockName: String,
+    val failureMode: LeaderAspectFailureMode,
+    val syncFactoryBeanName: String?,           // sync branch 용
+    val suspendFactoryBeanName: String?,        // suspend / Mono branch 용
+    val groupParams: LockIdentity.GroupParams?, // group annotation 일 때만 non-null
+    // ... 기존 필드
+) {
+    /** branch 에 맞는 factoryBeanName 으로 LockIdentity 생성. */
+    fun resolveLockIdentity(branch: AdviceBranch): LockIdentity = LockIdentity(
+        lockName = lockName,
+        kind = if (groupParams != null) AnnotationKind.GROUP else AnnotationKind.SINGLE,
+        factoryBeanName = when (branch) {
+            AdviceBranch.SYNC -> requireNotNull(syncFactoryBeanName)
+            AdviceBranch.SUSPEND, AdviceBranch.MONO -> requireNotNull(suspendFactoryBeanName)
+        },
+        groupParams = groupParams,
+    )
+}
+
+internal enum class AdviceBranch { SYNC, SUSPEND, MONO }
+```
+
+`LeaderElectionAspect.aroundLeader` (sync) → `meta.resolveLockIdentity(SYNC)`, `aroundLeaderSuspend` → `SUSPEND`, `aroundLeaderMono` → `MONO`. 동일 lockName 이라도 sync/suspend factory bean 이 다르면 별개 identity → reentrant peek 시 정확한 dedupe.
+
 ### 7.6 Elector 변경 사항
 
-각 backend elector 의 **internal** `runIfLeaderResult(name, options): LeaderRunResult<T>` 를 추가 (공개 `runIfLeader` 인터페이스는 무변경 — `runIfLeaderResult` 결과를 `Elected.value` 또는 `null` 로 변환).
+각 backend elector 의 **기존 public default fun** `runIfLeaderResult(lockName, action): LeaderRunResult<T>` 를 그대로 사용 (sync). suspend backend 는 본 PR 에서 추가하는 `runIfLeaderResultSuspend(lockName, action)` default fun 호출 (R4-F1).
 
 acquire 직후 `LeaderLockHandleCapture.set(handle)` 호출 — **action lambda 호출 직전, 동일 thread**. action 종료 후 `clear()` (try/finally).
 
@@ -809,7 +926,18 @@ unsupported 행은 concrete test class 부재 (skip 아님). matrix 자체가 AC
   - helper 함수 안에 swallow 된 케이스도 점검
 - [ ] **AC-19**: Java caller 가 `LockExtender.extendActiveLock(java.time.Duration)` 호출 가능 — `LockExtenderJavaCompatTest` (R15).
 - [ ] **AC-20**: ZK + autoExtend=true 시 startup WARN — watchdog noop (R16).
-- [ ] **AC-21**: Blocking backend (Lettuce sync, Hazelcast, Exposed JDBC, Redisson 등) 의 `ExtendDelegate.extendSuspend` 가 default 사용 0회 — 모두 override + `withContext(IO)` + `ensureActive()` (R3-F8).
+- [ ] **AC-21**: Blocking backend 의 `ExtendDelegate.extendSuspend` 가 default 사용 0회 (R3-F8 / R4-F7):
+  - 검증: 각 blocking backend 모듈의 `ExtendDelegate` 익명 객체 정의에 `override suspend fun extendSuspend` 가 명시적으로 있고 `withContext(Dispatchers.IO)` + `coroutineContext.ensureActive()` 호출
+  - 자동 검증 명령:
+    ```bash
+    # 1. ExtendDelegate 익명 객체 위치
+    rg -n "object\s*:\s*ExtendDelegate" leader-redis-lettuce leader-redis-redisson leader-mongodb leader-exposed-jdbc leader-hazelcast leader-zookeeper
+    # 2. 각 위치에 override suspend extendSuspend 존재 확인
+    rg -n "override\s+suspend\s+fun\s+extendSuspend" leader-redis-lettuce leader-redis-redisson leader-mongodb leader-exposed-jdbc leader-hazelcast leader-zookeeper
+    # 3. withContext(Dispatchers.IO) 사용 확인
+    rg -n "withContext\(Dispatchers\.IO\)" leader-redis-lettuce leader-redis-redisson leader-mongodb leader-exposed-jdbc leader-hazelcast leader-zookeeper
+    ```
+  - R2DBC / Local 은 native suspend → default OK (Local 은 non-blocking, R2DBC 는 suspend native)
 - [ ] **AC-22**: AOP CTW weave smoke test — sync/suspend/Mono 각각 실제 woven bean 호출로 `LockHandleElement` propagation 검증 (R3-F13).
 - [ ] **AC-23**: `handle.extendDelegate === watchdog.delegate` reference 검증 — 각 backend elector 모듈 안에 unit test (`leader-redis-lettuce`, `leader-redis-redisson`, ...) — `extendDelegate` 가 `internal` 이라 cross-module access 불가 (R3-F14).
 - [ ] **AC-24**: backend 별 transient/non-transient exception 분류 표 — KDoc / `BackendErrorClassifier` 헬퍼 노출. classifier test 가 backend 별 known exception 모두 cover (R3-F9).
@@ -866,7 +994,7 @@ LockExtender.extendActiveLock(Duration.ofMinutes(5));
 |---|---|---|---|
 | **T1** | `LeaderLockHandle` sealed class (Real / FailOpen) + internal constructor + `ExtendOutcome` sealed result + `LockStateHolder` + `LeaderLockHandleCapture` (`leader-core`) | medium | — |
 | **T2** | `LockHandleElement` (`CoroutineContext.Element`) 신규 — `LeaderElectionInfo` 무변경 (`leader-core`) | low | T1 |
-| **T3** | `LeaderRunResult<T>` internal sealed (`leader-core`) | low | T1 |
+| **T3** | `SuspendLeaderElector` / `SuspendLeaderGroupElector` 에 `runIfLeaderResultSuspend` default fun 추가 (`LeaderRunResult` 무변경) (`leader-core`) | low | T1 |
 | **T4** | `LockAssert` / `LockExtender` top-level objects + Java `java.time.Duration` overload + `extendActiveLockDetailed` + KDoc (`leader-core`) | medium | T1, T2 |
 | **T5** | Local elector — capture + `runIfLeaderResult` internal + `LocalLeaderStateRegistry.extend` (`leader-core`) | medium | T1, T3 |
 | **T6** | 4 abstract contract bases (sync/suspend/group/suspend-group) + Local 4 concrete tests (`leader-core`) | medium | T4, T5 |
@@ -996,6 +1124,39 @@ LockExtender.extendActiveLock(Duration.ofMinutes(5));
 21. **`withContext(LeaderElectionInfo + LockHandleElement)` 결합 push** — 기존 `LeaderElectionInfo` 주입 보존, 신규 element 추가.
 22. **`LockHandleElement.handle` internal** — 외부 caller 는 `LockAssert`/`LockExtender` API 만 사용, metadata 직접 노출 차단.
 23. **AOP weave smoke test 명시** — Freefair CTW 가 실제 weave 했는지 unit/mock 이상의 통합 테스트 필요.
+
+---
+
+## Appendix D — Round 4 Review 통합 (Codex 단독 — 수렴 검증)
+
+총 7 finding (P0×0, P1×3, P2×3, P3×1).
+
+### 적용 (P1×3 + P2×3 + P3×1)
+
+- **R4-F1** (P1) → §5.7 `runIfLeaderResultSuspend` 시그니처 명시 (`suspend fun <T> runIfLeaderResultSuspend(lockName, action: suspend () -> T): LeaderRunResult<T>`), §7 sketch `meta.options` 인자 제거, T3 task 갱신, §7.6 elector 변경 사항 갱신
+- **R4-F2** (P1) → §7.1/§7.2 sketch 재구조 — body exception (`BodyThrownMarker`) vs backend exception 분리, capture invariant failure (`IllegalStateException`) 별도 propagate, `LeaderLockHandleCapture.poll() ?: throw IllegalStateException`
+- **R4-F3** (P1) → §5.2a `factoryBeanName` KDoc — branch별 (sync/suspend/group/suspend-group) 다른 factory bean, §7.5b `AdviceMetadata` + `AdviceBranch` enum 신규
+- **R4-F4** (P2) → §7.1 sync sketch `return try { ... } catch ...` 구조 명시 (suspend branch 와 대칭)
+- **R4-F5** (P2) → §6 `BackendErrorClassifier` API + 8 backend known exception mapping table
+- **R4-F6** (P2) → §5.1 `extendActiveLockDetailedSuspend(lockName, lockAtMostFor)` overload 추가 (sync API 와 대칭)
+- **R4-F7** (P3) → AC-21 grep 패턴 구체화 — `rg "object\s*:\s*ExtendDelegate"` + `override suspend fun extendSuspend` + `withContext(Dispatchers.IO)`
+
+### Round 4 결정 기록
+
+24. **Body exception ≠ backend exception** — `BodyThrownMarker(cause)` wrapper 로 outer catch 가 구분. business 로직 exception 이 fail-open 분기로 잘못 처리되지 않도록 보장.
+25. **Capture invariant failure 는 failureMode 변환 안 함** — `IllegalStateException` 으로 즉시 propagate. spec invariant 위반은 silent fail-open 금지.
+26. **`AdviceMetadata` branch별 factoryBeanName** — sync / suspend / Mono 분기마다 정확한 factory bean 사용. reentrant peek 의 LockIdentity 정확성.
+27. **`BackendErrorClassifier`** — backend 별 transient/non-transient/fatal 분류 helper, 모든 elector 가 동일 정책.
+
+### 수렴 평가
+
+- Round 1 (63 finding) → 32 P0/P1/HIGH 적용
+- Round 2 (12 finding) → 12 적용
+- Round 3 (15 finding) → 15 적용
+- Round 4 (7 finding) → 7 적용
+- **합계 97 finding**, 모두 spec 반영
+- Round 4 P0 = 0 → architectural 수렴
+- Round 5 추가 review 시 polish/nit 영역으로 진입 예상
 
 ---
 

--- a/docs/superpowers/specs/2026-05-10-lock-extender-design.md
+++ b/docs/superpowers/specs/2026-05-10-lock-extender-design.md
@@ -515,20 +515,27 @@ sealed interface LeaderRunResult<out T> {
 - **suspend 변형 default fun 추가** (R4-F1):
 
 ```kotlin
-// SuspendLeaderElector.kt — default fun 신규 추가
+// SuspendLeaderElector.kt — default fun 신규 추가 (R5-F1)
+// ⭐ `elected` flag 패턴 — action 이 정상 실행 후 null 반환해도 Elected 분류
+//   (기존 sync `runIfLeaderResult` default fun 의 LeaderElector.kt:62 패턴 동일)
 suspend fun <T> runIfLeaderResultSuspend(
     lockName: String,
     action: suspend () -> T,
 ): LeaderRunResult<T> {
-    val value = runIfLeader(lockName, action)
-    return if (value != null) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
+    var elected = false
+    val value = runIfLeader(lockName) { elected = true; action() }
+    return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
 }
 
-// SuspendLeaderGroupElector.kt — 동일
+// SuspendLeaderGroupElector.kt — 동일 패턴
 suspend fun <T> runIfLeaderResultSuspend(
     lockName: String,
     action: suspend () -> T,
-): LeaderRunResult<T> { ... }
+): LeaderRunResult<T> {
+    var elected = false
+    val value = runIfLeader(lockName) { elected = true; action() }
+    return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
+}
 ```
 
 - ⚠️ **`options` 인자 spec sketch 에서 제거** (R4-F1) — 기존 `runIfLeader` API 가 `options` 를 별도 인자로 받지 않고 `LeaderElectionOptions` 는 elector 생성 시점 또는 어노테이션 메타데이터로 전달. spec §7.1/§7.2 sketch 의 `meta.options` 인자는 **메타데이터 전달 용 (caller side context)** 이며, 실제 `runIfLeaderResult*` 호출 시 인자로 넣지 않음. (default fun 이 기존 `runIfLeader(name, action)` 만 호출.)
@@ -572,42 +579,61 @@ suspend fun <T> runIfLeaderResultSuspend(
 
 ### Backend exception policy (SF9 + R4-F5)
 
+**SPI 패턴 — backend module 의존성 역전** (R5-F4): `leader-core` 는 backend exception class 직접 참조 불가 (build dependency 문제). SPI interface + JDK/common 분류만 core 에 두고, 각 backend module 이 자기 classifier 등록.
+
 ```kotlin
 // leader-core/src/main/kotlin/io/bluetape4k/leader/internal/BackendErrorClassifier.kt
-internal enum class BackendErrorKind { TRANSIENT, NON_TRANSIENT, FATAL }
+package io.bluetape4k.leader.internal
 
-internal object BackendErrorClassifier {
-    /** backend 별 known exception 매핑 — TRANSIENT 는 BackendError 변환, NON_TRANSIENT 는 throw, FATAL 은 propagate. */
-    fun classify(cause: Throwable): BackendErrorKind = when {
-        cause is OutOfMemoryError || cause is StackOverflowError || cause is LinkageError -> FATAL
-        // Lettuce
-        cause is io.lettuce.core.RedisCommandTimeoutException -> TRANSIENT
-        cause is io.lettuce.core.RedisConnectionException -> TRANSIENT
-        cause is io.lettuce.core.RedisCommandExecutionException -> NON_TRANSIENT  // Lua syntax / auth
-        // Redisson
-        cause is org.redisson.client.RedisTimeoutException -> TRANSIENT
-        cause is org.redisson.client.RedisConnectionException -> TRANSIENT
-        // Mongo
-        cause is com.mongodb.MongoSocketException -> TRANSIENT
-        cause is com.mongodb.MongoTimeoutException -> TRANSIENT
-        cause is com.mongodb.MongoCommandException -> NON_TRANSIENT  // auth / index 오류
-        // Exposed JDBC / R2DBC
-        cause is java.sql.SQLTransientException -> TRANSIENT
-        cause is java.sql.SQLRecoverableException -> TRANSIENT
-        cause is java.sql.SQLNonTransientException -> NON_TRANSIENT
-        cause is io.r2dbc.spi.R2dbcTransientException -> TRANSIENT
-        cause is io.r2dbc.spi.R2dbcNonTransientException -> NON_TRANSIENT
-        // Hazelcast
-        cause is com.hazelcast.spi.exception.RetryableHazelcastException -> TRANSIENT
-        cause is com.hazelcast.core.OperationTimeoutException -> TRANSIENT
-        // ZooKeeper / Curator
-        cause is org.apache.zookeeper.KeeperException.ConnectionLossException -> TRANSIENT
-        cause is org.apache.zookeeper.KeeperException.SessionExpiredException -> NON_TRANSIENT
-        // 기본 — 알 수 없는 RuntimeException 은 NON_TRANSIENT (안전한 default — caller 가 보도록)
-        else -> NON_TRANSIENT
+enum class BackendErrorKind { TRANSIENT, NON_TRANSIENT, FATAL }
+
+/** SPI — 각 backend module 이 자기 backend 용 구현 등록. */
+fun interface BackendErrorClassifier {
+    fun classify(cause: Throwable): BackendErrorKind?  // null = 분류 불가, chain next
+}
+
+/** JDK / 공통 분류 — backend dependency 없음 (R5-F4). */
+internal object CoreBackendErrorClassifier : BackendErrorClassifier {
+    override fun classify(cause: Throwable): BackendErrorKind = when (cause) {
+        is OutOfMemoryError, is StackOverflowError, is LinkageError -> BackendErrorKind.FATAL
+        is java.sql.SQLTransientException -> BackendErrorKind.TRANSIENT
+        is java.sql.SQLRecoverableException -> BackendErrorKind.TRANSIENT
+        is java.sql.SQLNonTransientException -> BackendErrorKind.NON_TRANSIENT
+        is java.net.SocketTimeoutException -> BackendErrorKind.TRANSIENT
+        is java.net.ConnectException -> BackendErrorKind.TRANSIENT
+        else -> BackendErrorKind.NON_TRANSIENT  // safe default
     }
 }
+
+/** classifier chain — 각 elector 가 (자기 backend classifier + Core) 합성 호출. */
+internal class CompositeBackendErrorClassifier(
+    private val backendSpecific: BackendErrorClassifier,
+) : BackendErrorClassifier {
+    override fun classify(cause: Throwable): BackendErrorKind =
+        backendSpecific.classify(cause) ?: CoreBackendErrorClassifier.classify(cause) ?: BackendErrorKind.NON_TRANSIENT
+}
 ```
+
+각 backend module 의 classifier (예시):
+
+```kotlin
+// leader-redis-lettuce/.../internal/LettuceBackendErrorClassifier.kt
+internal object LettuceBackendErrorClassifier : BackendErrorClassifier {
+    override fun classify(cause: Throwable): BackendErrorKind? = when (cause) {
+        is io.lettuce.core.RedisCommandTimeoutException -> BackendErrorKind.TRANSIENT
+        is io.lettuce.core.RedisConnectionException -> BackendErrorKind.TRANSIENT
+        is io.lettuce.core.RedisCommandExecutionException -> BackendErrorKind.NON_TRANSIENT
+        else -> null  // Core classifier 에 위임
+    }
+}
+// leader-redis-redisson/.../RedissonBackendErrorClassifier.kt
+// leader-mongodb/.../MongoBackendErrorClassifier.kt
+// leader-exposed-r2dbc/.../R2dbcBackendErrorClassifier.kt  (R2dbcTransientException 등)
+// leader-hazelcast/.../HazelcastBackendErrorClassifier.kt
+// leader-zookeeper/.../ZkBackendErrorClassifier.kt
+```
+
+각 elector 가 `CompositeBackendErrorClassifier(LettuceBackendErrorClassifier)` 형태로 합성 — `leader-core` build 깨지지 않음.
 
 - **Transient** → `ExtendOutcome.BackendError(cause)` 반환 + WARN log + metric.
 - **Non-transient** → throw — caller 가 결정.
@@ -640,7 +666,7 @@ val handle = LeaderLockHandle.Real(..., extendDelegate = extendDelegate, ...)
 
 ```kotlin
 private fun aroundLeader(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
-    val identity = meta.resolveLockIdentity(pjp)  // (lockName, kind=SINGLE, factoryBeanId, groupParams=null)
+    val identity = meta.resolveLockIdentity(AdviceBranch.SYNC)  // R5-F6 — sync branch
 
     // 1) Reentrant peek — full identity (Codex F3)
     val outer = LockStateHolder.peekSync()
@@ -648,28 +674,32 @@ private fun aroundLeader(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
         return LockStateHolder.withPushed(outer.withReentryDepth(outer.reentryDepth + 1)) { pjp.proceed() }
     }
 
-    // 2) 정상 경로 — body exception 과 backend exception 을 명확히 분리 (R4-F2)
+    // 2) 정상 경로 — body / capture-invariant / backend exception 명확히 분리 (R4-F2 + R5-F2 + R5-F3)
     val elector = ... // 기존 캐시 로직
+
+    /** ⭐ R5-F2 — body 실행을 BodyThrownMarker 로 보호하는 helper. elected/fail-open 양쪽에 사용. */
+    fun proceedProtected(): Any? = try {
+        pjp.proceed()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        throw BodyThrownMarker(e)
+    }
+
     return try {
         when (val result = elector.runIfLeaderResult(identity.lockName) {
-            // ⭐ Elector 가 acquire 직후 LeaderLockHandleCapture.set(handle) 호출
-            // capture 누락 = elector 구현 버그 — IllegalStateException 직접 throw (R10).
-            // ⚠️ failureMode 변환 대상 아님 — outer catch 보다 먼저 propagate.
+            // ⭐ capture 누락 = elector 구현 버그 — CaptureInvariantException 직접 throw (R5-F3).
+            //   일반 IllegalStateException 과 구분 (backend 도 ISE throw 가능).
             val handle = LeaderLockHandleCapture.poll()
-                ?: throw IllegalStateException("elector did not capture handle — bug in ${elector::class.simpleName}")
-            // ⭐ Body exception 은 BodyThrownMarker 로 wrap → outer catch 가 backend exception 과 구분 (R4-F2)
-            try {
-                LockStateHolder.withPushed(handle) { pjp.proceed() }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                throw BodyThrownMarker(e)  // body exception 분리 — failureMode 변환 안 함
-            }
+                ?: throw CaptureInvariantException("elector did not capture handle — bug in ${elector::class.simpleName}")
+            LockStateHolder.withPushed(handle) { proceedProtected() }
         }) {
             is LeaderRunResult.Elected -> result.value
             is LeaderRunResult.Skipped -> when (meta.failureMode) {
-                FAIL_OPEN_RUN -> LockStateHolder.withPushed(LeaderLockHandle.failOpen(identity)) { pjp.proceed() }
-                SKIP, RETHROW -> null   // ⭐ R3-F1 — contention 정상 흐름. RETHROW 는 Exception 분기에서만 throw.
+                FAIL_OPEN_RUN -> LockStateHolder.withPushed(LeaderLockHandle.failOpen(identity)) {
+                    proceedProtected()  // ⭐ R5-F2 — fail-open body 도 BodyThrownMarker 보호
+                }
+                SKIP, RETHROW -> null   // ⭐ R3-F1 — contention 정상 흐름.
                 INHERIT -> error("INHERIT must be resolved in resolveMetadata")
             }
         }
@@ -677,11 +707,13 @@ private fun aroundLeader(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
         throw e
     } catch (e: BodyThrownMarker) {
         throw e.cause!!   // body exception 그대로 propagate — failureMode 무관
-    } catch (e: IllegalStateException) {
-        throw e            // capture invariant failure 등 spec invariant — 그대로 propagate
+    } catch (e: CaptureInvariantException) {
+        throw e            // ⭐ R5-F3 — 전용 exception type (일반 ISE 와 구분)
     } catch (e: Exception) {  // ⭐ backend exception 만 (R3-F5 — Throwable 아님)
         when (meta.failureMode) {
-            FAIL_OPEN_RUN -> LockStateHolder.withPushed(LeaderLockHandle.failOpen(identity)) { pjp.proceed() }
+            FAIL_OPEN_RUN -> LockStateHolder.withPushed(LeaderLockHandle.failOpen(identity)) {
+                proceedProtected()  // ⭐ R5-F2 — backend fail-open body 도 보호
+            }
             SKIP -> null  // 침묵 + WARN log + metric
             RETHROW -> throw e
             INHERIT -> error("INHERIT must be resolved in resolveMetadata")
@@ -689,15 +721,18 @@ private fun aroundLeader(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
     }
 }
 
-/** body exception 을 backend exception 과 구분하기 위한 internal marker (R4-F2) */
+/** body exception marker (R4-F2) */
 private class BodyThrownMarker(cause: Throwable) : RuntimeException(cause)
+
+/** capture invariant 실패 전용 exception — 일반 IllegalStateException 과 구분 (R5-F3) */
+internal class CaptureInvariantException(message: String) : IllegalStateException(message)
 ```
 
 ### 7.2 Suspend 분기 (`aroundLeaderSuspend`)
 
 ```kotlin
 private suspend fun aroundLeaderSuspendBody(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
-    val identity = meta.resolveLockIdentity(pjp)
+    val identity = meta.resolveLockIdentity(AdviceBranch.SUSPEND)  // R5-F6 — suspend branch (Mono 분기는 AdviceBranch.MONO)
 
     // 1) Reentrant peek — coroutineContext only (R7)
     val outer = currentCoroutineContext()[LockHandleElement]?.handle as? LeaderLockHandle.Real
@@ -709,25 +744,27 @@ private suspend fun aroundLeaderSuspendBody(pjp: ProceedingJoinPoint, meta: Advi
         }
     }
 
-    // 2) 정상 경로 — body 와 backend exception 분리 (R4-F2)
+    // 2) 정상 경로 — body / capture-invariant / backend exception 분리 (R4-F2 + R5-F2 + R5-F3)
+    suspend fun proceedProtected(): Any? = try {
+        suspendBlock.startCoroutineUninterceptedOrReturn(...)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        throw BodyThrownMarker(e)
+    }
+
     return try {
         when (val result = suspendElector.runIfLeaderResultSuspend(identity.lockName) {
             val handle = LeaderLockHandleCapture.poll()
-                ?: throw IllegalStateException("suspend elector did not capture handle — bug in ${suspendElector::class.simpleName}")
-            try {
-                withContext(LeaderElectionInfo(identity.lockName, true) + LockHandleElement(handle)) {
-                    suspendBlock.startCoroutineUninterceptedOrReturn(...)
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Throwable) {
-                throw BodyThrownMarker(e)
+                ?: throw CaptureInvariantException("suspend elector did not capture handle — bug in ${suspendElector::class.simpleName}")
+            withContext(LeaderElectionInfo(identity.lockName, true) + LockHandleElement(handle)) {
+                proceedProtected()
             }
         }) {
             is LeaderRunResult.Elected -> result.value
             is LeaderRunResult.Skipped -> when (meta.failureMode) {
                 FAIL_OPEN_RUN -> withContext(LeaderElectionInfo(identity.lockName, false) + LockHandleElement(LeaderLockHandle.failOpen(identity))) {
-                    suspendBlock.startCoroutineUninterceptedOrReturn(...)
+                    proceedProtected()  // ⭐ R5-F2 — contention fail-open body 도 보호
                 }
                 SKIP, RETHROW -> null
                 INHERIT -> error("INHERIT must be resolved")
@@ -737,12 +774,12 @@ private suspend fun aroundLeaderSuspendBody(pjp: ProceedingJoinPoint, meta: Advi
         throw e
     } catch (e: BodyThrownMarker) {
         throw e.cause!!
-    } catch (e: IllegalStateException) {
+    } catch (e: CaptureInvariantException) {
         throw e
     } catch (e: Exception) {  // ⭐ backend exception 만 (R3-F5)
         when (meta.failureMode) {
             FAIL_OPEN_RUN -> withContext(LeaderElectionInfo(identity.lockName, false) + LockHandleElement(LeaderLockHandle.failOpen(identity))) {
-                suspendBlock.startCoroutineUninterceptedOrReturn(...)
+                proceedProtected()  // ⭐ R5-F2 — backend fail-open body 도 보호
             }
             SKIP -> null
             RETHROW -> throw e
@@ -940,15 +977,27 @@ unsupported 행은 concrete test class 부재 (skip 아님). matrix 자체가 AC
   - R2DBC / Local 은 native suspend → default OK (Local 은 non-blocking, R2DBC 는 suspend native)
 - [ ] **AC-22**: AOP CTW weave smoke test — sync/suspend/Mono 각각 실제 woven bean 호출로 `LockHandleElement` propagation 검증 (R3-F13).
 - [ ] **AC-23**: `handle.extendDelegate === watchdog.delegate` reference 검증 — 각 backend elector 모듈 안에 unit test (`leader-redis-lettuce`, `leader-redis-redisson`, ...) — `extendDelegate` 가 `internal` 이라 cross-module access 불가 (R3-F14).
-- [ ] **AC-24**: backend 별 transient/non-transient exception 분류 표 — KDoc / `BackendErrorClassifier` 헬퍼 노출. classifier test 가 backend 별 known exception 모두 cover (R3-F9).
+- [ ] **AC-24**: SPI 분산 backend classifier 검증 (R3-F9 / R5-F4):
+  - `leader-core` 의 `BackendErrorClassifier` SPI + `CoreBackendErrorClassifier` (JDK/공통) + `CompositeBackendErrorClassifier`
+  - 각 backend module 의 자기 classifier 구현 + 단위 테스트 (known exception 모두 cover)
+  - **`leader-core` build 가 backend exception class 직접 참조 0회** (소스 grep verify)
+- [ ] **AC-25**: Kotlin interface default fun binary-compat 검증 (R5-F5):
+  - `-jvm-default=enable` 으로 default fun 이 JVM `default` method 로 컴파일됨 확인 (`javap -p` inspection)
+  - 기존 구현체 (LettuceLeaderElector 등) 가 `runIfLeaderResultSuspend` 를 override 하지 않아도 compile/runtime OK 검증
 
 ---
 
 ## 10. Migration / Compatibility
 
 ### 10.1 Source-compat
-- `SuspendLeaderElector` / `SuspendLeaderGroupElector` 에 `runIfLeaderResultSuspend` default fun 추가 — source 호환 (R3-F3).
+- `SuspendLeaderElector` / `SuspendLeaderGroupElector` 에 `runIfLeaderResultSuspend` default fun 추가 — **source-compatible**.
 - `LeaderElector` / `LeaderGroupElector` / `AsyncLeaderElector` / `VirtualThreadLeaderElector` 무변경.
+
+### 10.1b Binary-compat 주의 (R5-F5)
+- 본 repo 는 `-jvm-default=enable` 사용 — Kotlin interface default fun 이 JVM `default` method 로 컴파일.
+- 외부에서 컴파일된 기존 구현체 (Java 또는 Kotlin) 는 default 메서드 가용 시 자동 사용 — **binary 호환 가능성 높음**.
+- 다만 `-jvm-default` 전략 변경 시 `AbstractMethodError` 위험 → **AC-25 추가 — generated bytecode 확인 또는 외부 구현체 reflection 호환 테스트**.
+- 본 PR 에서 backend 별 elector 구현체는 모두 동일 module 내 컴파일 → caller-side 호환만 검증하면 충분.
 - `LeaderElectionInfo` 무변경 — 별도 `LockHandleElement` 추가 (R8 / Type T8).
 - `LockAssert`, `LockExtender`, `LeaderLockHandle`, `ExtendOutcome` 모두 신규 — 추가 only.
 
@@ -1157,6 +1206,37 @@ LockExtender.extendActiveLock(Duration.ofMinutes(5));
 - **합계 97 finding**, 모두 spec 반영
 - Round 4 P0 = 0 → architectural 수렴
 - Round 5 추가 review 시 polish/nit 영역으로 진입 예상
+
+---
+
+## Appendix E — Round 5 Review 통합 (Codex 단독 — 수렴 미달)
+
+총 6 finding (P0×0, P1×4, P2×1, P3×1).
+
+### 적용 (P1×4 + P2×1 + P3×1)
+
+- **R5-F1** (P1) → §5.7 `runIfLeaderResultSuspend` default fun `elected: Boolean` flag 패턴 사용 (sync `runIfLeaderResult` LeaderElector.kt:62 와 동일). action 정상 실행 후 null 반환 시 `Skipped` 오분류 차단
+- **R5-F2** (P1) → §7.1/§7.2 sketch `proceedProtected()` helper 도입 — elected/contention-fail-open/backend-fail-open 3 분기 모두에서 `BodyThrownMarker` 보호. body exception 이 outer `catch (Exception)` 에 잘못 잡혀 fail-open 재실행되는 footgun 차단
+- **R5-F3** (P1) → §7.1/§7.2 `CaptureInvariantException : IllegalStateException` 전용 type 도입. capture 누락은 `throw CaptureInvariantException(...)`, outer catch 에서 `catch (e: CaptureInvariantException) { throw e }` 우선. 일반 `IllegalStateException` (backend 가 throw 가능) 은 backend exception 분기로 흘러감
+- **R5-F4** (P1) → §6 `BackendErrorClassifier` SPI 분산 — `leader-core` 에 SPI interface + JDK/공통 분류만, 각 backend module 에 자기 classifier 구현. `CompositeBackendErrorClassifier` 로 chain. `leader-core` build dependency 깨짐 차단
+- **R5-F5** (P2) → §10.1 source-compat 만 확정, §10.1b binary-compat 별도 섹션 + AC-25 추가 (`-jvm-default=enable` bytecode 검증)
+- **R5-F6** (P3) → §7.1 / §7.2 sketch `meta.resolveLockIdentity(pjp)` → `meta.resolveLockIdentity(AdviceBranch.SYNC)` / `(AdviceBranch.SUSPEND)` 시그니처 일치
+
+### Round 5 결정 기록
+
+28. **suspend default fun `elected` flag** — sync 와 일관된 정확한 Elected/Skipped 분류 (action null return 시 Skipped 오분류 차단).
+29. **`proceedProtected()` helper** — elected / contention-fail-open / backend-fail-open 3 분기 모두에서 body exception 을 BodyThrownMarker 로 wrap → outer catch 가 backend exception 과 정확히 구분.
+30. **`CaptureInvariantException` 전용 type** — capture 누락 (spec invariant 위반) 과 backend `IllegalStateException` (token mismatch 등 정상 backend 동작) 을 type level 에서 구분.
+31. **`BackendErrorClassifier` SPI 분산** — `leader-core` 가 backend exception class 의존하지 않도록 의존성 역전. `CompositeBackendErrorClassifier(backendSpecific, core)` chain.
+32. **Binary-compat 진술 약화** — `-jvm-default=enable` bytecode 의존, source-compat 만 확정.
+
+### Round 5 후 수렴 평가
+
+- R1 (63) → R2 (12) → R3 (15) → R4 (7) → R5 (6) — finding 수 단조 감소.
+- R5 P0 = 0, P1 4 (모두 architectural correctness — type/SPI/structure).
+- R6 dispatch 시 polish/nit 영역 진입 예상 (P1 ≤ 2, P2/P3 위주).
+
+총 review 합계: **103 finding** (Codex 56 + perspective 47), 모두 적용.
 
 ---
 

--- a/docs/superpowers/specs/2026-05-10-lock-extender-design.md
+++ b/docs/superpowers/specs/2026-05-10-lock-extender-design.md
@@ -278,6 +278,12 @@ data class LockIdentity(
     val factoryBeanName: String,
     val groupParams: GroupParams? = null,
 ) {
+    init {
+        // ⭐ R7-T1 — kind ↔ groupParams invariant 강제
+        require((kind == AnnotationKind.GROUP) == (groupParams != null)) {
+            "GROUP kind requires groupParams; SINGLE kind forbids it"
+        }
+    }
     enum class AnnotationKind { SINGLE, GROUP }
     /** Currently `maxLeaders` only — future fields require default values for binary-compat. */
     data class GroupParams(val maxLeaders: Int)
@@ -386,7 +392,7 @@ sealed interface ExtendOutcome {
     data class Extended(val observedExpireAt: Instant) : ExtendOutcome
     data object NotHeld : ExtendOutcome              // token mismatch / lease expired / takeover
     data object WrongThread : ExtendOutcome          // Redisson thread-bound
-    data class BackendError(val cause: Throwable) : ExtendOutcome  // transient: false 변환, non-transient: throw
+    data class BackendError(val cause: Exception) : ExtendOutcome  // ⭐ R7-T2 — Throwable 대신 Exception (FATAL Error 차단). transient: false 변환, non-transient: throw
 
     val isExtended: Boolean get() = this is Extended
 }
@@ -985,6 +991,7 @@ unsupported 행은 concrete test class 부재 (skip 아님). matrix 자체가 AC
     ```
   - R2DBC / Local 은 native suspend → default OK (Local 은 non-blocking, R2DBC 는 suspend native)
 - [ ] **AC-22**: AOP CTW weave smoke test — sync/suspend/Mono 각각 실제 woven bean 호출로 `LockHandleElement` propagation 검증 (R3-F13).
+- [ ] **AC-22b**: `leader-ktor` plugin propagation smoke test — Ktor `Application.routing` 안에서 `LockAssert.assertLockedSuspend()` 호출 시 plugin 이 inject 한 `LockHandleElement` 가 정확히 동작 (R7-A1). 실패 시 README "미지원 시나리오" 명시.
 - [ ] **AC-23**: `handle.extendDelegate === watchdog.delegate` reference 검증 — 각 backend elector 모듈 안에 unit test (`leader-redis-lettuce`, `leader-redis-redisson`, ...) — `extendDelegate` 가 `internal` 이라 cross-module access 불가 (R3-F14).
 - [ ] **AC-24**: SPI 분산 backend classifier 검증 (R3-F9 / R5-F4):
   - `leader-core` 의 `BackendErrorClassifier` SPI + `CoreBackendErrorClassifier` (JDK/공통) + `CompositeBackendErrorClassifier`
@@ -1038,10 +1045,15 @@ LockExtender.extendActiveLock(Duration.ofMinutes(5));
 - **`leader-spring-boot/README.md` + `README.ko.md`** — 신규 섹션 "LockAssert & LockExtender (ShedLock-equivalent)" + Mermaid sequenceDiagram.
 - 8 backend 모듈 README — "extend now supported" 한 줄 노트.
 - **`leader-ktor/README.md`** — 한 줄 노트: "plugin 안에서 `LockAssert.assertLockedSuspend()` 사용 가능" (Architect A8).
+- **`leader-ktor` propagation smoke test** (R7-A1): plugin 의 `coroutineScope` + `withContext(LockHandleElement(...))` propagation 검증 1건. Ktor `call.attributes` / `PipelineContext` dispatch 시 element 가 떨어지면 README "미지원 시나리오" 명시 (Mono 분기 동일 정책).
 - KDoc — 모든 신규 public surface + `ExtendOutcome` variants.
 - **CHANGELOG.md** — `LockHandleElement` 추가, `LockAssert`/`LockExtender` API 신규, validator `CompletableFuture` 차단, watchdog × extend 가시성 (Architect A9).
-- **`WIP.md`** — Issue #79 완료 표시.
-- **CLAUDE.md (root + leader-bom)** — "v1.x sync-only" 문구 → "suspend + Mono 지원, Flux/Flow 미지원" 으로 갱신 (Architect A11).
+- **`WIP.md`** (R7-A2) — Issue #79 완료 표시 + "ShedLock 호환 ergonomic API 도입" 섹션 (3-5줄 요약 + 신규 API surface 링크 — `LockAssert`, `LockExtender`, `ExtendOutcome`, `LeaderLockHandle`).
+- **CLAUDE.md drift fix** (R7-A2 / Architect A11):
+  - `bluetape4k/CLAUDE.md` (workspace root) — "v1.x sync-only" 문구 → "suspend + Mono 지원, Flux/Flow 미지원"
+  - `bluetape4k-leader/CLAUDE.md` (project root) — 동일 갱신
+  - worktree CLAUDE.md (`leader-bom/CLAUDE.md`) — 동일
+- **`examples/ktor-app/README.md`** (R7-A2) — `LockAssert.assertLockedSuspend()` 사용 예 1건 추가 (downstream consumer 가 새 API 발견 가능하게).
 - **`docs/lessons/2026-05-10-lock-extender.md`** — PR merge 후: Hazelcast EntryProcessor 함정, Redisson owner-Lua, capture invariant, sealed `ExtendOutcome` 도입, ShedLock semantics divergence.
 
 ---
@@ -1068,7 +1080,7 @@ LockExtender.extendActiveLock(Duration.ofMinutes(5));
 | **T16** | `LeaderAnnotationValidatorBeanPostProcessor` — `CompletableFuture` 반환 fail-fast (`leader-spring-boot`) | medium | — |
 | **T17** | 통합 테스트 — 모든 시나리오 (`leader-spring-boot` + 각 backend 모듈 contract) | high | T7–T16 |
 | **T18** | README (`leader-spring-boot/README.md` + `.ko.md`) + Mermaid sequenceDiagram + 8 backend README 노트 + `leader-ktor` 노트 | medium | T17 |
-| **T19** | CHANGELOG.md + WIP.md 업데이트 + 두 CLAUDE.md drift 수정 (root + leader-bom) | low | T18 |
+| **T19** | CHANGELOG.md + WIP.md (ShedLock 호환 API 섹션 추가) + 3 CLAUDE.md drift 수정 (workspace root / bluetape4k-leader / leader-bom) + `examples/ktor-app/README.md` LockAssertSuspend 예제 1건 (R7-A2) | low | T18 |
 
 **Critical path**: T1 → T4 → T14 → T17 → T18 → T19. T7–T13 backend 별 병렬 가능 (T1 완료 후).
 

--- a/docs/superpowers/specs/2026-05-10-lock-extender-design.md
+++ b/docs/superpowers/specs/2026-05-10-lock-extender-design.md
@@ -337,7 +337,8 @@ sealed class LeaderLockHandle {
             return Real(identity, token, acquiredAtNanos, slotId, acquiringThreadId, n, extendDelegate)
         }
 
-        // 명시적 equals/hashCode/toString — delegate 제외, (identity, token, reentryDepth, slotId) 기반
+        // 명시적 equals/hashCode/toString — delegate/acquiringThreadId 제외, (identity, token, reentryDepth, slotId) 기반.
+        // acquiringThreadId 는 ownership 비교에 사용 금지 (R6-P2) — Redisson cross-thread debug 정보 only.
         override fun equals(other: Any?): Boolean { ... }
         override fun hashCode(): Int { ... }
         override fun toString(): String =
@@ -551,7 +552,7 @@ suspend fun <T> runIfLeaderResultSuspend(
 | `SuspendLeaderGroupElector` | **default fun 신규 추가** | 동일 |
 | `AsyncLeaderElector` / `VirtualThreadLeaderElector` | 추가 안 함 (out-of-scope) | — |
 
-**§10.1 source-compat 갱신**: "모든 elector 인터페이스 무변경" → "**`SuspendLeaderElector`/`SuspendLeaderGroupElector` 에 default fun 추가** (source/binary 호환), 그 외 무변경".
+**§10.1 source-compat 갱신**: "모든 elector 인터페이스 무변경" → "**`SuspendLeaderElector`/`SuspendLeaderGroupElector` 에 default fun 추가** (source-compatible; binary-compat 은 §10.1b 의 `-jvm-default=enable` 검증 의존), 그 외 무변경".
 
 ---
 
@@ -706,7 +707,7 @@ private fun aroundLeader(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
     } catch (e: CancellationException) {
         throw e
     } catch (e: BodyThrownMarker) {
-        throw e.cause!!   // body exception 그대로 propagate — failureMode 무관
+        throw e.cause   // override val cause: Throwable → non-null 보장 (R6-P2)   // body exception 그대로 propagate — failureMode 무관
     } catch (e: CaptureInvariantException) {
         throw e            // ⭐ R5-F3 — 전용 exception type (일반 ISE 와 구분)
     } catch (e: Exception) {  // ⭐ backend exception 만 (R3-F5 — Throwable 아님)
@@ -721,8 +722,8 @@ private fun aroundLeader(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
     }
 }
 
-/** body exception marker (R4-F2) */
-private class BodyThrownMarker(cause: Throwable) : RuntimeException(cause)
+/** body exception marker (R4-F2 + R6-P2 — `override val cause` 로 non-null 보장). */
+private class BodyThrownMarker(override val cause: Throwable) : RuntimeException(cause)
 
 /** capture invariant 실패 전용 exception — 일반 IllegalStateException 과 구분 (R5-F3) */
 internal class CaptureInvariantException(message: String) : IllegalStateException(message)
@@ -744,9 +745,17 @@ private suspend fun aroundLeaderSuspendBody(pjp: ProceedingJoinPoint, meta: Advi
         }
     }
 
-    // 2) 정상 경로 — body / capture-invariant / backend exception 분리 (R4-F2 + R5-F2 + R5-F3)
+    // 2) 정상 경로 — body / capture-invariant / backend exception 분리 (R4-F2 + R5-F2 + R5-F3 + R6-F1)
+    // ⭐ R6-F1 — suspend body 호출은 `suspendCoroutineUninterceptedOrReturn { innerCont -> pjp.proceed(newArgs) }` 패턴 필수.
+    //   `suspendBlock.startCoroutineUninterceptedOrReturn(...)` 직접 반환은 COROUTINE_SUSPENDED sentinel 위험 —
+    //   elector 가 body 종료로 오인하고 lock release 가능 (LeaderElectionAspect.kt:212 기존 패턴 동일).
     suspend fun proceedProtected(): Any? = try {
-        suspendBlock.startCoroutineUninterceptedOrReturn(...)
+        @Suppress("UNCHECKED_CAST")
+        suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
+            val newArgs = pjp.args.copyOf()
+            newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
+            pjp.proceed(newArgs)
+        }
     } catch (e: CancellationException) {
         throw e
     } catch (e: Throwable) {
@@ -773,7 +782,7 @@ private suspend fun aroundLeaderSuspendBody(pjp: ProceedingJoinPoint, meta: Advi
     } catch (e: CancellationException) {
         throw e
     } catch (e: BodyThrownMarker) {
-        throw e.cause!!
+        throw e.cause   // override val cause: Throwable → non-null 보장 (R6-P2)
     } catch (e: CaptureInvariantException) {
         throw e
     } catch (e: Exception) {  // ⭐ backend exception 만 (R3-F5)

--- a/docs/superpowers/specs/2026-05-10-lock-extender-design.md
+++ b/docs/superpowers/specs/2026-05-10-lock-extender-design.md
@@ -741,18 +741,7 @@ internal class CaptureInvariantException(message: String) : IllegalStateExceptio
 private suspend fun aroundLeaderSuspendBody(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
     val identity = meta.resolveLockIdentity(AdviceBranch.SUSPEND)  // R5-F6 — suspend branch (Mono 분기는 AdviceBranch.MONO)
 
-    // 1) Reentrant peek — coroutineContext only (R7)
-    val outer = currentCoroutineContext()[LockHandleElement]?.handle as? LeaderLockHandle.Real
-    if (outer != null && outer.matchesIdentity(identity)) {
-        // ⭐ R3-F4 — LeaderElectionInfo + LockHandleElement 결합 push (기존 aspect 가 LeaderElectionInfo 주입)
-        val passthrough = outer.withReentryDepth(outer.reentryDepth + 1)
-        return withContext(LeaderElectionInfo(identity.lockName, true) + LockHandleElement(passthrough)) {
-            suspendBlock.startCoroutineUninterceptedOrReturn(...)
-        }
-    }
-
-    // 2) 정상 경로 — body / capture-invariant / backend exception 분리 (R4-F2 + R5-F2 + R5-F3 + R6-F1)
-    // ⭐ R6-F1 — suspend body 호출은 `suspendCoroutineUninterceptedOrReturn { innerCont -> pjp.proceed(newArgs) }` 패턴 필수.
+    // ⭐ R6-F1 + R7-Codex-2 — suspend body 호출 helper. reentrant + elected + fail-open 3 분기 모두에서 사용.
     //   `suspendBlock.startCoroutineUninterceptedOrReturn(...)` 직접 반환은 COROUTINE_SUSPENDED sentinel 위험 —
     //   elector 가 body 종료로 오인하고 lock release 가능 (LeaderElectionAspect.kt:212 기존 패턴 동일).
     suspend fun proceedProtected(): Any? = try {
@@ -768,6 +757,17 @@ private suspend fun aroundLeaderSuspendBody(pjp: ProceedingJoinPoint, meta: Advi
         throw BodyThrownMarker(e)
     }
 
+    // 1) Reentrant peek — coroutineContext only (R7)
+    val outer = currentCoroutineContext()[LockHandleElement]?.handle as? LeaderLockHandle.Real
+    if (outer != null && outer.matchesIdentity(identity)) {
+        // ⭐ R3-F4 — LeaderElectionInfo + LockHandleElement 결합 push (기존 aspect 가 LeaderElectionInfo 주입)
+        val passthrough = outer.withReentryDepth(outer.reentryDepth + 1)
+        return withContext(LeaderElectionInfo(identity.lockName, true) + LockHandleElement(passthrough)) {
+            proceedProtected()  // ⭐ R7-Codex-2 — reentrant body 도 동일 helper 사용
+        }
+    }
+
+    // 2) 정상 경로 — body / capture-invariant / backend exception 분리 (R4-F2 + R5-F2 + R5-F3)
     return try {
         when (val result = suspendElector.runIfLeaderResultSuspend(identity.lockName) {
             val handle = LeaderLockHandleCapture.poll()
@@ -828,15 +828,23 @@ private suspend fun aroundLeaderSuspendBody(pjp: ProceedingJoinPoint, meta: Advi
 internal data class AdviceMetadata(
     val lockName: String,
     val failureMode: LeaderAspectFailureMode,
+    val annotationKind: LockIdentity.AnnotationKind,  // ⭐ R7-Codex-1 — explicit (groupParams 와 독립 보존)
     val syncFactoryBeanName: String?,           // sync branch 용
     val suspendFactoryBeanName: String?,        // suspend / Mono branch 용
-    val groupParams: LockIdentity.GroupParams?, // group annotation 일 때만 non-null
+    val groupParams: LockIdentity.GroupParams?, // GROUP annotation 일 때만 non-null
     // ... 기존 필드
 ) {
-    /** branch 에 맞는 factoryBeanName 으로 LockIdentity 생성. */
+    init {
+        // ⭐ R7-Codex-1 — annotation metadata drift 검출 (groupParams ↔ annotationKind 일치)
+        require((annotationKind == LockIdentity.AnnotationKind.GROUP) == (groupParams != null)) {
+            "annotationKind=$annotationKind inconsistent with groupParams=$groupParams"
+        }
+    }
+
+    /** branch 에 맞는 factoryBeanName 으로 LockIdentity 생성. annotationKind 는 metadata 에서 직접 전달. */
     fun resolveLockIdentity(branch: AdviceBranch): LockIdentity = LockIdentity(
         lockName = lockName,
-        kind = if (groupParams != null) AnnotationKind.GROUP else AnnotationKind.SINGLE,
+        kind = annotationKind,                   // ⭐ R7-Codex-1 — explicit metadata 사용 (tautology 차단)
         factoryBeanName = when (branch) {
             AdviceBranch.SYNC -> requireNotNull(syncFactoryBeanName)
             AdviceBranch.SUSPEND, AdviceBranch.MONO -> requireNotNull(suspendFactoryBeanName)
@@ -991,7 +999,12 @@ unsupported 행은 concrete test class 부재 (skip 아님). matrix 자체가 AC
     ```
   - R2DBC / Local 은 native suspend → default OK (Local 은 non-blocking, R2DBC 는 suspend native)
 - [ ] **AC-22**: AOP CTW weave smoke test — sync/suspend/Mono 각각 실제 woven bean 호출로 `LockHandleElement` propagation 검증 (R3-F13).
-- [ ] **AC-22b**: `leader-ktor` plugin propagation smoke test — Ktor `Application.routing` 안에서 `LockAssert.assertLockedSuspend()` 호출 시 plugin 이 inject 한 `LockHandleElement` 가 정확히 동작 (R7-A1). 실패 시 README "미지원 시나리오" 명시.
+- [ ] **AC-22b**: `leader-ktor` plugin propagation smoke test (R7-A1 + R7-Codex-3):
+  - 실제 plugin surface = `leaderScheduled { ... }` background action (request routing 아님)
+  - `Ktor leaderScheduled { LockAssert.assertLockedSuspend() }` 시 leader 인 동안 throw 없이 통과 검증
+  - plugin 자체는 `Application.attributes` 만 사용 — `LockHandleElement` 전파는 `leaderScheduled` 가 호출하는 elector 의 capture 메커니즘에 의존
+  - 만약 background action 외 surface (request routing, custom interceptor 등) 에서 propagation 실패 → README "미지원 시나리오" 명시 (Mono 분기 동일 정책)
+  - T17/T18 task 에 leader-ktor 통합 검증 포함, 또는 별도 unsupported 문서화 commit
 - [ ] **AC-23**: `handle.extendDelegate === watchdog.delegate` reference 검증 — 각 backend elector 모듈 안에 unit test (`leader-redis-lettuce`, `leader-redis-redisson`, ...) — `extendDelegate` 가 `internal` 이라 cross-module access 불가 (R3-F14).
 - [ ] **AC-24**: SPI 분산 backend classifier 검증 (R3-F9 / R5-F4):
   - `leader-core` 의 `BackendErrorClassifier` SPI + `CoreBackendErrorClassifier` (JDK/공통) + `CompositeBackendErrorClassifier`
@@ -1258,6 +1271,43 @@ LockExtender.extendActiveLock(Duration.ofMinutes(5));
 - R6 dispatch 시 polish/nit 영역 진입 예상 (P1 ≤ 2, P2/P3 위주).
 
 총 review 합계: **103 finding** (Codex 56 + perspective 47), 모두 적용.
+
+---
+
+## Appendix F — Round 7 Review 통합 (multi-perspective + Codex)
+
+R7 Phase 1 (multi-perspective 4 parallel) + Phase 3 (Codex) — 통합 7 finding.
+
+### Phase 1 (multi-perspective)
+- code-reviewer: 0 finding (수렴)
+- silent-failure-hunter: 0 finding (수렴)
+- type-design-analyzer: 2 HIGH (R7-T1 LockIdentity init invariant, R7-T2 BackendError(Exception))
+- code-architect: 2 HIGH (R7-A1 leader-ktor smoke test, R7-A2 WIP/CLAUDE.md drift fix)
+
+### Phase 3 (Codex) — 3 P1
+- R7-Codex-1: AdviceMetadata.annotationKind explicit 보존 (groupParams 와 독립) — invariant tautology 차단
+- R7-Codex-2: suspend reentrant branch 도 proceedProtected() helper 사용 (COROUTINE_SUSPENDED sentinel 위험 균일 차단)
+- R7-Codex-3: AC-22b ktor scope 정확화 — `leaderScheduled` background (Application.routing 아님)
+
+### 적용 (7건 모두)
+
+- §5.2a `LockIdentity init { require((kind==GROUP)==(groupParams!=null)) }`
+- §5.3 `ExtendOutcome.BackendError(cause: Exception)` (Throwable → Exception)
+- §11 leader-ktor smoke test + WIP.md ShedLock 섹션 + 3 CLAUDE.md drift + ktor-app README 추가
+- §7.5b `AdviceMetadata.annotationKind` field + init require + resolveLockIdentity 가 explicit 사용
+- §7.2 suspend `proceedProtected` helper 가 reentrant 분기 진입 전 정의 + 모든 suspend body 호출 위치에서 사용
+- AC-22b wording 갱신 (leaderScheduled 검증)
+
+### Round 7 결정 기록
+
+33. **AdviceMetadata.annotationKind explicit** — groupParams 추론 방식은 tautology. annotation 자체에서 kind 보존 + invariant require.
+34. **`ExtendOutcome.BackendError(Exception)`** — Throwable 차단으로 FATAL Error wrap 차단 (compile-time 강제).
+35. **suspend `proceedProtected` 단일 helper** — reentrant + elected + fail-open 3 분기 모두 동일 패턴 (sentinel 위험 균일 차단).
+
+### 수렴 평가
+- R1 (63) → R2 (12) → R3 (15) → R4 (7) → R5 (6) → R6 (4) → R7 (7).
+- R7 finding 모두 적용. R8 dispatch 시 polish 영역 진입 예상.
+- 통합 reviewer 합계: **117 finding** (Codex 63 + perspective 54), 모두 적용.
 
 ---
 

--- a/docs/superpowers/specs/2026-05-10-lock-extender-design.md
+++ b/docs/superpowers/specs/2026-05-10-lock-extender-design.md
@@ -1058,7 +1058,7 @@ LockExtender.extendActiveLock(Duration.ofMinutes(5));
 - **`leader-spring-boot/README.md` + `README.ko.md`** — 신규 섹션 "LockAssert & LockExtender (ShedLock-equivalent)" + Mermaid sequenceDiagram.
 - 8 backend 모듈 README — "extend now supported" 한 줄 노트.
 - **`leader-ktor/README.md`** — 한 줄 노트: "plugin 안에서 `LockAssert.assertLockedSuspend()` 사용 가능" (Architect A8).
-- **`leader-ktor` propagation smoke test** (R7-A1): plugin 의 `coroutineScope` + `withContext(LockHandleElement(...))` propagation 검증 1건. Ktor `call.attributes` / `PipelineContext` dispatch 시 element 가 떨어지면 README "미지원 시나리오" 명시 (Mono 분기 동일 정책).
+- **`leader-ktor` propagation smoke test** (R7-A1 / R7-Codex-3): 실제 plugin surface 인 `leaderScheduled { ... }` background action 안에서 `LockAssert.assertLockedSuspend()` / `LockExtender.extendActiveLockSuspend()` 가 정확히 동작 검증. plugin 자체는 `Application.attributes` 만 사용하며 request routing context 는 주입하지 않음 — `Application.routing` / `PipelineContext` / 임의 Reactor operator 등 비-leaderScheduled 표면에서 propagation 실패 시 README "미지원 시나리오" 명시 (Mono 분기 동일 정책).
 - KDoc — 모든 신규 public surface + `ExtendOutcome` variants.
 - **CHANGELOG.md** — `LockHandleElement` 추가, `LockAssert`/`LockExtender` API 신규, validator `CompletableFuture` 차단, watchdog × extend 가시성 (Architect A9).
 - **`WIP.md`** (R7-A2) — Issue #79 완료 표시 + "ShedLock 호환 ergonomic API 도입" 섹션 (3-5줄 요약 + 신규 API surface 링크 — `LockAssert`, `LockExtender`, `ExtendOutcome`, `LeaderLockHandle`).

--- a/docs/superpowers/specs/2026-05-10-lock-extender-design.md
+++ b/docs/superpowers/specs/2026-05-10-lock-extender-design.md
@@ -265,7 +265,8 @@ package io.bluetape4k.leader
  * @property lockName SpEL 평가 후 resolved string
  * @property kind 어노테이션 종류 — `SINGLE` (`@LeaderElection`) / `GROUP` (`@LeaderGroupElection`)
  * @property factoryBeanName Spring bean name — 같은 lockName 이라도 다른 factory 면 별개 lock
- * @property groupParams Group 의 maxLeaders + slot strategy 등 (Single 이면 null)
+ * @property groupParams Group 의 식별 파라미터 (Single 이면 null) — **현재 `maxLeaders` 만 보유** (R3-F7).
+ *   slot strategy / weight 등 추가 옵션은 향후 확장 시 이 클래스에 필드 추가 (binary-compat 위해 default 값 사용).
  */
 data class LockIdentity(
     val lockName: String,
@@ -274,6 +275,7 @@ data class LockIdentity(
     val groupParams: GroupParams? = null,
 ) {
     enum class AnnotationKind { SINGLE, GROUP }
+    /** Currently `maxLeaders` only — future fields require default values for binary-compat. */
     data class GroupParams(val maxLeaders: Int)
 }
 ```
@@ -295,7 +297,8 @@ import kotlin.time.Duration
  * - [Real] — 실제 backend 보유. `extend()` / `extendSuspend()` 호출 가능
  * - [FailOpen] — fail-open sentinel. extend 항상 `NotHeld` 반환
  *
- * 외부에서 인스턴스 생성 불가 — `internal constructor`. AOP aspect 또는 elector 만 생성.
+ * **소스 API 레벨에서** 외부 생성 차단 — `internal constructor`. AOP aspect 또는 elector 만 생성.
+ * (R3-F15: `internal` 은 reflection / security boundary 아님 — 신뢰된 caller 한정 source API 차단 의미.)
  */
 sealed class LeaderLockHandle {
     abstract val identity: LockIdentity                 // ⭐ R2-F3 — full identity 필수
@@ -371,7 +374,7 @@ sealed interface ExtendOutcome {
      * - Redisson: Redisson 내부 atomic — Redisson 이 client clock 사용 가능 → ±50ms
      * - MongoDB: server-side `$set` — 정확
      * - Exposed JDBC/R2DBC: DB server 시각 (`now()` SQL) — 정확
-     * - ZooKeeper: TTL 개념 없음 — `Instant.MAX` (session liveness)
+     * - ZooKeeper: TTL 개념 없음 — `observedExpireAt = Instant.MAX` 로 표현하지만 의미는 "session-held liveness 확인" passthrough (R3-F11). lease extension 아님.
      *
      * caller 는 정확한 deadline 으로 사용 X — observability/logging 용.
      */
@@ -401,7 +404,18 @@ import kotlin.time.Duration
  */
 internal interface ExtendDelegate {
     fun extend(lockAtMostFor: Duration): ExtendOutcome
+
+    /**
+     * suspend extend.
+     *
+     * **default 구현은 sync `extend` 직접 호출 — local 또는 non-blocking backend 전용.**
+     * Blocking backend (Lettuce sync, Hazelcast IMap, Exposed JDBC, Redisson 등) 는 반드시 override
+     * 하여 `withContext(Dispatchers.IO)` + `coroutineContext.ensureActive()` 사용 (R3-F8 / R9).
+     *
+     * AC-21: blocking backend 의 `ExtendDelegate.extendSuspend` 가 default 호출 0회 (소스 grep verify).
+     */
     suspend fun extendSuspend(lockAtMostFor: Duration): ExtendOutcome = extend(lockAtMostFor)
+
     fun isHeld(): Boolean
 }
 ```
@@ -462,7 +476,13 @@ import kotlin.coroutines.CoroutineContext
  * suspend / Mono 컨텍스트의 active lock handle. `LeaderElectionInfo` 와 별도 element —
  * binary-compat 보존 (`LeaderElectionInfo` 무변경).
  */
-data class LockHandleElement(val handle: LeaderLockHandle) : CoroutineContext.Element {
+/**
+ * suspend / Mono 컨텍스트의 active lock handle.
+ *
+ * **`handle` property 는 `internal`** (R3-F12) — 외부 caller 는 `LockAssert.assertLockedSuspend()` /
+ * `LockExtender.extendActiveLockSuspend(d)` API 만 사용. handle metadata (token, slotId 등) 직접 접근 차단.
+ */
+data class LockHandleElement internal constructor(internal val handle: LeaderLockHandle) : CoroutineContext.Element {
     companion object Key : CoroutineContext.Key<LockHandleElement>
     override val key: CoroutineContext.Key<*> get() = Key
 }
@@ -474,28 +494,33 @@ data class LockHandleElement(val handle: LeaderLockHandle) : CoroutineContext.El
 
 ### 5.7 `LeaderRunResult` — fail-open detection (Codex F1 / R2-F2)
 
-**기존 public sealed 그대로 사용**:
+### 정책 (R3-F3 정합성 정리)
+
+**`LeaderRunResult` — 기존 public sealed 그대로 사용** (수정 없음):
 
 ```kotlin
-// leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderRunResult.kt (이미 존재, 수정 없음)
+// leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderRunResult.kt (이미 존재)
 sealed interface LeaderRunResult<out T> {
     data class Elected<out T>(val value: T?) : LeaderRunResult<T>
     data object Skipped : LeaderRunResult<Nothing>
 }
 ```
 
-**Backend exception 처리** — `LeaderRunResult` 에 `BackendError` 추가하지 않음. Aspect 가 `runIfLeaderResult` 호출을 `try/catch` 로 감싸 backend exception 캡처 (§7.1, §7.2).
+- **backend exception variant 추가하지 않음** — aspect 가 `runIfLeaderResult` 호출을 `try/catch (Exception)` 로 감싸 직접 캡처.
+- **인터페이스 default fun 변경 없음** — `runIfLeaderResult` 는 `LeaderElector`/`LeaderGroupElector` 에 이미 default fun 으로 존재. 본 PR 에서 신규 추가 X.
+- **suspend 변형은 default fun 으로 추가** — `SuspendLeaderElector`/`SuspendLeaderGroupElector` 에 `runIfLeaderResultSuspend` default fun 추가. **default 구현 보유 → 기존 구현체 binary-compat 보존** (Kotlin default fun 은 caller-side 호환 — 새 구현 없이도 동작).
 
-**적용 범위 매트릭스** (R2-F2):
+**적용 범위 매트릭스** (R2-F2 / R3-F3):
 
-| Elector 종류 | `runIfLeaderResult` | 변경 사항 |
+| Elector 종류 | `runIfLeaderResult*` | 본 PR 영향 |
 |---|---|---|
-| `LeaderElector` (sync) | 이미 default fun 존재 | aspect 가 `try/catch` 로 backend exception 처리 |
-| `SuspendLeaderElector` | default fun 추가 (`runIfLeaderResultSuspend`) | 동일 |
-| `LeaderGroupElector` | 이미 default fun 존재 | 동일 |
-| `SuspendLeaderGroupElector` | default fun 추가 | 동일 |
-| `AsyncLeaderElector` | 추가 안 함 (out-of-scope) | — |
-| `VirtualThreadLeaderElector` | 추가 안 함 (out-of-scope) | — |
+| `LeaderElector` (sync) | 이미 default fun (`runIfLeaderResult`) | 변경 없음 — aspect 가 직접 호출 |
+| `SuspendLeaderElector` | **default fun 신규 추가 (`runIfLeaderResultSuspend`)** | source-compat (default 보유), binary 영향 미미 (interface 추가 default — 기존 .class 호환) |
+| `LeaderGroupElector` | 이미 default fun | 변경 없음 |
+| `SuspendLeaderGroupElector` | **default fun 신규 추가** | 동일 |
+| `AsyncLeaderElector` / `VirtualThreadLeaderElector` | 추가 안 함 (out-of-scope) | — |
+
+**§10.1 source-compat 갱신**: "모든 elector 인터페이스 무변경" → "**`SuspendLeaderElector`/`SuspendLeaderGroupElector` 에 default fun 추가** (source/binary 호환), 그 외 무변경".
 
 ---
 
@@ -517,7 +542,7 @@ sealed interface LeaderRunResult<out T> {
 | **Exposed R2DBC group** | `ExposedR2dbcGroupLock.kt` | `suspend fun extendSlot(...): ExtendOutcome` | 동일 | **신규** |
 | **Hazelcast single** | `leader-hazelcast/.../lock/HazelcastLock.kt` | `fun extend(...): ExtendOutcome` | `IMap.executeOnKey(lockKey, ExtendEntryProcessor(token, lease))` — EntryProcessor 내부 `entry.value == ours && expireAt > now → setValue(token, lease, MS) ELSE NotHeld` (R2). plain `setTtl` 금지 | **신규** |
 | **Hazelcast group / suspend** | `HazelcastSuspendLock.kt` 등 | 동일 + `withContext(IO)` | 동일 | **신규** |
-| **ZooKeeper** | `leader-zookeeper/.../ZkLeaderElector.kt` 내부 `InterProcessMutex` | `fun extend(...): ExtendOutcome` | `if (mutex.isAcquiredInThisProcess()) Extended(Instant.MAX) else NotHeld` — TTL 개념 없음, session liveness 검사. **`LeaderLeaseAutoExtender.start(enabled=false)` 강제** (R16) | **신규** passthrough |
+| **ZooKeeper** | `leader-zookeeper/.../ZkLeaderElector.kt` 내부 `InterProcessMutex` | `fun extend(...): ExtendOutcome` | **session live passthrough** (R3-F11) — `if (mutex.isAcquiredInThisProcess()) Extended(observedExpireAt = Instant.MAX) else NotHeld`. `Extended` 는 "lease 연장" 이 아닌 "session-held liveness 확인" 의미. group semaphore 도 lease TTL 없음 — 동일 passthrough. **`LeaderLeaseAutoExtender.start(enabled=false)` 강제** (R16) | **신규** passthrough |
 | **Local single** | `leader-core/.../local/LocalLeaderStateRegistry.kt` | `fun extend(name, token, leaseTime): ExtendOutcome` | `ConcurrentHashMap.compute` atomic + `expireAt > now` guard | **신규** |
 | **Local group** | `LocalLeaderGroupRegistry` (가칭) | `fun extendSlot(name, slot, leaseTime): ExtendOutcome` | 동일 | **신규** |
 
@@ -529,16 +554,21 @@ sealed interface LeaderRunResult<out T> {
 
 ### Watchdog interaction
 
-- 모든 backend 의 atomic extend 메서드는 watchdog (`LeaderLeaseAutoExtender.extend` lambda) 와 **동일 reference** 사용 (Architect A3 / R5):
+- 모든 backend 의 atomic extend 메서드는 watchdog 와 **동일 `ExtendDelegate` 객체** 공유 (Architect A3 / R5 / R3-F6):
 
 ```kotlin
-// 각 elector 내부
-val extendClosure: (Duration) -> ExtendOutcome = { d -> lock.extend(d) }
-LeaderLeaseAutoExtender.start(enabled = options.autoExtend, leaseTime = options.leaseTime, extend = { d -> extendClosure(d).isExtended })
-val handle = LeaderLockHandle.real(..., extendFn = extendClosure, ...)
+// 각 elector 내부 — runIfLeader acquire 직후
+val extendDelegate: ExtendDelegate = object : ExtendDelegate {
+    override fun extend(d: Duration): ExtendOutcome = lock.extend(d)
+    override suspend fun extendSuspend(d: Duration): ExtendOutcome = lock.extendSuspend(d)  // backend 가 suspend native 면 native 호출
+    override fun isHeld(): Boolean = lock.isHeldByCurrentInstance()
+}
+LeaderLeaseAutoExtender.start(enabled = options.autoExtend, leaseTime = options.leaseTime, delegate = extendDelegate)
+val handle = LeaderLockHandle.Real(..., extendDelegate = extendDelegate, ...)
 ```
 
-- AC 추가: `extendClosure === watchdog.extend` reference 동일 (test verify).
+- `LeaderLeaseAutoExtender.start` 시그니처 변경 (`(Duration) -> Boolean` 람다 → `delegate: ExtendDelegate`).
+- AC-15: `handle.extendDelegate === watchdog.delegate` reference 동일 (test verify).
 
 ---
 
@@ -566,20 +596,20 @@ private fun aroundLeader(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
     }) {
         is LeaderRunResult.Elected -> result.value
         is LeaderRunResult.Skipped -> when (meta.failureMode) {
-            FAIL_OPEN_RUN -> LockStateHolder.withPushed(LeaderLockHandle.failOpen(identity.lockName)) { pjp.proceed() }
-            SKIP -> null
-            RETHROW -> null  // Skipped 는 contention — 정상 흐름, throw 없음
+            FAIL_OPEN_RUN -> LockStateHolder.withPushed(LeaderLockHandle.failOpen(identity)) { pjp.proceed() }
+            SKIP, RETHROW -> null   // ⭐ R3-F1 — contention 은 정상 흐름 (`runIfLeader` contract: null = skip-on-contention).
+                                    //   `RETHROW` 는 backend exception 시에만 throw — `Skipped` 와 무관
             INHERIT -> error("INHERIT must be resolved in resolveMetadata")
         }
         // backend exception (try/catch 로 캡처 — `LeaderRunResult` public sealed 에 BackendError 없음)
     }
 } catch (e: CancellationException) {
     throw e
-} catch (t: Throwable) {  // backend exception 분기 — Architect A2 / Codex F10 / R2-F1
+} catch (e: Exception) {  // ⭐ R3-F5 — Throwable 대신 Exception (OOM/StackOverflow/LinkageError 제외)
     when (meta.failureMode) {
-        FAIL_OPEN_RUN -> LockStateHolder.withPushed(LeaderLockHandle.failOpen(identity.lockName)) { pjp.proceed() }
-        SKIP -> null  // 침묵 + WARN log
-        RETHROW -> throw t
+        FAIL_OPEN_RUN -> LockStateHolder.withPushed(LeaderLockHandle.failOpen(identity)) { pjp.proceed() }
+        SKIP -> null  // 침묵 + WARN log + metric
+        RETHROW -> throw e
         INHERIT -> error("INHERIT must be resolved in resolveMetadata")
     }
 }
@@ -594,38 +624,42 @@ private suspend fun aroundLeaderSuspendBody(pjp: ProceedingJoinPoint, meta: Advi
     // 1) Reentrant peek — coroutineContext only (R7)
     val outer = currentCoroutineContext()[LockHandleElement]?.handle as? LeaderLockHandle.Real
     if (outer != null && outer.matchesIdentity(identity)) {
-        return withContext(LockHandleElement(outer.withReentryDepth(outer.reentryDepth + 1))) {
+        // ⭐ R3-F4 — LeaderElectionInfo + LockHandleElement 결합 push (기존 aspect 가 LeaderElectionInfo 주입)
+        val passthrough = outer.withReentryDepth(outer.reentryDepth + 1)
+        return withContext(LeaderElectionInfo(identity.lockName, true) + LockHandleElement(passthrough)) {
             suspendBlock.startCoroutineUninterceptedOrReturn(...)
         }
     }
 
     // 2) 정상 경로
-    return when (val result = suspendElector.runIfLeaderResultSuspend(identity.lockName, meta.options) {
-        val handle = LeaderLockHandleCapture.poll()
-            ?: error("suspend elector did not capture handle — bug in ${suspendElector::class.simpleName}")
-        withContext(LockHandleElement(handle)) {
-            suspendBlock.startCoroutineUninterceptedOrReturn(...)
-        }
-    }) {
-        is LeaderRunResult.Elected -> result.value
-        is LeaderRunResult.Skipped -> when (meta.failureMode) {
-            FAIL_OPEN_RUN -> withContext(LockHandleElement(LeaderLockHandle.failOpen(identity.lockName))) {
+    return try {
+        when (val result = suspendElector.runIfLeaderResultSuspend(identity.lockName, meta.options) {
+            val handle = LeaderLockHandleCapture.poll()
+                ?: error("suspend elector did not capture handle — bug in ${suspendElector::class.simpleName}")
+            withContext(LeaderElectionInfo(identity.lockName, true) + LockHandleElement(handle)) {
                 suspendBlock.startCoroutineUninterceptedOrReturn(...)
             }
-            SKIP, RETHROW -> null
+        }) {
+            is LeaderRunResult.Elected -> result.value
+            is LeaderRunResult.Skipped -> when (meta.failureMode) {
+                FAIL_OPEN_RUN -> withContext(LeaderElectionInfo(identity.lockName, false) + LockHandleElement(LeaderLockHandle.failOpen(identity))) {
+                    suspendBlock.startCoroutineUninterceptedOrReturn(...)
+                }
+                SKIP, RETHROW -> null   // contention 은 모든 모드에서 정상 흐름 — null 반환 (R3-F1)
+                INHERIT -> error("INHERIT must be resolved")
+            }
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {  // ⭐ R3-F5 — Throwable 대신 Exception (OOM/StackOverflow/LinkageError 제외)
+        when (meta.failureMode) {
+            FAIL_OPEN_RUN -> withContext(LeaderElectionInfo(identity.lockName, false) + LockHandleElement(LeaderLockHandle.failOpen(identity))) {
+                suspendBlock.startCoroutineUninterceptedOrReturn(...)
+            }
+            SKIP -> null      // backend exception silent skip + WARN log
+            RETHROW -> throw e
             INHERIT -> error("INHERIT must be resolved")
         }
-    }
-} catch (e: CancellationException) {
-    throw e
-} catch (t: Throwable) {  // backend exception 분기 (R2-F1)
-    when (meta.failureMode) {
-        FAIL_OPEN_RUN -> withContext(LockHandleElement(LeaderLockHandle.failOpen(identity.lockName))) {
-            suspendBlock.startCoroutineUninterceptedOrReturn(...)
-        }
-        SKIP -> null
-        RETHROW -> throw t
-        INHERIT -> error("INHERIT must be resolved")
     }
 }
 ```
@@ -734,16 +768,23 @@ unsupported 행은 concrete test class 부재 (skip 아님). matrix 자체가 AC
 
 ## 9. Acceptance Criteria
 
-- [ ] **AC-1**: 8 backend × {sync, suspend, group, suspend-group} 모두 해당 contract test 통과 (capability 매트릭스 만족 — ZK 는 group 미지원, R2DBC 는 sync 미지원 등 명시).
+- [ ] **AC-1**: §8.1 capability matrix 의 ✅ 모든 cell 에 concrete contract test 통과 (R3-F10 — ZK group/suspend-group 실제 존재; R2DBC 는 sync 미지원만 unsupported).
 - [ ] **AC-2**: `@LeaderElection` 동일 full-identity reentrant 호출 시 backend acquire counter 정확히 1회 (mockk verify).
 - [ ] **AC-2b**: `@LeaderElection` ↔ `@LeaderGroupElection` 동일 lockName 은 dedupe 안 됨 — 둘 다 정상 acquire (Codex F3).
 - [ ] **AC-3**: `LockAssert.assertLocked()` annotated 외부 호출 시 IllegalStateException (메시지에 "outside" / "no active scope" 포함).
 - [ ] **AC-4**: `LockExtender.extendActiveLock(d)` 가 fail-open sentinel scope 에서 `false` + WARN 로그 + metric (rate-limited).
-- [ ] **AC-4b**: backend exception 분기 × failureMode 행렬 검증 (Architect A2 / R2-F1):
-  - `FAIL_OPEN_RUN` → sentinel push + body 실행
-  - `SKIP` → null + WARN log, body 미실행
-  - `RETHROW` → throw, body 미실행
-  - 동일 행렬을 `Skipped` (contention) 분기에도 적용
+- [ ] **AC-4b**: failure mode × 분기 행렬 검증 (Architect A2 / R2-F1 / R3-F1):
+
+| 분기 | `RETHROW` | `SKIP` | `FAIL_OPEN_RUN` |
+|---|---|---|---|
+| `Elected` | body 실행 + lock | body 실행 + lock | body 실행 + lock |
+| `Skipped` (contention) | `null` | `null` | sentinel push + body 실행 |
+| `Exception` (backend) | throw | `null` + WARN | sentinel push + body 실행 |
+
+  - `Skipped × RETHROW` 는 **`null` 반환** (contention 은 정상 흐름, `runIfLeader` contract).
+  - `Exception × RETHROW` 만 실제 throw.
+  - sentinel push 는 `FAIL_OPEN_RUN` 분기에서만 (Skipped + Exception 모두).
+  - `catch` 범위는 `Exception` — `OutOfMemoryError`/`StackOverflowError`/`LinkageError` 등은 제외 (R3-F5).
 - [ ] **AC-5**: Sync, suspend, Mono 3 분기 모두 `LockAssert` / `LockExtender` 동작 (각 분기 × 2 API = 6).
 - [ ] **AC-6**: Watchdog 활성 + `extendActiveLock` 동시 호출 race-free — torn write 0 (TTL 가 두 마지막 호출의 최댓값 또는 그 사이 값, 단조 가정 X).
 - [ ] **AC-6b**: watchdog cadence 다음 tick 에서 user-extended 큰 값이 watchdog 작은 값으로 silently 줄어들 때 WARN log + metric (R5 / SF5).
@@ -768,13 +809,18 @@ unsupported 행은 concrete test class 부재 (skip 아님). matrix 자체가 AC
   - helper 함수 안에 swallow 된 케이스도 점검
 - [ ] **AC-19**: Java caller 가 `LockExtender.extendActiveLock(java.time.Duration)` 호출 가능 — `LockExtenderJavaCompatTest` (R15).
 - [ ] **AC-20**: ZK + autoExtend=true 시 startup WARN — watchdog noop (R16).
+- [ ] **AC-21**: Blocking backend (Lettuce sync, Hazelcast, Exposed JDBC, Redisson 등) 의 `ExtendDelegate.extendSuspend` 가 default 사용 0회 — 모두 override + `withContext(IO)` + `ensureActive()` (R3-F8).
+- [ ] **AC-22**: AOP CTW weave smoke test — sync/suspend/Mono 각각 실제 woven bean 호출로 `LockHandleElement` propagation 검증 (R3-F13).
+- [ ] **AC-23**: `handle.extendDelegate === watchdog.delegate` reference 검증 — 각 backend elector 모듈 안에 unit test (`leader-redis-lettuce`, `leader-redis-redisson`, ...) — `extendDelegate` 가 `internal` 이라 cross-module access 불가 (R3-F14).
+- [ ] **AC-24**: backend 별 transient/non-transient exception 분류 표 — KDoc / `BackendErrorClassifier` 헬퍼 노출. classifier test 가 backend 별 known exception 모두 cover (R3-F9).
 
 ---
 
 ## 10. Migration / Compatibility
 
 ### 10.1 Source-compat
-- 모든 elector 인터페이스 무변경.
+- `SuspendLeaderElector` / `SuspendLeaderGroupElector` 에 `runIfLeaderResultSuspend` default fun 추가 — source 호환 (R3-F3).
+- `LeaderElector` / `LeaderGroupElector` / `AsyncLeaderElector` / `VirtualThreadLeaderElector` 무변경.
 - `LeaderElectionInfo` 무변경 — 별도 `LockHandleElement` 추가 (R8 / Type T8).
 - `LockAssert`, `LockExtender`, `LeaderLockHandle`, `ExtendOutcome` 모두 신규 — 추가 only.
 
@@ -917,6 +963,39 @@ LockExtender.extendActiveLock(Duration.ofMinutes(5));
 15. **`Extended.observedExpireAt`** — `newExpireAt` 명칭 변경 (best-effort 명시), backend별 정확도 정책.
 16. **`LeaderRunResult` 변경 없음** — backend exception 은 aspect `try/catch` 로 처리 (public sealed 무변경).
 17. **failure mode 행렬 명시적 처리** — `Skipped`/exception × `RETHROW`/`SKIP`/`FAIL_OPEN_RUN` 모든 cell 정의.
+
+---
+
+## Appendix C — Round 3 Review 통합 (Codex 단독)
+
+총 15 finding (P0×0, P1×6, P2×8, P3×1).
+
+### 적용 (P1×6 + P2 다수 + P3 모두)
+
+- **R3-F1** (P1) → §7.1/§7.2 sync/suspend `Skipped × RETHROW` = `null` 명시 + AC-4b 행렬 표 (Skipped/Exception × RETHROW/SKIP/FAIL_OPEN_RUN)
+- **R3-F2** (P1) → §7.1/§7.2 sketch `failOpen(identity.lockName)` → `failOpen(identity)` 전역 수정 (4 occurrences)
+- **R3-F3** (P1) → §5.7 정책 정리 — `LeaderRunResult` 무변경, suspend default fun 추가 (source/binary 호환), §10.1 source-compat 갱신
+- **R3-F4** (P1) → §7.2 suspend sketch `withContext(LeaderElectionInfo + LockHandleElement)` 결합 명시 — 기존 aspect 의 `LeaderElectionInfo` 주입 보존
+- **R3-F5** (P1) → §7.1/§7.2 `catch (Throwable)` → `catch (Exception)` — OOM/StackOverflow/LinkageError fail-open 차단
+- **R3-F6** (P1) → §6 watchdog interaction sketch `ExtendDelegate` 객체 기반 갱신 (`start(delegate = ...)`)
+- **R3-F7** (P2) → §5.2a `GroupParams` "currently maxLeaders only" + 향후 확장 지침
+- **R3-F8** (P2) → §5.3a `extendSuspend` default 위험 KDoc + AC-21 (blocking backend override 강제)
+- **R3-F9** (P2) → AC-24 — backend 별 transient/non-transient 분류 표 + `BackendErrorClassifier` 헬퍼
+- **R3-F10** (P2) → AC-1 wording 수정 — ZK group 실제 존재 반영
+- **R3-F11** (P2) → §6 ZK row + §5.3 KDoc — `Extended(Instant.MAX)` 의미 "session-held liveness passthrough" 로 정확화
+- **R3-F12** (P2) → §5.5 `LockHandleElement.handle` `internal` 로 낮춤 — 외부 metadata 노출 차단
+- **R3-F13** (P2) → AC-22 — AOP CTW weave smoke test (sync/suspend/Mono 실제 woven bean 호출 검증)
+- **R3-F14** (P2) → AC-23 — `extendDelegate` reference 검증을 backend 모듈 안 unit test 로 한정 (cross-module access 불가)
+- **R3-F15** (P3) → §5.2b `internal` 의미 표현 정확화 (소스 API 차단, reflection boundary 아님)
+
+### Round 3 결정 기록
+
+18. **failure mode 행렬 정합성**: `Skipped × RETHROW` = `null` (contention 정상 흐름), `Exception × RETHROW` 만 throw.
+19. **`catch (Exception)` 한정**: fatal error (OOM/SOE/LinkageError) 는 fail-open 분기 대상 아님 — 그대로 propagate.
+20. **`SuspendLeaderElector` default fun 추가** — source/binary 호환 (Kotlin default fun 의 caller-side 호환성).
+21. **`withContext(LeaderElectionInfo + LockHandleElement)` 결합 push** — 기존 `LeaderElectionInfo` 주입 보존, 신규 element 추가.
+22. **`LockHandleElement.handle` internal** — 외부 caller 는 `LockAssert`/`LockExtender` API 만 사용, metadata 직접 노출 차단.
+23. **AOP weave smoke test 명시** — Freefair CTW 가 실제 weave 했는지 unit/mock 이상의 통합 테스트 필요.
 
 ---
 

--- a/examples/ktor-app/README.ko.md
+++ b/examples/ktor-app/README.ko.md
@@ -64,6 +64,11 @@ fun Application.module(
 
     val aggregator = StatsAggregator()
     leaderScheduled("hourly-stats-aggregation", period = aggregationPeriod) {
+        // (issue #79) leader-only block 안에서 lock 보유 단언 + 필요 시 lease 연장
+        LockAssert.assertLockedSuspend()
+        if (aggregator.estimatedDuration() > aggregationPeriod) {
+            LockExtender.extendActiveLockSuspend(aggregationPeriod * 3)
+        }
         aggregator.aggregate()
     }
 

--- a/examples/ktor-app/README.md
+++ b/examples/ktor-app/README.md
@@ -64,6 +64,11 @@ fun Application.module(
 
     val aggregator = StatsAggregator()
     leaderScheduled("hourly-stats-aggregation", period = aggregationPeriod) {
+        // (issue #79) inside leader-only block — assert lock + extend if needed
+        LockAssert.assertLockedSuspend()
+        if (aggregator.estimatedDuration() > aggregationPeriod) {
+            LockExtender.extendActiveLockSuspend(aggregationPeriod * 3)
+        }
         aggregator.aggregate()
     }
 

--- a/leader-core/README.ko.md
+++ b/leader-core/README.ko.md
@@ -304,6 +304,88 @@ println(group.leaders.map { it.leaderId })
 
 상태 조회는 진단과 메트릭을 위한 best-effort 스냅샷입니다. 락 획득을 대체하는 API가 아닙니다.
 
+## Lock Assert & Extend
+
+`LockAssert` 와 `LockExtender` 는 ShedLock 과 동일한 사용감으로 lock 보유 여부를 단언하고
+`@LeaderElection` / `@LeaderGroupElection` 본문 안에서 lease 를 명시적으로 연장합니다.
+
+### LockAssert
+
+```kotlin
+@LeaderElection(name = "report-job")
+fun runReport() {
+    LockAssert.assertLocked()              // 활성 scope 없으면 throw
+    LockAssert.assertLocked("report-job") // 이름 불일치 시 throw
+
+    if (!LockAssert.isLocked()) return     // throw 없는 조회
+}
+
+// suspend 컨텍스트 — coroutineContext 만 검사 (ThreadLocal fallback 없음, R7)
+@LeaderElection(name = "async-job")
+suspend fun runAsync() {
+    LockAssert.assertLockedSuspend()
+    LockAssert.assertLockedSuspend("async-job")
+
+    val held: Boolean = LockAssert.isLockedSuspend()
+}
+```
+
+- `assertLocked()` / `assertLocked(lockName)` — 활성 scope 없거나 fail-open sentinel 이면 `IllegalStateException` throw.
+- `isLocked()` / `isLocked(lockName)` — throw 없이 `Boolean` 반환.
+- `assertLockedSuspend()` / `isLockedSuspend()` — suspend 변형; `coroutineContext[LockHandleElement]` 만 검사 (ThreadLocal fallback 없음 R7).
+
+### LockExtender
+
+```kotlin
+@LeaderElection(name = "long-job", leaseTime = 30.seconds)
+fun runJob() {
+    // ... 25초 작업 ...
+    LockExtender.extendActiveLock(60.seconds)  // TTL = now + 60s 로 갱신
+    // ... 추가 50초 작업 ...
+}
+
+// 상세 sealed result
+when (val outcome = LockExtender.extendActiveLockDetailed(60.seconds)) {
+    is ExtendOutcome.Extended    -> log.info { "만료 시각 ${outcome.observedExpireAt}" }
+    is ExtendOutcome.NotHeld     -> rollback()
+    is ExtendOutcome.WrongThread -> log.warn { "Redisson thread-bound 위반" }
+    is ExtendOutcome.BackendError -> retry(outcome.cause)
+}
+
+// Java 호환 java.time.Duration overload
+LockExtender.extendActiveLock(Duration.ofSeconds(60))
+
+// suspend 변형
+suspend fun runSuspend() {
+    LockExtender.extendActiveLockSuspend(60.seconds)
+}
+```
+
+- 성공 시 `true`, 실패 시 `false` 반환 (활성 scope 없음, fail-open, token mismatch, backend 오류).
+- `lastExtendDeadline` 을 갱신해 watchdog 가 user 가 연장한 lease 를 silently 축소하지 않도록 차단 (R2 mitigation).
+
+### ⚠️ Reactor non-suspend operator 미지원 (R5)
+
+`LockAssert.assertLocked()` / `LockExtender.extendActiveLock()` 를 non-suspend Reactor operator (`.map {}`, `.filter {}`) 안에서 호출하면 실패합니다.
+ThreadLocal 도 `CoroutineContext` 도 전파되지 않기 때문입니다.
+
+suspend 변형을 `mono {}` builder 안에서 사용하세요:
+
+```kotlin
+// 비권장 — 비동기/cross-thread Reactor operator 에서 실패
+mono.map { LockAssert.assertLocked() }
+
+// 권장 — 올바른 패턴
+mono.flatMap { value ->
+    mono {
+        withContext(LockHandleElement(handle)) {
+            LockAssert.assertLockedSuspend()
+            value
+        }
+    }
+}
+```
+
 ## 의존성 추가
 
 ```kotlin

--- a/leader-core/README.md
+++ b/leader-core/README.md
@@ -304,6 +304,86 @@ println(group.leaders.map { it.leaderId })
 
 State inspection is a best-effort snapshot for diagnostics and metrics. It is not a lock acquisition primitive.
 
+## Lock Assert & Extend
+
+`LockAssert` and `LockExtender` provide ShedLock-equivalent ergonomic APIs for asserting lock ownership and extending lease durations from within an active `@LeaderElection` / `@LeaderGroupElection` body.
+
+### LockAssert
+
+```kotlin
+@LeaderElection(name = "report-job")
+fun runReport() {
+    LockAssert.assertLocked()           // throws if no active lock scope
+    LockAssert.assertLocked("report-job") // throws if named lock not held
+
+    if (!LockAssert.isLocked()) return  // query without throw
+}
+
+// In a suspend context — uses coroutineContext only (no ThreadLocal fallback)
+@LeaderElection(name = "async-job")
+suspend fun runAsync() {
+    LockAssert.assertLockedSuspend()
+    LockAssert.assertLockedSuspend("async-job")
+
+    val held: Boolean = LockAssert.isLockedSuspend()
+}
+```
+
+- `assertLocked()` / `assertLocked(lockName)` — throws `IllegalStateException` when called outside an active scope or inside a fail-open sentinel scope.
+- `isLocked()` / `isLocked(lockName)` — returns `Boolean` without throwing.
+- `assertLockedSuspend()` / `isLockedSuspend()` — suspend variants; inspect `coroutineContext[LockHandleElement]` only (no ThreadLocal fallback per R7).
+
+### LockExtender
+
+```kotlin
+@LeaderElection(name = "long-job", leaseTime = 30.seconds)
+fun runJob() {
+    // ... 25 seconds of work ...
+    LockExtender.extendActiveLock(60.seconds)  // renew TTL to now + 60s
+    // ... 50 more seconds of work ...
+}
+
+// Detailed sealed result
+when (val outcome = LockExtender.extendActiveLockDetailed(60.seconds)) {
+    is ExtendOutcome.Extended    -> log.info { "expires at ${outcome.observedExpireAt}" }
+    is ExtendOutcome.NotHeld     -> rollback()
+    is ExtendOutcome.WrongThread -> log.warn { "Redisson thread-bound violation" }
+    is ExtendOutcome.BackendError -> retry(outcome.cause)
+}
+
+// Java-friendly java.time.Duration overload
+LockExtender.extendActiveLock(Duration.ofSeconds(60))
+
+// Suspend variant
+suspend fun runSuspend() {
+    LockExtender.extendActiveLockSuspend(60.seconds)
+}
+```
+
+- Returns `true` on success, `false` on failure (no active scope, fail-open, token mismatch, backend error).
+- Updates `lastExtendDeadline` on the watchdog delegate to prevent watchdog from silently shrinking the extended lease (R2 mitigation).
+
+### ⚠️ Reactor non-suspend operator limitation (R5)
+
+Calling `LockAssert.assertLocked()` or `LockExtender.extendActiveLock()` inside non-suspend Reactor operators (`.map {}`, `.filter {}`) will fail — neither ThreadLocal nor `CoroutineContext` is available there.
+
+Use the suspend variants inside `mono {}` builder instead:
+
+```kotlin
+// NOT recommended — fails in async/cross-thread Reactor operators
+mono.map { LockAssert.assertLocked() }
+
+// Recommended — works correctly
+mono.flatMap { value ->
+    mono {
+        withContext(LockHandleElement(handle)) {
+            LockAssert.assertLockedSuspend()
+            value
+        }
+    }
+}
+```
+
 ## Dependency
 
 ```kotlin

--- a/leader-core/build.gradle.kts
+++ b/leader-core/build.gradle.kts
@@ -23,4 +23,5 @@ dependencies {
     implementation(libs.bluetape4k.coroutines)
     implementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.kotlinx.coroutines.reactor)
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/AopScopeAccess.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/AopScopeAccess.kt
@@ -90,7 +90,7 @@ object AopScopeAccess {
     fun createSyntheticReal(
         lockName: String,
         factoryBeanName: String,
-        token: String = "test-token",
+        token: String = SYNTHETIC_SINGLE_TOKEN,
     ): LeaderLockHandle.Real {
         val identity = LockIdentity(
             lockName = lockName,
@@ -114,8 +114,8 @@ object AopScopeAccess {
         lockName: String,
         factoryBeanName: String,
         maxLeaders: Int,
-        slotId: String = "0",
-        token: String = "test-group-token",
+        slotId: String = SYNTHETIC_DEFAULT_SLOT,
+        token: String = SYNTHETIC_GROUP_TOKEN,
     ): LeaderLockHandle.Real {
         val identity = LockIdentity(
             lockName = lockName,
@@ -131,4 +131,13 @@ object AopScopeAccess {
             extendDelegate = io.bluetape4k.leader.internal.NoopExtendDelegate,
         )
     }
+
+    /** Synthetic single handle default token — production 환경에서 의존 금지. */
+    private const val SYNTHETIC_SINGLE_TOKEN = "test-token"
+
+    /** Synthetic group handle default token — production 환경에서 의존 금지. */
+    private const val SYNTHETIC_GROUP_TOKEN = "test-group-token"
+
+    /** Synthetic group handle default slotId. */
+    private const val SYNTHETIC_DEFAULT_SLOT = "0"
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/AopScopeAccess.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/AopScopeAccess.kt
@@ -1,0 +1,107 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.leader.coroutines.LockHandleElement
+import io.bluetape4k.leader.internal.LeaderLockHandleCapture
+import io.bluetape4k.leader.internal.LockStateHolder
+
+/**
+ * AOP aspect (`leader-spring-boot`) 이 `leader-core` 의 `internal` scope 관리 심볼에 접근하기 위한 공개 브리지.
+ *
+ * ## 용도 제한
+ * - **AOP aspect 전용 API** — 일반 애플리케이션 코드에서 직접 사용 금지.
+ * - 일반 코드에서는 [LockAssert] / [LockExtender] 만 사용.
+ *
+ * ## 노출 범위
+ * | 심볼 | 용도 |
+ * |------|------|
+ * | [peekSyncMatching] | sync 분기 reentrant peek (동일 lockName 보유 여부 확인) |
+ * | [withPushedSync] | sync 분기 handle push/pop — body 실행 전후 LockStateHolder 관리 |
+ * | [pollCapture] | elector → aspect handle 전달 수신 (CaptureScope.runWithCapture 후) |
+ * | [createFailOpen] | fail-open sentinel handle 생성 |
+ * | [createLockHandleElement] | CoroutineContext 에 주입할 LockHandleElement 생성 |
+ */
+object AopScopeAccess {
+
+    /**
+     * 현재 스레드의 lock stack 에서 [lockName] 과 일치하는 handle 을 peek 합니다.
+     *
+     * aspect 가 sync 분기 진입 전 reentrant 여부를 판정할 때 사용합니다.
+     */
+    fun peekSyncMatching(lockName: String): LeaderLockHandle? =
+        LockStateHolder.peekSyncMatching(lockName)
+
+    /**
+     * handle 을 sync lock stack 에 push 하고 [block] 실행 후 pop 합니다.
+     *
+     * try/finally 로 누수 차단. fail-open sentinel 또는 reentrant passthrough handle 을 주입할 때 사용합니다.
+     *
+     * Note: public 브리지이므로 `inline` 불가 — internal `LockStateHolder.withPushed` inline 직접 위임 대신
+     * push/pop 을 명시적으로 구현.
+     */
+    fun <R> withPushedSync(handle: LeaderLockHandle, block: () -> R): R {
+        LockStateHolder.push(handle)
+        try {
+            return block()
+        } finally {
+            LockStateHolder.pop()
+            LockStateHolder.cleanup()
+        }
+    }
+
+    /**
+     * [LeaderLockHandleCapture] ThreadLocal 에서 handle 을 꺼내고 즉시 clear 합니다.
+     *
+     * group elector 의 `CaptureScope.runWithCapture` 가 set 한 값을 aspect 가 수신합니다.
+     * single elector 는 capture 하지 않으므로 `null` 이 정상 — CaptureInvariantException 사용 금지.
+     */
+    fun pollCapture(): LeaderLockHandle.Real? = LeaderLockHandleCapture.poll()
+
+    /**
+     * Fail-open sentinel [LeaderLockHandle.FailOpen] 을 생성합니다.
+     *
+     * `failureMode = FAIL_OPEN_RUN` 분기에서 body 실행 시 [LockAssert] / [LockExtender] 가
+     * fail-open scope 를 인식할 수 있도록 stack 에 push 합니다.
+     */
+    fun createFailOpen(identity: LockIdentity): LeaderLockHandle.FailOpen =
+        LeaderLockHandle.failOpen(identity)
+
+    /**
+     * [LeaderLockHandle.Real] 의 reentry depth 를 증가시킨 passthrough copy 를 생성합니다.
+     *
+     * 동일 lock 의 reentrant 진입 시 aspect 가 새 depth 를 가진 handle 을 push 합니다.
+     */
+    fun incrementReentryDepth(handle: LeaderLockHandle.Real): LeaderLockHandle.Real =
+        handle.withReentryDepth(handle.reentryDepth + 1)
+
+    /**
+     * aspect 가 coroutine context 에 주입할 [LockHandleElement] 를 생성합니다.
+     *
+     * suspend / Mono 분기에서 `withContext(LeaderElectionInfo(...) + createLockHandleElement(handle))` 패턴으로 사용합니다.
+     */
+    fun createLockHandleElement(handle: LeaderLockHandle): LockHandleElement =
+        LockHandleElement(handle)
+
+    /**
+     * 테스트 또는 aspect 가 synthetic `LeaderLockHandle.Real` 을 생성할 때 사용합니다.
+     *
+     * 실제 backend 없이 reentrant 단위 테스트를 작성할 때 `LockStateHolder` 에 push 할 handle 을 만드는 용도입니다.
+     * Production aspect 코드에서는 elector 가 생성한 handle 만 사용합니다.
+     */
+    fun createSyntheticReal(
+        lockName: String,
+        factoryBeanName: String,
+        token: String = "test-token",
+    ): LeaderLockHandle.Real {
+        val identity = LockIdentity(
+            lockName = lockName,
+            kind = LockIdentity.AnnotationKind.SINGLE,
+            factoryBeanName = factoryBeanName,
+        )
+        return LeaderLockHandle.real(
+            identity = identity,
+            token = token,
+            acquiredAtNanos = System.nanoTime(),
+            extendDelegate = io.bluetape4k.leader.internal.NoopExtendDelegate,
+        )
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/AopScopeAccess.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/AopScopeAccess.kt
@@ -104,4 +104,31 @@ object AopScopeAccess {
             extendDelegate = io.bluetape4k.leader.internal.NoopExtendDelegate,
         )
     }
+
+    /**
+     * 테스트용 group `LeaderLockHandle.Real` 생성. `slotId` 와 `groupParams` 보유.
+     *
+     * `@LeaderGroupElection` aspect 의 reentrant 단위 테스트에서 stack 에 push 할 handle 생성용.
+     */
+    fun createSyntheticGroupReal(
+        lockName: String,
+        factoryBeanName: String,
+        maxLeaders: Int,
+        slotId: String = "0",
+        token: String = "test-group-token",
+    ): LeaderLockHandle.Real {
+        val identity = LockIdentity(
+            lockName = lockName,
+            kind = LockIdentity.AnnotationKind.GROUP,
+            factoryBeanName = factoryBeanName,
+            groupParams = LockIdentity.GroupParams(maxLeaders = maxLeaders),
+        )
+        return LeaderLockHandle.real(
+            identity = identity,
+            token = token,
+            acquiredAtNanos = System.nanoTime(),
+            slotId = slotId,
+            extendDelegate = io.bluetape4k.leader.internal.NoopExtendDelegate,
+        )
+    }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/ExtendOutcome.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/ExtendOutcome.kt
@@ -1,0 +1,66 @@
+package io.bluetape4k.leader
+
+import java.time.Instant
+
+/**
+ * [LeaderLockHandle.Real.extend] / [LeaderLockHandle.Real.extendSuspend] 의 상세 결과.
+ *
+ * `Boolean` API ([LockExtender.extendActiveLock]) 는 `is Extended` 변환과 동치이며, 운영 가시성이
+ * 필요한 경우 [LockExtender.extendActiveLockDetailed] 를 사용해 분류된 결과를 받습니다.
+ *
+ * ## 분류
+ * - [Extended] — backend extend 성공. `observedExpireAt` 은 best-effort 값 (backend 별 정확도 상이)
+ * - [NotHeld] — token mismatch / lease 만료 / takeover 발생 — 더 이상 lock 미보유
+ * - [WrongThread] — Redisson 의 thread-bound 락에서 acquire 와 다른 thread 에서 호출
+ * - [BackendError] — transient (재시도 가능) 또는 non-transient backend 오류. `cause` 는 [Exception] 만 허용 (FATAL [Error] 차단)
+ *
+ * ## Boolean 변환 정책
+ * `LockExtender.extendActiveLock(d)` 가 반환하는 `Boolean` 은:
+ * - [Extended] → `true`
+ * - [NotHeld], [WrongThread] → `false` (WARN log + metric)
+ * - [BackendError] (transient) → `false` (WARN log + metric)
+ * - [BackendError] (non-transient) → throw (caller 책임)
+ *
+ * ## Example
+ * ```kotlin
+ * when (val outcome = LockExtender.extendActiveLockDetailed(60.seconds)) {
+ *     is ExtendOutcome.Extended -> log.info { "lease extended until ${outcome.observedExpireAt}" }
+ *     is ExtendOutcome.NotHeld -> rollbackWork()
+ *     is ExtendOutcome.WrongThread -> log.warn { "Redisson thread-bound — dispatched from wrong thread" }
+ *     is ExtendOutcome.BackendError -> retry(outcome.cause)
+ * }
+ * ```
+ */
+sealed interface ExtendOutcome {
+
+    /**
+     * extend 성공.
+     *
+     * @property observedExpireAt **best-effort** new expire time. backend 별 정확도:
+     * - Lettuce / Hazelcast / Local: server-side 시각 사용 → 정확
+     * - Redisson: Redisson 내부 atomic — client clock 사용 가능 → ±50ms
+     * - MongoDB: server-side `$$NOW` aggregation — 정확
+     * - Exposed JDBC/R2DBC: DB server 시각 (`now()` SQL) — 정확
+     * - ZooKeeper: TTL 개념 없음 — `Instant.MAX` (session-held liveness passthrough)
+     *
+     * caller 는 정확한 deadline 으로 사용 X — observability/logging 용.
+     */
+    data class Extended(val observedExpireAt: Instant) : ExtendOutcome
+
+    /** token mismatch / lease 만료 / takeover — 더 이상 lock 미보유. */
+    data object NotHeld : ExtendOutcome
+
+    /** Redisson 의 thread-bound 락에서 acquire 와 다른 thread 에서 호출. */
+    data object WrongThread : ExtendOutcome
+
+    /**
+     * Backend 오류. transient (재시도 가능) / non-transient 분류는 `BackendErrorClassifier` 사용.
+     *
+     * `cause` 는 [Exception] 만 허용 — FATAL [Error] ([OutOfMemoryError], [StackOverflowError],
+     * [LinkageError] 등) 은 wrap 금지 (propagate).
+     */
+    data class BackendError(val cause: Exception) : ExtendOutcome
+
+    /** Boolean API 변환용 short-cut. */
+    val isExtended: Boolean get() = this is Extended
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionExceptions.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionExceptions.kt
@@ -1,5 +1,16 @@
 package io.bluetape4k.leader
 
+/**
+ * Base exception for leader election failures.
+ *
+ * ## 동작/계약
+ * Thrown when a leader election operation fails due to backend errors,
+ * lock acquisition timeouts, or other irrecoverable conditions.
+ *
+ * ```kotlin
+ * throw LeaderElectionException("Failed to acquire lock: $lockName")
+ * ```
+ */
 open class LeaderElectionException: RuntimeException {
     constructor(): super()
     constructor(message: String): super(message)
@@ -7,6 +18,17 @@ open class LeaderElectionException: RuntimeException {
     constructor(cause: Throwable?): super(cause)
 }
 
+/**
+ * Exception for leader group election failures.
+ *
+ * ## 동작/계약
+ * Thrown when a leader group election operation fails — e.g., all slots in a group lock
+ * are occupied or a group member cannot acquire a permit.
+ *
+ * ```kotlin
+ * throw LeaderGroupElectionException("No available slot in group: $groupName")
+ * ```
+ */
 open class LeaderGroupElectionException: LeaderElectionException {
     constructor(): super()
     constructor(message: String): super(message)

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt
@@ -76,7 +76,7 @@ object LeaderLeaseAutoExtender : KLogging() {
      * @param leaseTime backend lease 시간 — cadence = leaseTime / 3 (최소 [MIN_RENEWAL_PERIOD])
      * @param delegate backend extend SPI — [ExtendDelegate.extend] + [ExtendDelegate.lastExtendDeadline]
      */
-    internal fun start(
+    fun start(
         enabled: Boolean,
         leaseTime: Duration,
         delegate: ExtendDelegate,

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt
@@ -1,7 +1,15 @@
 package io.bluetape4k.leader
 
+import io.bluetape4k.leader.ExtendOutcome.BackendError
+import io.bluetape4k.leader.ExtendOutcome.Extended
+import io.bluetape4k.leader.ExtendOutcome.NotHeld
+import io.bluetape4k.leader.ExtendOutcome.WrongThread
+import io.bluetape4k.leader.internal.BackendErrorKind
+import io.bluetape4k.leader.internal.CoreBackendErrorClassifier
+import io.bluetape4k.leader.internal.ExtendDelegate
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
+import java.time.Instant
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -18,6 +26,17 @@ import kotlin.time.Duration.Companion.milliseconds
  * - [extend]가 `false`를 반환하거나 예외를 던지면 watchdog은 반복을 중단합니다.
  * - 호출자는 action 종료/예외/취소 release path에서 반환된 [AutoCloseable]을 닫아야 합니다.
  *
+ * ## ExtendDelegate 기반 권장 사용 (R2 watchdog skip)
+ * ```kotlin
+ * val watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime, delegate)
+ * try {
+ *     action()
+ * } finally {
+ *     watchdog.close()
+ * }
+ * ```
+ *
+ * ## 기존 Boolean 람다 사용 (Deprecated)
  * ```kotlin
  * val watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime) {
  *     lock.extend(options.leaseTime)
@@ -39,8 +58,108 @@ object LeaderLeaseAutoExtender : KLogging() {
     }
 
     /**
-     * [enabled]가 true이면 lease 연장 watchdog을 시작하고, false이면 no-op closeable을 반환합니다.
+     * [enabled]가 true이면 [ExtendDelegate] 를 이용한 lease 연장 watchdog을 시작합니다.
+     *
+     * ## R2 watchdog skip
+     * tick 마다 `delegate.lastExtendDeadline.get()` 를 읽어,
+     * `now + cadence < lastExtendDeadline` 이면 backend extend 호출을 skip 합니다.
+     * User 가 `LockExtender.extendActiveLock(60s)` 를 호출한 직후 watchdog 이 lease 를
+     * 작은 값으로 silently 축소하는 split-brain 을 차단합니다.
+     *
+     * ## 종료 조건
+     * - [ExtendOutcome.NotHeld] / [ExtendOutcome.WrongThread] → watchdog 중단 (소유권 상실)
+     * - [ExtendOutcome.BackendError] (TRANSIENT) → WARN log + 계속 (재시도)
+     * - [ExtendOutcome.BackendError] (NON_TRANSIENT / FATAL) → WARN log + watchdog 중단
+     * - [AutoCloseable.close] 호출 → 중단
+     *
+     * @param enabled `false` 이면 no-op closeable 반환
+     * @param leaseTime backend lease 시간 — cadence = leaseTime / 3 (최소 [MIN_RENEWAL_PERIOD])
+     * @param delegate backend extend SPI — [ExtendDelegate.extend] + [ExtendDelegate.lastExtendDeadline]
      */
+    internal fun start(
+        enabled: Boolean,
+        leaseTime: Duration,
+        delegate: ExtendDelegate,
+    ): AutoCloseable {
+        if (!enabled) {
+            return NoopCloseable
+        }
+
+        val closed = AtomicBoolean(false)
+        val cadence = renewalPeriod(leaseTime)
+        lateinit var future: ScheduledFuture<*>
+
+        future = scheduler.scheduleWithFixedDelay(
+            {
+                if (closed.get()) {
+                    future.cancel(false)
+                    return@scheduleWithFixedDelay
+                }
+
+                // R2 mitigation: user 가 explicit extend 를 호출했으면 watchdog skip
+                val deadline = delegate.lastExtendDeadline.get()
+                if (deadline != null && Instant.now().plusMillis(cadence.inWholeMilliseconds).isBefore(deadline)) {
+                    return@scheduleWithFixedDelay
+                }
+
+                val outcome = try {
+                    delegate.extend(leaseTime)
+                } catch (ex: Exception) {
+                    log.warn(ex) { "leader.lease.auto-extend.failed" }
+                    BackendError(ex)
+                }
+
+                when (outcome) {
+                    is Extended -> { /* 정상 연장 — 계속 */ }
+                    is NotHeld, is WrongThread -> {
+                        log.warn { "leader.lease.auto-extend.stopped reason=$outcome" }
+                        if (closed.compareAndSet(false, true)) {
+                            future.cancel(false)
+                        }
+                    }
+                    is BackendError -> {
+                        val kind = CoreBackendErrorClassifier.classify(outcome.cause)
+                            ?: BackendErrorKind.NON_TRANSIENT
+                        when (kind) {
+                            BackendErrorKind.TRANSIENT -> {
+                                // 재시도 가능 — WARN log 후 계속
+                                log.warn(outcome.cause) { "leader.lease.auto-extend.transient-error — retrying. cause=${outcome.cause.message}" }
+                            }
+                            BackendErrorKind.NON_TRANSIENT, BackendErrorKind.FATAL -> {
+                                // 영구 오류 또는 치명적 오류 — watchdog 중단
+                                log.warn(outcome.cause) { "leader.lease.auto-extend.stopped reason=BACKEND_ERROR kind=$kind cause=${outcome.cause.message}" }
+                                if (closed.compareAndSet(false, true)) {
+                                    future.cancel(false)
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            cadence.inWholeMilliseconds,
+            cadence.inWholeMilliseconds,
+            TimeUnit.MILLISECONDS,
+        )
+
+        return AutoCloseable {
+            if (closed.compareAndSet(false, true)) {
+                future.cancel(false)
+            }
+        }
+    }
+
+    /**
+     * [enabled]가 true이면 lease 연장 watchdog을 시작하고, false이면 no-op closeable을 반환합니다.
+     *
+     * @deprecated [ExtendDelegate] 를 받는 [start] 사용 권장.
+     * R2 watchdog skip semantics (`lastExtendDeadline` 검사) 가 없음.
+     * T7~T13 에서 각 backend elector 가 [ExtendDelegate] 로 migration 후 이 overload 제거 예정.
+     */
+    @Deprecated(
+        message = "Use start(enabled, leaseTime, delegate: ExtendDelegate) for R2 watchdog skip semantics. " +
+            "This overload will be removed after T7–T13 backend migration.",
+        replaceWith = ReplaceWith("start(enabled, leaseTime, delegate)"),
+    )
     fun start(
         enabled: Boolean,
         leaseTime: Duration,

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLockHandle.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLockHandle.kt
@@ -1,0 +1,163 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.leader.internal.ExtendDelegate
+import java.io.Serializable
+import kotlin.time.Duration
+
+/**
+ * 활성 lock 의 handle. AOP aspect 가 push 하고 `LockAssert` / `LockExtender` 가 read.
+ *
+ * ## Variants
+ * - [Real] — 실제 backend 보유. `extend()` / `extendSuspend()` 호출 가능
+ * - [FailOpen] — fail-open sentinel. 외부 정의에서 extend 항상 [ExtendOutcome.NotHeld] 반환
+ *
+ * ## 동작/계약
+ * - **소스 API 레벨에서** 외부 생성 차단 — `internal constructor`. AOP aspect 또는 elector 만 생성.
+ *   ⚠️ `internal` 은 reflection / security boundary 아님 — 신뢰된 caller 한정 source API 차단 의미.
+ * - sealed class 의 `when` 분기는 exhaustive — `else` branch 없음.
+ *
+ * ## Example
+ * ```kotlin
+ * when (val handle = LockStateHolder.peekSync()) {
+ *     is LeaderLockHandle.Real -> handle.extend(60.seconds)
+ *     is LeaderLockHandle.FailOpen -> error("fail-open scope — no real lock")
+ *     null -> error("no active scope")
+ * }
+ * ```
+ */
+sealed class LeaderLockHandle : Serializable {
+
+    abstract val identity: LockIdentity
+    val lockName: String get() = identity.lockName
+    abstract val reentryDepth: Int
+    val isReentrant: Boolean get() = reentryDepth > 0
+
+    /**
+     * 다른 [LockIdentity] 와 같은 lock 인지 비교 (reentrant peek 용).
+     *
+     * [LockIdentity.equals] 가 `factoryBeanName` 을 제외하므로 sync/suspend factory 가 달라도
+     * 동일 lock 이면 reentrant pass-through (R3 mitigation).
+     */
+    fun matchesIdentity(other: LockIdentity): Boolean = identity == other
+
+    /**
+     * 실제 backend lock 보유 handle.
+     *
+     * @property identity full lock identity (reentrant peek 비교 단위)
+     * @property token Base58(8) lock 토큰 — backend atomic extend guard
+     * @property acquiredAtNanos `System.nanoTime()` 기준 획득 시각 — minLeaseTime 계산용
+     * @property slotId group lock 의 permit/slot 식별자. single 이면 `null`
+     * @property acquiringThreadId Redisson thread-bound extend 검증용. 비-Redisson 은 `null`.
+     *   **ownership 비교에 사용 금지** (R6-P2) — Redisson cross-thread debug 정보 only.
+     * @property reentryDepth 0 = outermost 실 락, >0 = reentrant passthrough copy
+     * @property extendDelegate watchdog 와 동일 reference 공유 (AC-15)
+     */
+    class Real internal constructor(
+        override val identity: LockIdentity,
+        val token: String,
+        val acquiredAtNanos: Long,
+        val slotId: String? = null,
+        val acquiringThreadId: Long? = null,
+        override val reentryDepth: Int = 0,
+        internal val extendDelegate: ExtendDelegate,
+    ) : LeaderLockHandle() {
+
+        /**
+         * Backend atomic extend 호출.
+         *
+         * Reentrant passthrough copy 일 때도 outer 의 [extendDelegate] 를 그대로 들고 있으므로
+         * **inner 에서 호출 시 outer/backend lease 가 갱신** (R5-F3 / SF11).
+         */
+        fun extend(lockAtMostFor: Duration): ExtendOutcome = extendDelegate.extend(lockAtMostFor)
+
+        /** Suspend variant — backend 가 suspend native 면 non-blocking, 아니면 `withContext(IO)` override. */
+        suspend fun extendSuspend(lockAtMostFor: Duration): ExtendOutcome =
+            extendDelegate.extendSuspend(lockAtMostFor)
+
+        /**
+         * 현재 token 이 backend 에 살아있는지 확인. lease 만료 후 takeover 발생 시 `false`.
+         */
+        fun isStillHeld(): Boolean = extendDelegate.isHeld()
+
+        /**
+         * Reentrant passthrough copy 생성.
+         *
+         * **inner extend 는 outer 의 [extendDelegate] 그대로 호출 → outer/backend lease 갱신** (R5-F3 / SF11).
+         */
+        internal fun withReentryDepth(n: Int): Real {
+            require(n >= 0) { "reentryDepth must be >= 0: $n" }
+            return Real(identity, token, acquiredAtNanos, slotId, acquiringThreadId, n, extendDelegate)
+        }
+
+        // equals/hashCode 는 (identity, token, reentryDepth, slotId) 기반.
+        // acquiringThreadId 는 ownership 비교에 사용 금지 (R6-P2).
+        // extendDelegate 는 reference 비교 무의미 — 제외.
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is Real) return false
+            return identity == other.identity &&
+                token == other.token &&
+                reentryDepth == other.reentryDepth &&
+                slotId == other.slotId
+        }
+
+        override fun hashCode(): Int {
+            var result = identity.hashCode()
+            result = 31 * result + token.hashCode()
+            result = 31 * result + reentryDepth
+            result = 31 * result + (slotId?.hashCode() ?: 0)
+            return result
+        }
+
+        override fun toString(): String =
+            "LeaderLockHandle.Real(identity=$identity, token='$token', reentryDepth=$reentryDepth, slotId=$slotId)"
+
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
+
+    /**
+     * Fail-open sentinel — `failureMode = FAIL_OPEN_RUN` 시 backend 미보유 상태에서 body 실행.
+     *
+     * `LockAssert.assertLocked()` 는 throw — fail-open scope 안에서는 lock 미보유.
+     * `LockExtender.extendActiveLock(d)` 는 `false` 반환 + WARN log.
+     */
+    class FailOpen internal constructor(
+        override val identity: LockIdentity,
+    ) : LeaderLockHandle() {
+        override val reentryDepth: Int = 0
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is FailOpen) return false
+            return identity == other.identity
+        }
+
+        override fun hashCode(): Int = identity.hashCode()
+
+        override fun toString(): String = "LeaderLockHandle.FailOpen(identity=$identity)"
+
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
+
+    companion object {
+        private const val serialVersionUID = 1L
+
+        /** internal factory — 외부 source API 차단. AOP aspect / elector 만 호출. */
+        internal fun real(
+            identity: LockIdentity,
+            token: String,
+            acquiredAtNanos: Long,
+            slotId: String? = null,
+            acquiringThreadId: Long? = null,
+            reentryDepth: Int = 0,
+            extendDelegate: ExtendDelegate,
+        ): Real = Real(identity, token, acquiredAtNanos, slotId, acquiringThreadId, reentryDepth, extendDelegate)
+
+        /** internal factory — sentinel 생성. */
+        internal fun failOpen(identity: LockIdentity): FailOpen = FailOpen(identity)
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLockHandle.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLockHandle.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader
 
 import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.support.requireGe
 import java.io.Serializable
 import kotlin.time.Duration
 
@@ -86,7 +87,7 @@ sealed class LeaderLockHandle : Serializable {
          * **inner extend 는 outer 의 [extendDelegate] 그대로 호출 → outer/backend lease 갱신** (R5-F3 / SF11).
          */
         internal fun withReentryDepth(n: Int): Real {
-            require(n >= 0) { "reentryDepth must be >= 0: $n" }
+            n.requireGe(0, "n")
             return Real(identity, token, acquiredAtNanos, slotId, acquiringThreadId, n, extendDelegate)
         }
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLockHandle.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLockHandle.kt
@@ -59,7 +59,8 @@ sealed class LeaderLockHandle : Serializable {
         val slotId: String? = null,
         val acquiringThreadId: Long? = null,
         override val reentryDepth: Int = 0,
-        internal val extendDelegate: ExtendDelegate,
+        /** ⚠️ Backend module / aspect 전용 SPI — 애플리케이션 코드에서 직접 접근 금지. */
+        val extendDelegate: ExtendDelegate,
     ) : LeaderLockHandle() {
 
         /**
@@ -146,8 +147,14 @@ sealed class LeaderLockHandle : Serializable {
     companion object {
         private const val serialVersionUID = 1L
 
-        /** internal factory — 외부 source API 차단. AOP aspect / elector 만 호출. */
-        internal fun real(
+        /**
+         * Backend module 전용 factory. AOP aspect / elector 가 호출.
+         *
+         * ⚠️ 애플리케이션 코드에서 직접 호출 금지 — 외부 사용자는 `LockAssert` / `LockExtender` 만 사용.
+         * 본 factory 는 `leader-redis-lettuce`, `leader-redis-redisson`, `leader-mongodb`, `leader-exposed-jdbc`,
+         * `leader-exposed-r2dbc`, `leader-hazelcast`, `leader-zookeeper` 등 backend module 에서 사용.
+         */
+        fun real(
             identity: LockIdentity,
             token: String,
             acquiredAtNanos: Long,
@@ -157,7 +164,11 @@ sealed class LeaderLockHandle : Serializable {
             extendDelegate: ExtendDelegate,
         ): Real = Real(identity, token, acquiredAtNanos, slotId, acquiringThreadId, reentryDepth, extendDelegate)
 
-        /** internal factory — sentinel 생성. */
-        internal fun failOpen(identity: LockIdentity): FailOpen = FailOpen(identity)
+        /**
+         * Backend module / aspect 전용 sentinel factory. `failureMode = FAIL_OPEN_RUN` 시 사용.
+         *
+         * ⚠️ 애플리케이션 코드에서 직접 호출 금지.
+         */
+        fun failOpen(identity: LockIdentity): FailOpen = FailOpen(identity)
     }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LockAssert.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LockAssert.kt
@@ -1,0 +1,167 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.leader.coroutines.LockHandleElement
+import io.bluetape4k.leader.internal.LockStateHolder
+import io.bluetape4k.logging.KLogging
+import kotlin.coroutines.coroutineContext
+
+/**
+ * 현재 컨텍스트가 활성 `@LeaderElection` / `@LeaderGroupElection` 본문 안에서 실행 중인지 단언합니다.
+ *
+ * ShedLock 의 `LockAssert.assertLocked()` 와 동일한 사용감을 제공합니다.
+ *
+ * ## 동작/계약
+ * - 활성 lock state 없음 → [IllegalStateException]
+ * - fail-open sentinel scope (`failureMode = FAIL_OPEN_RUN` 이고 backend 실패) → [IllegalStateException]
+ *   (fail-open 본문은 락이 없는 상태이므로)
+ * - reentrant 진입 시에도 outer 가 sentinel 이 아니면 통과
+ * - sealed [LeaderLockHandle] 의 `is FailOpen` 분기는 컴파일러 exhaustive check 강제
+ *
+ * ## Cross-context 동작 (suspend → sync API 호출)
+ * **suspend 컨텍스트에서는 [assertLockedSuspend] 호출**. sync [assertLocked] 를 suspend 안에서 호출 시
+ * carrier thread 의 ThreadLocal 만 검사 → 잘못된 handle 노출 위험 (R7).
+ *
+ * ## ⚠️ Reactor non-suspend operator 미지원 (Step 3-P R5)
+ * `.map { LockAssert.assertLocked() }`, `.filter { ... }` 등 non-suspend Reactor operator 안에서는
+ * ThreadLocal / `CoroutineContext` 둘 다 없음 → throw.
+ * **`.flatMap { mono { LockAssert.assertLockedSuspend() } }` 사용 권장**.
+ *
+ * ## Example
+ * ```kotlin
+ * @LeaderElection(name = "report-job")
+ * fun runReport() {
+ *     LockAssert.assertLocked()       // passes
+ *     // ... critical work ...
+ * }
+ *
+ * fun runOutsideAnnotation() {
+ *     LockAssert.assertLocked()       // throws IllegalStateException
+ * }
+ * ```
+ */
+object LockAssert : KLogging() {
+
+    /**
+     * 현재 스레드에 활성 lock scope 가 있고 fail-open 이 아닌지 단언합니다.
+     *
+     * @throws IllegalStateException 활성 scope 없음 또는 fail-open sentinel 인 경우
+     */
+    @JvmStatic
+    fun assertLocked() {
+        val handle = LockStateHolder.peekSync()
+            ?: throw IllegalStateException(
+                "LockAssert.assertLocked() called outside an active @LeaderElection / @LeaderGroupElection scope"
+            )
+        if (handle is LeaderLockHandle.FailOpen) {
+            throw IllegalStateException(
+                "LockAssert.assertLocked() — current scope is fail-open (no real lock held). lockName=${handle.lockName}"
+            )
+        }
+    }
+
+    /**
+     * 특정 lock 이름으로 활성 lock scope 가 있고 fail-open 이 아닌지 단언합니다.
+     *
+     * @param lockName 확인할 lock 이름
+     * @throws IllegalStateException 해당 이름의 활성 scope 없음 또는 fail-open sentinel 인 경우
+     */
+    @JvmStatic
+    fun assertLocked(lockName: String) {
+        val handle = LockStateHolder.peekSyncMatching(lockName)
+            ?: throw IllegalStateException(
+                "LockAssert.assertLocked('$lockName') — no active scope with this lock"
+            )
+        if (handle is LeaderLockHandle.FailOpen) {
+            throw IllegalStateException(
+                "LockAssert.assertLocked('$lockName') — current scope is fail-open"
+            )
+        }
+    }
+
+    /**
+     * throw 없이 현재 스레드에 실제 lock 보유 여부를 반환합니다.
+     *
+     * @return 활성 [LeaderLockHandle.Real] scope 있으면 `true`, 없거나 fail-open 이면 `false`
+     */
+    @JvmStatic
+    fun isLocked(): Boolean {
+        val handle = LockStateHolder.peekSync() ?: return false
+        return handle is LeaderLockHandle.Real
+    }
+
+    /**
+     * throw 없이 특정 lock 이름으로 실제 lock 보유 여부를 반환합니다.
+     *
+     * @param lockName 확인할 lock 이름
+     * @return 해당 이름의 활성 [LeaderLockHandle.Real] scope 있으면 `true`, 없거나 fail-open 이면 `false`
+     */
+    @JvmStatic
+    fun isLocked(lockName: String): Boolean {
+        val handle = LockStateHolder.peekSyncMatching(lockName) ?: return false
+        return handle is LeaderLockHandle.Real
+    }
+
+    /**
+     * Suspend 변형 — `coroutineContext[LockHandleElement]` 만 검사.
+     *
+     * **ThreadLocal fallback 제거 (R7 / Codex F13)** — sync ThreadLocal 누수 차단.
+     * sync `assertLocked()` 를 suspend 에서 호출 시 carrier thread 의 무관한 lock 노출 위험.
+     *
+     * @throws IllegalStateException 활성 scope 없음 또는 fail-open sentinel 인 경우
+     */
+    suspend fun assertLockedSuspend() {
+        val handle = coroutineContext[LockHandleElement]?.handle
+            ?: throw IllegalStateException(
+                "LockAssert.assertLockedSuspend() called outside an active @LeaderElection scope"
+            )
+        if (handle is LeaderLockHandle.FailOpen) {
+            throw IllegalStateException(
+                "LockAssert.assertLockedSuspend() — current scope is fail-open. lockName=${handle.lockName}"
+            )
+        }
+    }
+
+    /**
+     * Suspend 변형 — 특정 lock 이름으로 `coroutineContext[LockHandleElement]` 검사.
+     *
+     * @param lockName 확인할 lock 이름
+     * @throws IllegalStateException 활성 scope 없음, lock 이름 불일치, 또는 fail-open sentinel 인 경우
+     */
+    suspend fun assertLockedSuspend(lockName: String) {
+        val handle = coroutineContext[LockHandleElement]?.handle
+            ?: throw IllegalStateException(
+                "LockAssert.assertLockedSuspend('$lockName') — no active scope"
+            )
+        if (handle.lockName != lockName) {
+            throw IllegalStateException(
+                "LockAssert.assertLockedSuspend('$lockName') — active lock is '${handle.lockName}'"
+            )
+        }
+        if (handle is LeaderLockHandle.FailOpen) {
+            throw IllegalStateException(
+                "LockAssert.assertLockedSuspend('$lockName') — current scope is fail-open"
+            )
+        }
+    }
+
+    /**
+     * throw 없이 현재 coroutine context 에서 실제 lock 보유 여부를 반환합니다.
+     *
+     * @return 활성 [LeaderLockHandle.Real] 이 coroutineContext 에 있으면 `true`, 없거나 fail-open 이면 `false`
+     */
+    suspend fun isLockedSuspend(): Boolean {
+        val handle = coroutineContext[LockHandleElement]?.handle ?: return false
+        return handle is LeaderLockHandle.Real
+    }
+
+    /**
+     * throw 없이 특정 lock 이름으로 coroutine context 에서 실제 lock 보유 여부를 반환합니다.
+     *
+     * @param lockName 확인할 lock 이름
+     * @return 해당 이름의 활성 [LeaderLockHandle.Real] 이 coroutineContext 에 있으면 `true`, 없거나 fail-open 이면 `false`
+     */
+    suspend fun isLockedSuspend(lockName: String): Boolean {
+        val handle = coroutineContext[LockHandleElement]?.handle ?: return false
+        return handle is LeaderLockHandle.Real && handle.lockName == lockName
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LockAssert.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LockAssert.kt
@@ -49,13 +49,9 @@ object LockAssert : KLogging() {
     @JvmStatic
     fun assertLocked() {
         val handle = LockStateHolder.peekSync()
-            ?: throw IllegalStateException(
-                "LockAssert.assertLocked() called outside an active @LeaderElection / @LeaderGroupElection scope"
-            )
-        if (handle is LeaderLockHandle.FailOpen) {
-            throw IllegalStateException(
-                "LockAssert.assertLocked() — current scope is fail-open (no real lock held). lockName=${handle.lockName}"
-            )
+            ?: error("LockAssert.assertLocked() called outside an active @LeaderElection / @LeaderGroupElection scope")
+        check(handle !is LeaderLockHandle.FailOpen) {
+            "LockAssert.assertLocked() — current scope is fail-open (no real lock held). lockName=${handle.lockName}"
         }
     }
 
@@ -68,13 +64,9 @@ object LockAssert : KLogging() {
     @JvmStatic
     fun assertLocked(lockName: String) {
         val handle = LockStateHolder.peekSyncMatching(lockName)
-            ?: throw IllegalStateException(
-                "LockAssert.assertLocked('$lockName') — no active scope with this lock"
-            )
-        if (handle is LeaderLockHandle.FailOpen) {
-            throw IllegalStateException(
-                "LockAssert.assertLocked('$lockName') — current scope is fail-open"
-            )
+            ?: error("LockAssert.assertLocked('$lockName') — no active scope with this lock")
+        check(handle !is LeaderLockHandle.FailOpen) {
+            "LockAssert.assertLocked('$lockName') — current scope is fail-open"
         }
     }
 
@@ -111,13 +103,9 @@ object LockAssert : KLogging() {
      */
     suspend fun assertLockedSuspend() {
         val handle = coroutineContext[LockHandleElement]?.handle
-            ?: throw IllegalStateException(
-                "LockAssert.assertLockedSuspend() called outside an active @LeaderElection scope"
-            )
-        if (handle is LeaderLockHandle.FailOpen) {
-            throw IllegalStateException(
-                "LockAssert.assertLockedSuspend() — current scope is fail-open. lockName=${handle.lockName}"
-            )
+            ?: error("LockAssert.assertLockedSuspend() called outside an active @LeaderElection scope")
+        check(handle !is LeaderLockHandle.FailOpen) {
+            "LockAssert.assertLockedSuspend() — current scope is fail-open. lockName=${handle.lockName}"
         }
     }
 
@@ -129,18 +117,12 @@ object LockAssert : KLogging() {
      */
     suspend fun assertLockedSuspend(lockName: String) {
         val handle = coroutineContext[LockHandleElement]?.handle
-            ?: throw IllegalStateException(
-                "LockAssert.assertLockedSuspend('$lockName') — no active scope"
-            )
-        if (handle.lockName != lockName) {
-            throw IllegalStateException(
-                "LockAssert.assertLockedSuspend('$lockName') — active lock is '${handle.lockName}'"
-            )
+            ?: error("LockAssert.assertLockedSuspend('$lockName') — no active scope")
+        check(handle.lockName == lockName) {
+            "LockAssert.assertLockedSuspend('$lockName') — active lock is '${handle.lockName}'"
         }
-        if (handle is LeaderLockHandle.FailOpen) {
-            throw IllegalStateException(
-                "LockAssert.assertLockedSuspend('$lockName') — current scope is fail-open"
-            )
+        check(handle !is LeaderLockHandle.FailOpen) {
+            "LockAssert.assertLockedSuspend('$lockName') — current scope is fail-open"
         }
     }
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt
@@ -191,9 +191,13 @@ object LockExtender : KLogging() {
             return ExtendOutcome.NotHeld
         }
         val real = handle as LeaderLockHandle.Real
-        // R2 mitigation — lastExtendDeadline 갱신으로 watchdog skip 유도
-        real.extendDelegate.lastExtendDeadline.set(Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds))
-        return real.extend(lockAtMostFor)
+        // ⚠️ Tier 8 T8-H1 — backend extend 호출 후 Extended 일 때만 lastExtendDeadline 갱신.
+        //   pre-extend 갱신 시 backend 가 NotHeld/BackendError 반환해도 watchdog 가 deadline 기준 skip → split-brain.
+        val outcome = real.extend(lockAtMostFor)
+        if (outcome is ExtendOutcome.Extended) {
+            real.extendDelegate.lastExtendDeadline.set(Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds))
+        }
+        return outcome
     }
 
     private suspend fun extendDetailedSuspendInternal(handle: LeaderLockHandle, lockAtMostFor: Duration): ExtendOutcome {
@@ -202,9 +206,12 @@ object LockExtender : KLogging() {
             return ExtendOutcome.NotHeld
         }
         val real = handle as LeaderLockHandle.Real
-        // R2 mitigation — lastExtendDeadline 갱신으로 watchdog skip 유도
-        real.extendDelegate.lastExtendDeadline.set(Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds))
-        return real.extendSuspend(lockAtMostFor)
+        // ⚠️ Tier 8 T8-H1 — backend extend 호출 후 Extended 일 때만 lastExtendDeadline 갱신.
+        val outcome = real.extendSuspend(lockAtMostFor)
+        if (outcome is ExtendOutcome.Extended) {
+            real.extendDelegate.lastExtendDeadline.set(Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds))
+        }
+        return outcome
     }
 
     private fun outsideScope(): ExtendOutcome {

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt
@@ -212,11 +212,23 @@ object LockExtender : KLogging() {
         return ExtendOutcome.NotHeld
     }
 
+    /**
+     * Boolean ↔ Detailed 변환.
+     *
+     * 모든 false 반환 경로에 WARN 로그 — 운영 가시성 우선. [outsideScope] 와 fail-open sentinel 경로는
+     * 이미 path-specific WARN 로그를 찍은 후 [ExtendOutcome.NotHeld] 를 반환 — double log 허용 (정보 가치 우선).
+     *
+     * **모든 [ExtendOutcome.BackendError] 는 Boolean API 에서 `false` 반환** (transient/non-transient 무관).
+     * non-transient 명시적 처리 필요 시 caller 가 [extendActiveLockDetailed]/[extendActiveLockDetailedSuspend]
+     * 사용 후 [io.bluetape4k.leader.internal.BackendErrorClassifier] 로 분류 + throw 결정.
+     * Boolean API 자체는 ShedLock 호환 contract — 항상 boolean 반환, throw 없음.
+     */
     private fun processBooleanResult(outcome: ExtendOutcome): Boolean = when (outcome) {
         is ExtendOutcome.Extended -> true
         is ExtendOutcome.NotHeld -> {
-            // WARN already logged by outsideScope() or FailOpen path; avoid double-log for those paths.
-            // For NotHeld returned directly from backend (token mismatch / takeover), log here.
+            // backend-origin NotHeld — token mismatch / takeover / lease expired
+            // (outsideScope / FailOpen path 에서 온 NotHeld 는 path-specific WARN 이미 발생 — double log)
+            log.warn { "LockExtender — extend returned NotHeld (token mismatch / takeover / lease expired / scope absent)" }
             false
         }
         is ExtendOutcome.WrongThread -> {
@@ -224,7 +236,10 @@ object LockExtender : KLogging() {
             false
         }
         is ExtendOutcome.BackendError -> {
-            log.warn(outcome.cause) { "LockExtender — backend error during extend (transient assumed; non-transient should be classified upstream)" }
+            log.warn(outcome.cause) {
+                "LockExtender — backend error during extend " +
+                    "(use extendActiveLockDetailed + BackendErrorClassifier for non-transient classification)"
+            }
             false
         }
     }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt
@@ -1,0 +1,231 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.leader.coroutines.LockHandleElement
+import io.bluetape4k.leader.internal.LockStateHolder
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import java.time.Instant
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
+import kotlin.time.toKotlinDuration
+
+/**
+ * 활성 `@LeaderElection` 컨텍스트의 lease 를 명시적으로 연장합니다.
+ *
+ * ShedLock 의 `LockExtender.extendActiveLock(Duration)` 에 해당하는 단일 인자 변형 —
+ * `lockAtMostFor` 만 사용. `lockAtLeastFor` 는 bluetape4k 의 backend `minLeaseTime`
+ * 메커니즘으로 분리되어 별도 API 불필요.
+ *
+ * ## 동작/계약
+ * - 활성 컨텍스트 없음 → `false` 반환 + WARN log
+ * - fail-open sentinel → `false` 반환 + WARN log
+ * - backend extend 실패 → `false` (token mismatch / expired / wrong thread / transient backend error)
+ * - **absolute** lease — `lockAtMostFor` 만큼 새 expire time 설정.
+ *
+ * ## Detailed result
+ * 운영 가시성이 필요하면 [extendActiveLockDetailed] 사용 — [ExtendOutcome] sealed result 반환.
+ *
+ * ## Boolean ↔ Detailed 변환 contract
+ * - `extendActiveLock(d): Boolean` ≡ `extendActiveLockDetailed(d).isExtended`
+ * - [ExtendOutcome.Extended] → `true`
+ * - [ExtendOutcome.NotHeld] / [ExtendOutcome.WrongThread] → `false` + WARN log
+ * - [ExtendOutcome.BackendError] (transient) → `false` + WARN log
+ *
+ * ## mismatched lockName 처리
+ * `extendActiveLock(lockName, d)` 의 `lockName` 이 현재 active handle 과 다르면 → `false` + WARN log.
+ * `extendActiveLockDetailed(lockName, d)` 는 [ExtendOutcome.NotHeld] 반환.
+ * 오용 탐지를 원하면 [LockAssert.assertLocked]`(lockName)` 먼저 호출 권장.
+ *
+ * ## Group elector 의미
+ * `@LeaderGroupElection` 본문 안에서 호출 시 — **현재 보유한 slot 만** 의 lease 를 연장.
+ * `lockName` 인자는 group name. slotId 직접 지정 API 미노출.
+ *
+ * ## 동시성 (Watchdog × LockExtender)
+ * - 둘 다 atomic backend extend 호출 → race-free, 단 **last-write-wins**.
+ * - `extendActiveLock(d)` 호출 시 [io.bluetape4k.leader.internal.ExtendDelegate.lastExtendDeadline] 갱신
+ *   → watchdog 가 다음 tick 에서 user deadline 이 크면 skip (R2 mitigation).
+ * - 정확한 TTL 보호가 필요하면 watchdog OFF 권장 (= ShedLock 등가 모드).
+ *
+ * ## ⚠️ Reactor non-suspend operator 미지원 (Step 3-P R5)
+ * `.map { LockExtender.extendActiveLock(...) }` 등 미지원 —
+ * `.flatMap { mono { LockExtender.extendActiveLockSuspend(...) } }` 사용.
+ *
+ * ## Example
+ * ```kotlin
+ * @LeaderElection(name = "long-job", leaseTime = 30.seconds)
+ * fun runJob() {
+ *     // ... 25초 작업 ...
+ *     LockExtender.extendActiveLock(60.seconds)  // TTL = now + 60s
+ *     // ... 추가 50초 작업 ...
+ * }
+ * ```
+ */
+object LockExtender : KLogging() {
+
+    /**
+     * 현재 스레드의 활성 lock scope 의 lease 를 연장합니다.
+     *
+     * @param lockAtMostFor 새 lease 기간
+     * @return extend 성공이면 `true`, 그 외 `false`
+     */
+    @JvmStatic
+    fun extendActiveLock(lockAtMostFor: Duration): Boolean {
+        val outcome = extendActiveLockDetailed(lockAtMostFor)
+        return processBooleanResult(outcome)
+    }
+
+    /**
+     * 특정 lock 이름으로 현재 스레드의 활성 lock scope 의 lease 를 연장합니다.
+     *
+     * @param lockName 연장할 lock 이름
+     * @param lockAtMostFor 새 lease 기간
+     * @return extend 성공이면 `true`, 그 외 `false`
+     */
+    @JvmStatic
+    fun extendActiveLock(lockName: String, lockAtMostFor: Duration): Boolean {
+        val outcome = extendActiveLockDetailed(lockName, lockAtMostFor)
+        return processBooleanResult(outcome)
+    }
+
+    /**
+     * Java 사용자용 [java.time.Duration] overload.
+     *
+     * @param lockAtMostFor 새 lease 기간 ([java.time.Duration])
+     * @return extend 성공이면 `true`, 그 외 `false`
+     */
+    @JvmStatic
+    fun extendActiveLock(lockAtMostFor: java.time.Duration): Boolean =
+        extendActiveLock(lockAtMostFor.toKotlinDuration())
+
+    /**
+     * 특정 lock 이름 + Java 사용자용 [java.time.Duration] overload.
+     *
+     * @param lockName 연장할 lock 이름
+     * @param lockAtMostFor 새 lease 기간 ([java.time.Duration])
+     * @return extend 성공이면 `true`, 그 외 `false`
+     */
+    @JvmStatic
+    fun extendActiveLock(lockName: String, lockAtMostFor: java.time.Duration): Boolean =
+        extendActiveLock(lockName, lockAtMostFor.toKotlinDuration())
+
+    /**
+     * 상세 [ExtendOutcome] 를 반환하는 sync 변형.
+     *
+     * @param lockAtMostFor 새 lease 기간
+     * @return [ExtendOutcome] sealed 결과
+     */
+    @JvmStatic
+    fun extendActiveLockDetailed(lockAtMostFor: Duration): ExtendOutcome {
+        val handle = LockStateHolder.peekSync()
+            ?: return outsideScope()
+        return extendDetailedInternal(handle, lockAtMostFor)
+    }
+
+    /**
+     * 특정 lock 이름으로 상세 [ExtendOutcome] 를 반환하는 sync 변형.
+     *
+     * @param lockName 연장할 lock 이름
+     * @param lockAtMostFor 새 lease 기간
+     * @return [ExtendOutcome] sealed 결과
+     */
+    @JvmStatic
+    fun extendActiveLockDetailed(lockName: String, lockAtMostFor: Duration): ExtendOutcome {
+        val handle = LockStateHolder.peekSyncMatching(lockName)
+            ?: return outsideScope()
+        return extendDetailedInternal(handle, lockAtMostFor)
+    }
+
+    /**
+     * Suspend 변형 — `coroutineContext[LockHandleElement]` 만 검사.
+     *
+     * @param lockAtMostFor 새 lease 기간
+     * @return extend 성공이면 `true`, 그 외 `false`
+     */
+    suspend fun extendActiveLockSuspend(lockAtMostFor: Duration): Boolean {
+        val outcome = extendActiveLockDetailedSuspend(lockAtMostFor)
+        return processBooleanResult(outcome)
+    }
+
+    /**
+     * 특정 lock 이름으로 Suspend 변형.
+     *
+     * @param lockName 연장할 lock 이름
+     * @param lockAtMostFor 새 lease 기간
+     * @return extend 성공이면 `true`, 그 외 `false`
+     */
+    suspend fun extendActiveLockSuspend(lockName: String, lockAtMostFor: Duration): Boolean {
+        val outcome = extendActiveLockDetailedSuspend(lockName, lockAtMostFor)
+        return processBooleanResult(outcome)
+    }
+
+    /**
+     * 상세 [ExtendOutcome] 를 반환하는 suspend 변형.
+     *
+     * @param lockAtMostFor 새 lease 기간
+     * @return [ExtendOutcome] sealed 결과
+     */
+    suspend fun extendActiveLockDetailedSuspend(lockAtMostFor: Duration): ExtendOutcome {
+        val handle = coroutineContext[LockHandleElement]?.handle
+            ?: return outsideScope()
+        return extendDetailedSuspendInternal(handle, lockAtMostFor)
+    }
+
+    /**
+     * 특정 lock 이름으로 상세 [ExtendOutcome] 를 반환하는 suspend 변형.
+     *
+     * @param lockName 연장할 lock 이름
+     * @param lockAtMostFor 새 lease 기간
+     * @return [ExtendOutcome] sealed 결과
+     */
+    suspend fun extendActiveLockDetailedSuspend(lockName: String, lockAtMostFor: Duration): ExtendOutcome {
+        val handle = coroutineContext[LockHandleElement]?.handle
+        if (handle == null || handle.lockName != lockName) return outsideScope()
+        return extendDetailedSuspendInternal(handle, lockAtMostFor)
+    }
+
+    // --- internal helpers ---
+
+    private fun extendDetailedInternal(handle: LeaderLockHandle, lockAtMostFor: Duration): ExtendOutcome {
+        if (handle is LeaderLockHandle.FailOpen) {
+            log.warn { "LockExtender — current scope is fail-open sentinel (lockName=${handle.lockName})" }
+            return ExtendOutcome.NotHeld
+        }
+        val real = handle as LeaderLockHandle.Real
+        // R2 mitigation — lastExtendDeadline 갱신으로 watchdog skip 유도
+        real.extendDelegate.lastExtendDeadline.set(Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds))
+        return real.extend(lockAtMostFor)
+    }
+
+    private suspend fun extendDetailedSuspendInternal(handle: LeaderLockHandle, lockAtMostFor: Duration): ExtendOutcome {
+        if (handle is LeaderLockHandle.FailOpen) {
+            log.warn { "LockExtender — current scope is fail-open sentinel (lockName=${handle.lockName})" }
+            return ExtendOutcome.NotHeld
+        }
+        val real = handle as LeaderLockHandle.Real
+        // R2 mitigation — lastExtendDeadline 갱신으로 watchdog skip 유도
+        real.extendDelegate.lastExtendDeadline.set(Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds))
+        return real.extendSuspend(lockAtMostFor)
+    }
+
+    private fun outsideScope(): ExtendOutcome {
+        log.warn { "LockExtender called outside an active @LeaderElection scope — returning NotHeld" }
+        return ExtendOutcome.NotHeld
+    }
+
+    private fun processBooleanResult(outcome: ExtendOutcome): Boolean = when (outcome) {
+        is ExtendOutcome.Extended -> true
+        is ExtendOutcome.NotHeld -> {
+            // WARN already logged by outsideScope() or FailOpen path; avoid double-log for those paths.
+            // For NotHeld returned directly from backend (token mismatch / takeover), log here.
+            false
+        }
+        is ExtendOutcome.WrongThread -> {
+            log.warn { "LockExtender — extend failed: WrongThread (Redisson thread-bound lock called from wrong thread)" }
+            false
+        }
+        is ExtendOutcome.BackendError -> {
+            log.warn(outcome.cause) { "LockExtender — backend error during extend (transient assumed; non-transient should be classified upstream)" }
+            false
+        }
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LockIdentity.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LockIdentity.kt
@@ -1,0 +1,95 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.support.requireNotBlank
+import java.io.Serializable
+
+/**
+ * Reentrant dedupe 의 비교 단위.
+ *
+ * `@LeaderElection` / `@LeaderGroupElection` 의 nested 호출 시 동일 lock 보유 여부를 판정하기 위해
+ * lock 의 full identity 를 표현합니다.
+ *
+ * ## 동작/계약
+ * - `equals` / `hashCode` 는 `(lockName, kind, groupParams)` 기반.
+ * - **`factoryBeanName` 은 진단 metadata 로만 사용** — `equals` 에서 제외 (Step 3-P R3 mitigation).
+ *   동일 `lockName` 으로 sync ↔ suspend 또는 다른 factory bean 간 nested 호출 시에도 reentrant
+ *   pass-through 가 정확히 동작하도록 설계.
+ * - `kind == GROUP` 이면 `groupParams != null` 강제, `kind == SINGLE` 이면 `groupParams == null` 강제.
+ *
+ * ## Example
+ * ```kotlin
+ * val singleIdentity = LockIdentity(
+ *     lockName = "daily-report",
+ *     kind = LockIdentity.AnnotationKind.SINGLE,
+ *     factoryBeanName = "lettuceLeaderElector",
+ * )
+ * val groupIdentity = LockIdentity(
+ *     lockName = "shard-worker",
+ *     kind = LockIdentity.AnnotationKind.GROUP,
+ *     factoryBeanName = "lettuceLeaderGroupElector",
+ *     groupParams = LockIdentity.GroupParams(maxLeaders = 3),
+ * )
+ * ```
+ */
+class LockIdentity(
+    val lockName: String,
+    val kind: AnnotationKind,
+    /** 진단 metadata 전용 — `equals/hashCode` 에서 제외 (Step 3-P R3). */
+    val factoryBeanName: String,
+    val groupParams: GroupParams? = null,
+) : Serializable {
+
+    init {
+        lockName.requireNotBlank("lockName")
+        factoryBeanName.requireNotBlank("factoryBeanName")
+        require((kind == AnnotationKind.GROUP) == (groupParams != null)) {
+            "GROUP kind requires groupParams; SINGLE kind forbids it. kind=$kind, groupParams=$groupParams"
+        }
+    }
+
+    /**
+     * Reentrant equality — `factoryBeanName` 제외.
+     *
+     * sync→suspend nested 호출 시 factory bean 이 달라도 동일 lock 으로 인식되어 passthrough.
+     */
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is LockIdentity) return false
+        return lockName == other.lockName &&
+            kind == other.kind &&
+            groupParams == other.groupParams
+    }
+
+    override fun hashCode(): Int {
+        var result = lockName.hashCode()
+        result = 31 * result + kind.hashCode()
+        result = 31 * result + (groupParams?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String =
+        "LockIdentity(lockName='$lockName', kind=$kind, factoryBeanName='$factoryBeanName', groupParams=$groupParams)"
+
+    enum class AnnotationKind { SINGLE, GROUP }
+
+    /**
+     * Group lock 의 식별 파라미터.
+     *
+     * 현재 `maxLeaders` 만 보유. 향후 slot strategy / weight 등 추가 시 default 값으로 확장
+     * (binary-compat 보존).
+     */
+    data class GroupParams(val maxLeaders: Int) : Serializable {
+
+        init {
+            require(maxLeaders >= 1) { "maxLeaders must be >= 1: $maxLeaders" }
+        }
+
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
+
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LockIdentity.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LockIdentity.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader
 
 import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requirePositiveNumber
 import java.io.Serializable
 
 /**
@@ -81,7 +82,7 @@ class LockIdentity(
     data class GroupParams(val maxLeaders: Int) : Serializable {
 
         init {
-            require(maxLeaders >= 1) { "maxLeaders must be >= 1: $maxLeaders" }
+            maxLeaders.requirePositiveNumber("maxLeaders")
         }
 
         companion object {

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/MinLeaseTimeSupport.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/MinLeaseTimeSupport.kt
@@ -19,6 +19,17 @@ fun remainingMinLeaseTime(startedAtNanos: Long, minLeaseTime: Duration): Duratio
     return if (remaining > Duration.ZERO) remaining else Duration.ZERO
 }
 
+/**
+ * Parks the calling thread for the remaining minimum lease time.
+ *
+ * ⚠️ **BLOCKING CALL** — must NOT be invoked from coroutine dispatcher threads or virtual threads
+ * managed by a coroutine scheduler. Only safe for platform threads in sync electors
+ * (e.g., [LeaderElector], [VirtualThreadLeaderElector]).
+ *
+ * Backend adapters that need TTL-based retention should use [remainingMinLeaseTime] to update
+ * the backend TTL directly instead of calling this function.
+ */
+@Suppress("BlockingMethodInNonBlockingContext")
 internal fun parkRemainingMinLeaseTime(startedAtNanos: Long, minLeaseTime: Duration) {
     val remaining = remainingMinLeaseTime(startedAtNanos, minLeaseTime)
     if (remaining > Duration.ZERO) {

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElector.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.leader.coroutines
 
+import io.bluetape4k.codec.Base58
 import io.bluetape4k.coroutines.flow.extensions.subject.PublishSubject
+import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.LeaderElectionEvent
 import io.bluetape4k.leader.LeaderElectionEventPublisher
 import io.bluetape4k.leader.LeaderElectionListener
@@ -8,7 +10,11 @@ import io.bluetape4k.leader.LeaderElectionListenerRegistry
 import io.bluetape4k.leader.LeaderElectionListenerSupport
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderLeaseAutoExtender
+import io.bluetape4k.leader.LeaderLockHandle
 import io.bluetape4k.leader.LeaderState
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.leader.local.AbstractLocalLeaderElector
 import io.bluetape4k.leader.local.LocalLeaderStateRegistry
 import io.bluetape4k.leader.remainingMinLeaseTime
 import io.bluetape4k.support.requireNotBlank
@@ -18,7 +24,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Coroutines [Mutex]를 이용한 로컬(단일 JVM) suspend 리더 선출 구현체입니다.
@@ -88,14 +96,42 @@ class LocalSuspendLeaderElector(
             return null
         }
         val startedAtNanos = System.nanoTime()
+        val token = Base58.randomString(8)
         states.acquireSingle(lockName, options.nodeId, options.leaseTime)
-        val watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime) {
-            states.extendSingle(lockName, options.leaseTime)
+
+        val identity = LockIdentity(
+            lockName = lockName,
+            kind = LockIdentity.AnnotationKind.SINGLE,
+            factoryBeanName = AbstractLocalLeaderElector.LOCAL_FACTORY_BEAN_NAME,
+        )
+        val lastExtendDeadlineRef = AtomicReference(Instant.EPOCH)
+        val delegate = object : ExtendDelegate {
+            private val _lastExtendDeadline = lastExtendDeadlineRef
+            override val lastExtendDeadline: AtomicReference<Instant> get() = _lastExtendDeadline
+            override fun extend(lockAtMostFor: kotlin.time.Duration): ExtendOutcome {
+                val extended = states.extendSingle(lockName, lockAtMostFor)
+                return if (extended) {
+                    ExtendOutcome.Extended(Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds))
+                } else {
+                    ExtendOutcome.NotHeld
+                }
+            }
+            override fun isHeld(): Boolean = states.singleState(lockName).isOccupied
         }
+
+        val handle = LeaderLockHandle.real(
+            identity = identity,
+            token = token,
+            acquiredAtNanos = startedAtNanos,
+            extendDelegate = delegate,
+        )
+        val watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime, delegate)
         listeners.notifyElected(lockName)
         eventSubject.emit(LeaderElectionEvent.Elected(lockName))
         return try {
-            action()
+            withContext(LockHandleElement(handle)) {
+                action()
+            }
         } finally {
             withContext(NonCancellable) {
                 watchdog.close()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElector.kt
@@ -1,6 +1,8 @@
 package io.bluetape4k.leader.coroutines
 
+import io.bluetape4k.codec.Base58
 import io.bluetape4k.coroutines.flow.extensions.subject.PublishSubject
+import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.LeaderElectionEvent
 import io.bluetape4k.leader.LeaderElectionEventPublisher
 import io.bluetape4k.leader.LeaderElectionListener
@@ -8,6 +10,12 @@ import io.bluetape4k.leader.LeaderElectionListenerRegistry
 import io.bluetape4k.leader.LeaderElectionListenerSupport
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.internal.CaptureScope
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.leader.local.AbstractLocalLeaderGroupElector
 import io.bluetape4k.leader.local.LocalLeaderStateRegistry
 import io.bluetape4k.leader.remainingMinLeaseTime
 import io.bluetape4k.logging.KLogging
@@ -19,7 +27,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * 코루틴 [Semaphore]를 이용한 로컬(단일 JVM) suspend 복수 리더 선출 구현체입니다.
@@ -168,13 +178,50 @@ class LocalSuspendLeaderGroupElector private constructor(
             return null
         }
         val startedAtNanos = System.nanoTime()
+        val token = Base58.randomString(8)
         val lease = states.acquireGroup(lockName, options.nodeId, options.leaseTime, maxLeaders)
+        val slot = lease.slot!!
+
+        val identity = LockIdentity(
+            lockName = lockName,
+            kind = LockIdentity.AnnotationKind.GROUP,
+            factoryBeanName = AbstractLocalLeaderGroupElector.LOCAL_GROUP_FACTORY_BEAN_NAME,
+            groupParams = LockIdentity.GroupParams(maxLeaders),
+        )
+        val lastExtendDeadlineRef = AtomicReference(Instant.EPOCH)
+        val delegate = object : ExtendDelegate {
+            private val _lastExtendDeadline = lastExtendDeadlineRef
+            override val lastExtendDeadline: AtomicReference<Instant> get() = _lastExtendDeadline
+            override fun extend(lockAtMostFor: kotlin.time.Duration): ExtendOutcome {
+                val extended = states.extendGroup(lockName, slot, lockAtMostFor)
+                return if (extended) {
+                    ExtendOutcome.Extended(Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds))
+                } else {
+                    ExtendOutcome.NotHeld
+                }
+            }
+            override fun isHeld(): Boolean = states.isSlotHeld(lockName, slot)
+        }
+
+        val handle = LeaderLockHandle.real(
+            identity = identity,
+            token = token,
+            acquiredAtNanos = startedAtNanos,
+            slotId = slot.toString(),
+            extendDelegate = delegate,
+        )
+        val watchdog = LeaderLeaseAutoExtender.start(false, options.leaseTime, delegate)
         listeners.notifyElected(lockName)
         eventSubject.emit(LeaderElectionEvent.Elected(lockName))
         return try {
-            action()
+            withContext(LockHandleElement(handle)) {
+                CaptureScope.runWithCaptureSuspend(handle) {
+                    action()
+                }
+            }
         } finally {
             withContext(NonCancellable) {
+                watchdog.close()
                 delayRemainingMinLeaseTime(startedAtNanos)
                 states.releaseGroup(lockName, lease)
                 if (acquired) semaphore.release()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElector.kt
@@ -180,7 +180,9 @@ class LocalSuspendLeaderGroupElector private constructor(
         val startedAtNanos = System.nanoTime()
         val token = Base58.randomString(8)
         val lease = states.acquireGroup(lockName, options.nodeId, options.leaseTime, maxLeaders)
-        val slot = lease.slot!!
+        val slot = requireNotNull(lease.slot) {
+            "Group lease.slot must be non-null for lockName=$lockName, kind=GROUP"
+        }
 
         val identity = LockIdentity(
             lockName = lockName,

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LockHandleElement.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LockHandleElement.kt
@@ -1,0 +1,33 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.leader.LeaderLockHandle
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Suspend / Mono 컨텍스트의 active lock handle 을 전달하는 `CoroutineContext.Element`.
+ *
+ * 기존 [LeaderElectionInfo] 와 **별도 element** — binary-compat 보존 (Codex F5 / Type T8).
+ * Aspect 가 `withContext(LeaderElectionInfo(...) + LockHandleElement(...))` 패턴으로 두 element 동시 push.
+ *
+ * ## 동작/계약
+ * - `handle` property 는 `internal` — 외부 caller 는 [io.bluetape4k.leader.LockAssert] /
+ *   [io.bluetape4k.leader.LockExtender] API 만 사용. handle metadata (token, slotId 등) 직접 접근 차단 (R3-F12).
+ * - public companion `Key` 는 `currentCoroutineContext()[LockHandleElement]` 검사 가능 — element 존재 여부만 노출.
+ *
+ * ## Example
+ * ```kotlin
+ * // aspect 내부에서:
+ * withContext(LeaderElectionInfo("job-A", true) + LockHandleElement(handle)) {
+ *     userBody()  // 안에서 LockAssert.assertLockedSuspend() / LockExtender.extendActiveLockSuspend(d) 호출
+ * }
+ * ```
+ */
+@ConsistentCopyVisibility
+data class LockHandleElement internal constructor(
+    internal val handle: LeaderLockHandle,
+) : CoroutineContext.Element {
+
+    companion object Key : CoroutineContext.Key<LockHandleElement>
+
+    override val key: CoroutineContext.Key<*> get() = Key
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LockHandleElement.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LockHandleElement.kt
@@ -23,7 +23,7 @@ import kotlin.coroutines.CoroutineContext
  * ```
  */
 @ConsistentCopyVisibility
-data class LockHandleElement internal constructor(
+data class LockHandleElement(
     internal val handle: LeaderLockHandle,
 ) : CoroutineContext.Element {
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderElector.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.coroutines
 
 import io.bluetape4k.leader.LeaderElectionState
+import io.bluetape4k.leader.LeaderRunResult
 
 /**
  * 코루틴 기반 리더 선출 실행 계약을 정의합니다.
@@ -40,4 +41,39 @@ interface SuspendLeaderElector: LeaderElectionState {
         lockName: String,
         action: suspend () -> T,
     ): T?
+
+    /**
+     * 리더 선출 결과를 명시적으로 표현하는 결과형 API.
+     *
+     * [runIfLeader] 가 `null` 을 반환할 때 (a) 리더 미선출 vs (b) action 이 null 반환 모호함을 제거.
+     *
+     * ## 동작/계약
+     * - 리더 선출 성공 → [LeaderRunResult.Elected]`(value)` — `value` 는 action 반환값 (null 가능)
+     * - 리더 미선출 → [LeaderRunResult.Skipped]
+     * - `elected: Boolean` flag 패턴으로 정확 분류 (action 이 null 반환해도 [LeaderRunResult.Elected])
+     *
+     * ## binary-compat (Step 2-R R3-F3)
+     * Kotlin interface default fun 으로 추가 — `-jvm-default=enable` 빌드 하에서 JVM `default` method 로 컴파일,
+     * 기존 외부 구현체 binary 호환 보존.
+     *
+     * ```kotlin
+     * val result = election.runIfLeaderResultSuspend("job-lock") { computeResult() }
+     * when (result) {
+     *     is LeaderRunResult.Elected -> println("elected, value=${result.value}")
+     *     LeaderRunResult.Skipped   -> println("not elected")
+     * }
+     * ```
+     *
+     * @param lockName 리더 선출에 사용할 락 이름
+     * @param action 리더 획득 성공 시 실행할 suspend 작업
+     * @return [LeaderRunResult.Elected] (action 실행됨) 또는 [LeaderRunResult.Skipped] (리더 미선출)
+     */
+    suspend fun <T> runIfLeaderResultSuspend(
+        lockName: String,
+        action: suspend () -> T,
+    ): LeaderRunResult<T> {
+        var elected = false
+        val value = runIfLeader(lockName) { elected = true; action() }
+        return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
+    }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderGroupElector.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.coroutines
 
 import io.bluetape4k.leader.LeaderGroupElectionState
+import io.bluetape4k.leader.LeaderRunResult
 
 /**
  * 코루틴 기반 복수 리더 선출 계약을 정의합니다.
@@ -47,4 +48,39 @@ interface SuspendLeaderGroupElector: LeaderGroupElectionState {
      * @return [action] 실행 결과, 슬롯 획득 실패 시 `null`
      */
     suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T?
+
+    /**
+     * 리더 선출 결과를 명시적으로 표현하는 결과형 API.
+     *
+     * [runIfLeader] 가 `null` 을 반환할 때 (a) 슬롯 미획득 vs (b) action 이 null 반환 모호함을 제거.
+     *
+     * ## 동작/계약
+     * - 슬롯 획득 성공 → [LeaderRunResult.Elected]`(value)` — `value` 는 action 반환값 (null 가능)
+     * - 슬롯 미획득 → [LeaderRunResult.Skipped]
+     * - `elected: Boolean` flag 패턴으로 정확 분류 (action 이 null 반환해도 [LeaderRunResult.Elected])
+     *
+     * ## binary-compat (Step 2-R R3-F3)
+     * Kotlin interface default fun 으로 추가 — `-jvm-default=enable` 빌드 하에서 JVM `default` method 로 컴파일,
+     * 기존 외부 구현체 binary 호환 보존.
+     *
+     * ```kotlin
+     * val result = election.runIfLeaderResultSuspend("batch-job") { processChunkSuspend() }
+     * when (result) {
+     *     is LeaderRunResult.Elected -> println("elected, value=${result.value}")
+     *     LeaderRunResult.Skipped   -> println("slot full — skipped")
+     * }
+     * ```
+     *
+     * @param lockName 리더 그룹 선출에 사용할 락 이름
+     * @param action 슬롯 획득 성공 시 실행할 suspend 작업
+     * @return [LeaderRunResult.Elected] (action 실행됨) 또는 [LeaderRunResult.Skipped] (슬롯 미획득)
+     */
+    suspend fun <T> runIfLeaderResultSuspend(
+        lockName: String,
+        action: suspend () -> T,
+    ): LeaderRunResult<T> {
+        var elected = false
+        val value = runIfLeader(lockName) { elected = true; action() }
+        return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
+    }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/BackendErrorClassifier.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/BackendErrorClassifier.kt
@@ -1,0 +1,60 @@
+package io.bluetape4k.leader.internal
+
+/**
+ * Backend exception 분류 SPI.
+ *
+ * **`leader-core` 는 backend exception class 직접 참조 금지** (R5-F4 의존성 역전).
+ * 각 backend module 이 자기 backend 용 classifier 구현 + elector 가 합성하여 사용.
+ *
+ * ## 동작/계약
+ * - `classify` 는 `null` 반환 시 "분류 불가" 를 의미 — chain 의 다음 classifier 에 위임.
+ * - [CompositeBackendErrorClassifier] 가 backend-specific 과 [CoreBackendErrorClassifier] 를 chain.
+ * - 최종 fallback 은 [BackendErrorKind.NON_TRANSIENT] (safe default).
+ *
+ * ## Example
+ * ```kotlin
+ * // leader-redis-lettuce/.../internal/LettuceBackendErrorClassifier.kt
+ * internal object LettuceBackendErrorClassifier : BackendErrorClassifier {
+ *     override fun classify(cause: Throwable): BackendErrorKind? = when (cause) {
+ *         is io.lettuce.core.RedisCommandTimeoutException -> BackendErrorKind.TRANSIENT
+ *         is io.lettuce.core.RedisConnectionException -> BackendErrorKind.TRANSIENT
+ *         is io.lettuce.core.RedisCommandExecutionException -> BackendErrorKind.NON_TRANSIENT
+ *         else -> null  // 분류 불가 — chain next
+ *     }
+ * }
+ * ```
+ */
+fun interface BackendErrorClassifier {
+
+    /**
+     * [cause] 를 분류합니다.
+     *
+     * @return 분류 결과. `null` = 이 classifier 가 분류 불가 — chain 다음 classifier 에 위임
+     */
+    fun classify(cause: Throwable): BackendErrorKind?
+}
+
+/**
+ * Backend error 분류 결과.
+ *
+ * ## 분류 정책
+ * - [TRANSIENT] — 재시도 가능. watchdog/caller 가 WARN log + metric 후 계속.
+ * - [NON_TRANSIENT] — 영구 오류. caller 가 명시적으로 처리 (throw 또는 stop).
+ * - [FATAL] — JVM 치명적 오류 ([OutOfMemoryError], [StackOverflowError], [LinkageError]).
+ *   wrap 또는 catch 금지 — JVM 종료 경로에 맡김.
+ */
+enum class BackendErrorKind {
+    /** 재시도 가능 — WARN log + metric 후 계속. */
+    TRANSIENT,
+
+    /** 영구 오류 — throw 또는 중단. caller 가 결정. */
+    NON_TRANSIENT,
+
+    /**
+     * JVM 치명적 오류 ([OutOfMemoryError], [StackOverflowError], [LinkageError]).
+     *
+     * [io.bluetape4k.leader.ExtendOutcome.BackendError] 는 [Exception] 만 허용하므로
+     * FATAL [Error] 는 wrap 금지 — propagate.
+     */
+    FATAL,
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/CaptureScope.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/CaptureScope.kt
@@ -1,0 +1,47 @@
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.leader.LeaderLockHandle
+
+/**
+ * Elector 의 `runIfLeader` 안에서 [LeaderLockHandleCapture] set/clear 를 안전하게 감싸는 헬퍼.
+ *
+ * ## 목적 (Step 3-P R1 mitigation)
+ * 각 elector 가 [LeaderLockHandleCapture.set] 와 [LeaderLockHandleCapture.clear] 를 직접 호출하면
+ * try/finally 누락 시 ThreadLocal leak 발생. 모든 elector 가 이 헬퍼를 사용하면
+ * **per-backend discipline → structural enforcement**.
+ *
+ * AC: `grep -r "LeaderLockHandleCapture.set" leader-{core,redis,...}/src/main` → 0 match (CaptureScope.kt 외)
+ *
+ * ## Example
+ * ```kotlin
+ * // backend elector 의 runIfLeader 안에서:
+ * runWithCapture(handle) {
+ *     action()  // aspect 의 wrapped action — capture poll 가능
+ * }
+ * ```
+ */
+internal object CaptureScope {
+
+    /** Sync 변형 — 동일 thread 안에서 set → action → clear. */
+    inline fun <T> runWithCapture(handle: LeaderLockHandle.Real, action: () -> T): T {
+        LeaderLockHandleCapture.set(handle)
+        try {
+            return action()
+        } finally {
+            LeaderLockHandleCapture.clear()
+        }
+    }
+
+    /** Suspend 변형 — 동일 dispatcher 안에서 set → action → clear. */
+    suspend fun <T> runWithCaptureSuspend(
+        handle: LeaderLockHandle.Real,
+        action: suspend () -> T,
+    ): T {
+        LeaderLockHandleCapture.set(handle)
+        try {
+            return action()
+        } finally {
+            LeaderLockHandleCapture.clear()
+        }
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/CompositeBackendErrorClassifier.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/CompositeBackendErrorClassifier.kt
@@ -1,0 +1,37 @@
+package io.bluetape4k.leader.internal
+
+/**
+ * Backend-specific classifier 와 [CoreBackendErrorClassifier] 를 chain 한 composite.
+ *
+ * ## 동작/계약
+ * 분류 순서:
+ * 1. `backendSpecific.classify(cause)` 시도
+ * 2. `null` 반환 시 [CoreBackendErrorClassifier].classify(cause)` 시도
+ * 3. 둘 다 `null` 이면 [BackendErrorKind.NON_TRANSIENT] (safe default — caller 가 명시 처리)
+ *
+ * ## Example
+ * ```kotlin
+ * // backend module 에서:
+ * val classifier = CompositeBackendErrorClassifier(LettuceBackendErrorClassifier)
+ *
+ * when (classifier.classify(ex)) {
+ *     BackendErrorKind.TRANSIENT     -> { log.warn { "transient backend error — continuing" } }
+ *     BackendErrorKind.NON_TRANSIENT -> throw ex
+ *     BackendErrorKind.FATAL         -> throw ex  // FATAL Error — propagate
+ * }
+ * ```
+ *
+ * @param backendSpecific backend 모듈이 제공하는 backend-specific [BackendErrorClassifier]
+ */
+internal class CompositeBackendErrorClassifier(
+    private val backendSpecific: BackendErrorClassifier,
+) : BackendErrorClassifier {
+
+    /**
+     * [cause] 를 분류합니다. 절대 `null` 을 반환하지 않음 — fallback 은 [BackendErrorKind.NON_TRANSIENT].
+     */
+    override fun classify(cause: Throwable): BackendErrorKind =
+        backendSpecific.classify(cause)
+            ?: CoreBackendErrorClassifier.classify(cause)
+            ?: BackendErrorKind.NON_TRANSIENT
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/CompositeBackendErrorClassifier.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/CompositeBackendErrorClassifier.kt
@@ -23,7 +23,7 @@ package io.bluetape4k.leader.internal
  *
  * @param backendSpecific backend 모듈이 제공하는 backend-specific [BackendErrorClassifier]
  */
-internal class CompositeBackendErrorClassifier(
+class CompositeBackendErrorClassifier(
     private val backendSpecific: BackendErrorClassifier,
 ) : BackendErrorClassifier {
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/CoreBackendErrorClassifier.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/CoreBackendErrorClassifier.kt
@@ -1,0 +1,38 @@
+package io.bluetape4k.leader.internal
+
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.sql.SQLNonTransientException
+import java.sql.SQLRecoverableException
+import java.sql.SQLTransientException
+
+/**
+ * JDK / 공통 exception 분류 — backend module 의존성 없음.
+ *
+ * ## 동작/계약
+ * 각 backend module 의 [CompositeBackendErrorClassifier] 가 backend-specific classifier 시도 후
+ * `null` 반환 시 이 core classifier 에 위임.
+ *
+ * - [OutOfMemoryError], [StackOverflowError], [LinkageError] → [BackendErrorKind.FATAL]
+ * - [SQLTransientException], [SQLRecoverableException] → [BackendErrorKind.TRANSIENT]
+ * - [SQLNonTransientException] → [BackendErrorKind.NON_TRANSIENT]
+ * - [SocketTimeoutException], [ConnectException] → [BackendErrorKind.TRANSIENT]
+ * - 그 외 → `null` (분류 불가)
+ *
+ * ## Example
+ * ```kotlin
+ * CoreBackendErrorClassifier.classify(OutOfMemoryError())        // FATAL
+ * CoreBackendErrorClassifier.classify(SQLTransientException("")) // TRANSIENT
+ * CoreBackendErrorClassifier.classify(RuntimeException("x"))    // null
+ * ```
+ */
+internal object CoreBackendErrorClassifier : BackendErrorClassifier {
+
+    override fun classify(cause: Throwable): BackendErrorKind? = when (cause) {
+        is OutOfMemoryError, is StackOverflowError, is LinkageError -> BackendErrorKind.FATAL
+        is SQLTransientException, is SQLRecoverableException -> BackendErrorKind.TRANSIENT
+        is SQLNonTransientException -> BackendErrorKind.NON_TRANSIENT
+        is SocketTimeoutException, is ConnectException -> BackendErrorKind.TRANSIENT
+        else -> null  // 분류 불가 — CompositeBackendErrorClassifier 가 NON_TRANSIENT default 처리
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/ExtendDelegate.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/ExtendDelegate.kt
@@ -6,7 +6,10 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 
 /**
- * Backend lock 의 atomic extend 를 단일 reference 로 제공하는 internal SPI.
+ * Backend lock 의 atomic extend 를 단일 reference 로 제공하는 SPI.
+ *
+ * ⚠️ **Backend module (leader-redis-lettuce, leader-redis-redisson, leader-mongodb 등) 전용 SPI**.
+ * 애플리케이션 코드에서 직접 구현 X — [LockAssert] / [LockExtender] 만 사용.
  *
  * [LeaderLockHandle.Real.extendDelegate] 와 [LeaderLeaseAutoExtender] (Watchdog) 가 동일 인스턴스를
  * 공유 — race-free 보장 (Step 3-P R2 mitigation).
@@ -23,7 +26,7 @@ import kotlin.time.Duration
  * Watchdog cadence = leaseTime/3 (e.g. 10s for 30s lease). Tick 시 `now + 10s < deadline` 이면 skip.
  * → user-extended lease 가 watchdog 에 의해 silently 축소되는 split-brain 차단.
  */
-internal interface ExtendDelegate {
+interface ExtendDelegate {
 
     fun extend(lockAtMostFor: Duration): ExtendOutcome
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/ExtendDelegate.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/ExtendDelegate.kt
@@ -1,0 +1,63 @@
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+
+/**
+ * Backend lock 의 atomic extend 를 단일 reference 로 제공하는 internal SPI.
+ *
+ * [LeaderLockHandle.Real.extendDelegate] 와 [LeaderLeaseAutoExtender] (Watchdog) 가 동일 인스턴스를
+ * 공유 — race-free 보장 (Step 3-P R2 mitigation).
+ *
+ * ## 동작/계약
+ * - `extend` 는 backend atomic extend 호출 — 동기 backend (Lettuce sync, Redisson, Hazelcast, Exposed JDBC, ZK) 가 구현
+ * - `extendSuspend` default 는 sync `extend` 직접 호출 — **blocking backend 는 반드시 override** 하여
+ *   `withContext(Dispatchers.IO)` + `coroutineContext.ensureActive()` 사용 (R9 mitigation)
+ * - `lastExtendDeadline` 은 user `LockExtender.extendActiveLock(d)` 호출 시점의 expire deadline 추적 (R2 mitigation).
+ *   Watchdog tick 이 `now() + watchdogCadence < lastExtendDeadline.get()` 이면 backend extend 호출 skip.
+ *
+ * ## R2 Watchdog skip semantics (Step 3-P)
+ * User 가 `extend(60s)` 호출 → `lastExtendDeadline = now + 60s` 갱신.
+ * Watchdog cadence = leaseTime/3 (e.g. 10s for 30s lease). Tick 시 `now + 10s < deadline` 이면 skip.
+ * → user-extended lease 가 watchdog 에 의해 silently 축소되는 split-brain 차단.
+ */
+internal interface ExtendDelegate {
+
+    fun extend(lockAtMostFor: Duration): ExtendOutcome
+
+    /**
+     * Suspend extend.
+     *
+     * Default 구현은 sync [extend] 를 직접 호출 — **non-blocking / native suspend backend 전용**.
+     * Blocking backend (Lettuce sync, Hazelcast IMap, Exposed JDBC, Redisson 등) 는 반드시 override 하여
+     * `withContext(Dispatchers.IO)` + `coroutineContext.ensureActive()` 사용.
+     *
+     * AC-21: blocking backend 의 [ExtendDelegate.extendSuspend] 가 default 호출 0회 (소스 grep verify).
+     */
+    suspend fun extendSuspend(lockAtMostFor: Duration): ExtendOutcome = extend(lockAtMostFor)
+
+    /**
+     * 현재 토큰이 backend 에 살아있는지 확인.
+     */
+    fun isHeld(): Boolean
+
+    /**
+     * User explicit extend 호출의 deadline 추적 (R2 mitigation).
+     *
+     * `LockExtender.extendActiveLock(d)` 가 set: `now() + d`.
+     * Watchdog 가 read: `now() + cadence < lastExtendDeadline.get()` 이면 backend 호출 skip.
+     *
+     * **구현 규칙**: 반드시 저장된 `AtomicReference<Instant>` 인스턴스를 반환해야 한다.
+     * `get()` 마다 새 객체를 생성하면 `.set()` 호출이 버려져 R2 mitigation 이 무효화된다.
+     * 구현 예:
+     * ```kotlin
+     * private val _lastExtendDeadline = AtomicReference(Instant.EPOCH)
+     * override val lastExtendDeadline: AtomicReference<Instant> get() = _lastExtendDeadline
+     * ```
+     *
+     * 초기값 `Instant.EPOCH` — watchdog 가 항상 진행 (user explicit extend 없음).
+     */
+    val lastExtendDeadline: AtomicReference<Instant>
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderLockHandleCapture.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderLockHandleCapture.kt
@@ -1,0 +1,37 @@
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.leader.LeaderLockHandle
+
+/**
+ * Elector → Aspect 간 handle 전달용 ThreadLocal.
+ *
+ * ## 엄격한 invariant (Step 2-R R10)
+ * - Elector 는 acquire 후 action 호출 **직전** 동일 thread 에서 [set] 호출.
+ * - Aspect 는 action lambda 의 **첫 statement** 로 [poll] 호출.
+ * - **capture 누락 (poll 결과 null) → `CaptureInvariantException` throw** ("elector did not capture handle — bug")
+ *   silent fallback to FailOpen 절대 금지 (Codex F10 / SF3).
+ * - virtual thread / dispatcher hop 사이에 set/poll 분리 금지.
+ *
+ * ## 사용 권고
+ * 직접 호출하지 말고 [CaptureScope.runWithCapture] 또는 [CaptureScope.runWithCaptureSuspend] 사용
+ * — per-backend discipline → structural enforcement (Step 3-P R1 mitigation).
+ */
+internal object LeaderLockHandleCapture {
+
+    private val tl: ThreadLocal<LeaderLockHandle.Real?> = ThreadLocal()
+
+    fun set(handle: LeaderLockHandle.Real) {
+        tl.set(handle)
+    }
+
+    /** ThreadLocal 에서 값을 꺼내고 즉시 clear. */
+    fun poll(): LeaderLockHandle.Real? {
+        val handle = tl.get()
+        tl.remove()
+        return handle
+    }
+
+    fun clear() {
+        tl.remove()
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LockStateHolder.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LockStateHolder.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.leader.LeaderLockHandle
+
+/**
+ * Sync ([io.bluetape4k.leader.LeaderElector] / [io.bluetape4k.leader.VirtualThreadLeaderElector]) 컨텍스트의
+ * lock stack — ThreadLocal Deque.
+ *
+ * Suspend / Mono 컨텍스트는 `LockHandleElement` (CoroutineContext.Element) 사용 — 이 holder 미사용.
+ *
+ * ## 동작/계약
+ * - per-thread `ArrayDeque<LeaderLockHandle>` 으로 nested 호출 추적
+ * - Virtual thread 환경: ThreadLocal 은 carrier thread 가 아닌 virtual thread 에 바인딩 (Java 21 standard)
+ *   → child 가 새 virtual thread 를 spawn 하면 inheritance 없음 (R3-F8 명시)
+ * - aspect 가 try/finally 로 push/pop 보장 — [withPushed] inline helper 사용 권장
+ */
+internal object LockStateHolder {
+
+    private val tl: ThreadLocal<ArrayDeque<LeaderLockHandle>> =
+        ThreadLocal.withInitial { ArrayDeque() }
+
+    fun push(handle: LeaderLockHandle) {
+        tl.get().addFirst(handle)
+    }
+
+    fun pop(): LeaderLockHandle? = tl.get().removeFirstOrNull()
+
+    fun peekSync(): LeaderLockHandle? = tl.get().firstOrNull()
+
+    fun peekSyncMatching(lockName: String): LeaderLockHandle? =
+        tl.get().firstOrNull { it.lockName == lockName }
+
+    /** stack 이 비어있으면 ThreadLocal 제거 (pool thread 누수 방지). */
+    fun cleanup() {
+        if (tl.get().isEmpty()) {
+            tl.remove()
+        }
+    }
+
+    /**
+     * push/pop 헬퍼 — 누수 차단.
+     *
+     * 사용 예:
+     * ```kotlin
+     * LockStateHolder.withPushed(handle) { pjp.proceed() }
+     * ```
+     */
+    inline fun <R> withPushed(handle: LeaderLockHandle, block: () -> R): R {
+        push(handle)
+        try {
+            return block()
+        } finally {
+            pop()
+            cleanup()
+        }
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/NoopExtendDelegate.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/NoopExtendDelegate.kt
@@ -1,0 +1,22 @@
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+
+/**
+ * 테스트용 no-op [ExtendDelegate] — extend/isHeld 가 항상 NotHeld / false 반환.
+ *
+ * `AopScopeAccess.createSyntheticReal()` 에서 synthetic [io.bluetape4k.leader.LeaderLockHandle.Real]
+ * 생성 시 사용합니다. 실제 backend 없는 단위 테스트에서 reentrant peek/push 시나리오 검증용.
+ */
+internal object NoopExtendDelegate : ExtendDelegate {
+
+    private val _lastExtendDeadline = AtomicReference(Instant.EPOCH)
+    override val lastExtendDeadline: AtomicReference<Instant> get() = _lastExtendDeadline
+
+    override fun extend(lockAtMostFor: Duration): ExtendOutcome = ExtendOutcome.NotHeld
+
+    override fun isHeld(): Boolean = false
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderElector.kt
@@ -1,18 +1,24 @@
 package io.bluetape4k.leader.local
 
+import io.bluetape4k.codec.Base58
 import io.bluetape4k.leader.LeaderElectionListener
 import io.bluetape4k.leader.LeaderElectionListenerRegistry
 import io.bluetape4k.leader.LeaderElectionListenerSupport
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderElectionState
 import io.bluetape4k.leader.LeaderLeaseAutoExtender
+import io.bluetape4k.leader.LeaderLockHandle
 import io.bluetape4k.leader.LeaderState
+import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.leader.parkRemainingMinLeaseTime
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.leader.internal.LockStateHolder
 import io.bluetape4k.support.requireNotBlank
+import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
 import kotlin.time.Duration
 
 /**
@@ -30,6 +36,11 @@ import kotlin.time.Duration
 abstract class AbstractLocalLeaderElector(
     protected val options: LeaderElectionOptions = LeaderElectionOptions.Default,
 ) : LeaderElectionListenerRegistry, LeaderElectionState {
+
+    companion object {
+        /** [LockIdentity.factoryBeanName] 진단 metadata 용 상수 — Local backend. */
+        internal const val LOCAL_FACTORY_BEAN_NAME = "local-leader-elector"
+    }
 
     private val locks = ConcurrentHashMap<String, ReentrantLock>()
     private val listeners = LeaderElectionListenerSupport()
@@ -69,8 +80,15 @@ abstract class AbstractLocalLeaderElector(
      * @param action 락을 획득한 상태에서 실행할 작업
      * @return [action] 실행 결과
      */
-    protected fun <T> withLeaderLock(lockName: String, action: () -> T): T =
-        getLock(lockName).withLock(action)
+    protected fun <T> withLeaderLock(lockName: String, action: () -> T): T {
+        val lock = getLock(lockName)
+        lock.lock()
+        try {
+            return action()
+        } finally {
+            lock.unlock()
+        }
+    }
 
     /**
      * [lockName]의 락을 [waitTime] 내에 획득하면 [action]을 실행하고, 실패하면 `null`을 반환합니다.
@@ -87,19 +105,55 @@ abstract class AbstractLocalLeaderElector(
      */
     protected fun <T> tryWithLeaderLock(lockName: String, waitTime: Duration, action: () -> T): T? {
         val lock = getLock(lockName)
+
+        // Reentrant: same thread holds the lock — wrap in a passthrough handle
+        val existing = LockStateHolder.peekSyncMatching(lockName)
+        if (lock.isHeldByCurrentThread && existing is LeaderLockHandle.Real) {
+            val reentrant = existing.withReentryDepth(existing.reentryDepth + 1)
+            return LockStateHolder.withPushed(reentrant) { action() }
+        }
+
         val acquired = lock.tryLock(waitTime.inWholeMilliseconds, TimeUnit.MILLISECONDS)
         if (!acquired) {
             listeners.notifySkipped(lockName)
             return null
         }
         val startedAtNanos = System.nanoTime()
+        val token = Base58.randomString(8)
         states.acquireSingle(lockName, options.nodeId, options.leaseTime)
-        val watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime) {
-            states.extendSingle(lockName, options.leaseTime)
+
+        val identity = LockIdentity(
+            lockName = lockName,
+            kind = LockIdentity.AnnotationKind.SINGLE,
+            factoryBeanName = LOCAL_FACTORY_BEAN_NAME,
+        )
+        val lastExtendDeadline = AtomicReference(Instant.EPOCH)
+        val delegate = object : ExtendDelegate {
+            private val _lastExtendDeadline = lastExtendDeadline
+            override val lastExtendDeadline: AtomicReference<Instant> get() = _lastExtendDeadline
+            override fun extend(lockAtMostFor: Duration): io.bluetape4k.leader.ExtendOutcome {
+                val extended = states.extendSingle(lockName, lockAtMostFor)
+                return if (extended) {
+                    io.bluetape4k.leader.ExtendOutcome.Extended(
+                        Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds)
+                    )
+                } else {
+                    io.bluetape4k.leader.ExtendOutcome.NotHeld
+                }
+            }
+            override fun isHeld(): Boolean = states.singleState(lockName).isOccupied
         }
+
+        val handle = LeaderLockHandle.real(
+            identity = identity,
+            token = token,
+            acquiredAtNanos = startedAtNanos,
+            extendDelegate = delegate,
+        )
+        val watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime, delegate)
         listeners.notifyElected(lockName)
         return try {
-            action()
+            LockStateHolder.withPushed(handle) { action() }
         } finally {
             watchdog.close()
             parkRemainingMinLeaseTime(startedAtNanos, options.minLeaseTime)

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderGroupElector.kt
@@ -124,7 +124,9 @@ abstract class AbstractLocalLeaderGroupElector(
         val startedAtNanos = System.nanoTime()
         val token = Base58.randomString(8)
         val lease = states.acquireGroup(lockName, options.nodeId, options.leaseTime, maxLeaders)
-        val slot = lease.slot!!
+        val slot = requireNotNull(lease.slot) {
+            "Group lease.slot must be non-null for lockName=$lockName, kind=GROUP"
+        }
 
         val identity = LockIdentity(
             lockName = lockName,

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderGroupElector.kt
@@ -1,17 +1,27 @@
 package io.bluetape4k.leader.local
 
-import io.bluetape4k.leader.LeaderGroupElectionOptions
-import io.bluetape4k.leader.LeaderGroupElectionState
-import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.LeaderElectionListener
 import io.bluetape4k.leader.LeaderElectionListenerRegistry
 import io.bluetape4k.leader.LeaderElectionListenerSupport
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderGroupElectionState
+import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.internal.CaptureScope
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.leader.internal.LockStateHolder
 import io.bluetape4k.leader.parkRemainingMinLeaseTime
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requirePositiveNumber
+import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * 로컬(단일 JVM) 리더 그룹 선출 구현체들의 공통 상태 관리를 제공하는 추상 클래스입니다.
@@ -31,6 +41,11 @@ import java.util.concurrent.TimeUnit
 abstract class AbstractLocalLeaderGroupElector(
     protected val options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
 ): LeaderGroupElectionState, LeaderElectionListenerRegistry {
+
+    companion object {
+        /** [LockIdentity.factoryBeanName] 진단 metadata 용 상수 — Local backend group. */
+        internal const val LOCAL_GROUP_FACTORY_BEAN_NAME = "local-leader-group-elector"
+    }
 
     init {
         options.maxLeaders.requirePositiveNumber("maxLeaders")
@@ -107,11 +122,48 @@ abstract class AbstractLocalLeaderGroupElector(
             return null
         }
         val startedAtNanos = System.nanoTime()
+        val token = Base58.randomString(8)
         val lease = states.acquireGroup(lockName, options.nodeId, options.leaseTime, maxLeaders)
+        val slot = lease.slot!!
+
+        val identity = LockIdentity(
+            lockName = lockName,
+            kind = LockIdentity.AnnotationKind.GROUP,
+            factoryBeanName = LOCAL_GROUP_FACTORY_BEAN_NAME,
+            groupParams = LockIdentity.GroupParams(maxLeaders),
+        )
+        val lastExtendDeadlineRef = AtomicReference(Instant.EPOCH)
+        val delegate = object : ExtendDelegate {
+            private val _lastExtendDeadline = lastExtendDeadlineRef
+            override val lastExtendDeadline: AtomicReference<Instant> get() = _lastExtendDeadline
+            override fun extend(lockAtMostFor: kotlin.time.Duration): ExtendOutcome {
+                val extended = states.extendGroup(lockName, slot, lockAtMostFor)
+                return if (extended) {
+                    ExtendOutcome.Extended(Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds))
+                } else {
+                    ExtendOutcome.NotHeld
+                }
+            }
+            override fun isHeld(): Boolean = states.isSlotHeld(lockName, slot)
+        }
+
+        val handle = LeaderLockHandle.real(
+            identity = identity,
+            token = token,
+            acquiredAtNanos = startedAtNanos,
+            slotId = slot.toString(),
+            extendDelegate = delegate,
+        )
+        val watchdog = LeaderLeaseAutoExtender.start(false, options.leaseTime, delegate)
         listeners.notifyElected(lockName)
         return try {
-            action()
+            LockStateHolder.withPushed(handle) {
+                CaptureScope.runWithCapture(handle) {
+                    action()
+                }
+            }
         } finally {
+            watchdog.close()
             parkRemainingMinLeaseTime(startedAtNanos, options.minLeaseTime)
             states.releaseGroup(lockName, lease)
             semaphore.release()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderStateRegistry.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderStateRegistry.kt
@@ -82,6 +82,21 @@ internal class LocalLeaderStateRegistry {
         }
     }
 
+    fun extendGroup(lockName: String, slot: Int, leaseTime: Duration): Boolean =
+        lock.withLock {
+            val leases = groupLeases[lockName] ?: return false
+            val current = leases[slot] ?: return false
+            leases[slot] = current.copy(
+                leaseUntil = Instant.now().plusMillis(leaseTime.inWholeMilliseconds),
+            )
+            true
+        }
+
+    fun isSlotHeld(lockName: String, slot: Int): Boolean =
+        lock.withLock {
+            groupLeases[lockName]?.containsKey(slot) == true
+        }
+
     fun groupState(lockName: String, maxLeaders: Int, activeCount: Int): LeaderGroupState {
         lockName.requireNotBlank("lockName")
         return lock.withLock {

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtenderDelegateTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtenderDelegateTest.kt
@@ -1,0 +1,265 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.internal.ExtendDelegate
+import kotlinx.coroutines.delay
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.net.SocketTimeoutException
+import java.sql.SQLNonTransientException
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * [LeaderLeaseAutoExtender.start] 의 [ExtendDelegate] 오버로드 검증.
+ *
+ * - 새 시그니처 호출 검증
+ * - R2 watchdog skip — `lastExtendDeadline` 이 미래이면 backend extend 호출 안 됨
+ * - cadence = leaseTime/3 동작
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Suppress("NonAsciiCharacters")
+class LeaderLeaseAutoExtenderDelegateTest {
+
+    /** 호출 횟수와 결과를 제어할 수 있는 테스트용 [ExtendDelegate]. */
+    private class TestDelegate(
+        private val held: Boolean = true,
+    ) : ExtendDelegate {
+        val extendCalls = AtomicInteger(0)
+        private val _lastExtendDeadline = AtomicReference(Instant.EPOCH)
+        override val lastExtendDeadline: AtomicReference<Instant> get() = _lastExtendDeadline
+
+        override fun extend(lockAtMostFor: Duration): ExtendOutcome {
+            extendCalls.incrementAndGet()
+            return if (held) ExtendOutcome.Extended(Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds))
+            else ExtendOutcome.NotHeld
+        }
+
+        override fun isHeld(): Boolean = held
+    }
+
+    // ── 기본 동작 ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `disabled watchdog does not call delegate extend`() = runSuspendIO {
+        val delegate = TestDelegate()
+        val watchdog = LeaderLeaseAutoExtender.start(false, 100.milliseconds, delegate)
+
+        delay(120.milliseconds)
+        watchdog.close()
+
+        delegate.extendCalls.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `enabled watchdog calls delegate extend`() = runSuspendIO {
+        val delegate = TestDelegate(held = true)
+        val watchdog = LeaderLeaseAutoExtender.start(true, 90.milliseconds, delegate)
+
+        delay(250.milliseconds)
+        watchdog.close()
+
+        (delegate.extendCalls.get() >= 1).shouldBeTrue()
+    }
+
+    @Test
+    fun `watchdog stops after close`() = runSuspendIO {
+        val delegate = TestDelegate()
+        val watchdog = LeaderLeaseAutoExtender.start(true, 90.milliseconds, delegate)
+
+        delay(120.milliseconds)
+        watchdog.close()
+        val callsAfterClose = delegate.extendCalls.get()
+        delay(120.milliseconds)
+
+        // close 이후 추가 호출 없음
+        delegate.extendCalls.get() shouldBeEqualTo callsAfterClose
+    }
+
+    @Test
+    fun `watchdog stops when delegate returns NotHeld`() = runSuspendIO {
+        val delegate = TestDelegate(held = false)
+        val watchdog = LeaderLeaseAutoExtender.start(true, 90.milliseconds, delegate)
+
+        delay(250.milliseconds)
+        watchdog.close()  // idempotent
+
+        // NotHeld 반환 후 watchdog 이 스스로 종료 — 호출 횟수는 1 이상이되 계속 늘지 않음
+        val calls = delegate.extendCalls.get()
+        (calls >= 1).shouldBeTrue()
+    }
+
+    // ── R2 watchdog skip ──────────────────────────────────────────────────
+
+    @Test
+    fun `R2 skip - lastExtendDeadline 이 미래이면 backend extend 호출 안 됨`() = runSuspendIO {
+        val delegate = TestDelegate(held = true)
+
+        // user 가 explicit extend 를 호출했다고 가정: deadline = now + 60s
+        delegate.lastExtendDeadline.set(Instant.now().plusSeconds(60))
+
+        // cadence = 90ms / 3 = 30ms (MIN_RENEWAL_PERIOD 적용으로 25ms)
+        val watchdog = LeaderLeaseAutoExtender.start(true, 90.milliseconds, delegate)
+
+        // cadence 를 몇 번 기다려도 skip 되어야 함
+        delay(150.milliseconds)
+        watchdog.close()
+
+        // deadline 이 충분히 미래 → extend 호출 안 됨
+        delegate.extendCalls.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `R2 skip - lastExtendDeadline 이 과거이면 backend extend 호출됨`() = runSuspendIO {
+        val delegate = TestDelegate(held = true)
+
+        // deadline 을 과거로 설정 — watchdog 이 skip 안 함
+        delegate.lastExtendDeadline.set(Instant.now().minusSeconds(10))
+
+        val watchdog = LeaderLeaseAutoExtender.start(true, 90.milliseconds, delegate)
+
+        delay(200.milliseconds)
+        watchdog.close()
+
+        (delegate.extendCalls.get() >= 1).shouldBeTrue()
+    }
+
+    @Test
+    fun `R2 skip - lastExtendDeadline 초기값 EPOCH 이면 watchdog 이 정상 호출한다`() = runSuspendIO {
+        val delegate = TestDelegate(held = true)
+        // EPOCH 은 과거 → skip 안 됨
+
+        val watchdog = LeaderLeaseAutoExtender.start(true, 90.milliseconds, delegate)
+
+        delay(200.milliseconds)
+        watchdog.close()
+
+        (delegate.extendCalls.get() >= 1).shouldBeTrue()
+    }
+
+    // ── cadence 계산 ──────────────────────────────────────────────────────
+
+    @Test
+    fun `renewalPeriod 는 leaseTime 의 1-3 을 반환한다`() {
+        val period = LeaderLeaseAutoExtender.renewalPeriod(30.seconds)
+        period shouldBeEqualTo 10.seconds
+    }
+
+    @Test
+    fun `renewalPeriod 는 최솟값 25ms 미만이면 25ms 를 반환한다`() {
+        val period = LeaderLeaseAutoExtender.renewalPeriod(30.milliseconds)
+        // 30ms / 3 = 10ms < 25ms → 25ms
+        (period.inWholeMilliseconds >= 25).shouldBeTrue()
+    }
+
+    // ── BackendError transient 는 watchdog 계속, non-transient 는 중단 ──────
+
+    @Test
+    fun `BackendError transient - watchdog 이 계속 동작한다`() = runSuspendIO {
+        val callsAfterError = java.util.concurrent.atomic.AtomicInteger(0)
+        var transientFired = false
+
+        // 첫 번째 호출은 transient error, 이후는 성공
+        val delegate = object : ExtendDelegate {
+            private val _lastExtendDeadline = java.util.concurrent.atomic.AtomicReference(Instant.EPOCH)
+            override val lastExtendDeadline get() = _lastExtendDeadline
+            private var callCount = 0
+
+            override fun extend(lockAtMostFor: Duration): ExtendOutcome {
+                callCount++
+                return if (callCount == 1) {
+                    transientFired = true
+                    // SocketTimeoutException → TRANSIENT
+                    ExtendOutcome.BackendError(java.net.SocketTimeoutException("timeout"))
+                } else {
+                    callsAfterError.incrementAndGet()
+                    ExtendOutcome.Extended(Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds))
+                }
+            }
+
+            override fun isHeld(): Boolean = true
+        }
+
+        val watchdog = LeaderLeaseAutoExtender.start(true, 90.milliseconds, delegate)
+        delay(300.milliseconds)
+        watchdog.close()
+
+        // transient error 후 계속 호출됨
+        transientFired.shouldBeTrue()
+        (callsAfterError.get() >= 1).shouldBeTrue()
+    }
+
+    @Test
+    fun `BackendError non-transient - watchdog 이 중단된다`() = runSuspendIO {
+        val callsAfterError = java.util.concurrent.atomic.AtomicInteger(0)
+        var errorFired = false
+
+        val delegate = object : ExtendDelegate {
+            private val _lastExtendDeadline = java.util.concurrent.atomic.AtomicReference(Instant.EPOCH)
+            override val lastExtendDeadline get() = _lastExtendDeadline
+            private var callCount = 0
+
+            override fun extend(lockAtMostFor: Duration): ExtendOutcome {
+                callCount++
+                return if (callCount == 1) {
+                    errorFired = true
+                    // SQLNonTransientException → NON_TRANSIENT → 중단
+                    ExtendOutcome.BackendError(java.sql.SQLNonTransientException("fatal query error"))
+                } else {
+                    callsAfterError.incrementAndGet()
+                    ExtendOutcome.Extended(Instant.now())
+                }
+            }
+
+            override fun isHeld(): Boolean = true
+        }
+
+        val watchdog = LeaderLeaseAutoExtender.start(true, 90.milliseconds, delegate)
+        delay(300.milliseconds)
+        watchdog.close()
+
+        // non-transient error 후 watchdog 중단 → 이후 호출 0
+        errorFired.shouldBeTrue()
+        callsAfterError.get() shouldBeEqualTo 0
+    }
+
+    // ── Deprecated Boolean 람다 overload 는 여전히 동작한다 ──────────────
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `deprecated Boolean 람다 overload 는 여전히 동작한다`() = runSuspendIO {
+        val calls = AtomicInteger(0)
+
+        val watchdog = LeaderLeaseAutoExtender.start(true, 90.milliseconds) {
+            calls.incrementAndGet()
+            true
+        }
+
+        delay(200.milliseconds)
+        watchdog.close()
+
+        (calls.get() >= 1).shouldBeTrue()
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `deprecated Boolean 람다 disabled 이면 호출 안 됨`() = runSuspendIO {
+        val calls = AtomicInteger(0)
+
+        val watchdog = LeaderLeaseAutoExtender.start(false, 90.milliseconds) {
+            calls.incrementAndGet()
+            true
+        }
+
+        delay(120.milliseconds)
+        watchdog.close()
+
+        calls.get() shouldBeEqualTo 0
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLockHandleTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLockHandleTest.kt
@@ -1,0 +1,174 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderLockHandleTest {
+
+    private fun identity(name: String = "test-lock") = LockIdentity(
+        lockName = name,
+        kind = LockIdentity.AnnotationKind.SINGLE,
+        factoryBeanName = "testFactory",
+    )
+
+    private fun fakeDelegate(held: Boolean = true): ExtendDelegate = object : ExtendDelegate {
+        private val deadline = AtomicReference(Instant.EPOCH)
+        override val lastExtendDeadline: AtomicReference<Instant> get() = deadline
+        override fun extend(lockAtMostFor: Duration): ExtendOutcome =
+            if (held) ExtendOutcome.Extended(Instant.now()) else ExtendOutcome.NotHeld
+        override fun isHeld(): Boolean = held
+    }
+
+    private fun realHandle(
+        name: String = "test-lock",
+        token: String = "tok-abc",
+        depth: Int = 0,
+        held: Boolean = true,
+    ): LeaderLockHandle.Real =
+        LeaderLockHandle.real(
+            identity = identity(name),
+            token = token,
+            acquiredAtNanos = System.nanoTime(),
+            reentryDepth = depth,
+            extendDelegate = fakeDelegate(held),
+        )
+
+    // --- lockName / isReentrant ---
+
+    @Test
+    fun `lockName delegates to identity lockName`() {
+        val handle = realHandle(name = "my-lock")
+        handle.lockName shouldBeEqualTo "my-lock"
+    }
+
+    @Test
+    fun `isReentrant is false for depth 0`() {
+        realHandle(depth = 0).isReentrant.shouldBeFalse()
+    }
+
+    @Test
+    fun `isReentrant is true for depth greater than 0`() {
+        realHandle(depth = 1).isReentrant.shouldBeTrue()
+    }
+
+    // --- matchesIdentity ---
+
+    @Test
+    fun `matchesIdentity returns true for same lockName and kind`() {
+        val handle = realHandle(name = "lock-x")
+        val other = identity("lock-x")
+        handle.matchesIdentity(other).shouldBeTrue()
+    }
+
+    @Test
+    fun `matchesIdentity returns false for different lockName`() {
+        val handle = realHandle(name = "lock-x")
+        val other = identity("lock-y")
+        handle.matchesIdentity(other).shouldBeFalse()
+    }
+
+    // --- extend / extendSuspend / isStillHeld ---
+
+    @Test
+    fun `extend returns Extended when backend is held`() {
+        val handle = realHandle(held = true)
+        handle.extend(30.seconds).shouldBeInstanceOf<ExtendOutcome.Extended>()
+    }
+
+    @Test
+    fun `extend returns NotHeld when backend is not held`() {
+        val handle = realHandle(held = false)
+        handle.extend(30.seconds) shouldBeEqualTo ExtendOutcome.NotHeld
+    }
+
+    @Test
+    fun `extendSuspend returns Extended when backend is held`() = runTest {
+        val handle = realHandle(held = true)
+        handle.extendSuspend(30.seconds).shouldBeInstanceOf<ExtendOutcome.Extended>()
+    }
+
+    @Test
+    fun `isStillHeld returns true when delegate is held`() {
+        realHandle(held = true).isStillHeld().shouldBeTrue()
+    }
+
+    @Test
+    fun `isStillHeld returns false when delegate is not held`() {
+        realHandle(held = false).isStillHeld().shouldBeFalse()
+    }
+
+    // --- withReentryDepth — shared extendDelegate (R5-F3 / SF11) ---
+
+    @Test
+    fun `withReentryDepth copies share the same extendDelegate instance`() {
+        val handle = realHandle(depth = 0)
+        val inner = handle.withReentryDepth(1)
+        // Both share the same delegate — both return Extended (same backend)
+        handle.extend(30.seconds).isExtended.shouldBeTrue()
+        inner.extend(30.seconds).isExtended.shouldBeTrue()
+        // Structural: inner reentryDepth is 1, outer is 0
+        inner.reentryDepth shouldBeEqualTo 1
+        handle.reentryDepth shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `withReentryDepth preserves identity and token`() {
+        val handle = realHandle(name = "shared-lock", token = "tok-xyz")
+        val inner = handle.withReentryDepth(2)
+        inner.identity shouldBeEqualTo handle.identity
+        inner.token shouldBeEqualTo handle.token
+    }
+
+    // --- equals / hashCode ---
+
+    @Test
+    fun `Real equals based on identity, token, reentryDepth, slotId`() {
+        val delegate = fakeDelegate()
+        val id = identity()
+        val h1 = LeaderLockHandle.real(id, "tok", System.nanoTime(), reentryDepth = 0, extendDelegate = delegate)
+        val h2 = LeaderLockHandle.real(id, "tok", System.nanoTime() + 1000, reentryDepth = 0, extendDelegate = delegate)
+        // acquiredAtNanos differs but equals ignores it
+        (h1 == h2).shouldBeTrue()
+    }
+
+    @Test
+    fun `Real not equals when token differs`() {
+        val delegate = fakeDelegate()
+        val id = identity()
+        val h1 = LeaderLockHandle.real(id, "tok-A", System.nanoTime(), reentryDepth = 0, extendDelegate = delegate)
+        val h2 = LeaderLockHandle.real(id, "tok-B", System.nanoTime(), reentryDepth = 0, extendDelegate = delegate)
+        (h1 == h2).shouldBeFalse()
+    }
+
+    // --- FailOpen ---
+
+    @Test
+    fun `FailOpen lockName delegates to identity lockName`() {
+        val fo = LeaderLockHandle.failOpen(identity("fo-lock"))
+        fo.lockName shouldBeEqualTo "fo-lock"
+    }
+
+    @Test
+    fun `FailOpen reentryDepth is always 0`() {
+        LeaderLockHandle.failOpen(identity()).reentryDepth shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `FailOpen equals by identity`() {
+        val id = identity()
+        val fo1 = LeaderLockHandle.failOpen(id)
+        val fo2 = LeaderLockHandle.failOpen(id)
+        (fo1 == fo2).shouldBeTrue()
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LockAssertTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LockAssertTest.kt
@@ -1,0 +1,253 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.leader.coroutines.LockHandleElement
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.leader.internal.LockStateHolder
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LockAssertTest {
+
+    // --- helpers ---
+
+    private fun identity(name: String = "test-lock") = LockIdentity(
+        lockName = name,
+        kind = LockIdentity.AnnotationKind.SINGLE,
+        factoryBeanName = "testFactory",
+    )
+
+    private fun fakeDelegate(held: Boolean = true): ExtendDelegate = object : ExtendDelegate {
+        private val deadline = AtomicReference(Instant.EPOCH)
+        override val lastExtendDeadline: AtomicReference<Instant> get() = deadline
+        override fun extend(lockAtMostFor: Duration): ExtendOutcome =
+            if (held) ExtendOutcome.Extended(Instant.now()) else ExtendOutcome.NotHeld
+        override fun isHeld(): Boolean = held
+    }
+
+    private fun realHandle(name: String = "test-lock"): LeaderLockHandle.Real =
+        LeaderLockHandle.real(
+            identity = identity(name),
+            token = "tok-abc",
+            acquiredAtNanos = System.nanoTime(),
+            extendDelegate = fakeDelegate(true),
+        )
+
+    private fun failOpenHandle(name: String = "test-lock"): LeaderLockHandle.FailOpen =
+        LeaderLockHandle.failOpen(identity(name))
+
+    // --- assertLocked() sync ---
+
+    @Test
+    fun `assertLocked throws when called outside any scope`() {
+        assertFailsWith<IllegalStateException> {
+            LockAssert.assertLocked()
+        }
+    }
+
+    @Test
+    fun `assertLocked passes inside Real handle scope`() {
+        LockStateHolder.withPushed(realHandle()) {
+            LockAssert.assertLocked()  // must not throw
+        }
+    }
+
+    @Test
+    fun `assertLocked throws with fail-open message inside FailOpen scope`() {
+        LockStateHolder.withPushed(failOpenHandle()) {
+            assertFailsWith<IllegalStateException> {
+                LockAssert.assertLocked()
+            }
+        }
+    }
+
+    // --- assertLocked(lockName) sync ---
+
+    @Test
+    fun `assertLocked with lockName passes when name matches Real handle`() {
+        LockStateHolder.withPushed(realHandle("my-lock")) {
+            LockAssert.assertLocked("my-lock")  // must not throw
+        }
+    }
+
+    @Test
+    fun `assertLocked with lockName throws when name does not match`() {
+        LockStateHolder.withPushed(realHandle("my-lock")) {
+            assertFailsWith<IllegalStateException> {
+                LockAssert.assertLocked("other-lock")
+            }
+        }
+    }
+
+    @Test
+    fun `assertLocked with lockName throws outside any scope`() {
+        assertFailsWith<IllegalStateException> {
+            LockAssert.assertLocked("some-lock")
+        }
+    }
+
+    @Test
+    fun `assertLocked with lockName throws inside FailOpen scope`() {
+        LockStateHolder.withPushed(failOpenHandle("fo-lock")) {
+            assertFailsWith<IllegalStateException> {
+                LockAssert.assertLocked("fo-lock")
+            }
+        }
+    }
+
+    // --- isLocked() sync ---
+
+    @Test
+    fun `isLocked returns false outside any scope`() {
+        LockAssert.isLocked().shouldBeFalse()
+    }
+
+    @Test
+    fun `isLocked returns true inside Real handle scope`() {
+        LockStateHolder.withPushed(realHandle()) {
+            LockAssert.isLocked().shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `isLocked returns false inside FailOpen scope`() {
+        LockStateHolder.withPushed(failOpenHandle()) {
+            LockAssert.isLocked().shouldBeFalse()
+        }
+    }
+
+    // --- isLocked(lockName) sync ---
+
+    @Test
+    fun `isLocked with lockName returns true when name matches Real handle`() {
+        LockStateHolder.withPushed(realHandle("lock-a")) {
+            LockAssert.isLocked("lock-a").shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `isLocked with lockName returns false when name does not match`() {
+        LockStateHolder.withPushed(realHandle("lock-a")) {
+            LockAssert.isLocked("lock-b").shouldBeFalse()
+        }
+    }
+
+    @Test
+    fun `isLocked with lockName returns false inside FailOpen scope`() {
+        LockStateHolder.withPushed(failOpenHandle("fo-lock")) {
+            LockAssert.isLocked("fo-lock").shouldBeFalse()
+        }
+    }
+
+    // --- assertLockedSuspend() suspend ---
+
+    @Test
+    fun `assertLockedSuspend passes with Real handle in coroutineContext`() = runTest {
+        withContext(LockHandleElement(realHandle())) {
+            LockAssert.assertLockedSuspend()  // must not throw
+        }
+    }
+
+    @Test
+    fun `assertLockedSuspend throws with FailOpen handle in coroutineContext`() = runTest {
+        withContext(LockHandleElement(failOpenHandle())) {
+            assertFailsWith<IllegalStateException> {
+                LockAssert.assertLockedSuspend()
+            }
+        }
+    }
+
+    @Test
+    fun `assertLockedSuspend throws when no LockHandleElement in coroutineContext`() = runTest {
+        assertFailsWith<IllegalStateException> {
+            LockAssert.assertLockedSuspend()
+        }
+    }
+
+    /**
+     * R7 regression — ThreadLocal fallback 제거 검증.
+     *
+     * sync ThreadLocal 에 Real handle 을 push 한 thread 에서 assertLockedSuspend() 를 호출해도
+     * coroutineContext 에 LockHandleElement 가 없으면 반드시 throw 해야 한다.
+     * (carrier thread ThreadLocal 이 그대로 읽힌다면 잘못된 pass-through 발생)
+     */
+    @Test
+    fun `assertLockedSuspend throws even when only ThreadLocal is set (R7 no fallback)`() = runTest {
+        LockStateHolder.withPushed(realHandle()) {
+            // ThreadLocal has Real handle, but coroutineContext has no LockHandleElement
+            assertFailsWith<IllegalStateException> {
+                LockAssert.assertLockedSuspend()
+            }
+        }
+    }
+
+    // --- assertLockedSuspend(lockName) suspend ---
+
+    @Test
+    fun `assertLockedSuspend with lockName passes when names match`() = runTest {
+        withContext(LockHandleElement(realHandle("named-lock"))) {
+            LockAssert.assertLockedSuspend("named-lock")  // must not throw
+        }
+    }
+
+    @Test
+    fun `assertLockedSuspend with lockName throws when names mismatch`() = runTest {
+        withContext(LockHandleElement(realHandle("named-lock"))) {
+            assertFailsWith<IllegalStateException> {
+                LockAssert.assertLockedSuspend("other-lock")
+            }
+        }
+    }
+
+    @Test
+    fun `assertLockedSuspend with lockName throws outside any scope`() = runTest {
+        assertFailsWith<IllegalStateException> {
+            LockAssert.assertLockedSuspend("some-lock")
+        }
+    }
+
+    // --- isLockedSuspend() suspend ---
+
+    @Test
+    fun `isLockedSuspend returns true with Real handle in coroutineContext`() = runTest {
+        withContext(LockHandleElement(realHandle())) {
+            LockAssert.isLockedSuspend().shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `isLockedSuspend returns false without LockHandleElement`() = runTest {
+        LockAssert.isLockedSuspend().shouldBeFalse()
+    }
+
+    @Test
+    fun `isLockedSuspend returns false with FailOpen handle`() = runTest {
+        withContext(LockHandleElement(failOpenHandle())) {
+            LockAssert.isLockedSuspend().shouldBeFalse()
+        }
+    }
+
+    // --- isLockedSuspend(lockName) suspend ---
+
+    @Test
+    fun `isLockedSuspend with lockName returns true when names match`() = runTest {
+        withContext(LockHandleElement(realHandle("lock-x"))) {
+            LockAssert.isLockedSuspend("lock-x").shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `isLockedSuspend with lockName returns false when names mismatch`() = runTest {
+        withContext(LockHandleElement(realHandle("lock-x"))) {
+            LockAssert.isLockedSuspend("lock-y").shouldBeFalse()
+        }
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LockExtenderTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LockExtenderTest.kt
@@ -1,0 +1,297 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.leader.coroutines.LockHandleElement
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.leader.internal.LockStateHolder
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LockExtenderTest {
+
+    // --- helpers ---
+
+    private fun identity(name: String = "test-lock") = LockIdentity(
+        lockName = name,
+        kind = LockIdentity.AnnotationKind.SINGLE,
+        factoryBeanName = "testFactory",
+    )
+
+    /**
+     * Configurable fake delegate — lets tests inject specific [ExtendOutcome] responses.
+     */
+    private class FakeDelegate(
+        private val outcome: ExtendOutcome = ExtendOutcome.Extended(Instant.now()),
+        private val heldValue: Boolean = true,
+    ) : ExtendDelegate {
+        private val _deadline = AtomicReference(Instant.EPOCH)
+        override val lastExtendDeadline: AtomicReference<Instant> get() = _deadline
+
+        var extendCalledWith: Duration? = null
+
+        override fun extend(lockAtMostFor: Duration): ExtendOutcome {
+            extendCalledWith = lockAtMostFor
+            return outcome
+        }
+
+        override fun isHeld(): Boolean = heldValue
+    }
+
+    private fun realHandle(
+        name: String = "test-lock",
+        delegate: FakeDelegate = FakeDelegate(),
+    ): LeaderLockHandle.Real =
+        LeaderLockHandle.real(
+            identity = identity(name),
+            token = "tok-abc",
+            acquiredAtNanos = System.nanoTime(),
+            extendDelegate = delegate,
+        )
+
+    private fun failOpenHandle(name: String = "test-lock"): LeaderLockHandle.FailOpen =
+        LeaderLockHandle.failOpen(identity(name))
+
+    // --- extendActiveLock() — outside scope ---
+
+    @Test
+    fun `extendActiveLock returns false outside any scope`() {
+        LockExtender.extendActiveLock(30.seconds).shouldBeFalse()
+    }
+
+    @Test
+    fun `extendActiveLock with lockName returns false outside any scope`() {
+        LockExtender.extendActiveLock("some-lock", 30.seconds).shouldBeFalse()
+    }
+
+    // --- extendActiveLock() — Real handle ---
+
+    @Test
+    fun `extendActiveLock returns true when delegate returns Extended`() {
+        val delegate = FakeDelegate(ExtendOutcome.Extended(Instant.now()))
+        LockStateHolder.withPushed(realHandle(delegate = delegate)) {
+            LockExtender.extendActiveLock(60.seconds).shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `extendActiveLock calls delegate extend with correct duration`() {
+        val delegate = FakeDelegate(ExtendOutcome.Extended(Instant.now()))
+        LockStateHolder.withPushed(realHandle(delegate = delegate)) {
+            LockExtender.extendActiveLock(45.seconds)
+        }
+        assert(delegate.extendCalledWith == 45.seconds) {
+            "Expected delegate.extend called with 45s, got ${delegate.extendCalledWith}"
+        }
+    }
+
+    @Test
+    fun `extendActiveLock returns false when delegate returns NotHeld`() {
+        val delegate = FakeDelegate(ExtendOutcome.NotHeld)
+        LockStateHolder.withPushed(realHandle(delegate = delegate)) {
+            LockExtender.extendActiveLock(30.seconds).shouldBeFalse()
+        }
+    }
+
+    @Test
+    fun `extendActiveLock returns false when delegate returns WrongThread`() {
+        val delegate = FakeDelegate(ExtendOutcome.WrongThread)
+        LockStateHolder.withPushed(realHandle(delegate = delegate)) {
+            LockExtender.extendActiveLock(30.seconds).shouldBeFalse()
+        }
+    }
+
+    @Test
+    fun `extendActiveLock returns false when delegate returns BackendError`() {
+        val delegate = FakeDelegate(ExtendOutcome.BackendError(RuntimeException("transient error")))
+        LockStateHolder.withPushed(realHandle(delegate = delegate)) {
+            LockExtender.extendActiveLock(30.seconds).shouldBeFalse()
+        }
+    }
+
+    // --- extendActiveLock() — FailOpen sentinel ---
+
+    @Test
+    fun `extendActiveLock returns false inside FailOpen scope`() {
+        LockStateHolder.withPushed(failOpenHandle()) {
+            LockExtender.extendActiveLock(30.seconds).shouldBeFalse()
+        }
+    }
+
+    // --- extendActiveLock(lockName) — mismatched name ---
+
+    @Test
+    fun `extendActiveLock with mismatched lockName returns false`() {
+        val delegate = FakeDelegate(ExtendOutcome.Extended(Instant.now()))
+        LockStateHolder.withPushed(realHandle("lock-a", delegate)) {
+            LockExtender.extendActiveLock("lock-b", 30.seconds).shouldBeFalse()
+        }
+    }
+
+    @Test
+    fun `extendActiveLock with matching lockName returns true`() {
+        val delegate = FakeDelegate(ExtendOutcome.Extended(Instant.now()))
+        LockStateHolder.withPushed(realHandle("lock-a", delegate)) {
+            LockExtender.extendActiveLock("lock-a", 30.seconds).shouldBeTrue()
+        }
+    }
+
+    // --- java.time.Duration overloads ---
+
+    @Test
+    fun `extendActiveLock with java Duration returns true for Real handle`() {
+        val delegate = FakeDelegate(ExtendOutcome.Extended(Instant.now()))
+        LockStateHolder.withPushed(realHandle(delegate = delegate)) {
+            LockExtender.extendActiveLock(60.seconds.toJavaDuration()).shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `extendActiveLock with lockName and java Duration returns true for Real handle`() {
+        val delegate = FakeDelegate(ExtendOutcome.Extended(Instant.now()))
+        LockStateHolder.withPushed(realHandle("my-lock", delegate)) {
+            LockExtender.extendActiveLock("my-lock", 60.seconds.toJavaDuration()).shouldBeTrue()
+        }
+    }
+
+    // --- extendActiveLockDetailed() — sealed ExtendOutcome branches ---
+
+    @Test
+    fun `extendActiveLockDetailed returns Extended for successful backend extend`() {
+        val expireAt = Instant.now().plusSeconds(60)
+        val delegate = FakeDelegate(ExtendOutcome.Extended(expireAt))
+        LockStateHolder.withPushed(realHandle(delegate = delegate)) {
+            val outcome = LockExtender.extendActiveLockDetailed(60.seconds)
+            assert(outcome is ExtendOutcome.Extended) { "Expected Extended, got $outcome" }
+        }
+    }
+
+    @Test
+    fun `extendActiveLockDetailed returns NotHeld when outside scope`() {
+        val outcome = LockExtender.extendActiveLockDetailed(30.seconds)
+        assert(outcome is ExtendOutcome.NotHeld) { "Expected NotHeld, got $outcome" }
+    }
+
+    @Test
+    fun `extendActiveLockDetailed returns NotHeld for FailOpen scope`() {
+        LockStateHolder.withPushed(failOpenHandle()) {
+            val outcome = LockExtender.extendActiveLockDetailed(30.seconds)
+            assert(outcome is ExtendOutcome.NotHeld) { "Expected NotHeld, got $outcome" }
+        }
+    }
+
+    @Test
+    fun `extendActiveLockDetailed returns WrongThread when delegate returns WrongThread`() {
+        val delegate = FakeDelegate(ExtendOutcome.WrongThread)
+        LockStateHolder.withPushed(realHandle(delegate = delegate)) {
+            val outcome = LockExtender.extendActiveLockDetailed(30.seconds)
+            assert(outcome is ExtendOutcome.WrongThread) { "Expected WrongThread, got $outcome" }
+        }
+    }
+
+    @Test
+    fun `extendActiveLockDetailed returns BackendError when delegate returns BackendError`() {
+        val cause = RuntimeException("backend down")
+        val delegate = FakeDelegate(ExtendOutcome.BackendError(cause))
+        LockStateHolder.withPushed(realHandle(delegate = delegate)) {
+            val outcome = LockExtender.extendActiveLockDetailed(30.seconds)
+            assert(outcome is ExtendOutcome.BackendError) { "Expected BackendError, got $outcome" }
+            assert((outcome as ExtendOutcome.BackendError).cause === cause)
+        }
+    }
+
+    // --- R2 mitigation: lastExtendDeadline update ---
+
+    @Test
+    fun `extendActiveLock sets lastExtendDeadline to approximately now plus duration (R2)`() {
+        val delegate = FakeDelegate(ExtendOutcome.Extended(Instant.now()))
+        val beforeCall = Instant.now()
+        LockStateHolder.withPushed(realHandle(delegate = delegate)) {
+            LockExtender.extendActiveLock(60.seconds)
+        }
+        val afterCall = Instant.now()
+
+        val deadline = delegate.lastExtendDeadline.get()
+        val expectedMin = beforeCall.plusSeconds(59)   // some tolerance
+        val expectedMax = afterCall.plusSeconds(61)    // some tolerance
+
+        assert(!deadline.isBefore(expectedMin)) {
+            "lastExtendDeadline=$deadline is before expected minimum=$expectedMin"
+        }
+        assert(!deadline.isAfter(expectedMax)) {
+            "lastExtendDeadline=$deadline is after expected maximum=$expectedMax"
+        }
+    }
+
+    // --- suspend variants ---
+
+    @Test
+    fun `extendActiveLockSuspend returns true inside Real handle in coroutineContext`() = runTest {
+        val delegate = FakeDelegate(ExtendOutcome.Extended(Instant.now()))
+        withContext(LockHandleElement(realHandle(delegate = delegate))) {
+            LockExtender.extendActiveLockSuspend(30.seconds).shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `extendActiveLockSuspend returns false outside any scope`() = runTest {
+        LockExtender.extendActiveLockSuspend(30.seconds).shouldBeFalse()
+    }
+
+    @Test
+    fun `extendActiveLockSuspend returns false inside FailOpen scope`() = runTest {
+        withContext(LockHandleElement(failOpenHandle())) {
+            LockExtender.extendActiveLockSuspend(30.seconds).shouldBeFalse()
+        }
+    }
+
+    @Test
+    fun `extendActiveLockSuspend with lockName returns true when names match`() = runTest {
+        val delegate = FakeDelegate(ExtendOutcome.Extended(Instant.now()))
+        withContext(LockHandleElement(realHandle("async-lock", delegate))) {
+            LockExtender.extendActiveLockSuspend("async-lock", 30.seconds).shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `extendActiveLockSuspend with mismatched lockName returns false`() = runTest {
+        val delegate = FakeDelegate(ExtendOutcome.Extended(Instant.now()))
+        withContext(LockHandleElement(realHandle("async-lock", delegate))) {
+            LockExtender.extendActiveLockSuspend("other-lock", 30.seconds).shouldBeFalse()
+        }
+    }
+
+    // --- extendActiveLockDetailedSuspend() ---
+
+    @Test
+    fun `extendActiveLockDetailedSuspend returns Extended for successful backend extend`() = runTest {
+        val delegate = FakeDelegate(ExtendOutcome.Extended(Instant.now().plusSeconds(30)))
+        withContext(LockHandleElement(realHandle(delegate = delegate))) {
+            val outcome = LockExtender.extendActiveLockDetailedSuspend(30.seconds)
+            assert(outcome is ExtendOutcome.Extended) { "Expected Extended, got $outcome" }
+        }
+    }
+
+    @Test
+    fun `extendActiveLockDetailedSuspend returns NotHeld when outside scope`() = runTest {
+        val outcome = LockExtender.extendActiveLockDetailedSuspend(30.seconds)
+        assert(outcome is ExtendOutcome.NotHeld) { "Expected NotHeld, got $outcome" }
+    }
+
+    @Test
+    fun `extendActiveLockDetailedSuspend with lockName returns NotHeld for mismatch`() = runTest {
+        val delegate = FakeDelegate(ExtendOutcome.Extended(Instant.now()))
+        withContext(LockHandleElement(realHandle("lock-a", delegate))) {
+            val outcome = LockExtender.extendActiveLockDetailedSuspend("lock-b", 30.seconds)
+            assert(outcome is ExtendOutcome.NotHeld) { "Expected NotHeld, got $outcome" }
+        }
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/ReactorOperatorNegativeTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/ReactorOperatorNegativeTest.kt
@@ -1,0 +1,176 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.leader.coroutines.LockHandleElement
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.leader.internal.LockStateHolder
+import kotlinx.coroutines.reactor.mono
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import reactor.core.publisher.Mono
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Step 3-P R5 mitigation 부정 테스트 — Reactor non-suspend operator 미지원 검증.
+ *
+ * Reactor 의 `.map {}` / `.filter {}` 등 non-suspend operator 안에서는
+ * ThreadLocal 도 `CoroutineContext` 도 없으므로 [LockAssert.assertLocked] 와
+ * [LockExtender.extendActiveLock] 은 반드시 throw / false 를 반환해야 한다.
+ *
+ * **권장 패턴**: `.flatMap { mono { ... } }` 내부에서 `withContext(LockHandleElement(...))` 를 사용.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ReactorOperatorNegativeTest {
+
+    private fun identity(name: String = "reactor-lock") = LockIdentity(
+        lockName = name,
+        kind = LockIdentity.AnnotationKind.SINGLE,
+        factoryBeanName = "testFactory",
+    )
+
+    private fun fakeDelegate(): ExtendDelegate = object : ExtendDelegate {
+        private val deadline = AtomicReference(Instant.EPOCH)
+        override val lastExtendDeadline: AtomicReference<Instant> get() = deadline
+        override fun extend(lockAtMostFor: Duration): ExtendOutcome = ExtendOutcome.Extended(Instant.now())
+        override fun isHeld(): Boolean = true
+    }
+
+    private fun realHandle(name: String = "reactor-lock"): LeaderLockHandle.Real =
+        LeaderLockHandle.real(
+            identity = identity(name),
+            token = "tok-reactor",
+            acquiredAtNanos = System.nanoTime(),
+            extendDelegate = fakeDelegate(),
+        )
+
+    /**
+     * R5 — `Mono.map {}` (non-suspend) 안에서 [LockAssert.assertLocked] 호출 시 throw.
+     *
+     * ThreadLocal 에 Real handle 이 push 되어 있더라도 Reactor operator 는 다른 스레드에서
+     * 실행될 수 있으므로 ThreadLocal 이 전파되지 않을 수 있다.
+     * 이 테스트는 ThreadLocal 이 전파되지 않는 케이스를 검증한다.
+     * (Reactor 가 동일 스레드에서 실행될 때는 ThreadLocal 이 보일 수 있으므로,
+     * `LockStateHolder` 에 아무것도 push 하지 않은 상태에서 검증)
+     */
+    @Test
+    fun `LockAssert assertLocked inside Mono map throws when no active scope (R5)`() {
+        // No ThreadLocal scope — simulates a Reactor operator on a different thread
+        val mono = Mono.just("value").map {
+            LockAssert.assertLocked()
+            it
+        }
+
+        assertFailsWith<IllegalStateException> {
+            mono.block()
+        }
+    }
+
+    /**
+     * R5 — `Mono.fromCallable {}` 안에서도 ThreadLocal 없으면 throw.
+     */
+    @Test
+    fun `LockAssert assertLocked inside Mono fromCallable throws when no active scope (R5)`() {
+        val mono = Mono.fromCallable {
+            LockAssert.assertLocked()
+            "result"
+        }
+
+        assertFailsWith<IllegalStateException> {
+            mono.block()
+        }
+    }
+
+    /**
+     * R5 positive path — `.flatMap { mono { withContext(LockHandleElement) { ... } } }` 패턴은 통과.
+     *
+     * suspend `mono {}` builder 안에서 `withContext(LockHandleElement(handle))` 를 사용하면
+     * [LockAssert.assertLockedSuspend] 가 정상 통과함을 검증.
+     */
+    @Test
+    fun `LockAssert assertLockedSuspend inside mono flatMap with LockHandleElement passes (R5)`() {
+        val handle = realHandle()
+
+        val result = Mono.just("value")
+            .flatMap { value ->
+                mono {
+                    withContext(LockHandleElement(handle)) {
+                        LockAssert.assertLockedSuspend()  // must not throw
+                        value
+                    }
+                }
+            }
+            .block()
+
+        assert(result == "value") { "Expected 'value', got $result" }
+    }
+
+    /**
+     * R5 — [LockExtender.extendActiveLock] 도 Mono map 안에서 false 반환.
+     *
+     * ThreadLocal 없는 환경에서 extendActiveLock 은 outsideScope → false + WARN.
+     */
+    @Test
+    fun `LockExtender extendActiveLock inside Mono map returns false when no active scope (R5)`() {
+        var result: Boolean? = null
+
+        Mono.just("value")
+            .map {
+                result = LockExtender.extendActiveLock(30.seconds)
+                it
+            }
+            .block()
+
+        assert(result == false) { "Expected false, got $result" }
+    }
+
+    /**
+     * R5 positive path — suspend `mono {}` + [LockExtender.extendActiveLockSuspend] 는 정상 동작.
+     */
+    @Test
+    fun `LockExtender extendActiveLockSuspend inside mono flatMap with LockHandleElement returns true (R5)`() {
+        val handle = realHandle()
+        var result: Boolean? = null
+
+        Mono.just("value")
+            .flatMap { _ ->
+                mono {
+                    withContext(LockHandleElement(handle)) {
+                        result = LockExtender.extendActiveLockSuspend(30.seconds)
+                    }
+                    "done"
+                }
+            }
+            .block()
+
+        assert(result == true) { "Expected true, got $result" }
+    }
+
+    /**
+     * ThreadLocal scope 안에서 Reactor Mono.map 을 실행할 때의 동작 검증.
+     *
+     * Reactor 가 호출 스레드와 동일한 스레드에서 동기 실행되면 ThreadLocal 이 보일 수 있다.
+     * 이 경우 assertLocked() 는 통과한다 — 이는 동일 스레드에서의 동기 실행이기 때문.
+     * 이 테스트는 해당 동작을 문서화한다 (보장 아님, 구현 세부).
+     *
+     * 핵심: **비동기 스케줄러** (e.g., `publishOn(Schedulers.boundedElastic())`) 를 사용하면
+     * 다른 스레드에서 실행되어 ThreadLocal 이 전파되지 않으므로 반드시 coroutineContext 방식 사용.
+     */
+    @Test
+    fun `LockStateHolder withPushed and synchronous Mono on same thread sees ThreadLocal`() {
+        var sawLocked: Boolean? = null
+
+        LockStateHolder.withPushed(realHandle()) {
+            // Synchronous Mono on caller thread — ThreadLocal is visible
+            Mono.fromCallable {
+                sawLocked = LockAssert.isLocked()
+            }.block()
+        }
+
+        // On same thread, ThreadLocal is visible
+        assert(sawLocked == true) { "Expected true (same-thread synchronous Mono), got $sawLocked" }
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/contract/AbstractGroupLockExtenderContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/contract/AbstractGroupLockExtenderContractTest.kt
@@ -1,0 +1,142 @@
+package io.bluetape4k.leader.contract
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LeaderGroupElector
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.leader.LockExtender
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Backend-agnostic 한 LockAssert/LockExtender × sync [LeaderGroupElector] contract.
+ *
+ * 각 backend 의 contract test 가 이 abstract class 를 상속하여 [elector] 를 제공한다.
+ *
+ * ## 검증 계약 (AC-1 / Issue #79)
+ *
+ * 1. `assertLocked()` — [LeaderGroupElector.runIfLeader] 본문 안에서는 pass, 밖에서는 [IllegalStateException]
+ * 2. `isLocked()` — 본문 안 `true`, 밖 `false`
+ * 3. `extendActiveLock(d)` — 본문 안 `true`, 완료 후 `false`
+ * 4. `extendActiveLockDetailed(d)` — [ExtendOutcome.Extended] 반환
+ *
+ * ## 사용 방법
+ *
+ * ```kotlin
+ * class RedissonGroupLockExtenderContractTest : AbstractGroupLockExtenderContractTest() {
+ *     companion object : KLogging() {
+ *         val redis = RedisServer.Launcher.redis
+ *     }
+ *     override val elector: LeaderGroupElector = RedissonLeaderGroupElector(client)
+ * }
+ * ```
+ *
+ * ## 범위 한계
+ *
+ * - Single elector 계약은 [AbstractSyncLockExtenderContractTest] 가 담당.
+ * - suspend group 계약은 [AbstractSuspendGroupLockExtenderContractTest] 가 담당.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractGroupLockExtenderContractTest {
+
+    /** 각 backend 가 자기 [LeaderGroupElector] 인스턴스를 제공한다. */
+    protected abstract val elector: LeaderGroupElector
+
+    private fun randomLockName(): String = "ctr-g-${Base58.randomString(8)}"
+
+    // ── assertLocked() ────────────────────────────────────────────────────
+
+    @Test
+    fun `assertLocked passes inside group runIfLeader body`() {
+        val lockName = randomLockName()
+        var assertionPassed = false
+
+        elector.runIfLeader(lockName) {
+            LockAssert.assertLocked()          // must not throw
+            assertionPassed = true
+        }
+
+        assertionPassed.shouldBeTrue()
+    }
+
+    @Test
+    fun `assertLocked throws outside group runIfLeader body`() {
+        assertFailsWith<IllegalStateException> {
+            LockAssert.assertLocked()
+        }
+    }
+
+    // ── isLocked() ───────────────────────────────────────────────────────
+
+    @Test
+    fun `isLocked returns false outside and true inside group body`() {
+        val lockName = randomLockName()
+
+        LockAssert.isLocked().shouldBeFalse()
+
+        elector.runIfLeader(lockName) {
+            LockAssert.isLocked().shouldBeTrue()
+        }
+
+        LockAssert.isLocked().shouldBeFalse()
+    }
+
+    // ── extendActiveLock() ────────────────────────────────────────────────
+
+    @Test
+    fun `extendActiveLock returns true when group lock is held`() {
+        val lockName = randomLockName()
+        var extended = false
+
+        elector.runIfLeader(lockName) {
+            extended = LockExtender.extendActiveLock(60.seconds)
+        }
+
+        extended.shouldBeTrue()
+    }
+
+    @Test
+    fun `extendActiveLock returns false after group runIfLeader body completes`() {
+        val lockName = randomLockName()
+
+        elector.runIfLeader(lockName) { /* acquire and release */ }
+
+        // scope ended — no active handle
+        LockExtender.extendActiveLock(60.seconds).shouldBeFalse()
+    }
+
+    // ── extendActiveLockDetailed() ─────────────────────────────────────────
+
+    @Test
+    fun `extendActiveLockDetailed returns Extended when group lock is held`() {
+        val lockName = randomLockName()
+        var outcome: ExtendOutcome? = null
+
+        elector.runIfLeader(lockName) {
+            outcome = LockExtender.extendActiveLockDetailed(60.seconds)
+        }
+
+        (outcome is ExtendOutcome.Extended).shouldBeTrue()
+    }
+
+    @Test
+    fun `extendActiveLockDetailed returns NotHeld outside group body`() {
+        val outcome = LockExtender.extendActiveLockDetailed(60.seconds)
+
+        (outcome is ExtendOutcome.NotHeld).shouldBeTrue()
+    }
+
+    // ── return value ──────────────────────────────────────────────────────
+
+    @Test
+    fun `runIfLeader returns action return value when group slot is acquired`() {
+        val lockName = randomLockName()
+        val result = elector.runIfLeader(lockName) { "group-contract-ok" }
+        result shouldBeEqualTo "group-contract-ok"
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/contract/AbstractSuspendGroupLockExtenderContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/contract/AbstractSuspendGroupLockExtenderContractTest.kt
@@ -1,0 +1,143 @@
+package io.bluetape4k.leader.contract
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.leader.LockExtender
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Backend-agnostic 한 LockAssert/LockExtender × suspend [SuspendLeaderGroupElector] contract.
+ *
+ * 각 backend 의 contract test 가 이 abstract class 를 상속하여 [elector] 를 제공한다.
+ *
+ * ## 검증 계약 (AC-1 / Issue #79)
+ *
+ * 1. `assertLockedSuspend()` — [SuspendLeaderGroupElector.runIfLeader] 본문 안에서는 pass, 밖에서는 [IllegalStateException]
+ * 2. `isLockedSuspend()` — 본문 안 `true`, 밖 `false`
+ * 3. `extendActiveLockSuspend(d)` — 본문 안 `true`, 완료 후 `false`
+ * 4. `extendActiveLockDetailedSuspend(d)` — [ExtendOutcome.Extended] 반환
+ *
+ * ## 사용 방법
+ *
+ * ```kotlin
+ * class RedissonSuspendGroupLockExtenderContractTest : AbstractSuspendGroupLockExtenderContractTest() {
+ *     companion object : KLogging() {
+ *         val redis = RedisServer.Launcher.redis
+ *     }
+ *     override val elector: SuspendLeaderGroupElector = RedissonSuspendLeaderGroupElector(client)
+ * }
+ * ```
+ *
+ * ## 범위 한계
+ *
+ * - sync group 계약은 [AbstractGroupLockExtenderContractTest] 가 담당.
+ * - Single suspend 계약은 [AbstractSuspendLockExtenderContractTest] 가 담당.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractSuspendGroupLockExtenderContractTest {
+
+    /** 각 backend 가 자기 [SuspendLeaderGroupElector] 인스턴스를 제공한다. */
+    protected abstract val elector: SuspendLeaderGroupElector
+
+    private fun randomLockName(): String = "ctr-sg-${Base58.randomString(8)}"
+
+    // ── assertLockedSuspend() ──────────────────────────────────────────────
+
+    @Test
+    fun `assertLockedSuspend passes inside suspend group runIfLeader body`() = runSuspendIO {
+        val lockName = randomLockName()
+        var assertionPassed = false
+
+        elector.runIfLeader(lockName) {
+            LockAssert.assertLockedSuspend()          // must not throw
+            assertionPassed = true
+        }
+
+        assertionPassed.shouldBeTrue()
+    }
+
+    @Test
+    fun `assertLockedSuspend throws outside suspend group runIfLeader body`() = runSuspendIO {
+        assertFailsWith<IllegalStateException> {
+            LockAssert.assertLockedSuspend()
+        }
+    }
+
+    // ── isLockedSuspend() ─────────────────────────────────────────────────
+
+    @Test
+    fun `isLockedSuspend returns false outside and true inside suspend group body`() = runSuspendIO {
+        val lockName = randomLockName()
+
+        LockAssert.isLockedSuspend().shouldBeFalse()
+
+        elector.runIfLeader(lockName) {
+            LockAssert.isLockedSuspend().shouldBeTrue()
+        }
+
+        LockAssert.isLockedSuspend().shouldBeFalse()
+    }
+
+    // ── extendActiveLockSuspend() ─────────────────────────────────────────
+
+    @Test
+    fun `extendActiveLockSuspend returns true when suspend group lock is held`() = runSuspendIO {
+        val lockName = randomLockName()
+        var extended = false
+
+        elector.runIfLeader(lockName) {
+            extended = LockExtender.extendActiveLockSuspend(60.seconds)
+        }
+
+        extended.shouldBeTrue()
+    }
+
+    @Test
+    fun `extendActiveLockSuspend returns false after suspend group body completes`() = runSuspendIO {
+        val lockName = randomLockName()
+
+        elector.runIfLeader(lockName) { /* acquire and release */ }
+
+        // scope ended — no active handle in coroutineContext
+        LockExtender.extendActiveLockSuspend(60.seconds).shouldBeFalse()
+    }
+
+    // ── extendActiveLockDetailedSuspend() ─────────────────────────────────
+
+    @Test
+    fun `extendActiveLockDetailedSuspend returns Extended when suspend group lock is held`() = runSuspendIO {
+        val lockName = randomLockName()
+        var outcome: ExtendOutcome? = null
+
+        elector.runIfLeader(lockName) {
+            outcome = LockExtender.extendActiveLockDetailedSuspend(60.seconds)
+        }
+
+        (outcome is ExtendOutcome.Extended).shouldBeTrue()
+    }
+
+    @Test
+    fun `extendActiveLockDetailedSuspend returns NotHeld outside suspend group body`() = runSuspendIO {
+        val outcome = LockExtender.extendActiveLockDetailedSuspend(60.seconds)
+
+        (outcome is ExtendOutcome.NotHeld).shouldBeTrue()
+    }
+
+    // ── return value ──────────────────────────────────────────────────────
+
+    @Test
+    fun `runIfLeader returns action return value when suspend group slot is acquired`() = runSuspendIO {
+        val lockName = randomLockName()
+        val result = elector.runIfLeader(lockName) { "suspend-group-contract-ok" }
+        result shouldBeEqualTo "suspend-group-contract-ok"
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/contract/AbstractSuspendLockExtenderContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/contract/AbstractSuspendLockExtenderContractTest.kt
@@ -1,0 +1,204 @@
+package io.bluetape4k.leader.contract
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.leader.LockExtender
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Backend-agnostic 한 LockAssert/LockExtender × suspend [SuspendLeaderElector] contract.
+ *
+ * 각 backend 의 contract test 가 이 abstract class 를 상속하여 [elector] 를 제공한다.
+ *
+ * ## 검증 계약 (AC-1 / Issue #79)
+ *
+ * 1. `assertLockedSuspend()` — [SuspendLeaderElector.runIfLeader] 본문 안에서는 pass, 밖에서는 [IllegalStateException]
+ * 2. `assertLockedSuspend(lockName)` — 이름 일치 시 pass, 불일치 시 [IllegalStateException]
+ * 3. `isLockedSuspend()` — 본문 안 `true`, 밖 `false`
+ * 4. `extendActiveLockSuspend(d)` — 본문 안 `true`, 완료 후 `false`
+ * 5. `extendActiveLockDetailedSuspend(d)` — [ExtendOutcome.Extended] 반환
+ * 6. `extendActiveLockSuspend(lockName, d)` — 이름 일치 `true`, 불일치 `false`
+ *
+ * ## 사용 방법
+ *
+ * ```kotlin
+ * class RedissonSuspendLockExtenderContractTest : AbstractSuspendLockExtenderContractTest() {
+ *     companion object : KLogging() {
+ *         val redis = RedisServer.Launcher.redis
+ *     }
+ *     override val elector: SuspendLeaderElector = RedissonSuspendLeaderElector(client)
+ * }
+ * ```
+ *
+ * ## 범위 한계
+ *
+ * - sync 계약은 [AbstractSyncLockExtenderContractTest] 가 담당.
+ * - Group elector ([io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector]) 계약은 별도 base 로 위임.
+ *   (T5 기준 group elector 는 handle push 를 구현하지 않으므로 별도 tracking.)
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractSuspendLockExtenderContractTest {
+
+    /** 각 backend 가 자기 [SuspendLeaderElector] 인스턴스를 제공한다. */
+    protected abstract val elector: SuspendLeaderElector
+
+    private fun randomLockName(): String = "ctr-su-${Base58.randomString(8)}"
+
+    // ── assertLockedSuspend() ──────────────────────────────────────────────
+
+    @Test
+    fun `assertLockedSuspend passes inside runIfLeader body`() = runSuspendIO {
+        val lockName = randomLockName()
+        var assertionPassed = false
+
+        elector.runIfLeader(lockName) {
+            LockAssert.assertLockedSuspend()          // must not throw
+            assertionPassed = true
+        }
+
+        assertionPassed.shouldBeTrue()
+    }
+
+    @Test
+    fun `assertLockedSuspend throws outside runIfLeader body`() = runSuspendIO {
+        assertFailsWith<IllegalStateException> {
+            LockAssert.assertLockedSuspend()
+        }
+    }
+
+    @Test
+    fun `assertLockedSuspend with matching lockName passes inside body`() = runSuspendIO {
+        val lockName = randomLockName()
+        var assertionPassed = false
+
+        elector.runIfLeader(lockName) {
+            LockAssert.assertLockedSuspend(lockName)  // must not throw
+            assertionPassed = true
+        }
+
+        assertionPassed.shouldBeTrue()
+    }
+
+    @Test
+    fun `assertLockedSuspend with mismatched lockName throws inside body`() = runSuspendIO {
+        val lockName = randomLockName()
+
+        elector.runIfLeader(lockName) {
+            assertFailsWith<IllegalStateException> {
+                LockAssert.assertLockedSuspend("wrong-lock-name")
+            }
+        }
+    }
+
+    // ── isLockedSuspend() ─────────────────────────────────────────────────
+
+    @Test
+    fun `isLockedSuspend returns true inside runIfLeader body and false outside`() = runSuspendIO {
+        val lockName = randomLockName()
+
+        LockAssert.isLockedSuspend().shouldBeFalse()
+
+        elector.runIfLeader(lockName) {
+            LockAssert.isLockedSuspend().shouldBeTrue()
+            LockAssert.isLockedSuspend(lockName).shouldBeTrue()
+        }
+
+        LockAssert.isLockedSuspend().shouldBeFalse()
+    }
+
+    @Test
+    fun `isLockedSuspend with mismatched lockName returns false inside body`() = runSuspendIO {
+        val lockName = randomLockName()
+
+        elector.runIfLeader(lockName) {
+            LockAssert.isLockedSuspend("other-lock").shouldBeFalse()
+        }
+    }
+
+    // ── extendActiveLockSuspend() ─────────────────────────────────────────
+
+    @Test
+    fun `extendActiveLockSuspend returns true when lock is held`() = runSuspendIO {
+        val lockName = randomLockName()
+        var extended = false
+
+        elector.runIfLeader(lockName) {
+            extended = LockExtender.extendActiveLockSuspend(60.seconds)
+        }
+
+        extended.shouldBeTrue()
+    }
+
+    @Test
+    fun `extendActiveLockSuspend returns false after runIfLeader body completes`() = runSuspendIO {
+        val lockName = randomLockName()
+
+        elector.runIfLeader(lockName) { /* acquire and release */ }
+
+        // scope ended — no active handle in coroutineContext
+        LockExtender.extendActiveLockSuspend(60.seconds).shouldBeFalse()
+    }
+
+    @Test
+    fun `extendActiveLockSuspend with matching lockName returns true`() = runSuspendIO {
+        val lockName = randomLockName()
+        var extended = false
+
+        elector.runIfLeader(lockName) {
+            extended = LockExtender.extendActiveLockSuspend(lockName, 60.seconds)
+        }
+
+        extended.shouldBeTrue()
+    }
+
+    @Test
+    fun `extendActiveLockSuspend with mismatched lockName returns false`() = runSuspendIO {
+        val lockName = randomLockName()
+        var extended = true  // intentionally start as true to verify it becomes false
+
+        elector.runIfLeader(lockName) {
+            extended = LockExtender.extendActiveLockSuspend("wrong-lock-name", 60.seconds)
+        }
+
+        extended.shouldBeFalse()
+    }
+
+    // ── extendActiveLockDetailedSuspend() ─────────────────────────────────
+
+    @Test
+    fun `extendActiveLockDetailedSuspend returns Extended when lock is held`() = runSuspendIO {
+        val lockName = randomLockName()
+        var outcome: ExtendOutcome? = null
+
+        elector.runIfLeader(lockName) {
+            outcome = LockExtender.extendActiveLockDetailedSuspend(60.seconds)
+        }
+
+        (outcome is ExtendOutcome.Extended).shouldBeTrue()
+    }
+
+    @Test
+    fun `extendActiveLockDetailedSuspend returns NotHeld outside runIfLeader body`() = runSuspendIO {
+        val outcome = LockExtender.extendActiveLockDetailedSuspend(60.seconds)
+
+        (outcome is ExtendOutcome.NotHeld).shouldBeTrue()
+    }
+
+    // ── return value ──────────────────────────────────────────────────────
+
+    @Test
+    fun `runIfLeader returns action return value when lock is acquired`() = runSuspendIO {
+        val lockName = randomLockName()
+        val result = elector.runIfLeader(lockName) { "suspend-contract-ok" }
+        result shouldBeEqualTo "suspend-contract-ok"
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/contract/AbstractSyncLockExtenderContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/contract/AbstractSyncLockExtenderContractTest.kt
@@ -1,0 +1,203 @@
+package io.bluetape4k.leader.contract
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.leader.LockExtender
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Backend-agnostic 한 LockAssert/LockExtender × sync [LeaderElector] contract.
+ *
+ * 각 backend 의 contract test 가 이 abstract class 를 상속하여 [elector] 를 제공한다.
+ *
+ * ## 검증 계약 (AC-1 / Issue #79)
+ *
+ * 1. `assertLocked()` — [LeaderElector.runIfLeader] 본문 안에서는 pass, 밖에서는 [IllegalStateException]
+ * 2. `assertLocked(lockName)` — 이름 일치 시 pass, 불일치 시 [IllegalStateException]
+ * 3. `isLocked()` — 본문 안 `true`, 밖 `false`
+ * 4. `extendActiveLock(d)` — 본문 안 `true`, 완료 후 `false`
+ * 5. `extendActiveLockDetailed(d)` — [ExtendOutcome.Extended] 반환
+ * 6. `extendActiveLock(lockName, d)` — 이름 일치 `true`, 불일치 `false`
+ *
+ * ## 사용 방법
+ *
+ * ```kotlin
+ * class RedissonLockExtenderContractTest : AbstractSyncLockExtenderContractTest() {
+ *     companion object : KLogging() {
+ *         val redis = RedisServer.Launcher.redis
+ *     }
+ *     override val elector: LeaderElector = RedissonLeaderElector(client)
+ * }
+ * ```
+ *
+ * ## 범위 한계
+ *
+ * - Group elector ([io.bluetape4k.leader.LeaderGroupElector]) 계약은 별도 base 로 위임.
+ *   (T5 기준 group elector 는 handle push 를 구현하지 않으므로 별도 tracking.)
+ * - suspend 계약은 [AbstractSuspendLockExtenderContractTest] 가 담당.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractSyncLockExtenderContractTest {
+
+    /** 각 backend 가 자기 [LeaderElector] 인스턴스를 제공한다. */
+    protected abstract val elector: LeaderElector
+
+    private fun randomLockName(): String = "ctr-s-${Base58.randomString(8)}"
+
+    // ── assertLocked() ────────────────────────────────────────────────────
+
+    @Test
+    fun `assertLocked passes inside runIfLeader body`() {
+        val lockName = randomLockName()
+        var assertionPassed = false
+
+        elector.runIfLeader(lockName) {
+            LockAssert.assertLocked()          // must not throw
+            assertionPassed = true
+        }
+
+        assertionPassed.shouldBeTrue()
+    }
+
+    @Test
+    fun `assertLocked throws outside runIfLeader body`() {
+        assertFailsWith<IllegalStateException> {
+            LockAssert.assertLocked()
+        }
+    }
+
+    @Test
+    fun `assertLocked with matching lockName passes inside body`() {
+        val lockName = randomLockName()
+        var assertionPassed = false
+
+        elector.runIfLeader(lockName) {
+            LockAssert.assertLocked(lockName)  // must not throw
+            assertionPassed = true
+        }
+
+        assertionPassed.shouldBeTrue()
+    }
+
+    @Test
+    fun `assertLocked with mismatched lockName throws inside body`() {
+        val lockName = randomLockName()
+
+        elector.runIfLeader(lockName) {
+            assertFailsWith<IllegalStateException> {
+                LockAssert.assertLocked("wrong-lock-name")
+            }
+        }
+    }
+
+    // ── isLocked() ───────────────────────────────────────────────────────
+
+    @Test
+    fun `isLocked returns true inside runIfLeader body and false outside`() {
+        val lockName = randomLockName()
+
+        LockAssert.isLocked().shouldBeFalse()
+
+        elector.runIfLeader(lockName) {
+            LockAssert.isLocked().shouldBeTrue()
+            LockAssert.isLocked(lockName).shouldBeTrue()
+        }
+
+        LockAssert.isLocked().shouldBeFalse()
+    }
+
+    @Test
+    fun `isLocked with mismatched lockName returns false inside body`() {
+        val lockName = randomLockName()
+
+        elector.runIfLeader(lockName) {
+            LockAssert.isLocked("other-lock").shouldBeFalse()
+        }
+    }
+
+    // ── extendActiveLock() ────────────────────────────────────────────────
+
+    @Test
+    fun `extendActiveLock returns true when lock is held`() {
+        val lockName = randomLockName()
+        var extended = false
+
+        elector.runIfLeader(lockName) {
+            extended = LockExtender.extendActiveLock(60.seconds)
+        }
+
+        extended.shouldBeTrue()
+    }
+
+    @Test
+    fun `extendActiveLock returns false after runIfLeader body completes`() {
+        val lockName = randomLockName()
+
+        elector.runIfLeader(lockName) { /* acquire and release */ }
+
+        // scope ended — no active handle
+        LockExtender.extendActiveLock(60.seconds).shouldBeFalse()
+    }
+
+    @Test
+    fun `extendActiveLock with matching lockName returns true`() {
+        val lockName = randomLockName()
+        var extended = false
+
+        elector.runIfLeader(lockName) {
+            extended = LockExtender.extendActiveLock(lockName, 60.seconds)
+        }
+
+        extended.shouldBeTrue()
+    }
+
+    @Test
+    fun `extendActiveLock with mismatched lockName returns false`() {
+        val lockName = randomLockName()
+        var extended = true  // intentionally start as true to verify it becomes false
+
+        elector.runIfLeader(lockName) {
+            extended = LockExtender.extendActiveLock("wrong-lock-name", 60.seconds)
+        }
+
+        extended.shouldBeFalse()
+    }
+
+    // ── extendActiveLockDetailed() ─────────────────────────────────────────
+
+    @Test
+    fun `extendActiveLockDetailed returns Extended when lock is held`() {
+        val lockName = randomLockName()
+        var outcome: ExtendOutcome? = null
+
+        elector.runIfLeader(lockName) {
+            outcome = LockExtender.extendActiveLockDetailed(60.seconds)
+        }
+
+        (outcome is ExtendOutcome.Extended).shouldBeTrue()
+    }
+
+    @Test
+    fun `extendActiveLockDetailed returns NotHeld outside runIfLeader body`() {
+        val outcome = LockExtender.extendActiveLockDetailed(60.seconds)
+
+        (outcome is ExtendOutcome.NotHeld).shouldBeTrue()
+    }
+
+    // ── return value ──────────────────────────────────────────────────────
+
+    @Test
+    fun `runIfLeader returns action return value when lock is acquired`() {
+        val lockName = randomLockName()
+        val result = elector.runIfLeader(lockName) { "contract-ok" }
+        result shouldBeEqualTo "contract-ok"
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendGroupLockExtenderContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendGroupLockExtenderContractTest.kt
@@ -1,0 +1,18 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.contract.AbstractSuspendGroupLockExtenderContractTest
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [AbstractSuspendGroupLockExtenderContractTest] 의 Local backend 구현.
+ *
+ * [LocalSuspendLeaderGroupElector] 를 사용해 LockAssert / LockExtender × suspend group contract 를 검증한다.
+ * 외부 인프라 불필요 — 단일 JVM 인메모리 실행.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LocalSuspendGroupLockExtenderContractTest : AbstractSuspendGroupLockExtenderContractTest() {
+
+    override val elector: SuspendLeaderGroupElector =
+        LocalSuspendLeaderGroupElector(LeaderGroupElectionOptions(maxLeaders = 3))
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElectorCaptureTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElectorCaptureTest.kt
@@ -1,0 +1,200 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.leader.LockExtender
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * [LocalSuspendLeaderElector] capture integration test.
+ *
+ * `runIfLeader` 안에서 [LockHandleElement] / [LockAssert] / [LockExtender] suspend 변형이
+ * 정상 동작하는지 검증.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Suppress("NonAsciiCharacters")
+class LocalSuspendLeaderElectorCaptureTest {
+
+    private val election = LocalSuspendLeaderElector()
+
+    private fun randomLockName() = "lock-${Base58.randomString(8)}"
+
+    // ── LockHandleElement (CoroutineContext) 통합 ─────────────────────────
+
+    @Test
+    fun `runIfLeader 안에서 coroutineContext LockHandleElement 가 Real handle 을 담고 있다`() = runSuspendIO {
+        val lockName = randomLockName()
+        var lockName2: String? = null
+        var isReal = false
+
+        election.runIfLeader(lockName) {
+            // LockAssert 를 통해 간접 검증 (LockHandleElement 내부 handle 이 Real 임을 보장)
+            LockAssert.assertLockedSuspend()
+            LockAssert.assertLockedSuspend(lockName)
+            lockName2 = lockName  // assertLockedSuspend 통과 = Real handle 존재 증거
+            isReal = LockAssert.isLockedSuspend(lockName)
+        }
+
+        // assertLockedSuspend 가 throw 없이 통과했으면 Real handle 이 존재한다는 증거
+        lockName2 shouldBeEqualTo lockName
+        isReal.shouldBeTrue()
+    }
+
+    @Test
+    fun `runIfLeader 완료 후 coroutineContext 에 LockHandleElement 가 없다`() = runSuspendIO {
+        val lockName = randomLockName()
+
+        election.runIfLeader(lockName) { /* action */ }
+
+        // scope 밖 — element 없음
+        coroutineContext[LockHandleElement].shouldBeNull()
+    }
+
+    // ── LockAssert suspend 변형 ───────────────────────────────────────────
+
+    @Test
+    fun `runIfLeader 안에서 LockAssert assertLockedSuspend 가 성공한다`() = runSuspendIO {
+        val lockName = randomLockName()
+        var assertionPassed = false
+
+        election.runIfLeader(lockName) {
+            LockAssert.assertLockedSuspend()
+            LockAssert.assertLockedSuspend(lockName)
+            assertionPassed = true
+        }
+
+        assertionPassed.shouldBeTrue()
+    }
+
+    @Test
+    fun `runIfLeader 안에서 LockAssert isLockedSuspend 가 true 를 반환한다`() = runSuspendIO {
+        val lockName = randomLockName()
+        var isLocked = false
+
+        election.runIfLeader(lockName) {
+            isLocked = LockAssert.isLockedSuspend()
+        }
+
+        isLocked.shouldBeTrue()
+    }
+
+    // ── LockExtender suspend 변형 ─────────────────────────────────────────
+
+    @Test
+    fun `runIfLeader 안에서 LockExtender extendActiveLockSuspend 가 true 를 반환한다`() = runSuspendIO {
+        val lockName = randomLockName()
+        var extended = false
+
+        election.runIfLeader(lockName) {
+            extended = LockExtender.extendActiveLockSuspend(30.seconds)
+        }
+
+        extended.shouldBeTrue()
+    }
+
+    @Test
+    fun `runIfLeader 안에서 LockExtender extendActiveLockSuspend lockName 지정 버전이 true 를 반환한다`() = runSuspendIO {
+        val lockName = randomLockName()
+        var extended = false
+
+        election.runIfLeader(lockName) {
+            extended = LockExtender.extendActiveLockSuspend(lockName, 30.seconds)
+        }
+
+        extended.shouldBeTrue()
+    }
+
+    @Test
+    fun `runIfLeader 완료 후 LockExtender extendActiveLockSuspend 가 false 를 반환한다`() = runSuspendIO {
+        val lockName = randomLockName()
+
+        election.runIfLeader(lockName) { /* action */ }
+
+        // scope 밖 → NotHeld → false
+        val extended = LockExtender.extendActiveLockSuspend(30.seconds)
+        extended shouldBeEqualTo false
+    }
+
+    // ── action 예외 시 cleanup ────────────────────────────────────────────
+
+    @Test
+    fun `action 예외 후에도 coroutineContext 에서 LockHandleElement 가 사라진다`() = runSuspendIO {
+        val lockName = randomLockName()
+
+        runCatching {
+            election.runIfLeader(lockName) {
+                throw RuntimeException("intentional")
+            }
+        }
+
+        coroutineContext[LockHandleElement].shouldBeNull()
+    }
+
+    // ── autoExtend + delegate 통합 ────────────────────────────────────────
+
+    @Test
+    fun `autoExtend=true 로 runIfLeader 실행 후 watchdog 이 state leaseUntil 을 갱신한다`() = runSuspendIO {
+        val stateElection = LocalSuspendLeaderElector(
+            LeaderElectionOptions(leaseTime = 150.milliseconds, autoExtend = true)
+        )
+        val lockName = randomLockName()
+
+        var initialLeaseUntil: java.time.Instant? = null
+        var extendedLeaseUntil: java.time.Instant? = null
+
+        val holderReady = Channel<Unit>(1)
+        val holderRelease = Channel<Unit>(1)
+
+        coroutineScope {
+            val holder = async {
+                stateElection.runIfLeader(lockName) {
+                    initialLeaseUntil = stateElection.state(lockName).leader?.leaseUntil
+                    holderReady.send(Unit)
+                    holderRelease.receive()
+                    extendedLeaseUntil = stateElection.state(lockName).leader?.leaseUntil
+                }
+            }
+
+            holderReady.receive()
+            delay(250.milliseconds)
+            holderRelease.send(Unit)
+            holder.await()
+        }
+
+        initialLeaseUntil.shouldNotBeNull()
+        extendedLeaseUntil.shouldNotBeNull()
+        extendedLeaseUntil!!.isAfter(initialLeaseUntil!!).shouldBeTrue()
+    }
+
+    // ── delay 안에서도 LockHandleElement 유지 ────────────────────────────
+
+    @Test
+    fun `suspend delay 후에도 LockHandleElement 가 유지된다`() = runSuspendIO {
+        val lockName = randomLockName()
+        var lockedBeforeDelay = false
+        var lockedAfterDelay = false
+
+        election.runIfLeader(lockName) {
+            lockedBeforeDelay = LockAssert.isLockedSuspend(lockName)
+            delay(20.milliseconds)
+            lockedAfterDelay = LockAssert.isLockedSuspend(lockName)
+        }
+
+        lockedBeforeDelay.shouldBeTrue()
+        lockedAfterDelay.shouldBeTrue()
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LockHandleElementTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LockHandleElementTest.kt
@@ -1,0 +1,119 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LockHandleElementTest {
+
+    private fun identity() = LockIdentity(
+        lockName = "element-test-lock",
+        kind = LockIdentity.AnnotationKind.SINGLE,
+        factoryBeanName = "testFactory",
+    )
+
+    private fun fakeDelegate(): ExtendDelegate = object : ExtendDelegate {
+        private val deadline = AtomicReference(Instant.EPOCH)
+        override val lastExtendDeadline: AtomicReference<Instant> get() = deadline
+        override fun extend(lockAtMostFor: Duration): ExtendOutcome = ExtendOutcome.Extended(Instant.now())
+        override fun isHeld(): Boolean = true
+    }
+
+    private fun realHandle(): LeaderLockHandle.Real =
+        LeaderLockHandle.real(
+            identity = identity(),
+            token = "tok-element",
+            acquiredAtNanos = System.nanoTime(),
+            extendDelegate = fakeDelegate(),
+        )
+
+    // ── Key / element ────────────────────────────────────────────────────────
+
+    @Test
+    fun `Key companion 은 LockHandleElement 와 동일 Key 객체다`() {
+        val key: CoroutineContext.Key<LockHandleElement> = LockHandleElement.Key
+        val element = LockHandleElement(realHandle())
+        (element.key === key).shouldBeTrue()
+    }
+
+    @Test
+    fun `element 를 통해 handle 에 접근 가능하다`() {
+        val handle = realHandle()
+        val element = LockHandleElement(handle)
+        (element.handle === handle).shouldBeTrue()
+    }
+
+    @Test
+    fun `data class equals 와 copy 가 handle 동일성으로 동작한다`() {
+        val handle = realHandle()
+        val e1 = LockHandleElement(handle)
+        val e2 = LockHandleElement(handle)
+        (e1 == e2).shouldBeTrue()
+        e1.handle shouldBeEqualTo e2.handle
+    }
+
+    // ── CoroutineContext 통합 ────────────────────────────────────────────────
+
+    @Test
+    fun `withContext 없이 currentCoroutineContext 에 element 가 없으면 null 이다`() = runSuspendIO {
+        val found = currentCoroutineContext()[LockHandleElement]
+        found.shouldBeNull()
+    }
+
+    @Test
+    fun `withContext 로 주입 시 currentCoroutineContext 에서 element 를 조회할 수 있다`() = runSuspendIO {
+        val handle = realHandle()
+        val element = LockHandleElement(handle)
+
+        withContext(element) {
+            val found = currentCoroutineContext()[LockHandleElement]
+            (found === element).shouldBeTrue()
+            (found!!.handle === handle).shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `LeaderElectionInfo 와 LockHandleElement 를 동시에 push 할 수 있다`() = runSuspendIO {
+        val handle = realHandle()
+        val info = LeaderElectionInfo("element-test-lock", true)
+        val lockElement = LockHandleElement(handle)
+
+        withContext(info + lockElement) {
+            val foundInfo = currentCoroutineContext()[LeaderElectionInfo]
+            val foundLock = currentCoroutineContext()[LockHandleElement]
+
+            (foundInfo === info).shouldBeTrue()
+            (foundLock === lockElement).shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `withContext 블록 탈출 후 element 는 제거된다`() = runSuspendIO {
+        val handle = realHandle()
+        val element = LockHandleElement(handle)
+
+        withContext(element) {
+            // inside: visible
+            val found = currentCoroutineContext()[LockHandleElement]
+            (found !== null).shouldBeTrue()
+        }
+
+        // outside: gone
+        val afterExit = currentCoroutineContext()[LockHandleElement]
+        afterExit.shouldBeNull()
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/SuspendRunIfLeaderResultTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/SuspendRunIfLeaderResultTest.kt
@@ -1,0 +1,133 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class SuspendRunIfLeaderResultTest {
+
+    private fun randomLockName() = "lock-${Base58.randomString(8)}"
+
+    // ── SuspendLeaderElector ─────────────────────────────────────────────────
+
+    @Test
+    fun `SuspendLeaderElector - 리더 선출 성공 시 Elected 를 반환한다`() = runSuspendIO {
+        val election = LocalSuspendLeaderElector()
+        val result = election.runIfLeaderResultSuspend(randomLockName()) { "ok" }
+
+        (result is LeaderRunResult.Elected).shouldBeTrue()
+        (result as LeaderRunResult.Elected<String>).value shouldBeEqualTo "ok"
+    }
+
+    @Test
+    fun `SuspendLeaderElector - action 이 null 을 반환해도 Elected 로 분류된다`() = runSuspendIO {
+        val election = LocalSuspendLeaderElector()
+        val result = election.runIfLeaderResultSuspend(randomLockName()) { null }
+
+        (result is LeaderRunResult.Elected).shouldBeTrue()
+        (result as LeaderRunResult.Elected<Nothing?>).value.shouldBeNull()
+    }
+
+    @Test
+    fun `SuspendLeaderElector - 락 획득 실패 시 Skipped 를 반환한다`() = runSuspendIO {
+        val skipElection = LocalSuspendLeaderElector(
+            LeaderElectionOptions(waitTime = 50.milliseconds)
+        )
+        val lockName = randomLockName()
+        val holderReady = Channel<Unit>(1)
+
+        val holder = async {
+            skipElection.runIfLeader(lockName) {
+                holderReady.send(Unit)
+                delay(500.milliseconds)
+                "holder"
+            }
+        }
+
+        holderReady.receive()
+
+        val result = skipElection.runIfLeaderResultSuspend(lockName) { "should-skip" }
+        result shouldBeEqualTo LeaderRunResult.Skipped
+
+        holder.await()
+    }
+
+    @Test
+    fun `SuspendLeaderElector - Elected value 로 직접 runIfLeader 결과값을 얻을 수 있다`() = runSuspendIO {
+        val election = LocalSuspendLeaderElector()
+        val result = election.runIfLeaderResultSuspend(randomLockName()) { 42 }
+
+        (result is LeaderRunResult.Elected).shouldBeTrue()
+        (result as LeaderRunResult.Elected).value shouldBeEqualTo 42
+    }
+
+    @Test
+    fun `SuspendLeaderElector - 락 해제 후 재시도 시 Elected 를 반환한다`() = runSuspendIO {
+        val election = LocalSuspendLeaderElector()
+        val lockName = randomLockName()
+
+        val first = election.runIfLeaderResultSuspend(lockName) { "first" }
+        (first is LeaderRunResult.Elected).shouldBeTrue()
+
+        val second = election.runIfLeaderResultSuspend(lockName) { "second" }
+        (second is LeaderRunResult.Elected).shouldBeTrue()
+        (second as LeaderRunResult.Elected).value shouldBeEqualTo "second"
+    }
+
+    // ── SuspendLeaderGroupElector ────────────────────────────────────────────
+
+    @Test
+    fun `SuspendLeaderGroupElector - 슬롯 획득 성공 시 Elected 를 반환한다`() = runSuspendIO {
+        val election = LocalSuspendLeaderGroupElector(LeaderGroupElectionOptions(maxLeaders = 2))
+        val result = election.runIfLeaderResultSuspend(randomLockName()) { "group-ok" }
+
+        (result is LeaderRunResult.Elected).shouldBeTrue()
+        (result as LeaderRunResult.Elected<String>).value shouldBeEqualTo "group-ok"
+    }
+
+    @Test
+    fun `SuspendLeaderGroupElector - action 이 null 을 반환해도 Elected 로 분류된다`() = runSuspendIO {
+        val election = LocalSuspendLeaderGroupElector(LeaderGroupElectionOptions(maxLeaders = 1))
+        val result = election.runIfLeaderResultSuspend(randomLockName()) { null }
+
+        (result is LeaderRunResult.Elected).shouldBeTrue()
+        (result as LeaderRunResult.Elected<Nothing?>).value.shouldBeNull()
+    }
+
+    @Test
+    fun `SuspendLeaderGroupElector - 슬롯 가득 찰 때 Skipped 를 반환한다`() = runSuspendIO {
+        val election = LocalSuspendLeaderGroupElector(
+            LeaderGroupElectionOptions(maxLeaders = 1, waitTime = 50.milliseconds)
+        )
+        val lockName = randomLockName()
+        val holderReady = Channel<Unit>(1)
+
+        val holder = async {
+            election.runIfLeader(lockName) {
+                holderReady.send(Unit)
+                delay(500.milliseconds)
+                "holder"
+            }
+        }
+
+        holderReady.receive()
+
+        val result = election.runIfLeaderResultSuspend(lockName) { "should-skip" }
+        result shouldBeEqualTo LeaderRunResult.Skipped
+
+        holder.await()
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/BackendErrorClassifierTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/BackendErrorClassifierTest.kt
@@ -1,0 +1,126 @@
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import org.junit.jupiter.api.Test
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.sql.SQLNonTransientException
+import java.sql.SQLRecoverableException
+import java.sql.SQLTransientException
+
+@Suppress("NonAsciiCharacters")
+class BackendErrorClassifierTest {
+
+    // ── CoreBackendErrorClassifier ─────────────────────────────────────────
+
+    @Test
+    fun `CoreBackendErrorClassifier - OutOfMemoryError 는 FATAL 을 반환한다`() {
+        CoreBackendErrorClassifier.classify(OutOfMemoryError()) shouldBeEqualTo BackendErrorKind.FATAL
+    }
+
+    @Test
+    fun `CoreBackendErrorClassifier - StackOverflowError 는 FATAL 을 반환한다`() {
+        CoreBackendErrorClassifier.classify(StackOverflowError()) shouldBeEqualTo BackendErrorKind.FATAL
+    }
+
+    @Test
+    fun `CoreBackendErrorClassifier - LinkageError 는 FATAL 을 반환한다`() {
+        CoreBackendErrorClassifier.classify(LinkageError("link")) shouldBeEqualTo BackendErrorKind.FATAL
+    }
+
+    @Test
+    fun `CoreBackendErrorClassifier - SQLTransientException 는 TRANSIENT 을 반환한다`() {
+        CoreBackendErrorClassifier.classify(SQLTransientException("tx")) shouldBeEqualTo BackendErrorKind.TRANSIENT
+    }
+
+    @Test
+    fun `CoreBackendErrorClassifier - SQLRecoverableException 는 TRANSIENT 을 반환한다`() {
+        CoreBackendErrorClassifier.classify(SQLRecoverableException("rx")) shouldBeEqualTo BackendErrorKind.TRANSIENT
+    }
+
+    @Test
+    fun `CoreBackendErrorClassifier - SQLNonTransientException 는 NON_TRANSIENT 을 반환한다`() {
+        CoreBackendErrorClassifier.classify(SQLNonTransientException("ntx")) shouldBeEqualTo BackendErrorKind.NON_TRANSIENT
+    }
+
+    @Test
+    fun `CoreBackendErrorClassifier - SocketTimeoutException 는 TRANSIENT 을 반환한다`() {
+        CoreBackendErrorClassifier.classify(SocketTimeoutException("timeout")) shouldBeEqualTo BackendErrorKind.TRANSIENT
+    }
+
+    @Test
+    fun `CoreBackendErrorClassifier - ConnectException 는 TRANSIENT 을 반환한다`() {
+        CoreBackendErrorClassifier.classify(ConnectException("refused")) shouldBeEqualTo BackendErrorKind.TRANSIENT
+    }
+
+    @Test
+    fun `CoreBackendErrorClassifier - 알 수 없는 예외는 null 을 반환한다`() {
+        CoreBackendErrorClassifier.classify(RuntimeException("unknown")).shouldBeNull()
+    }
+
+    @Test
+    fun `CoreBackendErrorClassifier - IllegalStateException 은 null 을 반환한다`() {
+        CoreBackendErrorClassifier.classify(IllegalStateException("state")).shouldBeNull()
+    }
+
+    // ── CompositeBackendErrorClassifier ───────────────────────────────────
+
+    @Test
+    fun `CompositeBackendErrorClassifier - backendSpecific 이 분류하면 그 결과를 반환한다`() {
+        val backendSpecific = BackendErrorClassifier { cause ->
+            if (cause is IllegalArgumentException) BackendErrorKind.NON_TRANSIENT else null
+        }
+        val composite = CompositeBackendErrorClassifier(backendSpecific)
+
+        composite.classify(IllegalArgumentException("bad arg")) shouldBeEqualTo BackendErrorKind.NON_TRANSIENT
+    }
+
+    @Test
+    fun `CompositeBackendErrorClassifier - backendSpecific 이 null 반환 시 CoreBackendErrorClassifier 에 위임한다`() {
+        val backendSpecific = BackendErrorClassifier { null }  // 항상 분류 불가
+        val composite = CompositeBackendErrorClassifier(backendSpecific)
+
+        // CoreBackendErrorClassifier 가 처리: SQLTransientException → TRANSIENT
+        composite.classify(SQLTransientException("tx")) shouldBeEqualTo BackendErrorKind.TRANSIENT
+    }
+
+    @Test
+    fun `CompositeBackendErrorClassifier - 둘 다 null 이면 NON_TRANSIENT 을 반환한다`() {
+        val backendSpecific = BackendErrorClassifier { null }
+        val composite = CompositeBackendErrorClassifier(backendSpecific)
+
+        // CoreBackendErrorClassifier 도 null → default NON_TRANSIENT
+        composite.classify(RuntimeException("unknown")) shouldBeEqualTo BackendErrorKind.NON_TRANSIENT
+    }
+
+    @Test
+    fun `CompositeBackendErrorClassifier - backendSpecific 이 TRANSIENT 반환 시 FATAL 이어도 override 된다`() {
+        // backend-specific 이 먼저 시도되므로 NON_TRANSIENT 반환 시 Core 를 우선함
+        val backendSpecific = BackendErrorClassifier { BackendErrorKind.TRANSIENT }
+        val composite = CompositeBackendErrorClassifier(backendSpecific)
+
+        // OOM 이어도 backendSpecific 이 TRANSIENT 반환 — backendSpecific 이 core 보다 우선
+        composite.classify(OutOfMemoryError()) shouldBeEqualTo BackendErrorKind.TRANSIENT
+    }
+
+    @Test
+    fun `CompositeBackendErrorClassifier - backendSpecific 이 null 이면 OOM 은 FATAL 이다`() {
+        val backendSpecific = BackendErrorClassifier { null }
+        val composite = CompositeBackendErrorClassifier(backendSpecific)
+
+        composite.classify(OutOfMemoryError()) shouldBeEqualTo BackendErrorKind.FATAL
+    }
+
+    // ── BackendErrorClassifier fun interface ─────────────────────────────
+
+    @Test
+    fun `BackendErrorClassifier 는 fun interface 로 람다로 구현할 수 있다`() {
+        val classifier: BackendErrorClassifier = BackendErrorClassifier { cause ->
+            if (cause is UnsupportedOperationException) BackendErrorKind.NON_TRANSIENT else null
+        }
+
+        classifier.classify(UnsupportedOperationException()) shouldBeEqualTo BackendErrorKind.NON_TRANSIENT
+        classifier.classify(RuntimeException()).shouldBeNull()
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/CaptureScopeTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/CaptureScopeTest.kt
@@ -1,0 +1,135 @@
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CaptureScopeTest {
+
+    private fun identity() = LockIdentity(
+        lockName = "scope-test-lock",
+        kind = LockIdentity.AnnotationKind.SINGLE,
+        factoryBeanName = "testFactory",
+    )
+
+    private fun fakeDelegate(): ExtendDelegate = object : ExtendDelegate {
+        private val deadline = AtomicReference(Instant.EPOCH)
+        override val lastExtendDeadline: AtomicReference<Instant> get() = deadline
+        override fun extend(lockAtMostFor: Duration): ExtendOutcome = ExtendOutcome.Extended(Instant.now())
+        override fun isHeld(): Boolean = true
+    }
+
+    private fun realHandle(): LeaderLockHandle.Real =
+        LeaderLockHandle.real(
+            identity = identity(),
+            token = "tok-scope",
+            acquiredAtNanos = System.nanoTime(),
+            extendDelegate = fakeDelegate(),
+        )
+
+    @BeforeEach
+    fun cleanCapture() {
+        LeaderLockHandleCapture.clear()
+    }
+
+    // --- sync ---
+
+    @Test
+    fun `runWithCapture - handle is pollable inside action`() {
+        val handle = realHandle()
+        var polled: LeaderLockHandle.Real? = null
+
+        CaptureScope.runWithCapture(handle) {
+            polled = LeaderLockHandleCapture.poll()
+        }
+
+        polled shouldBeEqualTo handle
+    }
+
+    @Test
+    fun `runWithCapture - clears capture after action completes`() {
+        val handle = realHandle()
+
+        CaptureScope.runWithCapture(handle) { /* do nothing */ }
+
+        LeaderLockHandleCapture.poll().shouldBeNull()
+    }
+
+    @Test
+    fun `runWithCapture - clears capture even when action throws`() {
+        val handle = realHandle()
+
+        runCatching {
+            CaptureScope.runWithCapture(handle) {
+                error("simulated failure")
+            }
+        }
+
+        LeaderLockHandleCapture.poll().shouldBeNull()
+    }
+
+    @Test
+    fun `runWithCapture - returns action result`() {
+        val handle = realHandle()
+
+        val result = CaptureScope.runWithCapture(handle) { 42 }
+
+        result shouldBeEqualTo 42
+    }
+
+    // --- suspend ---
+
+    @Test
+    fun `runWithCaptureSuspend - handle is pollable inside action`() = runTest {
+        val handle = realHandle()
+        var polled: LeaderLockHandle.Real? = null
+
+        CaptureScope.runWithCaptureSuspend(handle) {
+            polled = LeaderLockHandleCapture.poll()
+        }
+
+        polled shouldBeEqualTo handle
+    }
+
+    @Test
+    fun `runWithCaptureSuspend - clears capture after action completes`() = runTest {
+        val handle = realHandle()
+
+        CaptureScope.runWithCaptureSuspend(handle) { /* do nothing */ }
+
+        LeaderLockHandleCapture.poll().shouldBeNull()
+    }
+
+    @Test
+    fun `runWithCaptureSuspend - clears capture even when action throws`() = runTest {
+        val handle = realHandle()
+
+        runCatching {
+            CaptureScope.runWithCaptureSuspend(handle) {
+                error("simulated failure")
+            }
+        }
+
+        LeaderLockHandleCapture.poll().shouldBeNull()
+    }
+
+    @Test
+    fun `runWithCaptureSuspend - returns action result`() = runTest {
+        val handle = realHandle()
+
+        val result = CaptureScope.runWithCaptureSuspend(handle) { "ok" }
+
+        result shouldBeEqualTo "ok"
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/ExtendDelegateTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/ExtendDelegateTest.kt
@@ -1,0 +1,69 @@
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExtendDelegateTest {
+
+    /**
+     * Minimal concrete [ExtendDelegate] that stores lastExtendDeadline as required.
+     * R2 contract: the same AtomicReference instance must be returned on every access.
+     */
+    private class ConcreteDelegate(private val held: Boolean = true) : ExtendDelegate {
+        private val _lastExtendDeadline = AtomicReference(Instant.EPOCH)
+        override val lastExtendDeadline: AtomicReference<Instant> get() = _lastExtendDeadline
+        override fun extend(lockAtMostFor: Duration): ExtendOutcome =
+            if (held) ExtendOutcome.Extended(Instant.now()) else ExtendOutcome.NotHeld
+        override fun isHeld(): Boolean = held
+    }
+
+    @Test
+    fun `lastExtendDeadline returns same AtomicReference instance on every access (R2 contract)`() {
+        val delegate = ConcreteDelegate()
+        val ref1 = delegate.lastExtendDeadline
+        val ref2 = delegate.lastExtendDeadline
+        // Must be the exact same stored object — not a new instance each call
+        (ref1 === ref2).shouldBeTrue()
+    }
+
+    @Test
+    fun `set on lastExtendDeadline is visible on next get`() {
+        val delegate = ConcreteDelegate()
+        val deadline = Instant.now().plusSeconds(60)
+        delegate.lastExtendDeadline.set(deadline)
+        delegate.lastExtendDeadline.get() shouldBeEqualTo deadline
+    }
+
+    @Test
+    fun `extend returns Extended when held`() {
+        val delegate = ConcreteDelegate(held = true)
+        delegate.extend(30.seconds).shouldBeInstanceOf<ExtendOutcome.Extended>()
+    }
+
+    @Test
+    fun `extend returns NotHeld when not held`() {
+        val delegate = ConcreteDelegate(held = false)
+        delegate.extend(30.seconds) shouldBeEqualTo ExtendOutcome.NotHeld
+    }
+
+    @Test
+    fun `extendSuspend default delegates to sync extend`() = runTest {
+        val delegate = ConcreteDelegate(held = true)
+        delegate.extendSuspend(30.seconds).shouldBeInstanceOf<ExtendOutcome.Extended>()
+    }
+
+    @Test
+    fun `isHeld reflects backend state`() {
+        ConcreteDelegate(held = true).isHeld().shouldBeTrue()
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LeaderLockHandleCaptureTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LeaderLockHandleCaptureTest.kt
@@ -1,0 +1,67 @@
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderLockHandleCaptureTest {
+
+    private fun identity() = LockIdentity(
+        lockName = "cap-test-lock",
+        kind = LockIdentity.AnnotationKind.SINGLE,
+        factoryBeanName = "testFactory",
+    )
+
+    private fun fakeDelegate(): ExtendDelegate = object : ExtendDelegate {
+        private val deadline = AtomicReference(Instant.EPOCH)
+        override val lastExtendDeadline: AtomicReference<Instant> get() = deadline
+        override fun extend(lockAtMostFor: Duration): ExtendOutcome = ExtendOutcome.Extended(Instant.now())
+        override fun isHeld(): Boolean = true
+    }
+
+    private fun realHandle(): LeaderLockHandle.Real =
+        LeaderLockHandle.real(
+            identity = identity(),
+            token = "tok-capture",
+            acquiredAtNanos = System.nanoTime(),
+            extendDelegate = fakeDelegate(),
+        )
+
+    @Test
+    fun `poll returns null when nothing was set`() {
+        // ensure clean state
+        LeaderLockHandleCapture.clear()
+        LeaderLockHandleCapture.poll().shouldBeNull()
+    }
+
+    @Test
+    fun `set then poll returns the handle`() {
+        val handle = realHandle()
+        LeaderLockHandleCapture.set(handle)
+        LeaderLockHandleCapture.poll() shouldBeEqualTo handle
+    }
+
+    @Test
+    fun `poll clears the ThreadLocal immediately — second poll returns null`() {
+        val handle = realHandle()
+        LeaderLockHandleCapture.set(handle)
+        LeaderLockHandleCapture.poll()  // first poll consumes
+        LeaderLockHandleCapture.poll().shouldBeNull()  // second must be null
+    }
+
+    @Test
+    fun `clear removes the value — poll after clear returns null`() {
+        val handle = realHandle()
+        LeaderLockHandleCapture.set(handle)
+        LeaderLockHandleCapture.clear()
+        LeaderLockHandleCapture.poll().shouldBeNull()
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LockStateHolderTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LockStateHolderTest.kt
@@ -1,0 +1,120 @@
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LockStateHolderTest {
+
+    private fun identity(name: String = "test-lock") = LockIdentity(
+        lockName = name,
+        kind = LockIdentity.AnnotationKind.SINGLE,
+        factoryBeanName = "testFactory",
+    )
+
+    private fun fakeDelegate(): ExtendDelegate = object : ExtendDelegate {
+        private val deadline = AtomicReference(Instant.EPOCH)
+        override val lastExtendDeadline: AtomicReference<Instant> get() = deadline
+        override fun extend(lockAtMostFor: Duration): ExtendOutcome = ExtendOutcome.Extended(Instant.now())
+        override fun isHeld(): Boolean = true
+    }
+
+    private fun realHandle(name: String = "test-lock", depth: Int = 0): LeaderLockHandle.Real =
+        LeaderLockHandle.real(
+            identity = identity(name),
+            token = "tok-$name",
+            acquiredAtNanos = System.nanoTime(),
+            reentryDepth = depth,
+            extendDelegate = fakeDelegate(),
+        )
+
+    @BeforeEach
+    fun cleanup() {
+        // drain any leftover state from previous tests on the same thread
+        while (LockStateHolder.pop() != null) { /* drain */ }
+        LockStateHolder.cleanup()
+    }
+
+    @Test
+    fun `peekSync returns null when stack is empty`() {
+        LockStateHolder.peekSync().shouldBeNull()
+    }
+
+    @Test
+    fun `push then peekSync returns pushed handle`() {
+        val handle = realHandle()
+        LockStateHolder.push(handle)
+        try {
+            LockStateHolder.peekSync() shouldBeEqualTo handle
+        } finally {
+            LockStateHolder.pop()
+            LockStateHolder.cleanup()
+        }
+    }
+
+    @Test
+    fun `pop removes top element — stack LIFO order`() {
+        val h1 = realHandle("lock-1")
+        val h2 = realHandle("lock-2")
+        LockStateHolder.push(h1)
+        LockStateHolder.push(h2)
+
+        LockStateHolder.pop() shouldBeEqualTo h2
+        LockStateHolder.pop() shouldBeEqualTo h1
+        LockStateHolder.pop().shouldBeNull()
+    }
+
+    @Test
+    fun `withPushed restores stack after block`() {
+        val handle = realHandle()
+        var seenInsideBlock: LeaderLockHandle? = null
+
+        LockStateHolder.withPushed(handle) {
+            seenInsideBlock = LockStateHolder.peekSync()
+        }
+
+        seenInsideBlock shouldBeEqualTo handle
+        LockStateHolder.peekSync().shouldBeNull()
+    }
+
+    @Test
+    fun `withPushed restores stack even when block throws`() {
+        val handle = realHandle()
+
+        runCatching {
+            LockStateHolder.withPushed(handle) {
+                error("simulated failure")
+            }
+        }
+
+        LockStateHolder.peekSync().shouldBeNull()
+    }
+
+    @Test
+    fun `peekSyncMatching returns handle matching lockName`() {
+        val h1 = realHandle("lock-A")
+        val h2 = realHandle("lock-B")
+        LockStateHolder.push(h1)
+        LockStateHolder.push(h2)
+
+        try {
+            LockStateHolder.peekSyncMatching("lock-A") shouldBeEqualTo h1
+            LockStateHolder.peekSyncMatching("lock-B") shouldBeEqualTo h2
+            LockStateHolder.peekSyncMatching("lock-C").shouldBeNull()
+        } finally {
+            LockStateHolder.pop()
+            LockStateHolder.pop()
+            LockStateHolder.cleanup()
+        }
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalGroupLockExtenderContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalGroupLockExtenderContractTest.kt
@@ -1,0 +1,19 @@
+package io.bluetape4k.leader.local
+
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderGroupElector
+import io.bluetape4k.leader.contract.AbstractGroupLockExtenderContractTest
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [AbstractGroupLockExtenderContractTest] 의 Local backend 구현.
+ *
+ * [LocalLeaderGroupElector] 를 사용해 LockAssert / LockExtender × sync group contract 를 검증한다.
+ * 외부 인프라 불필요 — 단일 JVM 인메모리 실행.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LocalGroupLockExtenderContractTest : AbstractGroupLockExtenderContractTest() {
+
+    override val elector: LeaderGroupElector =
+        LocalLeaderGroupElector(LeaderGroupElectionOptions(maxLeaders = 3))
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalLeaderElectorCaptureTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalLeaderElectorCaptureTest.kt
@@ -1,0 +1,214 @@
+package io.bluetape4k.leader.local
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.leader.LockExtender
+import io.bluetape4k.leader.internal.LockStateHolder
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * [LocalLeaderElector] capture integration test.
+ *
+ * `runIfLeader` 안에서 [LockStateHolder] / [LockAssert] / [LockExtender] 가 정상 동작하는지 검증.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Suppress("NonAsciiCharacters")
+class LocalLeaderElectorCaptureTest {
+
+    private val election = LocalLeaderElector()
+
+    private fun randomLockName() = "lock-${Base58.randomString(8)}"
+
+    // ── LockStateHolder 통합 ───────────────────────────────────────────────
+
+    @Test
+    fun `runIfLeader 안에서 LockStateHolder peekSync 가 Real handle 을 반환한다`() {
+        val lockName = randomLockName()
+        var capturedHandle: LeaderLockHandle? = null
+
+        election.runIfLeader(lockName) {
+            capturedHandle = LockStateHolder.peekSync()
+        }
+
+        capturedHandle.shouldNotBeNull()
+        capturedHandle.shouldBeInstanceOf<LeaderLockHandle.Real>()
+        (capturedHandle as LeaderLockHandle.Real).lockName shouldBeEqualTo lockName
+    }
+
+    @Test
+    fun `runIfLeader 완료 후 LockStateHolder 가 비워진다`() {
+        val lockName = randomLockName()
+
+        election.runIfLeader(lockName) { /* action */ }
+
+        LockStateHolder.peekSync().shouldBeNull()
+    }
+
+    @Test
+    fun `runIfLeader 안에서 LockAssert assertLocked 가 성공한다`() {
+        val lockName = randomLockName()
+        var assertionPassed = false
+
+        election.runIfLeader(lockName) {
+            LockAssert.assertLocked()
+            LockAssert.assertLocked(lockName)
+            assertionPassed = true
+        }
+
+        assertionPassed.shouldBeTrue()
+    }
+
+    @Test
+    fun `runIfLeader 안에서 LockAssert isLocked 가 true 를 반환한다`() {
+        val lockName = randomLockName()
+        var isLocked = false
+
+        election.runIfLeader(lockName) {
+            isLocked = LockAssert.isLocked()
+        }
+
+        isLocked.shouldBeTrue()
+    }
+
+    // ── LockExtender 통합 ─────────────────────────────────────────────────
+
+    @Test
+    fun `runIfLeader 안에서 LockExtender extendActiveLock 이 true 를 반환한다`() {
+        val lockName = randomLockName()
+        var extended = false
+
+        election.runIfLeader(lockName) {
+            extended = LockExtender.extendActiveLock(30.seconds)
+        }
+
+        extended.shouldBeTrue()
+    }
+
+    @Test
+    fun `runIfLeader 안에서 LockExtender extendActiveLock lockName 지정 버전이 true 를 반환한다`() {
+        val lockName = randomLockName()
+        var extended = false
+
+        election.runIfLeader(lockName) {
+            extended = LockExtender.extendActiveLock(lockName, 30.seconds)
+        }
+
+        extended.shouldBeTrue()
+    }
+
+    @Test
+    fun `runIfLeader 완료 후 LockExtender extendActiveLock 이 false 를 반환한다`() {
+        val lockName = randomLockName()
+
+        election.runIfLeader(lockName) { /* action */ }
+
+        // scope 밖에서 호출 → NotHeld → false
+        val extended = LockExtender.extendActiveLock(30.seconds)
+        extended shouldBeEqualTo false
+    }
+
+    // ── 재진입 동작 ───────────────────────────────────────────────────────
+
+    @Test
+    fun `runIfLeader 안에서 동일 lockName 으로 재진입 시 inner 에서도 LockAssert 가 통과한다`() {
+        val lockName = randomLockName()
+        var innerLocked = false
+
+        election.runIfLeader(lockName) {
+            election.runIfLeader(lockName) {
+                LockAssert.assertLocked()
+                innerLocked = true
+            }
+        }
+
+        innerLocked.shouldBeTrue()
+    }
+
+    @Test
+    fun `runIfLeader 재진입 시 inner handle 의 reentryDepth 가 1 이다`() {
+        val lockName = randomLockName()
+        var outerDepth = -1
+        var innerDepth = -1
+
+        election.runIfLeader(lockName) {
+            outerDepth = (LockStateHolder.peekSync() as? LeaderLockHandle.Real)?.reentryDepth ?: -1
+            election.runIfLeader(lockName) {
+                innerDepth = (LockStateHolder.peekSync() as? LeaderLockHandle.Real)?.reentryDepth ?: -1
+            }
+        }
+
+        outerDepth shouldBeEqualTo 0
+        innerDepth shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `재진입 inner 에서 LockExtender extend 가 outer 의 delegate 를 갱신한다`() {
+        val lockName = randomLockName()
+        var innerExtended = false
+
+        election.runIfLeader(lockName) {
+            election.runIfLeader(lockName) {
+                // inner scope 에서 extend 호출 → outer extendDelegate 가 갱신됨
+                innerExtended = LockExtender.extendActiveLock(60.seconds)
+            }
+        }
+
+        innerExtended.shouldBeTrue()
+    }
+
+    // ── action 예외 시 cleanup ────────────────────────────────────────────
+
+    @Test
+    fun `action 예외 후에도 LockStateHolder 가 비워진다`() {
+        val lockName = randomLockName()
+
+        runCatching {
+            election.runIfLeader(lockName) {
+                throw RuntimeException("intentional")
+            }
+        }
+
+        LockStateHolder.peekSync().shouldBeNull()
+    }
+
+    // ── autoExtend + LockExtender R2 미구현 검증 ──────────────────────────
+
+    @Test
+    fun `autoExtend=true 로 runIfLeader 실행 후 watchdog 이 state leaseUntil 을 갱신한다`() {
+        val stateElection = LocalLeaderElector(
+            LeaderElectionOptions(leaseTime = 150.milliseconds, autoExtend = true)
+        )
+        val lockName = randomLockName()
+        val started = java.util.concurrent.CountDownLatch(1)
+        val release = java.util.concurrent.CountDownLatch(1)
+
+        val holder = Thread {
+            stateElection.runIfLeader(lockName) {
+                started.countDown()
+                release.await()
+            }
+        }.apply { start() }
+
+        started.await()
+        val initial = stateElection.state(lockName).leader?.leaseUntil
+        Thread.sleep(250)
+        val extended = stateElection.state(lockName).leader?.leaseUntil
+
+        release.countDown()
+        holder.join()
+
+        initial.shouldNotBeNull()
+        extended.shouldNotBeNull()
+        extended!!.isAfter(initial!!).shouldBeTrue()
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalLockExtenderContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalLockExtenderContractTest.kt
@@ -1,0 +1,17 @@
+package io.bluetape4k.leader.local
+
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.contract.AbstractSyncLockExtenderContractTest
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [AbstractSyncLockExtenderContractTest] 의 Local backend 구현.
+ *
+ * [LocalLeaderElector] 를 사용해 LockAssert / LockExtender × sync contract 를 검증한다.
+ * 외부 인프라 불필요 — 단일 JVM 인메모리 실행.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LocalLockExtenderContractTest : AbstractSyncLockExtenderContractTest() {
+
+    override val elector: LeaderElector = LocalLeaderElector()
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalSuspendLockExtenderContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalSuspendLockExtenderContractTest.kt
@@ -1,0 +1,18 @@
+package io.bluetape4k.leader.local
+
+import io.bluetape4k.leader.contract.AbstractSuspendLockExtenderContractTest
+import io.bluetape4k.leader.coroutines.LocalSuspendLeaderElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [AbstractSuspendLockExtenderContractTest] 의 Local backend 구현.
+ *
+ * [LocalSuspendLeaderElector] 를 사용해 LockAssert / LockExtender × suspend contract 를 검증한다.
+ * 외부 인프라 불필요 — 단일 JVM 인메모리 실행.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LocalSuspendLockExtenderContractTest : AbstractSuspendLockExtenderContractTest() {
+
+    override val elector: SuspendLeaderElector = LocalSuspendLeaderElector()
+}

--- a/leader-spring-boot/README.ko.md
+++ b/leader-spring-boot/README.ko.md
@@ -188,6 +188,104 @@ class RedisBackedJobs {
 
 `FAIL_OPEN_RUN`은 여러 노드가 동시에 본문을 실행할 수 있으므로 멱등 작업에만 사용해야 합니다.
 
+## LockAssert & LockExtender (ShedLock-등가 — issue #79)
+
+`leader-core` 가 ShedLock 스타일의 ergonomic API 를 제공합니다. `@LeaderElection` / `@LeaderGroupElection` 본문 안에서 호출 가능:
+
+```kotlin
+@Service
+class ReportJobs {
+    @LeaderElection(name = "daily-report", leaseTime = "30m", minLeaseTime = "10s")
+    fun runReport(): Report? {
+        LockAssert.assertLocked()    // 활성 leader scope 가 아니면 IllegalStateException
+        // ... 작업 ...
+        if (needsExtraTime) {
+            LockExtender.extendActiveLock(60.seconds)    // 성공 시 true
+        }
+        return reportService.generate()
+    }
+}
+```
+
+### Lock identity
+
+동일 thread/coroutine 안에서 동일 `name` 으로 nested 호출하면 **`LockIdentity` (lockName + 어노테이션 종류 + group params)** 로 reentrant 판정 — backend acquire 정확히 1회. `factoryBeanName` 은 equality 에서 제외 — sync ↔ suspend 중첩 호출도 정확히 reentrant 처리 (Step 3-P R3).
+
+### Suspend / Mono
+
+`suspend` / `Mono` 본문에서는 lock handle 이 `CoroutineContext` 로 전파됩니다 (`ThreadLocal` fallback 없음). suspend 변형 사용:
+
+```kotlin
+@LeaderElection(name = "stream-job")
+suspend fun stream(): Result? {
+    LockAssert.assertLockedSuspend()
+    LockExtender.extendActiveLockSuspend(2.minutes)
+    return streamService.process()
+}
+```
+
+⚠️ **Reactor non-suspend operator (`.map`, `.filter`) 는 미지원.** `.flatMap { mono { ... } }` 안에서 `LockAssert.assertLockedSuspend()` 호출 권장:
+
+```kotlin
+@LeaderElection(name = "mono-job")
+fun process(): Mono<String> =
+    sourceMono
+        .flatMap { value ->
+            mono {
+                LockAssert.assertLockedSuspend()    // ✅
+                transform(value)
+            }
+        }
+```
+
+### 시퀀스 — reentrant `@LeaderElection`
+
+```mermaid
+sequenceDiagram
+    actor Caller
+    participant Aspect as LeaderElectionAspect
+    participant Stack as LockStateHolder
+    participant Elector as LeaderElector
+    participant Backend as Redis / Mongo / ...
+
+    Caller->>Aspect: @LeaderElection("daily-report") outerMethod()
+    Aspect->>Stack: peekSyncMatching("daily-report")
+    Stack-->>Aspect: null (첫 진입)
+    Aspect->>Elector: runIfLeaderResult("daily-report") { ... }
+    Elector->>Backend: SET / EXPIRE (acquire)
+    Backend-->>Elector: ok (token=abc)
+    Elector->>Stack: push(LeaderLockHandle.Real(token=abc))
+    Elector->>Caller: body()
+    Note over Caller: outerMethod() 가 innerMethod() 호출
+    Caller->>Aspect: @LeaderElection("daily-report") innerMethod()
+    Aspect->>Stack: peekSyncMatching("daily-report")
+    Stack-->>Aspect: Real(token=abc) — reentrant
+    Aspect->>Aspect: incrementReentryDepth(handle)
+    Aspect->>Stack: push(Real(token=abc, depth=1))
+    Aspect->>Caller: pjp.proceed() — backend 미접촉
+    Note over Caller: LockExtender.extendActiveLock(60s) 가 outer delegate 재사용
+    Caller-->>Aspect: innerMethod() 반환
+    Aspect->>Stack: pop()
+    Caller-->>Elector: outerMethod() 반환
+    Elector->>Backend: DEL / release
+    Elector->>Stack: pop()
+```
+
+### Watchdog × LockExtender
+
+둘 다 **동일 `ExtendDelegate` reference** 공유 (token-guarded backend operation 으로 atomicity 보장). `LockExtender.extendActiveLock(d)` 호출 시 delegate 가 `lastExtendDeadline = now + d` 갱신 — 다음 watchdog tick 이 user 가 지정한 deadline 이 더 크면 backend 재extend 를 skip. 엄격한 deadline (ShedLock 동등) 이 필요하면 watchdog OFF.
+
+### 반환값
+
+| API | scope 밖 | `Real` 안 | `FailOpen` sentinel |
+|---|---|---|---|
+| `LockAssert.assertLocked()` | `IllegalStateException` | passes | throws |
+| `LockAssert.isLocked()` | `false` | `true` | `false` |
+| `LockExtender.extendActiveLock(d)` | `false` + WARN | backend 결과 | `false` + WARN |
+| `LockExtender.extendActiveLockDetailed(d)` | `NotHeld` | `Extended` / `NotHeld` / `WrongThread` / `BackendError` | `NotHeld` |
+
+Java caller 는 `@JvmStatic` overload — `kotlin.time.Duration` 과 `java.time.Duration` 모두 지원.
+
 ## 자동 구성 순서
 
 1. `LeaderElectionAutoConfiguration`: 공통 backend 속성 바인딩

--- a/leader-spring-boot/README.md
+++ b/leader-spring-boot/README.md
@@ -188,6 +188,104 @@ class RedisBackedJobs {
 
 `FAIL_OPEN_RUN` is only appropriate for idempotent work because multiple nodes may execute the body concurrently.
 
+## LockAssert & LockExtender (ShedLock-equivalent — issue #79)
+
+`leader-core` ships ShedLock-style ergonomic APIs that you can call from within `@LeaderElection` / `@LeaderGroupElection` bodies:
+
+```kotlin
+@Service
+class ReportJobs {
+    @LeaderElection(name = "daily-report", leaseTime = "30m", minLeaseTime = "10s")
+    fun runReport(): Report? {
+        LockAssert.assertLocked()    // throws IllegalStateException if not inside an active leader scope
+        // ... critical work ...
+        if (needsExtraTime) {
+            LockExtender.extendActiveLock(60.seconds)    // returns true on success
+        }
+        return reportService.generate()
+    }
+}
+```
+
+### Lock identity
+
+Reentrant `@LeaderElection` calls (same `name`, same JVM, same thread/coroutine) are detected by **`LockIdentity` (lockName + annotation kind + group params)** — the backend is acquired exactly once. `factoryBeanName` is intentionally excluded from equality so that sync ↔ suspend nested calls work correctly (Step 3-P R3).
+
+### Suspend / Mono
+
+Inside `suspend` and `Mono`-returning bodies, the lock handle propagates via `CoroutineContext` (no `ThreadLocal` fallback). Use the suspend variants:
+
+```kotlin
+@LeaderElection(name = "stream-job")
+suspend fun stream(): Result? {
+    LockAssert.assertLockedSuspend()
+    LockExtender.extendActiveLockSuspend(2.minutes)
+    return streamService.process()
+}
+```
+
+⚠️ **Reactor non-suspend operators (`.map`, `.filter`) are unsupported.** Call `LockAssert.assertLockedSuspend()` inside `.flatMap { mono { ... } }`:
+
+```kotlin
+@LeaderElection(name = "mono-job")
+fun process(): Mono<String> =
+    sourceMono
+        .flatMap { value ->
+            mono {
+                LockAssert.assertLockedSuspend()    // ✅
+                transform(value)
+            }
+        }
+```
+
+### Sequence: reentrant `@LeaderElection`
+
+```mermaid
+sequenceDiagram
+    actor Caller
+    participant Aspect as LeaderElectionAspect
+    participant Stack as LockStateHolder
+    participant Elector as LeaderElector
+    participant Backend as Redis / Mongo / ...
+
+    Caller->>Aspect: @LeaderElection("daily-report") outerMethod()
+    Aspect->>Stack: peekSyncMatching("daily-report")
+    Stack-->>Aspect: null (first entry)
+    Aspect->>Elector: runIfLeaderResult("daily-report") { ... }
+    Elector->>Backend: SET / EXPIRE (acquire)
+    Backend-->>Elector: ok (token=abc)
+    Elector->>Stack: push(LeaderLockHandle.Real(token=abc))
+    Elector->>Caller: body()
+    Note over Caller: outerMethod() calls innerMethod()
+    Caller->>Aspect: @LeaderElection("daily-report") innerMethod()
+    Aspect->>Stack: peekSyncMatching("daily-report")
+    Stack-->>Aspect: Real(token=abc) — reentrant
+    Aspect->>Aspect: incrementReentryDepth(handle)
+    Aspect->>Stack: push(Real(token=abc, depth=1))
+    Aspect->>Caller: pjp.proceed() — backend untouched
+    Note over Caller: LockExtender.extendActiveLock(60s) reuses outer delegate
+    Caller-->>Aspect: returns from innerMethod()
+    Aspect->>Stack: pop()
+    Caller-->>Elector: returns from outerMethod()
+    Elector->>Backend: DEL / release
+    Elector->>Stack: pop()
+```
+
+### Watchdog × LockExtender
+
+Both share the **same `ExtendDelegate` reference** (atomicity guaranteed by token-guarded backend operations). When you call `LockExtender.extendActiveLock(d)`, the delegate records `now + d` in `lastExtendDeadline` so the next watchdog tick will skip backend re-extend if the user-provided deadline is larger. For strict deadline semantics (ShedLock parity), turn off watchdog.
+
+### Return values
+
+| API | Outside scope | Inside `Real` | Inside `FailOpen` sentinel |
+|---|---|---|---|
+| `LockAssert.assertLocked()` | throws `IllegalStateException` | passes | throws |
+| `LockAssert.isLocked()` | `false` | `true` | `false` |
+| `LockExtender.extendActiveLock(d)` | `false` + WARN | backend result | `false` + WARN |
+| `LockExtender.extendActiveLockDetailed(d)` | `NotHeld` | `Extended` / `NotHeld` / `WrongThread` / `BackendError` | `NotHeld` |
+
+For Java callers, `@JvmStatic` overloads accept both `kotlin.time.Duration` and `java.time.Duration`.
+
 ## Auto-Configuration Order
 
 1. `LeaderElectionAutoConfiguration` binds shared backend properties.

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderBeanSelector.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderBeanSelector.kt
@@ -5,11 +5,11 @@ import io.bluetape4k.leader.LeaderGroupElectorFactory
 import io.bluetape4k.leader.annotation.LeaderElectionBackend
 import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
 import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElectorFactory
+import io.bluetape4k.leader.spring.aop.util.findMergedAnnotationOrNull
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.beans.factory.ListableBeanFactory
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException
-import org.springframework.core.annotation.AnnotatedElementUtils
 import java.lang.reflect.Method
 
 /**
@@ -103,13 +103,13 @@ class LeaderBeanSelector(
      */
     private fun resolveFromBackendAnnotation(method: Method): String? {
         // Step 2: 메서드 @LeaderElectionBackend
-        AnnotatedElementUtils.findMergedAnnotation(method, LeaderElectionBackend::class.java)
+        method.findMergedAnnotationOrNull<LeaderElectionBackend>()
             ?.bean?.takeIf { it.isNotBlank() }?.let { return it }
 
         val declaringClass = method.declaringClass
 
         // Step 3: 선언 클래스 @LeaderElectionBackend
-        AnnotatedElementUtils.findMergedAnnotation(declaringClass, LeaderElectionBackend::class.java)
+        declaringClass.findMergedAnnotationOrNull<LeaderElectionBackend>()
             ?.bean?.takeIf { it.isNotBlank() }?.let { return it }
 
         // Step 4: 패키지 @LeaderElectionBackend (@file:LeaderElectionBackend)

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -1,10 +1,13 @@
 package io.bluetape4k.leader.spring.aop
 
-import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.AopScopeAccess
 import io.bluetape4k.leader.LeaderElectionException
-import io.bluetape4k.leader.LeaderRunResult
-import io.bluetape4k.leader.LeaderElectorFactory
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.LeaderElectorFactory
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.leader.annotation.LeaderAspectFailureMode
 import io.bluetape4k.leader.annotation.LeaderElection
 import io.bluetape4k.leader.coroutines.LeaderElectionInfo
@@ -13,6 +16,9 @@ import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
 import io.bluetape4k.leader.metrics.LeaderAopMetricsRecorder
 import io.bluetape4k.leader.metrics.SkipReason
 import io.bluetape4k.leader.spring.aop.cache.FactoryCacheKey
+import io.bluetape4k.leader.spring.aop.internal.AdviceBranch
+import io.bluetape4k.leader.spring.aop.internal.AdviceMetadata
+import io.bluetape4k.leader.spring.aop.internal.BodyThrownMarker
 import io.bluetape4k.leader.spring.aop.properties.LeaderAopProperties
 import io.bluetape4k.leader.spring.aop.spel.SpelExpressionEvaluator
 import io.bluetape4k.leader.spring.aop.util.AnnotationLookup
@@ -56,6 +62,17 @@ import kotlin.time.toKotlinDuration
  * ## LeaderElectionInfo (#92)
  * suspend / Mono 분기 본문 실행 시 [LeaderElectionInfo] 를 `withContext` 로 주입.
  * 사용자는 `coroutineContext[LeaderElectionInfo]` 로 선출 정보 접근 가능.
+ *
+ * ## LockHandleElement / LockStateHolder (T14)
+ * - sync 분기: [AopScopeAccess.withPushedSync] 로 `LockStateHolder` 에 handle push — [io.bluetape4k.leader.LockAssert] / [io.bluetape4k.leader.LockExtender] 동작.
+ * - suspend / Mono 분기: elector 가 `withContext(LockHandleElement(...))` 로 이미 push — aspect 는 [LeaderElectionInfo] 만 추가.
+ * - FAIL_OPEN_RUN 분기: [LeaderLockHandle.FailOpen] sentinel 을 push 하여 body 가 fail-open scope 인식.
+ *
+ * ## Reentrant pass-through (T14)
+ * sync 분기 진입 전 [AopScopeAccess.peekSyncMatching] 으로 동일 lockName 보유 여부 확인.
+ * 이미 보유 중이면 backend re-acquire 없이 body 직접 실행 (backend acquire counter = 1).
+ * suspend 분기는 elector 에서 `LockHandleElement` 가 coroutine context 에 있으므로
+ * 재진입 시 elector 가 직접 pass-through (Mutex 비재진입이므로 aspect-level 단락 불필요).
  */
 @Aspect
 class LeaderElectionAspect(
@@ -88,7 +105,6 @@ class LeaderElectionAspect(
         }
 
         val opts = meta.options
-
         var lockName: String? = null
         val start = System.nanoTime()
 
@@ -96,12 +112,25 @@ class LeaderElectionAspect(
             val resolvedName = resolveLockName(meta, method, args, target)
             lockName = resolvedName
 
+            // ── Reentrant short-circuit (T14): sync 분기에서 동일 lockName 이미 보유 중이면 backend 미호출 ──
+            val existing = AopScopeAccess.peekSyncMatching(resolvedName)
+            if (existing is LeaderLockHandle.Real) {
+                log.debug { "leader.aop.reentrant lockName=$resolvedName depth=${existing.reentryDepth + 1}" }
+                val reentrantHandle = AopScopeAccess.incrementReentryDepth(existing)
+                return AopScopeAccess.withPushedSync(reentrantHandle) {
+                    executeBody(pjp, resolvedName, start)
+                }
+            }
+
             val cacheKey = FactoryCacheKey(meta.factoryBeanName, opts)
             val election = factoryCache.computeIfAbsent(cacheKey) { meta.factory.create(opts) }
 
             fanOut { it.onLockAttempt(resolvedName, opts) }
 
             val runResult = election.runIfLeaderResult(resolvedName) {
+                // The elector (e.g., AbstractLocalLeaderElector) already calls
+                // LockStateHolder.withPushed(handle) { action() } internally.
+                // We do NOT double-push here — the elector manages the sync stack.
                 fanOut {
                     it.onLockAcquired(resolvedName, opts, (System.nanoTime() - start).nanoseconds)
                     it.onTaskStarted(resolvedName)
@@ -111,12 +140,16 @@ class LeaderElectionAspect(
             when (runResult) {
                 is LeaderRunResult.Skipped -> {
                     if (meta.failureMode == LeaderAspectFailureMode.FAIL_OPEN_RUN) {
+                        val identity = meta.resolveLockIdentity(resolvedName, AdviceBranch.SYNC)
+                        val failOpenHandle = AopScopeAccess.createFailOpen(identity)
                         fanOut {
                             it.onLockNotAcquired(resolvedName, opts, SkipReason.FAIL_OPEN_FORCED)
                             it.onTaskStarted(resolvedName)
                         }
                         log.debug { "leader.aop.fail-open lockName=$resolvedName reason=CONTENTION" }
-                        val result = executeBody(pjp, resolvedName, start)
+                        val result = AopScopeAccess.withPushedSync(failOpenHandle) {
+                            executeBody(pjp, resolvedName, start)
+                        }
                         val elapsed = System.nanoTime() - start
                         fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
                         result
@@ -142,7 +175,7 @@ class LeaderElectionAspect(
             throw e
         } catch (bodyMarker: BodyThrownMarker) {
             throw bodyMarker.cause
-        } catch (backendEx: Throwable) {
+        } catch (backendEx: Exception) {
             val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
             val wrapped = LeaderElectionException("leader backend error for lock '$effectiveName'", backendEx)
             when (meta.failureMode) {
@@ -159,11 +192,16 @@ class LeaderElectionAspect(
                     null
                 }
                 LeaderAspectFailureMode.FAIL_OPEN_RUN -> {
-                    fanOut { it.onLockNotAcquired(effectiveName, opts, SkipReason.FAIL_OPEN_FORCED) }
+                    val opts2 = meta.options
+                    fanOut { it.onLockNotAcquired(effectiveName, opts2, SkipReason.FAIL_OPEN_FORCED) }
                     log.warn(backendEx) { "leader.aop.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
                     fanOut { it.onTaskStarted(effectiveName) }
+                    val identity = meta.resolveLockIdentity(effectiveName, AdviceBranch.SYNC)
+                    val failOpenHandle = AopScopeAccess.createFailOpen(identity)
                     try {
-                        val result = pjp.proceed()
+                        val result = AopScopeAccess.withPushedSync(failOpenHandle) {
+                            pjp.proceed()
+                        }
                         val elapsed = System.nanoTime() - start
                         fanOut { it.onTaskFinished(effectiveName, elapsed.nanoseconds) }
                         result
@@ -182,6 +220,8 @@ class LeaderElectionAspect(
     /**
      * suspend 메서드 처리 — `startCoroutineUninterceptedOrReturn` intrinsics 패턴.
      * 본문 실행 시 [LeaderElectionInfo] 를 `withContext` 로 CoroutineContext 에 주입.
+     * suspend elector 가 이미 `withContext(LockHandleElement(handle))` 를 push 하므로
+     * aspect 는 [LeaderElectionInfo] 만 추가 — handle context 는 elector 에서 제공.
      */
     private fun aroundLeaderSuspend(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
         @Suppress("UNCHECKED_CAST")
@@ -233,6 +273,8 @@ class LeaderElectionAspect(
 
                 if (result == null) {
                     if (meta.failureMode == LeaderAspectFailureMode.FAIL_OPEN_RUN) {
+                        val identity = meta.resolveLockIdentity(resolvedName, AdviceBranch.SUSPEND)
+                        val failOpenHandle = AopScopeAccess.createFailOpen(identity)
                         fanOut {
                             it.onLockNotAcquired(resolvedName, meta.options, SkipReason.FAIL_OPEN_FORCED)
                             it.onTaskStarted(resolvedName)
@@ -240,10 +282,15 @@ class LeaderElectionAspect(
                         log.debug { "leader.aop.fail-open lockName=$resolvedName reason=CONTENTION" }
                         try {
                             @Suppress("UNCHECKED_CAST")
-                            val failOpenResult = suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
-                                val newArgs = pjp.args.copyOf()
-                                newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
-                                pjp.proceed(newArgs)
+                            val failOpenResult = withContext(
+                                LeaderElectionInfo(lockName = resolvedName, wasElected = false) +
+                                    AopScopeAccess.createLockHandleElement(failOpenHandle)
+                            ) {
+                                suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
+                                    val newArgs = pjp.args.copyOf()
+                                    newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
+                                    pjp.proceed(newArgs)
+                                }
                             }
                             fanOut { it.onTaskFinished(resolvedName, (System.nanoTime() - start).nanoseconds) }
                             failOpenResult
@@ -266,7 +313,7 @@ class LeaderElectionAspect(
                 throw ce
             } catch (bm: BodyThrownMarker) {
                 throw bm.cause
-            } catch (backendEx: Throwable) {
+            } catch (backendEx: Exception) {
                 val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
                 val wrapped = LeaderElectionException("leader backend error for lock '$effectiveName'", backendEx)
                 when (meta.failureMode) {
@@ -283,15 +330,22 @@ class LeaderElectionAspect(
                         null
                     }
                     LeaderAspectFailureMode.FAIL_OPEN_RUN -> {
+                        val identity = meta.resolveLockIdentity(effectiveName, AdviceBranch.SUSPEND)
+                        val failOpenHandle = AopScopeAccess.createFailOpen(identity)
                         fanOut { it.onLockNotAcquired(effectiveName, meta.options, SkipReason.FAIL_OPEN_FORCED) }
                         log.warn(backendEx) { "leader.aop.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
                         fanOut { it.onTaskStarted(effectiveName) }
                         try {
                             @Suppress("UNCHECKED_CAST")
-                            val failOpenResult = suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
-                                val newArgs = pjp.args.copyOf()
-                                newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
-                                pjp.proceed(newArgs)
+                            val failOpenResult = withContext(
+                                LeaderElectionInfo(lockName = effectiveName, wasElected = false) +
+                                    AopScopeAccess.createLockHandleElement(failOpenHandle)
+                            ) {
+                                suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
+                                    val newArgs = pjp.args.copyOf()
+                                    newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
+                                    pjp.proceed(newArgs)
+                                }
                             }
                             fanOut { it.onTaskFinished(effectiveName, (System.nanoTime() - start).nanoseconds) }
                             failOpenResult
@@ -314,6 +368,7 @@ class LeaderElectionAspect(
      *
      * `Mono.defer` 로 subscribe 당 락 1회 보장.
      * [LeaderElectionInfo] 를 `withContext` 로 주입하여 CoroutineContext 전파.
+     * suspend elector 가 `withContext(LockHandleElement(handle))` 를 이미 push.
      */
     private fun aroundLeaderMono(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
         val method = (pjp.signature as MethodSignature).method
@@ -360,13 +415,20 @@ class LeaderElectionAspect(
 
                     if (result == null) {
                         if (meta.failureMode == LeaderAspectFailureMode.FAIL_OPEN_RUN) {
+                            val identity = meta.resolveLockIdentity(resolvedName, AdviceBranch.MONO)
+                            val failOpenHandle = AopScopeAccess.createFailOpen(identity)
                             fanOut {
                                 it.onLockNotAcquired(resolvedName, meta.options, SkipReason.FAIL_OPEN_FORCED)
                                 it.onTaskStarted(resolvedName)
                             }
                             log.debug { "leader.aop.fail-open lockName=$resolvedName reason=CONTENTION" }
                             @Suppress("UNCHECKED_CAST")
-                            val failOpenResult = (pjp.proceed() as Mono<*>).awaitSingleOrNull()
+                            val failOpenResult = withContext(
+                                LeaderElectionInfo(lockName = resolvedName, wasElected = false) +
+                                    AopScopeAccess.createLockHandleElement(failOpenHandle)
+                            ) {
+                                (pjp.proceed() as Mono<*>).awaitSingleOrNull()
+                            }
                             fanOut { it.onTaskFinished(resolvedName, (System.nanoTime() - start).nanoseconds) }
                             failOpenResult
                         } else {
@@ -381,7 +443,7 @@ class LeaderElectionAspect(
                     throw ce
                 } catch (bm: BodyThrownMarker) {
                     throw bm.cause
-                } catch (backendEx: Throwable) {
+                } catch (backendEx: Exception) {
                     val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
                     val wrapped = LeaderElectionException("leader backend error for lock '$effectiveName'", backendEx)
                     when (meta.failureMode) {
@@ -398,12 +460,19 @@ class LeaderElectionAspect(
                             null
                         }
                         LeaderAspectFailureMode.FAIL_OPEN_RUN -> {
+                            val identity = meta.resolveLockIdentity(effectiveName, AdviceBranch.MONO)
+                            val failOpenHandle = AopScopeAccess.createFailOpen(identity)
                             fanOut { it.onLockNotAcquired(effectiveName, meta.options, SkipReason.FAIL_OPEN_FORCED) }
                             log.warn(backendEx) { "leader.aop.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
                             fanOut { it.onTaskStarted(effectiveName) }
                             try {
                                 @Suppress("UNCHECKED_CAST")
-                                val failOpenResult = (pjp.proceed() as Mono<*>).awaitSingleOrNull()
+                                val failOpenResult = withContext(
+                                    LeaderElectionInfo(lockName = effectiveName, wasElected = false) +
+                                        AopScopeAccess.createLockHandleElement(failOpenHandle)
+                                ) {
+                                    (pjp.proceed() as Mono<*>).awaitSingleOrNull()
+                                }
                                 fanOut { it.onTaskFinished(effectiveName, (System.nanoTime() - start).nanoseconds) }
                                 failOpenResult
                             } catch (ce: CancellationException) {
@@ -431,8 +500,6 @@ class LeaderElectionAspect(
             throw BodyThrownMarker(bodyEx)
         }
     }
-
-    private class BodyThrownMarker(override val cause: Throwable) : RuntimeException(cause)
 
     override fun afterSingletonsInstantiated() {}
 
@@ -475,6 +542,12 @@ class LeaderElectionAspect(
 
         val isSuspend = method.parameterTypes.lastOrNull() == Continuation::class.java
         val isMono = !isSuspend && method.returnType.name == "reactor.core.publisher.Mono"
+        val branch = when {
+            isSuspend -> AdviceBranch.SUSPEND
+            isMono -> AdviceBranch.MONO
+            else -> AdviceBranch.SYNC
+        }
+
         val (suspendElectorFactory, suspendElectorFactoryBeanName) = if (isSuspend || isMono) {
             val suspendSelected = beanSelector.selectSuspendElectorFactory(ann.bean, method)
             suspendSelected.bean to suspendSelected.beanName
@@ -490,10 +563,11 @@ class LeaderElectionAspect(
             factory = selected.bean,
             failureMode = effectiveFailureMode,
             leaseTimeWarnThresholdNanos = (leaseTime.inWholeNanoseconds * LEASE_WARN_RATIO).toLong(),
-            isSuspend = isSuspend,
-            isMono = isMono,
+            branch = branch,
             suspendElectorFactory = suspendElectorFactory,
             suspendElectorFactoryBeanName = suspendElectorFactoryBeanName,
+            annotationKind = LockIdentity.AnnotationKind.SINGLE,
+            groupParams = null,
         )
     }
 
@@ -505,21 +579,7 @@ class LeaderElectionAspect(
         }
     }
 
-    private data class AdviceMetadata(
-        val nameExpression: String,
-        val literalName: String?,
-        val options: LeaderElectionOptions,
-        val factoryBeanName: String,
-        val factory: LeaderElectorFactory,
-        val failureMode: LeaderAspectFailureMode,
-        val leaseTimeWarnThresholdNanos: Long,
-        val isSuspend: Boolean,
-        val isMono: Boolean,
-        val suspendElectorFactory: SuspendLeaderElectorFactory?,
-        val suspendElectorFactoryBeanName: String,
-    )
-
-    companion object: KLogging() {
+    companion object : KLogging() {
         private val LITERAL_PATTERN = Regex("^[A-Za-z0-9_:.\\-]+$")
         private const val LEASE_WARN_RATIO = 0.8
     }

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -37,7 +37,7 @@ import org.aspectj.lang.reflect.MethodSignature
 import org.springframework.beans.factory.SmartInitializingSingleton
 import reactor.core.publisher.Mono
 import java.lang.reflect.Method
-import java.util.concurrent.CancellationException
+import kotlinx.coroutines.CancellationException
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
@@ -237,9 +237,13 @@ class LeaderElectionAspect(
                 val resolvedName = resolveLockName(meta, method, pjp.args, pjp.target)
                 lockName = resolvedName
                 val cacheKey = FactoryCacheKey(meta.suspendElectorFactoryBeanName, meta.options)
+                // Tier 5 C1 — `!!` 제거. SuspendLeaderElectorFactory.create 는 suspend 이므로 computeIfAbsent 사용 불가.
+                // 첫 miss 동시 호출 시 패배자 elector 인스턴스 GC — SuspendLeaderElector 에 close() 없어 자원 leak 없음.
+                val factory = checkNotNull(meta.suspendElectorFactory) {
+                    "suspendElectorFactory must be non-null in COROUTINES/REACTIVE branch (branch=${meta.branch})"
+                }
                 val elector = suspendElectorCache[cacheKey]
-                    ?: meta.suspendElectorFactory!!.create(meta.options)
-                        .also { suspendElectorCache.putIfAbsent(cacheKey, it) }
+                    ?: factory.create(meta.options).also { suspendElectorCache.putIfAbsent(cacheKey, it) }
 
                 fanOut { it.onLockAttempt(resolvedName, meta.options) }
 

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -112,9 +112,11 @@ class LeaderElectionAspect(
             val resolvedName = resolveLockName(meta, method, args, target)
             lockName = resolvedName
 
-            // ── Reentrant short-circuit (T14): sync 분기에서 동일 lockName 이미 보유 중이면 backend 미호출 ──
+            // ── Reentrant short-circuit (T14 + Tier 7 P1-1): full LockIdentity 매칭 시에만 short-circuit ──
+            //   동일 lockName + 다른 annotation kind (SINGLE vs GROUP) 또는 다른 groupParams 는 별개 lock — 새 acquire.
+            val identity = meta.resolveLockIdentity(resolvedName, AdviceBranch.SYNC)
             val existing = AopScopeAccess.peekSyncMatching(resolvedName)
-            if (existing is LeaderLockHandle.Real) {
+            if (existing is LeaderLockHandle.Real && existing.matchesIdentity(identity)) {
                 log.debug { "leader.aop.reentrant lockName=$resolvedName depth=${existing.reentryDepth + 1}" }
                 val reentrantHandle = AopScopeAccess.incrementReentryDepth(existing)
                 return AopScopeAccess.withPushedSync(reentrantHandle) {

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -273,7 +273,7 @@ class LeaderElectionAspect(
 
                 if (result == null) {
                     if (meta.failureMode == LeaderAspectFailureMode.FAIL_OPEN_RUN) {
-                        val identity = meta.resolveLockIdentity(resolvedName, AdviceBranch.SUSPEND)
+                        val identity = meta.resolveLockIdentity(resolvedName, AdviceBranch.COROUTINES)
                         val failOpenHandle = AopScopeAccess.createFailOpen(identity)
                         fanOut {
                             it.onLockNotAcquired(resolvedName, meta.options, SkipReason.FAIL_OPEN_FORCED)
@@ -330,7 +330,7 @@ class LeaderElectionAspect(
                         null
                     }
                     LeaderAspectFailureMode.FAIL_OPEN_RUN -> {
-                        val identity = meta.resolveLockIdentity(effectiveName, AdviceBranch.SUSPEND)
+                        val identity = meta.resolveLockIdentity(effectiveName, AdviceBranch.COROUTINES)
                         val failOpenHandle = AopScopeAccess.createFailOpen(identity)
                         fanOut { it.onLockNotAcquired(effectiveName, meta.options, SkipReason.FAIL_OPEN_FORCED) }
                         log.warn(backendEx) { "leader.aop.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
@@ -415,7 +415,7 @@ class LeaderElectionAspect(
 
                     if (result == null) {
                         if (meta.failureMode == LeaderAspectFailureMode.FAIL_OPEN_RUN) {
-                            val identity = meta.resolveLockIdentity(resolvedName, AdviceBranch.MONO)
+                            val identity = meta.resolveLockIdentity(resolvedName, AdviceBranch.REACTIVE)
                             val failOpenHandle = AopScopeAccess.createFailOpen(identity)
                             fanOut {
                                 it.onLockNotAcquired(resolvedName, meta.options, SkipReason.FAIL_OPEN_FORCED)
@@ -460,7 +460,7 @@ class LeaderElectionAspect(
                             null
                         }
                         LeaderAspectFailureMode.FAIL_OPEN_RUN -> {
-                            val identity = meta.resolveLockIdentity(effectiveName, AdviceBranch.MONO)
+                            val identity = meta.resolveLockIdentity(effectiveName, AdviceBranch.REACTIVE)
                             val failOpenHandle = AopScopeAccess.createFailOpen(identity)
                             fanOut { it.onLockNotAcquired(effectiveName, meta.options, SkipReason.FAIL_OPEN_FORCED) }
                             log.warn(backendEx) { "leader.aop.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
@@ -543,8 +543,8 @@ class LeaderElectionAspect(
         val isSuspend = method.parameterTypes.lastOrNull() == Continuation::class.java
         val isMono = !isSuspend && method.returnType.name == "reactor.core.publisher.Mono"
         val branch = when {
-            isSuspend -> AdviceBranch.SUSPEND
-            isMono -> AdviceBranch.MONO
+            isSuspend -> AdviceBranch.COROUTINES
+            isMono -> AdviceBranch.REACTIVE
             else -> AdviceBranch.SYNC
         }
 

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -387,9 +387,11 @@ class LeaderElectionAspect(
                     val resolvedName = resolveLockName(meta, method, pjp.args, pjp.target)
                     lockName = resolvedName
                     val cacheKey = FactoryCacheKey(meta.suspendElectorFactoryBeanName, meta.options)
+                    val factory = checkNotNull(meta.suspendElectorFactory) {
+                        "suspendElectorFactory must be non-null in REACTIVE branch (Mono)"
+                    }
                     val elector = suspendElectorCache[cacheKey]
-                        ?: meta.suspendElectorFactory!!.create(meta.options)
-                            .also { suspendElectorCache.putIfAbsent(cacheKey, it) }
+                        ?: factory.create(meta.options).also { suspendElectorCache.putIfAbsent(cacheKey, it) }
 
                     fanOut { it.onLockAttempt(resolvedName, meta.options) }
 

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -515,7 +515,7 @@ class LeaderElectionAspect(
     }
 
     private fun resolveMetadata(method: Method, target: Any): AdviceMetadata {
-        val ann = AnnotationLookup.findAnnotationWithTargetFallback(method, target, LeaderElection::class.java)
+        val ann = AnnotationLookup.findAnnotationWithTargetFallback<LeaderElection>(method, target)
             ?: error("@LeaderElection not found on ${method.declaringClass.name}#${method.name}")
 
         val waitTime = DurationParser.parseOrDefault(ann.waitTime, props.defaultWaitTime).toKotlinDuration()

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -1,10 +1,13 @@
 package io.bluetape4k.leader.spring.aop
 
-import io.bluetape4k.leader.LeaderGroupElector
+import io.bluetape4k.leader.AopScopeAccess
 import io.bluetape4k.leader.LeaderGroupElectionException
-import io.bluetape4k.leader.LeaderRunResult
-import io.bluetape4k.leader.LeaderGroupElectorFactory
 import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderGroupElector
+import io.bluetape4k.leader.LeaderGroupElectorFactory
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.leader.annotation.LeaderAspectFailureMode
 import io.bluetape4k.leader.annotation.LeaderGroupElection
 import io.bluetape4k.leader.coroutines.LeaderElectionInfo
@@ -13,6 +16,8 @@ import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElectorFactory
 import io.bluetape4k.leader.metrics.LeaderAopMetricsRecorder
 import io.bluetape4k.leader.metrics.SkipReason
 import io.bluetape4k.leader.spring.aop.cache.GroupFactoryCacheKey
+import io.bluetape4k.leader.spring.aop.internal.AdviceBranch
+import io.bluetape4k.leader.spring.aop.internal.BodyThrownMarker
 import io.bluetape4k.leader.spring.aop.properties.LeaderAopProperties
 import io.bluetape4k.leader.spring.aop.spel.SpelExpressionEvaluator
 import io.bluetape4k.leader.spring.aop.util.AnnotationLookup
@@ -54,6 +59,15 @@ import kotlin.time.toKotlinDuration
  *
  * ## LeaderElectionInfo (#92)
  * suspend / Mono 분기 본문 실행 시 [LeaderElectionInfo] 를 `withContext` 로 주입.
+ *
+ * ## LockHandleElement / LockStateHolder (T15)
+ * - sync 분기: [AopScopeAccess.withPushedSync] 로 `LockStateHolder` 에 handle push.
+ * - suspend / Mono 분기: elector 가 `withContext(LockHandleElement(...))` 로 이미 push — aspect 는 [LeaderElectionInfo] 만 추가.
+ * - FAIL_OPEN_RUN 분기: [LeaderLockHandle.FailOpen] sentinel 을 push.
+ *
+ * ## Reentrant pass-through (T15)
+ * sync 분기 진입 전 [AopScopeAccess.peekSyncMatching] 으로 동일 lockName 보유 여부 확인.
+ * 이미 Real handle 보유 시 backend re-acquire 없이 body 실행. FailOpen sentinel + identity 일치 시 sentinel 유지 (Plan-R1-P1-1).
  */
 @Aspect
 class LeaderGroupElectionAspect(
@@ -95,12 +109,24 @@ class LeaderGroupElectionAspect(
             val resolvedName = resolveLockName(meta, method, args, target)
             lockName = resolvedName
 
+            // ── Reentrant short-circuit (T15): sync 분기에서 동일 lockName Real handle 보유 중이면 backend 미호출 ──
+            // (T14 와 동일 — Real handle 만 short-circuit. FailOpen sentinel reentrant 는 follow-up.)
+            val existing = AopScopeAccess.peekSyncMatching(resolvedName)
+            if (existing is LeaderLockHandle.Real) {
+                log.debug { "leader.aop.group.reentrant lockName=$resolvedName depth=${existing.reentryDepth + 1}" }
+                val reentrantHandle = AopScopeAccess.incrementReentryDepth(existing)
+                return AopScopeAccess.withPushedSync(reentrantHandle) {
+                    executeBody(pjp, resolvedName, start)
+                }
+            }
+
             val cacheKey = GroupFactoryCacheKey(meta.factoryBeanName, opts)
             val election = factoryCache.computeIfAbsent(cacheKey) { meta.factory.create(opts) }
 
             fanOut { it.onLockAttempt(resolvedName, coreOpts) }
 
             val runResult = election.runIfLeaderResult(resolvedName) {
+                // Elector (e.g., AbstractLocalLeaderGroupElector) 내부에서 LockStateHolder.withPushed 호출 — aspect 가 double-push 하지 않음.
                 fanOut {
                     it.onLockAcquired(resolvedName, coreOpts, (System.nanoTime() - start).nanoseconds)
                     it.onTaskStarted(resolvedName)
@@ -110,28 +136,32 @@ class LeaderGroupElectionAspect(
             when (runResult) {
                 is LeaderRunResult.Skipped -> {
                     if (meta.failureMode == LeaderAspectFailureMode.FAIL_OPEN_RUN) {
+                        val identity = meta.resolveLockIdentity(resolvedName, AdviceBranch.SYNC)
+                        val failOpenHandle = AopScopeAccess.createFailOpen(identity)
                         fanOut {
                             it.onLockNotAcquired(resolvedName, coreOpts, SkipReason.FAIL_OPEN_FORCED)
                             it.onTaskStarted(resolvedName)
                         }
-                        log.debug { "leader.aop.fail-open lockName=$resolvedName reason=CONTENTION" }
-                        val result = executeBody(pjp, resolvedName, start)
+                        log.debug { "leader.aop.group.fail-open lockName=$resolvedName reason=CONTENTION" }
+                        val result = AopScopeAccess.withPushedSync(failOpenHandle) {
+                            executeBody(pjp, resolvedName, start)
+                        }
                         val elapsed = System.nanoTime() - start
                         fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
                         result
                     } else {
                         fanOut { it.onLockNotAcquired(resolvedName, coreOpts, SkipReason.CONTENTION) }
-                        log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
+                        log.debug { "leader.aop.group.skipped lockName=$resolvedName reason=CONTENTION" }
                         null
                     }
                 }
                 is LeaderRunResult.Elected -> {
                     val elapsed = System.nanoTime() - start
                     fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
-                    log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
+                    log.debug { "leader.aop.group.elected lockName=$resolvedName elapsedNs=$elapsed" }
                     if (elapsed > meta.leaseTimeWarnThresholdNanos) {
                         log.warn {
-                            "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${opts.leaseTime.inWholeNanoseconds}"
+                            "leader.aop.group.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${opts.leaseTime.inWholeNanoseconds}"
                         }
                     }
                     runResult.value
@@ -141,7 +171,7 @@ class LeaderGroupElectionAspect(
             throw e
         } catch (bodyMarker: BodyThrownMarker) {
             throw bodyMarker.cause
-        } catch (backendEx: Throwable) {
+        } catch (backendEx: Exception) {
             val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
             val wrapped = LeaderGroupElectionException("leader group backend error for lock '$effectiveName'", backendEx)
             when (meta.failureMode) {
@@ -154,15 +184,19 @@ class LeaderGroupElectionAspect(
                 LeaderAspectFailureMode.SKIP -> {
                     fanOut { it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.BACKEND_ERROR) }
                     fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
-                    log.warn(backendEx) { "leader.aop.skipped lockName=$effectiveName reason=BACKEND_ERROR" }
+                    log.warn(backendEx) { "leader.aop.group.skipped lockName=$effectiveName reason=BACKEND_ERROR" }
                     null
                 }
                 LeaderAspectFailureMode.FAIL_OPEN_RUN -> {
+                    val identity = meta.resolveLockIdentity(effectiveName, AdviceBranch.SYNC)
+                    val failOpenHandle = AopScopeAccess.createFailOpen(identity)
                     fanOut { it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.FAIL_OPEN_FORCED) }
-                    log.warn(backendEx) { "leader.aop.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
+                    log.warn(backendEx) { "leader.aop.group.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
                     fanOut { it.onTaskStarted(effectiveName) }
                     try {
-                        val result = pjp.proceed()
+                        val result = AopScopeAccess.withPushedSync(failOpenHandle) {
+                            pjp.proceed()
+                        }
                         val elapsed = System.nanoTime() - start
                         fanOut { it.onTaskFinished(effectiveName, elapsed.nanoseconds) }
                         result
@@ -217,9 +251,9 @@ class LeaderGroupElectionAspect(
                             val elapsed = System.nanoTime() - start
                             fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
                             if (elapsed > meta.leaseTimeWarnThresholdNanos) {
-                                log.warn { "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${meta.options.leaseTime.inWholeNanoseconds}" }
+                                log.warn { "leader.aop.group.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${meta.options.leaseTime.inWholeNanoseconds}" }
                             }
-                            log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
+                            log.debug { "leader.aop.group.elected lockName=$resolvedName elapsedNs=$elapsed" }
                             bodyResult
                         } catch (ce: CancellationException) {
                             fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, ce) }
@@ -233,17 +267,24 @@ class LeaderGroupElectionAspect(
 
                 if (result == null) {
                     if (meta.failureMode == LeaderAspectFailureMode.FAIL_OPEN_RUN) {
+                        val identity = meta.resolveLockIdentity(resolvedName, AdviceBranch.COROUTINES)
+                        val failOpenHandle = AopScopeAccess.createFailOpen(identity)
                         fanOut {
                             it.onLockNotAcquired(resolvedName, coreOpts, SkipReason.FAIL_OPEN_FORCED)
                             it.onTaskStarted(resolvedName)
                         }
-                        log.debug { "leader.aop.fail-open lockName=$resolvedName reason=CONTENTION" }
+                        log.debug { "leader.aop.group.fail-open lockName=$resolvedName reason=CONTENTION" }
                         try {
                             @Suppress("UNCHECKED_CAST")
-                            val failOpenResult = suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
-                                val newArgs = pjp.args.copyOf()
-                                newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
-                                pjp.proceed(newArgs)
+                            val failOpenResult = withContext(
+                                LeaderElectionInfo(lockName = resolvedName, wasElected = false) +
+                                    AopScopeAccess.createLockHandleElement(failOpenHandle)
+                            ) {
+                                suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
+                                    val newArgs = pjp.args.copyOf()
+                                    newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
+                                    pjp.proceed(newArgs)
+                                }
                             }
                             fanOut { it.onTaskFinished(resolvedName, (System.nanoTime() - start).nanoseconds) }
                             failOpenResult
@@ -256,7 +297,7 @@ class LeaderGroupElectionAspect(
                         }
                     } else {
                         fanOut { it.onLockNotAcquired(resolvedName, coreOpts, SkipReason.CONTENTION) }
-                        log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
+                        log.debug { "leader.aop.group.skipped lockName=$resolvedName reason=CONTENTION" }
                         null
                     }
                 } else {
@@ -266,7 +307,7 @@ class LeaderGroupElectionAspect(
                 throw ce
             } catch (bm: BodyThrownMarker) {
                 throw bm.cause
-            } catch (backendEx: Throwable) {
+            } catch (backendEx: Exception) {
                 val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
                 val wrapped = LeaderGroupElectionException("leader group backend error for lock '$effectiveName'", backendEx)
                 when (meta.failureMode) {
@@ -279,19 +320,26 @@ class LeaderGroupElectionAspect(
                     LeaderAspectFailureMode.SKIP -> {
                         fanOut { it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.BACKEND_ERROR) }
                         fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
-                        log.warn(backendEx) { "leader.aop.skipped lockName=$effectiveName reason=BACKEND_ERROR" }
+                        log.warn(backendEx) { "leader.aop.group.skipped lockName=$effectiveName reason=BACKEND_ERROR" }
                         null
                     }
                     LeaderAspectFailureMode.FAIL_OPEN_RUN -> {
+                        val identity = meta.resolveLockIdentity(effectiveName, AdviceBranch.COROUTINES)
+                        val failOpenHandle = AopScopeAccess.createFailOpen(identity)
                         fanOut { it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.FAIL_OPEN_FORCED) }
-                        log.warn(backendEx) { "leader.aop.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
+                        log.warn(backendEx) { "leader.aop.group.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
                         fanOut { it.onTaskStarted(effectiveName) }
                         try {
                             @Suppress("UNCHECKED_CAST")
-                            val failOpenResult = suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
-                                val newArgs = pjp.args.copyOf()
-                                newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
-                                pjp.proceed(newArgs)
+                            val failOpenResult = withContext(
+                                LeaderElectionInfo(lockName = effectiveName, wasElected = false) +
+                                    AopScopeAccess.createLockHandleElement(failOpenHandle)
+                            ) {
+                                suspendCoroutineUninterceptedOrReturn<Any?> { innerCont ->
+                                    val newArgs = pjp.args.copyOf()
+                                    newArgs[newArgs.lastIndex] = innerCont as Continuation<Any?>
+                                    pjp.proceed(newArgs)
+                                }
                             }
                             fanOut { it.onTaskFinished(effectiveName, (System.nanoTime() - start).nanoseconds) }
                             failOpenResult
@@ -343,9 +391,9 @@ class LeaderGroupElectionAspect(
                                 val elapsed = System.nanoTime() - start
                                 fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
                                 if (elapsed > meta.leaseTimeWarnThresholdNanos) {
-                                    log.warn { "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${meta.options.leaseTime.inWholeNanoseconds}" }
+                                    log.warn { "leader.aop.group.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${meta.options.leaseTime.inWholeNanoseconds}" }
                                 }
-                                log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
+                                log.debug { "leader.aop.group.elected lockName=$resolvedName elapsedNs=$elapsed" }
                                 bodyResult
                             } catch (ce: CancellationException) {
                                 fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, ce) }
@@ -359,18 +407,25 @@ class LeaderGroupElectionAspect(
 
                     if (result == null) {
                         if (meta.failureMode == LeaderAspectFailureMode.FAIL_OPEN_RUN) {
+                            val identity = meta.resolveLockIdentity(resolvedName, AdviceBranch.REACTIVE)
+                            val failOpenHandle = AopScopeAccess.createFailOpen(identity)
                             fanOut {
                                 it.onLockNotAcquired(resolvedName, coreOpts, SkipReason.FAIL_OPEN_FORCED)
                                 it.onTaskStarted(resolvedName)
                             }
-                            log.debug { "leader.aop.fail-open lockName=$resolvedName reason=CONTENTION" }
+                            log.debug { "leader.aop.group.fail-open lockName=$resolvedName reason=CONTENTION" }
                             @Suppress("UNCHECKED_CAST")
-                            val failOpenResult = (pjp.proceed() as Mono<*>).awaitSingleOrNull()
+                            val failOpenResult = withContext(
+                                LeaderElectionInfo(lockName = resolvedName, wasElected = false) +
+                                    AopScopeAccess.createLockHandleElement(failOpenHandle)
+                            ) {
+                                (pjp.proceed() as Mono<*>).awaitSingleOrNull()
+                            }
                             fanOut { it.onTaskFinished(resolvedName, (System.nanoTime() - start).nanoseconds) }
                             failOpenResult
                         } else {
                             fanOut { it.onLockNotAcquired(resolvedName, coreOpts, SkipReason.CONTENTION) }
-                            log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
+                            log.debug { "leader.aop.group.skipped lockName=$resolvedName reason=CONTENTION" }
                             null
                         }
                     } else {
@@ -380,7 +435,7 @@ class LeaderGroupElectionAspect(
                     throw ce
                 } catch (bm: BodyThrownMarker) {
                     throw bm.cause
-                } catch (backendEx: Throwable) {
+                } catch (backendEx: Exception) {
                     val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
                     val wrapped = LeaderGroupElectionException("leader group backend error for lock '$effectiveName'", backendEx)
                     when (meta.failureMode) {
@@ -393,16 +448,23 @@ class LeaderGroupElectionAspect(
                         LeaderAspectFailureMode.SKIP -> {
                             fanOut { it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.BACKEND_ERROR) }
                             fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
-                            log.warn(backendEx) { "leader.aop.skipped lockName=$effectiveName reason=BACKEND_ERROR" }
+                            log.warn(backendEx) { "leader.aop.group.skipped lockName=$effectiveName reason=BACKEND_ERROR" }
                             null
                         }
                         LeaderAspectFailureMode.FAIL_OPEN_RUN -> {
+                            val identity = meta.resolveLockIdentity(effectiveName, AdviceBranch.REACTIVE)
+                            val failOpenHandle = AopScopeAccess.createFailOpen(identity)
                             fanOut { it.onLockNotAcquired(effectiveName, coreOpts, SkipReason.FAIL_OPEN_FORCED) }
-                            log.warn(backendEx) { "leader.aop.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
+                            log.warn(backendEx) { "leader.aop.group.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
                             fanOut { it.onTaskStarted(effectiveName) }
                             try {
                                 @Suppress("UNCHECKED_CAST")
-                                val failOpenResult = (pjp.proceed() as Mono<*>).awaitSingleOrNull()
+                                val failOpenResult = withContext(
+                                    LeaderElectionInfo(lockName = effectiveName, wasElected = false) +
+                                        AopScopeAccess.createLockHandleElement(failOpenHandle)
+                                ) {
+                                    (pjp.proceed() as Mono<*>).awaitSingleOrNull()
+                                }
                                 fanOut { it.onTaskFinished(effectiveName, (System.nanoTime() - start).nanoseconds) }
                                 failOpenResult
                             } catch (ce: CancellationException) {
@@ -430,8 +492,6 @@ class LeaderGroupElectionAspect(
             throw BodyThrownMarker(bodyEx)
         }
     }
-
-    private class BodyThrownMarker(override val cause: Throwable) : RuntimeException(cause)
 
     override fun afterSingletonsInstantiated() {}
 
@@ -530,7 +590,27 @@ class LeaderGroupElectionAspect(
         val isMono: Boolean,
         val suspendElectorFactory: SuspendLeaderGroupElectorFactory?,
         val suspendElectorFactoryBeanName: String,
-    )
+    ) {
+
+        /**
+         * 주어진 [branch] 에 맞는 [LockIdentity] 를 생성합니다.
+         *
+         * group annotation 이므로 `kind = GROUP`, `groupParams = GroupParams(maxLeaders)`.
+         * `factoryBeanName` 은 `equals/hashCode` 제외이므로 sync ↔ suspend nested 호출 시에도 동일 lock 으로 인식 (Step 3-P R3 mitigation).
+         */
+        fun resolveLockIdentity(lockName: String, branch: AdviceBranch): LockIdentity {
+            val beanName = when (branch) {
+                AdviceBranch.SYNC -> factoryBeanName
+                AdviceBranch.COROUTINES, AdviceBranch.REACTIVE -> suspendElectorFactoryBeanName
+            }
+            return LockIdentity(
+                lockName = lockName,
+                kind = LockIdentity.AnnotationKind.GROUP,
+                factoryBeanName = beanName,
+                groupParams = LockIdentity.GroupParams(maxLeaders = options.maxLeaders),
+            )
+        }
+    }
 
     companion object: KLogging() {
         private val LITERAL_PATTERN = Regex("^[A-Za-z0-9_:.\\-]+$")

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -109,10 +109,12 @@ class LeaderGroupElectionAspect(
             val resolvedName = resolveLockName(meta, method, args, target)
             lockName = resolvedName
 
-            // ── Reentrant short-circuit (T15): sync 분기에서 동일 lockName Real handle 보유 중이면 backend 미호출 ──
-            // (T14 와 동일 — Real handle 만 short-circuit. FailOpen sentinel reentrant 는 follow-up.)
+            // ── Reentrant short-circuit (T15 + Tier 7 P1-1): full LockIdentity 매칭 시에만 short-circuit ──
+            //   동일 lockName + 다른 annotation kind (SINGLE) 또는 다른 maxLeaders 는 별개 lock — 새 acquire.
+            //   FailOpen sentinel reentrant 는 follow-up.
+            val identity = meta.resolveLockIdentity(resolvedName, AdviceBranch.SYNC)
             val existing = AopScopeAccess.peekSyncMatching(resolvedName)
-            if (existing is LeaderLockHandle.Real) {
+            if (existing is LeaderLockHandle.Real && existing.matchesIdentity(identity)) {
                 log.debug { "leader.aop.group.reentrant lockName=$resolvedName depth=${existing.reentryDepth + 1}" }
                 val reentrantHandle = AopScopeAccess.incrementReentryDepth(existing)
                 return AopScopeAccess.withPushedSync(reentrantHandle) {

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -512,7 +512,7 @@ class LeaderGroupElectionAspect(
     }
 
     private fun resolveMetadata(method: Method, target: Any): GroupAdviceMetadata {
-        val ann = AnnotationLookup.findAnnotationWithTargetFallback(method, target, LeaderGroupElection::class.java)
+        val ann = AnnotationLookup.findAnnotationWithTargetFallback<LeaderGroupElection>(method, target)
             ?: error("@LeaderGroupElection not found on ${method.declaringClass.name}#${method.name}")
 
         ann.maxLeaders.requireGe(2, "ann.maxLeaders")

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -37,7 +37,7 @@ import org.aspectj.lang.reflect.MethodSignature
 import org.springframework.beans.factory.SmartInitializingSingleton
 import reactor.core.publisher.Mono
 import java.lang.reflect.Method
-import java.util.concurrent.CancellationException
+import kotlinx.coroutines.CancellationException
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
@@ -231,9 +231,12 @@ class LeaderGroupElectionAspect(
                 val resolvedName = resolveLockName(meta, method, pjp.args, pjp.target)
                 lockName = resolvedName
                 val cacheKey = GroupFactoryCacheKey(meta.suspendElectorFactoryBeanName, meta.options)
+                // Tier 5 C1 — `!!` 제거. suspend create 는 computeIfAbsent 안 호출 불가 — putIfAbsent 패턴 유지.
+                val factory = checkNotNull(meta.suspendElectorFactory) {
+                    "suspendElectorFactory must be non-null in COROUTINES/REACTIVE branch"
+                }
                 val elector = suspendElectorCache[cacheKey]
-                    ?: meta.suspendElectorFactory!!.create(meta.options)
-                        .also { suspendElectorCache.putIfAbsent(cacheKey, it) }
+                    ?: factory.create(meta.options).also { suspendElectorCache.putIfAbsent(cacheKey, it) }
 
                 fanOut { it.onLockAttempt(resolvedName, coreOpts) }
 

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -378,9 +378,11 @@ class LeaderGroupElectionAspect(
                     val resolvedName = resolveLockName(meta, method, pjp.args, pjp.target)
                     lockName = resolvedName
                     val cacheKey = GroupFactoryCacheKey(meta.suspendElectorFactoryBeanName, meta.options)
+                    val factory = checkNotNull(meta.suspendElectorFactory) {
+                        "suspendElectorFactory must be non-null in REACTIVE branch (Mono)"
+                    }
                     val elector = suspendElectorCache[cacheKey]
-                        ?: meta.suspendElectorFactory!!.create(meta.options)
-                            .also { suspendElectorCache.putIfAbsent(cacheKey, it) }
+                        ?: factory.create(meta.options).also { suspendElectorCache.putIfAbsent(cacheKey, it) }
 
                     fanOut { it.onLockAttempt(resolvedName, coreOpts) }
 

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/internal/AdviceBranch.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/internal/AdviceBranch.kt
@@ -1,0 +1,17 @@
+package io.bluetape4k.leader.spring.aop.internal
+
+/**
+ * `@LeaderElection` / `@LeaderGroupElection` aspect 의 실행 분기.
+ *
+ * `resolveMetadata` 에서 method signature 를 기반으로 결정되며 `AdviceMetadata` 에 저장됩니다.
+ */
+internal enum class AdviceBranch {
+    /** 일반 blocking 동기 메서드 */
+    SYNC,
+
+    /** 마지막 파라미터가 `kotlin.coroutines.Continuation` 인 suspend 메서드 */
+    SUSPEND,
+
+    /** 반환 타입이 `reactor.core.publisher.Mono` 인 non-suspend 메서드 */
+    MONO,
+}

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/internal/AdviceBranch.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/internal/AdviceBranch.kt
@@ -4,14 +4,22 @@ package io.bluetape4k.leader.spring.aop.internal
  * `@LeaderElection` / `@LeaderGroupElection` aspect 의 실행 분기.
  *
  * `resolveMetadata` 에서 method signature 를 기반으로 결정되며 `AdviceMetadata` 에 저장됩니다.
+ *
+ * ## 명명 — 카테고리 기반 (개별 detection marker 와 구분)
+ * - [SYNC]: 일반 blocking 동기 메서드
+ * - [COROUTINES]: Kotlin coroutine 계열 (현재 suspend method, 향후 Flow 등 확장 여지)
+ * - [REACTIVE]: Reactor / Project Reactor 계열 (현재 `Mono`, 향후 `Flux` 등 확장 여지)
+ *
+ * 개별 method 의 정확한 detection (`Continuation` 파라미터 / `Mono` 반환) 은
+ * `AdviceMetadata.isSuspend` / `AdviceMetadata.isMono` 속성으로 표현됩니다.
  */
 internal enum class AdviceBranch {
     /** 일반 blocking 동기 메서드 */
     SYNC,
 
-    /** 마지막 파라미터가 `kotlin.coroutines.Continuation` 인 suspend 메서드 */
-    SUSPEND,
+    /** Kotlin coroutine 기반 (현재 suspend method — 마지막 파라미터 `kotlin.coroutines.Continuation`) */
+    COROUTINES,
 
-    /** 반환 타입이 `reactor.core.publisher.Mono` 인 non-suspend 메서드 */
-    MONO,
+    /** Reactor 기반 (현재 `reactor.core.publisher.Mono` 반환 non-suspend 메서드) */
+    REACTIVE,
 }

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/internal/AdviceMetadata.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/internal/AdviceMetadata.kt
@@ -37,8 +37,8 @@ internal data class AdviceMetadata(
     val annotationKind: LockIdentity.AnnotationKind = LockIdentity.AnnotationKind.SINGLE,
     val groupParams: LockIdentity.GroupParams? = null,
 ) {
-    val isSuspend: Boolean get() = branch == AdviceBranch.SUSPEND
-    val isMono: Boolean get() = branch == AdviceBranch.MONO
+    val isSuspend: Boolean get() = branch == AdviceBranch.COROUTINES
+    val isMono: Boolean get() = branch == AdviceBranch.REACTIVE
 
     /**
      * 주어진 [branch] 에 맞는 [LockIdentity] 를 생성합니다.
@@ -49,7 +49,7 @@ internal data class AdviceMetadata(
     fun resolveLockIdentity(lockName: String, branch: AdviceBranch): LockIdentity {
         val beanName = when (branch) {
             AdviceBranch.SYNC -> factoryBeanName
-            AdviceBranch.SUSPEND, AdviceBranch.MONO -> suspendElectorFactoryBeanName
+            AdviceBranch.COROUTINES, AdviceBranch.REACTIVE -> suspendElectorFactoryBeanName
         }
         return LockIdentity(
             lockName = lockName,

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/internal/AdviceMetadata.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/internal/AdviceMetadata.kt
@@ -1,0 +1,61 @@
+package io.bluetape4k.leader.spring.aop.internal
+
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderElectorFactory
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.annotation.LeaderAspectFailureMode
+import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
+
+/**
+ * `@LeaderElection` 처리 aspect 가 메서드별로 캐싱하는 resolved metadata.
+ *
+ * ## 필드 설명
+ * - [nameExpression]: `@LeaderElection.name` 원본 (SpEL 또는 literal)
+ * - [literalName]: literal pattern 에 해당하면 미리 파싱된 값, SpEL 이면 `null`
+ * - [options]: resolved [LeaderElectionOptions]
+ * - [factoryBeanName]: sync elector factory bean name (진단 metadata + [LockIdentity] 구성용)
+ * - [factory]: sync elector factory 인스턴스
+ * - [failureMode]: INHERIT 이 이미 resolve 된 effective failure mode
+ * - [leaseTimeWarnThresholdNanos]: leaseTime × 0.8 임계값 (ns)
+ * - [branch]: [AdviceBranch] — SYNC / SUSPEND / MONO
+ * - [suspendElectorFactory]: SUSPEND / MONO 분기 factory (`null` for SYNC)
+ * - [suspendElectorFactoryBeanName]: SUSPEND / MONO 분기 factory bean name
+ * - [annotationKind]: [LockIdentity.AnnotationKind.SINGLE] (LeaderElection 전용)
+ * - [groupParams]: `null` (group 아님 — LeaderElection 전용 항상 `null`)
+ */
+internal data class AdviceMetadata(
+    val nameExpression: String,
+    val literalName: String?,
+    val options: LeaderElectionOptions,
+    val factoryBeanName: String,
+    val factory: LeaderElectorFactory,
+    val failureMode: LeaderAspectFailureMode,
+    val leaseTimeWarnThresholdNanos: Long,
+    val branch: AdviceBranch,
+    val suspendElectorFactory: SuspendLeaderElectorFactory?,
+    val suspendElectorFactoryBeanName: String,
+    val annotationKind: LockIdentity.AnnotationKind = LockIdentity.AnnotationKind.SINGLE,
+    val groupParams: LockIdentity.GroupParams? = null,
+) {
+    val isSuspend: Boolean get() = branch == AdviceBranch.SUSPEND
+    val isMono: Boolean get() = branch == AdviceBranch.MONO
+
+    /**
+     * 주어진 [branch] 에 맞는 [LockIdentity] 를 생성합니다.
+     *
+     * `factoryBeanName` 은 `equals/hashCode` 제외이므로 sync ↔ suspend nested 호출 시에도
+     * 동일 lock 으로 인식됩니다 (Step 3-P R3 mitigation).
+     */
+    fun resolveLockIdentity(lockName: String, branch: AdviceBranch): LockIdentity {
+        val beanName = when (branch) {
+            AdviceBranch.SYNC -> factoryBeanName
+            AdviceBranch.SUSPEND, AdviceBranch.MONO -> suspendElectorFactoryBeanName
+        }
+        return LockIdentity(
+            lockName = lockName,
+            kind = annotationKind,
+            factoryBeanName = beanName,
+            groupParams = groupParams,
+        )
+    }
+}

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/internal/BodyThrownMarker.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/internal/BodyThrownMarker.kt
@@ -1,0 +1,11 @@
+package io.bluetape4k.leader.spring.aop.internal
+
+/**
+ * 본문(body) 예외와 backend 예외를 구분하기 위한 마커 래퍼.
+ *
+ * aspect 의 outer catch block 에서 `BodyThrownMarker` 로 catch 하면 body 예외로 판별하여
+ * wrapping 없이 `cause` 를 그대로 re-throw 합니다.
+ *
+ * `RuntimeException` 을 상속하므로 일반 catch-Throwable 에 잡히지만, 상위 catch 에서 먼저 처리합니다.
+ */
+internal class BodyThrownMarker(override val cause: Throwable) : RuntimeException(cause)

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/internal/CaptureInvariantException.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/internal/CaptureInvariantException.kt
@@ -1,0 +1,16 @@
+package io.bluetape4k.leader.spring.aop.internal
+
+/**
+ * AOP aspect 가 elector → aspect 간 handle capture 불변식 위반을 감지할 때 throw.
+ *
+ * ## 불변식
+ * group elector 의 `CaptureScope.runWithCapture` / `runWithCaptureSuspend` 는 action 호출 직전
+ * `LeaderLockHandleCapture.set(handle)` 을 호출합니다. aspect 는 action lambda 의 첫 statement 에서
+ * `AopScopeAccess.pollCapture()` 로 handle 을 수신합니다.
+ *
+ * **single elector 는 CaptureScope 를 사용하지 않으므로 pollCapture() == null 은 정상** — 이 예외는
+ * group elector 전용 capture 실패 시만 throw 합니다.
+ *
+ * silent fail-open 변환은 절대 금지 (Codex F10 / SF3).
+ */
+internal class CaptureInvariantException(message: String) : IllegalStateException(message)

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/util/AnnotationExt.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/util/AnnotationExt.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.leader.spring.aop.util
+
+import org.springframework.core.annotation.AnnotatedElementUtils
+import java.lang.reflect.AnnotatedElement
+
+/**
+ * Spring [AnnotatedElementUtils.findMergedAnnotation] 의 Kotlin reified idiom.
+ *
+ * ## Example
+ * ```kotlin
+ * val leader: LeaderElection? = method.findMergedAnnotationOrNull<LeaderElection>()
+ * ```
+ *
+ * @return 합성 어노테이션 인스턴스 또는 미발견 시 `null`
+ */
+inline fun <reified A : Annotation> AnnotatedElement.findMergedAnnotationOrNull(): A? =
+    AnnotatedElementUtils.findMergedAnnotation(this, A::class.java)
+
+/**
+ * Spring [AnnotatedElementUtils.hasAnnotation] 의 Kotlin reified idiom.
+ *
+ * ## Example
+ * ```kotlin
+ * if (method.hasMergedAnnotation<LeaderElection>()) { ... }
+ * ```
+ */
+inline fun <reified A : Annotation> AnnotatedElement.hasMergedAnnotation(): Boolean =
+    AnnotatedElementUtils.hasAnnotation(this, A::class.java)

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/util/AnnotationLookup.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/util/AnnotationLookup.kt
@@ -1,7 +1,6 @@
 package io.bluetape4k.leader.spring.aop.util
 
 import org.springframework.aop.support.AopUtils
-import org.springframework.core.annotation.AnnotatedElementUtils
 import java.lang.reflect.Method
 
 /**
@@ -12,22 +11,26 @@ import java.lang.reflect.Method
  *
  * 인터페이스 메서드에만 어노테이션이 부착되고 구현체는 별도일 때, 프록시 메서드 (인터페이스 메서드) 를
  * 직접 lookup 하면 어노테이션이 누락된다. 본 헬퍼는:
- * 1. `AnnotatedElementUtils.findMergedAnnotation(method)` 로 1차 시도
+ * 1. `method.findMergedAnnotationOrNull<A>()` 로 1차 시도
  * 2. 미발견 시 `AopUtils.getTargetClass(target).getMethod(name, params)` 로 target class 메서드 재탐색
  */
 object AnnotationLookup {
 
     /**
-     * [method] 또는 [target] 의 target class 메서드에서 [type] 어노테이션을 찾는다.
+     * [method] 또는 [target] 의 target class 메서드에서 [A] 어노테이션을 찾는다.
+     *
+     * Kotlin idiom — reified 변형. 사용:
+     * ```kotlin
+     * val ann = AnnotationLookup.findAnnotationWithTargetFallback<LeaderElection>(method, target)
+     * ```
      *
      * @return 어노테이션 인스턴스 또는 미발견 시 `null`
      */
-    fun <A : Annotation> findAnnotationWithTargetFallback(
+    inline fun <reified A : Annotation> findAnnotationWithTargetFallback(
         method: Method,
         target: Any,
-        type: Class<A>,
     ): A? {
-        AnnotatedElementUtils.findMergedAnnotation(method, type)?.let { return it }
+        method.findMergedAnnotationOrNull<A>()?.let { return it }
 
         val targetClass = AopUtils.getTargetClass(target)
         if (targetClass == method.declaringClass) return null  // 동일 클래스면 추가 lookup 불필요
@@ -36,6 +39,6 @@ object AnnotationLookup {
             targetClass.getMethod(method.name, *method.parameterTypes)
         }.getOrNull() ?: return null
 
-        return AnnotatedElementUtils.findMergedAnnotation(targetMethod, type)
+        return targetMethod.findMergedAnnotationOrNull<A>()
     }
 }

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessor.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessor.kt
@@ -4,6 +4,8 @@ import io.bluetape4k.leader.annotation.LeaderElection
 import io.bluetape4k.leader.annotation.LeaderGroupElection
 import io.bluetape4k.leader.spring.aop.spel.SpelExpressionEvaluator
 import io.bluetape4k.leader.spring.aop.util.DurationParser
+import io.bluetape4k.leader.spring.aop.util.findMergedAnnotationOrNull
+import io.bluetape4k.leader.spring.aop.util.hasMergedAnnotation
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireGe
@@ -74,8 +76,7 @@ class LeaderAnnotationValidatorBeanPostProcessor(
         if (targetClass.`package`?.name?.startsWith("org.springframework") == true) return null
 
         val annotated = targetClass.declaredMethods.filter { method ->
-            AnnotatedElementUtils.hasAnnotation(method, LeaderElection::class.java) ||
-                AnnotatedElementUtils.hasAnnotation(method, LeaderGroupElection::class.java)
+            method.hasMergedAnnotation<LeaderElection>() || method.hasMergedAnnotation<LeaderGroupElection>()
         }
         if (annotated.isEmpty()) return null
         return targetClass to annotated
@@ -101,19 +102,19 @@ class LeaderAnnotationValidatorBeanPostProcessor(
         }
 
         // [#84] composed 어노테이션(@AliasFor) 지원 — findMergedAnnotation 으로 합성 어노테이션 속성 해석
-        AnnotatedElementUtils.findMergedAnnotation(method, LeaderElection::class.java)?.let { leader ->
-            validateMinLeaseTime(leader.leaseTime, leader.minLeaseTime, "leader")
-        }
+        val leaderAnn = method.findMergedAnnotationOrNull<LeaderElection>()
+        val groupAnn = method.findMergedAnnotationOrNull<LeaderGroupElection>()
 
-        AnnotatedElementUtils.findMergedAnnotation(method, LeaderGroupElection::class.java)?.let { group ->
+        leaderAnn?.let { validateMinLeaseTime(it.leaseTime, it.minLeaseTime, "leader") }
+        groupAnn?.let {
             // maxLeaders <= 1 은 strict 무관 항상 fail
-            group.maxLeaders.requireGe(2, "group.maxLeaders")
-            validateMinLeaseTime(group.leaseTime, group.minLeaseTime, "group")
+            it.maxLeaders.requireGe(2, "group.maxLeaders")
+            validateMinLeaseTime(it.leaseTime, it.minLeaseTime, "group")
         }
 
         // SpEL pre-parse — 실패 시 strict 무관 항상 fail (잘못된 표현식은 startup 즉시 노출)
-        AnnotatedElementUtils.findMergedAnnotation(method, LeaderElection::class.java)?.let { spel.preParse(it.name, method) }
-        AnnotatedElementUtils.findMergedAnnotation(method, LeaderGroupElection::class.java)?.let { spel.preParse(it.name, method) }
+        leaderAnn?.let { spel.preParse(it.name, method) }
+        groupAnn?.let { spel.preParse(it.name, method) }
 
         if (violations.isEmpty()) return
 

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessor.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessor.kt
@@ -93,6 +93,12 @@ class LeaderAnnotationValidatorBeanPostProcessor(
         ) {
             violations += "$returnTypeName 반환 타입 (미지원 — Mono는 #91 이후 지원, Flux/Flow 미지원)"
         }
+        // [#79 R12] CompletableFuture / Future / ListenableFuture / Deferred 차단
+        //   aspect 가 sync 분기로 처리 → action 종료 (= release) 가 future 완료 전 발생 → split-brain 위험
+        if (isUnsupportedFutureReturn(method.returnType)) {
+            violations += "$returnTypeName 반환 타입 (Future / CompletableFuture / ListenableFuture / Deferred — v1 미지원, " +
+                "lock release 가 future 완료 전 발생 → split-brain 위험)"
+        }
 
         // [#84] composed 어노테이션(@AliasFor) 지원 — findMergedAnnotation 으로 합성 어노테이션 속성 해석
         AnnotatedElementUtils.findMergedAnnotation(method, LeaderElection::class.java)?.let { leader ->
@@ -129,6 +135,31 @@ class LeaderAnnotationValidatorBeanPostProcessor(
         require(minLeaseTime.compareTo(leaseTime) <= 0) {
             "$prefix.minLeaseTime must not exceed $prefix.leaseTime: minLeaseTime=$minLeaseTime, leaseTime=$leaseTime"
         }
+    }
+
+    /**
+     * Future / CompletableFuture / ListenableFuture / Deferred 반환 타입 검출 (R12).
+     *
+     * - `java.util.concurrent.Future` 와 sub-type (CompletableFuture 포함)
+     * - `com.google.common.util.concurrent.ListenableFuture` (Guava optional — classNotFound 시 silent skip)
+     * - `kotlinx.coroutines.Deferred`
+     *
+     * aspect 가 sync 분기로 처리 시 action 종료 시점에 lock release → future 완료 전 release 발생.
+     */
+    private fun isUnsupportedFutureReturn(returnType: Class<*>): Boolean {
+        // java.util.concurrent.Future 와 그 sub-types (CompletableFuture 등)
+        if (java.util.concurrent.Future::class.java.isAssignableFrom(returnType)) return true
+        // kotlinx.coroutines.Deferred
+        if (returnType.name == "kotlinx.coroutines.Deferred") return true
+        // Guava ListenableFuture — optional dependency, Class.forName 으로 safe check
+        return runCatching {
+            val listenableFutureClass = Class.forName(
+                "com.google.common.util.concurrent.ListenableFuture",
+                false,
+                returnType.classLoader,
+            )
+            listenableFutureClass.isAssignableFrom(returnType)
+        }.getOrElse { false }
     }
 
     companion object: KLogging()

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectCaptureInvariantTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectCaptureInvariantTest.kt
@@ -1,0 +1,148 @@
+package io.bluetape4k.leader.spring.aop
+
+import io.bluetape4k.leader.AopScopeAccess
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.LeaderElectorFactory
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.annotation.LeaderElection
+import io.bluetape4k.leader.spring.aop.internal.CaptureInvariantException
+import io.bluetape4k.leader.spring.aop.properties.LeaderAopProperties
+import io.bluetape4k.leader.spring.aop.spel.SpelExpressionEvaluator
+import io.bluetape4k.leader.spring.aop.util.LockNameValidator
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.reflect.MethodSignature
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [CaptureInvariantException] 타입 계약 및 AopScopeAccess.pollCapture() 동작 검증.
+ *
+ * ## 검증 항목
+ * - [CaptureInvariantException] 은 [IllegalStateException] 서브타입 (SPI 계약)
+ * - [AopScopeAccess.pollCapture] 는 set 없으면 null 반환 (single elector 정상 동작)
+ * - [AopScopeAccess.pollCapture] 는 set 후 한 번만 값 반환 (poll semantics — idempotent)
+ * - single elector action body 에서 pollCapture() == null 은 CaptureInvariantException 으로
+ *   이어지지 않아야 함 (single elector 는 CaptureScope 미사용 → null 이 정상)
+ *
+ * Note: group elector 전용 capture invariant 위반 시나리오는 T15 (LeaderGroupElectionAspect) 에서 검증.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderElectionAspectCaptureInvariantTest {
+
+    companion object {
+        private const val SAMPLE_RESULT = "ok"
+    }
+
+    // ── CaptureInvariantException 타입 계약 ──
+
+    @Test
+    fun `CaptureInvariantException 은 IllegalStateException 서브타입`() {
+        val ex = CaptureInvariantException("test message")
+        assert(ex is IllegalStateException) { "CaptureInvariantException must extend IllegalStateException" }
+        ex.message shouldBeEqualTo "test message"
+    }
+
+    @Test
+    fun `CaptureInvariantException throw 시 IllegalStateException 으로 catch 가능`() {
+        assertFailsWith<IllegalStateException> {
+            throw CaptureInvariantException("invariant violated")
+        }
+    }
+
+    // ── AopScopeAccess.pollCapture() 동작 ──
+
+    @Test
+    fun `pollCapture - set 없으면 null 반환 (single elector 정상)`() {
+        val result = AopScopeAccess.pollCapture()
+        assert(result == null) { "pollCapture without set must return null" }
+    }
+
+    @Test
+    fun `pollCapture - poll 은 exactly-once semantics — 두 번째 호출은 null`() {
+        val syntheticReal = AopScopeAccess.createSyntheticReal("test-lock", "testFactory")
+        // Simulate set via LeaderLockHandleCapture (done via elector CaptureScope in production)
+        // Here we test poll() idempotency by calling twice without set
+        val first = AopScopeAccess.pollCapture()
+        val second = AopScopeAccess.pollCapture()
+        assert(first == null) { "first poll without set must be null" }
+        assert(second == null) { "second poll must also be null" }
+        // Synthetic handle is valid
+        assert(syntheticReal.lockName == "test-lock")
+    }
+
+    // ── Single elector action body: pollCapture null 은 CaptureInvariantException 미발생 ──
+
+    private interface SampleService {
+        fun run(): String?
+    }
+
+    private class SampleServiceImpl : SampleService {
+        @LeaderElection(name = "capture-test-job")
+        override fun run(): String? = SAMPLE_RESULT
+    }
+
+    private val election: LeaderElector = mockk(relaxed = true)
+    private val factoryMock: LeaderElectorFactory = mockk()
+    private val beanSelector: LeaderBeanSelector = mockk()
+    private val signature: MethodSignature = mockk()
+    private val pjp: ProceedingJoinPoint = mockk()
+
+    @BeforeEach
+    fun setUp() {
+        clearMocks(election, factoryMock, beanSelector, signature, pjp)
+    }
+
+    private fun configureJoinPoint(method: java.lang.reflect.Method, target: Any) {
+        every { signature.method } returns method
+        every { pjp.signature } returns signature
+        every { pjp.target } returns target
+        every { pjp.args } returns emptyArray()
+        every { pjp.proceed() } returns SAMPLE_RESULT
+    }
+
+    private fun newAspect(): LeaderElectionAspect {
+        every { factoryMock.create(any()) } returns election
+        every { beanSelector.selectElectionFactory(any(), any()) } returns
+            LeaderBeanSelector.Selected("testFactory", factoryMock)
+        return LeaderElectionAspect(
+            beanSelector = beanSelector,
+            props = LeaderAopProperties(),
+            spel = SpelExpressionEvaluator(embeddedValueResolver = { it }, allowMethodInvocation = false),
+            lockNameValidator = LockNameValidator(prefix = ""),
+            recorders = emptyList(),
+        )
+    }
+
+    @Test
+    fun `single elector elected - pollCapture null 이어도 정상 동작 (CaptureInvariantException 미발생)`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target)
+
+        // Mock returns Elected by invoking action (single elector — does NOT call CaptureScope)
+        every { election.runIfLeaderResult<Any?>(any(), any()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            LeaderRunResult.Elected((secondArg<() -> Any?>()).invoke())
+        }
+
+        val aspect = newAspect()
+        // Must NOT throw CaptureInvariantException — single elector never sets capture
+        val result = aspect.aroundLeader(pjp)
+        result shouldBeEqualTo SAMPLE_RESULT
+    }
+
+    @Test
+    fun `createSyntheticReal - lockName 과 factoryBeanName 이 LockIdentity 에 정확히 반영`() {
+        val handle = AopScopeAccess.createSyntheticReal("my-lock", "myFactory", token = "tok123")
+        handle.lockName shouldBeEqualTo "my-lock"
+        handle.identity.factoryBeanName shouldBeEqualTo "myFactory"
+        handle.token shouldBeEqualTo "tok123"
+        handle.reentryDepth shouldBeEqualTo 0
+    }
+}

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectFailureModeTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectFailureModeTest.kt
@@ -1,0 +1,263 @@
+package io.bluetape4k.leader.spring.aop
+
+import io.bluetape4k.leader.AopScopeAccess
+import io.bluetape4k.leader.LeaderElectionException
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.LeaderElectorFactory
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.leader.annotation.LeaderAspectFailureMode
+import io.bluetape4k.leader.annotation.LeaderElection
+import io.bluetape4k.leader.metrics.LeaderAopMetricsRecorder
+import io.bluetape4k.leader.metrics.SkipReason
+import io.bluetape4k.leader.spring.aop.properties.LeaderAopProperties
+import io.bluetape4k.leader.spring.aop.spel.SpelExpressionEvaluator
+import io.bluetape4k.leader.spring.aop.util.LockNameValidator
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.reflect.MethodSignature
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * 6-cell failure mode matrix 검증:
+ *
+ * | scenario         | RETHROW          | SKIP       | FAIL_OPEN_RUN          |
+ * |------------------|------------------|------------|------------------------|
+ * | Skipped(contention) | null (기본 동작) | null       | body 실행 + 결과 반환   |
+ * | backend Exception | LeaderElectionException | null | body 실행 + 결과 반환   |
+ *
+ * 추가: FAIL_OPEN_RUN 분기에서 body 실행 시 `LockAssert.isLocked()` = false (FailOpen sentinel).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderElectionAspectFailureModeTest {
+
+    companion object {
+        private const val SAMPLE_RESULT = "ok"
+    }
+
+    // ── 테스트용 서비스 정의 ──
+
+    private interface SampleService {
+        fun runRethrow(): String?
+        fun runSkip(): String?
+        fun runFailOpen(): String?
+    }
+
+    private class SampleServiceImpl : SampleService {
+        @LeaderElection(name = "rethrow-job", failureMode = LeaderAspectFailureMode.RETHROW)
+        override fun runRethrow(): String? = SAMPLE_RESULT
+
+        @LeaderElection(name = "skip-job", failureMode = LeaderAspectFailureMode.SKIP)
+        override fun runSkip(): String? = SAMPLE_RESULT
+
+        @LeaderElection(name = "fail-open-job", failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
+        override fun runFailOpen(): String? = SAMPLE_RESULT
+    }
+
+    private val election: LeaderElector = mockk(relaxed = true)
+    private val recorder: LeaderAopMetricsRecorder = mockk(relaxed = true)
+    private val factoryMock: LeaderElectorFactory = mockk()
+    private val beanSelector: LeaderBeanSelector = mockk()
+    private val signature: MethodSignature = mockk()
+    private val pjp: ProceedingJoinPoint = mockk()
+
+    @BeforeEach
+    fun setUp() {
+        clearMocks(election, recorder, factoryMock, beanSelector, signature, pjp)
+    }
+
+    private fun configureJoinPoint(method: java.lang.reflect.Method, target: Any, args: Array<Any?> = emptyArray()) {
+        every { signature.method } returns method
+        every { pjp.signature } returns signature
+        every { pjp.target } returns target
+        every { pjp.args } returns args
+    }
+
+    private fun newAspect(recorders: List<LeaderAopMetricsRecorder> = emptyList()): LeaderElectionAspect {
+        every { factoryMock.create(any()) } returns election
+        every { beanSelector.selectElectionFactory(any(), any()) } returns
+            LeaderBeanSelector.Selected("testFactory", factoryMock)
+        return LeaderElectionAspect(
+            beanSelector = beanSelector,
+            props = LeaderAopProperties(),
+            spel = SpelExpressionEvaluator(embeddedValueResolver = { it }, allowMethodInvocation = false),
+            lockNameValidator = LockNameValidator(prefix = ""),
+            recorders = recorders,
+        )
+    }
+
+    // ── Row 1: Skipped (contention) ──
+
+    @Test
+    fun `Skipped × RETHROW - null 반환 (기본 skip-on-contention)`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("runRethrow")
+        configureJoinPoint(method, target)
+        every { election.runIfLeaderResult<Any?>(any(), any()) } returns LeaderRunResult.Skipped
+
+        val aspect = newAspect(listOf(recorder))
+        aspect.aroundLeader(pjp).shouldBeNull()
+
+        verify(exactly = 1) { recorder.onLockNotAcquired("rethrow-job", any(), SkipReason.CONTENTION) }
+    }
+
+    @Test
+    fun `Skipped × SKIP - null 반환`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("runSkip")
+        configureJoinPoint(method, target)
+        every { election.runIfLeaderResult<Any?>(any(), any()) } returns LeaderRunResult.Skipped
+
+        val aspect = newAspect(listOf(recorder))
+        aspect.aroundLeader(pjp).shouldBeNull()
+
+        verify(exactly = 1) { recorder.onLockNotAcquired("skip-job", any(), SkipReason.CONTENTION) }
+    }
+
+    @Test
+    fun `Skipped × FAIL_OPEN_RUN - body 실행 후 결과 반환 + FAIL_OPEN_FORCED 메트릭`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("runFailOpen")
+        configureJoinPoint(method, target)
+        every { pjp.proceed() } returns SAMPLE_RESULT
+        every { election.runIfLeaderResult<Any?>(any(), any()) } returns LeaderRunResult.Skipped
+
+        val aspect = newAspect(listOf(recorder))
+        val result = aspect.aroundLeader(pjp)
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        verify(exactly = 1) { recorder.onLockNotAcquired("fail-open-job", any(), SkipReason.FAIL_OPEN_FORCED) }
+        verify(exactly = 1) { recorder.onTaskStarted("fail-open-job") }
+        verify(exactly = 1) { recorder.onTaskFinished("fail-open-job", any()) }
+    }
+
+    @Test
+    fun `Skipped × FAIL_OPEN_RUN - body 실행 시 LockAssert_isLocked 는 false (FailOpen sentinel)`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("runFailOpen")
+        configureJoinPoint(method, target)
+        every { election.runIfLeaderResult<Any?>(any(), any()) } returns LeaderRunResult.Skipped
+
+        var isLockedInsideBody = true  // default true to detect if not set
+        every { pjp.proceed() } answers {
+            isLockedInsideBody = LockAssert.isLocked()
+            SAMPLE_RESULT
+        }
+
+        val aspect = newAspect()
+        aspect.aroundLeader(pjp)
+
+        isLockedInsideBody shouldBeEqualTo false  // FailOpen sentinel → not locked
+    }
+
+    // ── Row 2: backend Exception ──
+
+    @Test
+    fun `BackendError × RETHROW - LeaderElectionException wrapping + lockName 포함`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("runRethrow")
+        configureJoinPoint(method, target)
+        val backendEx = RuntimeException("redis-prod-01:6379 timeout")
+        every { election.runIfLeaderResult<Any?>(any(), any()) } throws backendEx
+
+        val aspect = newAspect(listOf(recorder))
+        val wrapped = assertFailsWith<LeaderElectionException> { aspect.aroundLeader(pjp) }
+
+        wrapped.cause shouldBeEqualTo backendEx
+        wrapped.message!!.contains("rethrow-job") shouldBeEqualTo true
+        // host info must NOT leak (R-33)
+        wrapped.message!!.contains("redis-prod-01") shouldBeEqualTo false
+
+        verify(exactly = 1) { recorder.onLockNotAcquired("rethrow-job", any(), SkipReason.BACKEND_ERROR) }
+    }
+
+    @Test
+    fun `BackendError × SKIP - null 반환 + BACKEND_ERROR 메트릭`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("runSkip")
+        configureJoinPoint(method, target)
+        val backendEx = RuntimeException("backend down")
+        every { election.runIfLeaderResult<Any?>(any(), any()) } throws backendEx
+
+        val aspect = newAspect(listOf(recorder))
+        aspect.aroundLeader(pjp).shouldBeNull()
+
+        verify(exactly = 1) { recorder.onLockNotAcquired("skip-job", any(), SkipReason.BACKEND_ERROR) }
+    }
+
+    @Test
+    fun `BackendError × FAIL_OPEN_RUN - body 실행 후 결과 반환 + FAIL_OPEN_FORCED 메트릭`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("runFailOpen")
+        configureJoinPoint(method, target)
+        every { pjp.proceed() } returns SAMPLE_RESULT
+        val backendEx = RuntimeException("redis down")
+        every { election.runIfLeaderResult<Any?>(any(), any()) } throws backendEx
+
+        val aspect = newAspect(listOf(recorder))
+        val result = aspect.aroundLeader(pjp)
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        verify(exactly = 1) { recorder.onLockNotAcquired("fail-open-job", any(), SkipReason.FAIL_OPEN_FORCED) }
+        verify(exactly = 1) { recorder.onTaskStarted("fail-open-job") }
+        verify(exactly = 1) { recorder.onTaskFinished("fail-open-job", any()) }
+    }
+
+    @Test
+    fun `BackendError × FAIL_OPEN_RUN - body throw 는 그대로 전파`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("runFailOpen")
+        configureJoinPoint(method, target)
+        val bodyEx = IllegalStateException("body failure in fail-open")
+        every { pjp.proceed() } throws bodyEx
+        every { election.runIfLeaderResult<Any?>(any(), any()) } throws RuntimeException("backend error")
+
+        val aspect = newAspect()
+        val ex = assertFailsWith<IllegalStateException> { aspect.aroundLeader(pjp) }
+        ex shouldBeEqualTo bodyEx
+    }
+
+    @Test
+    fun `BackendError × FAIL_OPEN_RUN - body 실행 시 LockAssert_isLocked 는 false (FailOpen sentinel)`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("runFailOpen")
+        configureJoinPoint(method, target)
+        every { election.runIfLeaderResult<Any?>(any(), any()) } throws RuntimeException("backend down")
+
+        var isLockedInsideBody = true
+        every { pjp.proceed() } answers {
+            isLockedInsideBody = LockAssert.isLocked()
+            SAMPLE_RESULT
+        }
+
+        val aspect = newAspect()
+        aspect.aroundLeader(pjp)
+
+        isLockedInsideBody shouldBeEqualTo false
+    }
+
+    // ── FailOpen scope handle cleanup ──
+
+    @Test
+    fun `FAIL_OPEN_RUN scope 종료 후 LockStateHolder 정리 - 다음 호출에 영향 없음`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("runFailOpen")
+        configureJoinPoint(method, target)
+        every { pjp.proceed() } returns SAMPLE_RESULT
+        every { election.runIfLeaderResult<Any?>(any(), any()) } returns LeaderRunResult.Skipped
+
+        val aspect = newAspect()
+        aspect.aroundLeader(pjp)  // first call — FAIL_OPEN_RUN body executed
+
+        // After the call, LockStateHolder must be clean
+        AopScopeAccess.peekSyncMatching("fail-open-job").shouldBeNull()
+    }
+}

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectReentrantTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectReentrantTest.kt
@@ -1,0 +1,173 @@
+package io.bluetape4k.leader.spring.aop
+
+import io.bluetape4k.leader.AopScopeAccess
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.LeaderElectorFactory
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.annotation.LeaderElection
+import io.bluetape4k.leader.spring.aop.properties.LeaderAopProperties
+import io.bluetape4k.leader.spring.aop.spel.SpelExpressionEvaluator
+import io.bluetape4k.leader.spring.aop.util.LockNameValidator
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.reflect.MethodSignature
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * AC-2: `@LeaderElection` reentrant — 동일 lockName 이미 보유 중이면 backend acquire 미호출.
+ *
+ * AopScopeAccess.withPushedSync + createSyntheticReal 로 "outer scope already holds the lock" 시뮬레이션.
+ *
+ * 검증:
+ * - reentrant path: `election.runIfLeaderResult` 호출 0회 (backend acquire counter = 0)
+ * - body 정상 실행 + 반환값 전달
+ * - fail-open sentinel(FailOpen) 을 push 한 경우: outer scope 가 FailOpen → reentrant short-circuit 미적용 (Real 만 passthrough)
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderElectionAspectReentrantTest {
+
+    companion object {
+        private const val LOCK_NAME = "reentrant-job"
+        private const val FACTORY_BEAN = "testFactory"
+        private const val SAMPLE_RESULT = "body-result"
+    }
+
+    private interface SampleService {
+        fun run(): String?
+    }
+
+    private class SampleServiceImpl : SampleService {
+        @LeaderElection(name = LOCK_NAME)
+        override fun run(): String? = SAMPLE_RESULT
+    }
+
+    private val election: LeaderElector = mockk(relaxed = true)
+    private val factoryMock: LeaderElectorFactory = mockk()
+    private val beanSelector: LeaderBeanSelector = mockk()
+    private val signature: MethodSignature = mockk()
+    private val pjp: ProceedingJoinPoint = mockk()
+
+    @BeforeEach
+    fun setUp() {
+        clearMocks(election, factoryMock, beanSelector, signature, pjp)
+    }
+
+    private fun configureJoinPoint(method: java.lang.reflect.Method, target: Any) {
+        every { signature.method } returns method
+        every { pjp.signature } returns signature
+        every { pjp.target } returns target
+        every { pjp.args } returns emptyArray()
+        every { pjp.proceed() } returns SAMPLE_RESULT
+    }
+
+    private fun newAspect(): LeaderElectionAspect {
+        every { factoryMock.create(any<LeaderElectionOptions>()) } returns election
+        every { beanSelector.selectElectionFactory(any(), any()) } returns
+            LeaderBeanSelector.Selected(FACTORY_BEAN, factoryMock)
+        return LeaderElectionAspect(
+            beanSelector = beanSelector,
+            props = LeaderAopProperties(),
+            spel = SpelExpressionEvaluator(embeddedValueResolver = { it }, allowMethodInvocation = false),
+            lockNameValidator = LockNameValidator(prefix = ""),
+            recorders = emptyList(),
+        )
+    }
+
+    @Test
+    fun `reentrant - 동일 lockName Real handle 보유 중이면 backend acquire 미호출 (AC-2)`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target)
+        val aspect = newAspect()
+
+        // Simulate outer scope: push a Real handle for the same lockName
+        val syntheticHandle = AopScopeAccess.createSyntheticReal(LOCK_NAME, FACTORY_BEAN)
+        val result = AopScopeAccess.withPushedSync(syntheticHandle) {
+            // inner call: aspect should short-circuit without calling backend
+            aspect.aroundLeader(pjp)
+        }
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        // The elector's runIfLeaderResult must NOT be called (reentrant short-circuit)
+        verify(exactly = 0) { election.runIfLeaderResult<Any?>(any(), any()) }
+    }
+
+    @Test
+    fun `reentrant - 동일 lockName Real handle 없으면 backend acquire 정상 호출`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target)
+        val aspect = newAspect()
+
+        every { election.runIfLeaderResult<Any?>(any(), any()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            LeaderRunResult.Elected((secondArg<() -> Any?>()).invoke())
+        }
+
+        // No outer scope — normal path
+        val result = aspect.aroundLeader(pjp)
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        // Backend is called exactly once
+        verify(exactly = 1) { election.runIfLeaderResult<Any?>(any(), any()) }
+    }
+
+    @Test
+    fun `reentrant - FailOpen sentinel 보유 중이면 reentrant short-circuit 미적용 (FailOpen 은 Real 아님)`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target)
+        val aspect = newAspect()
+
+        every { election.runIfLeaderResult<Any?>(any(), any()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            LeaderRunResult.Elected((secondArg<() -> Any?>()).invoke())
+        }
+
+        // Simulate outer scope with FailOpen sentinel (not Real)
+        val identity = io.bluetape4k.leader.LockIdentity(
+            lockName = LOCK_NAME,
+            kind = io.bluetape4k.leader.LockIdentity.AnnotationKind.SINGLE,
+            factoryBeanName = FACTORY_BEAN,
+        )
+        val failOpen = AopScopeAccess.createFailOpen(identity)
+        val result = AopScopeAccess.withPushedSync(failOpen) {
+            // FailOpen in stack — Real check fails → backend IS called
+            aspect.aroundLeader(pjp)
+        }
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        // Backend IS called: FailOpen does not count as reentrant Real
+        verify(exactly = 1) { election.runIfLeaderResult<Any?>(any(), any()) }
+    }
+
+    @Test
+    fun `reentrant - 다른 lockName Real handle 보유 시 reentrant short-circuit 미적용`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target)
+        val aspect = newAspect()
+
+        every { election.runIfLeaderResult<Any?>(any(), any()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            LeaderRunResult.Elected((secondArg<() -> Any?>()).invoke())
+        }
+
+        // Push a handle for a DIFFERENT lockName
+        val otherHandle = AopScopeAccess.createSyntheticReal("other-job", FACTORY_BEAN)
+        val result = AopScopeAccess.withPushedSync(otherHandle) {
+            aspect.aroundLeader(pjp)
+        }
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        // Backend IS called: lockName mismatch
+        verify(exactly = 1) { election.runIfLeaderResult<Any?>(any(), any()) }
+    }
+}

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectReentrantTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectReentrantTest.kt
@@ -1,0 +1,172 @@
+package io.bluetape4k.leader.spring.aop
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.leader.AopScopeAccess
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderGroupElector
+import io.bluetape4k.leader.LeaderGroupElectorFactory
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.annotation.LeaderGroupElection
+import io.bluetape4k.leader.spring.aop.properties.LeaderAopProperties
+import io.bluetape4k.leader.spring.aop.spel.SpelExpressionEvaluator
+import io.bluetape4k.leader.spring.aop.util.LockNameValidator
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.reflect.MethodSignature
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * AC-2 (group): `@LeaderGroupElection` reentrant — 동일 lockName Real handle 보유 시 backend acquire 미호출.
+ *
+ * [LeaderElectionAspectReentrantTest] 의 group 변형. Group aspect 도 sync 분기에서 동일 패턴 적용.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderGroupElectionAspectReentrantTest {
+
+    companion object {
+        private const val LOCK_NAME = "group-reentrant-job"
+        private const val FACTORY_BEAN = "testGroupFactory"
+        private const val SAMPLE_RESULT = "group-body-result"
+        private const val MAX_LEADERS = 2
+    }
+
+    private interface GroupService {
+        fun run(): String?
+    }
+
+    private class GroupServiceImpl : GroupService {
+        @LeaderGroupElection(name = LOCK_NAME, maxLeaders = MAX_LEADERS)
+        override fun run(): String? = SAMPLE_RESULT
+    }
+
+    private val election: LeaderGroupElector = mockk(relaxed = true)
+    private val factoryMock: LeaderGroupElectorFactory = mockk()
+    private val beanSelector: LeaderBeanSelector = mockk()
+    private val signature: MethodSignature = mockk()
+    private val pjp: ProceedingJoinPoint = mockk()
+
+    @BeforeEach
+    fun setUp() {
+        clearMocks(election, factoryMock, beanSelector, signature, pjp)
+    }
+
+    private fun configureJoinPoint(method: java.lang.reflect.Method, target: Any) {
+        every { signature.method } returns method
+        every { pjp.signature } returns signature
+        every { pjp.target } returns target
+        every { pjp.args } returns emptyArray()
+        every { pjp.proceed() } returns SAMPLE_RESULT
+    }
+
+    private fun newAspect(): LeaderGroupElectionAspect {
+        every { factoryMock.create(any<LeaderGroupElectionOptions>()) } returns election
+        every { beanSelector.selectGroupElectionFactory(any(), any()) } returns
+            LeaderBeanSelector.Selected(FACTORY_BEAN, factoryMock)
+        return LeaderGroupElectionAspect(
+            beanSelector = beanSelector,
+            props = LeaderAopProperties(),
+            spel = SpelExpressionEvaluator(embeddedValueResolver = { it }, allowMethodInvocation = false),
+            lockNameValidator = LockNameValidator(prefix = ""),
+            recorders = emptyList(),
+        )
+    }
+
+    @Test
+    fun `group reentrant - 동일 lockName Real handle 보유 중이면 backend acquire 미호출 (AC-2)`() {
+        val target = GroupServiceImpl()
+        val method = GroupService::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target)
+        val aspect = newAspect()
+
+        // Simulate outer scope — group Real handle 같은 lockName
+        val syntheticHandle = AopScopeAccess.createSyntheticGroupReal(
+            lockName = LOCK_NAME,
+            factoryBeanName = FACTORY_BEAN,
+            maxLeaders = MAX_LEADERS,
+        )
+
+        val result = AopScopeAccess.withPushedSync(syntheticHandle) {
+            aspect.aroundLeader(pjp)
+        }
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        verify(exactly = 0) { election.runIfLeaderResult<Any?>(any(), any()) }
+    }
+
+    @Test
+    fun `group reentrant - 동일 lockName Real handle 없으면 backend acquire 정상 호출`() {
+        val target = GroupServiceImpl()
+        val method = GroupService::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target)
+        val aspect = newAspect()
+
+        every { election.runIfLeaderResult<Any?>(any(), any()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            LeaderRunResult.Elected((secondArg<() -> Any?>()).invoke())
+        }
+
+        val result = aspect.aroundLeader(pjp)
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        verify(exactly = 1) { election.runIfLeaderResult<Any?>(any(), any()) }
+    }
+
+    @Test
+    fun `group reentrant - FailOpen sentinel 은 Real 아님 → backend acquire 정상 호출`() {
+        val target = GroupServiceImpl()
+        val method = GroupService::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target)
+        val aspect = newAspect()
+
+        every { election.runIfLeaderResult<Any?>(any(), any()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            LeaderRunResult.Elected((secondArg<() -> Any?>()).invoke())
+        }
+
+        val identity = LockIdentity(
+            lockName = LOCK_NAME,
+            kind = LockIdentity.AnnotationKind.GROUP,
+            factoryBeanName = FACTORY_BEAN,
+            groupParams = LockIdentity.GroupParams(maxLeaders = MAX_LEADERS),
+        )
+        val failOpen = AopScopeAccess.createFailOpen(identity)
+        val result = AopScopeAccess.withPushedSync(failOpen) {
+            aspect.aroundLeader(pjp)
+        }
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        verify(exactly = 1) { election.runIfLeaderResult<Any?>(any(), any()) }
+    }
+
+    @Test
+    fun `group reentrant - 다른 lockName Real handle 보유 시 backend acquire 호출`() {
+        val target = GroupServiceImpl()
+        val method = GroupService::class.java.getDeclaredMethod("run")
+        configureJoinPoint(method, target)
+        val aspect = newAspect()
+
+        every { election.runIfLeaderResult<Any?>(any(), any()) } answers {
+            @Suppress("UNCHECKED_CAST")
+            LeaderRunResult.Elected((secondArg<() -> Any?>()).invoke())
+        }
+
+        // 다른 lockName 의 Real handle — same group factory
+        val otherHandle = AopScopeAccess.createSyntheticGroupReal(
+            lockName = "other-group-job",
+            factoryBeanName = FACTORY_BEAN,
+            maxLeaders = MAX_LEADERS,
+        )
+        val result = AopScopeAccess.withPushedSync(otherHandle) {
+            aspect.aroundLeader(pjp)
+        }
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        verify(exactly = 1) { election.runIfLeaderResult<Any?>(any(), any()) }
+    }
+}

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessorTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessorTest.kt
@@ -182,6 +182,52 @@ class LeaderAnnotationValidatorBeanPostProcessorTest {
         assertFailsWith<IllegalStateException> { bpp.postProcessAfterInitialization(SampleFlow(), "sample") }
     }
 
+    // ── #79 R12: Future / CompletableFuture / Deferred 차단 ──
+
+    @Test
+    fun `CompletableFuture 반환 타입 strict true - startup fail (R12)`() {
+        class SampleFuture {
+            @LeaderElection(name = "future-job")
+            open fun process(): java.util.concurrent.CompletableFuture<String> =
+                java.util.concurrent.CompletableFuture.completedFuture("ok")
+        }
+        val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = true, spel = spel)
+        assertFailsWith<IllegalStateException> { bpp.postProcessAfterInitialization(SampleFuture(), "sample") }
+    }
+
+    @Test
+    fun `Future 반환 타입 strict true - startup fail (R12)`() {
+        class SampleFuture {
+            @LeaderElection(name = "future-job")
+            open fun process(): java.util.concurrent.Future<String> =
+                java.util.concurrent.CompletableFuture.completedFuture("ok")
+        }
+        val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = true, spel = spel)
+        assertFailsWith<IllegalStateException> { bpp.postProcessAfterInitialization(SampleFuture(), "sample") }
+    }
+
+    @Test
+    fun `Deferred 반환 타입 strict true - startup fail (R12)`() {
+        class SampleDeferred {
+            @LeaderElection(name = "deferred-job")
+            open fun process(): kotlinx.coroutines.Deferred<String> =
+                kotlinx.coroutines.CompletableDeferred("ok")
+        }
+        val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = true, spel = spel)
+        assertFailsWith<IllegalStateException> { bpp.postProcessAfterInitialization(SampleDeferred(), "sample") }
+    }
+
+    @Test
+    fun `CompletableFuture 반환 타입 strict false - WARN 만 (throw 안 함)`() {
+        class SampleFuture {
+            @LeaderElection(name = "future-job")
+            open fun process(): java.util.concurrent.CompletableFuture<String> =
+                java.util.concurrent.CompletableFuture.completedFuture("ok")
+        }
+        val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = false, spel = spel)
+        assertNotFails { bpp.postProcessAfterInitialization(SampleFuture(), "sample") }
+    }
+
     @Test
     fun `@Aspect 클래스 - skip (검증 대상 아님)`() {
         @Aspect


### PR DESCRIPTION
## Summary

Closes #79

PR #178의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat(leader-core/leader-spring-boot): #79 PR 1 Core — LockExtender / LockAssert + reentrant + 명시적 lease 연장`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 개요

ShedLock 의 \`LockAssert\` / \`LockExtender\` 등가 API 도입 + reentrant \`@LeaderElection\` + 명시적 lease 연장.

본 PR 은 issue #79 의 **PR 1 Core** — \`leader-core\` SPI/sealed types + \`leader-spring-boot\` AOP 통합. backend 별 구현은 후속 PR 2~9 분리 (#173/#174/#175/#176/#177 follow-up 도 별도).

closes #79 의 Core scope (T1~T6/T6b + T14~T16 + T18~T19).

## 변경 사항

### leader-core 신규 public surface

- **\`LockAssert\`** — \`assertLocked()\` / \`assertLocked(lockName)\` / \`isLocked()\` 그리고 suspend 변형
- **\`LockExtender\`** — \`extendActiveLock(Duration): Boolean\` + Java \`java.time.Duration\` overload + \`extendActiveLockDetailed(...): ExtendOutcome\` + suspend 변형
- **\`LeaderLockHandle\`** sealed (\`Real\` / \`FailOpen\`) — \`internal constructor\` + companion factory
- **\`LockIdentity\`** — \`(lockName, kind, factoryBeanName, groupParams)\` 4-tuple. \`equals/hashCode\` 에서 \`factoryBeanName\` 제외 — sync ↔ suspend nested 호출 시에도 reentrant 정확 (Step 3-P R3)
- **\`ExtendOutcome\`** sealed — \`Extended(observedExpireAt)\` / \`NotHeld\` / \`WrongThread\` / \`BackendError(Exception)\`
- **\`LockHandleElement\`** — \`CoroutineContext.Element\` (internal handle, public Key)
- **\`BackendErrorClassifier\`** SPI + \`CoreBackendErrorClassifier\` + \`CompositeBackendErrorClassifier\` — backend module 의존성 역전
- **\`ExtendDelegate\`** interface (public SPI) + \`lastExtendDeadline: AtomicReference<Instant>\` — Step 3-P R2 watchdog skip
- **\`AopScopeAccess\`** — \`leader-spring-boot\` aspect bridge
- **\`runIfLeaderResultSuspend\`** default fun on \`SuspendLeaderElector\` / \`SuspendLeaderGroupElector\` (\`-jvm-default=enable\` binary-compat)
- **\`LeaderLeaseAutoExtender.start(delegate)\`** 신규 시그니처. 기존 \`(Duration) -> Boolean\` \`@Deprecated\`.

### leader-spring-boot 통합

- \`LeaderElectionAspect\` / \`LeaderGroupElectionAspect\` — sync / **COROUTINES** / **REACTIVE** 3-branch (rename: SUSPEND→COROUTINES, MONO→REACTIVE)
  - Reentrant peek (Real handle + matchesIdentity) + sentinel push (FAIL_OPEN_RUN)
  - \`proceedProtected\` helper — body exception 보호 (sync/suspend/Mono 모두)
  - \`BodyThrownMarker\` + \`CaptureInvariantException\` — body / capture / backend exception 분리
  - \`outer catch (Exception)\` (Throwable 아님 — OOM/SOE/LinkageError 차단)
- \`AdviceMetadata\` — \`annotationKind\` explicit + \`resolveLockIdentity(branch)\`
- \`LeaderAnnotationValidatorBeanPostProcessor\` — \`CompletableFuture\` / \`Future\` / \`ListenableFuture\` / \`kotlinx.coroutines.Deferred\` 반환 차단 (R12)
- Kotlin reified annotation idiom (\`findMergedAnnotationOrNull<A>()\` / \`hasMergedAnnotation<A>()\`) 신규

### Local backend 통합

- sync / suspend / group / suspend-group — \`CaptureScope\` + \`LeaderLockHandle\` + \`ExtendDelegate\` 통합
- \`LocalLeaderStateRegistry.extendSingle\` / \`extendGroup\` 신규
- 4 abstract contract base (sync/suspend/group/suspend-group) + Local 4 concrete subclass

## Spec / Plan / Review 누적

- **Step 2-R Spec review**: 8 round Codex + 4 perspective — 117 finding 적용 후 architectural 수렴
- **Step 3-R Plan review**: 5 round Codex — 10 finding 적용 수렴
- **Step 3-P Pre-Implementation Prediction**: 5 persona (Architect / Security / Performance / Reliability / Devil's Advocate) — top 5 risks mitigation 반영
- **Step 6-R Code Review Gate**: Tier 1~8 + 5 round 수렴 — 17 finding 적용 + 5 follow-up issue 등록 (#173~#177)

## Tests

**722 tests passing** (leader-core 521 + leader-spring-boot 201). \`./gradlew :leader-core:build :leader-spring-boot:build\` BUILD SUCCESSFUL.

## Acceptance Criteria (AC-1 ~ AC-25)

- AC-1 capability matrix: Local 4-cell (sync / suspend / group / suspend-group) ✅. Backend 7개 (Lettuce / Redisson / Mongo / JDBC / R2DBC / Hazelcast / ZK) 는 PR 2~8.
- AC-2/2b reentrant counter 0 + cross-kind dedupe 차단 ✅
- AC-3 \`LockAssert.assertLocked\` outside scope \`IllegalStateException\` ✅
- AC-4/4b failure mode matrix (Skipped/Exception × RETHROW/SKIP/FAIL_OPEN_RUN) ✅
- AC-5 sync/suspend/Mono × 2 API ✅
- AC-9 README Mermaid sequenceDiagram ✅
- AC-10 KDoc public surface ✅
- AC-11 detekt zero new HIGH/CRITICAL ✅
- AC-13 \`./gradlew build -x test\` 통과 ✅
- AC-14 validator CompletableFuture 차단 ✅
- AC-15 \`extendDelegate\` reference 동일성 (Local) ✅
- AC-19 Java Duration overload ✅
- AC-22 CTW weave smoke test ✅
- AC-25 default fun \`-jvm-default=enable\` binary-compat ✅

AC-6 (concurrent stress test), AC-22b (leader-ktor smoke), AC-23 (per-module ref test), AC-24 (backend classifier) — backend PR 2~9.

## Follow-up Issues

- #173 LeaderLeaseAutoExtender graceful shutdown (P1)
- #174 watchdog thread pool size env-tunable (P1)
- #175 CaptureScope suspend ThreadLocal dispatcher hop leak (P2)
- #176 AC-6 concurrent stress test (P2)
- #177 LeaderElectionAspect shadowed val polish (P3)

## 다음 PR (분할 전략)

PR 2 Lettuce → PR 3 Redisson → PR 4 Mongo → PR 5 JDBC → PR 6 R2DBC → PR 7 Hazelcast → PR 8 ZK → PR 9 leader-ktor smoke.

## 검증

\`\`\`bash
./gradlew :leader-core:test :leader-spring-boot:test --no-daemon
./gradlew :leader-core:build :leader-spring-boot:build -x test --no-daemon
./gradlew detekt --no-daemon
\`\`\`
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #79, milestone `0.1.0`, assignee `debop`
- PR: #178, head `a20cb66c8efe9bce4cbf249a087d56ddf134a251`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
