### PR TITLE
feat(leader-zookeeper): #79 PR 8 T13 ZooKeeper backend — passthrough ExtendDelegate + R16 autoExtend=false enforce

### DIFF
--- a/leader-zookeeper/build.gradle.kts
+++ b/leader-zookeeper/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
     api(project(":leader-core"))
     api(libs.curator.recipes)
 
+    testImplementation(testFixtures(project(":leader-core")))
+
     testImplementation(libs.bluetape4k.virtualthread.jdk21)
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.bluetape4k.testcontainers)

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperLeaderElector.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperLeaderElector.kt
@@ -1,8 +1,15 @@
 package io.bluetape4k.leader.zookeeper
 
 import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
+import io.bluetape4k.leader.AopScopeAccess
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
+import io.bluetape4k.leader.zookeeper.internal.ZooKeeperBackendErrorClassifier
+import io.bluetape4k.leader.zookeeper.internal.ZooKeeperLockExtendDelegate
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
@@ -21,6 +28,17 @@ import java.util.concurrent.TimeUnit
  * - 획득에 성공하면 [action]을 실행하고 `finally`에서 반드시 `release()`를 호출합니다.
  * - Curator recipe 특성상 세션이 끊기면 ZooKeeper ephemeral node가 사라져 락이 자동 해제됩니다.
  *
+ * ## ExtendDelegate 통합 (T13 PR 8 / Issue #79)
+ *
+ * - acquire 후 [ZooKeeperLockExtendDelegate] 를 생성하여 [LeaderLockHandle.Real] 와 동일 reference 공유 (AC-15).
+ * - aspect 가 `LockExtender.extendActiveLock` 호출 시 동일 delegate 를 통해 passthrough extend 반환 — Spec §6 row 12.
+ *
+ * ## R16 enforce — ZooKeeper 는 TTL 없음
+ *
+ * ZooKeeper 는 세션 기반 락 (ephemeral znode) — TTL 개념이 없습니다.
+ * 따라서 [LeaderLeaseAutoExtender.start] 는 **항상 `enabled=false`** 호출 강제 (사용자가 `options.autoExtend=true`
+ * 설정해도 무시 + WARN 로그). lease 갱신은 ZK 세션 keepalive 가 담당.
+ *
  * ```kotlin
  * val elector = ZooKeeperLeaderElector(curator)
  * val result = elector.runIfLeader("daily-job") { runJob() }
@@ -38,6 +56,8 @@ class ZooKeeperLeaderElector private constructor(
 
     companion object: KLogging() {
         const val DEFAULT_BASE_PATH = "/leader-election"
+        internal const val ZOOKEEPER_FACTORY_BEAN_NAME = "zookeeper-leader-elector"
+        internal val ERROR_CLASSIFIER = CompositeBackendErrorClassifier(ZooKeeperBackendErrorClassifier)
 
         @JvmStatic
         operator fun invoke(
@@ -70,9 +90,42 @@ class ZooKeeperLeaderElector private constructor(
         }
 
         log.debug { "ZooKeeper leader lock 획득 성공. path=$path" }
+
+        val acquiredAtNanos = System.nanoTime()
+        val delegate = ZooKeeperLockExtendDelegate(mutex, path)
+        val identity = LockIdentity(
+            lockName = lockName,
+            kind = LockIdentity.AnnotationKind.SINGLE,
+            factoryBeanName = ZOOKEEPER_FACTORY_BEAN_NAME,
+        )
+        val handle = LeaderLockHandle.real(
+            identity = identity,
+            token = lockName,
+            acquiredAtNanos = acquiredAtNanos,
+            extendDelegate = delegate,
+        )
+        // R16 enforce: ZK 는 TTL 없음 — autoExtend 강제 비활성화 (사용자 설정 무시 + WARN)
+        if (options.autoExtend) {
+            log.warn {
+                "ZooKeeper 는 TTL 이 없는 세션 기반 락 — autoExtend=true 설정이 무시됩니다. " +
+                    "ZK 세션 keepalive 가 lease 역할을 대신합니다. lockName=$lockName"
+            }
+        }
+        val watchdog = LeaderLeaseAutoExtender.start(
+            enabled = false,
+            leaseTime = options.leaseTime,
+            delegate = delegate,
+            classifier = ERROR_CLASSIFIER,
+        )
+
         return try {
-            action()
+            AopScopeAccess.withPushedSync(handle) { action() }
         } finally {
+            try {
+                watchdog.close()
+            } catch (e: Exception) {
+                log.warn(e) { "ZooKeeper watchdog close 실패. path=$path" }
+            }
             try {
                 mutex.release()
                 log.debug { "ZooKeeper leader lock 반납 완료. path=$path" }

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperLeaderGroupElector.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperLeaderGroupElector.kt
@@ -1,9 +1,16 @@
 package io.bluetape4k.leader.zookeeper
 
 import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
+import io.bluetape4k.leader.AopScopeAccess
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderGroupElector
 import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
+import io.bluetape4k.leader.zookeeper.internal.ZooKeeperBackendErrorClassifier
+import io.bluetape4k.leader.zookeeper.internal.ZooKeeperSlotExtendDelegate
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
@@ -23,6 +30,16 @@ import java.util.concurrent.TimeUnit
  * - lease 획득에 실패하면 [action]을 실행하지 않고 `null`을 반환합니다.
  * - 획득한 [Lease]는 `finally`에서 반드시 `close()`합니다.
  *
+ * ## ExtendDelegate 통합 (T13 PR 8 / Issue #79)
+ *
+ * - acquire 된 per-slot lease 에 대해 [ZooKeeperSlotExtendDelegate] 생성 — [LeaderLockHandle.Real] 와 동일 reference 공유 (AC-15).
+ * - sync group: `withPushedSync(handle)` + `setCapture(handle)` 양쪽에 push.
+ * - ZooKeeper group lease 도 TTL 이 없는 ephemeral znode 기반 — passthrough extend.
+ *
+ * ## R16 enforce
+ *
+ * [LeaderLeaseAutoExtender.start] 는 항상 `enabled=false` (group 옵션은 autoExtend 자체가 없음).
+ *
  * ```kotlin
  * val elector = ZooKeeperLeaderGroupElector(curator, LeaderGroupElectionOptions(maxLeaders = 3))
  * val result = elector.runIfLeader("batch-job") { processChunk() }
@@ -40,6 +57,8 @@ class ZooKeeperLeaderGroupElector private constructor(
 
     companion object: KLogging() {
         const val DEFAULT_BASE_PATH = "/leader-group-election"
+        internal const val ZOOKEEPER_GROUP_FACTORY_BEAN_NAME = "zookeeper-leader-group-elector"
+        internal val ERROR_CLASSIFIER = CompositeBackendErrorClassifier(ZooKeeperBackendErrorClassifier)
 
         @JvmStatic
         operator fun invoke(
@@ -54,6 +73,7 @@ class ZooKeeperLeaderGroupElector private constructor(
 
     override val maxLeaders: Int = options.maxLeaders
     private val waitTime = options.waitTime
+    private val leaseTime = options.leaseTime
 
     override fun activeCount(lockName: String): Int {
         val semaphore = semaphore(lockName)
@@ -88,9 +108,48 @@ class ZooKeeperLeaderGroupElector private constructor(
         } ?: return null
 
         log.debug { "ZooKeeper group lease 획득 성공. path=$path" }
+
+        val acquiredAtNanos = System.nanoTime()
+        val slotKey = path
+        val delegate = ZooKeeperSlotExtendDelegate(slotKey)
+        val identity = LockIdentity(
+            lockName = lockName,
+            kind = LockIdentity.AnnotationKind.GROUP,
+            factoryBeanName = ZOOKEEPER_GROUP_FACTORY_BEAN_NAME,
+            groupParams = LockIdentity.GroupParams(maxLeaders),
+        )
+        val handle = LeaderLockHandle.real(
+            identity = identity,
+            token = slotKey,
+            acquiredAtNanos = acquiredAtNanos,
+            slotId = lease.nodeName,
+            extendDelegate = delegate,
+        )
+        // R16 enforce: ZK 는 TTL 없음 — group 도 autoExtend=false (옵션 자체가 없음)
+        val watchdog = LeaderLeaseAutoExtender.start(
+            enabled = false,
+            leaseTime = leaseTime,
+            delegate = delegate,
+            classifier = ERROR_CLASSIFIER,
+        )
+
         return try {
-            action()
+            AopScopeAccess.withPushedSync(handle) {
+                AopScopeAccess.setCapture(handle)
+                try {
+                    action()
+                } finally {
+                    AopScopeAccess.clearCapture()
+                }
+            }
         } finally {
+            try {
+                watchdog.close()
+            } catch (e: Exception) {
+                log.warn(e) { "ZooKeeper group watchdog close 실패. path=$path" }
+            }
+            // delegate state 전이 (handle release 전): extend 호출 시 NotHeld 반환
+            delegate.markReleased()
             try {
                 lease.close()
                 log.debug { "ZooKeeper group lease 반납 완료. path=$path" }

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderElector.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderElector.kt
@@ -1,7 +1,14 @@
 package io.bluetape4k.leader.zookeeper
 
+import io.bluetape4k.leader.AopScopeAccess
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
+import io.bluetape4k.leader.zookeeper.internal.ZooKeeperBackendErrorClassifier
+import io.bluetape4k.leader.zookeeper.internal.ZooKeeperSuspendLockExtendDelegate
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
@@ -24,6 +31,16 @@ import java.util.concurrent.TimeUnit
  * - 취소 중에도 `withContext(NonCancellable)`에서 lock을 반납하고 [CancellationException]은 재전파합니다.
  * - [LeaderElectionOptions.leaseTime]은 ZooKeeper TTL로 쓰이지 않으며, 세션 종료/만료가 자동 해제 경계입니다.
  *
+ * ## ExtendDelegate 통합 (T13 PR 8 / Issue #79)
+ *
+ * - acquire 후 [ZooKeeperSuspendLockExtendDelegate] 를 생성하여 [LeaderLockHandle.Real] 와 동일 reference 공유 (AC-15).
+ * - aspect 의 `LockExtenderSuspend.extendActiveLockSuspend` 는 동일 delegate reference 를 사용합니다.
+ * - `withContext(AopScopeAccess.createLockHandleElement(handle))` 로 coroutineContext 에 handle 전파.
+ *
+ * ## R16 enforce — ZooKeeper 는 TTL 없음
+ *
+ * [LeaderLeaseAutoExtender.start] 는 **항상 `enabled=false`** 강제. 사용자가 `autoExtend=true` 설정 시 WARN 로그.
+ *
  * ```kotlin
  * val elector = ZooKeeperSuspendLeaderElector(curator)
  * val result = elector.runIfLeader("sync-job") { syncData() }
@@ -41,6 +58,8 @@ class ZooKeeperSuspendLeaderElector private constructor(
 
     companion object: KLoggingChannel() {
         const val DEFAULT_BASE_PATH = "/leader-election"
+        internal const val ZOOKEEPER_SUSPEND_FACTORY_BEAN_NAME = "zookeeper-suspend-leader-elector"
+        internal val ERROR_CLASSIFIER = CompositeBackendErrorClassifier(ZooKeeperBackendErrorClassifier)
 
         @JvmStatic
         operator fun invoke(
@@ -79,20 +98,56 @@ class ZooKeeperSuspendLeaderElector private constructor(
             }
 
             log.debug { "ZooKeeper suspend leader lock 획득 성공. path=$path" }
+
+            val acquiredAtNanos = System.nanoTime()
+            val delegate = ZooKeeperSuspendLockExtendDelegate(mutex, path)
+            val identity = LockIdentity(
+                lockName = lockName,
+                kind = LockIdentity.AnnotationKind.SINGLE,
+                factoryBeanName = ZOOKEEPER_SUSPEND_FACTORY_BEAN_NAME,
+            )
+            val handle = LeaderLockHandle.real(
+                identity = identity,
+                token = lockName,
+                acquiredAtNanos = acquiredAtNanos,
+                extendDelegate = delegate,
+            )
+            // R16 enforce: ZK 는 TTL 없음 — autoExtend 강제 비활성화 (사용자 설정 무시 + WARN)
+            if (options.autoExtend) {
+                log.warn {
+                    "ZooKeeper 는 TTL 이 없는 세션 기반 락 — autoExtend=true 설정이 무시됩니다. " +
+                        "ZK 세션 keepalive 가 lease 역할을 대신합니다. lockName=$lockName"
+                }
+            }
+            val watchdog = LeaderLeaseAutoExtender.start(
+                enabled = false,
+                leaseTime = options.leaseTime,
+                delegate = delegate,
+                classifier = ERROR_CLASSIFIER,
+            )
+
             try {
-                return action()
+                return withContext(AopScopeAccess.createLockHandleElement(handle)) {
+                    action()
+                }
             } finally {
-                try {
-                    withContext(NonCancellable) {
+                // NonCancellable: 코루틴 취소 시에도 watchdog close + 락 해제가 중단되지 않도록 보호
+                withContext(NonCancellable) {
+                    try {
+                        watchdog.close()
+                    } catch (e: Exception) {
+                        log.warn(e) { "ZooKeeper suspend watchdog close 실패. path=$path" }
+                    }
+                    try {
                         runInterruptible(ownerDispatcher) {
                             mutex.release()
                         }
+                        log.debug { "ZooKeeper suspend leader lock 반납 완료. path=$path" }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log.warn(e) { "ZooKeeper suspend leader lock 반납 실패. path=$path" }
                     }
-                    log.debug { "ZooKeeper suspend leader lock 반납 완료. path=$path" }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    log.warn(e) { "ZooKeeper suspend leader lock 반납 실패. path=$path" }
                 }
             }
         } finally {

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderGroupElector.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderGroupElector.kt
@@ -1,8 +1,15 @@
 package io.bluetape4k.leader.zookeeper
 
+import io.bluetape4k.leader.AopScopeAccess
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
+import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
+import io.bluetape4k.leader.zookeeper.internal.ZooKeeperBackendErrorClassifier
+import io.bluetape4k.leader.zookeeper.internal.ZooKeeperSuspendSlotExtendDelegate
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
@@ -23,6 +30,15 @@ import java.util.concurrent.TimeUnit
  * - lease 획득에 실패하면 [action]을 실행하지 않고 `null`을 반환합니다.
  * - 취소 중에도 `withContext(NonCancellable)`에서 lease를 반납하고 [CancellationException]은 재전파합니다.
  *
+ * ## ExtendDelegate 통합 (T13 PR 8 / Issue #79)
+ *
+ * - acquire 된 per-slot lease 에 [ZooKeeperSuspendSlotExtendDelegate] wrap — [LeaderLockHandle.Real] 와 동일 reference 공유 (AC-15).
+ * - suspend group: `setCapture(handle)` + `withContext(createLockHandleElement(handle))` 양쪽에 push.
+ *
+ * ## R16 enforce
+ *
+ * [LeaderLeaseAutoExtender.start] 는 항상 `enabled=false` — ZK 는 TTL 없음.
+ *
  * ```kotlin
  * val elector = ZooKeeperSuspendLeaderGroupElector(curator, LeaderGroupElectionOptions(maxLeaders = 3))
  * val result = elector.runIfLeader("batch-job") { processChunk() }
@@ -40,6 +56,8 @@ class ZooKeeperSuspendLeaderGroupElector private constructor(
 
     companion object: KLoggingChannel() {
         const val DEFAULT_BASE_PATH = "/leader-group-election"
+        internal const val ZOOKEEPER_SUSPEND_GROUP_FACTORY_BEAN_NAME = "zookeeper-suspend-leader-group-elector"
+        internal val ERROR_CLASSIFIER = CompositeBackendErrorClassifier(ZooKeeperBackendErrorClassifier)
 
         @JvmStatic
         operator fun invoke(
@@ -54,6 +72,7 @@ class ZooKeeperSuspendLeaderGroupElector private constructor(
 
     override val maxLeaders: Int = options.maxLeaders
     private val waitTime = options.waitTime
+    private val leaseTime = options.leaseTime
 
     override fun activeCount(lockName: String): Int {
         val semaphore = semaphore(lockName)
@@ -88,12 +107,53 @@ class ZooKeeperSuspendLeaderGroupElector private constructor(
         } ?: return null
 
         log.debug { "ZooKeeper suspend group lease 획득 성공. path=$path" }
+
+        val acquiredAtNanos = System.nanoTime()
+        val slotKey = path
+        val delegate = ZooKeeperSuspendSlotExtendDelegate(slotKey)
+        val identity = LockIdentity(
+            lockName = lockName,
+            kind = LockIdentity.AnnotationKind.GROUP,
+            factoryBeanName = ZOOKEEPER_SUSPEND_GROUP_FACTORY_BEAN_NAME,
+            groupParams = LockIdentity.GroupParams(maxLeaders),
+        )
+        val handle = LeaderLockHandle.real(
+            identity = identity,
+            token = slotKey,
+            acquiredAtNanos = acquiredAtNanos,
+            slotId = lease.nodeName,
+            extendDelegate = delegate,
+        )
+        // R16 enforce: ZK 는 TTL 없음 — group 도 autoExtend=false (옵션 자체가 없음)
+        val watchdog = LeaderLeaseAutoExtender.start(
+            enabled = false,
+            leaseTime = leaseTime,
+            delegate = delegate,
+            classifier = ERROR_CLASSIFIER,
+        )
+
         try {
-            return action()
+            AopScopeAccess.setCapture(handle)
+            try {
+                return withContext(AopScopeAccess.createLockHandleElement(handle)) {
+                    action()
+                }
+            } finally {
+                AopScopeAccess.clearCapture()
+            }
         } finally {
-            withContext(NonCancellable + Dispatchers.IO) {
+            // NonCancellable: 코루틴 취소 시에도 watchdog close + release 가 중단되지 않도록 보호
+            withContext(NonCancellable) {
                 try {
-                    lease.close()
+                    watchdog.close()
+                } catch (e: Exception) {
+                    log.warn(e) { "ZooKeeper suspend group watchdog close 실패. path=$path" }
+                }
+                delegate.markReleased()
+                try {
+                    withContext(Dispatchers.IO) {
+                        lease.close()
+                    }
                     log.debug { "ZooKeeper suspend group lease 반납 완료. path=$path" }
                 } catch (e: CancellationException) {
                     throw e

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperBackendErrorClassifier.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperBackendErrorClassifier.kt
@@ -1,0 +1,39 @@
+package io.bluetape4k.leader.zookeeper.internal
+
+import io.bluetape4k.leader.internal.BackendErrorClassifier
+import io.bluetape4k.leader.internal.BackendErrorKind
+import org.apache.zookeeper.KeeperException
+
+/**
+ * ZooKeeper backend exception 분류 — T13 PR 8 (Issue #79).
+ *
+ * ## 동작/계약
+ * - [KeeperException.ConnectionLossException] → [BackendErrorKind.TRANSIENT]
+ *   (네트워크 일시 단절 — 재시도 가능)
+ * - [KeeperException.OperationTimeoutException] → [BackendErrorKind.TRANSIENT]
+ *   (요청 타임아웃 — 재시도 가능)
+ * - [KeeperException.SessionExpiredException] → [BackendErrorKind.NON_TRANSIENT]
+ *   (세션 만료 — ephemeral 락 자동 해제, 복구 불가)
+ * - [KeeperException.SessionMovedException] → [BackendErrorKind.NON_TRANSIENT]
+ *   (세션 이동 — 클라이언트가 다른 server 로 연결됨, 락 상태 보장 불가)
+ * - 그 외 [KeeperException] → [BackendErrorKind.NON_TRANSIENT] (safe default)
+ * - 그 외 → `null` (분류 불가 — chain 다음 classifier 에 위임)
+ *
+ * ## 사용
+ * elector 가 [io.bluetape4k.leader.internal.CompositeBackendErrorClassifier] 에 chain 으로 등록.
+ *
+ * ## 비고 (R16)
+ * ZooKeeper 는 세션 기반 — TTL 개념이 없어 [io.bluetape4k.leader.LeaderLeaseAutoExtender] watchdog
+ * 가 비활성화되므로 backend 오류 분류는 주로 caller-driven `LockExtender.extendActiveLock` 경로에서만 사용됩니다.
+ */
+internal object ZooKeeperBackendErrorClassifier: BackendErrorClassifier {
+
+    override fun classify(cause: Throwable): BackendErrorKind? = when (cause) {
+        is KeeperException.ConnectionLossException -> BackendErrorKind.TRANSIENT
+        is KeeperException.OperationTimeoutException -> BackendErrorKind.TRANSIENT
+        is KeeperException.SessionExpiredException -> BackendErrorKind.NON_TRANSIENT
+        is KeeperException.SessionMovedException -> BackendErrorKind.NON_TRANSIENT
+        is KeeperException -> BackendErrorKind.NON_TRANSIENT
+        else -> null
+    }
+}

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperLockExtendDelegate.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperLockExtendDelegate.kt
@@ -1,0 +1,68 @@
+package io.bluetape4k.leader.zookeeper.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import org.apache.curator.framework.recipes.locks.InterProcessMutex
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+
+/**
+ * ZooKeeper [InterProcessMutex] (sync, Curator) 용 [ExtendDelegate] — T13 PR 8 (Issue #79).
+ *
+ * ## 동작/계약 (PASSTHROUGH — Spec §6 row 12)
+ *
+ * ZooKeeper 는 TTL 개념이 없는 **세션 기반 락** 입니다. [InterProcessMutex] 는 ephemeral znode 로
+ * 구현되며 ZK 세션이 살아있는 동안에만 락이 유효합니다. 따라서 `extend(d)` 는 lease 연장이 아닌
+ * **session-held liveness 확인** 의미입니다 (R3-F11).
+ *
+ * - [extend] : `mutex.isAcquiredInThisProcess()` 가 `true` 이면 [ExtendOutcome.Extended] (observedExpireAt = [Instant.MAX])
+ *   반환, `false` 이면 [ExtendOutcome.NotHeld] 반환. backend 예외는 [ExtendOutcome.BackendError] 로 wrap
+ * - [extendSuspend] : `isAcquiredInThisProcess()` 는 로컬 카운터 체크 — non-blocking. `withContext(IO)` 불필요.
+ *   CancellationException 재전파만 추가.
+ * - [isHeld] : `mutex.isAcquiredInThisProcess()` 직접 위임
+ * - [lastExtendDeadline] : `AtomicReference(Instant.EPOCH)` 단일 인스턴스 (R2 mitigation 인터페이스 정합 — ZK 에서는
+ *   watchdog 가 비활성화되어 cosmetic 이지만 [LockExtender.extendActiveLockDetailed] 가 set 호출함)
+ *
+ * Token-based 락 (session-bound) — thread 종속성 없음 (Redisson 처럼 WrongThread 사용 안 함).
+ *
+ * ## R16 enforce
+ * Elector 가 [io.bluetape4k.leader.LeaderLeaseAutoExtender.start] 호출 시 `enabled=false` 강제.
+ * 이 delegate 의 [extend] 는 user-driven `LockExtender.extendActiveLock` 경로에서만 호출됩니다.
+ */
+internal class ZooKeeperLockExtendDelegate(
+    private val mutex: InterProcessMutex,
+    private val lockKey: String,
+): ExtendDelegate {
+
+    companion object: KLogging()
+
+    private val _lastExtendDeadline = AtomicReference(Instant.EPOCH)
+    override val lastExtendDeadline: AtomicReference<Instant> get() = _lastExtendDeadline
+
+    override fun extend(lockAtMostFor: Duration): ExtendOutcome = doExtend()
+
+    /**
+     * `isAcquiredInThisProcess()` 는 Curator 의 로컬 카운터 — non-blocking. `withContext(IO)` 불필요.
+     */
+    override suspend fun extendSuspend(lockAtMostFor: Duration): ExtendOutcome = doExtend()
+
+    override fun isHeld(): Boolean =
+        try {
+            mutex.isAcquiredInThisProcess
+        } catch (e: Exception) {
+            log.warn(e) { "ZooKeeper isHeld failed. lockKey=$lockKey" }
+            false
+        }
+
+    private fun doExtend(): ExtendOutcome =
+        try {
+            if (mutex.isAcquiredInThisProcess) ExtendOutcome.Extended(Instant.MAX)
+            else ExtendOutcome.NotHeld
+        } catch (e: Exception) {
+            log.warn(e) { "ZooKeeper extend (passthrough) failed. lockKey=$lockKey" }
+            ExtendOutcome.BackendError(e)
+        }
+}

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperSlotExtendDelegate.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperSlotExtendDelegate.kt
@@ -1,0 +1,67 @@
+package io.bluetape4k.leader.zookeeper.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+
+/**
+ * ZooKeeper group elector 의 per-slot [org.apache.curator.framework.recipes.locks.Lease] 용 [ExtendDelegate]
+ * — T13 PR 8 (Issue #79).
+ *
+ * ## 동작/계약 (PASSTHROUGH — Spec §6 row 12)
+ *
+ * ZooKeeper [org.apache.curator.framework.recipes.locks.InterProcessSemaphoreV2] 의 `Lease` 는
+ * TTL 이 없는 ephemeral znode 입니다. `Lease.close()` 또는 세션 종료 시에만 반납됩니다.
+ *
+ * - [extend] / [extendSuspend] : delegate 가 살아있는 동안 (= handle 이 scope 에 push 된 동안)
+ *   [ExtendOutcome.Extended] (observedExpireAt = [Instant.MAX]) 반환. elector 가 finally 에서 [markReleased]
+ *   호출 후에는 [ExtendOutcome.NotHeld] 반환 (defensive — handle pop 후 호출되는 race 방어).
+ * - [isHeld] : [released] 상태 직접 위임. `true` = 아직 release 전.
+ *
+ * `Lease` 는 liveness query API 가 없어 elector 가 explicit 하게 [markReleased] 로 상태 전이 통지.
+ *
+ * ## R16 enforce
+ * Group elector 는 항상 `autoExtend=false` (옵션 부재) — watchdog 비활성화.
+ * 이 delegate 의 [extend] 는 user-driven `LockExtender.extendActiveLock` 경로에서만 호출됩니다.
+ */
+internal class ZooKeeperSlotExtendDelegate(
+    private val slotKey: String,
+): ExtendDelegate {
+
+    companion object: KLogging()
+
+    private val released = AtomicBoolean(false)
+
+    private val _lastExtendDeadline = AtomicReference(Instant.EPOCH)
+    override val lastExtendDeadline: AtomicReference<Instant> get() = _lastExtendDeadline
+
+    /**
+     * Elector 가 lease.close() 직전에 호출하여 delegate 를 NotHeld 상태로 전이합니다.
+     *
+     * race 방어 (handle pop 과 delegate state 동기화):
+     * - lease.close() 이후에도 user 가 보유한 handle reference 로 extend 호출 시 NotHeld 반환.
+     */
+    fun markReleased() {
+        released.set(true)
+    }
+
+    override fun extend(lockAtMostFor: Duration): ExtendOutcome = doExtend()
+
+    override suspend fun extendSuspend(lockAtMostFor: Duration): ExtendOutcome = doExtend()
+
+    override fun isHeld(): Boolean = !released.get()
+
+    private fun doExtend(): ExtendOutcome =
+        try {
+            if (released.get()) ExtendOutcome.NotHeld
+            else ExtendOutcome.Extended(Instant.MAX)
+        } catch (e: Exception) {
+            log.warn(e) { "ZooKeeper group extend (passthrough) failed. slotKey=$slotKey" }
+            ExtendOutcome.BackendError(e)
+        }
+}

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperSuspendLockExtendDelegate.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperSuspendLockExtendDelegate.kt
@@ -1,0 +1,69 @@
+package io.bluetape4k.leader.zookeeper.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.warn
+import kotlinx.coroutines.CancellationException
+import org.apache.curator.framework.recipes.locks.InterProcessMutex
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+
+/**
+ * ZooKeeper [InterProcessMutex] (suspend) 용 [ExtendDelegate] — T13 PR 8 (Issue #79).
+ *
+ * ## 동작/계약 (PASSTHROUGH — Spec §6 row 12)
+ *
+ * ZooKeeper 는 TTL 개념이 없는 **세션 기반 락** 입니다. `extend(d)` 는 lease 연장이 아닌
+ * **session-held liveness 확인** 의미입니다 (R3-F11).
+ *
+ * - [extend] / [extendSuspend] : `mutex.isAcquiredInThisProcess()` (Curator 로컬 카운터 — non-blocking)
+ *   결과에 따라 [ExtendOutcome.Extended] (observedExpireAt = [Instant.MAX]) 또는 [ExtendOutcome.NotHeld].
+ * - [extendSuspend] 는 로컬 카운터 체크이므로 `withContext(IO)` 래핑 불필요 — CancellationException 만 재전파.
+ * - [isHeld] : `isAcquiredInThisProcess` 직접 위임.
+ *
+ * Token-based 락 (session-bound) — thread 종속성 없음.
+ *
+ * ## R16 enforce
+ * Elector 가 [io.bluetape4k.leader.LeaderLeaseAutoExtender.start] 호출 시 `enabled=false` 강제.
+ */
+internal class ZooKeeperSuspendLockExtendDelegate(
+    private val mutex: InterProcessMutex,
+    private val lockKey: String,
+): ExtendDelegate {
+
+    companion object: KLoggingChannel()
+
+    private val _lastExtendDeadline = AtomicReference(Instant.EPOCH)
+    override val lastExtendDeadline: AtomicReference<Instant> get() = _lastExtendDeadline
+
+    override fun extend(lockAtMostFor: Duration): ExtendOutcome = doExtend()
+
+    override suspend fun extendSuspend(lockAtMostFor: Duration): ExtendOutcome =
+        try {
+            doExtend()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "ZooKeeperSuspend extendSuspend (passthrough) failed. lockKey=$lockKey" }
+            ExtendOutcome.BackendError(e)
+        }
+
+    override fun isHeld(): Boolean =
+        try {
+            mutex.isAcquiredInThisProcess
+        } catch (e: Exception) {
+            log.warn(e) { "ZooKeeperSuspend isHeld failed. lockKey=$lockKey" }
+            false
+        }
+
+    private fun doExtend(): ExtendOutcome =
+        try {
+            if (mutex.isAcquiredInThisProcess) ExtendOutcome.Extended(Instant.MAX)
+            else ExtendOutcome.NotHeld
+        } catch (e: Exception) {
+            log.warn(e) { "ZooKeeperSuspend extend (passthrough) failed. lockKey=$lockKey" }
+            ExtendOutcome.BackendError(e)
+        }
+}

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperSuspendSlotExtendDelegate.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperSuspendSlotExtendDelegate.kt
@@ -1,0 +1,64 @@
+package io.bluetape4k.leader.zookeeper.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.warn
+import kotlinx.coroutines.CancellationException
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+
+/**
+ * ZooKeeper suspend group elector 의 per-slot [org.apache.curator.framework.recipes.locks.Lease] 용 [ExtendDelegate]
+ * — T13 PR 8 (Issue #79).
+ *
+ * ## 동작/계약 (PASSTHROUGH — Spec §6 row 12)
+ *
+ * - [extend] / [extendSuspend] : delegate 가 살아있는 동안 [ExtendOutcome.Extended] (observedExpireAt = [Instant.MAX]) 반환.
+ *   elector 가 finally 에서 [markReleased] 호출 후에는 [ExtendOutcome.NotHeld].
+ * - [extendSuspend] 는 로컬 atomic 체크 — `withContext(IO)` 불필요.
+ * - [isHeld] : [released] 상태 직접 위임.
+ *
+ * ## R16 enforce
+ * Group elector 는 항상 `autoExtend=false` — watchdog 비활성화.
+ */
+internal class ZooKeeperSuspendSlotExtendDelegate(
+    private val slotKey: String,
+): ExtendDelegate {
+
+    companion object: KLoggingChannel()
+
+    private val released = AtomicBoolean(false)
+
+    private val _lastExtendDeadline = AtomicReference(Instant.EPOCH)
+    override val lastExtendDeadline: AtomicReference<Instant> get() = _lastExtendDeadline
+
+    fun markReleased() {
+        released.set(true)
+    }
+
+    override fun extend(lockAtMostFor: Duration): ExtendOutcome = doExtend()
+
+    override suspend fun extendSuspend(lockAtMostFor: Duration): ExtendOutcome =
+        try {
+            doExtend()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "ZooKeeperSuspend group extendSuspend (passthrough) failed. slotKey=$slotKey" }
+            ExtendOutcome.BackendError(e)
+        }
+
+    override fun isHeld(): Boolean = !released.get()
+
+    private fun doExtend(): ExtendOutcome =
+        try {
+            if (released.get()) ExtendOutcome.NotHeld
+            else ExtendOutcome.Extended(Instant.MAX)
+        } catch (e: Exception) {
+            log.warn(e) { "ZooKeeperSuspend group extend (passthrough) failed. slotKey=$slotKey" }
+            ExtendOutcome.BackendError(e)
+        }
+}

--- a/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/contract/ZooKeeperExtendDelegateReferenceTest.kt
+++ b/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/contract/ZooKeeperExtendDelegateReferenceTest.kt
@@ -1,0 +1,134 @@
+package io.bluetape4k.leader.zookeeper.contract
+
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.AopScopeAccess
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.leader.LockExtender
+import io.bluetape4k.leader.zookeeper.AbstractZooKeeperLeaderTest
+import io.bluetape4k.leader.zookeeper.ZooKeeperLeaderElector
+import io.bluetape4k.leader.zookeeper.ZooKeeperLeaderGroupElector
+import io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderElector
+import io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderGroupElector
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * AC-15 / AC-23 검증 — `handle.extendDelegate` 가 elector 가 생성한 delegate 와 **동일 reference** 인지 확인합니다
+ * (T13 PR 8, Issue #79).
+ *
+ * ## ZooKeeper PASSTHROUGH 특성 (Spec §6 row 12)
+ *
+ * ZooKeeper 는 TTL 이 없는 세션 기반 락 — `extend(d)` 는 lease 연장이 아닌 **session-held liveness 확인** 의미.
+ * 따라서 `runIfLeader` 본문 안에서 [LockExtender.extendActiveLockDetailed] 는 항상
+ * [ExtendOutcome.Extended] (observedExpireAt = [Instant.MAX]) 를 반환합니다.
+ *
+ * ## R16 enforce
+ *
+ * 모든 ZooKeeper elector 는 `LeaderLeaseAutoExtender.start(enabled=false, ...)` 강제 — watchdog 비활성화.
+ *
+ * ## 검증 케이스
+ * - sync single ([ZooKeeperLeaderElector])
+ * - suspend single ([ZooKeeperSuspendLeaderElector])
+ * - sync group ([ZooKeeperLeaderGroupElector])
+ * - suspend group ([ZooKeeperSuspendLeaderGroupElector])
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ZooKeeperExtendDelegateReferenceTest: AbstractZooKeeperLeaderTest() {
+
+    companion object: KLoggingChannel()
+
+    private fun randomLockName(): String = "extdelref-zk-${Base58.randomString(8)}"
+
+    @Test
+    fun `sync single — extendActiveLockDetailed returns Extended inside body (passthrough)`() {
+        val elector = ZooKeeperLeaderElector(curator)
+        val lockName = randomLockName()
+
+        var outcome: ExtendOutcome? = null
+        elector.runIfLeader(lockName) {
+            LockAssert.assertLocked()
+            outcome = LockExtender.extendActiveLockDetailed(60.seconds)
+        }
+
+        outcome.shouldBeInstanceOf<ExtendOutcome.Extended>()
+        // ZK passthrough: observedExpireAt = Instant.MAX (session-held semantics)
+        ((outcome as ExtendOutcome.Extended).observedExpireAt == Instant.MAX).shouldBeTrue()
+        (AopScopeAccess.pollCapture() == null).shouldBeTrue()
+    }
+
+    @Test
+    fun `suspend single — extendActiveLockDetailedSuspend returns Extended inside body (passthrough)`() = runSuspendIO {
+        val elector = ZooKeeperSuspendLeaderElector(curator)
+        val lockName = randomLockName()
+
+        var outcome: ExtendOutcome? = null
+        elector.runIfLeader(lockName) {
+            LockAssert.assertLockedSuspend()
+            outcome = LockExtender.extendActiveLockDetailedSuspend(60.seconds)
+        }
+
+        outcome.shouldBeInstanceOf<ExtendOutcome.Extended>()
+        ((outcome as ExtendOutcome.Extended).observedExpireAt == Instant.MAX).shouldBeTrue()
+    }
+
+    @Test
+    fun `sync group — extendActiveLockDetailed returns Extended inside body (passthrough)`() {
+        val elector = ZooKeeperLeaderGroupElector(
+            curator,
+            LeaderGroupElectionOptions(maxLeaders = 2),
+        )
+        val lockName = randomLockName()
+
+        var outcome: ExtendOutcome? = null
+        elector.runIfLeader(lockName) {
+            LockAssert.assertLocked()
+            outcome = LockExtender.extendActiveLockDetailed(60.seconds)
+        }
+
+        outcome.shouldBeInstanceOf<ExtendOutcome.Extended>()
+        ((outcome as ExtendOutcome.Extended).observedExpireAt == Instant.MAX).shouldBeTrue()
+        (AopScopeAccess.pollCapture() == null).shouldBeTrue()
+    }
+
+    @Test
+    fun `suspend group — extendActiveLockDetailedSuspend returns Extended inside body (passthrough)`() = runSuspendIO {
+        val elector = ZooKeeperSuspendLeaderGroupElector(
+            curator,
+            LeaderGroupElectionOptions(maxLeaders = 2),
+        )
+        val lockName = randomLockName()
+
+        var outcome: ExtendOutcome? = null
+        elector.runIfLeader(lockName) {
+            LockAssert.assertLockedSuspend()
+            outcome = LockExtender.extendActiveLockDetailedSuspend(60.seconds)
+        }
+
+        outcome.shouldBeInstanceOf<ExtendOutcome.Extended>()
+        ((outcome as ExtendOutcome.Extended).observedExpireAt == Instant.MAX).shouldBeTrue()
+        (AopScopeAccess.pollCapture() == null).shouldBeTrue()
+    }
+
+    @Test
+    fun `multiple sequential extends on same handle return Extended every time (session passthrough)`() {
+        val elector = ZooKeeperLeaderElector(curator)
+        val lockName = randomLockName()
+
+        val outcomes = mutableListOf<ExtendOutcome>()
+        elector.runIfLeader(lockName) {
+            outcomes += LockExtender.extendActiveLockDetailed(30.seconds)
+            outcomes += LockExtender.extendActiveLockDetailed(45.seconds)
+            outcomes += LockExtender.extendActiveLockDetailed(60.seconds)
+        }
+
+        outcomes.forEach { it.shouldBeInstanceOf<ExtendOutcome.Extended>() }
+    }
+}

--- a/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/contract/ZooKeeperGroupLockExtenderContractTest.kt
+++ b/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/contract/ZooKeeperGroupLockExtenderContractTest.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.leader.zookeeper.contract
+
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderGroupElector
+import io.bluetape4k.leader.contract.AbstractGroupLockExtenderContractTest
+import io.bluetape4k.leader.zookeeper.AbstractZooKeeperLeaderTest
+import io.bluetape4k.leader.zookeeper.ZooKeeperLeaderGroupElector
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [AbstractGroupLockExtenderContractTest] 의 ZooKeeper backend 구현 — T13 PR 8 (Issue #79).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ZooKeeperGroupLockExtenderContractTest: AbstractGroupLockExtenderContractTest() {
+
+    companion object: KLogging() {
+        val server = AbstractZooKeeperLeaderTest.zookeeper
+    }
+
+    override val elector: LeaderGroupElector =
+        ZooKeeperLeaderGroupElector(
+            AbstractZooKeeperLeaderTest.curator,
+            LeaderGroupElectionOptions(maxLeaders = 2),
+        )
+}

--- a/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/contract/ZooKeeperLockExtenderContractTest.kt
+++ b/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/contract/ZooKeeperLockExtenderContractTest.kt
@@ -1,0 +1,21 @@
+package io.bluetape4k.leader.zookeeper.contract
+
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.contract.AbstractSyncLockExtenderContractTest
+import io.bluetape4k.leader.zookeeper.AbstractZooKeeperLeaderTest
+import io.bluetape4k.leader.zookeeper.ZooKeeperLeaderElector
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [AbstractSyncLockExtenderContractTest] 의 ZooKeeper backend 구현 — T13 PR 8 (Issue #79).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ZooKeeperLockExtenderContractTest: AbstractSyncLockExtenderContractTest() {
+
+    companion object: KLogging() {
+        val server = AbstractZooKeeperLeaderTest.zookeeper
+    }
+
+    override val elector: LeaderElector = ZooKeeperLeaderElector(AbstractZooKeeperLeaderTest.curator)
+}

--- a/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/contract/ZooKeeperSuspendGroupLockExtenderContractTest.kt
+++ b/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/contract/ZooKeeperSuspendGroupLockExtenderContractTest.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.leader.zookeeper.contract
+
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.contract.AbstractSuspendGroupLockExtenderContractTest
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
+import io.bluetape4k.leader.zookeeper.AbstractZooKeeperLeaderTest
+import io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderGroupElector
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [AbstractSuspendGroupLockExtenderContractTest] 의 ZooKeeper backend 구현 — T13 PR 8 (Issue #79).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ZooKeeperSuspendGroupLockExtenderContractTest: AbstractSuspendGroupLockExtenderContractTest() {
+
+    companion object: KLoggingChannel() {
+        val server = AbstractZooKeeperLeaderTest.zookeeper
+    }
+
+    override val elector: SuspendLeaderGroupElector =
+        ZooKeeperSuspendLeaderGroupElector(
+            AbstractZooKeeperLeaderTest.curator,
+            LeaderGroupElectionOptions(maxLeaders = 2),
+        )
+}

--- a/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/contract/ZooKeeperSuspendLockExtenderContractTest.kt
+++ b/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/contract/ZooKeeperSuspendLockExtenderContractTest.kt
@@ -1,0 +1,22 @@
+package io.bluetape4k.leader.zookeeper.contract
+
+import io.bluetape4k.leader.contract.AbstractSuspendLockExtenderContractTest
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.leader.zookeeper.AbstractZooKeeperLeaderTest
+import io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderElector
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [AbstractSuspendLockExtenderContractTest] 의 ZooKeeper backend 구현 — T13 PR 8 (Issue #79).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ZooKeeperSuspendLockExtenderContractTest: AbstractSuspendLockExtenderContractTest() {
+
+    companion object: KLoggingChannel() {
+        val server = AbstractZooKeeperLeaderTest.zookeeper
+    }
+
+    override val elector: SuspendLeaderElector =
+        ZooKeeperSuspendLeaderElector(AbstractZooKeeperLeaderTest.curator)
+}


### PR DESCRIPTION
## Summary

PR #196의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat(leader-zookeeper): #79 PR 8 T13 ZooKeeper backend — passthrough ExtendDelegate + R16 autoExtend=false enforce`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

PR 8 of Issue #79 (LockExtender / LockAssert). Extends ZooKeeper backend with \`ExtendDelegate\` SPI integration using **passthrough semantics**.

**Sequence**: PR 1 Core ✅ → PR 2 Lettuce ✅ → PR 3 Redisson ✅ → PR 4 MongoDB ✅ → PR 5 JDBC ✅ → PR 6 R2DBC ✅ → PR 7 Hazelcast ✅ → **PR 8 ZooKeeper** (this) → PR 9 ktor smoke (last).

## Passthrough design (spec §6 row 12)

ZooKeeper has NO TTL — locks are session-bound. \`extend(d)\` is meaningless; lease lives as long as session lives. No TTL counter to refresh.

\`\`\`kotlin
fun extendDetailed(leaseTime: Duration): ExtendOutcome =
    if (mutex.isAcquiredInThisProcess()) ExtendOutcome.Extended(Instant.MAX)
    else ExtendOutcome.NotHeld
\`\`\`

\`Extended(Instant.MAX)\` = "session-held liveness" semantic. \`LockExtender.extendActiveLock\` callers get non-null Extended without backend interaction.

Token-based (via session) — NO \`WrongThread\`.

## R16 — watchdog enforced disabled

Every ZK elector hardcodes \`LeaderLeaseAutoExtender.start(enabled = false, ...)\` regardless of \`options.autoExtend\`. Single electors WARN-log on user-requested autoExtend=true. ZK doesn't need lease refresh.

## ExtendDelegate (4 — sync + suspend × single + group)

All passthrough — no actual extend call, just liveness check.

| Delegate | isHeld source |
|----------|---------------|
| \`ZooKeeperLockExtendDelegate\` (sync single) | \`InterProcessMutex.isAcquiredInThisProcess()\` (local Curator counter) |
| \`ZooKeeperSuspendLockExtendDelegate\` (suspend single) | same |
| \`ZooKeeperSlotExtendDelegate\` (sync group) | \`AtomicBoolean released\` flag (elector calls \`markReleased()\` before \`lease.close()\`) |
| \`ZooKeeperSuspendSlotExtendDelegate\` (suspend group) | same |

Curator \`Lease\` has no liveness API — explicit \`AtomicBoolean\` workaround.

\`extendSuspend()\` on sync delegate uses \`withContext(IO) + ensureActive()\` (Curator blocking). Suspend delegate's sync \`extend()\` is direct (local check, non-blocking).

## Elector integration (4 electors)

Single delegate reference shared between \`LeaderLockHandle.real(extendDelegate = delegate)\` and \`LeaderLeaseAutoExtender.start(false, ..., delegate, ERROR_CLASSIFIER)\` (AC-15).

Capture pattern matches MongoDB template (sync/suspend × single/group).

Group elector release order: \`watchdog.close() → markReleased() → lease.close()\` — flips held flag before lease close to win race with concurrent \`extendActiveLock\`.

Bean names: \`zookeeper-leader-elector\`, \`zookeeper-suspend-leader-elector\`, \`zookeeper-leader-group-elector\`, \`zookeeper-suspend-leader-group-elector\`.

## Backend error classifier

| Exception | Kind |
|-----------|------|
| \`ConnectionLossException\`, \`OperationTimeoutException\` | TRANSIENT |
| \`SessionExpiredException\`, \`SessionMovedException\` | NON_TRANSIENT |
| Other \`KeeperException\` | NON_TRANSIENT |
| Else | null (chain) |

## Test plan

\`\`\`
./gradlew :leader-zookeeper:test --no-daemon
\`\`\`

**Local result: 73/73 passing (6.3s, ZooKeeper Testcontainer)**

5 new contract tests (4 capability + 1 reference identity).

## Code review

Tier 4 (opus, code-reviewer) — CRITICAL=0, HIGH=0. **APPROVE**.

All 12 review criteria pass:
1. ✅ Passthrough semantics (\`Extended(Instant.MAX)\` / \`NotHeld\`)
2. ✅ R16 literal \`enabled = false\` + WARN
3. ✅ No \`WrongThread\` outcome
4. ✅ AC-15 ExtendDelegate reference identity
5. ✅ isHeld (Curator counter / AtomicBoolean+markReleased)
6. ✅ CancellationException rethrow
7. ✅ NonCancellable finally
8. ✅ Capture pattern
9. ✅ bluetape4k-patterns
10. ✅ Bean names exact
11. ✅ Classifier match-order
12. ✅ Idempotent close

Refs #79
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #196, head `c30be07fc26cfe8ed206fc0a42ecc628614da437`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
