### PR TITLE
chore: upgrade JetBrains Exposed 1.2.0 → 1.3.0

### DIFF
--- a/docs/lessons/2026-05-16-exposed-1.3.0-upgrade.md
+++ b/docs/lessons/2026-05-16-exposed-1.3.0-upgrade.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-05-16
 **Issue**: #280
-**PR**: TBD
+**PR**: #281
 **Modules affected**: `leader-exposed-core`, `leader-exposed-jdbc`, `leader-exposed-r2dbc`
 
 ## Summary

--- a/docs/lessons/2026-05-16-exposed-1.3.0-upgrade.md
+++ b/docs/lessons/2026-05-16-exposed-1.3.0-upgrade.md
@@ -1,0 +1,66 @@
+# Lesson: JetBrains Exposed 1.2.0 → 1.3.0 Upgrade
+
+**Date**: 2026-05-16
+**Issue**: #280
+**PR**: TBD
+**Modules affected**: `leader-exposed-core`, `leader-exposed-jdbc`, `leader-exposed-r2dbc`
+
+## Summary
+
+Upgraded JetBrains Exposed from `1.2.0` to `1.3.0`. The version bump was a one-line change in
+`gradle/libs.versions.toml`. One compilation error appeared in `leader-exposed-r2dbc` due to a
+new implicit receiver property named `options` introduced in the Exposed 1.3.0 `insert {}` DSL,
+which shadowed the outer `ExposedR2dbcLeaderGroupElectionOptions` variable.
+
+## Root Cause
+
+In Exposed 1.3.0, the `insert {}` statement block gained a new receiver that exposes a property
+named `options` (statement options). Inside `recordAcquired()` in
+`ExposedR2DbcSuspendLeaderGroupElector`, two accesses to the outer `options` field were
+resolved against the new inner receiver instead:
+
+```kotlin
+// Before fix (broken in 1.3.0)
+LeaderLockHistoryTable.insert {
+    it[LeaderLockHistoryTable.lockOwner] = options.lockOwner          // 'lockOwner' unresolved
+    it[LeaderLockHistoryTable.lockedUntil] = now.plusMillis(
+        options.leaderGroupOptions.leaseTime.inWholeMilliseconds      // 'leaderGroupOptions' unresolved
+    )
+}
+```
+
+## Fix
+
+Extract the values into local variables before entering the lambda — a pattern already
+documented in project memory as the standard fix for implicit-receiver shadowing in Exposed
+`insert/update/deleteWhere` blocks.
+
+```kotlin
+// After fix
+val lockOwner = options.lockOwner
+val leaseTimeMs = options.leaderGroupOptions.leaseTime.inWholeMilliseconds
+suspendTransaction(db) {
+    val now = Instant.now()
+    LeaderLockHistoryTable.insert {
+        it[LeaderLockHistoryTable.lockOwner] = lockOwner
+        it[LeaderLockHistoryTable.lockedUntil] = now.plusMillis(leaseTimeMs)
+        ...
+    }
+}
+```
+
+## Verification
+
+```
+:leader-exposed-core:test   — BUILD SUCCESSFUL (all tests pass)
+:leader-exposed-jdbc:test   — BUILD SUCCESSFUL (H2 + PostgreSQL + MySQL, Testcontainers)
+:leader-exposed-r2dbc:test  — BUILD SUCCESSFUL (H2 + PostgreSQL + MySQL, Testcontainers)
+```
+
+## Future Guidance
+
+- After any Exposed version bump, run `:leader-exposed-core:compileKotlin`,
+  `:leader-exposed-jdbc:compileKotlin`, and `:leader-exposed-r2dbc:compileKotlin` first.
+- Watch for new implicit receiver properties in Exposed DSL lambdas (`insert`, `update`,
+  `deleteWhere`, `upsert`). Extract conflicting outer variables before the lambda.
+- The implicit-receiver shadowing pattern is in project memory (`feedback_exposed_lambda_shadowing.md`).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ aspectjweaver = "1.9.25.1"  # https://mvnrepository.com/artifact/org.aspectj/asp
 lettuce = "6.8.2.RELEASE"  # https://mvnrepository.com/artifact/io.lettuce/lettuce-core
 redisson = "4.3.1"  # https://mvnrepository.com/artifact/org.redisson/redisson
 
-exposed = "1.2.0"  # https://mvnrepository.com/artifact/org.jetbrains.exposed/exposed-core
+exposed = "1.3.0"  # https://mvnrepository.com/artifact/org.jetbrains.exposed/exposed-core
 
 mongo-driver = "5.7.0"  # https://mvnrepository.com/artifact/org.mongodb/mongodb-driver-sync
 

--- a/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElector.kt
+++ b/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElector.kt
@@ -275,15 +275,17 @@ class ExposedR2DbcSuspendLeaderGroupElector private constructor(
 
     private suspend fun recordAcquired(lockName: String, token: String, slot: Int): Long? {
         if (!options.recordHistory) return null
+        val lockOwner = options.lockOwner
+        val leaseTimeMs = options.leaderGroupOptions.leaseTime.inWholeMilliseconds
         return try {
             suspendTransaction(db) {
                 val now = Instant.now()
                 LeaderLockHistoryTable.insert {
                     it[LeaderLockHistoryTable.lockName] = lockName
-                    it[LeaderLockHistoryTable.lockOwner] = options.lockOwner
+                    it[LeaderLockHistoryTable.lockOwner] = lockOwner
                     it[LeaderLockHistoryTable.token] = token
                     it[LeaderLockHistoryTable.slot] = slot
-                    it[LeaderLockHistoryTable.lockedUntil] = now.plusMillis(options.leaderGroupOptions.leaseTime.inWholeMilliseconds)
+                    it[LeaderLockHistoryTable.lockedUntil] = now.plusMillis(leaseTimeMs)
                     it[LeaderLockHistoryTable.status] = LeaderHistoryStatus.ACQUIRED.name
                     it[LeaderLockHistoryTable.startedAt] = now
                 }[LeaderLockHistoryTable.id]


### PR DESCRIPTION
## Summary

Closes #280

PR #281의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `chore: upgrade JetBrains Exposed 1.2.0 → 1.3.0`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Upgrades JetBrains Exposed from `1.2.0` to `1.3.0` across all `leader-exposed-*` modules.

Closes #280

## Changes

- `gradle/libs.versions.toml`: bump `exposed = "1.2.0"` → `"1.3.0"`
- `leader-exposed-r2dbc`: fix implicit-receiver shadowing in `ExposedR2DbcSuspendLeaderGroupElector.recordAcquired()` — extract `options.lockOwner` and `options.leaderGroupOptions.leaseTime` into local variables before the `insert {}` lambda, which acquires a new receiver named `options` in Exposed 1.3.0

## Root Cause (compilation fix)

Exposed 1.3.0 introduced a new implicit receiver property named `options` inside `insert {}` blocks. This shadowed the outer `ExposedR2dbcLeaderGroupElectionOptions` field, causing two `Unresolved reference` compilation errors:

```
ExposedR2DbcSuspendLeaderGroupElector.kt:283 Unresolved reference 'lockOwner'
ExposedR2DbcSuspendLeaderGroupElector.kt:286 Unresolved reference 'leaderGroupOptions'
```

Fix: extract both values as local variables before entering the lambda.

## Test Results

| Module | Result |
|--------|--------|
| `:leader-exposed-core:test` | ✅ BUILD SUCCESSFUL |
| `:leader-exposed-jdbc:test` | ✅ BUILD SUCCESSFUL (H2 + PostgreSQL + MySQL via Testcontainers) |
| `:leader-exposed-r2dbc:test` | ✅ BUILD SUCCESSFUL (H2 + PostgreSQL + MySQL via Testcontainers) |

## Verification Commands

```bash
./gradlew :leader-exposed-core:test :leader-exposed-jdbc:test :leader-exposed-r2dbc:test
```
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #280, milestone `0.1.0`, assignee `debop`
- PR: #281, head `4eb3abada97a2fc2362cb22ea3777a1ab69986d3`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
