### PR TITLE
feat: add leaderStateFlow() extension for LeaderElectionEventPublisher (#225)

### DIFF
--- a/docs/lessons/2026-05-15-leader-state-flow.md
+++ b/docs/lessons/2026-05-15-leader-state-flow.md
@@ -1,0 +1,87 @@
+# Lessons Learned — leaderStateFlow() Extension (#225) (2026-05-15)
+
+**관련 PR**: #225
+**영향 모듈**: `leader-core`
+
+## L1: `stateIn(scope = this)` in `runSuspendIO` causes 180s timeout for all tests
+
+### 문제
+
+`runSuspendIO { }` 내에서 `leaderStateFlow("my-lock", this)` 를 호출하면, `stateIn` 이 `this` (= `withTimeout` scope) 의 **child Job** 으로 컬렉션 코루틴을 launch 한다.
+Structured concurrency 규칙에 따라 `withTimeout` scope 는 모든 child 가 완료될 때까지 종료되지 않는다.
+`stateIn` 코루틴은 SharedFlow 에서 이벤트를 무한정 collect 하므로 절대 자연 종료되지 않는다.
+→ 테스트 본문의 assertions 이 통과해도 `withTimeout` 이 180초 타임아웃을 기다린 뒤 `TimeoutCancellationException` 을 던진다.
+→ **모든 9개 테스트가 3분 대기 후 실패** (27분 22초 전체 실행시간).
+
+### 교훈
+
+`runSuspendIO` (= `runBlocking { withTimeout { } }`) scope 에 수명이 테스트 본문보다 긴 코루틴을 launch 하면 안 된다.
+`leaderStateFlow` / `stateIn` 처럼 **무기한 collect 하는 flow** 를 위한 scope 는 반드시 독립적인 `CoroutineScope(Dispatchers.IO + Job())` 으로 분리하고, 테스트 종료 시 `finally { scope.cancel() }` 로 명시적으로 취소해야 한다.
+
+```kotlin
+// WRONG — stateIn coroutine blocks withTimeout
+runSuspendIO {
+    val flow = publisher.leaderStateFlow("my-lock", this)
+}
+
+// CORRECT — independent scope, explicit cancel
+runSuspendIO {
+    val scope = CoroutineScope(Dispatchers.IO + Job())
+    try {
+        val flow = publisher.leaderStateFlow("my-lock", scope)
+        // ...
+    } finally {
+        scope.cancel()
+    }
+}
+```
+
+---
+
+## L2: `MutableSharedFlow(replay = 0)` drops events emitted before stateIn subscribes
+
+### 문제
+
+`stateIn(SharingStarted.Eagerly)` 는 launch 후 **비동기적으로** upstream 을 collect 한다.
+`replay = 0` 인 `MutableSharedFlow` 에서 stateIn 코루틴이 구독 등록 전에 `emit()` 를 호출하면 이벤트가 **드롭**된다.
+`yield()` 만으로는 IO thread pool 에서 구독 등록 완료를 보장할 수 없어 `flow.first { predicate }` 가 영원히 대기한다.
+
+### 교훈
+
+테스트용 `FakeEventPublisher` 는 `MutableSharedFlow(replay = 1, ...)` 을 사용해야 한다.
+`replay = 1` 은 늦게 구독한 stateIn 코루틴도 마지막 이벤트를 수신할 수 있도록 보장한다.
+추가로 `delay(50)` 으로 구독 타이밍을 확보하면 더 안전하다.
+
+---
+
+## L3: Gradle test result cache 손상 → `KryoException: Buffer underflow`
+
+### 문제
+
+테스트 프로세스를 외부에서 강제 종료(SIGTERM/SIGKILL)하면 Gradle 의 직렬화된 테스트 결과 파일이 불완전하게 기록된다.
+이후 실행 시 `getPreviousFailedTestClasses` 에서 Kryo 역직렬화 시 `EOFException` 이 발생해 테스트가 실행조차 되지 않는다.
+
+### 교훈
+
+테스트가 반복적으로 `EOFException` / `KryoException` 으로 실패하면 아래 디렉터리를 삭제 후 재실행한다.
+
+```bash
+rm -rf leader-core/build/test-results \
+       leader-core/build/tmp/test \
+       leader-core/build/.gradle
+```
+
+---
+
+## L4: Codex review with correct worktree directory is essential
+
+### 문제
+
+`codex exec review` 는 CWD 기준 git 상태를 검토한다.
+Claude Code 세션의 기본 CWD 가 다른 worktree(`fix-173`)였기 때문에, 처음 5회의 `./gradlew :leader-core:test` 명령이 모두 잘못된 모듈에서 실행됐다.
+
+### 교훈
+
+- `./gradlew` 실행 시 `--project-dir <worktree-path>` 를 항상 명시한다.
+- `codex exec review` 는 해당 worktree 의 CWD 에서 실행해야 한다 (`bash -c 'cd <worktree> && codex exec review ...'`).
+- Claude Code 세션이 시작될 때 primary working directory 를 확인하고, 작업 worktree 와 다르면 즉시 절대 경로를 사용하도록 전환한다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LeaderStateFlowExt.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LeaderStateFlowExt.kt
@@ -1,0 +1,68 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.leader.LeaderElectionEvent
+import io.bluetape4k.leader.LeaderLease
+import io.bluetape4k.leader.LeaderNodeId
+import io.bluetape4k.leader.LeaderState
+import io.bluetape4k.leader.LeaderElectionEventPublisher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNot
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * Maps this publisher's event stream into a [StateFlow] that tracks the current [LeaderState]
+ * for [lockName].
+ *
+ * ## Behavior / Contract
+ * - Initial value is [LeaderState.empty] for [lockName].
+ * - [LeaderElectionEvent.Elected] transitions to [LeaderState.occupied]:
+ *   `auditLeaderId` is taken from [LeaderElectionEvent.Elected.leaderId] when available,
+ *   falling back to [LeaderNodeId.Default]; `leaseUntil` is taken from
+ *   [LeaderElectionEvent.Elected.leaseExpiry].
+ * - [LeaderElectionEvent.Revoked] transitions back to [LeaderState.empty].
+ * - [LeaderElectionEvent.Skipped] produces no state transition.
+ * - Events for other lock names are filtered out, so a single publisher serving multiple locks
+ *   can be safely observed per-lock.
+ * - The returned [StateFlow] is hot and shares the upstream according to [started].
+ *
+ * ```kotlin
+ * val stateFlow = elector.leaderStateFlow("my-lock", scope)
+ * stateFlow.collect { state ->
+ *     if (state.isOccupied) println("Leader: ${state.leader?.auditLeaderId}")
+ * }
+ * ```
+ *
+ * @param lockName the lock to observe.
+ * @param scope the [CoroutineScope] used to share the upstream flow.
+ * @param started sharing strategy; defaults to [SharingStarted.Eagerly].
+ */
+fun LeaderElectionEventPublisher.leaderStateFlow(
+    lockName: String,
+    scope: CoroutineScope,
+    started: SharingStarted = SharingStarted.Eagerly,
+): StateFlow<LeaderState> =
+    events
+        .filter { it.lockName == lockName }
+        .filterNot { it is LeaderElectionEvent.Skipped }
+        .map { event ->
+            when (event) {
+                is LeaderElectionEvent.Elected -> LeaderState.occupied(
+                    lockName,
+                    LeaderLease(
+                        auditLeaderId = event.leaderId ?: LeaderNodeId.Default,
+                        leaseUntil = event.leaseExpiry,
+                    )
+                )
+                is LeaderElectionEvent.Revoked -> LeaderState.empty(lockName)
+                is LeaderElectionEvent.Skipped -> LeaderState.empty(lockName)
+            }
+        }
+        .stateIn(
+            scope = scope,
+            started = started,
+            initialValue = LeaderState.empty(lockName),
+        )

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LeaderStateFlowExtTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LeaderStateFlowExtTest.kt
@@ -1,0 +1,160 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderElectionEvent
+import io.bluetape4k.leader.LeaderElectionEventPublisher
+import io.bluetape4k.leader.LeaderNodeId
+import io.bluetape4k.leader.LeaderState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderStateFlowExtTest {
+
+    private class FakeEventPublisher : LeaderElectionEventPublisher {
+        private val _events = MutableSharedFlow<LeaderElectionEvent>(replay = 1, extraBufferCapacity = 64)
+        override val events: Flow<LeaderElectionEvent> = _events
+        suspend fun emit(event: LeaderElectionEvent) = _events.emit(event)
+    }
+
+    /**
+     * Creates a leaderStateFlow in an independent scope (not a child of the calling scope),
+     * runs [block], then cancels the flow scope. Prevents structured concurrency from blocking
+     * the test's withTimeout waiting for the infinite stateIn collection coroutine.
+     */
+    private suspend fun withStateFlow(
+        lockName: String = "my-lock",
+        block: suspend (publisher: FakeEventPublisher, flow: StateFlow<LeaderState>) -> Unit,
+    ) {
+        val publisher = FakeEventPublisher()
+        val scope = CoroutineScope(Dispatchers.IO + Job())
+        try {
+            val flow = publisher.leaderStateFlow(lockName, scope)
+            delay(50) // Allow stateIn collection coroutine to subscribe
+            block(publisher, flow)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `initial state is empty`() = runSuspendIO {
+        withStateFlow { _, flow ->
+            flow.value.isEmpty.shouldBeTrue()
+            flow.value.isOccupied.shouldBeFalse()
+            flow.value.leader.shouldBeNull()
+        }
+    }
+
+    @Test
+    fun `Elected event transitions to occupied`() = runSuspendIO {
+        withStateFlow { publisher, flow ->
+            publisher.emit(LeaderElectionEvent.Elected("my-lock", leaderId = "node-1"))
+            flow.first { it.isOccupied }
+
+            flow.value.isOccupied.shouldBeTrue()
+            flow.value.leader?.auditLeaderId shouldBeEqualTo "node-1"
+        }
+    }
+
+    @Test
+    fun `Elected with null leaderId uses LeaderNodeId Default`() = runSuspendIO {
+        withStateFlow { publisher, flow ->
+            publisher.emit(LeaderElectionEvent.Elected("my-lock", leaderId = null))
+            flow.first { it.isOccupied }
+
+            flow.value.isOccupied.shouldBeTrue()
+            flow.value.leader?.auditLeaderId shouldBeEqualTo LeaderNodeId.Default
+        }
+    }
+
+    @Test
+    fun `Elected with leaseExpiry populates leaseUntil`() = runSuspendIO {
+        val expiry = Instant.now().plusSeconds(60)
+        withStateFlow { publisher, flow ->
+            publisher.emit(LeaderElectionEvent.Elected("my-lock", leaderId = "node-2", leaseExpiry = expiry))
+            flow.first { it.isOccupied }
+
+            flow.value.isOccupied.shouldBeTrue()
+            flow.value.leader?.leaseUntil shouldBeEqualTo expiry
+        }
+    }
+
+    @Test
+    fun `Revoked event transitions back to empty`() = runSuspendIO {
+        withStateFlow { publisher, flow ->
+            publisher.emit(LeaderElectionEvent.Elected("my-lock", leaderId = "node-3"))
+            flow.first { it.isOccupied }
+            flow.value.isOccupied.shouldBeTrue()
+
+            publisher.emit(LeaderElectionEvent.Revoked("my-lock"))
+            flow.first { it.isEmpty }
+
+            flow.value.isEmpty.shouldBeTrue()
+            flow.value.leader.shouldBeNull()
+        }
+    }
+
+    @Test
+    fun `Skipped event does not change state`() = runSuspendIO {
+        withStateFlow { publisher, flow ->
+            publisher.emit(LeaderElectionEvent.Skipped("my-lock"))
+            delay(50)
+
+            flow.value.isEmpty.shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `events for other lockNames are filtered out`() = runSuspendIO {
+        withStateFlow { publisher, flow ->
+            publisher.emit(LeaderElectionEvent.Elected("other-lock", leaderId = "node-X"))
+            delay(50)
+
+            flow.value.isEmpty.shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `multiple Elected events keep latest occupied state`() = runSuspendIO {
+        withStateFlow { publisher, flow ->
+            publisher.emit(LeaderElectionEvent.Elected("my-lock", leaderId = "node-1"))
+            flow.first { it.leader?.auditLeaderId == "node-1" }
+
+            publisher.emit(LeaderElectionEvent.Elected("my-lock", leaderId = "node-2"))
+            flow.first { it.leader?.auditLeaderId == "node-2" }
+
+            flow.value.isOccupied.shouldBeTrue()
+            flow.value.leader?.auditLeaderId shouldBeEqualTo "node-2"
+        }
+    }
+
+    @Test
+    fun `Skipped after Elected does not revert occupied state`() = runSuspendIO {
+        withStateFlow { publisher, flow ->
+            publisher.emit(LeaderElectionEvent.Elected("my-lock", leaderId = "node-5"))
+            flow.first { it.isOccupied }
+            flow.value.isOccupied.shouldBeTrue()
+
+            publisher.emit(LeaderElectionEvent.Skipped("my-lock"))
+            delay(50)
+
+            flow.value.isOccupied.shouldBeTrue()
+            flow.value.leader?.auditLeaderId shouldBeEqualTo "node-5"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #225

PR #235의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: add leaderStateFlow() extension for LeaderElectionEventPublisher (#225)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Closes #225.

Adds `LeaderStateFlowExt.kt` — a new extension function on `LeaderElectionEventPublisher` that maps the event stream into a `StateFlow<LeaderState>` for a given `lockName`.

## Behavior

| Event | State transition |
|-------|-----------------|
| `Elected(lockName, leaderId, leaseExpiry)` | → `LeaderState.occupied(lockName, LeaderLease(auditLeaderId, leaseUntil))` |
| `Revoked(lockName)` | → `LeaderState.empty(lockName)` |
| `Skipped(lockName)` | no transition (filtered) |
| any other lockName | no transition (filtered) |

- `leaderId = null` falls back to `LeaderNodeId.Default`
- `leaseExpiry` is propagated to `LeaderLease.leaseUntil`
- Initial value is `LeaderState.empty(lockName)`

## API

```kotlin
fun LeaderElectionEventPublisher.leaderStateFlow(
    lockName: String,
    scope: CoroutineScope,
    started: SharingStarted = SharingStarted.Eagerly,
): StateFlow<LeaderState>
```

## Test Results

Module: `:leader-core`
Result: **9 passing, 0 failed, 0 skipped**
Time: 1.518s
Command: `./gradlew :leader-core:test --tests 'io.bluetape4k.leader.coroutines.LeaderStateFlowExtTest'`

## Key design notes

- **Test scope isolation**: `stateIn` scope must be an independent `CoroutineScope(Dispatchers.IO + Job())`, not `this` from `runSuspendIO`. Passing `this` makes the infinite collection coroutine a child of `withTimeout`, blocking it until the 180s timeout fires.
- **FakeEventPublisher replay=1**: prevents event loss when `stateIn` subscribes after `emit()` in tests.
- **`flow.first { predicate }`**: deterministic state-change assertion without timing hacks.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #225, milestone `0.1.0`, assignee `debop`
- PR: #235, head `cbfdface2ea746d1d28340844b99d4b87b95d069`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
