### PR TITLE
feat(leader-core): enrich LeaderElectionEvent.Elected with leaderId and leaseExpiry (#223)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### leader-core
+
+- `LeaderElectionEvent.Elected` now carries optional `leaderId: String?` and `leaseExpiry: Instant?`
+  fields (both default to `null`).
+  **Binary incompatibility**: compiled callers that construct `Elected(lockName)` positionally will
+  fail to link against new bytecode. Recompilation is required. Source-compatible.
+- `LocalSuspendLeaderElector` and `LocalSuspendLeaderGroupElector` now populate `leaderId` on the
+  emitted `Elected` event using the `auditLeaderId` stamped on the lock handle.
+
 ### BREAKING CHANGES
 
 - **`leader-exposed-jdbc`**: `ExposedJdbcLeaderElector.runIfLeader()` now returns `null` instead of

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionListener.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionListener.kt
@@ -3,6 +3,8 @@ package io.bluetape4k.leader
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.flow.Flow
+import java.io.Serializable
+import java.time.Instant
 import java.util.concurrent.CopyOnWriteArrayList
 
 /**
@@ -44,8 +46,24 @@ sealed interface LeaderElectionEvent {
     /** 이벤트가 발생한 락 이름입니다. */
     val lockName: String
 
-    /** 리더 또는 그룹 슬롯을 획득한 이벤트입니다. */
-    data class Elected(override val lockName: String) : LeaderElectionEvent
+    /**
+     * Leader or group slot acquisition event.
+     *
+     * ## Behavior / Contract
+     * - [leaderId] is the identity of the node that won the election. Populated by local electors
+     *   and backends that carry identity; `null` when identity is unavailable (e.g. decorator path).
+     * - [leaseExpiry] is the absolute time at which the lease expires. Currently always `null`;
+     *   reserved for future backend implementations that can report expiry at election time.
+     */
+    data class Elected(
+        override val lockName: String,
+        val leaderId: String? = null,
+        val leaseExpiry: Instant? = null,
+    ) : LeaderElectionEvent, Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
 
     /** 리더십 또는 그룹 슬롯을 반납한 이벤트입니다. */
     data class Revoked(override val lockName: String) : LeaderElectionEvent

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElector.kt
@@ -189,7 +189,7 @@ class LocalSuspendLeaderElector(
         )
         val watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime, delegate)
         listeners.notifyElected(lockName)
-        eventSubject.emit(LeaderElectionEvent.Elected(lockName))
+        eventSubject.emit(LeaderElectionEvent.Elected(lockName, leaderId = auditLeaderId))
         return try {
             withContext(LockHandleElement(handle)) {
                 action()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElector.kt
@@ -281,7 +281,7 @@ class LocalSuspendLeaderGroupElector private constructor(
         )
         val watchdog = LeaderLeaseAutoExtender.start(false, options.leaseTime, delegate)
         listeners.notifyElected(lockName)
-        eventSubject.emit(LeaderElectionEvent.Elected(lockName))
+        eventSubject.emit(LeaderElectionEvent.Elected(lockName, leaderId = auditLeaderId))
         return try {
             withContext(LockHandleElement(handle)) {
                 action()

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionEventTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionEventTest.kt
@@ -1,0 +1,93 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.time.Instant
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderElectionEventTest {
+
+    @Test
+    fun `Elected - default construction leaves leaderId and leaseExpiry null`() {
+        val event = LeaderElectionEvent.Elected("my-lock")
+
+        event.lockName shouldBeEqualTo "my-lock"
+        event.leaderId.shouldBeNull()
+        event.leaseExpiry.shouldBeNull()
+    }
+
+    @Test
+    fun `Elected - explicit leaderId is preserved`() {
+        val event = LeaderElectionEvent.Elected("my-lock", leaderId = "node-1")
+
+        event.lockName shouldBeEqualTo "my-lock"
+        event.leaderId shouldBeEqualTo "node-1"
+        event.leaseExpiry.shouldBeNull()
+    }
+
+    @Test
+    fun `Elected - explicit leaderId and leaseExpiry are both preserved`() {
+        val expiry = Instant.parse("2025-06-01T00:00:00Z")
+        val event = LeaderElectionEvent.Elected("my-lock", leaderId = "node-1", leaseExpiry = expiry)
+
+        event.lockName shouldBeEqualTo "my-lock"
+        event.leaderId shouldBeEqualTo "node-1"
+        event.leaseExpiry shouldBeEqualTo expiry
+    }
+
+    @Test
+    fun `Elected - serialization round-trip preserves all fields`() {
+        val expiry = Instant.parse("2025-06-01T00:00:00Z")
+        val original = LeaderElectionEvent.Elected("my-lock", leaderId = "node-1", leaseExpiry = expiry)
+
+        val bytes = ByteArrayOutputStream().use { baos ->
+            ObjectOutputStream(baos).use { oos -> oos.writeObject(original) }
+            baos.toByteArray()
+        }
+        val deserialized = ByteArrayInputStream(bytes).use { bais ->
+            ObjectInputStream(bais).use { ois -> ois.readObject() as LeaderElectionEvent.Elected }
+        }
+
+        deserialized shouldBeEqualTo original
+        deserialized.lockName shouldBeEqualTo "my-lock"
+        deserialized.leaderId shouldBeEqualTo "node-1"
+        deserialized.leaseExpiry shouldBeEqualTo expiry
+    }
+
+    @Test
+    fun `Elected - serialization round-trip with null fields`() {
+        val original = LeaderElectionEvent.Elected("lock-x")
+
+        val bytes = ByteArrayOutputStream().use { baos ->
+            ObjectOutputStream(baos).use { oos -> oos.writeObject(original) }
+            baos.toByteArray()
+        }
+        val deserialized = ByteArrayInputStream(bytes).use { bais ->
+            ObjectInputStream(bais).use { ois -> ois.readObject() as LeaderElectionEvent.Elected }
+        }
+
+        deserialized shouldBeEqualTo original
+        deserialized.leaderId.shouldBeNull()
+        deserialized.leaseExpiry.shouldBeNull()
+    }
+
+    @Test
+    fun `Elected - data class equality considers leaderId and leaseExpiry`() {
+        val expiry = Instant.parse("2025-06-01T00:00:00Z")
+
+        val a = LeaderElectionEvent.Elected("lock", leaderId = "node-1", leaseExpiry = expiry)
+        val b = LeaderElectionEvent.Elected("lock", leaderId = "node-1", leaseExpiry = expiry)
+        val c = LeaderElectionEvent.Elected("lock", leaderId = "node-2", leaseExpiry = expiry)
+        val d = LeaderElectionEvent.Elected("lock")
+
+        a shouldBeEqualTo b
+        (a == c) shouldBeEqualTo false
+        (a == d) shouldBeEqualTo false
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionListenerTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionListenerTest.kt
@@ -157,7 +157,7 @@ class LeaderElectionListenerTest {
 
         result shouldBeEqualTo "done"
         collected.await() shouldBeEqualTo listOf(
-            LeaderElectionEvent.Elected("suspend-event-job"),
+            LeaderElectionEvent.Elected("suspend-event-job", leaderId = LeaderNodeId.Default),
             LeaderElectionEvent.Revoked("suspend-event-job"),
         )
     }


### PR DESCRIPTION
## Summary

Closes #223

PR #232의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat(leader-core): enrich LeaderElectionEvent.Elected with leaderId and leaseExpiry (#223)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Closes #223.

Adds optional  and  fields to . Both default to , preserving source compatibility for existing callers.

## Changes

### leader-core
- **`LeaderElectionEvent.Elected`**: added `leaderId` and `leaseExpiry` with `null` defaults; added `Serializable` + `serialVersionUID = 1L`.
- **`LocalSuspendLeaderElector`**: fills `leaderId = auditLeaderId` at election emit site.
- **`LocalSuspendLeaderGroupElector`**: same — uses `auditLeaderId` available at the emit site.
- Decorator paths (`ListeningSuspendLeaderElector`, etc.) leave `leaderId = null` — no identity available.
- New test: `LeaderElectionEventTest` — 6 cases covering default nulls, explicit values, and serialization round-trips.
- `LeaderElectionListenerTest` updated to assert `leaderId = LeaderNodeId.Default` for the local elector path.

### CHANGELOG.md
Binary incompatibility note added: compiled callers constructing `Elected(lockName)` positionally will fail to link; recompilation required.

## Compatibility

| Dimension | Status |
|---|---|
| Source | Compatible — both new fields have defaults |
| Binary | **Incompatible** — positional construction at the call site requires recompilation |
| Behavioral | No change — `null` fields carry no semantics in existing paths |

## Test Results

```
./gradlew :leader-core:test
BUILD SUCCESSFUL — 632 tests, 0 failures, 0 errors
```

## Dependency

This PR is a prerequisite for #225 (`leaderStateFlow` extension).
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #223, milestone `0.1.0`, assignee `debop`
- PR: #232, head `e01d534b0884cbe2786f2e472a0694d209c63f89`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
