### PR TITLE
fix: watchdog concurrency safety — scheduler capture + lifecycle ref-count (#242 #243)

### DIFF
--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt
@@ -64,11 +64,17 @@ object LeaderLeaseAutoExtender : KLogging() {
      * Safe to call multiple times. After shutdown, calls to [start] will throw [RejectedExecutionException]
      * from the scheduler until [restart] is invoked. The tick-body [RejectedExecutionException] catch
      * protects ticks whose delegate submits further work to a separately shut-down executor.
+     *
+     * ## Concurrency note
+     * The scheduler reference is captured once into a local variable before any blocking calls so that
+     * a concurrent [restart] cannot swap in a fresh executor between [shutdown][ScheduledThreadPoolExecutor.shutdown]
+     * and [awaitTermination][ScheduledThreadPoolExecutor.awaitTermination] / [shutdownNow][ScheduledThreadPoolExecutor.shutdownNow].
      */
     fun shutdown() {
-        scheduler.shutdown()
-        if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
-            scheduler.shutdownNow()
+        val current = scheduler
+        current.shutdown()
+        if (!current.awaitTermination(5, TimeUnit.SECONDS)) {
+            current.shutdownNow()
         }
     }
 

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/boot/LeaderLeaseAutoExtenderLifecycle.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/boot/LeaderLeaseAutoExtenderLifecycle.kt
@@ -25,16 +25,26 @@ class LeaderLeaseAutoExtenderLifecycle : InitializingBean, DisposableBean {
 
     companion object {
         internal val activeContextCount = AtomicInteger(0)
+
+        // Guards the increment-then-restart / decrement-then-shutdown sequences so that
+        // a concurrent destroy() cannot slip in between a decrement reaching zero and the
+        // actual shutdown() call while another afterPropertiesSet() has already incremented
+        // the count back above zero.
+        private val lifecycleLock = Any()
     }
 
     override fun afterPropertiesSet() {
-        activeContextCount.incrementAndGet()
-        LeaderLeaseAutoExtender.restart()
+        synchronized(lifecycleLock) {
+            activeContextCount.incrementAndGet()
+            LeaderLeaseAutoExtender.restart()
+        }
     }
 
     override fun destroy() {
-        if (activeContextCount.decrementAndGet() == 0) {
-            LeaderLeaseAutoExtender.shutdown()
+        synchronized(lifecycleLock) {
+            if (activeContextCount.decrementAndGet() == 0) {
+                LeaderLeaseAutoExtender.shutdown()
+            }
         }
     }
 }

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/boot/LeaderLeaseAutoExtenderLifecycle.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/boot/LeaderLeaseAutoExtenderLifecycle.kt
@@ -3,24 +3,38 @@ package io.bluetape4k.leader.spring.boot
 import io.bluetape4k.leader.LeaderLeaseAutoExtender
 import org.springframework.beans.factory.DisposableBean
 import org.springframework.beans.factory.InitializingBean
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Manages the [LeaderLeaseAutoExtender] lifecycle within a Spring application context.
  *
  * ## Behavior / Contract
- * - [afterPropertiesSet]: calls [LeaderLeaseAutoExtender.restart] so the shared JVM-scoped
- *   scheduler is running when the context starts. No-op when already running.
- * - [destroy]: calls [LeaderLeaseAutoExtender.shutdown] to drain in-flight ticks (up to 5 s)
- *   and stop the scheduler when the context closes.
- * - Both methods are idempotent and safe for multi-context JVM scenarios (e.g. `@DirtiesContext`
- *   in tests or sequential Spring context restarts in the same classloader).
+ * - [afterPropertiesSet]: increments the active-context counter and calls [LeaderLeaseAutoExtender.restart]
+ *   so the shared JVM-scoped scheduler is running. No-op when already running.
+ * - [destroy]: decrements the counter and calls [LeaderLeaseAutoExtender.shutdown] **only when the last
+ *   active context closes**. This prevents one context from stopping the global scheduler while other
+ *   contexts in the same JVM are still using it (e.g. parallel `@DirtiesContext` test suites or
+ *   multi-context application deployments).
+ *
+ * ## Ref-counting
+ * The [activeContextCount] companion-object counter tracks how many `ApplicationContext`s currently
+ * hold a live `LeaderLeaseAutoExtenderLifecycle` bean. [destroy] decrements first; only the caller
+ * that drives the counter to zero proceeds with [LeaderLeaseAutoExtender.shutdown].
  */
 class LeaderLeaseAutoExtenderLifecycle : InitializingBean, DisposableBean {
+
+    companion object {
+        internal val activeContextCount = AtomicInteger(0)
+    }
+
     override fun afterPropertiesSet() {
+        activeContextCount.incrementAndGet()
         LeaderLeaseAutoExtender.restart()
     }
 
     override fun destroy() {
-        LeaderLeaseAutoExtender.shutdown()
+        if (activeContextCount.decrementAndGet() == 0) {
+            LeaderLeaseAutoExtender.shutdown()
+        }
     }
 }

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/boot/LeaderLeaseAutoExtenderLifecycle.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/boot/LeaderLeaseAutoExtenderLifecycle.kt
@@ -3,30 +3,34 @@ package io.bluetape4k.leader.spring.boot
 import io.bluetape4k.leader.LeaderLeaseAutoExtender
 import org.springframework.beans.factory.DisposableBean
 import org.springframework.beans.factory.InitializingBean
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Manages the [LeaderLeaseAutoExtender] lifecycle within a Spring application context.
  *
  * ## Behavior / Contract
- * - [afterPropertiesSet]: increments the active-context counter and calls [LeaderLeaseAutoExtender.restart]
- *   so the shared JVM-scoped scheduler is running. No-op when already running.
- * - [destroy]: decrements the counter and calls [LeaderLeaseAutoExtender.shutdown] **only when the last
- *   active context closes**. This prevents one context from stopping the global scheduler while other
- *   contexts in the same JVM are still using it (e.g. parallel `@DirtiesContext` test suites or
- *   multi-context application deployments).
+ * - [afterPropertiesSet]: registers this instance (once) with the JVM-scoped ref-count and calls
+ *   [LeaderLeaseAutoExtender.restart] so the shared scheduler is running. Repeated calls on the
+ *   same instance are idempotent — the global counter is incremented at most once per instance.
+ * - [destroy]: unregisters this instance (once) and calls [LeaderLeaseAutoExtender.shutdown]
+ *   **only when the last active context closes**. Repeated calls on the same instance are
+ *   no-ops, preventing counter underflow.
  *
  * ## Ref-counting
  * The [activeContextCount] companion-object counter tracks how many `ApplicationContext`s currently
- * hold a live `LeaderLeaseAutoExtenderLifecycle` bean. [destroy] decrements first; only the caller
- * that drives the counter to zero proceeds with [LeaderLeaseAutoExtender.shutdown].
+ * hold a live `LeaderLeaseAutoExtenderLifecycle` bean. Each instance contributes exactly 1 to the
+ * count regardless of how many times its lifecycle callbacks are invoked. The [lifecycleLock] guards
+ * the register/unregister sequences so that concurrent calls cannot produce a spurious zero.
  */
 class LeaderLeaseAutoExtenderLifecycle : InitializingBean, DisposableBean {
+
+    private val registered = AtomicBoolean(false)
 
     companion object {
         internal val activeContextCount = AtomicInteger(0)
 
-        // Guards the increment-then-restart / decrement-then-shutdown sequences so that
+        // Guards the register-then-restart / unregister-then-shutdown sequences so that
         // a concurrent destroy() cannot slip in between a decrement reaching zero and the
         // actual shutdown() call while another afterPropertiesSet() has already incremented
         // the count back above zero.
@@ -35,15 +39,19 @@ class LeaderLeaseAutoExtenderLifecycle : InitializingBean, DisposableBean {
 
     override fun afterPropertiesSet() {
         synchronized(lifecycleLock) {
-            activeContextCount.incrementAndGet()
+            if (registered.compareAndSet(false, true)) {
+                activeContextCount.incrementAndGet()
+            }
             LeaderLeaseAutoExtender.restart()
         }
     }
 
     override fun destroy() {
         synchronized(lifecycleLock) {
-            if (activeContextCount.decrementAndGet() == 0) {
-                LeaderLeaseAutoExtender.shutdown()
+            if (registered.compareAndSet(true, false)) {
+                if (activeContextCount.decrementAndGet() == 0) {
+                    LeaderLeaseAutoExtender.shutdown()
+                }
             }
         }
     }

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/LeaderLeaseAutoExtenderLifecycleTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/LeaderLeaseAutoExtenderLifecycleTest.kt
@@ -13,34 +13,40 @@ import org.junit.jupiter.api.TestInstance
 class LeaderLeaseAutoExtenderLifecycleTest {
 
     @BeforeEach
-    fun ensureSchedulerRunning() {
-        // Guarantee a clean running scheduler before each test regardless of prior state.
+    fun resetState() {
+        // Reset ref-count and ensure scheduler is running before each test.
+        LeaderLeaseAutoExtenderLifecycle.activeContextCount.set(0)
         LeaderLeaseAutoExtender.restart()
     }
 
     @AfterEach
     fun restoreScheduler() {
+        LeaderLeaseAutoExtenderLifecycle.activeContextCount.set(0)
         LeaderLeaseAutoExtender.restart()
     }
 
     @Test
-    fun `destroy shuts down LeaderLeaseAutoExtender scheduler`() {
+    fun `destroy shuts down scheduler when last context closes`() {
         val lifecycle = LeaderLeaseAutoExtenderLifecycle()
+        lifecycle.afterPropertiesSet()  // count = 1
 
         LeaderLeaseAutoExtender.isShutdown().shouldBeFalse()
 
-        lifecycle.destroy()
+        lifecycle.destroy()             // count = 0 → shutdown
 
         LeaderLeaseAutoExtender.isShutdown().shouldBeTrue()
     }
 
     @Test
-    fun `destroy is idempotent — calling twice does not throw`() {
+    fun `destroy is idempotent — two afterPropertiesSet then two destroy`() {
         val lifecycle = LeaderLeaseAutoExtenderLifecycle()
+        lifecycle.afterPropertiesSet()  // count = 1
+        lifecycle.afterPropertiesSet()  // count = 2
 
-        lifecycle.destroy()
-        lifecycle.destroy()
+        lifecycle.destroy()             // count = 1 → no shutdown
+        LeaderLeaseAutoExtender.isShutdown().shouldBeFalse()
 
+        lifecycle.destroy()             // count = 0 → shutdown
         LeaderLeaseAutoExtender.isShutdown().shouldBeTrue()
     }
 
@@ -50,7 +56,7 @@ class LeaderLeaseAutoExtenderLifecycleTest {
         LeaderLeaseAutoExtender.isShutdown().shouldBeTrue()
 
         val lifecycle = LeaderLeaseAutoExtenderLifecycle()
-        lifecycle.afterPropertiesSet()
+        lifecycle.afterPropertiesSet()  // count = 1, restarts scheduler
 
         LeaderLeaseAutoExtender.isShutdown().shouldBeFalse()
     }
@@ -63,5 +69,19 @@ class LeaderLeaseAutoExtenderLifecycleTest {
         lifecycle.afterPropertiesSet()
 
         LeaderLeaseAutoExtender.isShutdown().shouldBeFalse()
+    }
+
+    @Test
+    fun `destroy with multiple active contexts does not shut down scheduler`() {
+        val lifecycle1 = LeaderLeaseAutoExtenderLifecycle()
+        val lifecycle2 = LeaderLeaseAutoExtenderLifecycle()
+        lifecycle1.afterPropertiesSet()  // count = 1
+        lifecycle2.afterPropertiesSet()  // count = 2
+
+        lifecycle1.destroy()             // count = 1 → scheduler still running
+        LeaderLeaseAutoExtender.isShutdown().shouldBeFalse()
+
+        lifecycle2.destroy()             // count = 0 → shutdown
+        LeaderLeaseAutoExtender.isShutdown().shouldBeTrue()
     }
 }

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/LeaderLeaseAutoExtenderLifecycleTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/LeaderLeaseAutoExtenderLifecycleTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.leader.spring
 
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.leader.LeaderLeaseAutoExtender
@@ -38,13 +39,25 @@ class LeaderLeaseAutoExtenderLifecycleTest {
     }
 
     @Test
-    fun `destroy is idempotent — two afterPropertiesSet then two destroy`() {
+    fun `destroy is idempotent — repeated destroy does not underflow counter`() {
         val lifecycle = LeaderLeaseAutoExtenderLifecycle()
-        lifecycle.afterPropertiesSet()  // count = 1
-        lifecycle.afterPropertiesSet()  // count = 2
+        lifecycle.afterPropertiesSet()  // count = 1 (registered)
 
-        lifecycle.destroy()             // count = 1 → no shutdown
-        LeaderLeaseAutoExtender.isShutdown().shouldBeFalse()
+        lifecycle.destroy()             // count = 0 → shutdown
+        LeaderLeaseAutoExtender.isShutdown().shouldBeTrue()
+
+        // Second destroy must be a no-op; counter must not go negative.
+        lifecycle.destroy()
+        LeaderLeaseAutoExtenderLifecycle.activeContextCount.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `afterPropertiesSet is idempotent — repeated call does not double-increment counter`() {
+        val lifecycle = LeaderLeaseAutoExtenderLifecycle()
+        lifecycle.afterPropertiesSet()  // count = 1 (registered)
+        lifecycle.afterPropertiesSet()  // no-op registration; count stays 1
+
+        LeaderLeaseAutoExtenderLifecycle.activeContextCount.get() shouldBeEqualTo 1
 
         lifecycle.destroy()             // count = 0 → shutdown
         LeaderLeaseAutoExtender.isShutdown().shouldBeTrue()


### PR DESCRIPTION
## Summary

Closes #242
Closes #243

PR #244의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: watchdog concurrency safety — scheduler capture + lifecycle ref-count (#242 #243)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
Closes #242, Closes #243

## Problem

Two concurrent bugs in `LeaderLeaseAutoExtender` and `LeaderLeaseAutoExtenderLifecycle`:

**#243 — `shutdown()` reads `scheduler` three times across a blocking sequence**
`scheduler` is a `@Volatile` field. `shutdown()` called `scheduler.shutdown()`, then `scheduler.awaitTermination()`, then `scheduler.shutdownNow()` — three separate reads. A concurrent `restart()` could swap in a fresh executor between any two reads, causing the new executor to receive `shutdownNow()` immediately after creation.

**#242 — `destroy()` calls global `shutdown()` unconditionally**
Multiple Spring `ApplicationContext`s in the same JVM (e.g. parallel `@DirtiesContext` test suites) each hold a `LeaderLeaseAutoExtenderLifecycle` bean. One closing context called `shutdown()` on the JVM-global scheduler, stopping watchdog tasks for all other live contexts.

## Fix

### `LeaderLeaseAutoExtender.shutdown()` — #243
Capture `val current = scheduler` once before any blocking call. All three operations operate on the same reference regardless of concurrent `restart()`.

### `LeaderLeaseAutoExtenderLifecycle` — #242
Added a JVM-scoped `AtomicInteger activeContextCount` with a `synchronized(lifecycleLock)` guard:
- `afterPropertiesSet()` increments the counter and calls `restart()`.
- `destroy()` decrements and calls `shutdown()` only when the counter reaches zero.
- Each instance has a per-instance `AtomicBoolean registered` flag so repeated `afterPropertiesSet()` / `destroy()` calls are idempotent — no counter underflow or double-increment.

## Tests

- `destroy shuts down scheduler when last context closes`
- `destroy is idempotent — repeated destroy does not underflow counter` (new)
- `afterPropertiesSet is idempotent — repeated call does not double-increment counter` (new)
- `afterPropertiesSet restarts a shutdown scheduler`
- `afterPropertiesSet is no-op when scheduler is already running`
- `destroy with multiple active contexts does not shut down scheduler`

## Test Results

Module: `:leader-spring-boot`
Result: **288 passing**, 0 failed, 0 skipped
Command: `./gradlew :leader-spring-boot:test`

## Verification Commands

```bash
./gradlew :leader-core:test
./gradlew :leader-spring-boot:test
```
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #242, #243, milestone `0.1.0`, assignee `debop`
- PR: #244, head `37d0282cf15a3c803e30b898a11efa9d288fb34b`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
