### PR TITLE
feat(leader-exposed-jdbc): #79 PR 5 T10 Exposed JDBC backend — R6 guard + ExtendDelegate + capture

### DIFF
--- a/leader-exposed-jdbc/build.gradle.kts
+++ b/leader-exposed-jdbc/build.gradle.kts
@@ -32,4 +32,7 @@ dependencies {
     testImplementation(libs.testcontainers.junit.jupiter)
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.testcontainers.mysql)
+
+    // T10 PR 5 — Abstract*ContractTest 사용 (Issue #79)
+    testImplementation(testFixtures(project(":leader-core")))
 }

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElector.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElector.kt
@@ -1,12 +1,19 @@
 package io.bluetape4k.leader.exposed.jdbc
 
+import io.bluetape4k.leader.AopScopeAccess
 import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.exposed.jdbc.internal.ExposedJdbcBackendErrorClassifier
+import io.bluetape4k.leader.exposed.jdbc.internal.ExposedJdbcLockExtendDelegate
 import io.bluetape4k.leader.exposed.jdbc.lock.ExposedJdbcLock
 import kotlinx.coroutines.CancellationException
 import io.bluetape4k.leader.exposed.jdbc.lock.ExposedJdbcSchemaInitializer
 import io.bluetape4k.leader.exposed.jdbc.lock.validateExposedLockName
 import io.bluetape4k.leader.exposed.tables.HistoryStatus
 import io.bluetape4k.leader.exposed.tables.LeaderLockHistoryTable
+import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
@@ -59,6 +66,9 @@ class ExposedJdbcLeaderElector private constructor(
 
     companion object : KLogging() {
 
+        internal const val EXPOSED_JDBC_FACTORY_BEAN_NAME = "exposed-jdbc-leader-elector"
+        internal val ERROR_CLASSIFIER = CompositeBackendErrorClassifier(ExposedJdbcBackendErrorClassifier)
+
         /**
          * [ExposedJdbcLeaderElector] 인스턴스를 생성합니다.
          *
@@ -103,11 +113,32 @@ class ExposedJdbcLeaderElector private constructor(
         val historyId = recordAcquired(lockName, lock.token)
         val startedAt = Instant.now()
         val acquiredAtNanos = System.nanoTime()
+
+        // T10 PR 5 (Issue #79) — ExtendDelegate / handle / watchdog 단일 reference 공유 (AC-15).
+        val delegate = ExposedJdbcLockExtendDelegate(lock)
+        val identity = LockIdentity(
+            lockName = lockName,
+            kind = LockIdentity.AnnotationKind.SINGLE,
+            factoryBeanName = EXPOSED_JDBC_FACTORY_BEAN_NAME,
+        )
+        val handle = LeaderLockHandle.real(
+            identity = identity,
+            token = lock.token,
+            acquiredAtNanos = acquiredAtNanos,
+            extendDelegate = delegate,
+        )
+        val watchdog = LeaderLeaseAutoExtender.start(
+            options.leaderOptions.autoExtend,
+            options.leaderOptions.leaseTime,
+            delegate,
+            ERROR_CLASSIFIER,
+        )
+
         var actionSucceeded = false
         var actionFailed = false
 
         try {
-            val result = action()
+            val result = AopScopeAccess.withPushedSync(handle) { action() }
             actionSucceeded = true
             return result
         } catch (e: CancellationException) {
@@ -117,6 +148,7 @@ class ExposedJdbcLeaderElector private constructor(
             actionFailed = true
             throw e
         } finally {
+            watchdog.close()
             when {
                 actionSucceeded -> recordCompleted(historyId, lock.token, startedAt)
                 actionFailed -> recordFailed(historyId, lock.token, startedAt)
@@ -167,9 +199,18 @@ class ExposedJdbcLeaderElector private constructor(
                     val historyId = recordAcquired(lockName, lock.token)
                     val startedAt = Instant.now()
                     val acquiredAtNanos = System.nanoTime()
+                    // T10 PR 5: async path 도 sync path 와 동일하게 watchdog/delegate 등록 (split-brain 방지)
+                    val delegate = ExposedJdbcLockExtendDelegate(lock)
+                    val watchdog = LeaderLeaseAutoExtender.start(
+                        options.leaderOptions.autoExtend,
+                        options.leaderOptions.leaseTime,
+                        delegate,
+                        ERROR_CLASSIFIER,
+                    )
 
                     val actionFuture = runCatching { action() }
                         .getOrElse { e ->
+                            watchdog.close()
                             recordFailed(historyId, lock.token, startedAt)
                             runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos) }
                                 .onFailure { ex -> log.warn(ex) { "락 해제 실패 (action 오류 경로). lockName=$lockName" } }
@@ -177,6 +218,7 @@ class ExposedJdbcLeaderElector private constructor(
                         }
 
                     actionFuture.whenCompleteAsync({ _, throwable ->
+                        watchdog.close()
                         when {
                             throwable == null -> recordCompleted(historyId, lock.token, startedAt)
                             // CompletableFuture.cancel 또는 코루틴 취소: FAILED 미기록 (취소이므로)

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElector.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElector.kt
@@ -1,13 +1,20 @@
 package io.bluetape4k.leader.exposed.jdbc
 
+import io.bluetape4k.leader.AopScopeAccess
 import io.bluetape4k.leader.LeaderGroupElector
 import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.exposed.jdbc.internal.ExposedJdbcBackendErrorClassifier
+import io.bluetape4k.leader.exposed.jdbc.internal.ExposedJdbcSlotExtendDelegate
 import io.bluetape4k.leader.exposed.jdbc.lock.ExposedJdbcGroupLock
 import io.bluetape4k.leader.exposed.jdbc.lock.ExposedJdbcSchemaInitializer
 import io.bluetape4k.leader.exposed.jdbc.lock.validateExposedLockName
 import io.bluetape4k.leader.exposed.tables.HistoryStatus
 import io.bluetape4k.leader.exposed.tables.LeaderGroupLockTable
 import io.bluetape4k.leader.exposed.tables.LeaderLockHistoryTable
+import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
@@ -65,6 +72,9 @@ class ExposedJdbcLeaderGroupElector private constructor(
 ) : LeaderGroupElector {
 
     companion object : KLogging() {
+
+        internal const val EXPOSED_JDBC_GROUP_FACTORY_BEAN_NAME = "exposed-jdbc-leader-group-elector"
+        internal val ERROR_CLASSIFIER = CompositeBackendErrorClassifier(ExposedJdbcBackendErrorClassifier)
 
         /**
          * [ExposedJdbcLeaderGroupElector] 인스턴스를 생성합니다.
@@ -170,11 +180,37 @@ class ExposedJdbcLeaderGroupElector private constructor(
             val historyId = recordAcquired(lockName, lock.token, slot)
             val startedAt = Instant.now()
             val acquiredAtNanos = System.nanoTime()
+
+            // T10 PR 5 (Issue #79) — per-slot ExtendDelegate / handle / watchdog 단일 reference 공유 (AC-15).
+            val delegate = ExposedJdbcSlotExtendDelegate(lock)
+            val identity = LockIdentity(
+                lockName = lockName,
+                kind = LockIdentity.AnnotationKind.GROUP,
+                factoryBeanName = EXPOSED_JDBC_GROUP_FACTORY_BEAN_NAME,
+                groupParams = LockIdentity.GroupParams(maxLeaders),
+            )
+            val handle = LeaderLockHandle.real(
+                identity = identity,
+                token = lock.token,
+                acquiredAtNanos = acquiredAtNanos,
+                slotId = slot.toString(),
+                extendDelegate = delegate,
+            )
+            // Group elector: autoExtend 옵션 부재 — caller 가 LockExtender 로 명시적 연장. watchdog disabled.
+            val watchdog = LeaderLeaseAutoExtender.start(false, leaseTime, delegate, ERROR_CLASSIFIER)
+
             var actionSucceeded = false
             var actionFailed = false
 
             try {
-                val result = action()
+                val result = AopScopeAccess.withPushedSync(handle) {
+                    AopScopeAccess.setCapture(handle)
+                    try {
+                        action()
+                    } finally {
+                        AopScopeAccess.clearCapture()
+                    }
+                }
                 actionSucceeded = true
                 return result
             } catch (e: CancellationException) {
@@ -183,6 +219,7 @@ class ExposedJdbcLeaderGroupElector private constructor(
                 actionFailed = true
                 throw e
             } finally {
+                watchdog.close()
                 when {
                     actionSucceeded -> recordCompleted(historyId, lock.token, startedAt, slot)
                     actionFailed -> recordFailed(historyId, lock.token, startedAt, slot)
@@ -246,9 +283,19 @@ class ExposedJdbcLeaderGroupElector private constructor(
                 val historyId = recordAcquired(lockName, lock.token, slot)
                 val startedAt = Instant.now()
                 val acquiredAtNanos = System.nanoTime()
+                // T10 PR 5: async path 도 sync path 와 동일하게 watchdog/delegate 등록 (split-brain 방지)
+                // Group elector: autoExtend 옵션 부재 — caller 가 LockExtender 로 명시적 연장. watchdog disabled.
+                val delegate = ExposedJdbcSlotExtendDelegate(lock)
+                val watchdog = LeaderLeaseAutoExtender.start(
+                    false,
+                    options.leaderGroupOptions.leaseTime,
+                    delegate,
+                    ERROR_CLASSIFIER,
+                )
 
                 val actionFuture = runCatching { action() }
                     .getOrElse { e ->
+                        watchdog.close()
                         recordFailed(historyId, lock.token, startedAt, slot)
                         runCatching { lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos) }
                             .onFailure { ex -> log.warn(ex) { "슬롯 해제 실패 (action 오류 경로). slot=$slot" } }
@@ -256,6 +303,7 @@ class ExposedJdbcLeaderGroupElector private constructor(
                     }
 
                 actionFuture.whenCompleteAsync({ _, throwable ->
+                    watchdog.close()
                     when {
                         throwable == null -> recordCompleted(historyId, lock.token, startedAt, slot)
                         // 취소(코루틴/CompletableFuture)는 FAILED로 기록하지 않음

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/internal/ExposedJdbcBackendErrorClassifier.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/internal/ExposedJdbcBackendErrorClassifier.kt
@@ -1,0 +1,58 @@
+package io.bluetape4k.leader.exposed.jdbc.internal
+
+import io.bluetape4k.leader.internal.BackendErrorClassifier
+import io.bluetape4k.leader.internal.BackendErrorKind
+import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
+import java.sql.SQLException
+import java.sql.SQLNonTransientException
+import java.sql.SQLRecoverableException
+import java.sql.SQLTransientException
+
+/**
+ * Exposed JDBC backend exception 분류 — T10 PR 5 (Issue #79).
+ *
+ * ## 동작/계약
+ * - [SQLTransientException] / [SQLRecoverableException] → [BackendErrorKind.TRANSIENT]
+ *   (재시도 가능 — 네트워크 일시 단절 / connection reset 등)
+ * - [SQLNonTransientException] → [BackendErrorKind.NON_TRANSIENT]
+ *   (영구 오류 — constraint violation, syntax error 등)
+ * - [ExposedSQLException] / [SQLException] → SQLState 기반 분류:
+ *     * `08xxx` (connection exception) → [BackendErrorKind.TRANSIENT]
+ *     * `40001` (serialization failure / deadlock) → [BackendErrorKind.TRANSIENT]
+ *     * 그 외 → [BackendErrorKind.NON_TRANSIENT]
+ * - 그 외 → `null` (분류 불가 — chain 다음 classifier 에 위임)
+ *
+ * ## 사용
+ * elector 가 [io.bluetape4k.leader.internal.CompositeBackendErrorClassifier] 에 chain 으로 등록.
+ *
+ * ```kotlin
+ * val classifier = CompositeBackendErrorClassifier(ExposedJdbcBackendErrorClassifier)
+ * ```
+ *
+ * ## 주의 사항
+ * Exposed 1.2.0 은 driver 의 [SQLException] 을 [ExposedSQLException] 으로 wrap 합니다.
+ * [ExposedSQLException] 은 [SQLException] 을 상속하므로 `getSQLState()` 가 cause 의 sqlState 를 그대로 노출합니다.
+ */
+internal object ExposedJdbcBackendErrorClassifier : BackendErrorClassifier {
+
+    /** SQLState class 08 — connection exception (RFC: connection lost / failure). */
+    private const val SQL_STATE_CONNECTION_PREFIX = "08"
+
+    /** SQLState 40001 — serialization failure / deadlock retry. */
+    private const val SQL_STATE_SERIALIZATION_FAILURE = "40001"
+
+    override fun classify(cause: Throwable): BackendErrorKind? = when (cause) {
+        is SQLTransientException -> BackendErrorKind.TRANSIENT
+        is SQLRecoverableException -> BackendErrorKind.TRANSIENT
+        is SQLNonTransientException -> BackendErrorKind.NON_TRANSIENT
+        is SQLException -> classifyBySqlState(cause.sqlState)  // ExposedSQLException 도 SQLException 상속
+        else -> null
+    }
+
+    private fun classifyBySqlState(sqlState: String?): BackendErrorKind = when {
+        sqlState.isNullOrBlank() -> BackendErrorKind.NON_TRANSIENT
+        sqlState.startsWith(SQL_STATE_CONNECTION_PREFIX) -> BackendErrorKind.TRANSIENT
+        sqlState == SQL_STATE_SERIALIZATION_FAILURE -> BackendErrorKind.TRANSIENT
+        else -> BackendErrorKind.NON_TRANSIENT
+    }
+}

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/internal/ExposedJdbcLockExtendDelegate.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/internal/ExposedJdbcLockExtendDelegate.kt
@@ -1,0 +1,72 @@
+package io.bluetape4k.leader.exposed.jdbc.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.exposed.jdbc.lock.ExposedJdbcLock
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
+
+/**
+ * [ExposedJdbcLock] (sync, blocking JDBC) 용 [ExtendDelegate] — T10 PR 5 (Issue #79).
+ *
+ * ## 동작/계약
+ * - [extend] : `lock.extendDetailed(d)` 결과를 그대로 반환. backend exception 은
+ *   [ExtendOutcome.BackendError] 로 wrap — 이후 classifier 가 TRANSIENT/NON_TRANSIENT 분류.
+ * - [extendSuspend] : JDBC 는 blocking IO 이므로 `withContext(Dispatchers.IO)` + `ensureActive()`
+ *   로 wrap (R9 / AC-21).
+ * - [isHeld] : `lock.isHeldByCurrentInstance()` 위임 (예외는 false 반환).
+ * - [lastExtendDeadline] : `AtomicReference(Instant.EPOCH)` 단일 인스턴스 보관 — R2 watchdog skip 용.
+ *
+ * Token-based 락이므로 thread 종속성 없음 (Exposed JDBC 는 [ExtendOutcome.WrongThread] 사용 안 함).
+ */
+internal class ExposedJdbcLockExtendDelegate(
+    private val lock: ExposedJdbcLock,
+) : ExtendDelegate {
+
+    companion object : KLogging()
+
+    private val _lastExtendDeadline = AtomicReference(Instant.EPOCH)
+    override val lastExtendDeadline: AtomicReference<Instant> get() = _lastExtendDeadline
+
+    override fun extend(lockAtMostFor: Duration): ExtendOutcome =
+        try {
+            lock.extendDetailed(lockAtMostFor)
+        } catch (e: Exception) {
+            log.warn(e) { "Exposed JDBC extend failed. lockName=${lock.lockName}" }
+            ExtendOutcome.BackendError(e)
+        }
+
+    /**
+     * JDBC 는 blocking — `withContext(Dispatchers.IO)` 로 dispatch.
+     *
+     * **runCatching {} 사용 금지** — suspend 안에서 [CancellationException] 을 삼킬 수 있음.
+     * 수동 try/catch + `catch(CancellationException) { throw e }` 사용.
+     */
+    override suspend fun extendSuspend(lockAtMostFor: Duration): ExtendOutcome = withContext(Dispatchers.IO) {
+        coroutineContext.ensureActive()
+        try {
+            lock.extendDetailed(lockAtMostFor)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "Exposed JDBC extendSuspend failed. lockName=${lock.lockName}" }
+            ExtendOutcome.BackendError(e)
+        }
+    }
+
+    override fun isHeld(): Boolean =
+        try {
+            lock.isHeldByCurrentInstance()
+        } catch (e: Exception) {
+            log.warn(e) { "Exposed JDBC isHeld failed. lockName=${lock.lockName}" }
+            false
+        }
+}

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/internal/ExposedJdbcSlotExtendDelegate.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/internal/ExposedJdbcSlotExtendDelegate.kt
@@ -1,0 +1,62 @@
+package io.bluetape4k.leader.exposed.jdbc.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.exposed.jdbc.lock.ExposedJdbcGroupLock
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
+
+/**
+ * Exposed JDBC group elector 의 per-slot [ExposedJdbcGroupLock] (`(lockName, slot)`) 용 [ExtendDelegate]
+ * — T10 PR 5 (Issue #79).
+ *
+ * ## 동작/계약
+ * - [extend] : `slotLock.extendDetailed(d)` 위임. R6 guard (`lockedUntil > now`) 적용.
+ * - [extendSuspend] : JDBC 는 blocking — `withContext(Dispatchers.IO)` + `ensureActive()` (R9 / AC-21).
+ * - [isHeld] : `slotLock.isHeldByCurrentInstance()` 위임.
+ */
+internal class ExposedJdbcSlotExtendDelegate(
+    private val slotLock: ExposedJdbcGroupLock,
+) : ExtendDelegate {
+
+    companion object : KLogging()
+
+    private val _lastExtendDeadline = AtomicReference(Instant.EPOCH)
+    override val lastExtendDeadline: AtomicReference<Instant> get() = _lastExtendDeadline
+
+    override fun extend(lockAtMostFor: Duration): ExtendOutcome =
+        try {
+            slotLock.extendDetailed(lockAtMostFor)
+        } catch (e: Exception) {
+            log.warn(e) { "Exposed JDBC group extend failed. lockName=${slotLock.lockName}, slot=${slotLock.slot}" }
+            ExtendOutcome.BackendError(e)
+        }
+
+    override suspend fun extendSuspend(lockAtMostFor: Duration): ExtendOutcome = withContext(Dispatchers.IO) {
+        coroutineContext.ensureActive()
+        try {
+            slotLock.extendDetailed(lockAtMostFor)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "Exposed JDBC group extendSuspend failed. lockName=${slotLock.lockName}, slot=${slotLock.slot}" }
+            ExtendOutcome.BackendError(e)
+        }
+    }
+
+    override fun isHeld(): Boolean =
+        try {
+            slotLock.isHeldByCurrentInstance()
+        } catch (e: Exception) {
+            log.warn(e) { "Exposed JDBC group isHeld failed. lockName=${slotLock.lockName}, slot=${slotLock.slot}" }
+            false
+        }
+}

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLock.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLock.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.exposed.jdbc.lock
 
 import io.bluetape4k.codec.Base58
+import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.remainingMinLeaseTime
 import io.bluetape4k.leader.exposed.retry.RetryStrategy
 import io.bluetape4k.support.requireZeroOrPositiveNumber
@@ -222,6 +223,65 @@ internal class ExposedJdbcGroupLock internal constructor(
             }
         }.onFailure { e ->
             log.warn(e) { "그룹 슬롯 해제 중 DB 오류: lockName=$lockName, slot=$slot" }
+        }
+    }
+
+    /**
+     * 슬롯 락의 `lockedUntil` 을 [leaseTime] 만큼 연장합니다.
+     *
+     * @deprecated [extendDetailed] 사용 권장 — R6 guard 적용 + [ExtendOutcome] 반환.
+     */
+    @Deprecated(
+        message = "Use extendDetailed(leaseTime) for R6 guard (lockedUntil > now) and ExtendOutcome result.",
+        replaceWith = ReplaceWith("extendDetailed(leaseTime).isExtended"),
+    )
+    fun extend(leaseTime: Duration): Boolean = extendDetailed(leaseTime).isExtended
+
+    /**
+     * 슬롯 락의 `lockedUntil` 을 [leaseTime] 만큼 atomic 하게 연장하고 [ExtendOutcome] 을 반환합니다.
+     *
+     * ## R6 guard (Issue #79 PR 5)
+     * `WHERE` 절에 `lockedUntil > now()` 를 추가하여 만료된 행을 다른 인스턴스가 재획득한 race 에서
+     * stale token 으로 expired row 를 revival 시키는 split-brain 을 차단합니다.
+     *
+     * ## SQL
+     * ```sql
+     * UPDATE leader_group_lock
+     * SET locked_until = ? -- now + leaseTime
+     * WHERE lock_name = ? AND slot = ? AND token = ? AND locked_until > ?  -- now
+     * ```
+     *
+     * ## 반환
+     * - `affectedRows == 1` → [ExtendOutcome.Extended] (`observedExpireAt = now + leaseTime`)
+     * - `affectedRows == 0` → [ExtendOutcome.NotHeld] (토큰 불일치 / lease 만료 / takeover)
+     * - DB 예외는 caller (delegate) 가 [ExtendOutcome.BackendError] 로 wrap — 본 함수는 그대로 throw
+     *
+     * Token-based 락이므로 [ExtendOutcome.WrongThread] 는 발생하지 않습니다.
+     */
+    fun extendDetailed(leaseTime: Duration): ExtendOutcome {
+        val lockNameVal = this@ExposedJdbcGroupLock.lockName
+        val slotVal = this@ExposedJdbcGroupLock.slot
+        val tokenVal = this@ExposedJdbcGroupLock.token
+
+        return transaction(db) {
+            val now = Instant.now()
+            val newLockedUntil = now.plusMillis(leaseTime.inWholeMilliseconds)
+            val updated = LeaderGroupLockTable.update(
+                where = {
+                    (LeaderGroupLockTable.lockName eq lockNameVal) and
+                        (LeaderGroupLockTable.slot eq slotVal) and
+                        (LeaderGroupLockTable.token eq tokenVal) and
+                        (LeaderGroupLockTable.lockedUntil greater now)  // R6: expired row revival 차단
+                }
+            ) {
+                it[LeaderGroupLockTable.lockedUntil] = newLockedUntil
+            }
+            if (updated > 0) {
+                ExtendOutcome.Extended(newLockedUntil)
+            } else {
+                log.debug { "Exposed JDBC group extend 실패 (NotHeld): lockName=$lockName, slot=$slot" }
+                ExtendOutcome.NotHeld
+            }
         }
     }
 }

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcLock.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcLock.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.exposed.jdbc.lock
 
 import io.bluetape4k.codec.Base58
+import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.remainingMinLeaseTime
 import io.bluetape4k.leader.exposed.retry.RetryStrategy
 import io.bluetape4k.leader.exposed.tables.LeaderLockTable
@@ -207,6 +208,63 @@ internal class ExposedJdbcLock internal constructor(
             }
         }.onFailure { e ->
             log.warn(e) { "락 해제 중 DB 오류: lockName=$lockName" }
+        }
+    }
+
+    /**
+     * 락의 `lockedUntil` 을 [leaseTime] 만큼 연장합니다.
+     *
+     * @deprecated [extendDetailed] 사용 권장 — R6 guard 적용 + [ExtendOutcome] 반환.
+     */
+    @Deprecated(
+        message = "Use extendDetailed(leaseTime) for R6 guard (lockedUntil > now) and ExtendOutcome result.",
+        replaceWith = ReplaceWith("extendDetailed(leaseTime).isExtended"),
+    )
+    fun extend(leaseTime: Duration): Boolean = extendDetailed(leaseTime).isExtended
+
+    /**
+     * 락의 `lockedUntil` 을 [leaseTime] 만큼 atomic 하게 연장하고 [ExtendOutcome] 을 반환합니다.
+     *
+     * ## R6 guard (Issue #79 PR 5)
+     * `WHERE` 절에 `lockedUntil > now()` 를 추가하여 만료된 행을 다른 인스턴스가 재획득한 race 에서
+     * stale token 으로 expired row 를 revival 시키는 split-brain 을 차단합니다.
+     *
+     * ## SQL
+     * ```sql
+     * UPDATE leader_lock
+     * SET locked_until = ? -- now + leaseTime
+     * WHERE lock_name = ? AND token = ? AND locked_until > ?  -- now
+     * ```
+     *
+     * ## 반환
+     * - `affectedRows == 1` → [ExtendOutcome.Extended] (`observedExpireAt = now + leaseTime`)
+     * - `affectedRows == 0` → [ExtendOutcome.NotHeld] (토큰 불일치 / lease 만료 / takeover)
+     * - DB 예외는 caller (delegate) 가 [ExtendOutcome.BackendError] 로 wrap — 본 함수는 그대로 throw
+     *
+     * Token-based 락이므로 [ExtendOutcome.WrongThread] 는 발생하지 않습니다 (Virtual Thread 안전).
+     */
+    fun extendDetailed(leaseTime: Duration): ExtendOutcome {
+        val lockNameVal = this@ExposedJdbcLock.lockName
+        val tokenVal = this@ExposedJdbcLock.token
+
+        return transaction(db) {
+            val now = Instant.now()
+            val newLockedUntil = now.plusMillis(leaseTime.inWholeMilliseconds)
+            val updated = LeaderLockTable.update(
+                where = {
+                    (LeaderLockTable.lockName eq lockNameVal) and
+                        (LeaderLockTable.token eq tokenVal) and
+                        (LeaderLockTable.lockedUntil greater now)  // R6: expired row revival 차단
+                }
+            ) {
+                it[LeaderLockTable.lockedUntil] = newLockedUntil
+            }
+            if (updated > 0) {
+                ExtendOutcome.Extended(newLockedUntil)
+            } else {
+                log.debug { "Exposed JDBC extend 실패 (NotHeld): lockName=$lockName" }
+                ExtendOutcome.NotHeld
+            }
         }
     }
 }

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/contract/ExposedJdbcExtendDelegateReferenceTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/contract/ExposedJdbcExtendDelegateReferenceTest.kt
@@ -1,0 +1,118 @@
+package io.bluetape4k.leader.exposed.jdbc.contract
+
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.exposed.tests.TestDB
+import io.bluetape4k.leader.AopScopeAccess
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.leader.LockExtender
+import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderElector
+import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderGroupElectionOptions
+import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderGroupElector
+import io.bluetape4k.leader.exposed.jdbc.lock.ExposedJdbcSchemaInitializer
+import io.bluetape4k.logging.KLogging
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * AC-15 / AC-23 검증 — `handle.extendDelegate` 가 elector 가 생성한 watchdog delegate 와
+ * **동일 reference** 인지 확인합니다 (T10 PR 5, Issue #79).
+ *
+ * ## 검증 방식
+ * - `internal` symbol 직접 접근 불가 → 공개 API ([LockAssert] / [LockExtender]) 를 통해 간접 검증.
+ * - body 안에서 [LockExtender.extendActiveLockDetailed] 호출 → [ExtendOutcome.Extended] 이면 handle 의 delegate 가
+ *   real backend 와 연결됨을 의미 (synthetic NoopExtendDelegate 가 아님).
+ * - capture 가 finally 에서 clear 되었음을 확인하기 위해 종료 후 `pollCapture() == null` 검사.
+ *
+ * ## 검증 케이스 (JDBC 는 sync only — suspend variants 는 R2DBC PR 6 에서 담당)
+ * - sync single ([ExposedJdbcLeaderElector])
+ * - sync group ([ExposedJdbcLeaderGroupElector])
+ *
+ * ## R6 guard 검증
+ * `extendDetailed` 가 `locked_until > now` guard 를 사용하므로 acquire 직후 (lease 미만료) 항상 Extended 가 반환됩니다.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExposedJdbcExtendDelegateReferenceTest {
+
+    companion object: KLogging() {
+        private val db: Database by lazy {
+            val testDb = TestDB.H2
+            val connection = testDb.db ?: testDb.connect()
+            ExposedJdbcSchemaInitializer.ensureSchema(connection)
+            connection
+        }
+    }
+
+    private fun randomLockName(): String = "extdelref-jdbc-${Base58.randomString(8)}"
+
+    @Test
+    fun `sync single — extendActiveLockDetailed returns Extended inside body`() {
+        val elector = ExposedJdbcLeaderElector(db)
+        val lockName = randomLockName()
+
+        var outcome: ExtendOutcome? = null
+        elector.runIfLeader(lockName) {
+            LockAssert.assertLocked()
+            outcome = LockExtender.extendActiveLockDetailed(60.seconds)
+        }
+
+        outcome.shouldBeInstanceOf<ExtendOutcome.Extended>()
+        (AopScopeAccess.pollCapture() == null).shouldBeTrue()
+    }
+
+    @Test
+    fun `sync group — extendActiveLockDetailed uses extendDetailed and Extended is returned`() {
+        val elector = ExposedJdbcLeaderGroupElector(
+            db,
+            ExposedJdbcLeaderGroupElectionOptions(
+                leaderGroupOptions = LeaderGroupElectionOptions(maxLeaders = 2),
+            ),
+        )
+        val lockName = randomLockName()
+
+        var outcome: ExtendOutcome? = null
+        elector.runIfLeader(lockName) {
+            LockAssert.assertLocked()
+            outcome = LockExtender.extendActiveLockDetailed(60.seconds)
+        }
+
+        outcome.shouldBeInstanceOf<ExtendOutcome.Extended>()
+        (AopScopeAccess.pollCapture() == null).shouldBeTrue()
+    }
+
+    @Test
+    fun `multiple sequential extends on same handle return Extended every time`() {
+        val elector = ExposedJdbcLeaderElector(db)
+        val lockName = randomLockName()
+
+        val outcomes = mutableListOf<ExtendOutcome>()
+        elector.runIfLeader(lockName) {
+            outcomes += LockExtender.extendActiveLockDetailed(30.seconds)
+            outcomes += LockExtender.extendActiveLockDetailed(45.seconds)
+            outcomes += LockExtender.extendActiveLockDetailed(60.seconds)
+        }
+
+        outcomes.forEach { it.shouldBeInstanceOf<ExtendOutcome.Extended>() }
+    }
+
+    @Test
+    fun `user explicit extend updates lastExtendDeadline (R2 mitigation reference proof)`() {
+        val elector = ExposedJdbcLeaderElector(db)
+        val lockName = randomLockName()
+
+        var preExtend: ExtendOutcome? = null
+        var postExtend: ExtendOutcome? = null
+        elector.runIfLeader(lockName) {
+            preExtend = LockExtender.extendActiveLockDetailed(120.seconds)
+            postExtend = LockExtender.extendActiveLockDetailed(60.seconds)
+        }
+
+        preExtend.shouldBeInstanceOf<ExtendOutcome.Extended>()
+        postExtend.shouldBeInstanceOf<ExtendOutcome.Extended>()
+    }
+}

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/contract/ExposedJdbcGroupLockExtenderContractTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/contract/ExposedJdbcGroupLockExtenderContractTest.kt
@@ -1,0 +1,38 @@
+package io.bluetape4k.leader.exposed.jdbc.contract
+
+import io.bluetape4k.exposed.tests.TestDB
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderGroupElector
+import io.bluetape4k.leader.contract.AbstractGroupLockExtenderContractTest
+import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderGroupElectionOptions
+import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderGroupElector
+import io.bluetape4k.leader.exposed.jdbc.lock.ExposedJdbcSchemaInitializer
+import io.bluetape4k.logging.KLogging
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [AbstractGroupLockExtenderContractTest] 의 Exposed JDBC backend 구현 — T10 PR 5 (Issue #79).
+ *
+ * `maxLeaders = 2` 로 기본 설정. per-slot row 의 R6 guard (`locked_until > now`) 적용된 extendDetailed 사용.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExposedJdbcGroupLockExtenderContractTest: AbstractGroupLockExtenderContractTest() {
+
+    companion object: KLogging() {
+        private val db: Database by lazy {
+            val testDb = TestDB.H2
+            val connection = testDb.db ?: testDb.connect()
+            ExposedJdbcSchemaInitializer.ensureSchema(connection)
+            connection
+        }
+    }
+
+    override val elector: LeaderGroupElector =
+        ExposedJdbcLeaderGroupElector(
+            db,
+            ExposedJdbcLeaderGroupElectionOptions(
+                leaderGroupOptions = LeaderGroupElectionOptions(maxLeaders = 2),
+            ),
+        )
+}

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/contract/ExposedJdbcLockExtenderContractTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/contract/ExposedJdbcLockExtenderContractTest.kt
@@ -1,0 +1,32 @@
+package io.bluetape4k.leader.exposed.jdbc.contract
+
+import io.bluetape4k.exposed.tests.TestDB
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.contract.AbstractSyncLockExtenderContractTest
+import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderElector
+import io.bluetape4k.leader.exposed.jdbc.lock.ExposedJdbcSchemaInitializer
+import io.bluetape4k.logging.KLogging
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [AbstractSyncLockExtenderContractTest] 의 Exposed JDBC backend 구현 — T10 PR 5 (Issue #79).
+ *
+ * H2 in-memory DB 를 기본으로 사용 — Testcontainers 없이 빠르게 실행됩니다.
+ * 모든 DB 방언에 대한 검증은 기존 [io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderElectionTest]
+ * 가 parameterized test 로 담당합니다.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ExposedJdbcLockExtenderContractTest: AbstractSyncLockExtenderContractTest() {
+
+    companion object: KLogging() {
+        private val db: Database by lazy {
+            val testDb = TestDB.H2
+            val connection = testDb.db ?: testDb.connect()
+            ExposedJdbcSchemaInitializer.ensureSchema(connection)
+            connection
+        }
+    }
+
+    override val elector: LeaderElector = ExposedJdbcLeaderElector(db)
+}


### PR DESCRIPTION
## Summary

PR #192의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat(leader-exposed-jdbc): #79 PR 5 T10 Exposed JDBC backend — R6 guard + ExtendDelegate + capture`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

PR 5 of Issue #79 (LockExtender / LockAssert). Extends Exposed JDBC backend with `ExtendDelegate` SPI. **JDBC is sync-only** — suspend variants go to PR 6 (R2DBC).

**Sequence**: PR 1 Core ✅ → PR 2 Lettuce ✅ → PR 3 Redisson ✅ → PR 4 MongoDB ✅ → **PR 5 Exposed JDBC** (this) → PR 6 Exposed R2DBC → PR 7 Hazelcast → PR 8 ZooKeeper → PR 9 ktor smoke.

## R6 guard (load-bearing)

\`ExposedJdbcLock.extendDetailed(d)\` / \`ExposedJdbcGroupLock.extendDetailed(d)\` add \`locked_until > now()\` to the WHERE clause alongside \`{lock_name, token}\`. Atomic guard blocks expired-row revival race.

\`\`\`sql
UPDATE leader_lock
SET locked_until = ? -- now + leaseTime
WHERE lock_name = ? AND token = ? AND locked_until > ?  -- now
\`\`\`

Legacy \`extend(d): Boolean\` kept as \`@Deprecated\` wrapper.

## ExtendDelegate

| Delegate | extend (sync) | extendSuspend |
|----------|---------------|---------------|
| \`ExposedJdbcLockExtendDelegate\` (sync single) | direct | \`withContext(IO) + ensureActive()\` |
| \`ExposedJdbcSlotExtendDelegate\` (sync group) | direct (per-slot ExposedJdbcGroupLock) | \`withContext(IO) + ensureActive()\` |

\`ExtendOutcome\` emits \`Extended\` / \`NotHeld\` / \`BackendError\` only — no \`WrongThread\` (token-based, virtual thread safe).

## Elector integration

Both \`ExposedJdbcLeaderElector\` and \`ExposedJdbcLeaderGroupElector\` integrate ExtendDelegate in **BOTH sync AND async** paths. Async path watchdog wiring was caught by Tier 4 review (HIGH-1) and fixed before commit.

Single delegate reference shared between \`LeaderLockHandle.real(extendDelegate = delegate)\` and \`LeaderLeaseAutoExtender.start(..., delegate, ERROR_CLASSIFIER)\` (AC-15).

Capture pattern matches MongoDB/Redisson:
- Sync single: \`withPushedSync(handle)\`
- Sync group: \`withPushedSync + setCapture/clearCapture\` in finally
- Async paths: watchdog only (AOP scope sync/suspend-only)

Bean names: \`exposed-jdbc-leader-elector\`, \`exposed-jdbc-leader-group-elector\`.

## Backend error classifier

| Exception | Kind |
|-----------|------|
| \`SQLTransientException\` / \`SQLRecoverableException\` | TRANSIENT |
| \`SQLException\` (state 08*/40001) | TRANSIENT |
| \`SQLNonTransientException\` | NON_TRANSIENT |
| Other \`SQLException\` | NON_TRANSIENT |
| Else | null (chain) |

## Test plan

\`\`\`
LEADER_TEST_DB=H2 ./gradlew :leader-exposed-jdbc:test --no-daemon
\`\`\`

**Local result: 107/107 passing in 12.1s** (H2 in-memory).

3 new contract tests:
- \`ExposedJdbcLockExtenderContractTest\` (sync single)
- \`ExposedJdbcGroupLockExtenderContractTest\` (sync group)
- \`ExposedJdbcExtendDelegateReferenceTest\` (AC-15 / AC-23 reference identity proof — sync only)

H2 used for fast contract verification. Multi-dialect (H2 / PostgreSQL / MySQL) continues via existing parameterized \`ExposedJdbcLeader*Test\` tests in CI.

## Code review

- **Tier 4 initial review** (opus): HIGH-1 found — \`runAsyncIfLeader\` lacked watchdog/delegate wiring → would cause split-brain if \`autoExtend=true\` with long-running async action
- **Fix applied**: added \`ExposedJdbc*ExtendDelegate\` + \`LeaderLeaseAutoExtender.start\` to both async methods; \`watchdog.close()\` in both error and completion paths
- **Re-review**: CRITICAL=0, HIGH=0 → APPROVE

Refs #79
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #192, head `c30c62d00f3cd6d67bd3a310d5360c90f4407ec2`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
