### PR TITLE
feat: support leader election Flux and Flow streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,15 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`leader-spring-boot`**: `@LeaderElection` AOP now supports `Flux<T>` and Kotlin `Flow<T>` stream
+  return types (issue #74).
+  - Added `@LeaderElection(streamBounded = true)` as an explicit opt-in for streams known to complete
+    within the configured lease window.
+  - Long-running streams should use `autoExtend = true`; unsafe stream signatures fail fast in the
+    validator and again at subscription/collection time.
+  - `@LeaderGroupElection` still rejects `Flux` / `Flow` return types until group lease extension
+    semantics are defined.
+
 - **`leader-core`** / **`leader-redis-lettuce`** / **`leader-redis-redisson`**: `LeaderSlot` audit identity propagation (issue #72 PR 2)
   - `LeaderSlot(lockName, leaderId)` — slot-aware identity carrier; `leaderId` propagates to `LeaderRunResult.Elected.leaderId`
   - `LeaderElectorBridgeLog` — throttled WARN logger that counts dropped audit and result-bridge calls when
@@ -245,7 +254,6 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - watchdog / lease auto-extend for long-running leader AOP work (issue #73)
 - `minLeaseTime` backend TTL delegation and `lockAtLeastFor` semantics (issue #77)
 - `LockExtender` / `LockAssert` style explicit lease extension API (issue #79)
-- Flux/Flow AOP return type support after lease renewal semantics are settled (issue #74)
 - Election state API, audit contract, multitenancy, and Prometheus runnable example (issues #68, #50, #42, #145)
 
 ---
@@ -295,4 +303,3 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 [Unreleased]: https://github.com/bluetape4k/bluetape4k-leader/compare/v0.1.0-SNAPSHOT...HEAD
 [0.1.0-SNAPSHOT]: https://github.com/bluetape4k/bluetape4k-leader/releases/tag/v0.1.0-SNAPSHOT
-

--- a/README.ko.md
+++ b/README.ko.md
@@ -451,8 +451,22 @@ class ReportService {
     // Fail-open: 락을 획득하지 못해도 본문 실행
     @LeaderElection(name = "nightly-cleanup", failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
     fun cleanup(): String { /* 항상 실행, 분산 락은 베스트에포트 */ }
+
+    @LeaderElection(name = "event-stream", autoExtend = true)
+    fun streamEvents(): Flux<Event> = eventRepository.stream()
+
+    @LeaderElection(name = "bounded-flow", streamBounded = true)
+    fun boundedFlow(): Flow<Event> = eventRepository.findRecent()
 }
 ```
+
+Stream 반환 규칙:
+
+- `@LeaderElection`은 `T?`, `suspend T?`, `Mono<T>`, `Flux<T>`, Kotlin `Flow<T>`를 지원합니다.
+- 길거나 무한에 가까운 stream에는 `autoExtend = true`를 사용하세요.
+- lease window 안에 끝나는 것이 확실한 stream에만 `streamBounded = true`를 사용하세요.
+- 안전하지 않은 `Flux` / `Flow` 시그니처는 validator와 subscription/collection 시점에 빠르게 실패합니다.
+- `@LeaderGroupElection`은 `T?`, `suspend T?`, `Mono<T>`를 지원하며, group lease extension 의미가 정의되기 전까지 `Flux` / `Flow` group stream은 거부됩니다.
 
 ### `failureMode`
 

--- a/README.md
+++ b/README.md
@@ -449,8 +449,22 @@ class ReportService {
     // Fail-open: run the body even when lock is not acquired or backend is unavailable
     @LeaderElection(name = "nightly-cleanup", failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
     fun cleanup(): String { /* always runs, lock is best-effort */ }
+
+    @LeaderElection(name = "event-stream", autoExtend = true)
+    fun streamEvents(): Flux<Event> = eventRepository.stream()
+
+    @LeaderElection(name = "bounded-flow", streamBounded = true)
+    fun boundedFlow(): Flow<Event> = eventRepository.findRecent()
 }
 ```
+
+Stream return rules:
+
+- `@LeaderElection` supports `T?`, `suspend T?`, `Mono<T>`, `Flux<T>`, and Kotlin `Flow<T>`.
+- Use `autoExtend = true` for long-running or unbounded streams.
+- Use `streamBounded = true` only when the stream is known to finish within the lease window.
+- Unsafe `Flux` / `Flow` signatures fail fast in the validator and at subscription/collection time.
+- `@LeaderGroupElection` supports `T?`, `suspend T?`, and `Mono<T>`; `Flux` / `Flow` group streams are rejected until group lease extension semantics are defined.
 
 ### `failureMode`
 

--- a/docs/lessons/2026-05-16-issue-74-flux-flow-aop.md
+++ b/docs/lessons/2026-05-16-issue-74-flux-flow-aop.md
@@ -1,0 +1,31 @@
+# Issue 74 Flux / Flow AOP
+
+## Context
+
+`@LeaderElection` already supported sync, suspend, and `Mono` methods, but `Flux` and Kotlin `Flow` were rejected because a stream can outlive the initial lease window.
+
+## Decision
+
+Support stream returns only for single-leader `@LeaderElection`, and require one of two explicit safety signals:
+
+- `autoExtend = true` for long-running or unbounded streams.
+- `streamBounded = true` for streams known to complete within the lease window.
+
+Keep `@LeaderGroupElection` stream returns unsupported until group lease extension semantics are defined.
+
+## Outcome
+
+The aspect now wraps `Flux` and `Flow` lazily so the lock is acquired at subscription or collection time and released on completion, error, or cancellation. `Flow` uses `channelFlow` with rendezvous buffering to avoid Flow context-preservation violations.
+
+The validator rejects unsafe stream signatures early, while runtime wrappers still fail at subscription or collection time when startup validation is disabled.
+
+Aspect tests verify that `autoExtend=true` enables stream signatures and passes the option through the normal `LeaderElectionOptions` path. Actual watchdog lease advancement remains covered by core elector auto-extension tests rather than by constructing real electors inside Spring AOP unit tests.
+
+## Verification
+
+- `./gradlew :leader-spring-boot:compileTestKotlin --no-configuration-cache --console=plain`
+- `./gradlew :leader-spring-boot:test --tests '*LeaderElectionAspectStreamTest*' --tests '*LeaderGroupElectionAspectSuspendMonoTest*' --tests '*LeaderAnnotationValidatorBeanPostProcessorTest*' --no-configuration-cache --console=plain`
+
+## Future Guard
+
+Do not test AOP stream `autoExtend` by constructing `LocalSuspendLeaderElector` directly in `leader-spring-boot` tests; the module's test runtime can expose coroutine binary drift unrelated to the aspect contract. Keep AOP tests focused on lazy acquisition, cancellation release, runtime validation, and validator policy, and cover actual lease extension in core elector contract tests.

--- a/docs/superpowers/plans/2026-05-16-issue-74-flux-flow-aop-plan.md
+++ b/docs/superpowers/plans/2026-05-16-issue-74-flux-flow-aop-plan.md
@@ -1,0 +1,271 @@
+# Implementation Plan — Issue #74 `Flux` / `Flow` return support for leader AOP
+
+## Scope
+
+Implement the approved spec:
+
+- Enable `Flux<T>` and Kotlin `Flow<T>` only for single-leader
+  `@LeaderElection`.
+- Add `@LeaderElection(streamBounded: Boolean = false)`.
+- Allow stream methods when `autoExtend=true` or `streamBounded=true`.
+- Keep `@LeaderGroupElection` `Flux<T>` / `Flow<T>` unsupported and prevent
+  sync fallback at runtime.
+- Hold the lock through stream completion, error, or cancellation.
+
+Spec: `docs/superpowers/specs/2026-05-16-issue-74-flux-flow-aop-design.md`
+
+## Task Plan
+
+┌──────┬────────────┬────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────┐
+│ ID   │ Complexity │ Task                                                       │ Evidence / Acceptance                                      │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T1   │ Low        │ Add `streamBounded` to `LeaderElection` KDoc/API.          │ Existing annotation usages compile due default value.      │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T2   │ Medium     │ Extend `AdviceMetadata` with exact return-shape flags:     │ `isMono`, `isFlux`, `isFlow`, `isSuspend` are distinct.    │
+│      │            │ Mono, Flux, Flow, suspend, and stream safety flag.         │ Branch routing can no longer confuse stream with sync.     │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T3   │ Medium     │ Add stream runtime rejection helpers before dispatch.       │ Invalid single stream config and all group streams produce │
+│      │            │                                                            │ error streams, never sync fallback.                        │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T4   │ High       │ Add `LeaderElectionAspect` stream dispatch before sync.    │ `Flux` / `Flow` methods return cold stream wrappers.       │
+│      │            │ Dispatch order: Flux, Flow, suspend, Mono, sync.           │ No backend call until subscription/collection.             │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T5   │ High       │ Implement `Flux` wrapper with `flux { ... }` and           │ Lock acquired once per subscription and held until         │
+│      │            │ `Publisher.asFlow().collect { send(it) }` inside           │ complete/error/cancel.                                     │
+│      │            │ `runIfLeaderResultSuspend`.                                │                                                            │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T6   │ High       │ Implement `Flow` wrapper with `channelFlow { ... }` and    │ No Flow context invariant violation; null values can pass  │
+│      │            │ `.buffer(Channel.RENDEZVOUS)`.                             │ through `Flow<T?>`.                                        │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T7   │ Medium     │ Wire `LeaderAopMetricsRecorder` in stream lifecycle.       │ Attempt/acquired/started/finished/failed fire at stream    │
+│      │            │                                                            │ subscription/collection lifecycle points.                  │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T8   │ High       │ Update `LeaderAnnotationValidatorBeanPostProcessor`.       │ Valid single stream configs pass; invalid stream configs   │
+│      │            │                                                            │ fail/warn with precise messages.                           │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T9   │ Low        │ Add composed annotation support/check for `streamBounded`. │ `@AliasFor(annotation = LeaderElection::class,             │
+│      │            │                                                            │ attribute = "streamBounded")` works in validator/aspect.   │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T10  │ Medium     │ Update `LeaderGroupElectionAspect` return detection for    │ `@LeaderGroupElection` Flux/Flow returns error streams at  │
+│      │            │ unsupported streams.                                       │ subscription/collection time.                              │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T11  │ High       │ Add single-leader Flux tests.                              │ Success, skip-empty, fail-open, body error, backend error, │
+│      │            │                                                            │ cancellation, multi-subscribe, autoExtend, metrics.        │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T12  │ High       │ Add single-leader Flow tests.                              │ Success, skip-empty, fail-open, body error, backend error, │
+│      │            │                                                            │ cancellation, null element, invariant-safe collection.     │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T13  │ High       │ Add validator and composed-annotation tests.               │ strict=true/false matrix, both-true cell, group rejection, │
+│      │            │                                                            │ and `@AliasFor(streamBounded)` covered.                    │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T14  │ Medium     │ Add group runtime rejection tests.                         │ Group Flux/Flow do not call `pjp.proceed()` and do not     │
+│      │            │                                                            │ acquire a group slot.                                      │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T15  │ High       │ Update English KDoc, README locale set, and CHANGELOG.     │ Annotation/aspect KDoc, `README.md`, `README.ko.md`, and   │
+│      │            │                                                            │ `CHANGELOG.md` describe behavior and runtime tightening.  │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T16  │ Low        │ Add lessons entry for stream AOP semantics.                │ Captures Flow context gotcha, channelFlow+rendezvous, and  │
+│      │            │                                                            │ runtime stream rejection rule.                             │
+├──────┼────────────┼────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────┤
+│ T17  │ High       │ Run targeted verification and review.                      │ Gradle tests/build, IDE diagnostics fallback, 6-tier code  │
+│      │            │                                                            │ review, and PR-ready status.                               │
+└──────┴────────────┴────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────┘
+
+## Implementation Details
+
+### Return Shape Detection
+
+Use constants for raw return type names:
+
+- `reactor.core.publisher.Mono`
+- `reactor.core.publisher.Flux`
+- `kotlinx.coroutines.flow.Flow`
+
+Do not use `Class.forName` for optional dependencies. `leader-spring-boot`
+already has `kotlinx-coroutines-reactor` as `compileOnly`, and stream methods
+are detected by return type name.
+
+### Stream Safety Validation
+
+For `@LeaderElection`:
+
+```text
+if return is Flux/Flow:
+  allowed = ann.autoExtend || ann.streamBounded
+  if !allowed -> invalid
+```
+
+For `@LeaderGroupElection`:
+
+```text
+if return is Flux/Flow:
+  invalid
+```
+
+Runtime aspect rejection repeats this check before dispatch so non-strict
+validator mode cannot permit sync fallback.
+
+### Stream Wrappers
+
+`Flux` branch:
+
+- return `Flux.defer { flux { ... } }` or a cold `flux { ... }`;
+- resolve metadata and lock name inside subscription;
+- call `SuspendLeaderElector.runIfLeaderResultSuspend`;
+- collect user `Flux` with `asFlow()` inside the guarded action;
+- `send` each element downstream;
+- map `Skipped` to empty completion.
+- wire metrics inside the stream body: attempt at subscription, acquired after
+  lock acquisition, taskStarted immediately before user stream collection,
+  taskFinished on normal completion, taskFailed on body/backend/cancel.
+
+`Flow` branch:
+
+- return `channelFlow { ... }.buffer(Channel.RENDEZVOUS)`;
+- resolve metadata and lock name inside collection;
+- call `SuspendLeaderElector.runIfLeaderResultSuspend`;
+- collect user `Flow` inside `withContext(LeaderElectionInfo(...))`;
+- send each element downstream;
+- map `Skipped` to empty completion.
+- wire metrics at the same lifecycle points as the Flux branch.
+
+Do not use `flow { withContext { emit(...) } }`.
+
+### Metrics
+
+Keep existing recorder API. Do not add `onTaskCancelled`.
+
+- normal completion: `onTaskFinished`;
+- body error, backend error, cancellation: `onTaskFailed`;
+- cancellation rethrows `CancellationException`;
+- downstream cancellation must not be converted into a Reactor/Flow error.
+- `LeaderElectionInfo` and `LockHandleElement` must be visible inside guarded
+  stream collection.
+
+## Test Plan
+
+### Unit Tests
+
+Extend `LeaderElectionAspectSuspendMonoTest` or add
+`LeaderElectionAspectStreamTest`:
+
+- Flux elected success returns all elements.
+- Flux skip returns empty stream and does not call `pjp.proceed()`.
+- Flux fail-open contention executes body stream under `wasElected=false`.
+- Flux backend error with `RETHROW` emits `LeaderElectionException`.
+- Flux body error propagates body exception and releases lock.
+- Flux cancellation releases lock and records failure.
+- Flux `Disposable.dispose()` cancellation releases lock and records failure.
+- Flux two subscriptions acquire twice and release twice.
+- Flux `autoExtend=true` stream uses a real `LocalSuspendLeaderElector` with a
+  short lease and verifies `state(lockName).leader.leaseUntil` advances while
+  the stream is active.
+- Flux empty-body / zero-emission stream still acquires and releases the lock.
+- Flux slow downstream consumer does not leak or complete early.
+- Flux `LeaderElectionInfo` and `LockAssert.assertLockedSuspend()` are visible
+  inside guarded stream collection.
+- Flow elected success returns all elements.
+- Flow skip returns empty flow and does not call `pjp.proceed()`.
+- Flow fail-open contention executes body stream under `wasElected=false`.
+- Flow backend error with `RETHROW` throws `LeaderElectionException`.
+- Flow body error propagates body exception and releases lock.
+- Flow cancellation releases lock and records failure.
+- Flow coroutine cancellation releases lock and records failure.
+- Flow nullable element path supports `Flow<String?>`.
+- Flow invariant regression: stream collection succeeds through
+  `channelFlow` + `send`, not `flow` + context-shifted `emit`.
+- Flow empty-body / zero-emission stream still acquires and releases the lock.
+- Flow `flowOn` on the user flow does not break guarded collection.
+- Flow slow collector keeps rendezvous/backpressure behavior and releases on
+  cancel.
+- Flow `LeaderElectionInfo` and `LockAssert.assertLockedSuspend()` are visible
+  inside guarded stream collection.
+
+Extend `LeaderGroupElectionAspectSuspendMonoTest`:
+
+- Group Flux returns error stream and does not call body.
+- Group Flow returns error stream and does not call body.
+
+Extend `LeaderAnnotationValidatorBeanPostProcessorTest`:
+
+- `@LeaderElection(autoExtend=true) fun flux(): Flux<T>` passes.
+- `@LeaderElection(streamBounded=true) fun flux(): Flux<T>` passes.
+- `@LeaderElection(autoExtend=true, streamBounded=true) fun flux(): Flux<T>` passes.
+- `@LeaderElection fun flux(): Flux<T>` fails in strict mode and warns in
+  non-strict mode.
+- Same matrix for `Flow<T>`.
+- `@LeaderGroupElection fun flux()/flow()` still fails in strict mode and warns
+  in non-strict mode.
+- A composed annotation can alias `streamBounded` with Spring `@AliasFor`.
+
+### Verification Commands
+
+```bash
+./gradlew :leader-core:compileKotlin :leader-spring-boot:compileKotlin --no-configuration-cache --console=plain
+./gradlew :leader-spring-boot:test --tests 'io.bluetape4k.leader.spring.aop.LeaderElectionAspectStreamTest' --no-configuration-cache --console=plain
+./gradlew :leader-spring-boot:test --tests 'io.bluetape4k.leader.spring.aop.LeaderGroupElectionAspectSuspendMonoTest' --tests 'io.bluetape4k.leader.spring.aop.validator.LeaderAnnotationValidatorBeanPostProcessorTest' --no-configuration-cache --console=plain
+./gradlew :leader-spring-boot:build --no-configuration-cache --console=plain
+```
+
+If IDE diagnostics are unavailable, use compile/test output plus import scan as
+fallback.
+
+## Rollback / Compatibility
+
+- `streamBounded` has a default value, so source usage remains compatible.
+- Existing `Flux` / `Flow` methods that only warned in non-strict mode will now
+  fail at runtime instead of executing with unsafe sync fallback. This is an
+  intentional safety tightening and must be called out in README upgrade notes
+  and `CHANGELOG.md`.
+- `@LeaderGroupElection` stream support remains a follow-up; no group API field
+  is added in this PR.
+
+## Step 3 Checklist Completion Report
+
+┌──────────────────────────────────────────────┬────────┬────────────────────────────────────────────────────────────┐
+│ Item                                         │ Status │ Notes                                                      │
+├──────────────────────────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
+│ Plan maps every spec requirement             │ Done   │ Tasks T1-T17 cover API, runtime, validation, tests, docs. │
+├──────────────────────────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
+│ Task order is implementable                  │ Done   │ API/metadata before aspect wrappers, then tests/docs.      │
+├──────────────────────────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
+│ Targeted verification commands named         │ Done   │ Compile, targeted tests, and module build listed.          │
+├──────────────────────────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
+│ README/KDoc/lesson tasks included            │ Done   │ T15-T16.                                                   │
+└──────────────────────────────────────────────┴────────┴────────────────────────────────────────────────────────────┘
+
+## Step 3-R Review Notes
+
+### Claude Code Opus Advisor
+
+Artifact: `.omx/artifacts/claude-issue-74-flux-flow-aop-plan-20260516-115339.md`
+Focused rerun: `.omx/artifacts/claude-issue-74-flux-flow-aop-plan-rerun-20260516-115712.md`
+
+┌──────────┬────────────────────────────────────────────────────────────┬──────────┬────────────────────────────────────────────────────────────┐
+│ Priority │ Finding                                                    │ Decision │ Follow-up                                                  │
+├──────────┼────────────────────────────────────────────────────────────┼──────────┼────────────────────────────────────────────────────────────┤
+│ P0       │ Runtime rejection helper was ordered after stream dispatch. │ Accepted │ T3 now precedes dispatch T4.                              │
+├──────────┼────────────────────────────────────────────────────────────┼──────────┼────────────────────────────────────────────────────────────┤
+│ P0       │ Metrics lifecycle wiring was missing as an implementation   │ Accepted │ T7 added and lifecycle points listed.                     │
+│          │ task.                                                       │          │                                                            │
+├──────────┼────────────────────────────────────────────────────────────┼──────────┼────────────────────────────────────────────────────────────┤
+│ P1       │ `@AliasFor(streamBounded)` handling and test were missing.  │ Accepted │ T9/T13 added.                                              │
+├──────────┼────────────────────────────────────────────────────────────┼──────────┼────────────────────────────────────────────────────────────┤
+│ P1       │ `autoExtend` test lacked assertion mechanism.               │ Accepted │ T11 uses real local elector and `leaseUntil` advancement.  │
+├──────────┼────────────────────────────────────────────────────────────┼──────────┼────────────────────────────────────────────────────────────┤
+│ P1       │ Flux cancellation missed Reactor `Disposable.dispose()`.    │ Accepted │ T11 test list includes explicit dispose path.              │
+└──────────┴────────────────────────────────────────────────────────────┴──────────┴────────────────────────────────────────────────────────────┘
+
+### Step 3-R Integrated Findings
+
+┌──────────┬───────┬───────┬────────────────────────────────────────────────────────────┐
+│ Priority │ Count │ Open  │ Notes                                                      │
+├──────────┼───────┼───────┼────────────────────────────────────────────────────────────┤
+│ P0       │ 2     │ 0     │ Rejection ordering and metrics lifecycle fixed.            │
+├──────────┼───────┼───────┼────────────────────────────────────────────────────────────┤
+│ P1       │ 3     │ 0     │ AliasFor, autoExtend assertion, dispose cancellation fixed.│
+├──────────┼───────┼───────┼────────────────────────────────────────────────────────────┤
+│ P2/P3    │ 4     │ 0     │ Backpressure, docs, lesson, and rollback notes accepted.   │
+└──────────┴───────┴───────┴────────────────────────────────────────────────────────────┘
+
+Focused rerun result: P0 = 0, P1 = 0.

--- a/docs/superpowers/specs/2026-05-16-issue-74-flux-flow-aop-design.md
+++ b/docs/superpowers/specs/2026-05-16-issue-74-flux-flow-aop-design.md
@@ -1,0 +1,369 @@
+# Design Spec — Issue #74 `Flux` / `Flow` return support for leader AOP
+
+## Context
+
+Issue #74 closes the remaining asynchronous return-shape gap in the single
+leader AOP surface. `@LeaderElection` and `@LeaderGroupElection` already
+support:
+
+- sync `T?` / `Unit`;
+- Kotlin `suspend fun`;
+- Reactor `Mono<T>`.
+
+`Flux<T>` and Kotlin `Flow<T>` are currently blocked by
+`LeaderAnnotationValidatorBeanPostProcessor` because returning a long-lived
+stream while releasing the lock at method-return time can create split-brain.
+This issue enables stream returns for `@LeaderElection` only. Group stream
+support remains a follow-up because group-election options do not have automatic
+lease renewal.
+
+The key requirement is therefore not "allow these return types"; it is:
+
+> acquire the leader lock per subscription/collection and release it only after
+> stream completion, error, or cancellation.
+
+## Current Evidence
+
+- `LeaderElectionAspect` handles `Mono<T>` with `Mono.defer { mono { ... } }`,
+  so lock acquisition happens per subscription.
+- `LeaderElectionAspect` calls `SuspendLeaderElector.runIfLeader(...)` for
+  suspend/Mono paths. Local suspend electors push `LockHandleElement`, start the
+  single-leader watchdog when `autoExtend=true`, and release in a
+  `NonCancellable` `finally` block.
+- `LeaderGroupElectionAspect` has the same suspend/Mono shape but group options
+  do not have `autoExtend`, so unbounded group streams cannot be made safe in
+  issue #74 without adding a separate group lease-renewal design.
+- `LeaderAnnotationValidatorBeanPostProcessor` currently treats `Flux` and
+  `Flow` as unsupported. In non-strict mode it warns only, which can still let
+  runtime execution fall through to the sync branch if the aspect does not
+  explicitly recognize the return type.
+- Reactor documentation recommends `doFinally` / `usingWhen` for cleanup on
+  complete, error, and cancel. For this codebase, `kotlinx.coroutines.reactor.flux`
+  is a better local fit because its coroutine is cancelled when the subscriber
+  disposes.
+- kotlinx-coroutines documentation and source confirm:
+  - `flux { ... }` is cold, starts a coroutine per subscriber, and cancellation
+    cancels that coroutine;
+  - `Flow.asFlux()` creates a cold Flux and cancellation cancels the original
+    Flow;
+  - `Publisher.asFlow()` cancels the subscription in `finally`.
+
+## Public API Decision
+
+Add a bounded-stream opt-in to `@LeaderElection`:
+
+```kotlin
+annotation class LeaderElection(
+    // existing properties...
+    val streamBounded: Boolean = false,
+)
+```
+
+### Meaning
+
+`streamBounded=true` is a caller contract that the returned `Flux` / `Flow` is
+finite enough to complete within the configured lease window, or that the stream
+body performs explicit lease extension through `LockExtender`.
+
+It is not a runtime timeout and it does not change release timing. Release timing
+is always tied to stream termination:
+
+- complete -> release lock and complete downstream;
+- error -> release lock and propagate the error;
+- cancel -> release lock and stop downstream emission.
+
+### Validation Rules
+
+For `@LeaderElection` methods returning `Flux<T>` or `Flow<T>`:
+
+- allowed when `autoExtend=true`; intended for long-lived streams;
+- allowed when `streamBounded=true`; intended for finite streams;
+- invalid when both are false.
+
+For `@LeaderGroupElection` methods returning `Flux<T>` or `Flow<T>`:
+
+- still unsupported in issue #74;
+- strict validation fails as before;
+- non-strict validation may warn, but the aspect must still refuse runtime
+  sync fallback by returning an error stream at subscription/collection time.
+
+Future group auto-extension can relax this rule, but issue #74 should not imply
+group stream safety.
+
+Composed annotations may expose `streamBounded` with Spring `@AliasFor` the same
+way they expose other `@LeaderElection` attributes.
+
+## Runtime Semantics
+
+### `Flux<T>`
+
+Return a cold `Flux` that does no backend work until subscription:
+
+```kotlin
+flux {
+    val result = elector.runIfLeaderResultSuspend(lockName) {
+        withContext(LeaderElectionInfo(lockName, true)) {
+            val upstream = pjp.proceed() as Flux<Any>
+            upstream.asFlow().collect { send(it) }
+        }
+    }
+    when (result) {
+        is Elected -> Unit
+        Skipped -> Unit // empty Flux
+        is ActionFailed -> throw result.cause
+    }
+}
+```
+
+The action does not return the body `Flux`; it collects and re-emits it inside
+the guarded scope. This is the essential split-brain mitigation.
+
+### `Flow<T>`
+
+Return a cold `Flow` that does no backend work until collection:
+
+```kotlin
+channelFlow {
+    val result = elector.runIfLeaderResultSuspend(lockName) {
+        withContext(LeaderElectionInfo(lockName, true)) {
+            val upstream = pjp.proceed() as Flow<Any?>
+            upstream.collect { send(it) }
+        }
+    }
+    when (result) {
+        is Elected -> Unit
+        Skipped -> Unit // empty Flow
+        is ActionFailed -> throw result.cause
+    }
+}.buffer(Channel.RENDEZVOUS)
+```
+
+`Flow<T?>` can emit null values. `Flux<T>` cannot emit null values by the
+Reactive Streams contract; that remains Reactor's normal constraint.
+
+Implementation must not use `flow { withContext { emit(...) } }`. Kotlin Flow
+enforces context preservation for `emit`, and context-shifting emits can throw a
+Flow invariant violation. Use `channelFlow { withContext(...) { upstream.collect { send(it) } } }`
+and add `buffer(Channel.RENDEZVOUS)` unless tests prove a different buffer is
+needed. This keeps the leader context in the guarded collection coroutine while
+using channel sends for cross-context emission.
+
+### Routing And Runtime Rejection
+
+Aspect dispatch order must classify stream return types before the sync branch:
+
+1. `Flux<T>` -> stream-reactive branch;
+2. `Flow<T>` -> stream-coroutine branch;
+3. `suspend fun` -> coroutine branch;
+4. `Mono<T>` -> reactive branch;
+5. sync fallback.
+
+Invalid stream configurations must fail at subscription/collection time even
+when the validator is configured with `strict=false` and only logged a warning.
+The aspect must never let `Flux` / `Flow` fall through to the sync branch.
+
+Runtime rejection mapping:
+
+- `Flux<T>` -> `Flux.error(LeaderElectionException(...))` or
+  `Flux.error(LeaderGroupElectionException(...))`;
+- `Flow<T>` -> `flow { throw LeaderElectionException(...) }` or group
+  equivalent.
+
+### Backpressure And Dispatcher
+
+The stream aspect does not add polling or eager buffering. For `Flux<T>`,
+`kotlinx.coroutines.reactor.flux { send(...) }` suspends sends according to
+downstream demand. For `Flow<T>`, use rendezvous buffering after `channelFlow`
+unless implementation tests require a different bounded buffer.
+
+The aspect should not pin a dispatcher. Caller-provided Reactor `subscribeOn` /
+`publishOn` and Flow `flowOn` remain the scheduling controls. Blocking work in
+stream bodies is still the caller's responsibility.
+
+### Failure Modes
+
+`RETHROW`:
+
+- backend acquisition failure emits stream error (`LeaderElectionException`);
+- body failure emits the body error.
+
+`SKIP`:
+
+- contention produces an empty stream;
+- backend failure produces an empty stream after metrics record the backend
+  failure.
+
+`FAIL_OPEN_RUN`:
+
+- contention or backend failure collects the user stream under
+  `LeaderElectionInfo(wasElected=false)` and a fail-open `LockHandleElement`;
+- downstream complete/error/cancel still bounds the fail-open scope.
+
+## Metrics Semantics
+
+Stream metrics map to stream lifecycle, not method-return lifecycle:
+
+- `onLockAttempt`: at subscription/collection time;
+- `onLockAcquired`: after the lock is acquired;
+- `onTaskStarted`: immediately before collecting the user stream;
+- `onTaskFinished`: only on normal stream completion;
+- `onTaskFailed`: on body error, backend error, or cancellation.
+
+Cancellation is treated consistently with existing suspend/Mono code: it is
+recorded as task failure and rethrown as `CancellationException` so Reactor/Flow
+cancellation remains cancellation, not a normal error signal.
+
+## Non-Goals
+
+- Native image support beyond existing Spring AOT coverage.
+- Changing `Mono<T>` semantics.
+- Supporting `Future`, `CompletableFuture`, `ListenableFuture`, or `Deferred`.
+- Adding automatic lease renewal to group-election options.
+- Supporting `Flux<T>` or `Flow<T>` on `@LeaderGroupElection`.
+- Adding a hard stream timeout.
+
+## Risks And Mitigations
+
+### R1: Lock released before stream termination
+
+Mitigation: AOP must collect/re-emit the stream inside `runIfLeaderResultSuspend`
+instead of returning the user stream from inside the guarded action.
+
+### R2: Non-strict validator warning still allows dangerous sync fallback
+
+Mitigation: aspect return-type detection must explicitly route `Flux` and `Flow`
+before the sync branch. Invalid stream shapes must return error streams at
+subscription/collection time and must not fall through to sync execution.
+
+### R3: Cancellation hides lock release
+
+Mitigation: use coroutine `flux {}` / `channelFlow {}` builders and rely on
+suspend elector `finally { withContext(NonCancellable) { release } }`. Add
+cancellation tests.
+
+### R4: Long stream without renewal
+
+Mitigation: require `autoExtend=true` or explicit `streamBounded=true` for
+single-leader streams. Keep group streams unsupported until a group renewal
+design exists.
+
+### R5: `LeaderElectionInfo` / `LockHandleElement` lost inside operators
+
+Mitigation: document that suspend contexts are available inside the guarded
+collection coroutine. Reactor non-suspend operators still cannot call suspend
+`LockAssert`; users should use `flatMap { mono { ... } }` for suspend checks.
+
+## Acceptance Criteria
+
+- `@LeaderElection` supports `Flux<T>` and `Flow<T>` with per-subscription /
+  per-collection locking.
+- `@LeaderGroupElection` `Flux<T>` / `Flow<T>` remains unsupported and cannot
+  fall through to sync execution.
+- `LeaderAnnotationValidatorBeanPostProcessor` accepts valid stream
+  configurations and rejects unsafe stream configurations.
+- `LeaderAnnotationValidatorBeanPostProcessor` rejects `@LeaderElection`
+  `Flux<T>` / `Flow<T>` when `autoExtend=false && streamBounded=false`.
+- Contention maps to empty stream for `SKIP`, and fail-open maps to body stream
+  execution with `wasElected=false`.
+- Complete, error, and cancel release the lock.
+- Multi-subscriber `Flux` acquires and releases the lock once per subscription.
+- `autoExtend=true` stream tests prove at least one lease extension while the
+  stream is active.
+- KDoc is updated in English; `README.md` and existing localized README files
+  such as `README.ko.md` describe stream contracts.
+- Targeted `leader-spring-boot` tests cover Flux and Flow success, skip,
+  fail-open, body error, backend error, and cancellation.
+
+## Step 2-R Review Notes
+
+### Local Multi-Perspective Review
+
+┌─────────────┬──────────┬────────────────────────────────────────────────────────────┬──────────┐
+│ Perspective │ Priority │ Finding                                                    │ Decision │
+├─────────────┼──────────┼────────────────────────────────────────────────────────────┼──────────┤
+│ Developer   │ P1       │ `Flow` emission inside `withContext` can violate Flow       │ Accepted │
+│             │          │ context preservation.                                       │          │
+├─────────────┼──────────┼────────────────────────────────────────────────────────────┼──────────┤
+│ Ops/SRE     │ P1       │ Group streams lack auto-renewal and can split-brain.        │ Accepted │
+├─────────────┼──────────┼────────────────────────────────────────────────────────────┼──────────┤
+│ User/API    │ P1       │ strict=false validator warning must not permit sync         │ Accepted │
+│             │          │ fallback for stream returns.                                │          │
+├─────────────┼──────────┼────────────────────────────────────────────────────────────┼──────────┤
+│ Security    │ P3       │ No new auth/secret boundary; keep SpEL handling unchanged. │ Accepted │
+└─────────────┴──────────┴────────────────────────────────────────────────────────────┴──────────┘
+
+### Claude Code Opus Advisor
+
+Artifact: `.omx/artifacts/claude-issue-74-flux-flow-aop-spec-20260516-114545.md`
+Focused rerun: `.omx/artifacts/claude-issue-74-flux-flow-aop-spec-rerun-20260516-114927.md`
+Final focused rerun: `.omx/artifacts/claude-issue-74-flux-flow-aop-spec-final-rerun-20260516-115108.md`
+
+┌──────────┬────────────────────────────────────────────────────────────┬──────────┬────────────────────────────────────────────────────────────┐
+│ Priority │ Finding                                                    │ Decision │ Follow-up                                                  │
+├──────────┼────────────────────────────────────────────────────────────┼──────────┼────────────────────────────────────────────────────────────┤
+│ P0       │ `flow { withContext { emitAll(...) } }` violates Flow       │ Accepted │ Use `channelFlow` + `send` + rendezvous buffer in spec.    │
+│          │ context preservation.                                      │          │                                                            │
+├──────────┼────────────────────────────────────────────────────────────┼──────────┼────────────────────────────────────────────────────────────┤
+│ P0       │ Group stream has no renewal path.                          │ Accepted │ Defer group `Flux` / `Flow`; runtime must reject streams.  │
+├──────────┼────────────────────────────────────────────────────────────┼──────────┼────────────────────────────────────────────────────────────┤
+│ P0       │ Validator non-strict mode can still allow sync fallback.    │ Accepted │ Add explicit stream dispatch and runtime rejection rule.   │
+├──────────┼────────────────────────────────────────────────────────────┼──────────┼────────────────────────────────────────────────────────────┤
+│ P1       │ Multi-subscriber, cancellation, autoExtend tests missing.  │ Accepted │ Added acceptance criteria; plan will include concrete      │
+│          │                                                            │          │ tests.                                                     │
+├──────────┼────────────────────────────────────────────────────────────┼──────────┼────────────────────────────────────────────────────────────┤
+│ P2       │ Backpressure and dispatcher policy under-specified.        │ Accepted │ Added policy: no eager buffering, rendezvous Flow bridge,  │
+│          │                                                            │          │ caller controls dispatcher.                                │
+└──────────┴────────────────────────────────────────────────────────────┴──────────┴────────────────────────────────────────────────────────────┘
+
+### Step 2-R Integrated Findings
+
+┌──────────┬───────┬───────┬────────────────────────────────────────────────────────────┐
+│ Priority │ Count │ Open  │ Notes                                                      │
+├──────────┼───────┼───────┼────────────────────────────────────────────────────────────┤
+│ P0       │ 3     │ 0     │ Flow invariant, group stream lease, sync fallback fixed in │
+│          │       │       │ spec.                                                      │
+├──────────┼───────┼───────┼────────────────────────────────────────────────────────────┤
+│ P1       │ 4     │ 0     │ Test and runtime contract gaps accepted into spec/plan.    │
+├──────────┼───────┼───────┼────────────────────────────────────────────────────────────┤
+│ P2       │ 3     │ 0     │ Backpressure/dispatcher/AliasFor notes accepted.           │
+├──────────┼───────┼───────┼────────────────────────────────────────────────────────────┤
+│ P3       │ 1     │ 0     │ No user-blocking open question.                            │
+└──────────┴───────┴───────┴────────────────────────────────────────────────────────────┘
+
+Final focused rerun result after canonical Flow example correction: P0 = 0, P1 = 0.
+
+## Step 2 / 2-R Checklist Completion Report
+
+┌──────────────────────────────────────────────┬────────┬────────────────────────────────────────────────────────────┐
+│ Item                                         │ Status │ Notes                                                      │
+├──────────────────────────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
+│ Draft spec written inside feature worktree   │ Done   │ This file is under the #74 worktree.                       │
+├──────────────────────────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
+│ Architecture options and API contract set    │ Done   │ Single-leader streams only; group streams deferred.        │
+├──────────────────────────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
+│ Step 2-R references loaded                   │ Done   │ `step-2r-spec-review.md` and Claude advisor reference.     │
+├──────────────────────────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
+│ Local multi-perspective review completed     │ Done   │ Developer, Ops/SRE, user/API, security perspectives.       │
+├──────────────────────────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
+│ Claude Code Opus advisor completed           │ Done   │ Initial + focused reruns saved under `.omx/artifacts/`.    │
+├──────────────────────────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
+│ P0/P1 convergence verified                   │ Done   │ Final focused rerun reports P0 = 0, P1 = 0.                │
+└──────────────────────────────────────────────┴────────┴────────────────────────────────────────────────────────────┘
+
+## Step 1 / 1-R Checklist Completion Report
+
+┌──────────────────────────────────────────────┬────────┬────────────────────────────────────────────────────────────┐
+│ Item                                         │ Status │ Notes                                                      │
+├──────────────────────────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
+│ Target repository confirmed                 │ Done   │ `bluetape4k-leader`, branch `feat/issue-74-flux-flow-aop`. │
+├──────────────────────────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
+│ Worktree created from current develop        │ Done   │ `origin/develop@8ab6e30a`.                                │
+├──────────────────────────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
+│ qmd / prior docs searched                    │ Done   │ Used `zsh -ic qmdq ...`; found AOP and lock extender docs. │
+├──────────────────────────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
+│ Current source inspected                     │ Done   │ AOP aspects, validator, annotations, suspend electors.     │
+├──────────────────────────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
+│ Official docs / source evidence checked      │ Done   │ Reactor and kotlinx-coroutines docs plus local source jars. │
+├──────────────────────────────────────────────┼────────┼────────────────────────────────────────────────────────────┤
+│ User intent and boundary clear               │ Done   │ New feature/API addition; use full design workflow.        │
+└──────────────────────────────────────────────┴────────┴────────────────────────────────────────────────────────────┘

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/annotation/LeaderElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/annotation/LeaderElection.kt
@@ -1,25 +1,28 @@
 package io.bluetape4k.leader.annotation
 
 /**
- * 메서드를 분산 환경에서 단일 리더 선출 진입으로 보호하는 어노테이션.
+ * Protects a method with single-leader election in a distributed environment.
  *
- * ## 동작
- * - 메서드 호출 시 [name] 으로 락 획득 시도. 성공 시 본문 실행, 실패 시 [failureMode] 에 따라 분기.
- * - 본 PR은 sync `T?` 반환만 지원. suspend / `Mono<T>` / `Flow<T>` 는 후속 [#80].
+ * ## Contract
+ * - The aspect resolves [name], attempts to acquire the leader lock, then runs the method body only
+ *   when this node is elected unless [failureMode] says otherwise.
+ * - Supported return shapes are `T?`, `suspend T?`, `Mono<T>`, `Flux<T>`, and Kotlin `Flow<T>`.
+ * - `Flux<T>` and `Flow<T>` stream returns require either [autoExtend] or [streamBounded].
+ * - `@LeaderGroupElection` does not support `Flux<T>` or `Flow<T>` yet.
  *
- * ## SpEL 평가
- * [name] 은 plain SpEL — 리터럴 prefix 는 따옴표 필수:
- * - ✅ `name = "daily-job"` (정적)
- * - ✅ `name = "'process-' + #region"`
- * - ✅ `name = "#user.tenantId"`
- * - ✅ `name = "\${spring.application.name}-warmup"` (Spring property placeholder 후 plain SpEL)
- * - ❌ `name = "process-#region"` — `process-` 가 식별자로 해석되어 startup pre-parse 실패
+ * ## SpEL evaluation
+ * [name] is plain SpEL. Literal prefixes must be quoted:
+ * - `name = "daily-job"` for a static lock name.
+ * - `name = "'process-' + #region"` for a prefixed dynamic name.
+ * - `name = "#user.tenantId"` for a property lookup.
+ * - `name = "\${spring.application.name}-warmup"` after Spring property placeholder resolution.
+ * - `name = "process-#region"` is invalid because `process-` is parsed as an identifier.
  *
- * ## 보안
- * - default 로 SpEL 메서드 호출 차단 (`#user.delete()` 같은 부작용 표현식).
- *   property `bluetape4k.leader.aop.spel.allow-method-invocation=true` 로 명시적 opt-in 가능.
+ * ## Security
+ * SpEL method invocation is disabled by default to avoid side-effect expressions such as
+ * `#user.delete()`. Set `bluetape4k.leader.aop.spel.allow-method-invocation=true` to opt in.
  *
- * ## 사용 예
+ * ## Usage
  * ```kotlin
  * @Scheduled(cron = "0 0 2 * * *")
  * @LeaderElection(name = "daily-settlement", leaseTime = "PT1H")
@@ -31,22 +34,31 @@ package io.bluetape4k.leader.annotation
  * // 다중 백엔드 환경에서 명시적 factory 선택
  * @LeaderElection(name = "audit", bean = "redissonLeaderElectionFactory")
  * fun audit() { ... }
+ *
+ * @LeaderElection(name = "event-stream", autoExtend = true)
+ * fun streamEvents(): Flux<Event> = repository.stream()
+ *
+ * @LeaderElection(name = "bounded-flow", streamBounded = true)
+ * fun boundedFlow(): Flow<Event> = repository.findRecent()
  * ```
  *
- * ## 미선출 시 매핑
- * - `T?` 반환 메서드: `null`
- * - `Unit` 메서드: 본문 미실행
+ * ## Not-elected mapping
+ * - `T?`: returns `null`.
+ * - `Unit`: skips the method body.
+ * - `Mono<T>`: completes empty.
+ * - `Flux<T>` / `Flow<T>`: emits no elements.
  *
- * @property name 락 이름 (필수). plain SpEL + `${...}` Spring property placeholder
- * @property waitTime 리더 획득 대기 시간 — 빈 문자열 시 property 또는 코어 default 폴백
- * @property leaseTime 리더 보유 시간 — 빈 문자열 시 property 또는 코어 default 폴백
- * @property minLeaseTime 최소 리더 보유 시간. `PT0S`이면 빠른 종료 시 즉시 해제
- * @property autoExtend 작업 실행 중 단일 리더 lease를 backend watchdog으로 주기 연장할지 여부
- * @property bean 사용할 [io.bluetape4k.leader.LeaderElectorFactory] 빈 이름 (literal only). 빈 문자열 시 default factory
- * @property failureMode 백엔드 예외 처리 정책. default `RETHROW`
+ * @property name Required lock name. Plain SpEL plus `${...}` Spring property placeholders.
+ * @property waitTime Maximum leader acquisition wait time. Empty means property or core default.
+ * @property leaseTime Leader lease duration. Empty means property or core default.
+ * @property minLeaseTime Minimum lease retention. `PT0S` releases immediately after fast completion.
+ * @property autoExtend Whether to periodically renew the single-leader lease while the action runs.
+ * @property streamBounded Opt-in marker that a `Flux` / `Flow` stream completes within the lease window.
+ * @property bean [io.bluetape4k.leader.LeaderElectorFactory] bean name to use. Empty means default factory.
+ * @property failureMode Backend error handling policy. Defaults to `RETHROW` after property resolution.
  *
- * @see LeaderGroupElection 다중 리더 (semaphore-based) 변형
- * @see LeaderAspectFailureMode failure mode enum
+ * @see LeaderGroupElection Semaphore-based multi-leader variant.
+ * @see LeaderAspectFailureMode Failure mode enum.
  */
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 @Retention(AnnotationRetention.RUNTIME)
@@ -57,6 +69,7 @@ annotation class LeaderElection(
     val leaseTime: String = "",
     val minLeaseTime: String = "PT0S",
     val autoExtend: Boolean = false,
+    val streamBounded: Boolean = false,
     val bean: String = "",
     val failureMode: LeaderAspectFailureMode = LeaderAspectFailureMode.INHERIT,
 )

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -27,14 +27,21 @@ import io.bluetape4k.leader.spring.aop.util.LockNameValidator
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.reactor.awaitSingleOrNull
+import kotlinx.coroutines.reactor.flux
 import kotlinx.coroutines.reactor.mono
+import kotlinx.coroutines.reactive.asFlow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.withContext
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.reflect.MethodSignature
 import org.springframework.beans.factory.SmartInitializingSingleton
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.lang.reflect.Method
 import kotlinx.coroutines.CancellationException
@@ -46,33 +53,44 @@ import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.toKotlinDuration
 
 /**
- * `@LeaderElection` 어노테이션 처리 Aspect — sync `T?`, suspend `T?`, `Mono<T>` 지원.
+ * Aspect that applies `@LeaderElection` to sync `T?`, suspend `T?`, `Mono<T>`,
+ * `Flux<T>`, and Kotlin `Flow<T>` methods.
  *
  * ## CTW (Freefair post-compile weaving)
- * `@EnableAspectJAutoProxy` 미사용. autoconfig 가 `@Bean` 으로 등록.
+ * The auto-configuration registers this aspect as a bean without requiring
+ * `@EnableAspectJAutoProxy`.
  *
- * ## suspend 지원 (#90)
- * 마지막 파라미터가 [Continuation] 인 메서드 → [aroundLeaderSuspend] 분기.
- * `startCoroutineUninterceptedOrReturn` + `suspendCoroutineUninterceptedOrReturn` intrinsics 패턴.
+ * ## Suspend support (#90)
+ * Methods whose last parameter is [Continuation] use [aroundLeaderSuspend].
+ * The implementation follows the `startCoroutineUninterceptedOrReturn` and
+ * `suspendCoroutineUninterceptedOrReturn` intrinsics pattern.
  *
- * ## Mono 지원 (#91)
- * 반환 타입이 `reactor.core.publisher.Mono` 인 메서드 → [aroundLeaderMono] 분기.
- * `Mono.defer { mono { suspendElector.runIfLeader(...) } }` 패턴 — subscribe 당 락 1회.
+ * ## Mono support (#91)
+ * `reactor.core.publisher.Mono` return types use [aroundLeaderMono] and defer
+ * leader acquisition until subscription.
+ *
+ * ## Stream support (#74)
+ * `Flux<T>` and `Flow<T>` return types hold the leader lock for the stream
+ * lifecycle. They require `autoExtend=true` or `streamBounded=true`, and unsafe
+ * stream configurations are rejected again at subscription or collection time
+ * even when startup validation is disabled.
  *
  * ## LeaderElectionInfo (#92)
- * suspend / Mono 분기 본문 실행 시 [LeaderElectionInfo] 를 `withContext` 로 주입.
- * 사용자는 `coroutineContext[LeaderElectionInfo]` 로 선출 정보 접근 가능.
+ * Suspend, Mono, Flux, and Flow branches install [LeaderElectionInfo] with
+ * `withContext` while the method body is collected or awaited.
  *
  * ## LockHandleElement / LockStateHolder (T14)
- * - sync 분기: [AopScopeAccess.withPushedSync] 로 `LockStateHolder` 에 handle push — [io.bluetape4k.leader.LockAssert] / [io.bluetape4k.leader.LockExtender] 동작.
- * - suspend / Mono 분기: elector 가 `withContext(LockHandleElement(...))` 로 이미 push — aspect 는 [LeaderElectionInfo] 만 추가.
- * - FAIL_OPEN_RUN 분기: [LeaderLockHandle.FailOpen] sentinel 을 push 하여 body 가 fail-open scope 인식.
+ * - Sync branch: the elector manages `LockStateHolder`, so [io.bluetape4k.leader.LockAssert]
+ *   and [io.bluetape4k.leader.LockExtender] see the active lock.
+ * - Coroutine / reactive branches: the elector already installs `LockHandleElement`; the aspect
+ *   adds only [LeaderElectionInfo].
+ * - `FAIL_OPEN_RUN` installs a [LeaderLockHandle.FailOpen] sentinel so the body can detect the
+ *   fail-open scope.
  *
  * ## Reentrant pass-through (T14)
- * sync 분기 진입 전 [AopScopeAccess.peekSyncMatching] 으로 동일 lockName 보유 여부 확인.
- * 이미 보유 중이면 backend re-acquire 없이 body 직접 실행 (backend acquire counter = 1).
- * suspend 분기는 elector 에서 `LockHandleElement` 가 coroutine context 에 있으므로
- * 재진입 시 elector 가 직접 pass-through (Mutex 비재진입이므로 aspect-level 단락 불필요).
+ * The sync branch short-circuits when [AopScopeAccess.peekSyncMatching] finds a matching real
+ * handle. Coroutine branches delegate reentrant handling to the elector because the lock handle
+ * lives in the coroutine context.
  */
 @Aspect
 class LeaderElectionAspect(
@@ -94,7 +112,19 @@ class LeaderElectionAspect(
         val target = pjp.target
         val args = pjp.args
 
-        if (method.returnType.name == "reactor.core.publisher.Mono") {
+        if (method.returnType.name == FLUX_RETURN_TYPE) {
+            return Flux.defer<Any> {
+                val meta = metadataCache.computeIfAbsent(method) { resolveMetadata(it, target) }
+                @Suppress("UNCHECKED_CAST")
+                aroundLeaderFlux(pjp, meta) as Flux<Any>
+            }
+        }
+
+        if (method.returnType.name == FLOW_RETURN_TYPE) {
+            return aroundLeaderFlow(pjp, method, target)
+        }
+
+        if (method.returnType.name == MONO_RETURN_TYPE) {
             return Mono.defer<Any> {
                 val meta = metadataCache.computeIfAbsent(method) { resolveMetadata(it, target) }
                 @Suppress("UNCHECKED_CAST")
@@ -383,6 +413,298 @@ class LeaderElectionAspect(
     }
 
     /**
+     * Handles methods returning `Flux`.
+     *
+     * The returned [Flux] is cold. Each subscription resolves the lock name,
+     * acquires the leader lock, collects the user [Flux], and releases the lock
+     * only after complete/error/cancel.
+     */
+    private fun aroundLeaderFlux(pjp: ProceedingJoinPoint, meta: AdviceMetadata): Any? {
+        val method = (pjp.signature as MethodSignature).method
+
+        return Flux.defer {
+            if (!meta.isStreamAllowed()) {
+                return@defer Flux.error(streamConfigurationException(method, meta, "Flux"))
+            }
+
+            flux<Any> {
+                val start = System.nanoTime()
+                var lockName: String? = null
+                var resolvedIdentity: LockIdentity? = null
+
+                fun resolveIdentity(name: String): LockIdentity =
+                    resolvedIdentity ?: meta.resolveLockIdentity(name, AdviceBranch.REACTIVE)
+                        .also { resolvedIdentity = it }
+
+                try {
+                    val resolvedName = resolveLockName(meta, method, pjp.args, pjp.target)
+                    lockName = resolvedName
+                    val cacheKey = FactoryCacheKey(meta.suspendElectorFactoryBeanName, meta.options)
+                    val factory = checkNotNull(meta.suspendElectorFactory) {
+                        "suspendElectorFactory must be non-null in REACTIVE branch (Flux)"
+                    }
+                    val elector = suspendElectorCache[cacheKey]
+                        ?: factory.create(meta.options).also { suspendElectorCache.putIfAbsent(cacheKey, it) }
+
+                    fanOut { it.onLockAttempt(resolvedName, meta.options) }
+
+                    val result = elector.runIfLeaderResultSuspend(resolvedName) {
+                        fanOut {
+                            it.onLockAcquired(resolvedName, meta.options, (System.nanoTime() - start).nanoseconds)
+                            it.onTaskStarted(resolvedName)
+                        }
+                        withContext(LeaderElectionInfo(lockName = resolvedName, wasElected = true)) {
+                            try {
+                                @Suppress("UNCHECKED_CAST")
+                                val upstream = pjp.proceed() as Flux<Any>
+                                upstream.asFlow().collect { send(it) }
+                                val elapsed = System.nanoTime() - start
+                                fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
+                                if (elapsed > meta.leaseTimeWarnThresholdNanos) {
+                                    log.warn { "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${meta.options.leaseTime.inWholeNanoseconds}" }
+                                }
+                                log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
+                            } catch (ce: CancellationException) {
+                                fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, ce) }
+                                throw ce
+                            } catch (bodyEx: Throwable) {
+                                fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                                throw BodyThrownMarker(bodyEx)
+                            }
+                        }
+                    }
+
+                    when (result) {
+                        is LeaderRunResult.Elected -> Unit
+                        is LeaderRunResult.Skipped -> {
+                            if (meta.failureMode == LeaderAspectFailureMode.FAIL_OPEN_RUN) {
+                                val failOpenHandle = AopScopeAccess.createFailOpen(resolveIdentity(resolvedName))
+                                fanOut {
+                                    it.onLockNotAcquired(resolvedName, meta.options, SkipReason.FAIL_OPEN_FORCED)
+                                    it.onTaskStarted(resolvedName)
+                                }
+                                log.debug { "leader.aop.fail-open lockName=$resolvedName reason=CONTENTION" }
+                                try {
+                                    withContext(
+                                        LeaderElectionInfo(lockName = resolvedName, wasElected = false) +
+                                            AopScopeAccess.createLockHandleElement(failOpenHandle)
+                                    ) {
+                                        @Suppress("UNCHECKED_CAST")
+                                        val upstream = pjp.proceed() as Flux<Any>
+                                        upstream.asFlow().collect { send(it) }
+                                    }
+                                    fanOut { it.onTaskFinished(resolvedName, (System.nanoTime() - start).nanoseconds) }
+                                } catch (ce: CancellationException) {
+                                    fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, ce) }
+                                    throw ce
+                                } catch (bodyEx: Throwable) {
+                                    fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                                    throw BodyThrownMarker(bodyEx)
+                                }
+                            } else {
+                                fanOut { it.onLockNotAcquired(resolvedName, meta.options, SkipReason.CONTENTION) }
+                                log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
+                            }
+                        }
+                        is LeaderRunResult.ActionFailed -> throw result.cause
+                    }
+                } catch (ce: CancellationException) {
+                    throw ce
+                } catch (bm: BodyThrownMarker) {
+                    throw bm.cause
+                } catch (backendEx: Exception) {
+                    val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
+                    val wrapped = LeaderElectionException("leader backend error for lock '$effectiveName'", backendEx)
+                    when (meta.failureMode) {
+                        LeaderAspectFailureMode.INHERIT -> error("INHERIT must be resolved in resolveMetadata")
+                        LeaderAspectFailureMode.RETHROW -> {
+                            fanOut { it.onLockNotAcquired(effectiveName, meta.options, SkipReason.BACKEND_ERROR) }
+                            fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
+                            throw wrapped
+                        }
+                        LeaderAspectFailureMode.SKIP -> {
+                            fanOut { it.onLockNotAcquired(effectiveName, meta.options, SkipReason.BACKEND_ERROR) }
+                            fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
+                            log.warn(backendEx) { "leader.aop.skipped lockName=$effectiveName reason=BACKEND_ERROR" }
+                        }
+                        LeaderAspectFailureMode.FAIL_OPEN_RUN -> {
+                            val failOpenHandle = AopScopeAccess.createFailOpen(
+                                meta.resolveLockIdentity(effectiveName, AdviceBranch.REACTIVE)
+                            )
+                            fanOut { it.onLockNotAcquired(effectiveName, meta.options, SkipReason.FAIL_OPEN_FORCED) }
+                            log.warn(backendEx) { "leader.aop.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
+                            fanOut { it.onTaskStarted(effectiveName) }
+                            try {
+                                withContext(
+                                    LeaderElectionInfo(lockName = effectiveName, wasElected = false) +
+                                        AopScopeAccess.createLockHandleElement(failOpenHandle)
+                                ) {
+                                    @Suppress("UNCHECKED_CAST")
+                                    val upstream = pjp.proceed() as Flux<Any>
+                                    upstream.asFlow().collect { send(it) }
+                                }
+                                fanOut { it.onTaskFinished(effectiveName, (System.nanoTime() - start).nanoseconds) }
+                            } catch (ce: CancellationException) {
+                                fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, ce) }
+                                throw ce
+                            } catch (bodyEx: Throwable) {
+                                fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                                throw bodyEx
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Handles methods returning Kotlin `Flow`.
+     *
+     * Uses [channelFlow] instead of `flow { withContext { emit(...) } }` so the
+     * leader context can be installed while values are sent without violating
+     * Kotlin Flow context-preservation rules.
+     */
+    private fun aroundLeaderFlow(
+        pjp: ProceedingJoinPoint,
+        method: Method,
+        target: Any,
+    ): Flow<Any?> =
+        channelFlow {
+            val meta = metadataCache.computeIfAbsent(method) { resolveMetadata(it, target) }
+            if (!meta.isStreamAllowed()) {
+                throw streamConfigurationException(method, meta, "Flow")
+            }
+
+            val start = System.nanoTime()
+            var lockName: String? = null
+            var resolvedIdentity: LockIdentity? = null
+
+            fun resolveIdentity(name: String): LockIdentity =
+                resolvedIdentity ?: meta.resolveLockIdentity(name, AdviceBranch.COROUTINES)
+                    .also { resolvedIdentity = it }
+
+            try {
+                val resolvedName = resolveLockName(meta, method, pjp.args, pjp.target)
+                lockName = resolvedName
+                val cacheKey = FactoryCacheKey(meta.suspendElectorFactoryBeanName, meta.options)
+                val factory = checkNotNull(meta.suspendElectorFactory) {
+                    "suspendElectorFactory must be non-null in COROUTINES branch (Flow)"
+                }
+                val elector = suspendElectorCache[cacheKey]
+                    ?: factory.create(meta.options).also { suspendElectorCache.putIfAbsent(cacheKey, it) }
+
+                fanOut { it.onLockAttempt(resolvedName, meta.options) }
+
+                val result = elector.runIfLeaderResultSuspend(resolvedName) {
+                    fanOut {
+                        it.onLockAcquired(resolvedName, meta.options, (System.nanoTime() - start).nanoseconds)
+                        it.onTaskStarted(resolvedName)
+                    }
+                    withContext(LeaderElectionInfo(lockName = resolvedName, wasElected = true)) {
+                        try {
+                            @Suppress("UNCHECKED_CAST")
+                            val upstream = pjp.proceed() as Flow<Any?>
+                            upstream.collect { send(it) }
+                            val elapsed = System.nanoTime() - start
+                            fanOut { it.onTaskFinished(resolvedName, elapsed.nanoseconds) }
+                            if (elapsed > meta.leaseTimeWarnThresholdNanos) {
+                                log.warn { "leader.aop.lease-warn lockName=$resolvedName elapsedNs=$elapsed leaseTimeNs=${meta.options.leaseTime.inWholeNanoseconds}" }
+                            }
+                            log.debug { "leader.aop.elected lockName=$resolvedName elapsedNs=$elapsed" }
+                        } catch (ce: CancellationException) {
+                            fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, ce) }
+                            throw ce
+                        } catch (bodyEx: Throwable) {
+                            fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                            throw BodyThrownMarker(bodyEx)
+                        }
+                    }
+                }
+
+                when (result) {
+                    is LeaderRunResult.Elected -> Unit
+                    is LeaderRunResult.Skipped -> {
+                        if (meta.failureMode == LeaderAspectFailureMode.FAIL_OPEN_RUN) {
+                            val failOpenHandle = AopScopeAccess.createFailOpen(resolveIdentity(resolvedName))
+                            fanOut {
+                                it.onLockNotAcquired(resolvedName, meta.options, SkipReason.FAIL_OPEN_FORCED)
+                                it.onTaskStarted(resolvedName)
+                            }
+                            log.debug { "leader.aop.fail-open lockName=$resolvedName reason=CONTENTION" }
+                            try {
+                                withContext(
+                                    LeaderElectionInfo(lockName = resolvedName, wasElected = false) +
+                                        AopScopeAccess.createLockHandleElement(failOpenHandle)
+                                ) {
+                                    @Suppress("UNCHECKED_CAST")
+                                    val upstream = pjp.proceed() as Flow<Any?>
+                                    upstream.collect { send(it) }
+                                }
+                                fanOut { it.onTaskFinished(resolvedName, (System.nanoTime() - start).nanoseconds) }
+                            } catch (ce: CancellationException) {
+                                fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, ce) }
+                                throw ce
+                            } catch (bodyEx: Throwable) {
+                                fanOut { it.onTaskFailed(resolvedName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                                throw BodyThrownMarker(bodyEx)
+                            }
+                        } else {
+                            fanOut { it.onLockNotAcquired(resolvedName, meta.options, SkipReason.CONTENTION) }
+                            log.debug { "leader.aop.skipped lockName=$resolvedName reason=CONTENTION" }
+                        }
+                    }
+                    is LeaderRunResult.ActionFailed -> throw result.cause
+                }
+            } catch (ce: CancellationException) {
+                throw ce
+            } catch (bm: BodyThrownMarker) {
+                throw bm.cause
+            } catch (backendEx: Exception) {
+                val effectiveName = lockName ?: "<unresolved:${meta.nameExpression}>"
+                val wrapped = LeaderElectionException("leader backend error for lock '$effectiveName'", backendEx)
+                when (meta.failureMode) {
+                    LeaderAspectFailureMode.INHERIT -> error("INHERIT must be resolved in resolveMetadata")
+                    LeaderAspectFailureMode.RETHROW -> {
+                        fanOut { it.onLockNotAcquired(effectiveName, meta.options, SkipReason.BACKEND_ERROR) }
+                        fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
+                        throw wrapped
+                    }
+                    LeaderAspectFailureMode.SKIP -> {
+                        fanOut { it.onLockNotAcquired(effectiveName, meta.options, SkipReason.BACKEND_ERROR) }
+                        fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, backendEx) }
+                        log.warn(backendEx) { "leader.aop.skipped lockName=$effectiveName reason=BACKEND_ERROR" }
+                    }
+                    LeaderAspectFailureMode.FAIL_OPEN_RUN -> {
+                        val failOpenHandle = AopScopeAccess.createFailOpen(
+                            meta.resolveLockIdentity(effectiveName, AdviceBranch.COROUTINES)
+                        )
+                        fanOut { it.onLockNotAcquired(effectiveName, meta.options, SkipReason.FAIL_OPEN_FORCED) }
+                        log.warn(backendEx) { "leader.aop.fail-open lockName=$effectiveName reason=BACKEND_ERROR" }
+                        fanOut { it.onTaskStarted(effectiveName) }
+                        try {
+                            withContext(
+                                LeaderElectionInfo(lockName = effectiveName, wasElected = false) +
+                                    AopScopeAccess.createLockHandleElement(failOpenHandle)
+                            ) {
+                                @Suppress("UNCHECKED_CAST")
+                                val upstream = pjp.proceed() as Flow<Any?>
+                                upstream.collect { send(it) }
+                            }
+                            fanOut { it.onTaskFinished(effectiveName, (System.nanoTime() - start).nanoseconds) }
+                        } catch (ce: CancellationException) {
+                            fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, ce) }
+                            throw ce
+                        } catch (bodyEx: Throwable) {
+                            fanOut { it.onTaskFailed(effectiveName, (System.nanoTime() - start).nanoseconds, bodyEx) }
+                            throw bodyEx
+                        }
+                    }
+                }
+            }
+        }.buffer(Channel.RENDEZVOUS)
+
+    /**
      * `Mono` 반환 타입 메서드 처리 — `Mono.defer { mono { suspendElector.runIfLeader(...) } }` 패턴.
      *
      * `Mono.defer` 로 subscribe 당 락 1회 보장.
@@ -565,15 +887,18 @@ class LeaderElectionAspect(
             ann.failureMode
         }
 
+        val returnTypeName = method.returnType.name
         val isSuspend = method.parameterTypes.lastOrNull() == Continuation::class.java
-        val isMono = !isSuspend && method.returnType.name == "reactor.core.publisher.Mono"
+        val isMono = !isSuspend && returnTypeName == MONO_RETURN_TYPE
+        val isFlux = !isSuspend && returnTypeName == FLUX_RETURN_TYPE
+        val isFlow = !isSuspend && returnTypeName == FLOW_RETURN_TYPE
         val branch = when {
-            isSuspend -> AdviceBranch.COROUTINES
-            isMono -> AdviceBranch.REACTIVE
+            isSuspend || isFlow -> AdviceBranch.COROUTINES
+            isMono || isFlux -> AdviceBranch.REACTIVE
             else -> AdviceBranch.SYNC
         }
 
-        val (suspendElectorFactory, suspendElectorFactoryBeanName) = if (isSuspend || isMono) {
+        val (suspendElectorFactory, suspendElectorFactoryBeanName) = if (isSuspend || isMono || isFlux || isFlow) {
             val suspendSelected = beanSelector.selectSuspendElectorFactory(ann.bean, method)
             suspendSelected.bean to suspendSelected.beanName
         } else {
@@ -589,12 +914,30 @@ class LeaderElectionAspect(
             failureMode = effectiveFailureMode,
             leaseTimeWarnThresholdNanos = (leaseTime.inWholeNanoseconds * LEASE_WARN_RATIO).toLong(),
             branch = branch,
+            isSuspend = isSuspend,
+            isMono = isMono,
+            isFlux = isFlux,
+            isFlow = isFlow,
+            streamBounded = ann.streamBounded,
             suspendElectorFactory = suspendElectorFactory,
             suspendElectorFactoryBeanName = suspendElectorFactoryBeanName,
             annotationKind = LockIdentity.AnnotationKind.SINGLE,
             groupParams = null,
         )
     }
+
+    private fun AdviceMetadata.isStreamAllowed(): Boolean =
+        !(isFlux || isFlow) || options.autoExtend || streamBounded
+
+    private fun streamConfigurationException(
+        method: Method,
+        meta: AdviceMetadata,
+        returnShape: String,
+    ): LeaderElectionException =
+        LeaderElectionException(
+            "@LeaderElection $returnShape stream requires autoExtend=true or streamBounded=true: " +
+                "${method.declaringClass.name}#${method.name} name='${meta.nameExpression}'",
+        )
 
     private inline fun fanOut(crossinline action: (LeaderAopMetricsRecorder) -> Unit) {
         if (!hasRecorders) return
@@ -607,5 +950,8 @@ class LeaderElectionAspect(
     companion object : KLogging() {
         private val LITERAL_PATTERN = Regex("^[A-Za-z0-9_:.\\-]+$")
         private const val LEASE_WARN_RATIO = 0.8
+        private const val MONO_RETURN_TYPE = "reactor.core.publisher.Mono"
+        private const val FLUX_RETURN_TYPE = "reactor.core.publisher.Flux"
+        private const val FLOW_RETURN_TYPE = "kotlinx.coroutines.flow.Flow"
     }
 }

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -27,6 +27,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireGe
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import kotlinx.coroutines.reactor.mono
 import kotlinx.coroutines.withContext
@@ -35,6 +36,7 @@ import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.reflect.MethodSignature
 import org.springframework.beans.factory.SmartInitializingSingleton
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.lang.reflect.Method
 import kotlinx.coroutines.CancellationException
@@ -46,28 +48,32 @@ import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.toKotlinDuration
 
 /**
- * `@LeaderGroupElection` 어노테이션 처리 Aspect — sync `T?`, suspend `T?`, `Mono<T>` 지원.
+ * Aspect that applies `@LeaderGroupElection` to sync `T?`, suspend `T?`, and `Mono<T>` methods.
+ * `Flux<T>` and `Flow<T>` return types are rejected until group lease extension semantics are defined.
  *
- * [LeaderElectionAspect] 와 동일 패턴 + `maxLeaders` 분기. backend 예외는
- * [LeaderGroupElectionException] 으로 wrapping.
+ * The implementation mirrors [LeaderElectionAspect] and adds the `maxLeaders` option. Backend
+ * failures are wrapped in [LeaderGroupElectionException].
  *
- * ## suspend 지원 (#90)
- * [LeaderElectionAspect.aroundLeaderSuspend] 와 동일 패턴 — [SuspendLeaderGroupElectorFactory] 사용.
+ * ## Suspend support (#90)
+ * Suspend methods use the same intrinsics pattern as [LeaderElectionAspect.aroundLeaderSuspend] and
+ * acquire through [SuspendLeaderGroupElectorFactory].
  *
- * ## Mono 지원 (#91)
- * 반환 타입이 `reactor.core.publisher.Mono` 인 메서드 → [aroundLeaderMono] 분기.
+ * ## Mono support (#91)
+ * `reactor.core.publisher.Mono` return types use [aroundLeaderMono] and defer group leader
+ * acquisition until subscription.
  *
  * ## LeaderElectionInfo (#92)
- * suspend / Mono 분기 본문 실행 시 [LeaderElectionInfo] 를 `withContext` 로 주입.
+ * Suspend and Mono branches install [LeaderElectionInfo] with `withContext` while the method body is
+ * awaited.
  *
  * ## LockHandleElement / LockStateHolder (T15)
- * - sync 분기: [AopScopeAccess.withPushedSync] 로 `LockStateHolder` 에 handle push.
- * - suspend / Mono 분기: elector 가 `withContext(LockHandleElement(...))` 로 이미 push — aspect 는 [LeaderElectionInfo] 만 추가.
- * - FAIL_OPEN_RUN 분기: [LeaderLockHandle.FailOpen] sentinel 을 push.
+ * - Sync branch: the elector manages the sync lock holder.
+ * - Coroutine / reactive branches: the elector already installs `LockHandleElement`; the aspect adds
+ *   only [LeaderElectionInfo].
+ * - `FAIL_OPEN_RUN` installs a [LeaderLockHandle.FailOpen] sentinel.
  *
  * ## Reentrant pass-through (T15)
- * sync 분기 진입 전 [AopScopeAccess.peekSyncMatching] 으로 동일 lockName 보유 여부 확인.
- * 이미 Real handle 보유 시 backend re-acquire 없이 body 실행. FailOpen sentinel + identity 일치 시 sentinel 유지 (Plan-R1-P1-1).
+ * The sync branch short-circuits when [AopScopeAccess.peekSyncMatching] finds a matching real handle.
  */
 @Aspect
 class LeaderGroupElectionAspect(
@@ -88,6 +94,18 @@ class LeaderGroupElectionAspect(
         val method = (pjp.signature as MethodSignature).method
         val target = pjp.target
         val args = pjp.args
+
+        if (method.returnType.name == FLUX_RETURN_TYPE) {
+            return Flux.defer<Any> {
+                Flux.error(unsupportedStreamException(method, "Flux"))
+            }
+        }
+
+        if (method.returnType.name == FLOW_RETURN_TYPE) {
+            return flow<Any?> {
+                throw unsupportedStreamException(method, "Flow")
+            }
+        }
 
         val meta = metadataCache.computeIfAbsent(method) { resolveMetadata(it, target) }
 
@@ -598,6 +616,12 @@ class LeaderGroupElectionAspect(
             minLeaseTime = minLeaseTime,
         )
 
+    private fun unsupportedStreamException(method: Method, returnShape: String): LeaderGroupElectionException =
+        LeaderGroupElectionException(
+            "@LeaderGroupElection does not support $returnShape streams yet: " +
+                "${method.declaringClass.name}#${method.name}",
+        )
+
     private data class GroupAdviceMetadata(
         val nameExpression: String,
         val literalName: String?,
@@ -635,5 +659,7 @@ class LeaderGroupElectionAspect(
     companion object: KLogging() {
         private val LITERAL_PATTERN = Regex("^[A-Za-z0-9_:.\\-]+$")
         private const val LEASE_WARN_RATIO = 0.8
+        private const val FLUX_RETURN_TYPE = "reactor.core.publisher.Flux"
+        private const val FLOW_RETURN_TYPE = "kotlinx.coroutines.flow.Flow"
     }
 }

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/internal/AdviceMetadata.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/internal/AdviceMetadata.kt
@@ -17,7 +17,9 @@ import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
  * - [factory]: sync elector factory 인스턴스
  * - [failureMode]: INHERIT 이 이미 resolve 된 effective failure mode
  * - [leaseTimeWarnThresholdNanos]: leaseTime × 0.8 임계값 (ns)
- * - [branch]: [AdviceBranch] — SYNC / SUSPEND / MONO
+ * - [branch]: [AdviceBranch] — SYNC / COROUTINES / REACTIVE
+ * - [isSuspend], [isMono], [isFlux], [isFlow]: exact method return-shape markers
+ * - [streamBounded]: caller opt-in for finite `Flux` / `Flow` streams without auto-extension
  * - [suspendElectorFactory]: SUSPEND / MONO 분기 factory (`null` for SYNC)
  * - [suspendElectorFactoryBeanName]: SUSPEND / MONO 분기 factory bean name
  * - [annotationKind]: [LockIdentity.AnnotationKind.SINGLE] (LeaderElection 전용)
@@ -32,14 +34,16 @@ internal data class AdviceMetadata(
     val failureMode: LeaderAspectFailureMode,
     val leaseTimeWarnThresholdNanos: Long,
     val branch: AdviceBranch,
+    val isSuspend: Boolean,
+    val isMono: Boolean,
+    val isFlux: Boolean,
+    val isFlow: Boolean,
+    val streamBounded: Boolean,
     val suspendElectorFactory: SuspendLeaderElectorFactory?,
     val suspendElectorFactoryBeanName: String,
     val annotationKind: LockIdentity.AnnotationKind = LockIdentity.AnnotationKind.SINGLE,
     val groupParams: LockIdentity.GroupParams? = null,
 ) {
-    val isSuspend: Boolean get() = branch == AdviceBranch.COROUTINES
-    val isMono: Boolean get() = branch == AdviceBranch.REACTIVE
-
     /**
      * 주어진 [branch] 에 맞는 [LockIdentity] 를 생성합니다.
      *

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessor.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessor.kt
@@ -22,7 +22,7 @@ import java.lang.reflect.Modifier
  * ## 검출 항목
  * - `final` / `private` 메서드 (proxy 적용 불가)
  * - `@LeaderGroupElection.maxLeaders` ≤ 1
- * - reactive 반환 (`Flux` / `Flow`) — 미지원 (`Mono`는 #91 이후 지원)
+ * - unsafe stream 반환 (`Flux` / `Flow`) — single leader requires `autoExtend` or `streamBounded`
  * - SpEL pre-parse 실패
  * - 같은 클래스에 어노테이션 부착 메서드 2+ (best-effort self-invocation WARN)
  *
@@ -88,11 +88,17 @@ class LeaderAnnotationValidatorBeanPostProcessor(
         if (Modifier.isFinal(method.modifiers)) violations += "final method (proxy 적용 불가)"
         if (Modifier.isPrivate(method.modifiers)) violations += "private method (proxy 적용 불가)"
 
+        val leaderAnn = method.findMergedAnnotationOrNull<LeaderElection>()
+        val groupAnn = method.findMergedAnnotationOrNull<LeaderGroupElection>()
+
         val returnTypeName = method.returnType.name
-        if (returnTypeName.endsWith(".Flux") ||
-            returnTypeName == "kotlinx.coroutines.flow.Flow"
-        ) {
-            violations += "$returnTypeName 반환 타입 (미지원 — Mono는 #91 이후 지원, Flux/Flow 미지원)"
+        if (isStreamReturn(returnTypeName)) {
+            if (leaderAnn != null && !leaderAnn.autoExtend && !leaderAnn.streamBounded) {
+                violations += "$returnTypeName 반환 타입은 autoExtend=true 또는 streamBounded=true 필요"
+            }
+            if (groupAnn != null) {
+                violations += "$returnTypeName 반환 타입 (LeaderGroupElection Flux/Flow 미지원)"
+            }
         }
         // [#79 R12] CompletableFuture / Future / ListenableFuture / Deferred 차단
         //   aspect 가 sync 분기로 처리 → action 종료 (= release) 가 future 완료 전 발생 → split-brain 위험
@@ -102,9 +108,6 @@ class LeaderAnnotationValidatorBeanPostProcessor(
         }
 
         // [#84] composed 어노테이션(@AliasFor) 지원 — findMergedAnnotation 으로 합성 어노테이션 속성 해석
-        val leaderAnn = method.findMergedAnnotationOrNull<LeaderElection>()
-        val groupAnn = method.findMergedAnnotationOrNull<LeaderGroupElection>()
-
         leaderAnn?.let { validateMinLeaseTime(it.leaseTime, it.minLeaseTime, "leader") }
         groupAnn?.let {
             // maxLeaders <= 1 은 strict 무관 항상 fail
@@ -162,6 +165,10 @@ class LeaderAnnotationValidatorBeanPostProcessor(
             listenableFutureClass.isAssignableFrom(returnType)
         }.getOrElse { false }
     }
+
+    private fun isStreamReturn(returnTypeName: String): Boolean =
+        returnTypeName == "reactor.core.publisher.Flux" ||
+            returnTypeName == "kotlinx.coroutines.flow.Flow"
 
     companion object: KLogging()
 }

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectStreamTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectStreamTest.kt
@@ -1,0 +1,360 @@
+package io.bluetape4k.leader.spring.aop
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.leader.AopScopeAccess
+import io.bluetape4k.leader.LeaderElectionException
+import io.bluetape4k.leader.LeaderElectorFactory
+import io.bluetape4k.leader.LockAssert
+import io.bluetape4k.leader.annotation.LeaderAspectFailureMode
+import io.bluetape4k.leader.annotation.LeaderElection
+import io.bluetape4k.leader.coroutines.LeaderElectionInfo
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
+import io.bluetape4k.leader.spring.aop.properties.LeaderAopProperties
+import io.bluetape4k.leader.spring.aop.spel.SpelExpressionEvaluator
+import io.bluetape4k.leader.spring.aop.util.LockNameValidator
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.reflect.MethodSignature
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import reactor.core.publisher.Flux
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LeaderElectionAspectStreamTest {
+
+    private interface StreamService {
+        fun fluxBounded(): Flux<String>
+        fun fluxAutoExtend(): Flux<String>
+        fun fluxFailOpen(): Flux<String>
+        fun fluxInvalid(): Flux<String>
+        fun flowBounded(): Flow<String?>
+        fun flowFailOpen(): Flow<String>
+        fun flowInvalid(): Flow<String>
+    }
+
+    private class StreamServiceImpl : StreamService {
+        @LeaderElection(name = "flux-bounded", streamBounded = true)
+        override fun fluxBounded(): Flux<String> = Flux.empty()
+
+        @LeaderElection(name = "flux-auto", leaseTime = "PT0.15S", autoExtend = true)
+        override fun fluxAutoExtend(): Flux<String> = Flux.empty()
+
+        @LeaderElection(
+            name = "flux-fail-open",
+            streamBounded = true,
+            failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN,
+        )
+        override fun fluxFailOpen(): Flux<String> = Flux.empty()
+
+        @LeaderElection(name = "flux-invalid")
+        override fun fluxInvalid(): Flux<String> = Flux.empty()
+
+        @LeaderElection(name = "flow-bounded", streamBounded = true)
+        override fun flowBounded(): Flow<String?> = flowOf()
+
+        @LeaderElection(
+            name = "flow-fail-open",
+            streamBounded = true,
+            failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN,
+        )
+        override fun flowFailOpen(): Flow<String> = flowOf()
+
+        @LeaderElection(name = "flow-invalid")
+        override fun flowInvalid(): Flow<String> = flowOf()
+    }
+
+    private class CountingSuspendElector(
+        private val elected: Boolean = true,
+    ) : SuspendLeaderElector {
+        val acquireCount = AtomicInteger()
+        val releaseCount = AtomicInteger()
+
+        override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? {
+            if (!elected) return null
+            acquireCount.incrementAndGet()
+            val handle = AopScopeAccess.createSyntheticReal(lockName, "testSuspendFactory")
+            return try {
+                kotlinx.coroutines.withContext(AopScopeAccess.createLockHandleElement(handle)) {
+                    action()
+                }
+            } finally {
+                releaseCount.incrementAndGet()
+            }
+        }
+
+        override fun state(lockName: String) =
+            io.bluetape4k.leader.LeaderState.empty(lockName)
+    }
+
+    private class BackendErrorSuspendElector(
+        private val error: Exception,
+    ) : SuspendLeaderElector {
+        override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? = throw error
+        override fun state(lockName: String) = io.bluetape4k.leader.LeaderState.empty(lockName)
+    }
+
+    private val factoryMock: LeaderElectorFactory = mockk()
+    private val beanSelector: LeaderBeanSelector = mockk()
+    private val signature: MethodSignature = mockk()
+    private val pjp: ProceedingJoinPoint = mockk()
+
+    @BeforeEach
+    fun setUp() {
+        clearMocks(factoryMock, beanSelector, signature, pjp)
+        every { beanSelector.selectElectionFactory(any(), any()) } returns
+            LeaderBeanSelector.Selected("testFactory", factoryMock)
+    }
+
+    private fun newAspect(factory: SuspendLeaderElectorFactory): LeaderElectionAspect {
+        every { beanSelector.selectSuspendElectorFactory(any(), any()) } returns
+            LeaderBeanSelector.Selected("testSuspendFactory", factory)
+        return LeaderElectionAspect(
+            beanSelector = beanSelector,
+            props = LeaderAopProperties(),
+            spel = SpelExpressionEvaluator(embeddedValueResolver = { it }, allowMethodInvocation = false),
+            lockNameValidator = LockNameValidator(prefix = ""),
+            recorders = emptyList(),
+        )
+    }
+
+    private fun fakeFactory(elector: SuspendLeaderElector): SuspendLeaderElectorFactory =
+        SuspendLeaderElectorFactory { _ -> elector }
+
+    private fun configureJoinPoint(methodName: String) {
+        val method = StreamService::class.java.getDeclaredMethod(methodName)
+        every { signature.method } returns method
+        every { pjp.signature } returns signature
+        every { pjp.target } returns StreamServiceImpl()
+        every { pjp.args } returns emptyArray()
+    }
+
+    @Test
+    fun `flux elected success keeps lock through stream completion`() {
+        configureJoinPoint("fluxBounded")
+        every { pjp.proceed() } returns Flux.just("a", "b")
+        val elector = CountingSuspendElector()
+
+        val aspect = newAspect(fakeFactory(elector))
+        val values = (aspect.aroundLeader(pjp) as Flux<*>).collectList().block()
+
+        values shouldBeEqualTo listOf("a", "b")
+        elector.acquireCount.get() shouldBeEqualTo 1
+        elector.releaseCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `flux skip returns empty stream without body call`() {
+        configureJoinPoint("fluxBounded")
+        val elector = CountingSuspendElector(elected = false)
+
+        val aspect = newAspect(fakeFactory(elector))
+        val values = (aspect.aroundLeader(pjp) as Flux<*>).collectList().block()
+
+        values shouldBeEqualTo emptyList<Any>()
+        elector.acquireCount.get() shouldBeEqualTo 0
+        elector.releaseCount.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `flux fail open executes body when not elected`() {
+        configureJoinPoint("fluxFailOpen")
+        every { pjp.proceed() } returns Flux.just("fail-open")
+
+        val aspect = newAspect(fakeFactory(CountingSuspendElector(elected = false)))
+        val values = (aspect.aroundLeader(pjp) as Flux<*>).collectList().block()
+
+        values shouldBeEqualTo listOf("fail-open")
+    }
+
+    @Test
+    fun `flux fail open body error propagates raw exception`() {
+        configureJoinPoint("fluxFailOpen")
+        val bodyEx = IllegalStateException("flux fail-open body failed")
+        every { pjp.proceed() } returns Flux.error<String>(bodyEx)
+
+        val aspect = newAspect(fakeFactory(CountingSuspendElector(elected = false)))
+        val flux = aspect.aroundLeader(pjp) as Flux<*>
+
+        val thrown = assertFailsWith<IllegalStateException> { flux.collectList().block() }
+        thrown.message shouldBeEqualTo bodyEx.message
+    }
+
+    @Test
+    fun `flux backend error rethrows leader exception`() {
+        configureJoinPoint("fluxBounded")
+        val aspect = newAspect(fakeFactory(BackendErrorSuspendElector(RuntimeException("backend down"))))
+
+        val flux = aspect.aroundLeader(pjp) as Flux<*>
+
+        assertFailsWith<LeaderElectionException> { flux.collectList().block() }
+    }
+
+    @Test
+    fun `flux body error propagates raw exception and releases lock`() {
+        configureJoinPoint("fluxBounded")
+        val bodyEx = IllegalStateException("flux body failed")
+        every { pjp.proceed() } returns Flux.error<String>(bodyEx)
+        val elector = CountingSuspendElector()
+
+        val aspect = newAspect(fakeFactory(elector))
+        val flux = aspect.aroundLeader(pjp) as Flux<*>
+
+        val thrown = assertFailsWith<IllegalStateException> { flux.collectList().block() }
+        thrown shouldBeEqualTo bodyEx
+        elector.releaseCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `flux dispose cancellation releases lock`() {
+        configureJoinPoint("fluxBounded")
+        val subscribed = CountDownLatch(1)
+        every { pjp.proceed() } returns Flux.never<String>().doOnSubscribe { subscribed.countDown() }
+        val elector = CountingSuspendElector()
+
+        val aspect = newAspect(fakeFactory(elector))
+        val disposable = (aspect.aroundLeader(pjp) as Flux<*>).subscribe()
+
+        subscribed.await(2, TimeUnit.SECONDS).shouldBeTrue()
+        disposable.dispose()
+        eventually { elector.releaseCount.get() == 1 }.shouldBeTrue()
+    }
+
+    @Test
+    fun `flux subscribes acquire independently per subscription`() {
+        configureJoinPoint("fluxBounded")
+        every { pjp.proceed() } returns Flux.just("x")
+        val elector = CountingSuspendElector()
+        val aspect = newAspect(fakeFactory(elector))
+        val flux = aspect.aroundLeader(pjp) as Flux<*>
+
+        flux.collectList().block()
+        flux.collectList().block()
+
+        elector.acquireCount.get() shouldBeEqualTo 2
+        elector.releaseCount.get() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `flux auto extend allows unbounded stream config`() {
+        configureJoinPoint("fluxAutoExtend")
+        every { pjp.proceed() } returns Flux.just("auto")
+        val elector = CountingSuspendElector()
+        val aspect = newAspect(fakeFactory(elector))
+
+        val values = (aspect.aroundLeader(pjp) as Flux<*>).collectList().block()
+
+        values shouldBeEqualTo listOf("auto")
+        elector.acquireCount.get() shouldBeEqualTo 1
+        elector.releaseCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `invalid flux config fails at subscription time`() {
+        configureJoinPoint("fluxInvalid")
+        val aspect = newAspect(fakeFactory(CountingSuspendElector()))
+        val flux = aspect.aroundLeader(pjp) as Flux<*>
+
+        assertFailsWith<LeaderElectionException> { flux.collectList().block() }
+    }
+
+    @Test
+    fun `flow elected success keeps lock and supports null element`() = runTest {
+        configureJoinPoint("flowBounded")
+        every { pjp.proceed() } returns flowOf("a", null, "b")
+        val elector = CountingSuspendElector()
+
+        val aspect = newAspect(fakeFactory(elector))
+        val values = (aspect.aroundLeader(pjp) as Flow<*>).toList()
+
+        values shouldBeEqualTo listOf("a", null, "b")
+        elector.acquireCount.get() shouldBeEqualTo 1
+        elector.releaseCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `flow fail open executes body with not elected context`() = runTest {
+        configureJoinPoint("flowFailOpen")
+        every { pjp.proceed() } returns flow {
+            emit(currentCoroutineContext()[LeaderElectionInfo]?.wasElected.toString())
+        }
+
+        val aspect = newAspect(fakeFactory(CountingSuspendElector(elected = false)))
+        val values = (aspect.aroundLeader(pjp) as Flow<*>).toList()
+
+        values shouldBeEqualTo listOf("false")
+    }
+
+    @Test
+    fun `flow fail open body error propagates raw exception`() = runTest {
+        configureJoinPoint("flowFailOpen")
+        val bodyEx = IllegalStateException("flow fail-open body failed")
+        every { pjp.proceed() } returns flow<String> { throw bodyEx }
+
+        val aspect = newAspect(fakeFactory(CountingSuspendElector(elected = false)))
+        val flow = aspect.aroundLeader(pjp) as Flow<*>
+
+        val thrown = assertFailsWith<IllegalStateException> { flow.toList() }
+        thrown.message shouldBeEqualTo bodyEx.message
+    }
+
+    @Test
+    fun `flow body can assert lock in guarded collection`() = runTest {
+        configureJoinPoint("flowBounded")
+        every { pjp.proceed() } returns flow {
+            LockAssert.assertLockedSuspend("flow-bounded")
+            emit("locked")
+        }
+
+        val aspect = newAspect(fakeFactory(CountingSuspendElector()))
+        val values = (aspect.aroundLeader(pjp) as Flow<*>).toList()
+
+        values shouldBeEqualTo listOf("locked")
+    }
+
+    @Test
+    fun `flow body error propagates raw exception and releases lock`() = runTest {
+        configureJoinPoint("flowBounded")
+        val bodyEx = IllegalStateException("flow body failed")
+        every { pjp.proceed() } returns flow<String> { throw bodyEx }
+        val elector = CountingSuspendElector()
+
+        val aspect = newAspect(fakeFactory(elector))
+        val flow = aspect.aroundLeader(pjp) as Flow<*>
+
+        val thrown = assertFailsWith<IllegalStateException> { flow.toList() }
+        thrown.message shouldBeEqualTo bodyEx.message
+        elector.releaseCount.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `invalid flow config fails at collection time`() = runTest {
+        configureJoinPoint("flowInvalid")
+        val aspect = newAspect(fakeFactory(CountingSuspendElector()))
+        val flow = aspect.aroundLeader(pjp) as Flow<*>
+
+        assertFailsWith<LeaderElectionException> { flow.toList() }
+    }
+
+    private fun eventually(block: () -> Boolean): Boolean {
+        repeat(40) {
+            if (block()) return true
+            Thread.sleep(25)
+        }
+        return block()
+    }
+}

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectSuspendMonoTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectSuspendMonoTest.kt
@@ -18,6 +18,9 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.assertFailsWith
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.test.runTest
 import org.aspectj.lang.ProceedingJoinPoint
@@ -25,6 +28,7 @@ import org.aspectj.lang.reflect.MethodSignature
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
@@ -75,6 +79,19 @@ class LeaderGroupElectionAspectSuspendMonoTest {
 
         @LeaderGroupElection(name = "g-mono-fail-open", maxLeaders = 3, failureMode = LeaderAspectFailureMode.FAIL_OPEN_RUN)
         override fun runMonoFailOpen(): Mono<String> = Mono.just(SAMPLE_RESULT)
+    }
+
+    private interface StreamGroupService {
+        fun runFlux(): Flux<String>
+        fun runFlow(): Flow<String>
+    }
+
+    private class StreamGroupServiceImpl : StreamGroupService {
+        @LeaderGroupElection(name = "g-flux-job", maxLeaders = 3)
+        override fun runFlux(): Flux<String> = Flux.just(SAMPLE_RESULT)
+
+        @LeaderGroupElection(name = "g-flow-job", maxLeaders = 3)
+        override fun runFlow(): Flow<String> = flowOf(SAMPLE_RESULT)
     }
 
     // ── Fake 구현체 ─────────────────────────────────────────────────────────
@@ -137,6 +154,14 @@ class LeaderGroupElectionAspectSuspendMonoTest {
 
     private fun configureMonoJoinPoint(methodName: String, target: Any) {
         val method = MonoGroupService::class.java.getDeclaredMethod(methodName)
+        every { signature.method } returns method
+        every { pjp.signature } returns signature
+        every { pjp.target } returns target
+        every { pjp.args } returns emptyArray()
+    }
+
+    private fun configureStreamJoinPoint(methodName: String, target: Any) {
+        val method = StreamGroupService::class.java.getDeclaredMethod(methodName)
         every { signature.method } returns method
         every { pjp.signature } returns signature
         every { pjp.target } returns target
@@ -317,5 +342,25 @@ class LeaderGroupElectionAspectSuspendMonoTest {
         val raw = aspect.aroundLeader(pjp)
 
         raw.shouldBeInstanceOf<Mono<*>>()
+    }
+
+    @Test
+    fun `group flux 미지원 - error stream 반환하고 본문 미실행`() {
+        configureStreamJoinPoint("runFlux", StreamGroupServiceImpl())
+
+        val aspect = newAspect(fakeGroupFactory(ElectedGroupElector()))
+        val flux = aspect.aroundLeader(pjp) as Flux<*>
+
+        assertFailsWith<LeaderGroupElectionException> { flux.collectList().block() }
+    }
+
+    @Test
+    fun `group flow 미지원 - collection 시 예외 반환하고 본문 미실행`() = runTest {
+        configureStreamJoinPoint("runFlow", StreamGroupServiceImpl())
+
+        val aspect = newAspect(fakeGroupFactory(ElectedGroupElector()))
+        val flow = aspect.aroundLeader(pjp) as Flow<*>
+
+        assertFailsWith<LeaderGroupElectionException> { flow.toList() }
     }
 }

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessorTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessorTest.kt
@@ -27,6 +27,16 @@ annotation class ComposedLeaderElection(
 
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
+@LeaderElection(name = "", streamBounded = true)
+annotation class ComposedBoundedLeaderStream(
+    @get:AliasFor(annotation = LeaderElection::class, attribute = "name")
+    val name: String = "composed-stream-job",
+    @get:AliasFor(annotation = LeaderElection::class, attribute = "streamBounded")
+    val streamBounded: Boolean = true,
+)
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
 @LeaderGroupElection(name = "", maxLeaders = 3)
 annotation class ComposedGroupElection(
     @get:AliasFor(annotation = LeaderGroupElection::class, attribute = "name")
@@ -180,6 +190,46 @@ class LeaderAnnotationValidatorBeanPostProcessorTest {
         }
         val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = true, spel = spel)
         assertFailsWith<IllegalStateException> { bpp.postProcessAfterInitialization(SampleFlow(), "sample") }
+    }
+
+    @Test
+    fun `Flux 반환 타입 streamBounded true - 위반 없음`() {
+        class SampleFlux {
+            @LeaderElection(name = "flux-job", streamBounded = true)
+            open fun process(): Flux<String> = Flux.just("ok")
+        }
+        val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = true, spel = spel)
+        assertNotFails { bpp.postProcessAfterInitialization(SampleFlux(), "sample") }
+    }
+
+    @Test
+    fun `Flow 반환 타입 autoExtend true - 위반 없음`() {
+        class SampleFlow {
+            @LeaderElection(name = "flow-job", autoExtend = true)
+            open fun process(): Flow<String> = flowOf("ok")
+        }
+        val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = true, spel = spel)
+        assertNotFails { bpp.postProcessAfterInitialization(SampleFlow(), "sample") }
+    }
+
+    @Test
+    fun `LeaderGroupElection Flux 반환 타입 strict true - startup fail`() {
+        class SampleFlux {
+            @LeaderGroupElection(name = "group-flux-job", maxLeaders = 3)
+            open fun process(): Flux<String> = Flux.just("ok")
+        }
+        val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = true, spel = spel)
+        assertFailsWith<IllegalStateException> { bpp.postProcessAfterInitialization(SampleFlux(), "sample") }
+    }
+
+    @Test
+    fun `composed bounded stream - AliasFor streamBounded 통과`() {
+        class SampleComposedStream {
+            @ComposedBoundedLeaderStream(name = "alias-stream-job")
+            open fun process(): Flux<String> = Flux.just("ok")
+        }
+        val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = true, spel = spel)
+        assertNotFails { bpp.postProcessAfterInitialization(SampleComposedStream(), "sample") }
     }
 
     // ── #79 R12: Future / CompletableFuture / Deferred 차단 ──


### PR DESCRIPTION
## Summary

Closes #74

PR #258의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: support leader election Flux and Flow streams`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Closes #74.

- Add `@LeaderElection(streamBounded = false)` as an explicit finite-stream opt-in.
- Support `@LeaderElection` methods returning Reactor `Flux<T>` and Kotlin `Flow<T>`.
- Require `autoExtend=true` or `streamBounded=true` for single-leader stream returns, with startup validator and runtime subscription/collection guards.
- Keep `@LeaderGroupElection` `Flux` / `Flow` unsupported and return error streams.
- Update README/README.ko, CHANGELOG, spec, plan, and lesson notes.

## Design Notes

- `Flux` is cold per subscription; lock acquisition, body collection, and release happen per subscription.
- `Flow` uses `channelFlow { ... }.buffer(Channel.RENDEZVOUS)` so values can be sent while leader context is installed without violating Flow context preservation.
- Body exceptions are protected with `BodyThrownMarker` so user failures propagate as user failures, not backend `LeaderElectionException`.

## Step 6-R Review Gate

| Gate | Result | Evidence |
|---|---:|---|
| Local six-tier review | P0=0 / P1=0 | Security/SRE/structure/Kotlin/tests/perf reviewed against final diff |
| Claude advisor initial | P0=0 / P1=2 | `.omx/artifacts/ask-claude-code-review-issue-74-flux-flow-aop-20260516-121700.md` |
| Claude P1 rerun | P0=0 / P1=1 | `.omx/artifacts/ask-claude-code-review-issue-74-flux-flow-aop-p1-rerun-20260516-122248.md` |
| Claude final P1 rerun | P0=0 / P1=0 | `.omx/artifacts/ask-claude-code-review-issue-74-flux-flow-aop-p1-final-rerun-20260516-122554.md` |

Accepted P1 fixes:
- Preserve `BodyThrownMarker` through `runIfLeaderResultSuspend` elected stream paths.
- Preserve `BodyThrownMarker` through fail-open skipped stream paths.
- Add Flux/Flow body-error tests for elected and fail-open paths.

Deferred P2/P3 items:
- Flux/Flow branch duplication can be refactored after this API lands.
- `AdviceMetadata` may later move from parallel boolean flags to a sealed return-shape enum.

## Verification

- `git diff --check`
- IntelliJ diagnostics: `LeaderElectionAspect.kt` errors=0
- `./gradlew :leader-core:compileKotlin :leader-spring-boot:compileKotlin :leader-spring-boot:test --tests '*LeaderElectionAspectStreamTest*' --tests '*LeaderGroupElectionAspectSuspendMonoTest*' --tests '*LeaderAnnotationValidatorBeanPostProcessorTest*' --no-configuration-cache --console=plain` — 55 tests passed after final targeted run
- `./gradlew :leader-spring-boot:test --no-configuration-cache --console=plain` — 316 tests passed

## Known Noise

- Existing AspectJ CTW warnings remain during `leader-spring-boot:compileKotlin`.
- The full Spring Boot test JVM logs `KLoggingChannel` coroutine binary-drift `NoSuchMethodError` on shutdown and Mongo monitor shutdown noise, but Gradle reports success.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #74, milestone `0.1.0`, assignee `debop`
- PR: #258, head `d9b4ddb882a1149874827cd6d52eec5a98d18ef8`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
