### PR TITLE
feat: expose leader election observability endpoints

### DIFF
--- a/docs/lessons/2026-05-16-issue-226-observability.md
+++ b/docs/lessons/2026-05-16-issue-226-observability.md
@@ -26,3 +26,4 @@ For Spring, expose a publisher-only listener adapter when no `LeaderElectionEven
 ## Future Notes
 
 Keep lock enumeration explicit or observed. If a future issue needs complete backend lock discovery, add a backend-specific listing contract instead of inferring names from state queries.
+Post-PR feedback confirmed the Spring Actuator path must be covered at the HTTP layer and Ktor management routes need explicit auth-boundary documentation because they share the main application port.

--- a/docs/lessons/2026-05-16-issue-226-observability.md
+++ b/docs/lessons/2026-05-16-issue-226-observability.md
@@ -1,0 +1,28 @@
+# Issue 226 Leader Observability
+
+## Context
+
+Spring Boot and Ktor users needed opt-in status endpoints for known leader election locks, plus a Spring `LeaderElectionEventPublisher` bean surface.
+
+## Decision
+
+Add a JVM-local lock-name registry and endpoint layer instead of trying to enumerate backend locks. Static lock names seed the registry, and listener-aware electors or Ktor `leaderScheduled()` calls can add observed names.
+
+For Spring, expose a publisher-only listener adapter when no `LeaderElectionEventPublisher` bean exists. Do not expose a `ListeningLeaderElector` fallback as an autowire candidate, because that makes `LeaderElector` injection ambiguous and can break existing auto-configuration tests.
+
+## Outcome
+
+- Spring adds `LeaderElectionObservabilityAutoConfiguration` and opt-in `LeaderElectionActuatorAutoConfiguration`.
+- Ktor adds opt-in `GET /management/leaderElection`.
+- Both surfaces return per-lock single-leader status using `auditLeaderId` and `leaseUntil`.
+
+## Verification
+
+- `./gradlew :leader-spring-boot:test --tests 'io.bluetape4k.leader.spring.observability.LeaderElectionObservabilityAutoConfigurationTest' --no-configuration-cache --console=plain`
+- `./gradlew :leader-ktor:test --tests 'io.bluetape4k.leader.ktor.LeaderElectionManagementRouteTest' --no-configuration-cache --console=plain`
+- `./gradlew :leader-spring-boot:test :leader-ktor:test --no-configuration-cache --console=plain`
+- Result: `leader-ktor` 16 tests and `leader-spring-boot` 293 tests passing. The full run printed pre-existing shutdown/logging thread warnings but completed successfully.
+
+## Future Notes
+
+Keep lock enumeration explicit or observed. If a future issue needs complete backend lock discovery, add a backend-specific listing contract instead of inferring names from state queries.

--- a/docs/superpowers/plans/2026-05-16-issue-226-observability-plan.md
+++ b/docs/superpowers/plans/2026-05-16-issue-226-observability-plan.md
@@ -4,7 +4,7 @@
 
 Implement the Spring Boot and Ktor observability surfaces defined in the spec:
 
-- Spring status registry, event publisher facade, and Actuator endpoint.
+- Spring status registry, fallback publisher adapter, and Actuator endpoint.
 - Ktor opt-in management route.
 - Tests, README updates, lesson, PR.
 
@@ -37,7 +37,7 @@ Implement the Spring Boot and Ktor observability surfaces defined in the spec:
 5. Tests
    - Spring ApplicationContextRunner tests:
      - registry seeded from properties;
-     - fallback publisher facade registered;
+     - fallback publisher adapter registered;
      - endpoint disabled by default;
      - endpoint registered when `management.endpoint.leaderElection.enabled=true`;
      - endpoint response shape for a known lock.

--- a/docs/superpowers/plans/2026-05-16-issue-226-observability-plan.md
+++ b/docs/superpowers/plans/2026-05-16-issue-226-observability-plan.md
@@ -1,0 +1,62 @@
+# Issue 226 Leader Observability Plan
+
+## Scope
+
+Implement the Spring Boot and Ktor observability surfaces defined in the spec:
+
+- Spring status registry, event publisher facade, and Actuator endpoint.
+- Ktor opt-in management route.
+- Tests, README updates, lesson, PR.
+
+## Tasks
+
+1. Spring properties and registry
+   - Add `LeaderObservabilityProperties`.
+   - Add `LeaderProperties.observability`.
+   - Add `LeaderElectionStatusRegistry`.
+   - Add configuration metadata for new properties.
+
+2. Spring auto-config
+   - Add `LeaderElectionObservabilityAutoConfiguration`.
+   - Add `LeaderElectionActuatorAutoConfiguration`.
+   - Register both in `AutoConfiguration.imports` after existing leader/aop phases.
+   - Guard Actuator types with `@ConditionalOnClass(name = [...])`.
+
+3. Spring endpoint
+   - Add `LeaderElectionStatusEndpoint`.
+   - Return serializable DTOs with `locks`, `name`, `status`, `leaderId`, and `leaseExpiry`.
+   - Use `LeaderLease.auditLeaderId`.
+
+4. Ktor management route
+   - Add an internal lock registry to `LeaderElectionPluginConfig`.
+   - Add route opt-in properties and lock registration helper.
+   - Install `GET /management/leaderElection` only when enabled.
+   - Record `leaderScheduled()` lock names when the plugin is installed.
+   - Return JSON text without adding serialization dependencies.
+
+5. Tests
+   - Spring ApplicationContextRunner tests:
+     - registry seeded from properties;
+     - fallback publisher facade registered;
+     - endpoint disabled by default;
+     - endpoint registered when `management.endpoint.leaderElection.enabled=true`;
+     - endpoint response shape for a known lock.
+   - Ktor tests:
+     - route disabled by default;
+     - route returns configured lock status when enabled;
+     - `leaderScheduled()` records lock names.
+
+6. Docs and durable capture
+   - Update `README.md` and `README.ko.md` for Spring/Ktor observability.
+   - Add `docs/lessons/2026-05-16-issue-226-observability.md`.
+
+7. Verification
+   - `./gradlew :leader-spring-boot:test --tests '*LeaderElectionObservability*' --tests '*LeaderElectionActuator*' --no-configuration-cache --console=plain`
+   - `./gradlew :leader-ktor:test --tests '*LeaderElectionManagement*' --no-configuration-cache --console=plain`
+   - Broaden to `:leader-spring-boot:test :leader-ktor:test` if targeted tests pass quickly.
+   - `git diff --check`.
+
+## Review Notes
+
+- P0/P1 design findings after local review: none.
+- Advisor gap: local Claude CLI hung during #238 review. For #226, use local review first and attempt advisor only after implementation if the CLI responds within a bounded timeout.

--- a/docs/superpowers/specs/2026-05-16-issue-226-observability-design.md
+++ b/docs/superpowers/specs/2026-05-16-issue-226-observability-design.md
@@ -32,8 +32,8 @@ It registers:
   - seeded from `bluetape4k.leader.observability.lock-names`;
   - implements `LeaderElectionListener` so listener-aware electors can add names from `onElected`, `onSkipped`, and `onRevoked`.
 - `LeaderElectionEventPublisher` fallback bean
-  - if no publisher bean exists and a `LeaderElector` exists, expose `elector.withListeners(statusRegistry)`;
-  - this is a publisher facade, not a transparent replacement for the original elector bean.
+  - if no publisher bean exists, expose a publisher-only listener adapter;
+  - the adapter emits events observed through `LeaderElectionListenerRegistry` beans and never becomes a `LeaderElector` candidate.
 - `LeaderElectionListenerRegistry` registrar
   - attaches the status registry to all listener-aware leader beans after singleton initialization.
 
@@ -79,7 +79,7 @@ The Ktor response is emitted as JSON text to avoid forcing a new serialization d
 
 ## Acceptance Mapping
 
-- `LeaderElectionEventPublisher` bean auto-registration: supported as a fallback publisher facade.
+- `LeaderElectionEventPublisher` bean auto-registration: supported as a fallback publisher-only listener adapter.
 - `/actuator/leaderElection`: supported when Actuator is present, endpoint is enabled, and web exposure includes it.
 - disabled by default: endpoint property has no `matchIfMissing`.
 - Ktor management route: supported by plugin opt-in flag.
@@ -87,6 +87,6 @@ The Ktor response is emitted as JSON text to avoid forcing a new serialization d
 
 ## Risks
 
-- The fallback publisher facade does not observe calls made through the original non-publisher elector bean.
+- The fallback publisher only observes listener callbacks. It does not observe calls made through non-listener-aware elector beans.
 - Endpoint lock-name completeness depends on static registration or observed listener/Ktor scheduled usage.
 - Spring endpoint ID uses the requested camel-case `leaderElection`; tests must verify Boot accepts it.

--- a/docs/superpowers/specs/2026-05-16-issue-226-observability-design.md
+++ b/docs/superpowers/specs/2026-05-16-issue-226-observability-design.md
@@ -1,0 +1,92 @@
+# Issue 226 Leader Observability Design
+
+## Context
+
+Issue #226 asks for Spring Boot observability around leader election:
+
+- expose a `LeaderElectionEventPublisher` bean when possible;
+- add an opt-in Actuator endpoint at `/actuator/leaderElection`;
+- add a Ktor equivalent route at `/management/leaderElection`;
+- return per-lock leadership status JSON.
+
+This branch is stacked on #224 because blocking `ListeningLeaderElector` and `ListeningLeaderGroupElector` implement `LeaderElectionEventPublisher` there.
+
+## Evidence
+
+- Spring Boot 4 official docs confirm custom Actuator endpoints use `@Endpoint(id = "...")` and `@ReadOperation`, and web exposure is controlled separately by `management.endpoints.web.exposure.include`. Only `health` is web-exposed by default.
+- Ktor official docs confirm `routing { get { call.respond(...) } }` and `testApplication` as the route/test surface.
+- Current repo has no global lock-name registry. `LeaderElectionState.state(lockName)` can query a known name, but cannot enumerate names.
+- Current repo has listener/event decorators, but creating a separate wrapper bean cannot intercept calls made through an already-injected original `LeaderElector`.
+- `qmdq` was unavailable in this shell, so memory lookup fell back to `rg` over repo docs and source.
+
+## Design
+
+### Spring Boot
+
+Add `LeaderElectionObservabilityAutoConfiguration` after the core/aop auto-config phases.
+
+It registers:
+
+- `LeaderElectionStatusRegistry`
+  - stores known lock names in a thread-safe sorted set;
+  - seeded from `bluetape4k.leader.observability.lock-names`;
+  - implements `LeaderElectionListener` so listener-aware electors can add names from `onElected`, `onSkipped`, and `onRevoked`.
+- `LeaderElectionEventPublisher` fallback bean
+  - if no publisher bean exists and a `LeaderElector` exists, expose `elector.withListeners(statusRegistry)`;
+  - this is a publisher facade, not a transparent replacement for the original elector bean.
+- `LeaderElectionListenerRegistry` registrar
+  - attaches the status registry to all listener-aware leader beans after singleton initialization.
+
+Add `LeaderElectionActuatorAutoConfiguration` after observability:
+
+- guarded by Actuator classes using `@ConditionalOnClass(name = [...])`;
+- endpoint bean is disabled by default with `management.endpoint.leaderElection.enabled=true`;
+- `@Endpoint(id = "leaderElection")`;
+- `@ReadOperation` returns `{ "locks": [...] }`;
+- each lock status reads from `LeaderElector.state(lockName)`;
+- use `auditLeaderId`, not deprecated `leaderId`.
+
+HTTP exposure remains the user/application responsibility:
+
+```yaml
+management:
+  endpoint:
+    leaderElection:
+      enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health,leaderElection
+```
+
+### Ktor
+
+Extend `LeaderElectionPluginConfig` with:
+
+- `managementRouteEnabled: Boolean = false`;
+- `managementRoutePath: String = "/management/leaderElection"`;
+- `managementLockNames(vararg lockNames: String)`.
+
+When enabled, the plugin installs a `GET` route that returns JSON with the same lock fields. `leaderScheduled()` records its lock name into the plugin registry when the plugin is installed.
+
+The Ktor response is emitted as JSON text to avoid forcing a new serialization dependency on users.
+
+## Non-Goals
+
+- Do not replace all existing `LeaderElector` beans with listener wrappers. That can break concrete-type injection and existing tests.
+- Do not promise complete lock enumeration for dynamic lock names that were never configured or observed.
+- Do not expose group elector status in this issue. Group state has different response semantics and follows #238.
+
+## Acceptance Mapping
+
+- `LeaderElectionEventPublisher` bean auto-registration: supported as a fallback publisher facade.
+- `/actuator/leaderElection`: supported when Actuator is present, endpoint is enabled, and web exposure includes it.
+- disabled by default: endpoint property has no `matchIfMissing`.
+- Ktor management route: supported by plugin opt-in flag.
+- response shape test: Spring endpoint and Ktor route tests cover the JSON/status shape.
+
+## Risks
+
+- The fallback publisher facade does not observe calls made through the original non-publisher elector bean.
+- Endpoint lock-name completeness depends on static registration or observed listener/Ktor scheduled usage.
+- Spring endpoint ID uses the requested camel-case `leaderElection`; tests must verify Boot accepts it.

--- a/leader-ktor/README.ko.md
+++ b/leader-ktor/README.ko.md
@@ -124,6 +124,8 @@ fun Application.module() {
 GET /management/leaderElection
 ```
 
+이 route는 Ktor 애플리케이션의 main port와 routing pipeline에 설치됩니다. 신뢰된 management boundary 밖으로 노출하기 전에 인증 plugin, network policy, 또는 별도 internal port로 보호하세요.
+
 ```json
 {
   "locks": [

--- a/leader-ktor/README.ko.md
+++ b/leader-ktor/README.ko.md
@@ -94,6 +94,8 @@ leaderScheduled(
 |-----------------------|-------------------------------|------|--------------------------------------------|
 | `leaderElection`      | `SuspendLeaderElector?`       | 예   | 단일 리더 선출 백엔드                      |
 | `leaderGroupElection` | `SuspendLeaderGroupElector?`  | 아니오 | 그룹/멀티 리더 백엔드 (선택)             |
+| `managementRouteEnabled` | `Boolean`                  | 아니오 | `GET /management/leaderElection` 활성화 |
+| `managementRoutePath` | `String`                      | 아니오 | Management route 경로                     |
 
 `leaderScheduled` 파라미터:
 
@@ -103,6 +105,39 @@ leaderScheduled(
 | `period`          | `kotlin.time.Duration`    | —                                | 양수 필수                                  |
 | `leaderElection`  | `SuspendLeaderElector`    | 설치된 플러그인 설정에서 조회    | 미지정 시 플러그인 설정 사용               |
 | `action`          | `suspend () -> Unit`      | —                                | 리더로 선출되었을 때만 실행                |
+
+## Management Route
+
+Management route는 기본 비활성입니다. 첫 scheduled run 전에 보여야 하는 정적 lock 이름이 있으면 함께 등록하세요:
+
+```kotlin
+fun Application.module() {
+    install(LeaderElectionPlugin) {
+        leaderElection = redissonElector
+        managementRouteEnabled = true
+        managementLockNames("batch-job", "migration-gate")
+    }
+}
+```
+
+```http
+GET /management/leaderElection
+```
+
+```json
+{
+  "locks": [
+    {
+      "name": "batch-job",
+      "status": "Empty",
+      "leaderId": null,
+      "leaseExpiry": null
+    }
+  ]
+}
+```
+
+`leaderScheduled()`는 플러그인이 설치되어 있을 때 자신의 lock 이름을 management registry에 기록합니다. 이 route는 JSON text를 직접 응답하므로, 이 endpoint만을 위해 Ktor content negotiation을 추가할 필요는 없습니다.
 
 ## `leaderScheduled` 안의 LockAssert / LockExtender (Issue #79)
 

--- a/leader-ktor/README.md
+++ b/leader-ktor/README.md
@@ -128,6 +128,8 @@ fun Application.module() {
 GET /management/leaderElection
 ```
 
+The route is installed on the main Ktor application port and routing pipeline. Protect it with an authentication plugin, network policy, or a dedicated internal port before exposing it outside a trusted management boundary.
+
 ```json
 {
   "locks": [

--- a/leader-ktor/README.md
+++ b/leader-ktor/README.md
@@ -98,6 +98,8 @@ leaderScheduled(
 |-----------------------|-------------------------------|----------|------------------------------------------|
 | `leaderElection`      | `SuspendLeaderElector?`       | Yes      | Single-leader elector backend            |
 | `leaderGroupElection` | `SuspendLeaderGroupElector?`  | No       | Group/multi-leader elector (optional)    |
+| `managementRouteEnabled` | `Boolean`                  | No       | Enables `GET /management/leaderElection` |
+| `managementRoutePath` | `String`                      | No       | Management route path                    |
 
 `leaderScheduled` parameters:
 
@@ -107,6 +109,39 @@ leaderScheduled(
 | `period`         | `kotlin.time.Duration`     | —                                    | Must be positive                            |
 | `leaderElection` | `SuspendLeaderElector`     | from installed plugin                | Falls back to plugin config if omitted      |
 | `action`         | `suspend () -> Unit`       | —                                    | Executed only when this node is leader      |
+
+## Management Route
+
+The management route is disabled by default. Enable it explicitly and register static lock names when you want them visible before the first scheduled run:
+
+```kotlin
+fun Application.module() {
+    install(LeaderElectionPlugin) {
+        leaderElection = redissonElector
+        managementRouteEnabled = true
+        managementLockNames("batch-job", "migration-gate")
+    }
+}
+```
+
+```http
+GET /management/leaderElection
+```
+
+```json
+{
+  "locks": [
+    {
+      "name": "batch-job",
+      "status": "Empty",
+      "leaderId": null,
+      "leaseExpiry": null
+    }
+  ]
+}
+```
+
+`leaderScheduled()` records its lock name into the management registry when the plugin is installed. The route emits JSON text directly, so applications do not need to install Ktor content negotiation just for this endpoint.
 
 ## LockAssert / LockExtender inside `leaderScheduled` (Issue #79)
 

--- a/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/ApplicationExt.kt
+++ b/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/ApplicationExt.kt
@@ -23,6 +23,9 @@ import kotlin.time.Duration
  * - [period] 간격으로 반복되며, [action] 예외는 WARN 로그 후 무시되고 다음 cycle 이 계속 진행됩니다 (poison-job 방지).
  * - [CancellationException] 은 항상 호출자에게 재전파되어 정상 취소됩니다.
  * - [leaderElection] 인자를 생략하면 [LeaderElectionPlugin] 의 설정에서 가져옵니다 — 플러그인 미설치 시 [IllegalStateException].
+ * - Management route registration happens only when [LeaderElectionPlugin] is already installed.
+ *   Install the plugin before calling [leaderScheduled] if `/management/leaderElection` should list
+ *   this lock automatically.
  *
  * ## 입력 검증
  * - [lockName] 은 비어있지 않아야 합니다 (`IllegalArgumentException`).

--- a/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/ApplicationExt.kt
+++ b/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/ApplicationExt.kt
@@ -55,6 +55,7 @@ fun Application.leaderScheduled(
 ): Job {
     lockName.requireNotBlank("lockName")
     period.inWholeMilliseconds.requirePositiveNumber("period")
+    attributes.getOrNull(LeaderElectionConfigKey)?.managementRegistry?.register(lockName)
 
     LeaderScheduledLogger.log.debug {
         "leaderScheduled 등록 — lockName=$lockName, period=$period"
@@ -82,7 +83,7 @@ fun Application.leaderScheduled(
  * ## 동작/계약
  * - 플러그인이 설치되지 않았거나 `leaderElection` 이 설정되지 않은 경우 [IllegalStateException] 을 던집니다.
  */
-private fun Application.resolveLeaderElection(): SuspendLeaderElector {
+internal fun Application.resolveLeaderElection(): SuspendLeaderElector {
     val config = leaderElectionPluginConfig()
     return requireNotNull(config.leaderElection) {
         "LeaderElectionPlugin 의 leaderElection 이 설정되지 않았습니다."

--- a/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderElectionManagementRoute.kt
+++ b/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderElectionManagementRoute.kt
@@ -43,6 +43,12 @@ class LeaderElectionManagementRegistry(
  * - [registry] provides the lock names to inspect.
  * - [leaderElection] is queried with `state(lockName)` at request time.
  * - The JSON is emitted as text so consumers do not need to install a serialization plugin.
+ * - This route is installed on the application's main routing pipeline. Protect it with an
+ *   authentication plugin, network policy, or a dedicated internal port before exposing it outside
+ *   a trusted management boundary.
+ *
+ * Requires [LeaderElectionPlugin] to be installed first when [leaderElection] or [registry] are not
+ * passed explicitly; otherwise the default argument resolution throws [IllegalStateException].
  */
 fun Application.leaderElectionManagementRoute(
     path: String = LeaderElectionPluginConfig.DefaultManagementRoutePath,

--- a/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderElectionManagementRoute.kt
+++ b/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderElectionManagementRoute.kt
@@ -1,0 +1,105 @@
+package io.bluetape4k.leader.ktor
+
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.support.requireNotBlank
+import io.ktor.http.ContentType
+import io.ktor.server.application.Application
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+import java.util.concurrent.ConcurrentSkipListSet
+
+/**
+ * JVM-local registry of lock names exposed through the Ktor management route.
+ */
+class LeaderElectionManagementRegistry(
+    initialLockNames: Iterable<String> = emptyList(),
+) {
+    private val lockNames = ConcurrentSkipListSet<String>()
+
+    init {
+        initialLockNames.forEach(::register)
+    }
+
+    /**
+     * Registers [lockName] as known to the management route.
+     */
+    fun register(lockName: String) {
+        lockName.requireNotBlank("lockName")
+        lockNames.add(lockName)
+    }
+
+    /**
+     * Returns a stable sorted snapshot of known lock names.
+     */
+    fun snapshot(): List<String> =
+        lockNames.toList()
+}
+
+/**
+ * Installs `GET /management/leaderElection`-style JSON status route.
+ *
+ * ## Behavior / Contract
+ * - [registry] provides the lock names to inspect.
+ * - [leaderElection] is queried with `state(lockName)` at request time.
+ * - The JSON is emitted as text so consumers do not need to install a serialization plugin.
+ */
+fun Application.leaderElectionManagementRoute(
+    path: String = LeaderElectionPluginConfig.DefaultManagementRoutePath,
+    leaderElection: SuspendLeaderElector = resolveLeaderElection(),
+    registry: LeaderElectionManagementRegistry = leaderElectionPluginConfig().managementRegistry,
+) {
+    path.requireNotBlank("path")
+    val routePath = if (path.startsWith("/")) path else "/$path"
+
+    routing {
+        get(routePath) {
+            call.respondText(
+                text = registry.toJson(leaderElection),
+                contentType = ContentType.Application.Json,
+            )
+        }
+    }
+}
+
+private fun LeaderElectionManagementRegistry.toJson(leaderElection: SuspendLeaderElector): String =
+    buildString {
+        append("{\"locks\":[")
+        snapshot().forEachIndexed { index, lockName ->
+            if (index > 0) append(',')
+            val state = leaderElection.state(lockName)
+            append('{')
+            append("\"name\":\"").append(lockName.jsonEscape()).append("\",")
+            append("\"status\":\"").append(state.status.name).append("\",")
+            append("\"leaderId\":").append(state.leader?.auditLeaderId?.jsonValue() ?: "null").append(',')
+            append("\"leaseExpiry\":").append(state.leader?.leaseUntil?.toString()?.jsonValue() ?: "null")
+            append('}')
+        }
+        append("]}")
+    }
+
+private fun String.jsonValue(): String =
+    "\"${jsonEscape()}\""
+
+private fun String.jsonEscape(): String =
+    buildString(length) {
+        this@jsonEscape.forEach { char ->
+            when (char) {
+                '\\' -> append("\\\\")
+                '"' -> append("\\\"")
+                '\b' -> append("\\b")
+                '\u000C' -> append("\\f")
+                '\n' -> append("\\n")
+                '\r' -> append("\\r")
+                '\t' -> append("\\t")
+                else -> {
+                    if (char.code < 0x20) {
+                        append("\\u")
+                        append(char.code.toString(16).padStart(4, '0'))
+                    } else {
+                        append(char)
+                    }
+                }
+            }
+        }
+    }

--- a/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderElectionPlugin.kt
+++ b/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderElectionPlugin.kt
@@ -41,12 +41,20 @@ val LeaderElectionPlugin = createApplicationPlugin(
     createConfiguration = ::LeaderElectionPluginConfig,
 ) {
     val config = pluginConfig
-    requireNotNull(config.leaderElection) {
+    val leaderElection = requireNotNull(config.leaderElection) {
         "LeaderElectionPlugin 설치 전 leaderElection 을 반드시 설정해야 합니다."
     }
 
     // 외부 (예: leaderScheduled 확장) 에서 설정에 접근할 수 있도록 Application attributes 에 저장한다.
     application.attributes.put(LeaderElectionConfigKey, config)
+
+    if (config.managementRouteEnabled) {
+        application.leaderElectionManagementRoute(
+            path = config.managementRoutePath,
+            leaderElection = leaderElection,
+            registry = config.managementRegistry,
+        )
+    }
 
     on(MonitoringEvent(ApplicationStarted)) { application ->
         LeaderElectionPluginInternals.log.info {

--- a/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderElectionPluginConfig.kt
+++ b/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderElectionPluginConfig.kt
@@ -20,14 +20,35 @@ import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
  * }
  * ```
  *
- * @property leaderElection 단일 리더 선출 구현체 (필수)
- * @property leaderGroupElection 멀티 리더 선출 구현체 (선택)
+ * @property leaderElection single-leader elector backend (required)
+ * @property leaderGroupElection group/multi-leader elector backend (optional)
+ * @property managementRouteEnabled whether to install the management status route
+ * @property managementRoutePath path for the management status route
  */
 class LeaderElectionPluginConfig {
 
-    /** 단일 리더 선출 구현체. 플러그인 사용 전 반드시 설정해야 합니다. */
+    companion object {
+        const val DefaultManagementRoutePath: String = "/management/leaderElection"
+    }
+
+    /** Single-leader elector backend. Required before installing the plugin. */
     var leaderElection: SuspendLeaderElector? = null
 
-    /** 멀티 리더(그룹) 선출 구현체. 필요 시 설정합니다. */
+    /** Group/multi-leader elector backend. Optional. */
     var leaderGroupElection: SuspendLeaderGroupElector? = null
+
+    /** Whether to install the Ktor management status route. Defaults to false. */
+    var managementRouteEnabled: Boolean = false
+
+    /** Management route path. Defaults to `/management/leaderElection`. */
+    var managementRoutePath: String = DefaultManagementRoutePath
+
+    internal val managementRegistry: LeaderElectionManagementRegistry = LeaderElectionManagementRegistry()
+
+    /**
+     * Registers static lock names exposed through the management route.
+     */
+    fun managementLockNames(vararg lockNames: String) {
+        lockNames.forEach(managementRegistry::register)
+    }
 }

--- a/leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/LeaderElectionManagementRouteTest.kt
+++ b/leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/LeaderElectionManagementRouteTest.kt
@@ -10,8 +10,10 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.install
 import io.ktor.server.testing.testApplication
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
 import kotlin.time.Duration.Companion.seconds
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class LeaderElectionManagementRouteTest {
 
     @Test
@@ -47,6 +49,26 @@ class LeaderElectionManagementRouteTest {
             response.status shouldBeEqualTo HttpStatusCode.OK
             response.bodyAsText() shouldBeEqualTo
                 """{"locks":[{"name":"batch-job","status":"Empty","leaderId":null,"leaseExpiry":null}]}"""
+        }
+    }
+
+    @Test
+    fun `management route supports custom path`() = runSuspendIO {
+        testApplication {
+            application {
+                install(LeaderElectionPlugin) {
+                    leaderElection = LocalSuspendLeaderElector()
+                    managementRouteEnabled = true
+                    managementRoutePath = "/internal/leader-status"
+                    managementLockNames("batch-job")
+                }
+            }
+            startApplication()
+
+            val response = client.get("/internal/leader-status")
+
+            response.status shouldBeEqualTo HttpStatusCode.OK
+            response.bodyAsText() shouldContain "\"name\":\"batch-job\""
         }
     }
 

--- a/leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/LeaderElectionManagementRouteTest.kt
+++ b/leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/LeaderElectionManagementRouteTest.kt
@@ -1,0 +1,74 @@
+package io.bluetape4k.leader.ktor
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.coroutines.LocalSuspendLeaderElector
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.install
+import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
+
+class LeaderElectionManagementRouteTest {
+
+    @Test
+    fun `management route is disabled by default`() = runSuspendIO {
+        testApplication {
+            application {
+                install(LeaderElectionPlugin) {
+                    leaderElection = LocalSuspendLeaderElector()
+                }
+            }
+            startApplication()
+
+            val response = client.get("/management/leaderElection")
+
+            response.status shouldBeEqualTo HttpStatusCode.NotFound
+        }
+    }
+
+    @Test
+    fun `management route returns configured lock status`() = runSuspendIO {
+        testApplication {
+            application {
+                install(LeaderElectionPlugin) {
+                    leaderElection = LocalSuspendLeaderElector()
+                    managementRouteEnabled = true
+                    managementLockNames("batch-job")
+                }
+            }
+            startApplication()
+
+            val response = client.get("/management/leaderElection")
+
+            response.status shouldBeEqualTo HttpStatusCode.OK
+            response.bodyAsText() shouldBeEqualTo
+                """{"locks":[{"name":"batch-job","status":"Empty","leaderId":null,"leaseExpiry":null}]}"""
+        }
+    }
+
+    @Test
+    fun `leaderScheduled records lock name for management route`() = runSuspendIO {
+        testApplication {
+            application {
+                install(LeaderElectionPlugin) {
+                    leaderElection = LocalSuspendLeaderElector()
+                    managementRouteEnabled = true
+                }
+
+                leaderScheduled("scheduled-job", 1.seconds) {
+                    // no-op
+                }
+            }
+            startApplication()
+
+            val response = client.get("/management/leaderElection")
+
+            response.status shouldBeEqualTo HttpStatusCode.OK
+            response.bodyAsText() shouldContain "\"name\":\"scheduled-job\""
+        }
+    }
+}

--- a/leader-spring-boot/README.ko.md
+++ b/leader-spring-boot/README.ko.md
@@ -293,6 +293,49 @@ Java caller 는 `@JvmStatic` overload — `kotlin.time.Duration` 과 `java.time.
 3. `LeaderMicrometerAutoConfiguration`: `MeterRegistry`가 있으면 `MicrometerLeaderAopMetricsRecorder` 등록
 4. `LeaderAopAutoConfiguration`: Aspect, SpEL evaluator, lock-name validator, annotation validator 등록
 5. `LeaderMicrometerHealthAutoConfiguration`: Actuator가 있으면 health indicator 등록
+6. `LeaderElectionObservabilityAutoConfiguration`: lock-name 상태 registry와 fallback event-publisher adapter 등록
+7. `LeaderElectionActuatorAutoConfiguration`: opt-in `/actuator/leaderElection` endpoint 등록
+
+## Leader Election Actuator Endpoint
+
+`leaderElection` endpoint는 기본 비활성입니다. endpoint 활성화와 HTTP 노출을 명시적으로 설정하세요:
+
+```yaml
+bluetape4k:
+  leader:
+    observability:
+      lock-names:
+        - batch-job
+        - migration-gate
+
+management:
+  endpoint:
+    leaderElection:
+      enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health,leaderElection
+```
+
+```http
+GET /actuator/leaderElection
+```
+
+```json
+{
+  "locks": [
+    {
+      "name": "batch-job",
+      "status": "Occupied",
+      "leaderId": "node-1",
+      "leaseExpiry": "2026-05-16T00:00:00Z"
+    }
+  ]
+}
+```
+
+`lock-names`는 첫 runtime event 전에 JVM-local status registry를 seed합니다. Listener-aware elector는 lifecycle event를 관찰하면서 lock 이름을 추가할 수도 있습니다. Fallback `LeaderElectionEventPublisher`는 publisher-only adapter라 `LeaderElector` 후보가 되지 않으므로 기존 elector 주입 경로가 유지됩니다.
 
 ## 마이그레이션 노트
 

--- a/leader-spring-boot/README.md
+++ b/leader-spring-boot/README.md
@@ -293,6 +293,49 @@ For Java callers, `@JvmStatic` overloads accept both `kotlin.time.Duration` and 
 3. `LeaderMicrometerAutoConfiguration` registers `MicrometerLeaderAopMetricsRecorder` when `MeterRegistry` exists.
 4. `LeaderAopAutoConfiguration` registers the Aspect, SpEL evaluator, lock-name validator, and annotation validator.
 5. `LeaderMicrometerHealthAutoConfiguration` registers the Actuator health indicator when Actuator is present.
+6. `LeaderElectionObservabilityAutoConfiguration` registers the lock-name status registry and fallback event-publisher adapter.
+7. `LeaderElectionActuatorAutoConfiguration` registers the opt-in `/actuator/leaderElection` endpoint.
+
+## Leader Election Actuator Endpoint
+
+The `leaderElection` endpoint is disabled by default. Enable the endpoint and expose it over HTTP explicitly:
+
+```yaml
+bluetape4k:
+  leader:
+    observability:
+      lock-names:
+        - batch-job
+        - migration-gate
+
+management:
+  endpoint:
+    leaderElection:
+      enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health,leaderElection
+```
+
+```http
+GET /actuator/leaderElection
+```
+
+```json
+{
+  "locks": [
+    {
+      "name": "batch-job",
+      "status": "Occupied",
+      "leaderId": "node-1",
+      "leaseExpiry": "2026-05-16T00:00:00Z"
+    }
+  ]
+}
+```
+
+`lock-names` seeds the JVM-local status registry before the first runtime event. Listener-aware electors can also add names as they observe lifecycle events. The fallback `LeaderElectionEventPublisher` is publisher-only and never becomes a `LeaderElector` candidate, so existing elector injection remains stable.
 
 ## Migration Notes
 

--- a/leader-spring-boot/build.gradle.kts
+++ b/leader-spring-boot/build.gradle.kts
@@ -76,6 +76,8 @@ dependencies {
     testImplementation(libs.r2dbc.h2)
 
     testImplementation("org.assertj:assertj-core")
+    testRuntimeOnly("org.springframework.boot:spring-boot-starter-actuator")
+    testRuntimeOnly("org.springframework.boot:spring-boot-starter-web")
 }
 
 tasks.compileJava {

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/LeaderProperties.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/LeaderProperties.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.spring
 
 import io.bluetape4k.leader.spring.properties.LeaderElectionProperties
 import io.bluetape4k.leader.spring.properties.LeaderGroupProperties
+import io.bluetape4k.leader.spring.properties.LeaderObservabilityProperties
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.NestedConfigurationProperty
 import java.time.Duration
@@ -18,6 +19,9 @@ import java.time.Duration
  *     lease-time: 60s
  *     watchdog-threads: 4          # optional; defaults to availableProcessors().coerceAtLeast(2)
  *     watchdog-async-extend: true  # optional; defaults to false
+ *     observability:
+ *       lock-names:
+ *         - batch-job
  *     group:
  *       max-leaders: 3
  *       wait-time: 5s
@@ -31,6 +35,7 @@ import java.time.Duration
  * @property leaseTime 단일 리더 보유 최대 시간. 기본 60초
  * @property watchdogThreads watchdog 스케줄러 스레드 수. null 이면 [LeaderLeaseAutoExtender.DEFAULT_WATCHDOG_THREADS] 사용
  * @property watchdogAsyncExtend true 이면 watchdog tick 마다 extend 를 virtual thread 로 비동기 디스패치
+ * @property observability leader status observability and endpoint seed options
  * @property group 멀티 리더 그룹 옵션
  * @property mongo MongoDB 백엔드 컬렉션 이름
  */
@@ -40,6 +45,8 @@ data class LeaderProperties(
     val leaseTime: Duration = LeaderElectionProperties.DefaultLeaseTime,
     val watchdogThreads: Int? = null,
     val watchdogAsyncExtend: Boolean = false,
+    @field:NestedConfigurationProperty
+    val observability: LeaderObservabilityProperties = LeaderObservabilityProperties(),
     @field:NestedConfigurationProperty
     val group: LeaderGroupProperties = LeaderGroupProperties(),
     @field:NestedConfigurationProperty

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/observability/LeaderElectionActuatorAutoConfiguration.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/observability/LeaderElectionActuatorAutoConfiguration.kt
@@ -1,0 +1,43 @@
+package io.bluetape4k.leader.spring.observability
+
+import io.bluetape4k.leader.LeaderElector
+import org.springframework.beans.factory.config.BeanDefinition
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Role
+
+/**
+ * Auto-configuration for the opt-in leader election Actuator endpoint.
+ *
+ * The endpoint bean is disabled by default. Applications must enable it with
+ * `management.endpoint.leaderElection.enabled=true`, and expose it over HTTP with
+ * `management.endpoints.web.exposure.include`.
+ */
+@AutoConfiguration(after = [LeaderElectionObservabilityAutoConfiguration::class])
+@ConditionalOnClass(
+    name = [
+        "org.springframework.boot.actuate.endpoint.annotation.Endpoint",
+        "org.springframework.boot.actuate.endpoint.annotation.ReadOperation",
+    ],
+)
+@ConditionalOnBean(LeaderElectionStatusRegistry::class, LeaderElector::class)
+@ConditionalOnProperty(
+    prefix = "management.endpoint.leaderElection",
+    name = ["enabled"],
+    havingValue = "true",
+)
+class LeaderElectionActuatorAutoConfiguration {
+
+    @Bean("leaderElectionStatusEndpoint")
+    @ConditionalOnMissingBean
+    @Role(BeanDefinition.ROLE_APPLICATION)
+    fun leaderElectionStatusEndpoint(
+        leaderElector: LeaderElector,
+        registry: LeaderElectionStatusRegistry,
+    ): LeaderElectionStatusEndpoint =
+        LeaderElectionStatusEndpoint(leaderElector, registry)
+}

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/observability/LeaderElectionObservabilityAutoConfiguration.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/observability/LeaderElectionObservabilityAutoConfiguration.kt
@@ -1,0 +1,74 @@
+package io.bluetape4k.leader.spring.observability
+
+import io.bluetape4k.leader.LeaderElectionEventPublisher
+import io.bluetape4k.leader.LeaderElectionListener
+import io.bluetape4k.leader.LeaderElectionListenerRegistry
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.spring.LeaderElectionAutoConfiguration
+import io.bluetape4k.leader.spring.LeaderProperties
+import io.bluetape4k.leader.spring.aop.autoconfigure.LeaderAopAutoConfiguration
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.SmartInitializingSingleton
+import org.springframework.beans.factory.config.BeanDefinition
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Role
+
+/**
+ * Spring Boot observability auto-configuration for leader election.
+ *
+ * ## Behavior / Contract
+ * - Registers a JVM-local [LeaderElectionStatusRegistry].
+ * - Exposes a publisher-only fallback [LeaderElectionEventPublisher] when no publisher bean exists.
+ * - Attaches the registry to listener-aware leader beans when they are present.
+ */
+@AutoConfiguration(
+    after = [
+        LeaderElectionAutoConfiguration::class,
+        LeaderAopAutoConfiguration::class,
+    ],
+)
+@ConditionalOnClass(LeaderElector::class)
+@ConditionalOnProperty(
+    prefix = "bluetape4k.leader.observability",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = true,
+)
+@EnableConfigurationProperties(LeaderProperties::class)
+class LeaderElectionObservabilityAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun leaderElectionStatusRegistry(props: LeaderProperties): LeaderElectionStatusRegistry =
+        LeaderElectionStatusRegistry(props.observability.lockNames)
+
+    @Bean("leaderElectionEventPublisher")
+    @ConditionalOnMissingBean(LeaderElectionEventPublisher::class)
+    @Role(BeanDefinition.ROLE_APPLICATION)
+    fun leaderElectionEventPublisher(
+        registry: LeaderElectionStatusRegistry,
+    ): LeaderElectionEventPublisher =
+        LeaderElectionObservedEventPublisher(registry)
+
+    @Bean
+    @ConditionalOnBean(LeaderElectionStatusRegistry::class)
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    fun leaderElectionStatusRegistryRegistrar(
+        listeners: ObjectProvider<LeaderElectionListener>,
+        listenerRegistries: ObjectProvider<LeaderElectionListenerRegistry>,
+    ): SmartInitializingSingleton =
+        SmartInitializingSingleton {
+            val listenerSnapshot = listeners.orderedStream().toList()
+            listenerRegistries.orderedStream().forEach { listenerRegistry ->
+                listenerSnapshot.forEach { listener ->
+                    listenerRegistry.addListener(listener)
+                }
+            }
+        }
+}

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/observability/LeaderElectionObservedEventPublisher.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/observability/LeaderElectionObservedEventPublisher.kt
@@ -1,0 +1,46 @@
+package io.bluetape4k.leader.spring.observability
+
+import io.bluetape4k.leader.LeaderElectionEvent
+import io.bluetape4k.leader.LeaderElectionEventPublisher
+import io.bluetape4k.leader.LeaderElectionListener
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+/**
+ * Publisher adapter that turns observed listener callbacks into leader election events.
+ *
+ * ## Behavior / Contract
+ * - This adapter is publisher-only; it does not implement [io.bluetape4k.leader.LeaderElector],
+ *   so it cannot make `LeaderElector` injection ambiguous.
+ * - It emits events observed through [LeaderElectionListener] callbacks.
+ * - Delivery is best-effort: the buffer keeps 64 events and drops the oldest buffered event
+ *   under back-pressure.
+ */
+class LeaderElectionObservedEventPublisher(
+    private val registry: LeaderElectionStatusRegistry,
+) : LeaderElectionListener, LeaderElectionEventPublisher {
+
+    private val eventSubject = MutableSharedFlow<LeaderElectionEvent>(
+        extraBufferCapacity = 64,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    override val events: Flow<LeaderElectionEvent> = eventSubject.asSharedFlow()
+
+    override fun onElected(lockName: String) {
+        registry.register(lockName)
+        eventSubject.tryEmit(LeaderElectionEvent.Elected(lockName))
+    }
+
+    override fun onRevoked(lockName: String) {
+        registry.register(lockName)
+        eventSubject.tryEmit(LeaderElectionEvent.Revoked(lockName))
+    }
+
+    override fun onSkipped(lockName: String) {
+        registry.register(lockName)
+        eventSubject.tryEmit(LeaderElectionEvent.Skipped(lockName))
+    }
+}

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/observability/LeaderElectionStatusEndpoint.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/observability/LeaderElectionStatusEndpoint.kt
@@ -1,0 +1,77 @@
+package io.bluetape4k.leader.spring.observability
+
+import io.bluetape4k.leader.LeaderElector
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation
+import java.io.Serializable
+import java.time.Instant
+
+/**
+ * Actuator endpoint that exposes best-effort single-leader status for known locks.
+ *
+ * ## Behavior / Contract
+ * - Lock names come from [LeaderElectionStatusRegistry].
+ * - Each lock state is read from [LeaderElector.state] at request time.
+ * - The response is JVM-local and should be used for diagnostics, not election decisions.
+ *
+ * ```json
+ * {
+ *   "locks": [
+ *     {
+ *       "name": "batch-job",
+ *       "status": "Occupied",
+ *       "leaderId": "node-1",
+ *       "leaseExpiry": "2026-05-16T00:00:00Z"
+ *     }
+ *   ]
+ * }
+ * ```
+ */
+@Endpoint(id = "leaderElection")
+class LeaderElectionStatusEndpoint(
+    private val leaderElector: LeaderElector,
+    private val registry: LeaderElectionStatusRegistry,
+) {
+
+    /**
+     * Returns single-leader status for all known lock names.
+     */
+    @ReadOperation
+    fun leaderElectionStatus(): LeaderElectionStatusResponse =
+        LeaderElectionStatusResponse(
+            locks = registry.snapshot().map { lockName ->
+                val state = leaderElector.state(lockName)
+                LeaderElectionLockStatus(
+                    name = lockName,
+                    status = state.status.name,
+                    leaderId = state.leader?.auditLeaderId,
+                    leaseExpiry = state.leader?.leaseUntil,
+                )
+            }
+        )
+}
+
+/**
+ * Actuator response body for the leader election endpoint.
+ */
+data class LeaderElectionStatusResponse(
+    val locks: List<LeaderElectionLockStatus>,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+
+/**
+ * Single known lock status entry returned by [LeaderElectionStatusEndpoint].
+ */
+data class LeaderElectionLockStatus(
+    val name: String,
+    val status: String,
+    val leaderId: String?,
+    val leaseExpiry: Instant?,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/observability/LeaderElectionStatusRegistry.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/observability/LeaderElectionStatusRegistry.kt
@@ -1,0 +1,50 @@
+package io.bluetape4k.leader.spring.observability
+
+import io.bluetape4k.leader.LeaderElectionListener
+import io.bluetape4k.support.requireNotBlank
+import java.util.concurrent.ConcurrentSkipListSet
+
+/**
+ * Registry of lock names known to the Spring Boot leader observability endpoint.
+ *
+ * ## Behavior / Contract
+ * - Static lock names can be seeded from configuration.
+ * - Listener callbacks record lock names observed through listener-aware electors.
+ * - The registry is best-effort and JVM-local; it does not discover arbitrary backend locks.
+ */
+class LeaderElectionStatusRegistry(
+    initialLockNames: Iterable<String> = emptyList(),
+) : LeaderElectionListener {
+
+    private val lockNames = ConcurrentSkipListSet<String>()
+
+    init {
+        initialLockNames.forEach(::register)
+    }
+
+    /**
+     * Registers [lockName] as known to observability endpoints.
+     */
+    fun register(lockName: String) {
+        lockName.requireNotBlank("lockName")
+        lockNames.add(lockName)
+    }
+
+    /**
+     * Returns a stable sorted snapshot of currently known lock names.
+     */
+    fun snapshot(): List<String> =
+        lockNames.toList()
+
+    override fun onElected(lockName: String) {
+        register(lockName)
+    }
+
+    override fun onRevoked(lockName: String) {
+        register(lockName)
+    }
+
+    override fun onSkipped(lockName: String) {
+        register(lockName)
+    }
+}

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/properties/LeaderObservabilityProperties.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/properties/LeaderObservabilityProperties.kt
@@ -1,0 +1,31 @@
+package io.bluetape4k.leader.spring.properties
+
+import java.io.Serializable
+
+/**
+ * Spring Boot observability options for leader election.
+ *
+ * ## Behavior / Contract
+ * - [enabled] controls leader observability support beans such as the status registry and
+ *   event-publisher facade.
+ * - [lockNames] seeds the status registry with statically known lock names so the Actuator
+ *   endpoint can report them before the first runtime event is observed.
+ *
+ * ```yaml
+ * bluetape4k:
+ *   leader:
+ *     observability:
+ *       enabled: true
+ *       lock-names:
+ *         - batch-job
+ *         - migration-gate
+ * ```
+ */
+data class LeaderObservabilityProperties(
+    val enabled: Boolean = true,
+    val lockNames: Set<String> = emptySet(),
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/leader-spring-boot/src/main/resources/META-INF/spring/additional-spring-configuration-metadata.json
+++ b/leader-spring-boot/src/main/resources/META-INF/spring/additional-spring-configuration-metadata.json
@@ -9,6 +9,11 @@
       "name": "bluetape4k.leader.aop.spel",
       "type": "io.bluetape4k.leader.spring.aop.properties.LeaderAopProperties$Spel",
       "description": "Leader AOP SpEL 보안 옵션."
+    },
+    {
+      "name": "bluetape4k.leader.observability",
+      "type": "io.bluetape4k.leader.spring.properties.LeaderObservabilityProperties",
+      "description": "Leader election observability options."
     }
   ],
   "properties": [
@@ -52,6 +57,23 @@
       "name": "bluetape4k.leader.aop.spel.allow-method-invocation",
       "type": "java.lang.Boolean",
       "description": "SpEL withMethodResolvers 활성화. CVE-2022-22947 회색지대 차단을 위해 default false.",
+      "defaultValue": false
+    },
+    {
+      "name": "bluetape4k.leader.observability.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable leader election observability support beans.",
+      "defaultValue": true
+    },
+    {
+      "name": "bluetape4k.leader.observability.lock-names",
+      "type": "java.util.Set<java.lang.String>",
+      "description": "Static lock names seeded into the leader election status registry."
+    },
+    {
+      "name": "management.endpoint.leaderElection.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable the custom leaderElection Actuator endpoint.",
       "defaultValue": false
     }
   ]

--- a/leader-spring-boot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/leader-spring-boot/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -7,6 +7,8 @@ io.bluetape4k.leader.spring.aop.autoconfigure.LeaderAopFactoryAutoConfiguration
 io.bluetape4k.leader.spring.metrics.LeaderMicrometerAutoConfiguration
 io.bluetape4k.leader.spring.metrics.LeaderMicrometerHealthAutoConfiguration
 io.bluetape4k.leader.spring.aop.autoconfigure.LeaderAopAutoConfiguration
+io.bluetape4k.leader.spring.observability.LeaderElectionObservabilityAutoConfiguration
+io.bluetape4k.leader.spring.observability.LeaderElectionActuatorAutoConfiguration
 # LeaderHistoryRetentionAutoConfiguration must appear after LeaderAopAutoConfiguration
 # so that @LeaderElection AOP is active when retention job beans are created.
 io.bluetape4k.leader.spring.history.LeaderHistoryRetentionAutoConfiguration

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/observability/LeaderElectionActuatorHttpPathTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/observability/LeaderElectionActuatorHttpPathTest.kt
@@ -1,0 +1,97 @@
+package io.bluetape4k.leader.spring.observability
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.LeaderLease
+import io.bluetape4k.leader.LeaderState
+import io.bluetape4k.leader.spring.LeaderTestApplication
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Instant
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+
+@SpringBootTest(
+    classes = [
+        LeaderTestApplication::class,
+        LeaderElectionActuatorHttpPathTest.TestLeaderElectorConfig::class,
+    ],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    properties = [
+        "management.endpoint.leaderElection.enabled=true",
+        "management.endpoints.web.exposure.include=leaderElection",
+        "bluetape4k.leader.observability.lock-names[0]=batch-job",
+    ],
+)
+@ImportAutoConfiguration(
+    LeaderElectionObservabilityAutoConfiguration::class,
+    LeaderElectionActuatorAutoConfiguration::class,
+)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderElectionActuatorHttpPathTest {
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    private val httpClient = HttpClient.newHttpClient()
+
+    @Test
+    fun `actuator endpoint is exposed at camel-case leaderElection path`() {
+        val request = HttpRequest.newBuilder()
+            .uri(URI.create("http://localhost:$port/actuator/leaderElection"))
+            .GET()
+            .build()
+        val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+
+        response.statusCode() shouldBeEqualTo 200
+        response.body().shouldContain("\"name\":\"batch-job\"")
+        response.body().shouldContain("\"status\":\"Occupied\"")
+        response.body().shouldContain("\"leaderId\":\"node-1\"")
+        response.body().shouldContain("\"leaseExpiry\":\"2026-05-16T00:00:00Z\"")
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableAutoConfiguration
+    class TestLeaderElectorConfig {
+        @Bean
+        fun testLeaderElector(): LeaderElector =
+            TestLeaderElector()
+    }
+
+    private class TestLeaderElector : LeaderElector {
+
+        override fun <T> runIfLeader(lockName: String, action: () -> T): T? =
+            action()
+
+        override fun <T> runAsyncIfLeader(
+            lockName: String,
+            executor: Executor,
+            action: () -> CompletableFuture<T>,
+        ): CompletableFuture<T?> =
+            action().thenApply { it }
+
+        override fun state(lockName: String): LeaderState =
+            if (lockName == "batch-job") {
+                LeaderState.occupied(
+                    lockName = lockName,
+                    leader = LeaderLease(
+                        auditLeaderId = "node-1",
+                        leaseUntil = Instant.parse("2026-05-16T00:00:00Z"),
+                    )
+                )
+            } else {
+                LeaderState.empty(lockName)
+            }
+    }
+}

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/observability/LeaderElectionObservabilityAutoConfigurationTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/observability/LeaderElectionObservabilityAutoConfigurationTest.kt
@@ -1,0 +1,129 @@
+package io.bluetape4k.leader.spring.observability
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.leader.LeaderElectionEventPublisher
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.LeaderLease
+import io.bluetape4k.leader.LeaderState
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.getBean
+import org.springframework.beans.factory.getBeansOfType
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Instant
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderElectionObservabilityAutoConfigurationTest {
+
+    private val runner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                LeaderElectionObservabilityAutoConfiguration::class.java,
+                LeaderElectionActuatorAutoConfiguration::class.java,
+            )
+        )
+        .withUserConfiguration(TestLeaderElectorConfig::class.java)
+
+    @Test
+    fun `registry is seeded from configured lock names`() {
+        runner
+            .withPropertyValues(
+                "bluetape4k.leader.observability.lock-names[0]=batch-job",
+                "bluetape4k.leader.observability.lock-names[1]=migration-gate",
+            )
+            .run { ctx ->
+                val registry = ctx.getBean<LeaderElectionStatusRegistry>()
+
+                registry.snapshot() shouldBeEqualTo listOf("batch-job", "migration-gate")
+            }
+    }
+
+    @Test
+    fun `fallback event publisher facade is registered when elector is not publisher aware`() {
+        runner.run { ctx ->
+            val publisher = ctx.getBean<LeaderElectionEventPublisher>()
+
+            publisher shouldBeInstanceOf LeaderElectionObservedEventPublisher::class
+        }
+    }
+
+    @Test
+    fun `actuator endpoint is disabled by default`() {
+        runner.run { ctx ->
+            ctx.getBeansOfType<LeaderElectionStatusEndpoint>().isEmpty().shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `actuator endpoint is registered when endpoint property is enabled`() {
+        runner
+            .withPropertyValues("management.endpoint.leaderElection.enabled=true")
+            .run { ctx ->
+                ctx.getBean<LeaderElectionStatusEndpoint>().shouldNotBeNull()
+            }
+    }
+
+    @Test
+    fun `actuator endpoint returns known lock response shape`() {
+        runner
+            .withPropertyValues(
+                "management.endpoint.leaderElection.enabled=true",
+                "bluetape4k.leader.observability.lock-names[0]=batch-job",
+            )
+            .run { ctx ->
+                val endpoint = ctx.getBean<LeaderElectionStatusEndpoint>()
+                val response = endpoint.leaderElectionStatus()
+
+                response.locks.size shouldBeEqualTo 1
+                response.locks[0].name shouldBeEqualTo "batch-job"
+                response.locks[0].status shouldBeEqualTo "Occupied"
+                response.locks[0].leaderId shouldBeEqualTo "node-1"
+                response.locks[0].leaseExpiry shouldBeEqualTo TestLeaderElector.LeaseUntil
+            }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    class TestLeaderElectorConfig {
+        @Bean
+        fun testLeaderElector(): LeaderElector =
+            TestLeaderElector()
+    }
+
+    private class TestLeaderElector : LeaderElector {
+
+        companion object {
+            val LeaseUntil: Instant = Instant.parse("2026-05-16T00:00:00Z")
+        }
+
+        override fun <T> runIfLeader(lockName: String, action: () -> T): T? =
+            action()
+
+        override fun <T> runAsyncIfLeader(
+            lockName: String,
+            executor: Executor,
+            action: () -> CompletableFuture<T>,
+        ): CompletableFuture<T?> =
+            action().thenApply { it }
+
+        override fun state(lockName: String): LeaderState =
+            if (lockName == "batch-job") {
+                LeaderState.occupied(
+                    lockName = lockName,
+                    leader = LeaderLease(
+                        auditLeaderId = "node-1",
+                        leaseUntil = LeaseUntil,
+                    )
+                )
+            } else {
+                LeaderState.empty(lockName)
+            }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #226

PR #253의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: expose leader election observability endpoints`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
Fixes #226.

Stacked on #249 / `feat/issue-224-listening-event-publisher` because the Spring publisher surface builds on listener-aware event publication from #224.

## What changed

- Added `LeaderElectionObservabilityAutoConfiguration` with a JVM-local lock-name status registry.
- Added a publisher-only fallback `LeaderElectionEventPublisher` adapter that does not become a `LeaderElector` candidate.
- Added opt-in `LeaderElectionActuatorAutoConfiguration` and `@Endpoint(id = "leaderElection")`.
- Added `bluetape4k.leader.observability.lock-names` to seed known locks.
- Added Ktor opt-in `GET /management/leaderElection` route and `managementLockNames(...)`.
- Made `leaderScheduled()` record scheduled lock names into the Ktor management registry.
- Updated Spring/Ktor README pairs and added durable design/plan/lesson docs.

## Verification

- [x] `./gradlew :leader-spring-boot:test :leader-ktor:test --no-configuration-cache --console=plain`
- [x] `./gradlew :leader-spring-boot:test --tests 'io.bluetape4k.leader.spring.observability.LeaderElectionObservabilityAutoConfigurationTest' --no-configuration-cache --console=plain`\n- [x] `./gradlew :leader-ktor:test --tests 'io.bluetape4k.leader.ktor.LeaderElectionManagementRouteTest' --no-configuration-cache --console=plain`\n- [x] `git diff --check`\n- [ ] GitHub Actions CI\n\n## Review notes\n\n- Full module test run passed: `leader-ktor` 16 tests and `leader-spring-boot` 293 tests.\n- The full run printed pre-existing shutdown/logging thread warnings but completed successfully.\n- Local Claude advisor was attempted for spec/plan and code review, but produced no usable output within bounded 45-second timeouts; artifacts are under `.omx/artifacts/` and ignored from git.\n- Lock enumeration is explicit/observed only; complete backend lock discovery is intentionally out of scope.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #226, milestone `0.1.0`, assignee `debop`
- PR: #253, head `a2a10a62c4caa5313f5a017862c22816712f58f0`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
