### PR TITLE
feat: clarify leader result action failures

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -304,10 +304,17 @@ sequenceDiagram
 when (val r = election.runIfLeaderResult("daily-job") { compute() }) {
     is LeaderRunResult.Elected -> println("선출됨, 결과=${r.value}")
     is LeaderRunResult.Skipped -> println("미선출 — 락 획득 실패")
+    is LeaderRunResult.ActionFailed -> println("작업 실패: ${r.cause.message}")
 }
 ```
 
-`LeaderRunResult`는 `Elected<T>(value: T?)`와 `Skipped` 두 변형을 가진 sealed interface입니다. 동기 `LeaderElector` 및 `LeaderGroupElector`에서만 제공되며, 비동기/코루틴 동등 메서드는 향후 릴리즈에서 추가될 예정입니다.
+`LeaderRunResult`는 세 변형을 가진 sealed interface입니다.
+
+- `Elected<T>(value: T?)`: 락/슬롯을 획득했고 `action`이 완료됨. `value`는 `null`일 수 있습니다.
+- `Skipped`: 락/슬롯을 획득하지 못했고 `action`은 실행되지 않음.
+- `ActionFailed(cause)`: 락/슬롯을 획득하고 `action`이 시작됐지만 작업 실행 중 실패함.
+
+동기 elector는 `runIfLeaderResult`, 코루틴 elector는 `runIfLeaderResultSuspend`, `CompletableFuture`/가상 스레드 elector는 `runAsyncIfLeaderResult`를 제공합니다. `CancellationException`은 `ActionFailed`로 감싸지 않습니다. 동기/코루틴 API는 재전파하고, async/가상 스레드 API는 예외 완료됩니다(`join()`에서는 cancellation을 감싼 `CompletionException`을 기대하세요. `isCancelled()` 보장은 아닙니다). 동기 API는 `InterruptedException`도 interrupt flag를 복원한 뒤 재전파합니다.
 
 ### 옵션 클래스
 

--- a/README.md
+++ b/README.md
@@ -304,10 +304,17 @@ sequenceDiagram
 when (val r = election.runIfLeaderResult("daily-job") { compute() }) {
     is LeaderRunResult.Elected -> println("elected, result=${r.value}")
     is LeaderRunResult.Skipped -> println("skipped — lock not acquired")
+    is LeaderRunResult.ActionFailed -> println("action failed: ${r.cause.message}")
 }
 ```
 
-`LeaderRunResult` is a sealed interface with two variants: `Elected<T>(value: T?)` and `Skipped`. Available on synchronous `LeaderElector` and `LeaderGroupElector` only (async/suspend equivalents planned for a future release).
+`LeaderRunResult` is a sealed interface with three variants:
+
+- `Elected<T>(value: T?)` — lock/slot acquired and `action` completed. `value` may be `null`.
+- `Skipped` — lock/slot was not acquired and `action` was not executed.
+- `ActionFailed(cause)` — lock/slot was acquired and `action` started, but the action failed.
+
+`runIfLeaderResult` is available for blocking electors, `runIfLeaderResultSuspend` for coroutine electors, and `runAsyncIfLeaderResult` for `CompletableFuture` / virtual-thread electors. `CancellationException` is not wrapped as `ActionFailed`: blocking and suspend APIs rethrow it, while async and virtual-thread APIs complete exceptionally (for `join()`, expect `CompletionException` wrapping the cancellation; `isCancelled()` is not guaranteed). Blocking APIs also rethrow `InterruptedException` after restoring the interrupt flag.
 
 ### Options
 

--- a/docs/lessons/2026-05-14-issue-213-actionfailed-result.md
+++ b/docs/lessons/2026-05-14-issue-213-actionfailed-result.md
@@ -1,0 +1,49 @@
+# Issue 213 ActionFailed Result Contract
+
+## Context
+
+`runIfLeaderResult` needed a clear outcome for action failures while preserving the simple `runIfLeader`
+contract.
+
+## Decision
+
+Use `LeaderRunResult.ActionFailed(cause)` for failures after leadership is acquired and the user action
+starts. Keep `runIfLeader` unchanged: contention returns `null`, action failure throws.
+
+Do not represent cancellation as a result. Blocking and suspend result APIs must rethrow
+`CancellationException`; async and virtual-thread result APIs must complete exceptionally instead of returning
+`ActionFailed`.
+
+## Outcome
+
+KDoc now documents `Elected`, `Skipped`, and `ActionFailed`. Core sync, suspend, async, virtual-thread,
+Lettuce, and Redisson result APIs return `ActionFailed` for action exceptions after leadership is acquired.
+Spring AOP rethrows `ActionFailed.cause` to preserve existing advice behavior.
+
+Claude review found three P1 gaps before PR: Redis backend result tests were missing, blocking APIs wrapped
+`InterruptedException`, and async/virtual-thread cancellation docs implied `isCancelled()` semantics that
+`CompletableFuture.handle` does not guarantee. The implementation now rethrows `InterruptedException` after
+restoring the interrupt flag, docs describe exceptional completion for async/virtual cancellation, and Lettuce
+plus Redisson sync/suspend single/group tests cover `ActionFailed` and `CancellationException`.
+
+## Verification
+
+- `./gradlew :leader-core:test --no-daemon` passed with 624 tests before the Redis review follow-up; after
+  adding interruption regressions, the targeted follow-up run executed 626 core tests successfully before
+  failing on overly strict Lettuce suspend exception identity assertions.
+- `./gradlew :leader-core:compileKotlin :leader-redis-lettuce:compileKotlin :leader-redis-redisson:compileKotlin :leader-spring-boot:compileKotlin --no-daemon` passed. Spring AspectJ emitted existing `unresolvableMember` / `adviceDidNotMatch` warnings.
+- `./gradlew :leader-redis-lettuce:test :leader-redis-redisson:test --tests io.bluetape4k.leader.lettuce.LettuceSuspendLeaderElectorTest --tests io.bluetape4k.leader.lettuce.LettuceSuspendLeaderGroupElectorTest --tests io.bluetape4k.leader.redisson.RedissonSuspendLeaderElectorTest --tests io.bluetape4k.leader.redisson.RedissonSuspendLeaderGroupElectorTest --no-daemon` passed: Lettuce 197 tests, Redisson 22 tests.
+- `./gradlew :leader-core:test :leader-redis-lettuce:test :leader-redis-redisson:test --tests io.bluetape4k.leader.LeaderRunResultTest --tests io.bluetape4k.leader.lettuce.LettuceLeaderElectionTest --tests io.bluetape4k.leader.lettuce.LettuceSuspendLeaderElectorTest --tests io.bluetape4k.leader.lettuce.LettuceLeaderGroupElectionTest --tests io.bluetape4k.leader.lettuce.LettuceSuspendLeaderGroupElectorTest --tests io.bluetape4k.leader.redisson.RedissonLeaderElectionTest --tests io.bluetape4k.leader.redisson.RedissonSuspendLeaderElectorTest --tests io.bluetape4k.leader.redisson.RedissonLeaderGroupElectionTest --tests io.bluetape4k.leader.redisson.RedissonSuspendLeaderGroupElectorTest --no-daemon` passed: Redisson 64 tests; core and Lettuce tasks were up-to-date from prior verification.
+- IntelliJ build diagnostics reported zero errors.
+- Repo inventory found 24 production result API files and zero files missing `ActionFailed` handling.
+- Repo search found no stale alternative result names.
+- Claude CLI review succeeded on the 5-minute retry and the P1 items were addressed. Artifact: `.omx/artifacts/claude-actionfailed-result-20260514183409.md`.
+
+## Future Guidance
+
+When adding result APIs for new backends, distinguish only three value outcomes: elected, skipped, and
+action failed. Keep backend/acquire failures as exceptions unless a separate backend-result contract is
+explicitly designed. Always test `CancellationException` and `InterruptedException` separately from action
+failure; broad `catch (Exception)` blocks can silently convert cancellation/interruption into an action
+failure. For `CompletableFuture` APIs, document cancellation as exceptional completion unless the code
+explicitly calls `cancel()`.

--- a/leader-core/README.ko.md
+++ b/leader-core/README.ko.md
@@ -17,22 +17,27 @@ classDiagram
     class AsyncLeaderElector {
         <<interface>>
         +runAsyncIfLeader(lockName, action) CompletableFuture~T?~
+        +runAsyncIfLeaderResult(slot, action) CompletableFuture~LeaderRunResult~
     }
     class LeaderElector {
         <<interface>>
         +runIfLeader(lockName, action) T?
+        +runIfLeaderResult(lockName, action) LeaderRunResult
     }
     class VirtualThreadLeaderElector {
         <<interface>>
         +runIfLeader(lockName, action) T?
+        +runAsyncIfLeaderResult(slot, action) VirtualFuture~LeaderRunResult~
     }
     class SuspendLeaderElector {
         <<interface>>
         +runIfLeader(lockName, action) T?
+        +runIfLeaderResultSuspend(lockName, action) LeaderRunResult
     }
     class AsyncLeaderGroupElector {
         <<interface>>
         +runAsyncIfLeader(lockName, action) CompletableFuture~T?~
+        +runAsyncIfLeaderResult(slot, action) CompletableFuture~LeaderRunResult~
         +state(lockName) LeaderGroupState
         +activeCount(lockName) Int
         +availableSlots(lockName) Int
@@ -40,10 +45,12 @@ classDiagram
     class LeaderGroupElector {
         <<interface>>
         +runIfLeader(lockName, action) T?
+        +runIfLeaderResult(lockName, action) LeaderRunResult
     }
     class SuspendLeaderGroupElector {
         <<interface>>
         +runIfLeader(lockName, action) T?
+        +runIfLeaderResultSuspend(lockName, action) LeaderRunResult
     }
 
     LeaderElector --|> AsyncLeaderElector
@@ -61,6 +68,28 @@ classDiagram
 - `waitTime` 내 획득 실패: **`null`** 반환 (경쟁 상황에서 예외를 던지지 않음)
 - `action` 내부에서 발생한 예외는 호출자에게 전파됩니다
 - `action` 완료 후 (또는 예외 발생 시) 락이 해제됩니다
+
+### `runIfLeaderResult*`: 명시적 실행 결과
+
+`null`이 정상 action 결과일 수 있거나, 경쟁으로 실행되지 않은 경우와 action 실패를 구분해야 하면 result API를 사용하세요.
+
+```kotlin
+when (val result = election.runIfLeaderResult("daily-job") { computeOrNull() }) {
+    is LeaderRunResult.Elected -> use(result.value)       // action 실행됨, value 는 null 가능
+    LeaderRunResult.Skipped -> recordContention()         // action 실행 안 됨
+    is LeaderRunResult.ActionFailed -> report(result.cause)
+}
+```
+
+`LeaderRunResult`는 세 상태를 가집니다.
+
+- `Elected(value, leaderId?)`: 락 또는 슬롯을 획득했고 action이 완료됨.
+- `Skipped`: 락 또는 슬롯을 획득하지 못해 action이 실행되지 않음.
+- `ActionFailed(cause)`: 락 또는 슬롯을 획득하고 action이 시작됐지만 실행 중 실패함.
+
+Result API는 `CancellationException`을 `ActionFailed`로 변환하지 않습니다. 동기/코루틴 API는 재전파하고,
+async/가상 스레드 API는 예외 완료됩니다(`join()`에서는 cancellation을 감싼 `CompletionException`을
+기대하세요. `isCancelled()` 보장은 아닙니다). 동기 API는 `InterruptedException`도 interrupt flag를 복원한 뒤 재전파합니다.
 
 ### 선출 생명주기 listener
 

--- a/leader-core/README.md
+++ b/leader-core/README.md
@@ -17,22 +17,27 @@ classDiagram
     class AsyncLeaderElector {
         <<interface>>
         +runAsyncIfLeader(lockName, action) CompletableFuture~T?~
+        +runAsyncIfLeaderResult(slot, action) CompletableFuture~LeaderRunResult~
     }
     class LeaderElector {
         <<interface>>
         +runIfLeader(lockName, action) T?
+        +runIfLeaderResult(lockName, action) LeaderRunResult
     }
     class VirtualThreadLeaderElector {
         <<interface>>
         +runIfLeader(lockName, action) T?
+        +runAsyncIfLeaderResult(slot, action) VirtualFuture~LeaderRunResult~
     }
     class SuspendLeaderElector {
         <<interface>>
         +runIfLeader(lockName, action) T?
+        +runIfLeaderResultSuspend(lockName, action) LeaderRunResult
     }
     class AsyncLeaderGroupElector {
         <<interface>>
         +runAsyncIfLeader(lockName, action) CompletableFuture~T?~
+        +runAsyncIfLeaderResult(slot, action) CompletableFuture~LeaderRunResult~
         +state(lockName) LeaderGroupState
         +activeCount(lockName) Int
         +availableSlots(lockName) Int
@@ -40,10 +45,12 @@ classDiagram
     class LeaderGroupElector {
         <<interface>>
         +runIfLeader(lockName, action) T?
+        +runIfLeaderResult(lockName, action) LeaderRunResult
     }
     class SuspendLeaderGroupElector {
         <<interface>>
         +runIfLeader(lockName, action) T?
+        +runIfLeaderResultSuspend(lockName, action) LeaderRunResult
     }
 
     LeaderElector --|> AsyncLeaderElector
@@ -61,6 +68,30 @@ classDiagram
 - If not acquired within `waitTime`: returns **`null`** (never throws on contention)
 - Exceptions from `action` are propagated to the caller
 - Lock is released after `action` completes (or on exception)
+
+### `runIfLeaderResult*`: explicit execution outcome
+
+Use result APIs when `null` is a valid action value or when callers need to distinguish contention from
+action failure:
+
+```kotlin
+when (val result = election.runIfLeaderResult("daily-job") { computeOrNull() }) {
+    is LeaderRunResult.Elected -> use(result.value)       // action ran; value may be null
+    LeaderRunResult.Skipped -> recordContention()         // action did not run
+    is LeaderRunResult.ActionFailed -> report(result.cause)
+}
+```
+
+`LeaderRunResult` has three states:
+
+- `Elected(value, leaderId?)`: lock or slot was acquired and the action completed.
+- `Skipped`: lock or slot was not acquired, so the action was not executed.
+- `ActionFailed(cause)`: lock or slot was acquired and the action started, but it failed.
+
+Result APIs never convert `CancellationException` into `ActionFailed`. Blocking and coroutine APIs rethrow it;
+async and virtual-thread APIs complete exceptionally instead (for `join()`, expect `CompletionException`
+wrapping the cancellation; `isCancelled()` is not guaranteed). Blocking APIs also rethrow
+`InterruptedException` after restoring the interrupt flag.
 
 ### Election lifecycle listeners
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderElector.kt
@@ -2,7 +2,9 @@ package io.bluetape4k.leader
 
 import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
 import io.bluetape4k.leader.identity.LeaderElectorBridgeLog
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -100,8 +102,27 @@ interface AsyncLeaderElector: LeaderElectionState {
         return runAsyncIfLeader(slot.lockName, executor) {
             elected.set(true)
             action()
-        }.thenApply { value ->
-            if (elected.get()) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
+        }.handle { value, failure ->
+            when {
+                failure != null && elected.get() -> failure.toActionFailedResult()
+                failure != null -> throw failure.asCompletionException()
+                elected.get() -> LeaderRunResult.Elected(value)
+                else -> LeaderRunResult.Skipped
+            }
         }
     }
+
+    private fun Throwable.unwrapCompletionCause(): Throwable =
+        (this as? CompletionException)?.cause ?: this
+
+    private fun Throwable.toActionFailedResult(): LeaderRunResult.ActionFailed {
+        val cause = unwrapCompletionCause()
+        if (cause is CancellationException) {
+            throw cause
+        }
+        return LeaderRunResult.ActionFailed(cause)
+    }
+
+    private fun Throwable.asCompletionException(): CompletionException =
+        this as? CompletionException ?: CompletionException(this)
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderGroupElector.kt
@@ -2,7 +2,9 @@ package io.bluetape4k.leader
 
 import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
 import io.bluetape4k.leader.identity.LeaderElectorBridgeLog
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -104,8 +106,27 @@ interface AsyncLeaderGroupElector: LeaderGroupElectionState {
         return runAsyncIfLeader(slot.lockName, executor) {
             elected.set(true)
             action()
-        }.thenApply { value ->
-            if (elected.get()) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
+        }.handle { value, failure ->
+            when {
+                failure != null && elected.get() -> failure.toActionFailedResult()
+                failure != null -> throw failure.asCompletionException()
+                elected.get() -> LeaderRunResult.Elected(value)
+                else -> LeaderRunResult.Skipped
+            }
         }
     }
+
+    private fun Throwable.unwrapCompletionCause(): Throwable =
+        (this as? CompletionException)?.cause ?: this
+
+    private fun Throwable.toActionFailedResult(): LeaderRunResult.ActionFailed {
+        val cause = unwrapCompletionCause()
+        if (cause is CancellationException) {
+            throw cause
+        }
+        return LeaderRunResult.ActionFailed(cause)
+    }
+
+    private fun Throwable.asCompletionException(): CompletionException =
+        this as? CompletionException ?: CompletionException(this)
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElector.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader
 
 import io.bluetape4k.leader.identity.LeaderElectorBridgeLog
+import java.util.concurrent.CancellationException
 
 /**
  * 동기 방식 리더 선출 실행 계약을 정의합니다.
@@ -46,24 +47,41 @@ interface LeaderElector: AsyncLeaderElector {
      * action()이 null을 반환해도 [LeaderRunResult.Elected]로 구분되고,
      * lock 미획득은 [LeaderRunResult.Skipped]로 구분됩니다.
      *
-     * NOTE: 동기 [LeaderElector] 전용입니다.
-     * `SuspendLeaderElector` / `AsyncLeaderElector` / `VirtualThreadLeaderElector` 의 동등
-     * 메서드는 v1.x 후속 이슈에서 추가 예정입니다.
+     * 동등 result API는 coroutine/async/virtual-thread elector에도 제공됩니다.
+     * `CancellationException`은 [LeaderRunResult.ActionFailed]로 감싸지 않고 호출자에게 전파됩니다.
+     * `InterruptedException`은 interrupt flag를 복원한 뒤 재전파합니다.
      *
      * ```kotlin
      * when (val r = election.runIfLeaderResult("job-lock") { compute() }) {
      *     is LeaderRunResult.Elected -> println("elected, value=${r.value}")
      *     is LeaderRunResult.Skipped -> println("skipped — lock not acquired")
+     *     is LeaderRunResult.ActionFailed -> println("action failed: ${r.cause.message}")
      * }
      * ```
      *
      * @param lockName 리더 선출에 사용할 락 이름
      * @param action 리더 획득 성공 시 실행할 동기 작업
-     * @return [LeaderRunResult.Elected] (action 실행됨) 또는 [LeaderRunResult.Skipped] (lock 미획득)
+     * @return [LeaderRunResult.Elected] (action 실행됨), [LeaderRunResult.Skipped] (lock 미획득),
+     *   또는 [LeaderRunResult.ActionFailed] (action 실패)
      */
     fun <T> runIfLeaderResult(lockName: String, action: () -> T): LeaderRunResult<T> {
         var elected = false
-        val value = runIfLeader(lockName) { elected = true; action() }
+        val value = try {
+            runIfLeader(lockName) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
+        }
         return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
     }
 
@@ -98,12 +116,28 @@ interface LeaderElector: AsyncLeaderElector {
      *
      * @param slot the [LeaderSlot] carrying both lock name and audit leader id.
      * @param action the action to run when elected.
-     * @return [LeaderRunResult.Elected] (action ran) or [LeaderRunResult.Skipped] (not elected).
+     * @return [LeaderRunResult.Elected] (action ran), [LeaderRunResult.Skipped] (not elected),
+     *   or [LeaderRunResult.ActionFailed] (action failed).
      */
     fun <T> runIfLeaderResult(slot: LeaderSlot, action: () -> T): LeaderRunResult<T> {
         LeaderElectorBridgeLog.global().warnOnResultBridgeUse(this::class, slot)
         var elected = false
-        val value = runIfLeader(slot.lockName) { elected = true; action() }
+        val value = try {
+            runIfLeader(slot.lockName) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
+        }
         return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
     }
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupElector.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader
 
 import io.bluetape4k.leader.identity.LeaderElectorBridgeLog
+import java.util.concurrent.CancellationException
 
 /**
  * Semaphore 기반 복수 리더 선출 계약을 정의합니다.
@@ -56,17 +57,33 @@ interface LeaderGroupElector: AsyncLeaderGroupElector {
      * action()이 null을 반환해도 [LeaderRunResult.Elected]로 구분되고,
      * 슬롯 미획득은 [LeaderRunResult.Skipped]로 구분됩니다.
      *
-     * NOTE: 동기 [LeaderGroupElector] 전용입니다.
-     * `SuspendLeaderGroupElector` / `AsyncLeaderGroupElector` 의 동등 메서드는
-     * v1.x 후속 이슈에서 추가 예정입니다.
+     * 동등 result API는 coroutine/async/virtual-thread group elector에도 제공됩니다.
+     * `CancellationException`은 [LeaderRunResult.ActionFailed]로 감싸지 않고 호출자에게 전파됩니다.
+     * `InterruptedException`은 interrupt flag를 복원한 뒤 재전파합니다.
      *
      * @param lockName 리더 그룹 선출에 사용할 락 이름
      * @param action 슬롯 획득 성공 시 실행할 동기 작업
-     * @return [LeaderRunResult.Elected] (action 실행됨) 또는 [LeaderRunResult.Skipped] (슬롯 미획득)
+     * @return [LeaderRunResult.Elected] (action 실행됨), [LeaderRunResult.Skipped] (슬롯 미획득),
+     *   또는 [LeaderRunResult.ActionFailed] (action 실패)
      */
     fun <T> runIfLeaderResult(lockName: String, action: () -> T): LeaderRunResult<T> {
         var elected = false
-        val value = runIfLeader(lockName) { elected = true; action() }
+        val value = try {
+            runIfLeader(lockName) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
+        }
         return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
     }
 
@@ -97,12 +114,28 @@ interface LeaderGroupElector: AsyncLeaderGroupElector {
      *
      * @param slot the [LeaderSlot] carrying both lock name and audit leader id.
      * @param action the action to run when a slot is acquired.
-     * @return [LeaderRunResult.Elected] (action ran) or [LeaderRunResult.Skipped] (no slot acquired).
+     * @return [LeaderRunResult.Elected] (action ran), [LeaderRunResult.Skipped] (no slot acquired),
+     *   or [LeaderRunResult.ActionFailed] (action failed).
      */
     fun <T> runIfLeaderResult(slot: LeaderSlot, action: () -> T): LeaderRunResult<T> {
         LeaderElectorBridgeLog.global().warnOnResultBridgeUse(this::class, slot)
         var elected = false
-        val value = runIfLeader(slot.lockName) { elected = true; action() }
+        val value = try {
+            runIfLeader(slot.lockName) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
+        }
         return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
     }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderRunResult.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderRunResult.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader
 
 import io.bluetape4k.logging.KLogging
+import java.io.Serializable
 
 /**
  * Result type of [LeaderElector.runIfLeaderResult] / [LeaderGroupElector.runIfLeaderResult].
@@ -13,8 +14,23 @@ import io.bluetape4k.logging.KLogging
  * ## States
  * - [Elected]: leader election succeeded — action was executed. Even if action returned null, [Elected] is returned.
  * - [Skipped]: leader election failed — action was not executed because the lock was not acquired.
+ * - [ActionFailed]: leader election succeeded, but the action failed while it was running.
+ *
+ * ## Cancellation
+ * Result APIs must not wrap `CancellationException` as [ActionFailed]. Blocking and suspend APIs rethrow it;
+ * async and virtual-thread APIs complete exceptionally instead of returning [ActionFailed].
+ * Blocking APIs also rethrow `InterruptedException` after restoring the interrupt flag.
+ *
+ * ## Usage
+ * ```kotlin
+ * when (val result = election.runIfLeaderResult("daily-job") { runJob() }) {
+ *     is LeaderRunResult.Elected -> process(result.value)
+ *     LeaderRunResult.Skipped -> log.info { "Skipped because another leader is active." }
+ *     is LeaderRunResult.ActionFailed -> log.warn(result.cause) { "Leader action failed." }
+ * }
+ * ```
  */
-sealed interface LeaderRunResult<out T> {
+sealed interface LeaderRunResult<out T>: Serializable {
 
     companion object : KLogging()
 
@@ -44,8 +60,24 @@ sealed interface LeaderRunResult<out T> {
     data class Elected<out T> @JvmOverloads constructor(
         val value: T?,
         val leaderId: String? = null,
-    ) : LeaderRunResult<T>
+    ) : LeaderRunResult<T> {
+        companion object {
+            private const val serialVersionUID: Long = 5711634040242986115L
+        }
+    }
 
     /** Leader election failed — action was not executed because the lock was not acquired. */
     data object Skipped : LeaderRunResult<Nothing>
+
+    /**
+     * Leader election succeeded, but the action failed while it was running.
+     *
+     * [cause] is an application/action failure. Implementations must propagate `CancellationException`
+     * directly and must not wrap it as [ActionFailed].
+     */
+    data class ActionFailed(val cause: Throwable) : LeaderRunResult<Nothing> {
+        companion object {
+            private const val serialVersionUID: Long = -1428070323206111594L
+        }
+    }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/VirtualThreadLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/VirtualThreadLeaderElector.kt
@@ -2,6 +2,8 @@ package io.bluetape4k.leader
 
 import io.bluetape4k.concurrent.virtualthread.VirtualFuture
 import io.bluetape4k.leader.identity.LeaderElectorBridgeLog
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletionException
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -91,13 +93,28 @@ interface VirtualThreadLeaderElector: LeaderElectionState {
             action()
         }
         val mapped: java.util.concurrent.CompletableFuture<LeaderRunResult<T>> =
-            source.toCompletableFuture().thenApply { value ->
-                if (elected.get()) {
-                    LeaderRunResult.Elected(value) as LeaderRunResult<T>
-                } else {
-                    LeaderRunResult.Skipped as LeaderRunResult<T>
+            source.toCompletableFuture().handle { value, failure ->
+                when {
+                    failure != null && elected.get() -> failure.toActionFailedResult()
+                    failure != null -> throw failure.asCompletionException()
+                    elected.get() -> LeaderRunResult.Elected(value) as LeaderRunResult<T>
+                    else -> LeaderRunResult.Skipped as LeaderRunResult<T>
                 }
             }
         return VirtualFuture(mapped)
     }
+
+    private fun Throwable.unwrapCompletionCause(): Throwable =
+        (this as? CompletionException)?.cause ?: this
+
+    private fun Throwable.toActionFailedResult(): LeaderRunResult.ActionFailed {
+        val cause = unwrapCompletionCause()
+        if (cause is CancellationException) {
+            throw cause
+        }
+        return LeaderRunResult.ActionFailed(cause)
+    }
+
+    private fun Throwable.asCompletionException(): CompletionException =
+        this as? CompletionException ?: CompletionException(this)
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/VirtualThreadLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/VirtualThreadLeaderGroupElector.kt
@@ -2,6 +2,8 @@ package io.bluetape4k.leader
 
 import io.bluetape4k.concurrent.virtualthread.VirtualFuture
 import io.bluetape4k.leader.identity.LeaderElectorBridgeLog
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletionException
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -94,13 +96,28 @@ interface VirtualThreadLeaderGroupElector: LeaderGroupElectionState {
             action()
         }
         val mapped: java.util.concurrent.CompletableFuture<LeaderRunResult<T>> =
-            source.toCompletableFuture().thenApply { value ->
-                if (elected.get()) {
-                    LeaderRunResult.Elected(value) as LeaderRunResult<T>
-                } else {
-                    LeaderRunResult.Skipped as LeaderRunResult<T>
+            source.toCompletableFuture().handle { value, failure ->
+                when {
+                    failure != null && elected.get() -> failure.toActionFailedResult()
+                    failure != null -> throw failure.asCompletionException()
+                    elected.get() -> LeaderRunResult.Elected(value) as LeaderRunResult<T>
+                    else -> LeaderRunResult.Skipped as LeaderRunResult<T>
                 }
             }
         return VirtualFuture(mapped)
     }
+
+    private fun Throwable.unwrapCompletionCause(): Throwable =
+        (this as? CompletionException)?.cause ?: this
+
+    private fun Throwable.toActionFailedResult(): LeaderRunResult.ActionFailed {
+        val cause = unwrapCompletionCause()
+        if (cause is CancellationException) {
+            throw cause
+        }
+        return LeaderRunResult.ActionFailed(cause)
+    }
+
+    private fun Throwable.asCompletionException(): CompletionException =
+        this as? CompletionException ?: CompletionException(this)
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElector.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Coroutines [Mutex]를 이용한 로컬(단일 JVM) suspend 리더 선출 구현체입니다.
@@ -119,13 +120,22 @@ class LocalSuspendLeaderElector(
         action: suspend () -> T,
     ): LeaderRunResult<T> {
         var elected = false
-        val value = tryWithLock(
-            lockName = slot.lockName,
-            auditLeaderId = slot.leaderId,
-            nodeId = options.nodeId,
-        ) {
-            elected = true
-            action()
+        val value = try {
+            tryWithLock(
+                lockName = slot.lockName,
+                auditLeaderId = slot.leaderId,
+                nodeId = options.nodeId,
+            ) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
         }
         return if (elected) LeaderRunResult.Elected(value, leaderId = slot.leaderId) else LeaderRunResult.Skipped
     }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElector.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * 코루틴 [Semaphore]를 이용한 로컬(단일 JVM) suspend 복수 리더 선출 구현체입니다.
@@ -200,13 +201,22 @@ class LocalSuspendLeaderGroupElector private constructor(
         action: suspend () -> T,
     ): LeaderRunResult<T> {
         var elected = false
-        val value = tryWithPermit(
-            lockName = slot.lockName,
-            auditLeaderId = slot.leaderId,
-            nodeId = options.nodeId,
-        ) {
-            elected = true
-            action()
+        val value = try {
+            tryWithPermit(
+                lockName = slot.lockName,
+                auditLeaderId = slot.leaderId,
+                nodeId = options.nodeId,
+            ) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
         }
         return if (elected) LeaderRunResult.Elected(value, leaderId = slot.leaderId) else LeaderRunResult.Skipped
     }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderElector.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.leader.LeaderElectionState
 import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.identity.LeaderElectorBridgeLog
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * 코루틴 기반 리더 선출 실행 계약을 정의합니다.
@@ -63,8 +64,11 @@ interface SuspendLeaderElector: LeaderElectionState {
      * when (result) {
      *     is LeaderRunResult.Elected -> println("elected, value=${result.value}")
      *     LeaderRunResult.Skipped   -> println("not elected")
+     *     is LeaderRunResult.ActionFailed -> println("action failed: ${result.cause.message}")
      * }
      * ```
+     *
+     * `CancellationException` is rethrown directly and is not wrapped as [LeaderRunResult.ActionFailed].
      *
      * @param lockName 리더 선출에 사용할 락 이름
      * @param action 리더 획득 성공 시 실행할 suspend 작업
@@ -75,7 +79,19 @@ interface SuspendLeaderElector: LeaderElectionState {
         action: suspend () -> T,
     ): LeaderRunResult<T> {
         var elected = false
-        val value = runIfLeader(lockName) { elected = true; action() }
+        val value = try {
+            runIfLeader(lockName) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
+        }
         return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
     }
 
@@ -116,9 +132,18 @@ interface SuspendLeaderElector: LeaderElectionState {
     ): LeaderRunResult<T> {
         LeaderElectorBridgeLog.global().warnOnResultBridgeUse(this::class, slot)
         var elected = false
-        val value = runIfLeader(slot.lockName) {
-            elected = true
-            action()
+        val value = try {
+            runIfLeader(slot.lockName) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
         }
         return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
     }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/SuspendLeaderGroupElector.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.leader.LeaderGroupElectionState
 import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.identity.LeaderElectorBridgeLog
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * 코루틴 기반 복수 리더 선출 계약을 정의합니다.
@@ -59,6 +60,8 @@ interface SuspendLeaderGroupElector: LeaderGroupElectionState {
      * ## 동작/계약
      * - 슬롯 획득 성공 → [LeaderRunResult.Elected]`(value)` — `value` 는 action 반환값 (null 가능)
      * - 슬롯 미획득 → [LeaderRunResult.Skipped]
+     * - action 실행 실패 → [LeaderRunResult.ActionFailed]
+     * - `CancellationException` 은 [LeaderRunResult.ActionFailed] 로 감싸지 않고 재전파
      * - `elected: Boolean` flag 패턴으로 정확 분류 (action 이 null 반환해도 [LeaderRunResult.Elected])
      *
      * ## binary-compat (Step 2-R R3-F3)
@@ -70,6 +73,7 @@ interface SuspendLeaderGroupElector: LeaderGroupElectionState {
      * when (result) {
      *     is LeaderRunResult.Elected -> println("elected, value=${result.value}")
      *     LeaderRunResult.Skipped   -> println("slot full — skipped")
+     *     is LeaderRunResult.ActionFailed -> println("action failed: ${result.cause.message}")
      * }
      * ```
      *
@@ -82,7 +86,19 @@ interface SuspendLeaderGroupElector: LeaderGroupElectionState {
         action: suspend () -> T,
     ): LeaderRunResult<T> {
         var elected = false
-        val value = runIfLeader(lockName) { elected = true; action() }
+        val value = try {
+            runIfLeader(lockName) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
+        }
         return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
     }
 
@@ -123,9 +139,18 @@ interface SuspendLeaderGroupElector: LeaderGroupElectionState {
     ): LeaderRunResult<T> {
         LeaderElectorBridgeLog.global().warnOnResultBridgeUse(this::class, slot)
         var elected = false
-        val value = runIfLeader(slot.lockName) {
-            elected = true
-            action()
+        val value = try {
+            runIfLeader(slot.lockName) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
         }
         return if (elected) LeaderRunResult.Elected(value) else LeaderRunResult.Skipped
     }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalAsyncLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalAsyncLeaderElector.kt
@@ -4,7 +4,9 @@ import io.bluetape4k.leader.AsyncLeaderElector
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
@@ -105,8 +107,27 @@ class LocalAsyncLeaderElector(
                 }
             },
             executor
-        ).thenApply { value ->
-            if (elected.get()) LeaderRunResult.Elected(value, leaderId = slot.leaderId) else LeaderRunResult.Skipped
+        ).handle { value, failure ->
+            when {
+                failure != null && elected.get() -> failure.toActionFailedResult()
+                failure != null -> throw failure.asCompletionException()
+                elected.get() -> LeaderRunResult.Elected(value, leaderId = slot.leaderId)
+                else -> LeaderRunResult.Skipped
+            }
         }
     }
+
+    private fun Throwable.unwrapCompletionCause(): Throwable =
+        (this as? CompletionException)?.cause ?: this
+
+    private fun Throwable.toActionFailedResult(): LeaderRunResult.ActionFailed {
+        val cause = unwrapCompletionCause()
+        if (cause is CancellationException) {
+            throw cause
+        }
+        return LeaderRunResult.ActionFailed(cause)
+    }
+
+    private fun Throwable.asCompletionException(): CompletionException =
+        this as? CompletionException ?: CompletionException(this)
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalAsyncLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalAsyncLeaderGroupElector.kt
@@ -7,7 +7,9 @@ import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.requirePositiveNumber
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -126,8 +128,27 @@ class LocalAsyncLeaderGroupElector private constructor(
                 }
             },
             executor
-        ).thenApply { value ->
-            if (elected.get()) LeaderRunResult.Elected(value, leaderId = slot.leaderId) else LeaderRunResult.Skipped
+        ).handle { value, failure ->
+            when {
+                failure != null && elected.get() -> failure.toActionFailedResult()
+                failure != null -> throw failure.asCompletionException()
+                elected.get() -> LeaderRunResult.Elected(value, leaderId = slot.leaderId)
+                else -> LeaderRunResult.Skipped
+            }
         }
     }
+
+    private fun Throwable.unwrapCompletionCause(): Throwable =
+        (this as? CompletionException)?.cause ?: this
+
+    private fun Throwable.toActionFailedResult(): LeaderRunResult.ActionFailed {
+        val cause = unwrapCompletionCause()
+        if (cause is CancellationException) {
+            throw cause
+        }
+        return LeaderRunResult.ActionFailed(cause)
+    }
+
+    private fun Throwable.asCompletionException(): CompletionException =
+        this as? CompletionException ?: CompletionException(this)
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderElector.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.leader.LeaderElector
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.concurrent.locks.ReentrantLock
@@ -94,14 +95,26 @@ class LocalLeaderElector(
      */
     override fun <T> runIfLeaderResult(slot: LeaderSlot, action: () -> T): LeaderRunResult<T> {
         var elected = false
-        val value = tryWithLeaderLock(
-            lockName = slot.lockName,
-            auditLeaderId = slot.leaderId,
-            nodeId = options.nodeId,
-            waitTime = options.waitTime,
-        ) {
-            elected = true
-            action()
+        val value = try {
+            tryWithLeaderLock(
+                lockName = slot.lockName,
+                auditLeaderId = slot.leaderId,
+                nodeId = options.nodeId,
+                waitTime = options.waitTime,
+            ) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
         }
         return if (elected) LeaderRunResult.Elected(value, leaderId = slot.leaderId) else LeaderRunResult.Skipped
     }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderGroupElector.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.requirePositiveNumber
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 
@@ -114,13 +115,25 @@ class LocalLeaderGroupElector private constructor(options: LeaderGroupElectionOp
      */
     override fun <T> runIfLeaderResult(slot: LeaderSlot, action: () -> T): LeaderRunResult<T> {
         var elected = false
-        val value = tryWithPermit(
-            lockName = slot.lockName,
-            auditLeaderId = slot.leaderId,
-            nodeId = options.nodeId,
-        ) {
-            elected = true
-            action()
+        val value = try {
+            tryWithPermit(
+                lockName = slot.lockName,
+                auditLeaderId = slot.leaderId,
+                nodeId = options.nodeId,
+            ) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
         }
         return if (elected) LeaderRunResult.Elected(value, leaderId = slot.leaderId) else LeaderRunResult.Skipped
     }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalVirtualThreadLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalVirtualThreadLeaderElector.kt
@@ -6,6 +6,8 @@ import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.VirtualThreadLeaderElector
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletionException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 
@@ -92,13 +94,28 @@ class LocalVirtualThreadLeaderElector(
             }
         }
         val mapped: java.util.concurrent.CompletableFuture<LeaderRunResult<T>> =
-            source.toCompletableFuture().thenApply { value ->
-                if (elected.get()) {
-                    LeaderRunResult.Elected(value, leaderId = slot.leaderId) as LeaderRunResult<T>
-                } else {
-                    LeaderRunResult.Skipped as LeaderRunResult<T>
+            source.toCompletableFuture().handle { value, failure ->
+                when {
+                    failure != null && elected.get() -> failure.toActionFailedResult()
+                    failure != null -> throw failure.asCompletionException()
+                    elected.get() -> LeaderRunResult.Elected(value, leaderId = slot.leaderId) as LeaderRunResult<T>
+                    else -> LeaderRunResult.Skipped as LeaderRunResult<T>
                 }
             }
         return VirtualFuture(mapped)
     }
+
+    private fun Throwable.unwrapCompletionCause(): Throwable =
+        (this as? CompletionException)?.cause ?: this
+
+    private fun Throwable.toActionFailedResult(): LeaderRunResult.ActionFailed {
+        val cause = unwrapCompletionCause()
+        if (cause is CancellationException) {
+            throw cause
+        }
+        return LeaderRunResult.ActionFailed(cause)
+    }
+
+    private fun Throwable.asCompletionException(): CompletionException =
+        this as? CompletionException ?: CompletionException(this)
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalVirtualThreadLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalVirtualThreadLeaderGroupElector.kt
@@ -8,6 +8,8 @@ import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.VirtualThreadLeaderGroupElector
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.requirePositiveNumber
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletionException
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -110,13 +112,28 @@ class LocalVirtualThreadLeaderGroupElector private constructor(
             }
         }
         val mapped: java.util.concurrent.CompletableFuture<LeaderRunResult<T>> =
-            source.toCompletableFuture().thenApply { value ->
-                if (elected.get()) {
-                    LeaderRunResult.Elected(value, leaderId = slot.leaderId) as LeaderRunResult<T>
-                } else {
-                    LeaderRunResult.Skipped as LeaderRunResult<T>
+            source.toCompletableFuture().handle { value, failure ->
+                when {
+                    failure != null && elected.get() -> failure.toActionFailedResult()
+                    failure != null -> throw failure.asCompletionException()
+                    elected.get() -> LeaderRunResult.Elected(value, leaderId = slot.leaderId) as LeaderRunResult<T>
+                    else -> LeaderRunResult.Skipped as LeaderRunResult<T>
                 }
             }
         return VirtualFuture(mapped)
     }
+
+    private fun Throwable.unwrapCompletionCause(): Throwable =
+        (this as? CompletionException)?.cause ?: this
+
+    private fun Throwable.toActionFailedResult(): LeaderRunResult.ActionFailed {
+        val cause = unwrapCompletionCause()
+        if (cause is CancellationException) {
+            throw cause
+        }
+        return LeaderRunResult.ActionFailed(cause)
+    }
+
+    private fun Throwable.asCompletionException(): CompletionException =
+        this as? CompletionException ?: CompletionException(this)
 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/AsyncLeaderElectorContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/AsyncLeaderElectorContractTest.kt
@@ -5,9 +5,11 @@ import io.bluetape4k.leader.local.LocalAsyncLeaderElector
 import io.bluetape4k.leader.local.LocalLeaderElector
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 import io.bluetape4k.assertions.assertFailsWith
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.Executors
@@ -72,6 +74,33 @@ class AsyncLeaderElectorContractTest {
     }
 
     @Test
+    fun `runAsyncIfLeaderResult - action future 실패는 ActionFailed 로 분류한다`() {
+        val election: AsyncLeaderElector = LocalAsyncLeaderElector()
+        val failure = IllegalStateException("async-boom")
+
+        val result = election.runAsyncIfLeaderResult(LeaderSlot(randomLockName(), "async-node")) {
+            CompletableFuture.failedFuture<Any?>(failure)
+        }.join()
+
+        (result is LeaderRunResult.ActionFailed).shouldBeTrue()
+        (result as LeaderRunResult.ActionFailed).cause shouldBeEqualTo failure
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult - CancellationException 은 ActionFailed 로 감싸지 않는다`() {
+        val election: AsyncLeaderElector = LocalAsyncLeaderElector()
+        val cancellation = CancellationException("async-cancelled")
+
+        val thrown = assertFailsWith<CompletionException> {
+            election.runAsyncIfLeaderResult(LeaderSlot(randomLockName(), "async-node")) {
+                CompletableFuture.failedFuture<Any?>(cancellation)
+            }.join()
+        }
+
+        thrown.cause shouldBeInstanceOf CancellationException::class
+    }
+
+    @Test
     fun `runAsyncIfLeader - 커스텀 executor 를 사용할 수 있다`() {
         val election: AsyncLeaderElector = LocalAsyncLeaderElector()
         val executor = Executors.newSingleThreadExecutor()
@@ -94,6 +123,19 @@ class AsyncLeaderElectorContractTest {
             CompletableFuture.completedFuture(99)
         }.join()
         result shouldBeEqualTo 99
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult - LocalLeaderElector default bridge 도 ActionFailed 를 반환한다`() {
+        val election: AsyncLeaderElector = LocalLeaderElector()
+        val failure = IllegalArgumentException("bridge-boom")
+
+        val result = election.runAsyncIfLeaderResult(LeaderSlot(randomLockName(), "bridge-node")) {
+            CompletableFuture.failedFuture<Any?>(failure)
+        }.join()
+
+        (result is LeaderRunResult.ActionFailed).shouldBeTrue()
+        (result as LeaderRunResult.ActionFailed).cause shouldBeEqualTo failure
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/AsyncLeaderGroupElectorContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/AsyncLeaderGroupElectorContractTest.kt
@@ -4,12 +4,16 @@ import io.bluetape4k.codec.Base58
 import io.bluetape4k.leader.local.LocalAsyncLeaderGroupElector
 import io.bluetape4k.leader.local.LocalLeaderGroupElector
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeLessOrEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -67,6 +71,33 @@ class AsyncLeaderGroupElectorContractTest {
             CompletableFuture.completedFuture("복구")
         }.join()
         result shouldBeEqualTo "복구"
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult - action future 실패는 ActionFailed 로 분류한다`() {
+        val election: AsyncLeaderGroupElector = LocalAsyncLeaderGroupElector(options)
+        val failure = IllegalStateException("async-group-boom")
+
+        val result = election.runAsyncIfLeaderResult(LeaderSlot(randomLockName(), "async-group-node")) {
+            CompletableFuture.failedFuture<Any?>(failure)
+        }.join()
+
+        (result is LeaderRunResult.ActionFailed).shouldBeTrue()
+        (result as LeaderRunResult.ActionFailed).cause shouldBeEqualTo failure
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult - CancellationException 은 ActionFailed 로 감싸지 않는다`() {
+        val election: AsyncLeaderGroupElector = LocalAsyncLeaderGroupElector(options)
+        val cancellation = CancellationException("async-group-cancelled")
+
+        val thrown = assertFailsWith<CompletionException> {
+            election.runAsyncIfLeaderResult(LeaderSlot(randomLockName(), "async-group-node")) {
+                CompletableFuture.failedFuture<Any?>(cancellation)
+            }.join()
+        }
+
+        thrown.cause shouldBeInstanceOf CancellationException::class
     }
 
     // ── 상태 조회 (LeaderGroupElectionState 상속) ─────────────────────────
@@ -150,5 +181,18 @@ class AsyncLeaderGroupElectorContractTest {
             CompletableFuture.completedFuture(42)
         }.join()
         result shouldBeEqualTo 42
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult - LocalLeaderGroupElector default bridge 도 ActionFailed 를 반환한다`() {
+        val election: AsyncLeaderGroupElector = LocalLeaderGroupElector(options)
+        val failure = IllegalArgumentException("group-bridge-boom")
+
+        val result = election.runAsyncIfLeaderResult(LeaderSlot(randomLockName(), "group-bridge-node")) {
+            CompletableFuture.failedFuture<Any?>(failure)
+        }.join()
+
+        (result is LeaderRunResult.ActionFailed).shouldBeTrue()
+        (result as LeaderRunResult.ActionFailed).cause shouldBeEqualTo failure
     }
 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderRunResultTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderRunResultTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader
 
 import io.bluetape4k.codec.Base58
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.leader.local.LocalLeaderElector
 import io.bluetape4k.leader.local.LocalLeaderGroupElector
 import io.bluetape4k.logging.KLogging
@@ -9,6 +10,7 @@ import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.CancellationException
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class LeaderRunResultTest {
@@ -39,6 +41,38 @@ class LeaderRunResultTest {
     }
 
     @Test
+    fun `runIfLeaderResult - action 실패는 ActionFailed 로 분류`() {
+        val failure = IllegalStateException("boom")
+        val result = election.runIfLeaderResult<Any?>(randomLockName()) { throw failure }
+
+        result shouldBeInstanceOf LeaderRunResult.ActionFailed::class
+        (result as LeaderRunResult.ActionFailed).cause shouldBeEqualTo failure
+    }
+
+    @Test
+    fun `runIfLeaderResult - CancellationException 은 ActionFailed 로 감싸지 않고 재전파한다`() {
+        val cancellation = CancellationException("cancelled")
+
+        val thrown = assertFailsWith<CancellationException> {
+            election.runIfLeaderResult<Any?>(randomLockName()) { throw cancellation }
+        }
+
+        thrown shouldBeEqualTo cancellation
+    }
+
+    @Test
+    fun `runIfLeaderResult - InterruptedException 은 interrupt flag 복원 후 재전파한다`() {
+        val interrupted = InterruptedException("interrupted")
+
+        val thrown = assertFailsWith<InterruptedException> {
+            election.runIfLeaderResult<Any?>(randomLockName()) { throw interrupted }
+        }
+
+        thrown shouldBeEqualTo interrupted
+        Thread.interrupted() shouldBeEqualTo true
+    }
+
+    @Test
     fun `runIfLeaderResult - 정수 결과도 Elected 로 반환`() {
         val result = election.runIfLeaderResult(randomLockName()) { 42 }
 
@@ -52,6 +86,7 @@ class LeaderRunResultTest {
         val output = when (result) {
             is LeaderRunResult.Elected -> result.value
             is LeaderRunResult.Skipped -> null
+            is LeaderRunResult.ActionFailed -> result.cause.message
         }
         output shouldBeEqualTo "value"
     }
@@ -72,6 +107,38 @@ class LeaderRunResultTest {
 
         result shouldBeInstanceOf LeaderRunResult.Elected::class
         (result as LeaderRunResult.Elected).value.shouldBeNull()
+    }
+
+    @Test
+    fun `group runIfLeaderResult - action 실패는 ActionFailed 로 분류`() {
+        val failure = IllegalArgumentException("group-boom")
+        val result = groupElection.runIfLeaderResult<Any?>(randomLockName()) { throw failure }
+
+        result shouldBeInstanceOf LeaderRunResult.ActionFailed::class
+        (result as LeaderRunResult.ActionFailed).cause shouldBeEqualTo failure
+    }
+
+    @Test
+    fun `group runIfLeaderResult - CancellationException 은 ActionFailed 로 감싸지 않고 재전파한다`() {
+        val cancellation = CancellationException("group-cancelled")
+
+        val thrown = assertFailsWith<CancellationException> {
+            groupElection.runIfLeaderResult<Any?>(randomLockName()) { throw cancellation }
+        }
+
+        thrown shouldBeEqualTo cancellation
+    }
+
+    @Test
+    fun `group runIfLeaderResult - InterruptedException 은 interrupt flag 복원 후 재전파한다`() {
+        val interrupted = InterruptedException("group-interrupted")
+
+        val thrown = assertFailsWith<InterruptedException> {
+            groupElection.runIfLeaderResult<Any?>(randomLockName()) { throw interrupted }
+        }
+
+        thrown shouldBeEqualTo interrupted
+        Thread.interrupted() shouldBeEqualTo true
     }
 
     // --- data class / object 특성 ---
@@ -133,5 +200,14 @@ class LeaderRunResultTest {
         val updated = orig.copy(leaderId = "node-b")
         updated.leaderId shouldBeEqualTo "node-b"
         updated.value shouldBeEqualTo "v"
+    }
+
+    @Test
+    fun `ActionFailed - cause 로 equals 비교`() {
+        val cause = IllegalStateException("failed")
+        val a = LeaderRunResult.ActionFailed(cause)
+        val b = LeaderRunResult.ActionFailed(cause)
+
+        a shouldBeEqualTo b
     }
 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/SuspendRunIfLeaderResultTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/SuspendRunIfLeaderResultTest.kt
@@ -1,11 +1,13 @@
 package io.bluetape4k.leader.coroutines
 
 import io.bluetape4k.codec.Base58
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import kotlinx.coroutines.async
@@ -13,6 +15,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -39,6 +42,28 @@ class SuspendRunIfLeaderResultTest {
 
         (result is LeaderRunResult.Elected).shouldBeTrue()
         (result as LeaderRunResult.Elected<Nothing?>).value.shouldBeNull()
+    }
+
+    @Test
+    fun `SuspendLeaderElector - action 실패는 ActionFailed 로 분류된다`() = runSuspendIO {
+        val election = LocalSuspendLeaderElector()
+        val failure = IllegalStateException("suspend-boom")
+        val result = election.runIfLeaderResultSuspend<Any?>(randomLockName()) { throw failure }
+
+        (result is LeaderRunResult.ActionFailed).shouldBeTrue()
+        (result as LeaderRunResult.ActionFailed).cause shouldBeInstanceOf IllegalStateException::class
+        result.cause.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `SuspendLeaderElector - CancellationException 은 ActionFailed 로 감싸지 않고 재전파한다`() = runSuspendIO {
+        val election = LocalSuspendLeaderElector()
+
+        assertFailsWith<CancellationException> {
+            election.runIfLeaderResultSuspend<Any?>(randomLockName()) {
+                throw CancellationException("cancelled")
+            }
+        }
     }
 
     @Test
@@ -106,6 +131,29 @@ class SuspendRunIfLeaderResultTest {
         (result is LeaderRunResult.Elected).shouldBeTrue()
         (result as LeaderRunResult.Elected<Nothing?>).value.shouldBeNull()
     }
+
+    @Test
+    fun `SuspendLeaderGroupElector - action 실패는 ActionFailed 로 분류된다`() = runSuspendIO {
+        val election = LocalSuspendLeaderGroupElector(LeaderGroupElectionOptions(maxLeaders = 1))
+        val failure = IllegalArgumentException("group-suspend-boom")
+        val result = election.runIfLeaderResultSuspend<Any?>(randomLockName()) { throw failure }
+
+        (result is LeaderRunResult.ActionFailed).shouldBeTrue()
+        (result as LeaderRunResult.ActionFailed).cause shouldBeInstanceOf IllegalArgumentException::class
+        result.cause.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `SuspendLeaderGroupElector - CancellationException 은 ActionFailed 로 감싸지 않고 재전파한다`() =
+        runSuspendIO {
+            val election = LocalSuspendLeaderGroupElector(LeaderGroupElectionOptions(maxLeaders = 1))
+
+            assertFailsWith<CancellationException> {
+                election.runIfLeaderResultSuspend<Any?>(randomLockName()) {
+                    throw CancellationException("group-cancelled")
+                }
+            }
+        }
 
     @Test
     fun `SuspendLeaderGroupElector - 슬롯 가득 찰 때 Skipped 를 반환한다`() = runSuspendIO {

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalVirtualThreadLeaderElectorTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalVirtualThreadLeaderElectorTest.kt
@@ -4,12 +4,18 @@ import io.bluetape4k.codec.Base58
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.leader.LeaderElectionException
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletionException
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -73,6 +79,31 @@ class LocalVirtualThreadLeaderElectorTest {
             .join()
 
         result shouldBeEqualTo 42
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult - action 실패는 ActionFailed 로 분류한다`() {
+        val failure = IllegalStateException("virtual-boom")
+
+        val result = election.runAsyncIfLeaderResult(LeaderSlot(randomLockName(), "virtual-node")) {
+            throw failure
+        }.await()
+
+        (result is LeaderRunResult.ActionFailed).shouldBeTrue()
+        (result as LeaderRunResult.ActionFailed).cause shouldBeEqualTo failure
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult - CancellationException 은 ActionFailed 로 감싸지 않는다`() {
+        val cancellation = CancellationException("virtual-cancelled")
+
+        val thrown = assertFailsWith<CompletionException> {
+            election.runAsyncIfLeaderResult(LeaderSlot(randomLockName(), "virtual-node")) {
+                throw cancellation
+            }.toCompletableFuture().join()
+        }
+
+        thrown.cause shouldBeInstanceOf CancellationException::class
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalVirtualThreadLeaderGroupElectorTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalVirtualThreadLeaderGroupElectorTest.kt
@@ -4,14 +4,20 @@ import io.bluetape4k.codec.Base58
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.leader.LeaderGroupElectionException
 import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeLessOrEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletionException
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -214,6 +220,31 @@ class LocalVirtualThreadLeaderGroupElectorTest {
             .run()
 
         counter.get() shouldBeEqualTo numThreads * roundsPerThread
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult - action 실패는 ActionFailed 로 분류한다`() {
+        val failure = IllegalArgumentException("virtual-group-boom")
+
+        val result = election.runAsyncIfLeaderResult(LeaderSlot(randomLockName(), "virtual-group-node")) {
+            throw failure
+        }.await()
+
+        (result is LeaderRunResult.ActionFailed).shouldBeTrue()
+        (result as LeaderRunResult.ActionFailed).cause shouldBeEqualTo failure
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult - CancellationException 은 ActionFailed 로 감싸지 않는다`() {
+        val cancellation = CancellationException("virtual-group-cancelled")
+
+        val thrown = assertFailsWith<CompletionException> {
+            election.runAsyncIfLeaderResult(LeaderSlot(randomLockName(), "virtual-group-node")) {
+                throw cancellation
+            }.toCompletableFuture().join()
+        }
+
+        thrown.cause shouldBeInstanceOf CancellationException::class
     }
 
     // ── skip-behavior (ShedLock 방식): 슬롯 획득 실패 시 null 반환 ──────────

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElector.kt
@@ -80,7 +80,22 @@ class LettuceLeaderElector @JvmOverloads constructor(
 
     override fun <T> runIfLeaderResult(slot: LeaderSlot, action: () -> T): LeaderRunResult<T> {
         var elected = false
-        val value = runImpl(slot.lockName, auditLeaderId = slot.leaderId) { elected = true; action() }
+        val value = try {
+            runImpl(slot.lockName, auditLeaderId = slot.leaderId) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
+        }
         return if (elected) LeaderRunResult.Elected(value, leaderId = slot.leaderId) else LeaderRunResult.Skipped
     }
 
@@ -219,4 +234,3 @@ class LettuceLeaderElector @JvmOverloads constructor(
         }
     }
 }
-

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElector.kt
@@ -19,6 +19,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import io.lettuce.core.api.StatefulRedisConnection
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
@@ -97,7 +98,22 @@ class LettuceLeaderGroupElector(
 
     override fun <T> runIfLeaderResult(slot: LeaderSlot, action: () -> T): LeaderRunResult<T> {
         var elected = false
-        val value = runImpl(slot.lockName, auditLeaderId = slot.leaderId) { elected = true; action() }
+        val value = try {
+            runImpl(slot.lockName, auditLeaderId = slot.leaderId) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
+        }
         return if (elected) LeaderRunResult.Elected(value, leaderId = slot.leaderId) else LeaderRunResult.Skipped
     }
 

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElector.kt
@@ -81,7 +81,19 @@ class LettuceSuspendLeaderElector(
 
     override suspend fun <T> runIfLeaderResultSuspend(slot: LeaderSlot, action: suspend () -> T): LeaderRunResult<T> {
         var elected = false
-        val value = runImpl(slot.lockName, auditLeaderId = slot.leaderId) { elected = true; action() }
+        val value = try {
+            runImpl(slot.lockName, auditLeaderId = slot.leaderId) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
+        }
         return if (elected) LeaderRunResult.Elected(value, leaderId = slot.leaderId) else LeaderRunResult.Skipped
     }
 

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElector.kt
@@ -98,7 +98,19 @@ class LettuceSuspendLeaderGroupElector(
 
     override suspend fun <T> runIfLeaderResultSuspend(slot: LeaderSlot, action: suspend () -> T): LeaderRunResult<T> {
         var elected = false
-        val value = runImpl(slot.lockName, auditLeaderId = slot.leaderId) { elected = true; action() }
+        val value = try {
+            runImpl(slot.lockName, auditLeaderId = slot.leaderId) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
+        }
         return if (elected) LeaderRunResult.Elected(value, leaderId = slot.leaderId) else LeaderRunResult.Skipped
     }
 

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElectionTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElectionTest.kt
@@ -4,16 +4,20 @@ import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
 import io.bluetape4k.leader.LeaderElectionException
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import io.bluetape4k.assertions.assertFailsWith
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -111,6 +115,31 @@ class LettuceLeaderElectionTest: AbstractLettuceLeaderTest() {
         assertFailsWith<LeaderElectionException> {
             election.runIfLeader(lockName) { throw LeaderElectionException("오류") }
         }
+    }
+
+    @Test
+    fun `runIfLeaderResult - action 실패는 ActionFailed 로 분류한다`() {
+        val failure = LeaderElectionException("result 오류")
+
+        val result = election.runIfLeaderResult(LeaderSlot(lockName, "lettuce-node")) {
+            throw failure
+        }
+
+        (result is LeaderRunResult.ActionFailed).shouldBeTrue()
+        (result as LeaderRunResult.ActionFailed).cause shouldBeEqualTo failure
+    }
+
+    @Test
+    fun `runIfLeaderResult - CancellationException 은 ActionFailed 로 감싸지 않고 재전파한다`() {
+        val cancellation = CancellationException("lettuce-cancelled")
+
+        val thrown = assertFailsWith<CancellationException> {
+            election.runIfLeaderResult<Any?>(LeaderSlot(lockName, "lettuce-node")) {
+                throw cancellation
+            }
+        }
+
+        thrown shouldBeEqualTo cancellation
     }
 
     @Test

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElectionTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElectionTest.kt
@@ -4,6 +4,8 @@ import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
 import io.bluetape4k.leader.LeaderGroupElectionException
 import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
@@ -16,6 +18,7 @@ import io.bluetape4k.assertions.assertFailsWith
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -78,6 +81,31 @@ class LettuceLeaderGroupElectionTest: AbstractLettuceLeaderTest() {
     fun `리더 선출 성공 시 action 실행`() {
         val result = election.runIfLeader(lockName) { "done" }
         result shouldBeEqualTo "done"
+    }
+
+    @Test
+    fun `runIfLeaderResult - action 실패는 ActionFailed 로 분류한다`() {
+        val failure = LeaderGroupElectionException("group result 오류")
+
+        val result = election.runIfLeaderResult(LeaderSlot(lockName, "lettuce-group-node")) {
+            throw failure
+        }
+
+        (result is LeaderRunResult.ActionFailed).shouldBeTrue()
+        (result as LeaderRunResult.ActionFailed).cause shouldBeEqualTo failure
+    }
+
+    @Test
+    fun `runIfLeaderResult - CancellationException 은 ActionFailed 로 감싸지 않고 재전파한다`() {
+        val cancellation = CancellationException("lettuce-group-cancelled")
+
+        val thrown = assertFailsWith<CancellationException> {
+            election.runIfLeaderResult<Any?>(LeaderSlot(lockName, "lettuce-group-node")) {
+                throw cancellation
+            }
+        }
+
+        thrown shouldBeEqualTo cancellation
     }
 
     @Test

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElectorTest.kt
@@ -4,19 +4,23 @@ import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.LeaderElectionException
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.logging.KLogging
 import kotlinx.coroutines.delay
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import io.bluetape4k.assertions.assertFailsWith
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import java.util.concurrent.CancellationException
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.time.Duration.Companion.milliseconds
 
 class LettuceSuspendLeaderElectorTest: AbstractLettuceLeaderTest() {
 
@@ -57,6 +61,34 @@ class LettuceSuspendLeaderElectorTest: AbstractLettuceLeaderTest() {
         val result = suspendElection.runIfLeader(lockName) { "recovered" }
         result shouldBeEqualTo "recovered"
     }
+
+    @Test
+    fun `runIfLeaderResultSuspend - action 실패는 ActionFailed 로 분류한다`() = runSuspendIO {
+        val failure = LeaderElectionException("suspend result 오류")
+
+        val result = suspendElection.runIfLeaderResultSuspend(LeaderSlot(lockName, "lettuce-suspend-node")) {
+            throw failure
+        }
+
+        (result is LeaderRunResult.ActionFailed).shouldBeTrue()
+        val cause = (result as LeaderRunResult.ActionFailed).cause
+        cause.shouldBeInstanceOf<LeaderElectionException>()
+        cause.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `runIfLeaderResultSuspend - CancellationException 은 ActionFailed 로 감싸지 않고 재전파한다`() =
+        runSuspendIO {
+            val cancellation = CancellationException("lettuce-suspend-cancelled")
+
+            val thrown = assertFailsWith<CancellationException> {
+                suspendElection.runIfLeaderResultSuspend<Any?>(LeaderSlot(lockName, "lettuce-suspend-node")) {
+                    throw cancellation
+                }
+            }
+
+            thrown.message shouldBeEqualTo cancellation.message
+        }
 
     // =========================================================================
     // 확장 함수

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderGroupElectorTest.kt
@@ -2,7 +2,10 @@ package io.bluetape4k.leader.lettuce
 
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderGroupElectionException
 import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.logging.KLogging
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -11,15 +14,18 @@ import kotlinx.coroutines.delay
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldBeInRange
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.assertFailsWith
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import java.util.concurrent.CancellationException
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.time.Duration.Companion.milliseconds
 
 class LettuceSuspendLeaderGroupElectorTest: AbstractLettuceLeaderTest() {
 
@@ -47,6 +53,34 @@ class LettuceSuspendLeaderGroupElectorTest: AbstractLettuceLeaderTest() {
         val result = suspendElection.runIfLeader(lockName) { "suspend-done" }
         result shouldBeEqualTo "suspend-done"
     }
+
+    @Test
+    fun `runIfLeaderResultSuspend - action 실패는 ActionFailed 로 분류한다`() = runSuspendIO {
+        val failure = LeaderGroupElectionException("suspend group result 오류")
+
+        val result = suspendElection.runIfLeaderResultSuspend(LeaderSlot(lockName, "lettuce-suspend-group-node")) {
+            throw failure
+        }
+
+        (result is LeaderRunResult.ActionFailed).shouldBeTrue()
+        val cause = (result as LeaderRunResult.ActionFailed).cause
+        cause.shouldBeInstanceOf<LeaderGroupElectionException>()
+        cause.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `runIfLeaderResultSuspend - CancellationException 은 ActionFailed 로 감싸지 않고 재전파한다`() =
+        runSuspendIO {
+            val cancellation = CancellationException("lettuce-suspend-group-cancelled")
+
+            val thrown = assertFailsWith<CancellationException> {
+                suspendElection.runIfLeaderResultSuspend<Any?>(LeaderSlot(lockName, "lettuce-suspend-group-node")) {
+                    throw cancellation
+                }
+            }
+
+            thrown.message shouldBeEqualTo cancellation.message
+        }
 
     @Test
     fun `코루틴 복수 리더 동시 실행`() = runSuspendIO {

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElector.kt
@@ -20,6 +20,7 @@ import io.bluetape4k.support.requireNotBlank
 import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
 import org.redisson.client.RedisException
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.concurrent.ForkJoinPool
@@ -81,7 +82,22 @@ class RedissonLeaderElector private constructor(
 
     override fun <T> runIfLeaderResult(slot: LeaderSlot, action: () -> T): LeaderRunResult<T> {
         var elected = false
-        val value = runImpl(slot.lockName, auditLeaderId = slot.leaderId) { elected = true; action() }
+        val value = try {
+            runImpl(slot.lockName, auditLeaderId = slot.leaderId) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
+        }
         return if (elected) LeaderRunResult.Elected(value, leaderId = slot.leaderId) else LeaderRunResult.Skipped
     }
 

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElector.kt
@@ -24,6 +24,7 @@ import org.redisson.api.RMap
 import org.redisson.api.RPermitExpirableSemaphore
 import org.redisson.api.RedissonClient
 import org.redisson.client.RedisException
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
@@ -109,7 +110,22 @@ class RedissonLeaderGroupElector private constructor(
 
     override fun <T> runIfLeaderResult(slot: LeaderSlot, action: () -> T): LeaderRunResult<T> {
         var elected = false
-        val value = runImpl(slot.lockName, auditLeaderId = slot.leaderId) { elected = true; action() }
+        val value = try {
+            runImpl(slot.lockName, auditLeaderId = slot.leaderId) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
+        }
         return if (elected) LeaderRunResult.Elected(value, leaderId = slot.leaderId) else LeaderRunResult.Skipped
     }
 

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElector.kt
@@ -142,7 +142,19 @@ class RedissonSuspendLeaderElector private constructor(
 
     override suspend fun <T> runIfLeaderResultSuspend(slot: LeaderSlot, action: suspend () -> T): LeaderRunResult<T> {
         var elected = false
-        val value = runImpl(slot.lockName, auditLeaderId = slot.leaderId) { elected = true; action() }
+        val value = try {
+            runImpl(slot.lockName, auditLeaderId = slot.leaderId) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
+        }
         return if (elected) LeaderRunResult.Elected(value, leaderId = slot.leaderId) else LeaderRunResult.Skipped
     }
 

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElector.kt
@@ -114,7 +114,19 @@ class RedissonSuspendLeaderGroupElector private constructor(
 
     override suspend fun <T> runIfLeaderResultSuspend(slot: LeaderSlot, action: suspend () -> T): LeaderRunResult<T> {
         var elected = false
-        val value = runImpl(slot.lockName, auditLeaderId = slot.leaderId) { elected = true; action() }
+        val value = try {
+            runImpl(slot.lockName, auditLeaderId = slot.leaderId) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
+        }
         return if (elected) LeaderRunResult.Elected(value, leaderId = slot.leaderId) else LeaderRunResult.Skipped
     }
 

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElectionTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElectionTest.kt
@@ -5,6 +5,8 @@ import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.utils.Runtimex
@@ -19,6 +21,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletionException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -115,6 +118,34 @@ class RedissonLeaderElectionTest: AbstractRedissonLeaderTest() {
         leaderElection
             .runAsyncIfLeader(lockName) { CompletableFuture.completedFuture(1) }
             .get(2, TimeUnit.SECONDS) shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `runIfLeaderResult - action 실패는 ActionFailed 로 분류한다`() {
+        val lockName = randomName()
+        val leaderElection = RedissonLeaderElector(redissonClient)
+        val failure = IllegalStateException("redisson-result-boom")
+
+        val result = leaderElection.runIfLeaderResult(LeaderSlot(lockName, "redisson-node")) {
+            throw failure
+        }
+
+        result shouldBeEqualTo LeaderRunResult.ActionFailed(failure)
+    }
+
+    @Test
+    fun `runIfLeaderResult - CancellationException 은 ActionFailed 로 감싸지 않고 재전파한다`() {
+        val lockName = randomName()
+        val leaderElection = RedissonLeaderElector(redissonClient)
+        val cancellation = CancellationException("redisson-cancelled")
+
+        val thrown = assertFailsWith<CancellationException> {
+            leaderElection.runIfLeaderResult<Any?>(LeaderSlot(lockName, "redisson-node")) {
+                throw cancellation
+            }
+        }
+
+        thrown shouldBeEqualTo cancellation
     }
 
     @Test

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElectionTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElectionTest.kt
@@ -6,6 +6,8 @@ import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
 import io.bluetape4k.leader.LeaderGroupElectionException
 import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.assertions.shouldBeEqualTo
@@ -20,6 +22,7 @@ import org.junit.jupiter.api.condition.JRE
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletionException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -78,6 +81,30 @@ class RedissonLeaderGroupElectionTest: AbstractRedissonLeaderTest() {
 
         val result = election.runIfLeader(lockName) { "복구 성공" }
         result shouldBeEqualTo "복구 성공"
+    }
+
+    @Test
+    fun `runIfLeaderResult - action 실패는 ActionFailed 로 분류한다`() {
+        val failure = LeaderGroupElectionException("redisson-group-result-boom")
+
+        val result = election.runIfLeaderResult(LeaderSlot(randomName(), "redisson-group-node")) {
+            throw failure
+        }
+
+        result shouldBeEqualTo LeaderRunResult.ActionFailed(failure)
+    }
+
+    @Test
+    fun `runIfLeaderResult - CancellationException 은 ActionFailed 로 감싸지 않고 재전파한다`() {
+        val cancellation = CancellationException("redisson-group-cancelled")
+
+        val thrown = assertFailsWith<CancellationException> {
+            election.runIfLeaderResult<Any?>(LeaderSlot(randomName(), "redisson-group-node")) {
+                throw cancellation
+            }
+        }
+
+        thrown shouldBeEqualTo cancellation
     }
 
     @Test

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElectorTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElectorTest.kt
@@ -2,21 +2,26 @@ package io.bluetape4k.leader.redisson
 
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import java.util.concurrent.CancellationException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.random.Random
-import kotlin.time.Duration.Companion.milliseconds
 
 class RedissonSuspendLeaderElectorTest: AbstractRedissonLeaderTest() {
 
@@ -101,6 +106,38 @@ class RedissonSuspendLeaderElectorTest: AbstractRedissonLeaderTest() {
             }
         }
     }
+
+    @Test
+    fun `runIfLeaderResultSuspend - action 실패는 ActionFailed 로 분류한다`() = runSuspendIO {
+        val lockName = randomName()
+        val leaderElection = RedissonSuspendLeaderElector(redissonClient)
+        val failure = IllegalStateException("redisson-suspend-result-boom")
+
+        val result = leaderElection.runIfLeaderResultSuspend(LeaderSlot(lockName, "redisson-suspend-node")) {
+            throw failure
+        }
+
+        (result is LeaderRunResult.ActionFailed).shouldBeTrue()
+        val cause = (result as LeaderRunResult.ActionFailed).cause
+        cause.shouldBeInstanceOf<IllegalStateException>()
+        cause.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `runIfLeaderResultSuspend - CancellationException 은 ActionFailed 로 감싸지 않고 재전파한다`() =
+        runSuspendIO {
+            val lockName = randomName()
+            val leaderElection = RedissonSuspendLeaderElector(redissonClient)
+            val cancellation = CancellationException("redisson-suspend-cancelled")
+
+            val thrown = assertFailsWith<CancellationException> {
+                leaderElection.runIfLeaderResultSuspend<Any?>(LeaderSlot(lockName, "redisson-suspend-node")) {
+                    throw cancellation
+                }
+            }
+
+            thrown.message shouldBeEqualTo cancellation.message
+        }
 
     /**
      * [SuspendedJobTester]를 사용하여 짧은 `waitTime` 환경에서 여러 코루틴이 동시에

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElectorTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElectorTest.kt
@@ -4,6 +4,8 @@ import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.LeaderGroupElectionException
 import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import kotlinx.coroutines.CompletableDeferred
@@ -14,6 +16,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeLessOrEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
@@ -21,10 +24,10 @@ import io.bluetape4k.assertions.assertFailsWith
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import java.util.concurrent.CancellationException
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.max
 import kotlin.random.Random
-import kotlin.time.Duration.Companion.milliseconds
 
 class RedissonSuspendLeaderGroupElectorTest: AbstractRedissonLeaderTest() {
 
@@ -77,6 +80,34 @@ class RedissonSuspendLeaderGroupElectorTest: AbstractRedissonLeaderTest() {
         val result = election.runIfLeader(lockName) { "복구 성공" }
         result shouldBeEqualTo "복구 성공"
     }
+
+    @Test
+    fun `runIfLeaderResultSuspend - action 실패는 ActionFailed 로 분류한다`() = runSuspendIO {
+        val failure = LeaderGroupElectionException("redisson-suspend-group-result-boom")
+
+        val result = election.runIfLeaderResultSuspend(LeaderSlot(randomName(), "redisson-suspend-group-node")) {
+            throw failure
+        }
+
+        (result is LeaderRunResult.ActionFailed).shouldBeTrue()
+        val cause = (result as LeaderRunResult.ActionFailed).cause
+        cause.shouldBeInstanceOf<LeaderGroupElectionException>()
+        cause.message shouldBeEqualTo failure.message
+    }
+
+    @Test
+    fun `runIfLeaderResultSuspend - CancellationException 은 ActionFailed 로 감싸지 않고 재전파한다`() =
+        runSuspendIO {
+            val cancellation = CancellationException("redisson-suspend-group-cancelled")
+
+            val thrown = assertFailsWith<CancellationException> {
+                election.runIfLeaderResultSuspend<Any?>(LeaderSlot(randomName(), "redisson-suspend-group-node")) {
+                    throw cancellation
+                }
+            }
+
+            thrown.message shouldBeEqualTo cancellation.message
+        }
 
     // ── 동시 실행 제한 ────────────────────────────────────────────────────
 

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -179,6 +179,7 @@ class LeaderElectionAspect(
                     }
                     runResult.value
                 }
+                is LeaderRunResult.ActionFailed -> throw BodyThrownMarker(runResult.cause)
             }
         } catch (e: CancellationException) {
             throw e

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -171,6 +171,7 @@ class LeaderGroupElectionAspect(
                     }
                     runResult.value
                 }
+                is LeaderRunResult.ActionFailed -> throw BodyThrownMarker(runResult.cause)
             }
         } catch (e: CancellationException) {
             throw e


### PR DESCRIPTION
## Summary

Closes #213

PR #221의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: clarify leader result action failures`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

- Closes #213 by representing post-election user action failures as `LeaderRunResult.ActionFailed(cause)`.
- Preserves `runIfLeader` semantics: contention returns `null`; action exceptions still throw.
- Keeps `CancellationException` and `InterruptedException` out of value results; blocking APIs restore interrupt status before rethrowing interruption.
- Updates core/local, coroutine, async, virtual-thread, Lettuce, Redisson, Spring AOP, README/KDoc, regression tests, and lessons.

## Review Notes

- Claude CLI review succeeded on a 5-minute retry and found three P1 gaps: missing Redis backend regressions, blocking interruption handling, and async/virtual cancellation wording.
- All three P1 findings were addressed before this PR.
- Advisor artifact: `.omx/artifacts/claude-actionfailed-result-20260514183409.md` (local/ignored artifact).
- Lesson: `docs/lessons/2026-05-14-issue-213-actionfailed-result.md`.

## Verification

- `./gradlew :leader-core:test --no-daemon`
- `./gradlew :leader-core:compileKotlin :leader-redis-lettuce:compileKotlin :leader-redis-redisson:compileKotlin :leader-spring-boot:compileKotlin --no-daemon`
- `./gradlew :leader-redis-lettuce:test :leader-redis-redisson:test --tests io.bluetape4k.leader.lettuce.LettuceSuspendLeaderElectorTest --tests io.bluetape4k.leader.lettuce.LettuceSuspendLeaderGroupElectorTest --tests io.bluetape4k.leader.redisson.RedissonSuspendLeaderElectorTest --tests io.bluetape4k.leader.redisson.RedissonSuspendLeaderGroupElectorTest --no-daemon`
- `./gradlew :leader-core:test :leader-redis-lettuce:test :leader-redis-redisson:test --tests io.bluetape4k.leader.LeaderRunResultTest --tests io.bluetape4k.leader.lettuce.LettuceLeaderElectionTest --tests io.bluetape4k.leader.lettuce.LettuceSuspendLeaderElectorTest --tests io.bluetape4k.leader.lettuce.LettuceLeaderGroupElectionTest --tests io.bluetape4k.leader.lettuce.LettuceSuspendLeaderGroupElectorTest --tests io.bluetape4k.leader.redisson.RedissonLeaderElectionTest --tests io.bluetape4k.leader.redisson.RedissonSuspendLeaderElectorTest --tests io.bluetape4k.leader.redisson.RedissonLeaderGroupElectionTest --tests io.bluetape4k.leader.redisson.RedissonSuspendLeaderGroupElectorTest --no-daemon`
- `git diff --check`
- stale result-name search for `ExecuteFailed|ExecutionFailed|ExecutionCancelled`

## Not Tested

- Full repository test suite.

## Notes

Spring compile still emits existing AspectJ `unresolvableMember` / `adviceDidNotMatch` warnings.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #213, milestone `0.1.0`, assignee `debop`
- PR: #221, head `8f9a2765b5ac384d1328d76fe3c22453ef86c2ef`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
