### PR TITLE
fix(leader-core): watchdog graceful shutdown and RejectedExecutionException handling (#173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`leader-core`**: `LeaderLeaseAutoExtender` now supports graceful shutdown (#173).
+  - Added `shutdown()`: drains in-flight ticks (up to 5 s via `awaitTermination`) then calls `shutdownNow()`.
+  - Added `restart()`: recreates the scheduler after shutdown; no-op when already running.
+  - `start()` now catches `RejectedExecutionException` at the `scheduleWithFixedDelay` call site and
+    returns a no-op `AutoCloseable` instead of throwing, preserving the `runIfLeader never throws` contract
+    during concurrent application shutdown.
+- **`leader-spring-boot`**: `LeaderLeaseAutoExtenderLifecycle` (`InitializingBean` + `DisposableBean`) wired
+  into `LeaderElectionAutoConfiguration`. Calls `restart()` on context start and `shutdown()` on context close.
+  Safe for multi-context JVM scenarios (`@DirtiesContext`, sequential context restarts).
+
 ### leader-core
 
 - `LeaderElectionEvent.Elected` now carries optional `leaderId: String?` and `leaseExpiry: Instant?`
@@ -283,3 +295,4 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 [Unreleased]: https://github.com/bluetape4k/bluetape4k-leader/compare/v0.1.0-SNAPSHOT...HEAD
 [0.1.0-SNAPSHOT]: https://github.com/bluetape4k/bluetape4k-leader/releases/tag/v0.1.0-SNAPSHOT
+

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt
@@ -12,11 +12,13 @@ import io.bluetape4k.leader.internal.ExtendDelegate
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
 import java.time.Instant
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -53,13 +55,41 @@ import kotlin.time.Duration.Companion.milliseconds
 object LeaderLeaseAutoExtender : KLogging() {
 
     private val threadSeq = AtomicInteger()
-    private val scheduler = ScheduledThreadPoolExecutor(DEFAULT_WATCHDOG_THREADS) { runnable ->
-        Thread(runnable, "bluetape4k-leader-lease-watchdog-${threadSeq.incrementAndGet()}").apply {
-            isDaemon = true
+
+    @Volatile
+    private var scheduler: ScheduledThreadPoolExecutor = newScheduler()
+
+    /**
+     * Shuts down the shared watchdog scheduler, waiting up to 5 seconds for in-flight ticks to finish.
+     * Safe to call multiple times. After shutdown, calls to [start] will throw [RejectedExecutionException]
+     * from the scheduler until [restart] is invoked. The tick-body [RejectedExecutionException] catch
+     * protects ticks whose delegate submits further work to a separately shut-down executor.
+     */
+    fun shutdown() {
+        scheduler.shutdown()
+        if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+            scheduler.shutdownNow()
         }
-    }.apply {
-        removeOnCancelPolicy = true
     }
+
+    /**
+     * Replaces the scheduler with a fresh instance if the current one has been shut down.
+     * No-op when the scheduler is still running.
+     */
+    fun restart() {
+        if (!scheduler.isShutdown) return
+        scheduler = newScheduler()
+    }
+
+    /** Returns `true` if the shared watchdog scheduler has been shut down. */
+    fun isShutdown(): Boolean = scheduler.isShutdown
+
+    private fun newScheduler(): ScheduledThreadPoolExecutor =
+        ScheduledThreadPoolExecutor(DEFAULT_WATCHDOG_THREADS) { runnable ->
+            Thread(runnable, "bluetape4k-leader-lease-watchdog-${threadSeq.incrementAndGet()}").apply {
+                isDaemon = true
+            }
+        }.apply { removeOnCancelPolicy = true }
 
     /**
      * [enabled]가 true이면 [ExtendDelegate] 를 이용한 lease 연장 watchdog을 시작합니다.
@@ -97,59 +127,67 @@ object LeaderLeaseAutoExtender : KLogging() {
 
         val closed = AtomicBoolean(false)
         val cadence = renewalPeriod(leaseTime)
-        lateinit var future: ScheduledFuture<*>
+        val futureRef = AtomicReference<ScheduledFuture<*>?>(null)
 
-        future = scheduler.scheduleWithFixedDelay(
-            {
-                if (closed.get()) {
-                    future.cancel(false)
-                    return@scheduleWithFixedDelay
-                }
-
-                // R2 mitigation: user 가 explicit extend 를 호출했으면 watchdog skip
-                val deadline = delegate.lastExtendDeadline.get()
-                if (deadline != null && Instant.now().plusMillis(cadence.inWholeMilliseconds).isBefore(deadline)) {
-                    return@scheduleWithFixedDelay
-                }
-
-                val outcome = try {
-                    delegate.extend(leaseTime)
-                } catch (ex: Exception) {
-                    log.warn(ex) { "leader.lease.auto-extend.failed" }
-                    BackendError(ex)
-                }
-
-                when (outcome) {
-                    is Extended -> { /* 정상 연장 — 계속 */ }
-                    is NotHeld, is WrongThread -> {
-                        log.warn { "leader.lease.auto-extend.stopped reason=$outcome" }
-                        if (closed.compareAndSet(false, true)) {
-                            future.cancel(false)
-                        }
+        val future = try {
+            scheduler.scheduleWithFixedDelay(
+                {
+                    if (closed.get()) {
+                        futureRef.get()?.cancel(false)
+                        return@scheduleWithFixedDelay
                     }
-                    is BackendError -> {
-                        val kind = errorClassifier.classify(outcome.cause)
-                            ?: BackendErrorKind.NON_TRANSIENT
-                        when (kind) {
-                            BackendErrorKind.TRANSIENT -> {
-                                // 재시도 가능 — WARN log 후 계속
-                                log.warn(outcome.cause) { "leader.lease.auto-extend.transient-error — retrying. cause=${outcome.cause.message}" }
+
+                    // R2 mitigation: user 가 explicit extend 를 호출했으면 watchdog skip
+                    val deadline = delegate.lastExtendDeadline.get()
+                    if (deadline != null && Instant.now().plusMillis(cadence.inWholeMilliseconds).isBefore(deadline)) {
+                        return@scheduleWithFixedDelay
+                    }
+
+                    val outcome = try {
+                        delegate.extend(leaseTime)
+                    } catch (ex: RejectedExecutionException) {
+                        log.warn(ex) { "Watchdog tick rejected — scheduler shut down. delegateId=${delegate.hashCode()}" }
+                        futureRef.get()?.cancel(false)
+                        return@scheduleWithFixedDelay
+                    } catch (ex: Exception) {
+                        log.warn(ex) { "leader.lease.auto-extend.failed" }
+                        BackendError(ex)
+                    }
+
+                    when (outcome) {
+                        is Extended -> { /* 정상 연장 — 계속 */ }
+                        is NotHeld, is WrongThread -> {
+                            log.warn { "leader.lease.auto-extend.stopped reason=$outcome" }
+                            if (closed.compareAndSet(false, true)) {
+                                futureRef.get()?.cancel(false)
                             }
-                            BackendErrorKind.NON_TRANSIENT, BackendErrorKind.FATAL -> {
-                                // 영구 오류 또는 치명적 오류 — watchdog 중단
-                                log.warn(outcome.cause) { "leader.lease.auto-extend.stopped reason=BACKEND_ERROR kind=$kind cause=${outcome.cause.message}" }
-                                if (closed.compareAndSet(false, true)) {
-                                    future.cancel(false)
+                        }
+                        is BackendError -> {
+                            val kind = errorClassifier.classify(outcome.cause)
+                                ?: BackendErrorKind.NON_TRANSIENT
+                            when (kind) {
+                                BackendErrorKind.TRANSIENT -> {
+                                    log.warn(outcome.cause) { "leader.lease.auto-extend.transient-error — retrying. cause=${outcome.cause.message}" }
+                                }
+                                BackendErrorKind.NON_TRANSIENT, BackendErrorKind.FATAL -> {
+                                    log.warn(outcome.cause) { "leader.lease.auto-extend.stopped reason=BACKEND_ERROR kind=$kind cause=${outcome.cause.message}" }
+                                    if (closed.compareAndSet(false, true)) {
+                                        futureRef.get()?.cancel(false)
+                                    }
                                 }
                             }
                         }
                     }
-                }
-            },
-            cadence.inWholeMilliseconds,
-            cadence.inWholeMilliseconds,
-            TimeUnit.MILLISECONDS,
-        )
+                },
+                cadence.inWholeMilliseconds,
+                cadence.inWholeMilliseconds,
+                TimeUnit.MILLISECONDS,
+            )
+        } catch (ex: RejectedExecutionException) {
+            log.warn(ex) { "Watchdog scheduling rejected — scheduler shut down. Returning no-op." }
+            return NoopCloseable
+        }
+        futureRef.set(future)
 
         return AutoCloseable {
             if (closed.compareAndSet(false, true)) {
@@ -181,28 +219,41 @@ object LeaderLeaseAutoExtender : KLogging() {
 
         val closed = AtomicBoolean(false)
         val period = renewalPeriod(leaseTime)
-        lateinit var future: ScheduledFuture<*>
+        val futureRef = AtomicReference<ScheduledFuture<*>?>(null)
 
-        future = scheduler.scheduleWithFixedDelay(
-            {
-                if (closed.get()) {
-                    future.cancel(false)
-                    return@scheduleWithFixedDelay
-                }
+        val future = try {
+            scheduler.scheduleWithFixedDelay(
+                {
+                    if (closed.get()) {
+                        futureRef.get()?.cancel(false)
+                        return@scheduleWithFixedDelay
+                    }
 
-                val extended = runCatching { extend() }
-                    .onFailure { log.warn(it) { "leader.lease.auto-extend.failed" } }
-                    .getOrDefault(false)
+                    val extendResult = runCatching { extend() }
+                        .onFailure { ex ->
+                            if (ex is RejectedExecutionException) {
+                                log.warn(ex) { "Watchdog tick rejected — scheduler shut down. extenderId=${extend.hashCode()}" }
+                                futureRef.get()?.cancel(false)
+                                return@scheduleWithFixedDelay
+                            }
+                            log.warn(ex) { "leader.lease.auto-extend.failed" }
+                        }
+                    val extended = extendResult.getOrDefault(false)
 
-                if (!extended && closed.compareAndSet(false, true)) {
-                    log.warn { "leader.lease.auto-extend.stopped reason=NOT_OWNER" }
-                    future.cancel(false)
-                }
-            },
-            period.inWholeMilliseconds,
-            period.inWholeMilliseconds,
-            TimeUnit.MILLISECONDS,
-        )
+                    if (!extended && closed.compareAndSet(false, true)) {
+                        log.warn { "leader.lease.auto-extend.stopped reason=NOT_OWNER" }
+                        futureRef.get()?.cancel(false)
+                    }
+                },
+                period.inWholeMilliseconds,
+                period.inWholeMilliseconds,
+                TimeUnit.MILLISECONDS,
+            )
+        } catch (ex: RejectedExecutionException) {
+            log.warn(ex) { "Watchdog scheduling rejected — scheduler shut down. Returning no-op." }
+            return NoopCloseable
+        }
+        futureRef.set(future)
 
         return AutoCloseable {
             if (closed.compareAndSet(false, true)) {

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtenderTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtenderTest.kt
@@ -1,20 +1,32 @@
 package io.bluetape4k.leader
 
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import kotlinx.coroutines.delay
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class LeaderLeaseAutoExtenderTest {
+
+    @AfterEach
+    fun restoreScheduler() {
+        // Ensure the shared singleton is always restored after each test that may call shutdown().
+        LeaderLeaseAutoExtender.restart()
+    }
 
     @Test
     fun `disabled watchdog does not call extender`() = runSuspendIO {
         val calls = AtomicInteger(0)
 
+        @Suppress("DEPRECATION")
         val watchdog = LeaderLeaseAutoExtender.start(false, 100.milliseconds) {
             calls.incrementAndGet()
             true
@@ -30,6 +42,7 @@ class LeaderLeaseAutoExtenderTest {
     fun `watchdog stops after close`() = runSuspendIO {
         val calls = AtomicInteger(0)
 
+        @Suppress("DEPRECATION")
         val watchdog = LeaderLeaseAutoExtender.start(true, 90.milliseconds) {
             calls.incrementAndGet()
             true
@@ -48,12 +61,58 @@ class LeaderLeaseAutoExtenderTest {
         val scheduler = scheduler()
         val before = scheduler.queue.size
 
+        @Suppress("DEPRECATION")
         val watchdogs = (1..20).map {
             LeaderLeaseAutoExtender.start(true, 30.seconds) { true }
         }
         watchdogs.forEach { it.close() }
 
         scheduler.queue.size shouldBeEqualTo before
+    }
+
+    @Test
+    fun `shutdown stops the scheduler`() {
+        LeaderLeaseAutoExtender.shutdown()
+        LeaderLeaseAutoExtender.isShutdown().shouldBeTrue()
+    }
+
+    @Test
+    fun `restart recreates the scheduler after shutdown`() {
+        LeaderLeaseAutoExtender.shutdown()
+        LeaderLeaseAutoExtender.isShutdown().shouldBeTrue()
+
+        LeaderLeaseAutoExtender.restart()
+        LeaderLeaseAutoExtender.isShutdown().shouldBeFalse()
+    }
+
+    @Test
+    fun `start after shutdown and restart works normally`() = runSuspendIO {
+        LeaderLeaseAutoExtender.shutdown()
+        LeaderLeaseAutoExtender.restart()
+
+        val calls = AtomicInteger(0)
+        @Suppress("DEPRECATION")
+        val watchdog = LeaderLeaseAutoExtender.start(true, 90.milliseconds) {
+            calls.incrementAndGet()
+            true
+        }
+        delay(200.milliseconds)
+        watchdog.close()
+
+        (calls.get() > 0).shouldBeTrue()
+    }
+
+    @Test
+    fun `start on shutdown scheduler returns NoopCloseable without throwing`() {
+        LeaderLeaseAutoExtender.shutdown()
+
+        val result = runCatching {
+            @Suppress("DEPRECATION")
+            LeaderLeaseAutoExtender.start(true, 90.milliseconds) { true }
+        }
+
+        result.isSuccess.shouldBeTrue()
+        LeaderLeaseAutoExtender.isShutdown().shouldBeTrue()
     }
 
     private fun scheduler(): ScheduledThreadPoolExecutor {

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/LeaderElectionAutoConfiguration.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/LeaderElectionAutoConfiguration.kt
@@ -7,9 +7,12 @@ import io.bluetape4k.leader.spring.backend.HazelcastLeaderConfiguration
 import io.bluetape4k.leader.spring.backend.LettuceLeaderConfiguration
 import io.bluetape4k.leader.spring.backend.MongoLeaderConfiguration
 import io.bluetape4k.leader.spring.backend.RedissonLeaderConfiguration
+import io.bluetape4k.leader.spring.boot.LeaderLeaseAutoExtenderLifecycle
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 
 /**
@@ -35,4 +38,10 @@ import org.springframework.context.annotation.Import
     ExposedJdbcLeaderConfiguration::class,
     ExposedR2dbcLeaderConfiguration::class,
 )
-class LeaderElectionAutoConfiguration
+class LeaderElectionAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun leaderLeaseAutoExtenderLifecycle(): LeaderLeaseAutoExtenderLifecycle =
+        LeaderLeaseAutoExtenderLifecycle()
+}

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/boot/LeaderLeaseAutoExtenderLifecycle.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/boot/LeaderLeaseAutoExtenderLifecycle.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.leader.spring.boot
+
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
+import org.springframework.beans.factory.DisposableBean
+import org.springframework.beans.factory.InitializingBean
+
+/**
+ * Manages the [LeaderLeaseAutoExtender] lifecycle within a Spring application context.
+ *
+ * ## Behavior / Contract
+ * - [afterPropertiesSet]: calls [LeaderLeaseAutoExtender.restart] so the shared JVM-scoped
+ *   scheduler is running when the context starts. No-op when already running.
+ * - [destroy]: calls [LeaderLeaseAutoExtender.shutdown] to drain in-flight ticks (up to 5 s)
+ *   and stop the scheduler when the context closes.
+ * - Both methods are idempotent and safe for multi-context JVM scenarios (e.g. `@DirtiesContext`
+ *   in tests or sequential Spring context restarts in the same classloader).
+ */
+class LeaderLeaseAutoExtenderLifecycle : InitializingBean, DisposableBean {
+    override fun afterPropertiesSet() {
+        LeaderLeaseAutoExtender.restart()
+    }
+
+    override fun destroy() {
+        LeaderLeaseAutoExtender.shutdown()
+    }
+}

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/LeaderLeaseAutoExtenderLifecycleTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/LeaderLeaseAutoExtenderLifecycleTest.kt
@@ -1,0 +1,67 @@
+package io.bluetape4k.leader.spring
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
+import io.bluetape4k.leader.spring.boot.LeaderLeaseAutoExtenderLifecycle
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderLeaseAutoExtenderLifecycleTest {
+
+    @BeforeEach
+    fun ensureSchedulerRunning() {
+        // Guarantee a clean running scheduler before each test regardless of prior state.
+        LeaderLeaseAutoExtender.restart()
+    }
+
+    @AfterEach
+    fun restoreScheduler() {
+        LeaderLeaseAutoExtender.restart()
+    }
+
+    @Test
+    fun `destroy shuts down LeaderLeaseAutoExtender scheduler`() {
+        val lifecycle = LeaderLeaseAutoExtenderLifecycle()
+
+        LeaderLeaseAutoExtender.isShutdown().shouldBeFalse()
+
+        lifecycle.destroy()
+
+        LeaderLeaseAutoExtender.isShutdown().shouldBeTrue()
+    }
+
+    @Test
+    fun `destroy is idempotent — calling twice does not throw`() {
+        val lifecycle = LeaderLeaseAutoExtenderLifecycle()
+
+        lifecycle.destroy()
+        lifecycle.destroy()
+
+        LeaderLeaseAutoExtender.isShutdown().shouldBeTrue()
+    }
+
+    @Test
+    fun `afterPropertiesSet restarts a shutdown scheduler`() {
+        LeaderLeaseAutoExtender.shutdown()
+        LeaderLeaseAutoExtender.isShutdown().shouldBeTrue()
+
+        val lifecycle = LeaderLeaseAutoExtenderLifecycle()
+        lifecycle.afterPropertiesSet()
+
+        LeaderLeaseAutoExtender.isShutdown().shouldBeFalse()
+    }
+
+    @Test
+    fun `afterPropertiesSet is no-op when scheduler is already running`() {
+        LeaderLeaseAutoExtender.isShutdown().shouldBeFalse()
+
+        val lifecycle = LeaderLeaseAutoExtenderLifecycle()
+        lifecycle.afterPropertiesSet()
+
+        LeaderLeaseAutoExtender.isShutdown().shouldBeFalse()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #173

PR #233의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix(leader-core): watchdog graceful shutdown and RejectedExecutionException handling (#173)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Closes #173.

Adds graceful shutdown capability to `LeaderLeaseAutoExtender` (JVM-wide watchdog object) and wires it as a Spring `DisposableBean` so the scheduler drains cleanly on application context close.

## Changes

### leader-core — `LeaderLeaseAutoExtender`
- `scheduler` changed from `val` to `@Volatile var`, initialized via `newScheduler()` factory.
- Added `shutdown()`: calls `scheduler.shutdown()`, waits up to 5 s via `awaitTermination`, then `shutdownNow()`.
- Added `restart()`: no-op if scheduler still running; replaces with a fresh `ScheduledThreadPoolExecutor` after shutdown.
- Added `isShutdown()`: exposes `scheduler.isShutdown` for tests and lifecycle bean.
- Added `RejectedExecutionException` catch **before** the broad `Exception` catch in the delegate-based `start()` tick body — logs WARN and cancels the future.
- Deprecated Boolean-lambda `start()` overload: `REE` handled inside `runCatching.onFailure` handler with early return.

### leader-spring-boot — new file `LeaderLeaseAutoExtenderLifecycle`
- `DisposableBean` that calls `LeaderLeaseAutoExtender.shutdown()` on `destroy()`.
- Registered as `@Bean @ConditionalOnMissingBean` in `LeaderElectionAutoConfiguration` (gated only on `@ConditionalOnClass(LeaderElector)`) — always registers regardless of AOP or backend conditions.

### Tests
- `LeaderLeaseAutoExtenderTest`: three new tests — shutdown stops scheduler, restart recreates scheduler, start-after-restart works normally. `@AfterEach restart()` restores object state for subsequent tests.
- `LeaderLeaseAutoExtenderLifecycleTest` (new): destroy shuts down scheduler; idempotency check. `@BeforeEach/@AfterEach restart()` for isolation.

## Scope (this PR only)
- Graceful shutdown + REE catch only.
- No metrics, no thread-pool sizing, no HOL-blocking fix (those are #174).

## Test Results

```
./gradlew :leader-core:test
BUILD SUCCESSFUL — 629 tests, 0 failures, 0 errors

./gradlew :leader-spring-boot:test
BUILD SUCCESSFUL — 284 tests, 0 failures, 0 errors

./gradlew detekt
BUILD SUCCESSFUL
```
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #173, milestone `0.1.0`, assignee `debop`
- PR: #233, head `70f45b34417e0404e205b543b78a7d17de717507`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
