### PR TITLE
fix(ci): remove rigid kover coverage threshold + add classifier unit test

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -91,10 +91,6 @@ jobs:
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
-      - name: Verify Kover threshold
-        run: ./gradlew :leader-core:koverVerify --no-daemon
-        env:
-          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       - name: Generate Kover XML report
         if: always()
         run: ./gradlew :leader-core:koverXmlReport --no-daemon
@@ -621,10 +617,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-      - name: Verify Kover threshold
-        run: ./gradlew :leader-zookeeper:koverVerify --no-daemon
-        env:
-          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
@@ -669,10 +661,6 @@ jobs:
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
-        env:
-          GRADLE_OPTS: "-Dorg.gradle.daemon=false"
-      - name: Verify Kover threshold
-        run: ./gradlew :leader-micrometer:koverVerify --no-daemon
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       - name: Generate Kover XML report
@@ -945,10 +933,6 @@ jobs:
           GRADLE_OPTS: '-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false'
           TESTCONTAINERS_RYUK_DISABLED: 'true'
           DOCKER_HOST: 'unix:///var/run/docker.sock'
-      - name: Verify Kover threshold
-        run: ./gradlew :leader-spring-boot:koverVerify --no-daemon
-        env:
-          GRADLE_OPTS: '-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false'
           TESTCONTAINERS_RYUK_DISABLED: 'true'
           DOCKER_HOST: 'unix:///var/run/docker.sock'
       - name: Generate Kover XML report

--- a/leader-core/build.gradle.kts
+++ b/leader-core/build.gradle.kts
@@ -2,18 +2,6 @@ plugins {
     `java-test-fixtures`
 }
 
-kover {
-    reports {
-        verify {
-            rule {
-                bound {
-                    minValue = 80
-                }
-            }
-        }
-    }
-}
-
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }

--- a/leader-micrometer/build.gradle.kts
+++ b/leader-micrometer/build.gradle.kts
@@ -1,15 +1,3 @@
-kover {
-    reports {
-        verify {
-            rule {
-                bound {
-                    minValue = 80
-                }
-            }
-        }
-    }
-}
-
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }

--- a/leader-spring-boot/build.gradle.kts
+++ b/leader-spring-boot/build.gradle.kts
@@ -6,19 +6,6 @@ plugins {
     id("io.freefair.aspectj.post-compile-weaving") version "9.5.0"
 }
 
-kover {
-    reports {
-        verify {
-            rule {
-                bound {
-                    // Spring Boot 통합 모듈 — nightly에서 전체 커버리지 측정
-                    minValue = 60
-                }
-            }
-        }
-    }
-}
-
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }

--- a/leader-zookeeper/build.gradle.kts
+++ b/leader-zookeeper/build.gradle.kts
@@ -2,18 +2,6 @@ configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }
 
-kover {
-    reports {
-        verify {
-            rule {
-                bound {
-                    minValue = 80
-                }
-            }
-        }
-    }
-}
-
 dependencies {
     api(project(":leader-core"))
     api(libs.curator.recipes)

--- a/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperBackendErrorClassifierTest.kt
+++ b/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperBackendErrorClassifierTest.kt
@@ -1,0 +1,56 @@
+package io.bluetape4k.leader.zookeeper.internal
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.leader.internal.BackendErrorKind
+import io.bluetape4k.logging.KLogging
+import org.apache.zookeeper.KeeperException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [ZooKeeperBackendErrorClassifier] 단위 테스트.
+ *
+ * 모든 분기 (TRANSIENT / NON_TRANSIENT / null) 를 직접 검증해 backend exception 분류 계약을 보장합니다.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ZooKeeperBackendErrorClassifierTest {
+
+    companion object: KLogging()
+
+    @Test
+    fun `ConnectionLossException 은 TRANSIENT 로 분류된다`() {
+        val cause = KeeperException.create(KeeperException.Code.CONNECTIONLOSS)
+        ZooKeeperBackendErrorClassifier.classify(cause) shouldBeEqualTo BackendErrorKind.TRANSIENT
+    }
+
+    @Test
+    fun `OperationTimeoutException 은 TRANSIENT 로 분류된다`() {
+        val cause = KeeperException.create(KeeperException.Code.OPERATIONTIMEOUT)
+        ZooKeeperBackendErrorClassifier.classify(cause) shouldBeEqualTo BackendErrorKind.TRANSIENT
+    }
+
+    @Test
+    fun `SessionExpiredException 은 NON_TRANSIENT 로 분류된다`() {
+        val cause = KeeperException.create(KeeperException.Code.SESSIONEXPIRED)
+        ZooKeeperBackendErrorClassifier.classify(cause) shouldBeEqualTo BackendErrorKind.NON_TRANSIENT
+    }
+
+    @Test
+    fun `SessionMovedException 은 NON_TRANSIENT 로 분류된다`() {
+        val cause = KeeperException.create(KeeperException.Code.SESSIONMOVED)
+        ZooKeeperBackendErrorClassifier.classify(cause) shouldBeEqualTo BackendErrorKind.NON_TRANSIENT
+    }
+
+    @Test
+    fun `그 외 KeeperException 은 NON_TRANSIENT 로 분류된다`() {
+        val cause = KeeperException.create(KeeperException.Code.NONODE)
+        ZooKeeperBackendErrorClassifier.classify(cause) shouldBeEqualTo BackendErrorKind.NON_TRANSIENT
+    }
+
+    @Test
+    fun `KeeperException 이 아닌 예외는 null 을 반환한다 (chain 위임)`() {
+        ZooKeeperBackendErrorClassifier.classify(RuntimeException("other")).shouldBeNull()
+        ZooKeeperBackendErrorClassifier.classify(IllegalStateException("other")).shouldBeNull()
+    }
+}


### PR DESCRIPTION
## Summary

PR #199의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix(ci): remove rigid kover coverage threshold + add classifier unit test`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Two-part fix for the nightly run #25682209939 failure (`leader-zookeeper:koverVerify lines covered 79.71% < 80%`).

## Part 1 — Remove rigid coverage threshold (per user feedback)

User: "koverVerify는 빼자. coverage summary를 보고 목표를 조절하고, 테스트 추가 활동을 해야 하지, 이렇게 rigid하게 되면 유연성이 떨어진다".

- Remove `kover { reports { verify { rule { bound { minValue } } } } }` from:
  - `leader-core/build.gradle.kts` (was 80%)
  - `leader-micrometer/build.gradle.kts` (was 80%)
  - `leader-spring-boot/build.gradle.kts` (was 60%)
  - `leader-zookeeper/build.gradle.kts` (was 80%)
- Remove 4 "Verify Kover threshold" steps from `.github/workflows/nightly.yml`.
- Keep `koverXmlReport` generation + Codecov upload — coverage trends remain visible.

The `-x koverVerify` exclusion flags in build commands stay (harmless after config removal).

## Part 2 — Add classifier unit test (kept as bonus)

`ZooKeeperBackendErrorClassifierTest` covers all 6 classification branches:
- `ConnectionLossException` → TRANSIENT
- `OperationTimeoutException` → TRANSIENT
- `SessionExpiredException` → NON_TRANSIENT
- `SessionMovedException` → NON_TRANSIENT
- Other `KeeperException` (NONODE) → NON_TRANSIENT
- Non-`KeeperException` → null (chain delegate)

Direct unit-level coverage independent of Testcontainers.

## Verification

```
./gradlew :leader-zookeeper:test --no-daemon
./gradlew :leader-zookeeper:build -x test --no-daemon
```

Both SUCCESS. 79 tests passing on `leader-zookeeper`. Build accepts removed kover config.

Refs #79 (nightly CI fix)
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #199, head `885cbac2c8d2a34dcd928b54810974f521562af3`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
