### PR TITLE
test: migrate concurrency tests from Executors to coroutines (issue #275)

### DIFF
--- a/docs/lessons/2026-05-16-multithreading-tester-migration.md
+++ b/docs/lessons/2026-05-16-multithreading-tester-migration.md
@@ -1,0 +1,79 @@
+# Lesson: Migrate Concurrency Tests to MultithreadingTester / SuspendedJobTester
+
+**Date**: 2026-05-16
+**Issue**: #275
+**PR**: TBD
+**Modules affected**: `leader-core`
+
+## Summary
+
+Migrated `LeaderGroupElectionStateTest.kt` from raw `Executors.newFixedThreadPool` + `CountDownLatch`
+to `coroutineScope` + `async(Dispatchers.IO)` + `AtomicInteger` polling, consistent with the pattern
+already established in `LocalSuspendLeaderGroupElectorTest.kt`.
+
+## Scope
+
+The initial audit found 33+ test files already using `MultithreadingTester` or `SuspendedJobTester`.
+The only remaining raw-executor pattern was a single test in `LeaderGroupElectionStateTest.kt`.
+`AsyncLeaderElectorContractTest.kt` and `AsyncLeaderGroupElectorContractTest.kt` had no raw thread
+primitives to migrate.
+
+## Migration Pattern
+
+**Before** (raw thread pool):
+```kotlin
+val startLatch = CountDownLatch(2)
+val holdLatch = CountDownLatch(1)
+val executor = Executors.newFixedThreadPool(2)
+
+repeat(2) {
+    executor.submit {
+        election.runIfLeader(lockName) {
+            startLatch.countDown()
+            holdLatch.await()
+        }
+    }
+}
+startLatch.await(2, TimeUnit.SECONDS)
+// check state ...
+holdLatch.countDown()
+executor.shutdown()
+executor.awaitTermination(3, TimeUnit.SECONDS)
+```
+
+**After** (coroutines + AtomicInteger polling):
+```kotlin
+val acquiredCount = AtomicInteger(0)
+val holdLatch = CountDownLatch(1)  // required: action lambda is blocking, not suspend
+
+coroutineScope {
+    val jobs = List(2) {
+        async(Dispatchers.IO) {
+            election.runIfLeader(lockName) {
+                acquiredCount.incrementAndGet()
+                holdLatch.await()
+            }
+        }
+    }
+    while (acquiredCount.get() < 2) { delay(5.milliseconds) }
+    // check state ...
+    holdLatch.countDown()
+    jobs.awaitAll()
+}
+```
+
+## Why CountDownLatch Remains
+
+`LocalLeaderGroupElector.runIfLeader` takes a `() -> T` blocking lambda — not a suspend lambda.
+`CountDownLatch.await()` is the correct mechanism to hold the lock inside a blocking action.
+This is consistent with the existing pattern in `LocalLeaderGroupElectionTest.kt`.
+
+The key improvement is replacing `Executors.newFixedThreadPool` (unstructured, leak-prone) with
+structured `coroutineScope { async(Dispatchers.IO) { } }`.
+
+## Future Guidance
+
+- `MultithreadingTester` / `SuspendedJobTester`: use for stress / fire-and-complete concurrency tests
+- `coroutineScope + async(Dispatchers.IO)` + `AtomicInteger` polling: use for "check while holding" correctness tests with blocking electors
+- `CountDownLatch.await()` inside a blocking action lambda is acceptable and expected
+- `Executors.newFixedThreadPool` in tests: always replace with coroutines (structured) or `MultithreadingTester`

--- a/docs/lessons/2026-05-16-multithreading-tester-migration.md
+++ b/docs/lessons/2026-05-16-multithreading-tester-migration.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-05-16
 **Issue**: #275
-**PR**: TBD
+**PR**: #282
 **Modules affected**: `leader-core`
 
 ## Summary

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderGroupElectionStateTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderGroupElectionStateTest.kt
@@ -13,10 +13,12 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * [LeaderGroupElectionState] 인터페이스 계약을 검증하는 테스트입니다.
@@ -82,8 +84,10 @@ class LeaderGroupElectionStateTest {
                 }
             }
 
-            while (acquiredCount.get() < 2) {
-                delay(5.milliseconds)
+            withTimeout(5.seconds) {
+                while (acquiredCount.get() < 2) {
+                    delay(5.milliseconds)
+                }
             }
 
             election.activeCount(lockName) shouldBeEqualTo 2

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderGroupElectionStateTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderGroupElectionStateTest.kt
@@ -1,16 +1,22 @@
 package io.bluetape4k.leader
 
 import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.local.LocalAsyncLeaderGroupElector
 import io.bluetape4k.leader.local.LocalLeaderGroupElector
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * [LeaderGroupElectionState] 인터페이스 계약을 검증하는 테스트입니다.
@@ -58,30 +64,35 @@ class LeaderGroupElectionStateTest {
     }
 
     @Test
-    fun `state - 슬롯 점유 중 activeCount 가 증가한다 (sync 구현체)`() {
+    fun `state - 슬롯 점유 중 activeCount 가 증가한다 (sync 구현체)`() = runSuspendIO {
         val election = LocalLeaderGroupElector(options)
         val lockName = randomLockName()
-        val startLatch = CountDownLatch(2)
+        val acquiredCount = AtomicInteger(0)
+        // CountDownLatch is intentional here: the action lambda is blocking (not suspend),
+        // so a latch is the correct signal to hold the lock inside the action body.
         val holdLatch = CountDownLatch(1)
-        val executor = Executors.newFixedThreadPool(2)
 
-        repeat(2) {
-            executor.submit {
-                election.runIfLeader(lockName) {
-                    startLatch.countDown()
-                    holdLatch.await()
+        coroutineScope {
+            val jobs = List(2) {
+                async(Dispatchers.IO) {
+                    election.runIfLeader(lockName) {
+                        acquiredCount.incrementAndGet()
+                        holdLatch.await()
+                    }
                 }
             }
+
+            while (acquiredCount.get() < 2) {
+                delay(5.milliseconds)
+            }
+
+            election.activeCount(lockName) shouldBeEqualTo 2
+            election.availableSlots(lockName) shouldBeEqualTo maxLeaders - 2
+            election.state(lockName).isEmpty.shouldBeFalse()
+
+            holdLatch.countDown()
+            jobs.awaitAll()
         }
-        startLatch.await(2, TimeUnit.SECONDS)
-
-        election.activeCount(lockName) shouldBeEqualTo 2
-        election.availableSlots(lockName) shouldBeEqualTo maxLeaders - 2
-        election.state(lockName).isEmpty.shouldBeFalse()
-
-        holdLatch.countDown()
-        executor.shutdown()
-        executor.awaitTermination(3, TimeUnit.SECONDS)
     }
 
     // ── LocalAsyncLeaderGroupElector 을 통한 LeaderGroupElectionState 계약 검증 ──


### PR DESCRIPTION
## Summary

Closes #275

PR #282의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `test: migrate concurrency tests from Executors to coroutines (issue #275)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Migrates `LeaderGroupElectionStateTest.kt` from raw `Executors.newFixedThreadPool` to structured `coroutineScope + async(Dispatchers.IO)`, consistent with the existing pattern in `LocalSuspendLeaderGroupElectorTest.kt`.

Closes #275

## Audit Findings

33+ test files already use `MultithreadingTester` or `SuspendedJobTester`. The only remaining raw-executor pattern was a single test in `LeaderGroupElectionStateTest.kt`. The async contract tests had no raw thread primitives.

## Changes

### `LeaderGroupElectionStateTest.kt`

**Before** — raw thread pool + dual CountDownLatch:
```kotlin
val startLatch = CountDownLatch(2)
val holdLatch  = CountDownLatch(1)
val executor   = Executors.newFixedThreadPool(2)
repeat(2) { executor.submit { election.runIfLeader(lockName) {
    startLatch.countDown(); holdLatch.await()
}}}
startLatch.await(2, TimeUnit.SECONDS)
```

**After** — coroutines + AtomicInteger polling:
```kotlin
val acquiredCount = AtomicInteger(0)
val holdLatch = CountDownLatch(1)  // required: action lambda is () -> T, not suspend
coroutineScope {
    val jobs = List(2) { async(Dispatchers.IO) {
        election.runIfLeader(lockName) { acquiredCount.incrementAndGet(); holdLatch.await() }
    }}
    while (acquiredCount.get() < 2) { delay(5.milliseconds) }
    // assert state...
    holdLatch.countDown(); jobs.awaitAll()
}
```

### Why `CountDownLatch` Remains

The action lambda is `() -> T` (blocking, not suspend). `CountDownLatch.await()` is the correct way to hold the slot inside a blocking action. This matches the existing pattern in `LocalLeaderGroupElectionTest.kt`.

## Test Results

```
:leader-core:test — BUILD SUCCESSFUL (all tests pass)
```
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #275, milestone `0.1.0`, assignee `debop`
- PR: #282, head `2e734e6ea68566c67f6f433498bcb962434a96bb`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
