### PR TITLE
fix: preserve group leader state after partial revoke

### DIFF
--- a/docs/lessons/2026-05-16-issue-238-stateflow-group-semantics.md
+++ b/docs/lessons/2026-05-16-issue-238-stateflow-group-semantics.md
@@ -1,0 +1,26 @@
+# Issue 238 StateFlow Group Semantics
+
+## Context
+
+`leaderStateFlow()` is a single-leader projection: every `Revoked(lockName)` maps to `LeaderState.empty(lockName)`. Group electors with `maxLeaders > 1` can still have active slots after one slot is revoked, so using `leaderStateFlow()` for group state can report an empty lock too early.
+
+## Decision
+
+Keep `leaderStateFlow()` as the single-leader API and document that boundary. Add `leaderGroupStateFlow(lockName, maxLeaders, scope, started)` for group electors, projecting lifecycle events into `LeaderGroupState.activeCount`.
+
+The group projection intentionally leaves `leaders` empty because `LeaderElectionEvent.Revoked` has no leader or slot identity. Count semantics are reliable for balanced elected/revoked events; identity semantics would require a future event contract change.
+
+## Outcome
+
+Group consumers can observe partial revokes without collapsing the whole group to empty. Existing single-leader behavior and the issue #237 eager hot-flow subscription fix remain unchanged.
+
+## Verification
+
+- `./gradlew :leader-core:test --tests 'io.bluetape4k.leader.coroutines.LeaderStateFlowExtTest' --no-configuration-cache --console=plain`
+- Result: 12 tests passing, build successful.
+- Added tests for partial revoke, max leader capping, skipped events, and lock-name filtering.
+- Claude advisor review was attempted twice, but the local CLI produced no usable output and was terminated after prolonged silence. Artifact: `.omx/artifacts/claude-issue-238-stateflow-group-semantics-20260516014229.md`.
+
+## Future Notes
+
+If group event identity becomes necessary, extend `LeaderElectionEvent.Revoked` with leader or slot identity before adding identity-preserving group state. Do not infer remaining leaders from a count-only revoke event.

--- a/docs/lessons/2026-05-16-issue-238-stateflow-group-semantics.md
+++ b/docs/lessons/2026-05-16-issue-238-stateflow-group-semantics.md
@@ -17,9 +17,9 @@ Group consumers can observe partial revokes without collapsing the whole group t
 ## Verification
 
 - `./gradlew :leader-core:test --tests 'io.bluetape4k.leader.coroutines.LeaderStateFlowExtTest' --no-configuration-cache --console=plain`
-- Result: 12 tests passing, build successful.
-- Added tests for partial revoke, max leader capping, skipped events, and lock-name filtering.
-- Claude advisor review was attempted twice, but the local CLI produced no usable output and was terminated after prolonged silence. Artifact: `.omx/artifacts/claude-issue-238-stateflow-group-semantics-20260516014229.md`.
+- Result: 14 tests passing, build successful.
+- Added tests for partial revoke, max leader capping, invalid max leaders, skipped events, and lock-name filtering.
+- Post-PR Claude feedback removed the group `Skipped` dead-code path, moved `maxLeaders` validation to the public function, split skipped/filtering tests, and documented the empty `leaders` invariant.
 
 ## Future Notes
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupState.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderGroupState.kt
@@ -20,6 +20,8 @@ import java.io.Serializable
  * @property maxLeaders 허용하는 최대 동시 리더 수
  * @property activeCount 현재 활성(실행 중인) 리더 수
  * @property leaders 현재 리더로 선출된 노드/슬롯 lease 목록. backend에 따라 빈 목록일 수 있습니다.
+ *   Event-stream projections such as `leaderGroupStateFlow()` always keep this empty because revoke events do not
+ *   identify the released slot.
  */
 data class LeaderGroupState(
     val lockName: String,

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LeaderStateFlowExt.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LeaderStateFlowExt.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.leader.LeaderGroupState
 import io.bluetape4k.leader.LeaderLease
 import io.bluetape4k.leader.LeaderNodeId
 import io.bluetape4k.leader.LeaderState
+import io.bluetape4k.support.requireGe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.Flow
@@ -94,6 +95,7 @@ fun LeaderElectionEventPublisher.leaderGroupStateFlow(
     scope: CoroutineScope,
     started: SharingStarted = SharingStarted.Eagerly,
 ): StateFlow<LeaderGroupState> {
+    maxLeaders.requireGe(1, "maxLeaders")
     val initialState = LeaderGroupState(lockName, maxLeaders, activeCount = 0)
     return events.toLeaderGroupStates(lockName, maxLeaders)
         .toStateFlow(initialState, scope, started)
@@ -109,7 +111,6 @@ private fun Flow<LeaderElectionEvent>.toLeaderGroupStates(
     maxLeaders: Int,
 ): Flow<LeaderGroupState> =
     filter { it.lockName == lockName }
-        .filterNot { it is LeaderElectionEvent.Skipped }
         .runningFold(0) { activeCount, event ->
             when (event) {
                 is LeaderElectionEvent.Elected -> (activeCount + 1).coerceAtMost(maxLeaders)

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LeaderStateFlowExt.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LeaderStateFlowExt.kt
@@ -1,10 +1,11 @@
 package io.bluetape4k.leader.coroutines
 
 import io.bluetape4k.leader.LeaderElectionEvent
+import io.bluetape4k.leader.LeaderElectionEventPublisher
+import io.bluetape4k.leader.LeaderGroupState
 import io.bluetape4k.leader.LeaderLease
 import io.bluetape4k.leader.LeaderNodeId
 import io.bluetape4k.leader.LeaderState
-import io.bluetape4k.leader.LeaderElectionEventPublisher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.Flow
@@ -16,12 +17,12 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.runningFold
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 /**
- * Maps this publisher's event stream into a [StateFlow] that tracks the current [LeaderState]
- * for [lockName].
+ * Maps this publisher's event stream into a single-leader [StateFlow] for [lockName].
  *
  * ## Behavior / Contract
  * - Initial value is [LeaderState.empty] for [lockName].
@@ -31,6 +32,8 @@ import kotlinx.coroutines.launch
  *   [LeaderElectionEvent.Elected.leaseExpiry].
  * - [LeaderElectionEvent.Revoked] transitions back to [LeaderState.empty].
  * - [LeaderElectionEvent.Skipped] produces no state transition.
+ * - This is a single-leader projection. For group electors with `maxLeaders > 1`, use
+ *   [leaderGroupStateFlow] so one revoked group slot does not clear the whole lock state.
  * - Events for other lock names are filtered out, so a single publisher serving multiple locks
  *   can be safely observed per-lock.
  * - The returned [StateFlow] is hot and shares the upstream according to [started].
@@ -55,12 +58,68 @@ fun LeaderElectionEventPublisher.leaderStateFlow(
     started: SharingStarted = SharingStarted.Eagerly,
 ): StateFlow<LeaderState> =
     events.toLeaderStates(lockName)
-        .toStateFlow(lockName, scope, started)
+        .toStateFlow(LeaderState.empty(lockName), scope, started)
+
+/**
+ * Maps this publisher's event stream into a group-leader [StateFlow] for [lockName].
+ *
+ * ## Behavior / Contract
+ * - Initial value is an empty [LeaderGroupState] for [lockName] and [maxLeaders].
+ * - [LeaderElectionEvent.Elected] increments [LeaderGroupState.activeCount] up to [maxLeaders].
+ * - [LeaderElectionEvent.Revoked] decrements [LeaderGroupState.activeCount] down to zero.
+ * - [LeaderElectionEvent.Skipped] produces no state transition.
+ * - The `leaders` list is intentionally empty because [LeaderElectionEvent.Revoked] does not
+ *   carry slot or leader identity, so this projection can report count semantics but cannot
+ *   prove which leader remains after a partial revoke.
+ * - Events for other lock names are filtered out, so a single publisher serving multiple locks
+ *   can be safely observed per-lock.
+ * - With the default [SharingStarted.Eagerly], the upstream collector starts undispatched before
+ *   this function returns, matching [leaderStateFlow] for hot publishers with no replay.
+ *
+ * ```kotlin
+ * val stateFlow = elector.leaderGroupStateFlow("batch-job", maxLeaders = 3, scope)
+ * stateFlow.collect { state ->
+ *     println("Active leaders: ${state.activeCount}/${state.maxLeaders}")
+ * }
+ * ```
+ *
+ * @param lockName the lock to observe.
+ * @param maxLeaders maximum number of leaders the group elector allows.
+ * @param scope the [CoroutineScope] used to share the upstream flow.
+ * @param started sharing strategy; defaults to [SharingStarted.Eagerly].
+ */
+fun LeaderElectionEventPublisher.leaderGroupStateFlow(
+    lockName: String,
+    maxLeaders: Int,
+    scope: CoroutineScope,
+    started: SharingStarted = SharingStarted.Eagerly,
+): StateFlow<LeaderGroupState> {
+    val initialState = LeaderGroupState(lockName, maxLeaders, activeCount = 0)
+    return events.toLeaderGroupStates(lockName, maxLeaders)
+        .toStateFlow(initialState, scope, started)
+}
 
 private fun Flow<LeaderElectionEvent>.toLeaderStates(lockName: String): Flow<LeaderState> =
     filter { it.lockName == lockName }
         .filterNot { it is LeaderElectionEvent.Skipped }
         .map { it.toLeaderState(lockName) }
+
+private fun Flow<LeaderElectionEvent>.toLeaderGroupStates(
+    lockName: String,
+    maxLeaders: Int,
+): Flow<LeaderGroupState> =
+    filter { it.lockName == lockName }
+        .filterNot { it is LeaderElectionEvent.Skipped }
+        .runningFold(0) { activeCount, event ->
+            when (event) {
+                is LeaderElectionEvent.Elected -> (activeCount + 1).coerceAtMost(maxLeaders)
+                is LeaderElectionEvent.Revoked -> (activeCount - 1).coerceAtLeast(0)
+                is LeaderElectionEvent.Skipped -> activeCount
+            }
+        }
+        .map { activeCount ->
+            LeaderGroupState(lockName, maxLeaders, activeCount)
+        }
 
 private fun LeaderElectionEvent.toLeaderState(lockName: String): LeaderState =
     when (this) {
@@ -76,15 +135,15 @@ private fun LeaderElectionEvent.toLeaderState(lockName: String): LeaderState =
         is LeaderElectionEvent.Skipped -> LeaderState.empty(lockName)
     }
 
-private fun Flow<LeaderState>.toStateFlow(
-    lockName: String,
+private fun <T> Flow<T>.toStateFlow(
+    initialValue: T,
     scope: CoroutineScope,
     started: SharingStarted,
-): StateFlow<LeaderState> =
+): StateFlow<T> =
     if (started == SharingStarted.Eagerly) {
         // Identity check is intentional: SharingStarted.Eagerly is a singleton. Custom eager-like strategies
         // use stateIn(), so only the standard eager path gets the no-drop startup guarantee for hot publishers.
-        val state = MutableStateFlow(LeaderState.empty(lockName))
+        val state = MutableStateFlow(initialValue)
         scope.launch(start = CoroutineStart.UNDISPATCHED) {
             collect { state.value = it }
         }
@@ -93,6 +152,6 @@ private fun Flow<LeaderState>.toStateFlow(
         stateIn(
             scope = scope,
             started = started,
-            initialValue = LeaderState.empty(lockName),
+            initialValue = initialValue,
         )
     }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LeaderStateFlowExtTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LeaderStateFlowExtTest.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.LeaderElectionEvent
 import io.bluetape4k.leader.LeaderElectionEventPublisher
+import io.bluetape4k.leader.LeaderGroupState
 import io.bluetape4k.leader.LeaderNodeId
 import io.bluetape4k.leader.LeaderState
 import kotlinx.coroutines.CoroutineScope
@@ -50,6 +51,21 @@ class LeaderStateFlowExtTest {
         val scope = CoroutineScope(Dispatchers.IO + Job())
         try {
             val flow = publisher.leaderStateFlow(lockName, scope)
+            block(publisher, flow)
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    private suspend fun withGroupStateFlow(
+        lockName: String = "my-lock",
+        maxLeaders: Int = 3,
+        block: suspend (publisher: FakeEventPublisher, flow: StateFlow<LeaderGroupState>) -> Unit,
+    ) {
+        val publisher = FakeEventPublisher()
+        val scope = CoroutineScope(Dispatchers.IO + Job())
+        try {
+            val flow = publisher.leaderGroupStateFlow(lockName, maxLeaders, scope)
             block(publisher, flow)
         } finally {
             scope.cancel()
@@ -182,6 +198,54 @@ class LeaderStateFlowExtTest {
 
             flow.value.isOccupied.shouldBeTrue()
             flow.value.leader?.auditLeaderId shouldBeEqualTo "node-5"
+        }
+    }
+
+    @Test
+    fun `group state flow keeps active count after partial revoke`() = runSuspendIO {
+        withGroupStateFlow(maxLeaders = 3) { publisher, flow ->
+            publisher.emit(LeaderElectionEvent.Elected("my-lock", leaderId = "node-1"))
+            flow.first { it.activeCount == 1 }
+
+            publisher.emit(LeaderElectionEvent.Elected("my-lock", leaderId = "node-2"))
+            flow.first { it.activeCount == 2 }
+
+            publisher.emit(LeaderElectionEvent.Revoked("my-lock"))
+            flow.first { it.activeCount == 1 }
+
+            flow.value.isEmpty.shouldBeFalse()
+            flow.value.availableSlots shouldBeEqualTo 2
+
+            publisher.emit(LeaderElectionEvent.Revoked("my-lock"))
+            flow.first { it.isEmpty }
+
+            flow.value.activeCount shouldBeEqualTo 0
+        }
+    }
+
+    @Test
+    fun `group state flow caps active count at max leaders`() = runSuspendIO {
+        withGroupStateFlow(maxLeaders = 2) { publisher, flow ->
+            publisher.emit(LeaderElectionEvent.Elected("my-lock", leaderId = "node-1"))
+            flow.first { it.activeCount == 1 }
+            publisher.emit(LeaderElectionEvent.Elected("my-lock", leaderId = "node-2"))
+            flow.first { it.activeCount == 2 }
+            publisher.emit(LeaderElectionEvent.Elected("my-lock", leaderId = "node-3"))
+            delay(50)
+
+            flow.value.activeCount shouldBeEqualTo 2
+            flow.value.isFull.shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `group state flow ignores skipped events and other lock names`() = runSuspendIO {
+        withGroupStateFlow { publisher, flow ->
+            publisher.emit(LeaderElectionEvent.Elected("other-lock", leaderId = "node-X"))
+            publisher.emit(LeaderElectionEvent.Skipped("my-lock"))
+            delay(50)
+
+            flow.value shouldBeEqualTo LeaderGroupState("my-lock", maxLeaders = 3, activeCount = 0)
         }
     }
 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LeaderStateFlowExtTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LeaderStateFlowExtTest.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.LeaderElectionEvent
 import io.bluetape4k.leader.LeaderElectionEventPublisher
@@ -239,10 +240,32 @@ class LeaderStateFlowExtTest {
     }
 
     @Test
-    fun `group state flow ignores skipped events and other lock names`() = runSuspendIO {
+    fun `group state flow rejects invalid max leaders`() = runSuspendIO {
+        val publisher = FakeEventPublisher()
+        val scope = CoroutineScope(Dispatchers.IO + Job())
+        try {
+            assertFailsWith<IllegalArgumentException> {
+                publisher.leaderGroupStateFlow("my-lock", maxLeaders = 0, scope)
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `group state flow ignores skipped events`() = runSuspendIO {
+        withGroupStateFlow { publisher, flow ->
+            publisher.emit(LeaderElectionEvent.Skipped("my-lock"))
+            delay(50)
+
+            flow.value shouldBeEqualTo LeaderGroupState("my-lock", maxLeaders = 3, activeCount = 0)
+        }
+    }
+
+    @Test
+    fun `group state flow ignores other lock names`() = runSuspendIO {
         withGroupStateFlow { publisher, flow ->
             publisher.emit(LeaderElectionEvent.Elected("other-lock", leaderId = "node-X"))
-            publisher.emit(LeaderElectionEvent.Skipped("my-lock"))
             delay(50)
 
             flow.value shouldBeEqualTo LeaderGroupState("my-lock", maxLeaders = 3, activeCount = 0)


### PR DESCRIPTION
## Summary

Closes #238

PR #252의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: preserve group leader state after partial revoke`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
Fixes #238.

Stacked on #251 / `fix/issue-237-stateflow-startup-race` because this change builds on the eager `leaderStateFlow()` startup fix.

## What changed

- Kept `leaderStateFlow()` as the documented single-leader projection.
- Added `leaderGroupStateFlow(lockName, maxLeaders, scope, started)` for group elector event streams.
- Project group events into `LeaderGroupState.activeCount`, preserving non-empty state after partial revoke.
- Documented that `leaders` remains empty because `LeaderElectionEvent.Revoked` has no leader or slot identity.
- Added regression tests for partial revoke, max leader capping, skipped events, and lock-name filtering.
- Added a lesson note for future event identity work.

## Verification

- [x] `./gradlew :leader-core:test --tests 'io.bluetape4k.leader.coroutines.LeaderStateFlowExtTest' --no-configuration-cache --console=plain`\n- [x] `git diff --check`\n- [ ] GitHub Actions CI\n\n## Review notes\n\n- Local Claude advisor was attempted twice but produced no usable output after prolonged silence; artifact recorded under `.omx/artifacts/claude-issue-238-stateflow-group-semantics-20260516014229.md` (ignored from git).\n- This PR intentionally preserves count semantics only. Identity semantics require adding leader or slot identity to revoke events first.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #238, milestone `0.1.0`, assignee `debop`
- PR: #252, head `1f8d71cd1216c8da47abc464c2dfd8db78d3f0ea`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
