### PR TITLE
chore: replace 1_000_000L magic number with TimeUnit.NANOSECONDS.toMillis()

### DIFF
--- a/docs/lessons/2026-05-16-nanos-per-ms-refactor.md
+++ b/docs/lessons/2026-05-16-nanos-per-ms-refactor.md
@@ -1,0 +1,44 @@
+# Lesson: Replace 1_000_000L magic number with TimeUnit.NANOSECONDS.toMillis()
+
+**Date**: 2026-05-16
+**Issue**: #265
+**PR**: TBD
+
+## Root Cause
+
+The magic number `1_000_000L` (nanoseconds-to-milliseconds divisor) appeared 21 times
+across 7 files in 4 modules with no named constant, making the intent opaque and
+creating a maintenance risk.
+
+## Decision
+
+Replaced `(System.nanoTime() - acquiredAtNanos) / 1_000_000L` with
+`TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)` in all 7 files.
+
+Chose `TimeUnit.NANOSECONDS.toMillis()` over a named constant (`NANOS_PER_MS`) because:
+- Self-documenting — no need to look up what the constant means
+- Standard JDK idiom (java.util.concurrent.TimeUnit)
+- No new constant to share across modules
+- Avoids cross-module visibility concerns (internal vs public)
+
+Not changed: `RETRY_DELAY_NANOS` and `SPIN_DELAY_NANOS` definitions in
+`LettuceLock.kt`, `LettuceSemaphore.kt`, `LettuceSlotTokenGroup.kt` — those
+multiply by `1_000_000L` as part of a named constant definition (already readable).
+
+## Files Changed
+
+7 production files across 4 modules:
+- `leader-exposed-jdbc`: `ExposedJdbcLeaderElector.kt` (4), `ExposedJdbcLeaderGroupElector.kt` (4)
+- `leader-exposed-r2dbc`: `ExposedR2DbcSuspendLeaderElector.kt` (2)
+- `leader-mongodb`: `MongoLeaderElector.kt` (4), `MongoSuspendLeaderElector.kt` (2)
+- `leader-redis-lettuce`: `LettuceLeaderElector.kt` (4), `LettuceSuspendLeaderElector.kt` (2)
+
+## Verification
+
+- `rg "/ 1_000_000L" --glob "*.kt"` → 0 matches in production code
+- `./gradlew :leader-exposed-jdbc:build :leader-exposed-r2dbc:build :leader-mongodb:build :leader-redis-lettuce:build -x test` → BUILD SUCCESSFUL
+
+## Future Guidance
+
+For any new duration-to-milliseconds conversion from `System.nanoTime()`:
+use `TimeUnit.NANOSECONDS.toMillis(nanos)` — not `/ 1_000_000L`.

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElector.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElector.kt
@@ -22,6 +22,7 @@ import org.jetbrains.exposed.v1.jdbc.Database
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
 
 /**
  * Exposed JDBC 기반 단일 리더 선출 구현체.
@@ -156,7 +157,7 @@ class ExposedJdbcLeaderElector private constructor(
             return try {
                 val result = AopScopeAccess.withPushedSync(handle) { action() }
                 val finishedAt = Instant.now()
-                val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                 effectiveKey?.let { historyRecorder?.recordCompleted(it, finishedAt, durationMs) }
                 result
             } catch (e: CancellationException) {
@@ -166,7 +167,7 @@ class ExposedJdbcLeaderElector private constructor(
                 throw e
             } catch (e: Exception) {
                 val finishedAt = Instant.now()
-                val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                 effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, e) }
                 throw e
             }
@@ -234,7 +235,7 @@ class ExposedJdbcLeaderElector private constructor(
                         .getOrElse { e ->
                             watchdog.close()
                             val finishedAt = Instant.now()
-                            val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                            val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                             effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, e) }
                             runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos) }
                                 .onFailure { ex -> log.warn(ex) { "락 해제 실패 (action 오류 경로). lockName=$lockName" } }
@@ -244,7 +245,7 @@ class ExposedJdbcLeaderElector private constructor(
                     actionFuture.whenCompleteAsync({ _, throwable ->
                         watchdog.close()
                         val finishedAt = Instant.now()
-                        val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                        val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                         when {
                             throwable == null -> effectiveKey?.let {
                                 historyRecorder?.recordCompleted(it, finishedAt, durationMs)

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElector.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElector.kt
@@ -31,6 +31,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
 import kotlin.random.Random
 
 /**
@@ -235,7 +236,7 @@ class ExposedJdbcLeaderGroupElector private constructor(
             } finally {
                 watchdog.close()
                 val finishedAt = Instant.now()
-                val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                 when {
                     actionSucceeded -> effectiveKey?.let { historyRecorder?.recordCompleted(it, finishedAt, durationMs) }
                     capturedError != null -> effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, capturedError) }
@@ -327,7 +328,7 @@ class ExposedJdbcLeaderGroupElector private constructor(
                     .getOrElse { e ->
                         watchdog.close()
                         val finishedAt = Instant.now()
-                        val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                        val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                         effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, e) }
                         runCatching { lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos) }
                             .onFailure { ex -> log.warn(ex) { "슬롯 해제 실패 (action 오류 경로). slot=$slot" } }
@@ -337,7 +338,7 @@ class ExposedJdbcLeaderGroupElector private constructor(
                 actionFuture.whenCompleteAsync({ _, throwable ->
                     watchdog.close()
                     val finishedAt = Instant.now()
-                    val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                    val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                     when {
                         throwable == null -> effectiveKey?.let { historyRecorder?.recordCompleted(it, finishedAt, durationMs) }
                         // 취소(코루틴/CompletableFuture)는 FAILED로 기록하지 않음

--- a/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderElector.kt
+++ b/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderElector.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 import org.jetbrains.exposed.v1.r2dbc.R2dbcDatabase
 import java.time.Instant
+import java.util.concurrent.TimeUnit
 
 /**
  * Exposed R2DBC 기반 코루틴 단일 리더 선출 구현체.
@@ -156,14 +157,14 @@ class ExposedR2DbcSuspendLeaderElector private constructor(
                     action()
                 }
                 val finishedAt = Instant.now()
-                val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                 effectiveKey?.let { historyRecorder?.recordCompleted(it, finishedAt, durationMs) }
                 result
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 val finishedAt = Instant.now()
-                val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                 effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, e) }
                 throw e
             }

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElector.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElector.kt
@@ -22,6 +22,7 @@ import org.bson.Document
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
 
 /**
  * MongoDB 분산 락을 이용한 단일 리더 선출 구현체입니다.
@@ -119,7 +120,7 @@ class MongoLeaderElector private constructor(
             return try {
                 val result = AopScopeAccess.withPushedSync(handle) { action() }
                 val finishedAt = Instant.now()
-                val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                 effectiveKey?.let { historyRecorder?.recordCompleted(it, finishedAt, durationMs) }
                 result
             } catch (e: InterruptedException) {
@@ -127,7 +128,7 @@ class MongoLeaderElector private constructor(
                 throw e
             } catch (e: Exception) {
                 val finishedAt = Instant.now()
-                val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                 effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, e) }
                 throw e
             }
@@ -182,7 +183,7 @@ class MongoLeaderElector private constructor(
                         .getOrElse { e ->
                             watchdog.close()
                             val finishedAt = Instant.now()
-                            val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                            val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                             effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, e) }
                             runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos) }
                                 .onFailure { ex -> log.warn(ex) { "락 해제 실패 (action 오류 경로). lockName=$lockName" } }
@@ -191,7 +192,7 @@ class MongoLeaderElector private constructor(
                     actionFuture.whenCompleteAsync({ _, throwable ->
                         watchdog.close()
                         val finishedAt = Instant.now()
-                        val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                        val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                         when {
                             throwable == null -> effectiveKey?.let {
                                 historyRecorder?.recordCompleted(it, finishedAt, durationMs)

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderElector.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderElector.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 import org.bson.Document
 import java.time.Instant
+import java.util.concurrent.TimeUnit
 
 /**
  * MongoDB 분산 락을 이용한 코루틴 기반 단일 리더 선출 구현체입니다.
@@ -119,14 +120,14 @@ class MongoSuspendLeaderElector private constructor(
                     action()
                 }
                 val finishedAt = Instant.now()
-                val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                 effectiveKey?.let { historyRecorder?.recordCompleted(it, finishedAt, durationMs) }
                 result
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 val finishedAt = Instant.now()
-                val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                 effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, e) }
                 throw e
             }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElector.kt
@@ -23,6 +23,7 @@ import io.lettuce.core.api.StatefulRedisConnection
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CancellationException
 
 /**
@@ -144,14 +145,14 @@ class LettuceLeaderElector @JvmOverloads constructor(
             return try {
                 val result = AopScopeAccess.withPushedSync(handle) { action() }
                 val finishedAt = Instant.now()
-                val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                 effectiveKey?.let { historyRecorder?.recordCompleted(it, finishedAt, durationMs) }
                 result
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 val finishedAt = Instant.now()
-                val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                 effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, e) }
                 throw e
             }
@@ -206,7 +207,7 @@ class LettuceLeaderElector @JvmOverloads constructor(
                     action().whenComplete { _, throwable ->
                         watchdog.close()
                         val finishedAt = Instant.now()
-                        val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                        val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                         when {
                             throwable == null -> effectiveKey?.let { historyRecorder?.recordCompleted(it, finishedAt, durationMs) }
                             throwable is java.util.concurrent.CancellationException -> { /* cancelled — no audit */ }
@@ -221,7 +222,7 @@ class LettuceLeaderElector @JvmOverloads constructor(
                 } catch (e: Throwable) {
                     watchdog.close()
                     val finishedAt = Instant.now()
-                    val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                    val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                     effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, e) }
                     runCatching {
                         if (lock.isHeldByCurrentInstance()) {

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElector.kt
@@ -21,6 +21,7 @@ import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireNotBlank
 import io.lettuce.core.api.StatefulRedisConnection
 import java.time.Instant
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
@@ -144,14 +145,14 @@ class LettuceSuspendLeaderElector(
                     action()
                 }
                 val finishedAt = Instant.now()
-                val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                 effectiveKey?.let { historyRecorder?.recordCompleted(it, finishedAt, durationMs) }
                 result
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 val finishedAt = Instant.now()
-                val durationMs = (System.nanoTime() - acquiredAtNanos) / 1_000_000L
+                val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                 effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, e) }
                 throw e
             }


### PR DESCRIPTION
## Summary

Closes #265

PR #273의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `chore: replace 1_000_000L magic number with TimeUnit.NANOSECONDS.toMillis()`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Closes #265

Replaces the magic number `1_000_000L` (nanos → ms divisor) with
`TimeUnit.NANOSECONDS.toMillis()` across 7 production files in 4 modules (21 sites).

## Approach

Chose `TimeUnit.NANOSECONDS.toMillis()` over a named constant (`NANOS_PER_MS`) because:
- Self-documenting — no reader needs to look up the constant
- Standard JDK idiom
- No cross-module visibility concerns

**Not changed**: `RETRY_DELAY_NANOS` / `SPIN_DELAY_NANOS` definitions in Lettuce lock/semaphore files — those multiply `1_000_000L` within a named constant definition (already readable).

## Files Changed (21 sites → 0)

| Module | File | Sites |
|--------|------|-------|
| `leader-exposed-jdbc` | `ExposedJdbcLeaderElector.kt` | 4 |
| `leader-exposed-jdbc` | `ExposedJdbcLeaderGroupElector.kt` | 4 |
| `leader-exposed-r2dbc` | `ExposedR2DbcSuspendLeaderElector.kt` | 2 |
| `leader-mongodb` | `MongoLeaderElector.kt` | 4 |
| `leader-mongodb` | `MongoSuspendLeaderElector.kt` | 2 |
| `leader-redis-lettuce` | `LettuceLeaderElector.kt` | 4 |
| `leader-redis-lettuce` | `LettuceSuspendLeaderElector.kt` | 2 |

## Verification

```
rg "/ 1_000_000L" --glob "*.kt" → 0 matches in production code
./gradlew :leader-exposed-jdbc:build :leader-exposed-r2dbc:build :leader-mongodb:build :leader-redis-lettuce:build -x test
BUILD SUCCESSFUL
```

## Checklist

- [x] All magic numbers replaced
- [x] Build successful
- [x] No logic changes — pure refactor
- [x] Lessons committed: `docs/lessons/2026-05-16-nanos-per-ms-refactor.md`
- [x] README: N/A (internal implementation only)
- [x] KDoc: N/A (no public API change)
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #265, milestone `0.1.0`, assignee `debop`
- PR: #273, head `c8180f0639d13b2fa43a939c6267d4ffef73b13f`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
