### PR TITLE
fix: prevent suspend capture ThreadLocal leaks

### DIFF
--- a/docs/lessons/2026-05-11-lock-extender.md
+++ b/docs/lessons/2026-05-11-lock-extender.md
@@ -68,7 +68,7 @@ AOP aspect 가 `@LeaderElection` 어노테이션에서 `LockExtender` 를 호출
 - **Sync single**: `AopScopeAccess.withPushedSync(handle) { action() }` — ThreadLocal push/pop
 - **Suspend single**: `withContext(coroutineContext + AopScopeAccess.createLockHandleElement(handle)) { action() }` — CoroutineContext.Element 주입
 - **Sync group**: `withPushedSync + setCapture(handle) + clearCapture()` in finally — group elector 의 capture invariant 위해 추가 ThreadLocal
-- **Suspend group**: `setCapture + createLockHandleElement` + `clearCapture()` in NonCancellable finally
+- **Suspend group**: `createLockHandleElement` only. Do not use ThreadLocal capture in suspend electors; dispatcher hops can split set/clear across carrier threads.
 - 4개 패턴 모두 MongoDB elector 가 reference template — 9개 backend 통일 적용.
 
 ---

--- a/docs/lessons/2026-05-14-issue-175-suspend-capture.md
+++ b/docs/lessons/2026-05-14-issue-175-suspend-capture.md
@@ -1,0 +1,37 @@
+## Context
+
+Issue #175 reported that `CaptureScope.runWithCaptureSuspend` used `ThreadLocal`
+capture around a suspend action. Dispatcher hops can resume cleanup on a
+different carrier thread, leaving a stale handle on the original thread.
+
+## Decision
+
+Suspend group election no longer uses `CaptureScope`, `AopScopeAccess.setCapture`,
+or `LeaderLockHandleCapture`. It relies only on `LockHandleElement` in the
+coroutine context. `CaptureScope` is now sync-only and its tests cover only
+synchronous ThreadLocal capture.
+
+## Outcome
+
+`LocalSuspendLeaderGroupElector` calls the suspend action directly inside
+`withContext(LockHandleElement(handle))`. Backend suspend group electors now use
+only `withContext(AopScopeAccess.createLockHandleElement(handle))` as well.
+A new stress test checks IO and Default dispatcher hops and verifies that
+`LeaderLockHandleCapture.poll()` remains null.
+
+## Verification
+
+- `./gradlew :leader-core:test --tests 'io.bluetape4k.leader.internal.CaptureScopeTest' --tests 'io.bluetape4k.leader.coroutines.LocalSuspendLeaderGroupElectorCaptureTest' --console=plain`
+  - 5 tests passed.
+- `./gradlew :leader-core:test --console=plain`
+  - 605 tests passed.
+- Claude Tier 4 advisor review found the same ThreadLocal-around-suspend pattern
+  in backend suspend group electors. The finding was accepted and fixed.
+- `./gradlew :leader-core:test :leader-spring-boot:compileKotlin :leader-redis-lettuce:compileTestKotlin :leader-redis-redisson:compileTestKotlin :leader-mongodb:compileTestKotlin :leader-hazelcast:compileTestKotlin :leader-zookeeper:compileTestKotlin :leader-exposed-r2dbc:compileTestKotlin --console=plain`
+  - Build successful; `leader-core` 605 tests passed.
+
+## Future Guidance
+
+Do not add ThreadLocal capture helpers to suspend electors. Use
+`LockHandleElement` for suspend lock handle propagation and reserve
+`CaptureScope.runWithCapture` for synchronous electors only.

--- a/docs/lessons/2026-05-14-issue-175-suspend-capture.md
+++ b/docs/lessons/2026-05-14-issue-175-suspend-capture.md
@@ -29,9 +29,20 @@ A new stress test checks IO and Default dispatcher hops and verifies that
   in backend suspend group electors. The finding was accepted and fixed.
 - `./gradlew :leader-core:test :leader-spring-boot:compileKotlin :leader-redis-lettuce:compileTestKotlin :leader-redis-redisson:compileTestKotlin :leader-mongodb:compileTestKotlin :leader-hazelcast:compileTestKotlin :leader-zookeeper:compileTestKotlin :leader-exposed-r2dbc:compileTestKotlin --console=plain`
   - Build successful; `leader-core` 605 tests passed.
+- Step 7-R dual PR review ran after PR creation:
+  - Codex PR review: approve, no P0/P1/P2/P3 findings.
+  - Claude PR review: initial comment for missing Spring AOP verification, then
+    approve after `./gradlew :leader-spring-boot:test --console=plain` passed
+    280 tests and `pollCapture` was confirmed absent from suspend group aspect
+    runtime paths.
+  - GitHub CI was green and merge state was clean; PR remained draft.
 
 ## Future Guidance
 
 Do not add ThreadLocal capture helpers to suspend electors. Use
 `LockHandleElement` for suspend lock handle propagation and reserve
 `CaptureScope.runWithCapture` for synchronous electors only.
+
+When Step 7-R is required, leave both a concise PR comment and a formal GitHub
+review entry. A plain issue comment is useful evidence but does not populate the
+PR review timeline.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/AopScopeAccess.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/AopScopeAccess.kt
@@ -16,7 +16,7 @@ import io.bluetape4k.leader.internal.LockStateHolder
  * |------|------|
  * | [peekSyncMatching] | sync 분기 reentrant peek (동일 lockName 보유 여부 확인) |
  * | [withPushedSync] | sync 분기 handle push/pop — body 실행 전후 LockStateHolder 관리 |
- * | [pollCapture] | elector → aspect handle 전달 수신 (CaptureScope.runWithCapture 후) |
+ * | [pollCapture] | sync group elector → aspect handle 전달 수신 (CaptureScope.runWithCapture 후) |
  * | [createFailOpen] | fail-open sentinel handle 생성 |
  * | [createLockHandleElement] | CoroutineContext 에 주입할 LockHandleElement 생성 |
  */
@@ -51,16 +51,21 @@ object AopScopeAccess {
     /**
      * [LeaderLockHandleCapture] ThreadLocal 에서 handle 을 꺼내고 즉시 clear 합니다.
      *
-     * group elector 의 `CaptureScope.runWithCapture` 가 set 한 값을 aspect 가 수신합니다.
+     * sync group elector 의 `CaptureScope.runWithCapture` 가 set 한 값을 aspect 가 수신합니다.
      * single elector 는 capture 하지 않으므로 `null` 이 정상 — CaptureInvariantException 사용 금지.
+     * suspend group elector 는 ThreadLocal capture 를 사용하지 않고 [createLockHandleElement] 만 사용합니다.
      */
     fun pollCapture(): LeaderLockHandle.Real? = LeaderLockHandleCapture.poll()
 
     /**
-     * Backend module 전용 — group elector 의 acquire 직후 aspect 가 poll 할 handle 을 set 합니다.
+     * Backend module 전용 — sync group elector 의 acquire 직후 aspect 가 poll 할 handle 을 set 합니다.
      *
      * ⚠️ 애플리케이션 코드에서 직접 호출 금지 — `leader-redis-lettuce`, `leader-redis-redisson`,
-     * `leader-mongodb` 등의 group elector 가 동일 thread 에서 `setCapture` → action → [clearCapture] 시퀀스를 보장해야 합니다.
+     * `leader-mongodb` 등의 sync group elector 가 동일 thread 에서
+     * `setCapture` → action → [clearCapture] 시퀀스를 보장해야 합니다.
+     *
+     * suspend group elector 는 dispatcher hop 으로 ThreadLocal set/clear thread 가 달라질 수 있으므로
+     * 호출하지 말고 [createLockHandleElement] 로 coroutine context 에 handle 을 전파해야 합니다.
      *
      * 일반적으로 try/finally 패턴으로 사용:
      *
@@ -80,9 +85,10 @@ object AopScopeAccess {
     }
 
     /**
-     * Backend module 전용 — [setCapture] 로 set 한 ThreadLocal 을 명시적으로 clear 합니다.
+     * Backend module 전용 — [setCapture] 로 set 한 sync group ThreadLocal 을 명시적으로 clear 합니다.
      *
      * `try/finally` finally 블록에서 호출하여 ThreadLocal leak 을 방지합니다.
+     * suspend group elector 에서는 호출하지 않습니다.
      */
     fun clearCapture() {
         LeaderLockHandleCapture.clear()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElector.kt
@@ -15,7 +15,6 @@ import io.bluetape4k.leader.LeaderLockHandle
 import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.LockIdentity
-import io.bluetape4k.leader.internal.CaptureScope
 import io.bluetape4k.leader.internal.ExtendDelegate
 import io.bluetape4k.leader.local.AbstractLocalLeaderGroupElector
 import io.bluetape4k.leader.local.LocalLeaderStateRegistry
@@ -275,9 +274,7 @@ class LocalSuspendLeaderGroupElector private constructor(
         eventSubject.emit(LeaderElectionEvent.Elected(lockName))
         return try {
             withContext(LockHandleElement(handle)) {
-                CaptureScope.runWithCaptureSuspend(handle) {
-                    action()
-                }
+                action()
             }
         } finally {
             withContext(NonCancellable) {

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/CaptureScope.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/CaptureScope.kt
@@ -1,16 +1,17 @@
 package io.bluetape4k.leader.internal
 
 import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.coroutines.LockHandleElement
 
 /**
- * Elector 의 `runIfLeader` 안에서 [LeaderLockHandleCapture] set/clear 를 안전하게 감싸는 헬퍼.
+ * Sync elector 의 `runIfLeader` 안에서 [LeaderLockHandleCapture] set/clear 를 안전하게 감싸는 헬퍼.
  *
  * ## 목적 (Step 3-P R1 mitigation)
  * 각 elector 가 [LeaderLockHandleCapture.set] 와 [LeaderLockHandleCapture.clear] 를 직접 호출하면
  * try/finally 누락 시 ThreadLocal leak 발생. 모든 elector 가 이 헬퍼를 사용하면
  * **per-backend discipline → structural enforcement**.
  *
- * AC: `grep -r "LeaderLockHandleCapture.set" leader-{core,redis,...}/src/main` → 0 match (CaptureScope.kt 외)
+ * AC: elector implementations do not call [LeaderLockHandleCapture.set] directly.
  *
  * ## Example
  * ```kotlin
@@ -19,24 +20,14 @@ import io.bluetape4k.leader.LeaderLockHandle
  *     action()  // aspect 의 wrapped action — capture poll 가능
  * }
  * ```
+ *
+ * Suspend elector 는 dispatcher hop 으로 ThreadLocal set/clear thread 가 달라질 수 있으므로
+ * 이 capture scope 를 사용하지 않는다. Suspend lock handle propagation 은 [LockHandleElement] 만 사용한다.
  */
 internal object CaptureScope {
 
     /** Sync 변형 — 동일 thread 안에서 set → action → clear. */
     inline fun <T> runWithCapture(handle: LeaderLockHandle.Real, action: () -> T): T {
-        LeaderLockHandleCapture.set(handle)
-        try {
-            return action()
-        } finally {
-            LeaderLockHandleCapture.clear()
-        }
-    }
-
-    /** Suspend 변형 — 동일 dispatcher 안에서 set → action → clear. */
-    suspend fun <T> runWithCaptureSuspend(
-        handle: LeaderLockHandle.Real,
-        action: suspend () -> T,
-    ): T {
         LeaderLockHandleCapture.set(handle)
         try {
             return action()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderLockHandleCapture.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderLockHandleCapture.kt
@@ -6,15 +6,16 @@ import io.bluetape4k.leader.LeaderLockHandle
  * Elector → Aspect 간 handle 전달용 ThreadLocal.
  *
  * ## 엄격한 invariant (Step 2-R R10)
- * - Elector 는 acquire 후 action 호출 **직전** 동일 thread 에서 [set] 호출.
- * - Aspect 는 action lambda 의 **첫 statement** 로 [poll] 호출.
+ * - Sync group elector 는 acquire 후 action 호출 **직전** 동일 thread 에서 [set] 호출.
+ * - Sync group aspect 는 action lambda 의 **첫 statement** 로 [poll] 호출.
  * - **capture 누락 (poll 결과 null) → `CaptureInvariantException` throw** ("elector did not capture handle — bug")
  *   silent fallback to FailOpen 절대 금지 (Codex F10 / SF3).
  * - virtual thread / dispatcher hop 사이에 set/poll 분리 금지.
  *
  * ## 사용 권고
- * 직접 호출하지 말고 [CaptureScope.runWithCapture] 또는 [CaptureScope.runWithCaptureSuspend] 사용
- * — per-backend discipline → structural enforcement (Step 3-P R1 mitigation).
+ * 직접 호출하지 말고 sync elector 에서는 [CaptureScope.runWithCapture] 를 사용한다.
+ * Suspend elector 는 dispatcher hop 으로 ThreadLocal set/clear thread 가 달라질 수 있으므로
+ * `LockHandleElement` 기반 coroutine context propagation 만 사용한다.
  */
 internal object LeaderLockHandleCapture {
 

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElectorCaptureTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElectorCaptureTest.kt
@@ -1,0 +1,67 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.leader.internal.LeaderLockHandleCapture
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.coroutineContext
+
+/**
+ * [LocalSuspendLeaderGroupElector] capture integration test.
+ *
+ * Suspend group election propagates lock handles through [LockHandleElement] only.
+ * It must not publish handles through [LeaderLockHandleCapture], because ThreadLocal
+ * set/clear can happen on different carrier threads after dispatcher hops.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Suppress("NonAsciiCharacters")
+class LocalSuspendLeaderGroupElectorCaptureTest {
+
+    private val election = LocalSuspendLeaderGroupElector(LeaderGroupElectionOptions(maxLeaders = 3))
+
+    @BeforeEach
+    fun clearThreadLocalCapture() {
+        LeaderLockHandleCapture.clear()
+    }
+
+    private fun randomLockName() = "group-lock-${Base58.randomString(8)}"
+
+    @Test
+    fun `group runIfLeader uses LockHandleElement only across dispatcher hops`() = runSuspendIO {
+        val checks = AtomicInteger()
+
+        repeat(100) {
+            election.runIfLeader(randomLockName()) {
+                assertCoroutineContextOnly(checks)
+
+                withContext(Dispatchers.IO) {
+                    assertCoroutineContextOnly(checks)
+                }
+
+                withContext(Dispatchers.Default) {
+                    assertCoroutineContextOnly(checks)
+                }
+            }
+        }
+
+        checks.get() shouldBeEqualTo 300
+        LeaderLockHandleCapture.poll().shouldBeNull()
+    }
+
+    private suspend fun assertCoroutineContextOnly(checks: AtomicInteger) {
+        LeaderLockHandleCapture.poll().shouldBeNull()
+        coroutineContext[LockHandleElement].shouldNotBeNull()
+        LockAssert.isLockedSuspend() shouldBeEqualTo true
+        checks.incrementAndGet()
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/CaptureScopeTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/CaptureScopeTest.kt
@@ -5,8 +5,6 @@ import io.bluetape4k.leader.LeaderLockHandle
 import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
-import io.bluetape4k.assertions.shouldNotBeNull
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -86,50 +84,5 @@ class CaptureScopeTest {
         val result = CaptureScope.runWithCapture(handle) { 42 }
 
         result shouldBeEqualTo 42
-    }
-
-    // --- suspend ---
-
-    @Test
-    fun `runWithCaptureSuspend - handle is pollable inside action`() = runTest {
-        val handle = realHandle()
-        var polled: LeaderLockHandle.Real? = null
-
-        CaptureScope.runWithCaptureSuspend(handle) {
-            polled = LeaderLockHandleCapture.poll()
-        }
-
-        polled shouldBeEqualTo handle
-    }
-
-    @Test
-    fun `runWithCaptureSuspend - clears capture after action completes`() = runTest {
-        val handle = realHandle()
-
-        CaptureScope.runWithCaptureSuspend(handle) { /* do nothing */ }
-
-        LeaderLockHandleCapture.poll().shouldBeNull()
-    }
-
-    @Test
-    fun `runWithCaptureSuspend - clears capture even when action throws`() = runTest {
-        val handle = realHandle()
-
-        runCatching {
-            CaptureScope.runWithCaptureSuspend(handle) {
-                error("simulated failure")
-            }
-        }
-
-        LeaderLockHandleCapture.poll().shouldBeNull()
-    }
-
-    @Test
-    fun `runWithCaptureSuspend - returns action result`() = runTest {
-        val handle = realHandle()
-
-        val result = CaptureScope.runWithCaptureSuspend(handle) { "ok" }
-
-        result shouldBeEqualTo "ok"
     }
 }

--- a/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElector.kt
+++ b/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElector.kt
@@ -30,9 +30,7 @@ import org.jetbrains.exposed.v1.r2dbc.insert
 import org.jetbrains.exposed.v1.r2dbc.selectAll
 import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
 import org.jetbrains.exposed.v1.r2dbc.update
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.random.Random
@@ -240,8 +238,6 @@ class ExposedR2DbcSuspendLeaderGroupElector private constructor(
             var actionFailed = false
 
             try {
-                // setCapture: ThreadLocal capture 도 함께 push (aspect dual-source: ThreadLocal + coroutineContext)
-                AopScopeAccess.setCapture(handle)
                 val result = withContext(AopScopeAccess.createLockHandleElement(handle)) {
                     action()
                 }
@@ -253,9 +249,8 @@ class ExposedR2DbcSuspendLeaderGroupElector private constructor(
                 actionFailed = true
                 throw e
             } finally {
-                // NonCancellable: 코루틴 취소 시에도 watchdog close + 캡쳐 clear + 락 해제가 중단되지 않도록 보호
+                // NonCancellable: 코루틴 취소 시에도 watchdog close + 락 해제가 중단되지 않도록 보호
                 withContext(NonCancellable) {
-                    AopScopeAccess.clearCapture()
                     watchdog.close()
                     cachedActiveCount.updateAndGet { it.coerceAtLeast(1) - 1 }
                     when {

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderGroupElector.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderGroupElector.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.withContext
  *
  * - acquire 된 per-slot [HazelcastSuspendLock] 을 [HazelcastSuspendSlotExtendDelegate] 로 wrap 하여 watchdog 와 동일 reference 공유 (AC-15).
  * - aspect 의 `LockExtenderSuspend.extendActiveLockSuspend` 는 동일 delegate reference 를 사용합니다.
- * - suspend group: `setCapture(handle)` + `withContext(createLockHandleElement(handle))` 양쪽에 push.
+ * - suspend group: `withContext(createLockHandleElement(handle))` 로 coroutineContext 에 handle 전파.
  *
  * ```kotlin
  * val election = HazelcastSuspendLeaderGroupElector(hazelcastInstance, LeaderGroupElectionOptions(maxLeaders = 3))
@@ -131,13 +131,8 @@ class HazelcastSuspendLeaderGroupElector private constructor(
         val watchdog = LeaderLeaseAutoExtender.start(false, leaseTime, delegate, ERROR_CLASSIFIER)
 
         try {
-            AopScopeAccess.setCapture(handle)
-            try {
-                return withContext(AopScopeAccess.createLockHandleElement(handle)) {
-                    action()
-                }
-            } finally {
-                AopScopeAccess.clearCapture()
+            return withContext(AopScopeAccess.createLockHandleElement(handle)) {
+                action()
             }
         } finally {
             // NonCancellable: 코루틴 취소 시에도 watchdog close + release 가 중단되지 않도록 보호

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderGroupElector.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderGroupElector.kt
@@ -39,7 +39,7 @@ import kotlin.random.Random
  *
  * - acquire 된 per-slot [MongoSuspendLock] 을 [MongoSuspendSlotExtendDelegate] 로 wrap 하여 watchdog 와 동일 reference 공유 (AC-15).
  * - aspect 의 `LockExtenderSuspend.extendActiveLockSuspend` 는 동일 delegate reference 를 사용합니다.
- * - suspend group: `setCapture(handle)` + `withContext(createLockHandleElement(handle))` 양쪽에 push.
+ * - suspend group: `withContext(createLockHandleElement(handle))` 로 coroutineContext 에 handle 전파.
  *
  * ```kotlin
  * val db = mongoClient.getDatabase("mydb")
@@ -165,14 +165,8 @@ class MongoSuspendLeaderGroupElector private constructor(
         val watchdog = LeaderLeaseAutoExtender.start(false, leaseTime, delegate, ERROR_CLASSIFIER)
 
         try {
-            // setCapture: ThreadLocal capture 도 함께 push (aspect dual-source: ThreadLocal + coroutineContext)
-            AopScopeAccess.setCapture(handle)
-            try {
-                return withContext(AopScopeAccess.createLockHandleElement(handle)) {
-                    action()
-                }
-            } finally {
-                AopScopeAccess.clearCapture()
+            return withContext(AopScopeAccess.createLockHandleElement(handle)) {
+                action()
             }
         } finally {
             // NonCancellable: 코루틴 취소 시에도 watchdog close + release 가 중단되지 않도록 보호

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElector.kt
@@ -48,7 +48,8 @@ fun StatefulRedisConnection<String, String>.suspendLeaderGroupElector(
  *
  * - 내부적으로 [LettuceSlotTokenGroup] (ZSET + Lua, server-side TIME) 사용.
  * - acquire 후 [LettuceSuspendSlotExtendDelegate] 를 생성하여 [LeaderLockHandle.Real] + watchdog 와 동일 reference 공유 (AC-15).
- * - `withContext(AopScopeAccess.createLockHandleElement(handle))` + `setCapture` 로 coroutineContext 와 ThreadLocal 양쪽에 handle 전파.
+ * - `withContext(AopScopeAccess.createLockHandleElement(handle))` 로
+ *   coroutineContext 에 handle 전파.
  * - 코루틴 취소 시에도 `withContext(NonCancellable)` 안에서 release 가 보장됩니다.
  * - `CancellationException` 은 항상 re-throw 합니다.
  *
@@ -131,14 +132,8 @@ class LettuceSuspendLeaderGroupElector(
         log.debug { "리더 선출 성공 (suspend): lockName=$lockName, token=$token" }
 
         try {
-            // setCapture: ThreadLocal capture 도 함께 push (aspect dual-source: ThreadLocal + coroutineContext)
-            AopScopeAccess.setCapture(handle)
-            try {
-                return withContext(AopScopeAccess.createLockHandleElement(handle)) {
-                    action()
-                }
-            } finally {
-                AopScopeAccess.clearCapture()
+            return withContext(AopScopeAccess.createLockHandleElement(handle)) {
+                action()
             }
         } finally {
             // NonCancellable: 코루틴 취소 시에도 슬롯 반납이 중단되지 않도록 보호

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElector.kt
@@ -45,7 +45,8 @@ import kotlin.time.Duration
  * ## ExtendDelegate 통합
  *
  * - acquire 후 [RedissonSuspendSemaphoreExtendDelegate] 를 생성하여 [LeaderLockHandle.Real] + watchdog 와 동일 reference 공유 (AC-15).
- * - `withContext(AopScopeAccess.createLockHandleElement(handle))` + `setCapture` 로 coroutineContext 와 ThreadLocal 양쪽에 handle 전파.
+ * - `withContext(AopScopeAccess.createLockHandleElement(handle))` 로
+ *   coroutineContext 에 handle 전파.
  *
  * ```kotlin
  * val options = LeaderGroupElectionOptions(maxLeaders = 3, minLeaseTime = 1.seconds)
@@ -180,14 +181,8 @@ class RedissonSuspendLeaderGroupElector private constructor(
         val watchdog = LeaderLeaseAutoExtender.start(false, options.leaseTime, delegate, ERROR_CLASSIFIER)
 
         try {
-            // setCapture: ThreadLocal capture 도 함께 push (aspect dual-source: ThreadLocal + coroutineContext)
-            AopScopeAccess.setCapture(handle)
-            try {
-                return withContext(AopScopeAccess.createLockHandleElement(handle)) {
-                    action()
-                }
-            } finally {
-                AopScopeAccess.clearCapture()
+            return withContext(AopScopeAccess.createLockHandleElement(handle)) {
+                action()
             }
         } finally {
             // NonCancellable: 코루틴 취소 시에도 release/extend 가 중단되지 않도록 보호

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/internal/CaptureInvariantException.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/internal/CaptureInvariantException.kt
@@ -4,9 +4,10 @@ package io.bluetape4k.leader.spring.aop.internal
  * AOP aspect 가 elector → aspect 간 handle capture 불변식 위반을 감지할 때 throw.
  *
  * ## 불변식
- * group elector 의 `CaptureScope.runWithCapture` / `runWithCaptureSuspend` 는 action 호출 직전
- * `LeaderLockHandleCapture.set(handle)` 을 호출합니다. aspect 는 action lambda 의 첫 statement 에서
- * `AopScopeAccess.pollCapture()` 로 handle 을 수신합니다.
+ * sync group elector 의 `CaptureScope.runWithCapture` 는 action 호출 직전
+ * `LeaderLockHandleCapture.set(handle)` 을 호출합니다. sync aspect 는 action lambda 의 첫 statement 에서
+ * `AopScopeAccess.pollCapture()` 로 handle 을 수신합니다. suspend group elector 는 ThreadLocal capture 를
+ * 사용하지 않고 `LockHandleElement` 로 coroutine context 에 handle 을 전파합니다.
  *
  * **single elector 는 CaptureScope 를 사용하지 않으므로 pollCapture() == null 은 정상** — 이 예외는
  * group elector 전용 capture 실패 시만 throw 합니다.

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderGroupElector.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderGroupElector.kt
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit
  * ## ExtendDelegate 통합 (T13 PR 8 / Issue #79)
  *
  * - acquire 된 per-slot lease 에 [ZooKeeperSuspendSlotExtendDelegate] wrap — [LeaderLockHandle.Real] 와 동일 reference 공유 (AC-15).
- * - suspend group: `setCapture(handle)` + `withContext(createLockHandleElement(handle))` 양쪽에 push.
+ * - suspend group: `withContext(createLockHandleElement(handle))` 로 coroutineContext 에 handle 전파.
  *
  * ## R16 enforce
  *
@@ -133,13 +133,8 @@ class ZooKeeperSuspendLeaderGroupElector private constructor(
         )
 
         try {
-            AopScopeAccess.setCapture(handle)
-            try {
-                return withContext(AopScopeAccess.createLockHandleElement(handle)) {
-                    action()
-                }
-            } finally {
-                AopScopeAccess.clearCapture()
+            return withContext(AopScopeAccess.createLockHandleElement(handle)) {
+                action()
             }
         } finally {
             // NonCancellable: 코루틴 취소 시에도 watchdog close + release 가 중단되지 않도록 보호


### PR DESCRIPTION
## Summary

Closes #175

PR #219의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: prevent suspend capture ThreadLocal leaks`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Closes #175.

This PR removes ThreadLocal-based capture from suspend leader group election paths. Suspend electors now propagate lock handles only through `LockHandleElement` / `AopScopeAccess.createLockHandleElement`, while synchronous group electors keep the existing `CaptureScope.runWithCapture` path.

## Changes

- Removed `CaptureScope.runWithCaptureSuspend` and narrowed `CaptureScope` / `LeaderLockHandleCapture` KDoc to synchronous group capture.
- Updated local and backend suspend group electors to avoid `AopScopeAccess.setCapture` / `clearCapture`:
  - `leader-core`
  - `leader-redis-lettuce`
  - `leader-redis-redisson`
  - `leader-mongodb`
  - `leader-hazelcast`
  - `leader-zookeeper`
  - `leader-exposed-r2dbc`
- Added a dispatcher-hop regression test for `LocalSuspendLeaderGroupElector` that verifies `LockHandleElement` remains available and `LeaderLockHandleCapture.poll()` remains null across `Dispatchers.IO` and `Dispatchers.Default` hops.
- Updated AOP bridge/KDoc and lessons to document the sync-only ThreadLocal capture contract.

## Claude Tier 4 Review

- Initial Claude Tier 4 advisor review: `REQUEST_CHANGES`
  - Found the same ThreadLocal-around-suspend pattern in six backend suspend group electors.
  - Found KDoc drift in `AopScopeAccess` and `CaptureInvariantException`.
- Follow-up Claude Tier 4 advisor review: `APPROVE`
  - CRITICAL/HIGH/MEDIUM/LOW findings: 0.
  - Confirmed backend suspend group electors, local elector, KDoc, tests, and lessons are consistent.

Local artifacts:

- `.omx/artifacts/claude-issue-175-tier4-review-20260514.md`
- `.omx/artifacts/claude-issue-175-tier4-followup-20260514.md`

These are local ignored artifacts and are summarized here rather than committed.

## Verification

- `./gradlew :leader-core:test --tests 'io.bluetape4k.leader.internal.CaptureScopeTest' --tests 'io.bluetape4k.leader.coroutines.LocalSuspendLeaderGroupElectorCaptureTest' --console=plain`
  - 5 tests passed.
- `./gradlew :leader-core:test --console=plain`
  - 605 tests passed.
- `./gradlew :leader-core:test :leader-spring-boot:compileKotlin :leader-redis-lettuce:compileTestKotlin :leader-redis-redisson:compileTestKotlin :leader-mongodb:compileTestKotlin :leader-hazelcast:compileTestKotlin :leader-zookeeper:compileTestKotlin :leader-exposed-r2dbc:compileTestKotlin --console=plain`
  - Build successful.
  - `leader-core` 605 tests passed.
- `git diff --check`
  - Passed.
- `rg "runWithCaptureSuspend" leader-*/src/main/kotlin`
  - No matches.
- `rg "AopScopeAccess\.(setCapture|clearCapture)" leader-*/*/main/kotlin/**/*SuspendLeaderGroupElector.kt`
  - No matches.

## Not Tested

- Container-backed backend integration tests beyond compile were not run.

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #175, milestone `0.1.0`, assignee `debop`
- PR: #219, head `8e93af9b80e46eb8777d9b2c4c8d7d98ab2f3cd7`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
