### PR TITLE
feat(leader-ktor): #79 PR 9 AC-22b — LockAssert / LockExtender smoke test in leaderScheduled

### DIFF
--- a/leader-ktor/README.ko.md
+++ b/leader-ktor/README.ko.md
@@ -104,6 +104,27 @@ leaderScheduled(
 | `leaderElection`  | `SuspendLeaderElector`    | 설치된 플러그인 설정에서 조회    | 미지정 시 플러그인 설정 사용               |
 | `action`          | `suspend () -> Unit`      | —                                | 리더로 선출되었을 때만 실행                |
 
+## `leaderScheduled` 안의 LockAssert / LockExtender (Issue #79)
+
+`leaderScheduled { ... }` background action 안에서 `LockAssert.assertLockedSuspend()` 와
+`LockExtender.extendActiveLockDetailedSuspend(d)` 가 정상 동작합니다. 내부 `SuspendLeaderElector` 의
+capture 메커니즘이 `LockHandleElement` 를 action 의 `CoroutineContext` 로 전파합니다.
+
+```kotlin
+leaderScheduled("daily-report", period = 1.hours) {
+    LockAssert.assertLockedSuspend()                              // 리더일 때 통과
+    val outcome = LockExtender.extendActiveLockDetailedSuspend(10.minutes)
+    if (outcome is ExtendOutcome.Extended) {
+        runLongRunningReport()
+    }
+}
+```
+
+**미지원 시나리오**: `Application.routing` 핸들러, `PipelineContext`, 그 외 `leaderScheduled` 가 아닌
+표면 (Ktor request pipeline 등). 플러그인은 `Application.attributes` 에만 설정을 저장하며 Ktor
+routing pipeline 에 `LockHandleElement` 를 주입하지 않습니다. 보장된 전파를 위해 반드시
+`leaderScheduled` 안에서 사용하세요.
+
 ## Dependency
 
 Gradle (Kotlin DSL):

--- a/leader-ktor/README.md
+++ b/leader-ktor/README.md
@@ -108,6 +108,28 @@ leaderScheduled(
 | `leaderElection` | `SuspendLeaderElector`     | from installed plugin                | Falls back to plugin config if omitted      |
 | `action`         | `suspend () -> Unit`       | —                                    | Executed only when this node is leader      |
 
+## LockAssert / LockExtender inside `leaderScheduled` (Issue #79)
+
+`LockAssert.assertLockedSuspend()` and `LockExtender.extendActiveLockDetailedSuspend(d)`
+work inside the `leaderScheduled { ... }` background action — the underlying
+`SuspendLeaderElector`'s capture mechanism propagates `LockHandleElement` through
+the action's `CoroutineContext`.
+
+```kotlin
+leaderScheduled("daily-report", period = 1.hours) {
+    LockAssert.assertLockedSuspend()                              // passes when we are leader
+    val outcome = LockExtender.extendActiveLockDetailedSuspend(10.minutes)
+    if (outcome is ExtendOutcome.Extended) {
+        runLongRunningReport()
+    }
+}
+```
+
+**Unsupported scenarios**: `Application.routing` handlers, `PipelineContext`,
+or any non-`leaderScheduled` surface. The plugin only stores configuration in
+`Application.attributes`; `LockHandleElement` is not injected into Ktor's
+routing pipeline. Use `leaderScheduled` for guaranteed propagation.
+
 ## Dependency
 
 Gradle (Kotlin DSL):

--- a/leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/LeaderScheduledLockAssertSmokeTest.kt
+++ b/leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/LeaderScheduledLockAssertSmokeTest.kt
@@ -1,0 +1,104 @@
+package io.bluetape4k.leader.ktor
+
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.leader.LockExtender
+import io.bluetape4k.leader.redisson.RedissonSuspendLeaderElector
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.ktor.server.application.install
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.Job
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.until
+import org.awaitility.kotlin.withPollInterval
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+/**
+ * AC-22b — `leader-ktor` plugin propagation smoke test (Issue #79, T13 PR 9).
+ *
+ * ## 검증 범위
+ * `leaderScheduled { ... }` background action 안에서 [LockAssert.assertLockedSuspend] /
+ * [LockExtender.extendActiveLockDetailedSuspend] 가 [SuspendLeaderElector] 의 capture 메커니즘을
+ * 통해 정상 propagation 되는지 검증합니다. plugin 자체는 `Application.attributes` 만 사용하며
+ * `LockHandleElement` 전파는 elector 의 capture (Mongo / Redisson / R2DBC / Hazelcast / ZooKeeper /
+ * Local Suspend) 가 담당합니다.
+ *
+ * ## 미지원 시나리오
+ * - `Application.routing` / `PipelineContext` / 임의 Reactor operator 등 비-`leaderScheduled` 표면에서는
+ *   `LockHandleElement` 전파가 불가능합니다. README "미지원 시나리오" 노트와 동일 정책 (Mono 분기와 동일).
+ */
+class LeaderScheduledLockAssertSmokeTest: AbstractLeaderKtorTest() {
+
+    companion object: KLoggingChannel() {
+        private val SHORT_PERIOD = 50.milliseconds
+        private val POLL_INTERVAL = 50.milliseconds
+        private val AWAIT_TIMEOUT = 15.seconds
+    }
+
+    @Test
+    fun `leaderScheduled body 안에서 LockAssert assertLockedSuspend 통과`() = runSuspendIO {
+        val elector = RedissonSuspendLeaderElector(redissonClient)
+        val lockName = randomName()
+        val asserted = AtomicReference<Throwable?>(null)
+        val passes = AtomicReference(0)
+
+        testApplication {
+            var job: Job? = null
+            application {
+                install(LeaderElectionPlugin) { leaderElection = elector }
+                job = leaderScheduled(lockName, SHORT_PERIOD) {
+                    try {
+                        LockAssert.assertLockedSuspend()
+                        LockAssert.assertLockedSuspend(lockName)
+                        passes.set(passes.get() + 1)
+                    } catch (t: Throwable) {
+                        asserted.set(t)
+                    }
+                }
+            }
+            startApplication()
+            await atMost AWAIT_TIMEOUT.toJavaDuration() withPollInterval POLL_INTERVAL.toJavaDuration() until {
+                passes.get() >= 1 || asserted.get() != null
+            }
+            job?.cancel()
+        }
+
+        // body 내부에서 던진 예외가 있으면 실패
+        (asserted.get() == null).shouldBeTrue()
+        (passes.get() >= 1).shouldBeTrue()
+    }
+
+    @Test
+    fun `leaderScheduled body 안에서 LockExtender extendActiveLockDetailedSuspend returns Extended`() = runSuspendIO {
+        val elector = RedissonSuspendLeaderElector(redissonClient)
+        val lockName = randomName()
+        val captured = AtomicReference<ExtendOutcome?>(null)
+
+        testApplication {
+            var job: Job? = null
+            application {
+                install(LeaderElectionPlugin) { leaderElection = elector }
+                job = leaderScheduled(lockName, SHORT_PERIOD) {
+                    if (captured.get() == null) {
+                        captured.set(LockExtender.extendActiveLockDetailedSuspend(30.seconds))
+                    }
+                }
+            }
+            startApplication()
+            await atMost AWAIT_TIMEOUT.toJavaDuration() withPollInterval POLL_INTERVAL.toJavaDuration() until {
+                captured.get() != null
+            }
+            job?.cancel()
+        }
+
+        captured.get().shouldBeInstanceOf<ExtendOutcome.Extended>()
+    }
+}


### PR DESCRIPTION
## Summary

PR #197의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat(leader-ktor): #79 PR 9 AC-22b — LockAssert / LockExtender smoke test in leaderScheduled`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

PR 9 (final) of Issue #79 (LockExtender / LockAssert). Verifies that \`LockAssert.assertLockedSuspend()\` and \`LockExtender.extendActiveLockDetailedSuspend(d)\` propagate correctly through \`leaderScheduled { ... }\` background action's CoroutineContext via the underlying SuspendLeaderElector's capture mechanism.

**Sequence (now complete)**: PR 1 Core ✅ → PR 2 Lettuce ✅ → PR 3 Redisson ✅ → PR 4 MongoDB ✅ → PR 5 JDBC ✅ → PR 6 R2DBC ✅ → PR 7 Hazelcast ✅ → PR 8 ZooKeeper ✅ → **PR 9 ktor smoke** (this — last).

## Smoke test

\`LeaderScheduledLockAssertSmokeTest\` covers:
1. \`LockAssert.assertLockedSuspend()\` + \`LockAssert.assertLockedSuspend(lockName)\` passing inside \`leaderScheduled\` body using Redisson backend.
2. \`LockExtender.extendActiveLockDetailedSuspend(30.seconds)\` returns \`ExtendOutcome.Extended\` inside \`leaderScheduled\` body.

Uses \`testApplication { application { install(...); leaderScheduled(...) } }\` with \`await ... until { ... }\` synchronization. Cancels the scheduled job explicitly to avoid leaking coroutines across tests.

## README documentation

Both \`leader-ktor/README.md\` and \`README.ko.md\` get a new "LockAssert / LockExtender inside leaderScheduled" section before "## Dependency":

- Confirms support for \`LockAssert.assertLockedSuspend()\` and \`LockExtender.extendActiveLockDetailedSuspend(d)\` inside \`leaderScheduled\` body.
- Documents unsupported scenarios: \`Application.routing\` handlers, \`PipelineContext\`, any non-\`leaderScheduled\` surface. The plugin stores configuration in \`Application.attributes\` only — \`LockHandleElement\` is NOT injected into Ktor's routing pipeline. Same policy as Mono branch in \`@LeaderElection\`.

## Test plan

\`\`\`
./gradlew :leader-ktor:test --no-daemon
\`\`\`

**Local result: 13/13 passing (5.4s)** — Redis Testcontainer.

## Code review

Same capture mechanism reused from 8 sibling PRs already merged (Lettuce / Redisson / MongoDB / JDBC / R2DBC / Hazelcast / ZooKeeper + spring-boot AOP). No new SPI surface.

Refs #79
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #197, head `d9f15e1d662f1f8d310f800a436ad9b1c96daae9`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
