### PR TITLE
docs: #267 convert strategy/scorer public KDoc to English

### DIFF
--- a/docs/lessons/2026-05-16-kdoc-strategy-scorer-english.md
+++ b/docs/lessons/2026-05-16-kdoc-strategy-scorer-english.md
@@ -1,0 +1,56 @@
+# Lesson: English KDoc for strategy/scorer public APIs
+
+**Date**: 2026-05-16
+**Issue**: #267
+**PR**: TBD
+
+## Root Cause
+
+Nine public classes and interfaces in the `leader-core` strategy/scorer subsystem had
+Korean KDoc. The workspace CLAUDE.md requires English KDoc for new or meaningfully
+changed public API; the Korean text was written before the English-first rule was adopted.
+
+## Files Updated
+
+| File | Change |
+|------|--------|
+| `strategy/CandidateScorer.kt` | Korean → English; added `## Behavior / Contract` and `## Example` |
+| `strategy/ElectionStrategy.kt` | Korean → English; added `## Behavior / Contract`, `## Built-in strategies`, updated custom-strategy example |
+| `strategy/scorers/IdleTimeScorer.kt` | Korean → English; added `## Behavior / Contract` and `## Example` |
+| `strategy/scorers/RecentSuccessScorer.kt` | Korean → English; renamed section headers |
+| `strategy/scorers/SuccessRateScorer.kt` | Korean → English |
+| `strategy/scorers/WeightedScorer.kt` | Korean → English; added `## Behavior / Contract` |
+| `strategy/strategies/FifoElectionStrategy.kt` | Korean → English; elimination reason strings also converted |
+| `strategy/strategies/RandomElectionStrategy.kt` | Korean → English; elimination reason strings converted |
+| `strategy/strategies/ScoredElectionStrategy.kt` | Korean → English; elimination reason strings converted |
+
+Note: `ListeningLeaderElectors.kt` and `TenantScopedLeaderElectors.kt` already had
+complete English KDoc and required no changes.
+
+## Elimination Reason Strings
+
+Elimination reason strings inside `ElectionResult` are part of the public audit trail
+exposed to callers. They were also converted to English so the public `ElectionResult`
+surface is consistent:
+
+- `"등록 시각 늦음"` → `"registered later"`
+- `"nodeId 사전순 뒤"` → `"nodeId lexicographically after winner"`
+- `"랜덤 선출 탈락"` → `"not selected by random election"`
+- `"점수 미달"` → `"score below winner"`
+- `"점수 동점"` → `"tied score — ranked lower by registeredAt/nodeId"`
+
+## KDoc Format Applied
+
+Per CLAUDE.md for public classes:
+1. One-line summary sentence.
+2. `## Behavior / Contract` section listing invariants and edge cases.
+3. `## Example` or `## Example / Built-in strategies` Kotlin code block.
+4. `@property` / `@param` / `@return` tags where a parameter's semantics are non-obvious.
+
+## Future Guidance
+
+When adding a new `ElectionStrategy` or `CandidateScorer`:
+1. Write English KDoc from the start.
+2. Include `## Behavior / Contract` — determinism invariant is mandatory for `ElectionStrategy`.
+3. Include an `## Example` showing typical usage.
+4. Translate any user-visible string literals (elimination reasons, log messages) to English.

--- a/docs/lessons/2026-05-16-kdoc-strategy-scorer-english.md
+++ b/docs/lessons/2026-05-16-kdoc-strategy-scorer-english.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-05-16
 **Issue**: #267
-**PR**: TBD
+**PR**: #277
 
 ## Root Cause
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/CandidateScorer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/CandidateScorer.kt
@@ -1,19 +1,31 @@
 package io.bluetape4k.leader.strategy
 
 /**
- * 후보 노드에 대해 선출 우선순위 점수를 계산하는 인터페이스입니다.
+ * Computes an election-priority score for a candidate node.
  *
- * 점수가 높을수록 리더로 선출될 가능성이 높습니다.
- * [ScoredElectionStrategy] 에서 사용됩니다.
+ * A higher score increases the likelihood that the candidate is elected leader.
+ * Used by [ScoredElectionStrategy].
+ *
+ * ## Behavior / Contract
+ * - Implementations must be pure: the same inputs must always produce the same output.
+ * - Scores from different scorers combined in a [io.bluetape4k.leader.strategy.scorers.WeightedScorer]
+ *   should use a compatible scale (e.g., 0.0–100.0).
+ *
+ * ## Example
+ * ```kotlin
+ * val scorer = CandidateScorer { candidate, _ ->
+ *     candidate.successRate * 100.0
+ * }
+ * ```
  */
 fun interface CandidateScorer {
 
     /**
-     * 후보 [candidate] 의 점수를 계산합니다.
+     * Computes the score for [candidate] relative to [all] candidates in the current election.
      *
-     * @param candidate 점수를 계산할 후보
-     * @param all 현재 선출에 참여 중인 전체 후보 목록 (상대 비교에 활용 가능)
-     * @return 점수 (높을수록 우선)
+     * @param candidate the candidate to score
+     * @param all all candidates participating in this election (available for relative comparison)
+     * @return priority score — higher means more likely to be elected
      */
     fun score(candidate: CandidateInfo, all: List<CandidateInfo>): Double
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/ElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/ElectionStrategy.kt
@@ -1,28 +1,28 @@
 package io.bluetape4k.leader.strategy
 
 /**
- * 후보 목록에서 리더를 선출하는 전략 인터페이스입니다.
+ * Strategy interface for electing a leader from a list of candidates.
  *
- * 모든 구현체는 동일한 [candidates] 입력에 대해 결정론적으로 동일한 결과를 반환해야 합니다.
- * 이를 통해 분산 환경에서 각 노드가 독립적으로 동일한 winner를 계산할 수 있습니다.
+ * ## Behavior / Contract
+ * - All implementations must be deterministic: the same [candidates] input must always produce
+ *   the same [ElectionResult]. This allows each node in a distributed environment to compute
+ *   the same winner independently without coordination.
+ * - Default tie-breaker: ascending [CandidateInfo.registeredAt], then lexicographic [CandidateInfo.nodeId].
  *
- * 동점 발생 시 기본 tie-breaker: `registeredAt` 오름차순 → `nodeId` 사전순.
+ * ## Built-in strategies
+ * - [io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy] — earliest-registered candidate
+ * - [io.bluetape4k.leader.strategy.strategies.RandomElectionStrategy] — deterministic random (requires shared seed)
+ * - [io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy] — highest-scoring candidate
  *
- * ## 내장 전략
- * - [io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy] — 가장 먼저 등록된 후보
- * - [io.bluetape4k.leader.strategy.strategies.RandomElectionStrategy] — 결정론적 랜덤 (seed 필요)
- * - [io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy] — 점수 최대 후보
- *
- * ## 커스텀 전략 예제
- *
+ * ## Custom strategy example
  * ```kotlin
- * // 짝수 nodeId 만 winner 후보로 인정하는 전략
+ * // Elect only candidates whose nodeId ends with an even digit
  * object EvenNodeStrategy : ElectionStrategy {
  *     override fun elect(candidates: List<CandidateInfo>): ElectionResult {
  *         val even = candidates.filter { it.nodeId.last().digitToIntOrNull()?.rem(2) == 0 }
  *         val winner = even.minByOrNull { it.registeredAt } ?: return ElectionResult.EMPTY
  *         val eliminations = candidates.filter { it.nodeId != winner.nodeId }
- *             .map { Elimination(it, "홀수 nodeId") }
+ *             .map { Elimination(it, "odd nodeId") }
  *         return ElectionResult(winner, eliminations)
  *     }
  * }
@@ -31,10 +31,11 @@ package io.bluetape4k.leader.strategy
 interface ElectionStrategy {
 
     /**
-     * [candidates] 중 리더를 선출하고, 탈락 후보별 사유를 포함한 [ElectionResult]를 반환합니다.
+     * Elects a leader from [candidates] and returns an [ElectionResult] containing
+     * the winner and the elimination reason for each losing candidate.
      *
-     * @param candidates 선출에 참여할 후보 목록
-     * @return 선출 결과 (winner + 탈락자 목록)
+     * @param candidates candidates participating in this election
+     * @return election result (winner + list of eliminations with reasons)
      */
     fun elect(candidates: List<CandidateInfo>): ElectionResult
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/IdleTimeScorer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/IdleTimeScorer.kt
@@ -4,19 +4,20 @@ import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateScorer
 
 /**
- * 마지막 작업 완료 이후 가장 오래 쉰 노드에 높은 점수를 부여하는 [CandidateScorer] 입니다.
+ * A [CandidateScorer] that assigns a higher score to the node that has been idle the longest
+ * since its last task completion.
  *
- * 실행 이력이 없는 노드는 [CandidateInfo.registeredAt] 기준 경과 시간으로 계산됩니다.
- * 부하 분산 목적으로 특정 노드의 작업 독점을 방지합니다.
+ * Nodes with no execution history are measured from [CandidateInfo.registeredAt].
+ * Prevents a single node from monopolizing work and distributes load across the pool.
  *
- * 점수는 후보 풀 내 최대 idle 시간을 기준으로 0.0 ~ 100.0 범위로 정규화됩니다.
- * [WeightedScorer] 와 다른 scorer 를 함께 사용할 때 단위 통일을 위함입니다.
+ * ## Behavior / Contract
+ * - Score is normalized to 0.0–100.0 based on the maximum idle duration in the candidate pool,
+ *   making it composable with other scorers in a [WeightedScorer].
  *
+ * ## Example
  * ```kotlin
  * val strategy = ScoredElectionStrategy(IdleTimeScorer)
- * election.runIfLeader("rotating-batch", strategy) {
- *     processBatch()
- * }
+ * election.runIfLeader("rotating-batch", strategy) { processBatch() }
  * ```
  */
 object IdleTimeScorer : CandidateScorer {

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/RecentSuccessScorer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/RecentSuccessScorer.kt
@@ -4,16 +4,20 @@ import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateScorer
 
 /**
- * 가장 최근에 성공 완료한 노드에 높은 점수를 부여하는 [CandidateScorer] 입니다.
+ * A [CandidateScorer] that assigns a higher score to the node that most recently completed
+ * a successful execution.
  *
- * 점수 계산:
- * - 마지막 실행이 성공: 후보 풀 내 최신 완료 시각 기준으로 0.0 ~ 100.0 정규화
- * - 마지막 실행이 실패 또는 이력 없음: 0.0
+ * ## Scoring rules
+ * - Last execution succeeded: score normalized 0.0–100.0 against the latest successful completion
+ *   time in the candidate pool.
+ * - Last execution failed, or no execution history: 0.0.
  *
- * 직전 작업이 성공한 노드를 재선출하여 연속 성공 가능성을 높입니다.
+ * Favors re-electing the node that succeeded last time, increasing the likelihood of consecutive
+ * successes (sticky-leader pattern).
  *
+ * ## Example
  * ```kotlin
- * // sticky leader: 성공한 노드 우선 + 일부 부하 분산
+ * // Sticky leader: prefer the last successful node, with partial load balancing
  * val scorer = WeightedScorer(
  *     RecentSuccessScorer to 0.7,
  *     IdleTimeScorer to 0.3,

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/SuccessRateScorer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/SuccessRateScorer.kt
@@ -4,13 +4,14 @@ import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateScorer
 
 /**
- * 성공률이 높은 노드에 높은 점수를 부여하는 [CandidateScorer] 입니다.
+ * A [CandidateScorer] that assigns a higher score to nodes with a higher success rate.
  *
- * 실행 이력이 없는 노드는 성공률 0.0으로 처리됩니다.
- * 복원력(Resilience) 목적으로 안정적인 노드를 선호합니다.
+ * Nodes with no execution history are assigned a success rate of 0.0.
+ * Designed for resilience: consistently stable nodes are preferred over unreliable ones.
  *
+ * ## Example
  * ```kotlin
- * // 안정성 우선: 성공률이 가장 높은 노드 선출
+ * // Stability first: elect the node with the highest success rate
  * val strategy = ScoredElectionStrategy(SuccessRateScorer)
  * election.runIfLeader("payment-job", strategy) { processPayments() }
  * ```

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/WeightedScorer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/scorers/WeightedScorer.kt
@@ -5,8 +5,14 @@ import io.bluetape4k.leader.strategy.CandidateScorer
 import io.bluetape4k.support.requireNotEmpty
 
 /**
- * 복수의 [CandidateScorer] 에 가중치를 적용해 합산하는 복합 scorer 입니다.
+ * A composite [CandidateScorer] that combines multiple scorers by applying individual weights
+ * and summing the results.
  *
+ * ## Behavior / Contract
+ * - Weights do not need to sum to 1.0; each scorer's result is scaled by its weight and summed.
+ * - All weights must be positive (enforced at construction).
+ *
+ * ## Example
  * ```kotlin
  * val scorer = WeightedScorer(
  *     IdleTimeScorer to 0.6,
@@ -14,7 +20,7 @@ import io.bluetape4k.support.requireNotEmpty
  * )
  * ```
  *
- * @property scorers (scorer, weight) 쌍 목록. weight 합계가 1.0일 필요는 없음.
+ * @property scorers list of (scorer, weight) pairs
  */
 class WeightedScorer(
     val scorers: List<Pair<CandidateScorer, Double>>,

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/FifoElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/FifoElectionStrategy.kt
@@ -6,9 +6,11 @@ import io.bluetape4k.leader.strategy.ElectionStrategy
 import io.bluetape4k.leader.strategy.Elimination
 
 /**
- * 가장 먼저 등록된 후보를 리더로 선출하는 FIFO 전략입니다.
+ * An [ElectionStrategy] that elects the earliest-registered candidate as leader (FIFO order).
  *
- * 동점(registeredAt 동일) 시 [CandidateInfo.nodeId] 사전순으로 결정합니다.
+ * ## Behavior / Contract
+ * - When two candidates share the same [CandidateInfo.registeredAt], the one with the
+ *   lexicographically earlier [CandidateInfo.nodeId] wins.
  */
 object FifoElectionStrategy : ElectionStrategy {
 
@@ -21,9 +23,9 @@ object FifoElectionStrategy : ElectionStrategy {
             .filter { it.nodeId != winner.nodeId }
             .map { c ->
                 val reason = if (c.registeredAt > winner.registeredAt) {
-                    "등록 시각 늦음 (${c.registeredAt} > ${winner.registeredAt})"
+                    "registered later (${c.registeredAt} > ${winner.registeredAt})"
                 } else {
-                    "nodeId 사전순 뒤 (${c.nodeId} > ${winner.nodeId})"
+                    "nodeId lexicographically after winner (${c.nodeId} > ${winner.nodeId})"
                 }
                 Elimination(c, reason)
             }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/RandomElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/RandomElectionStrategy.kt
@@ -7,18 +7,19 @@ import io.bluetape4k.leader.strategy.Elimination
 import kotlin.random.Random
 
 /**
- * 후보 중 무작위로 리더를 선출하는 전략입니다.
+ * An [ElectionStrategy] that elects a candidate at random.
  *
- * [seed] 를 지정하면 동일 후보 목록에 대해 결정론적 결과를 보장합니다.
+ * ## Behavior / Contract
+ * - When [seed] is provided, results are deterministic for the same candidate list.
+ * - Candidates are sorted by [CandidateInfo.nodeId] before random selection to remove
+ *   input-order dependency.
  *
- * **분산 환경 주의**: [seed] 가 `null` 이면 각 노드가 서로 다른 winner 를 계산할 수 있습니다 (split-brain 위험).
- * 분산 환경에서는 모든 노드가 동일한 [seed] 를 사용해야 합니다. seed 는 공유 백엔드(Redis 등)에서 epoch 단위로
- * 생성하여 배포하는 것을 권장합니다.
- * `seed=null` 은 단일 프로세스 테스트 또는 결과 분포가 중요하지 않은 경우에만 사용하세요.
+ * **Distributed-environment warning**: a `null` [seed] means each node may compute a different
+ * winner (split-brain risk). In distributed deployments, all nodes must share the same [seed].
+ * Generate the seed from a shared backend (e.g., Redis) on a per-epoch basis.
+ * Use `seed=null` only for single-process tests or when outcome distribution is not critical.
  *
- * 무작위 선출 전 후보 목록을 [CandidateInfo.nodeId] 사전순으로 정렬하여 입력 순서 의존성을 제거합니다.
- *
- * @property seed 난수 seed. `null` 이면 시스템 랜덤 사용 (비결정론적 — 분산 환경 비권장).
+ * @property seed random seed. `null` uses system random (non-deterministic — not recommended in distributed environments).
  */
 class RandomElectionStrategy(val seed: Long? = null) : ElectionStrategy {
 
@@ -29,7 +30,7 @@ class RandomElectionStrategy(val seed: Long? = null) : ElectionStrategy {
         val winner = sorted[random.nextInt(sorted.size)]
         val eliminations = candidates
             .filter { it.nodeId != winner.nodeId }
-            .map { c -> Elimination(c, "랜덤 선출 탈락 (winner: ${winner.nodeId})") }
+            .map { c -> Elimination(c, "not selected by random election (winner: ${winner.nodeId})") }
         return ElectionResult(winner, eliminations)
     }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/ScoredElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/ScoredElectionStrategy.kt
@@ -7,11 +7,13 @@ import io.bluetape4k.leader.strategy.ElectionStrategy
 import io.bluetape4k.leader.strategy.Elimination
 
 /**
- * [CandidateScorer] 로 계산한 점수가 가장 높은 후보를 선출하는 전략입니다.
+ * An [ElectionStrategy] that elects the candidate with the highest score computed by [scorer].
  *
- * 동점 시 [CandidateInfo.registeredAt] 오름차순 → [CandidateInfo.nodeId] 사전순으로 결정합니다.
+ * ## Behavior / Contract
+ * - Tie-breaking when scores are equal: ascending [CandidateInfo.registeredAt],
+ *   then lexicographic [CandidateInfo.nodeId].
  *
- * @property scorer 후보 점수 계산에 사용할 [CandidateScorer]
+ * @property scorer the [CandidateScorer] used to rank candidates
  */
 class ScoredElectionStrategy(val scorer: CandidateScorer) : ElectionStrategy {
 
@@ -30,9 +32,9 @@ class ScoredElectionStrategy(val scorer: CandidateScorer) : ElectionStrategy {
             .map { c ->
                 val score = scores.getValue(c)
                 val reason = if (score < winnerScore) {
-                    "점수 미달 (%.2f < %.2f)".format(score, winnerScore)
+                    "score below winner (%.2f < %.2f)".format(score, winnerScore)
                 } else {
-                    "점수 동점 — 등록 시각/nodeId 우선순위 낮음 (score: %.2f)".format(score)
+                    "tied score — ranked lower by registeredAt/nodeId (score: %.2f)".format(score)
                 }
                 Elimination(c, reason)
             }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/strategy/ElectionStrategyTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/strategy/ElectionStrategyTest.kt
@@ -80,7 +80,7 @@ class ElectionStrategyTest {
         val result = FifoElectionStrategy.elect(candidates)
         result.winner?.nodeId shouldBeEqualTo "a"
         result.eliminations.size shouldBeEqualTo 2
-        result.eliminations.all { it.reason.contains("등록 시각 늦음") }.shouldBeTrue()
+        result.eliminations.all { it.reason.contains("registered later") }.shouldBeTrue()
     }
 
     // ── RandomElectionStrategy ────────────────────────────────────────────────
@@ -106,7 +106,7 @@ class ElectionStrategyTest {
         val result = RandomElectionStrategy(seed = 42L).elect(candidates)
         result.winner.shouldNotBeNull()
         result.eliminations.size shouldBeEqualTo 2
-        result.eliminations.all { it.reason.contains("랜덤 선출 탈락") }.shouldBeTrue()
+        result.eliminations.all { it.reason.contains("not selected by random election") }.shouldBeTrue()
     }
 
     // ── ScoredElectionStrategy (IdleTimeScorer) ───────────────────────────────
@@ -156,7 +156,7 @@ class ElectionStrategyTest {
         val result = ScoredElectionStrategy(SuccessRateScorer).elect(candidates)
         result.winner?.nodeId shouldBeEqualTo "high"
         result.eliminations.size shouldBeEqualTo 1
-        result.eliminations.first().reason.contains("점수 미달").shouldBeTrue()
+        result.eliminations.first().reason.contains("score below winner").shouldBeTrue()
     }
 
     // ── ScoredElectionStrategy (WeightedScorer) ───────────────────────────────


### PR DESCRIPTION
## Summary

Closes #267

PR #277의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `docs: #267 convert strategy/scorer public KDoc to English`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Closes #267

### Changes

Nine public classes/interfaces in the `leader-core` strategy/scorer subsystem had Korean KDoc.
This PR converts all of them to English per the CLAUDE.md policy.

**Files updated:**

| File | Change |
|------|--------|
| `CandidateScorer` | Korean → English; added Behavior/Contract + Example |
| `ElectionStrategy` | Korean → English; added Behavior/Contract + Built-in strategies |
| `IdleTimeScorer` | Korean → English + Behavior/Contract |
| `RecentSuccessScorer` | Korean → English with Scoring rules section |
| `SuccessRateScorer` | Korean → English |
| `WeightedScorer` | Korean → English + Behavior/Contract |
| `FifoElectionStrategy` | Korean → English + elimination reason strings |
| `RandomElectionStrategy` | Korean → English + elimination reason strings |
| `ScoredElectionStrategy` | Korean → English + elimination reason strings |

No logic changes. Documentation only.

`ListeningLeaderElectors` and `TenantScopedLeaderElectors` already had complete English KDoc.

### Elimination Reason Strings

Elimination reason strings inside `ElectionResult` are part of the public audit trail.
Also converted to English for consistency.

### Verification

```
./gradlew :leader-core:compileKotlin → BUILD SUCCESSFUL
```

### Checklist
- [x] KDoc converted to English per CLAUDE.md policy
- [x] Behavior/Contract sections added to interfaces
- [x] Elimination reason strings (public API) converted to English
- [x] No logic changes
- [x] Lessons document committed
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #267, milestone `0.1.0`, assignee `debop`
- PR: #277, head `887210950d0ace61e3b069b57ac4db2d40c8c31e`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
