### PR TITLE
feat: Spring AOT compatibility test for leader-spring-boot (#256)

### DIFF
--- a/docs/lessons/2026-05-16-spring-aot-library-module.md
+++ b/docs/lessons/2026-05-16-spring-aot-library-module.md
@@ -1,0 +1,104 @@
+# Spring AOT 라이브러리 모듈 적용 — 버전 다운그레이드로 인한 NoSuchMethodError
+
+**날짜**: 2026-05-16  
+**관련 이슈**: #256
+
+---
+
+## 배경
+
+`leader-spring-boot` 라이브러리 모듈에서 Spring AOT 호환성 검증 테스트(`LocalLeaderAotTest`)를 구성했다.
+5개 테스트 중 suspend 관련 테스트 1개가 `NoSuchMethodError: Mutex.lock$default`로 실패했다.
+
+---
+
+## 근본 원인
+
+### kotlinx-coroutines 버전 분기
+
+| 모듈 | coroutines 버전 |
+|------|----------------|
+| `leader-core` (컴파일 시) | **1.11.0** |
+| `leader-spring-boot:testRuntimeClasspath` | **1.10.2** (Spring Boot BOM 강제) |
+
+coroutines **1.11.0**에서는 `Mutex.lock$default`가 **인터페이스 자체**에 static 메서드로 존재한다.
+
+```java
+// coroutines 1.11.0 — Mutex interface
+public static java.lang.Object lock$default(Mutex, Object, Continuation, int, Object);
+```
+
+coroutines **1.10.2**에서는 `lock$default`가 `Mutex$DefaultImpls`에만 존재한다.
+
+```java
+// coroutines 1.10.2 — Mutex$DefaultImpls (interface에는 없음)
+public static java.lang.Object lock$default(Mutex, Object, Continuation, int, Object);
+```
+
+`leader-core`가 1.11.0으로 컴파일될 때 `mutex.lock()` (default owner = null) 호출은
+`Mutex.lock$default(...)` (interface static)을 참조하는 바이트코드를 생성한다.
+런타임에 Spring Boot BOM이 coroutines를 1.10.2로 다운그레이드하면 해당 메서드가 없어서 `NoSuchMethodError`가 발생한다.
+
+### AOT 테스트에서만 나타나는 이유
+
+일반 `leader-spring-boot:test`에는 `LocalSuspendLeaderElector.tryWithLock()`을 직접 호출하는 경로가 없다.
+AOT 테스트에서 처음으로 suspend API를 end-to-end로 호출하면서 문제가 드러났다.
+
+---
+
+## 해결책
+
+`leader-spring-boot/build.gradle.kts`의 `dependencyManagement`에 `kotlinx-coroutines-bom`을 명시적으로 추가.
+Spring Boot BOM 이후에 import하여 coroutines 버전을 프로젝트 기준(1.11.0)으로 고정.
+
+```kotlin
+dependencyManagement {
+    imports {
+        mavenBom(libs.spring.boot4.dependencies.get().toString())
+        mavenBom(libs.kotlin.bom.get().toString())
+        // spring-boot-dependencies pins coroutines to 1.10.2, but leader-core
+        // is compiled against 1.11.0. Override to prevent NoSuchMethodError.
+        mavenBom(libs.kotlinx.coroutines.bom.get().toString())
+    }
+}
+```
+
+---
+
+## Spring AOT 라이브러리 모듈 적용 방법
+
+라이브러리 모듈에서 AOT 호환성을 검증하려면:
+
+1. **Spring Boot plugin 적용** (`apply false` 아닌 실제 적용): `processAot` / `processTestAot` task가 등록됨
+2. **bootJar 비활성화**: `tasks.bootJar { enabled = false }` + `tasks.jar { enabled = true }`
+3. **커스텀 `aotTest` task 등록**:
+   ```kotlin
+   val aotTest by tasks.registering(Test::class) {
+       dependsOn(tasks.named("aotTestClasses"))
+       useJUnitPlatform()
+       testClassesDirs = sourceSets.test.get().output.classesDirs
+       // aotTest sourceset의 AOT 생성 클래스 + 일반 test runtime classpath 조합
+       classpath = sourceSets["aotTest"].output.classesDirs +
+                   sourceSets.test.get().runtimeClasspath
+       jvmArgs("-Dspring.aot.enabled=true")
+       filter { includeTestsMatching("io.bluetape4k.leader.spring.aot.*") }
+   }
+   ```
+4. **BOM 버전 동기화**: 라이브러리 의존성이 Spring Boot BOM에 의해 다운그레이드되지 않도록 `kotlinx-coroutines-bom` 등 명시적 override 추가
+
+---
+
+## 검증 결과
+
+```
+aotTest: 5/5 passing (3.3s) — suspend runIfLeader 포함
+test   : 321/321 passing (1m 27s)
+```
+
+---
+
+## 핵심 교훈
+
+**Spring Boot 모듈에서 `dependencyManagement`에 BOM을 추가할 때**, Spring Boot BOM이 다운그레이드할 수 있는 의존성이 있는지 확인해야 한다. 특히 라이브러리 모듈은 Spring Boot App과 달리 의존성이 바깥에서 공급되므로, 버전 불일치가 런타임에만 드러날 수 있다.
+
+`kotlinx-coroutines-bom`처럼 다른 모듈이 더 높은 버전으로 컴파일한 경우 Spring Boot BOM의 다운그레이드는 바이너리 비호환성(ABI break)을 야기할 수 있다.

--- a/leader-spring-boot/build.gradle.kts
+++ b/leader-spring-boot/build.gradle.kts
@@ -14,6 +14,9 @@ apply(plugin = "org.springframework.boot.aot")
 // Library module: publish plain jar, not the fat bootJar.
 tasks.bootJar { enabled = false }
 tasks.jar { enabled = true }
+// processAot needs a main class — library modules have none; disable it.
+// processTestAot is what we need and is wired via aotTestClasses below.
+tasks.named("processAot") { enabled = false }
 
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())

--- a/leader-spring-boot/build.gradle.kts
+++ b/leader-spring-boot/build.gradle.kts
@@ -1,14 +1,45 @@
 plugins {
     alias(libs.plugins.kotlin.spring)
     alias(libs.plugins.kotlin.allopen)
-    alias(libs.plugins.spring.boot4) apply false
+    // Applied (not apply false) so bootJar / processAot tasks are registered.
+    // bootJar is disabled below to keep the published artifact a plain jar.
+    alias(libs.plugins.spring.boot4)
     // Freefair AspectJ post-compile-weaving (CTW-only — @EnableAspectJAutoProxy 미사용)
     id("io.freefair.aspectj.post-compile-weaving") version "9.5.0"
 }
 
+// org.springframework.boot.aot registers processAot / processTestAot tasks.
+apply(plugin = "org.springframework.boot.aot")
+
+// Library module: publish plain jar, not the fat bootJar.
+tasks.bootJar { enabled = false }
+tasks.jar { enabled = true }
+
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }
+
+// Runs @SpringBootTest classes in Spring AOT mode to validate auto-configuration AOT compatibility.
+// processTestAot gracefully skips Testcontainers-backed test classes when Docker is unavailable
+// (Spring Boot catches Throwable per class and logs a warning — the task itself does not fail).
+// aotTest then runs only the AOT-safe classes in io.bluetape4k.leader.spring.aot package.
+//
+// Classpath layout:
+//   sourceSets["aotTest"].output.classesDirs  — AOT-generated proxy/hint classes (build/classes/java/aotTest)
+//   sourceSets.test.runtimeClasspath          — regular test deps + test classes
+val aotTest by tasks.registering(Test::class) {
+    description = "Validates Spring AOT compatibility of leader-spring-boot auto-configurations"
+    group = "verification"
+    dependsOn(tasks.named("aotTestClasses"))
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets["aotTest"].output.classesDirs +
+                sourceSets.test.get().runtimeClasspath
+    jvmArgs("-Dspring.aot.enabled=true")
+    filter { includeTestsMatching("io.bluetape4k.leader.spring.aot.*") }
+    shouldRunAfter(tasks.test)
+}
+tasks.check { dependsOn(aotTest) }
 
 dependencyManagement {
     imports {
@@ -16,6 +47,10 @@ dependencyManagement {
         // spring-boot-dependencies는 kotlin.version=1.9.25를 강제하므로
         // kotlin-bom을 뒤에서 다시 import하여 프로젝트 Kotlin 버전을 우선시킨다.
         mavenBom(libs.kotlin.bom.get().toString())
+        // spring-boot-dependencies pins kotlinx-coroutines to 1.10.2, but leader-core
+        // is compiled against 1.11.0 which moves Mutex.$default methods to the interface.
+        // Override here to prevent NoSuchMethodError at runtime.
+        mavenBom(libs.kotlinx.coroutines.bom.get().toString())
     }
     dependencies {
         // mongodb-driver-core 버전을 driver-sync/driver-kotlin-coroutine과 일치시킨다.

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aot/LocalLeaderAotTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aot/LocalLeaderAotTest.kt
@@ -1,0 +1,83 @@
+package io.bluetape4k.leader.spring.aot
+
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.leader.local.LocalLeaderElector
+import io.bluetape4k.leader.coroutines.LocalSuspendLeaderElector
+import io.bluetape4k.leader.spring.LeaderElectionAutoConfiguration
+import io.bluetape4k.leader.spring.LeaderTestApplication
+import io.bluetape4k.leader.spring.backend.LocalLeaderConfiguration
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldNotBeNull
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+
+/**
+ * Validates that leader-spring-boot auto-configurations are AOT-compatible.
+ *
+ * Runs with `-Dspring.aot.enabled=true` (Spring AOT mode). Uses only [LocalLeaderElector]
+ * — no Redis, MongoDB, or Hazelcast required — so this test is safe for CI without Docker.
+ *
+ * Included by the `aotTest` Gradle task via `processTestAot` filtered to the `aot` package.
+ *
+ * ## Local command
+ * ```bash
+ * ./gradlew :leader-spring-boot:aotTest
+ * ```
+ */
+@SpringBootTest(
+    classes = [LeaderTestApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+)
+@ImportAutoConfiguration(
+    LeaderElectionAutoConfiguration::class,
+    LocalLeaderConfiguration::class,
+)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LocalLeaderAotTest {
+
+    @Autowired
+    private lateinit var context: ApplicationContext
+
+    @Autowired
+    private lateinit var leaderElector: LeaderElector
+
+    @Autowired
+    private lateinit var suspendLeaderElector: SuspendLeaderElector
+
+    @Test
+    fun `ApplicationContext loads with local backend in AOT mode`() {
+        context.shouldNotBeNull()
+    }
+
+    @Test
+    fun `LocalLeaderElector bean type is correct in AOT mode`() {
+        leaderElector.shouldBeInstanceOf<LocalLeaderElector>()
+    }
+
+    @Test
+    fun `LocalSuspendLeaderElector bean type is correct in AOT mode`() {
+        suspendLeaderElector.shouldBeInstanceOf<LocalSuspendLeaderElector>()
+    }
+
+    @Test
+    fun `runIfLeader returns action value in AOT mode`() {
+        val lockName = "aot-test-${Base58.randomString(6)}"
+        val result = leaderElector.runIfLeader(lockName) { "aot-ok" }
+        result shouldBeEqualTo "aot-ok"
+    }
+
+    @Test
+    fun `suspend runIfLeader returns action value in AOT mode`() {
+        val lockName = "aot-suspend-${Base58.randomString(6)}"
+        val result = runBlocking { suspendLeaderElector.runIfLeader(lockName) { "aot-suspend-ok" } }
+        result shouldBeEqualTo "aot-suspend-ok"
+    }
+}


### PR DESCRIPTION
## Summary

Closes #256

PR #284의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat: Spring AOT compatibility test for leader-spring-boot (#256)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Adds Spring AOT compatibility validation for the `leader-spring-boot` library module.

### Changes

- **`leader-spring-boot/build.gradle.kts`**:
  - Apply Spring Boot plugin (not `apply false`) so `processAot`/`processTestAot` tasks are registered
  - Disable `bootJar`, keep plain jar for publishing
  - Register custom `aotTest` task:
    - Depends on `aotTestClasses` (runs `processTestAot` first)
    - Classpath: AOT-generated classes + regular `testRuntimeClasspath`
    - JVM arg: `-Dspring.aot.enabled=true`
    - Filters to `io.bluetape4k.leader.spring.aot.*` package only
  - Add `kotlinx-coroutines-bom` to `dependencyManagement` to prevent Spring Boot BOM
    from downgrading coroutines 1.11.0 → 1.10.2

- **`LocalLeaderAotTest`** (new): 5 tests in `io.bluetape4k.leader.spring.aot` package
  1. ApplicationContext loads with local backend in AOT mode
  2. `LocalLeaderElector` bean type is correct
  3. `LocalSuspendLeaderElector` bean type is correct
  4. Blocking `runIfLeader` returns action value in AOT mode
  5. Suspend `runIfLeader` returns action value in AOT mode

### Root Cause Fix (coroutines version bifurcation)

`leader-core` is compiled against coroutines **1.11.0**, which places `Mutex.lock$default`
as a static method on the `Mutex` interface. Spring Boot BOM pins coroutines to **1.10.2**,
which only has `lock$default` on `Mutex$DefaultImpls`. This causes
`NoSuchMethodError: Mutex.lock$default` at runtime. Fixed by importing `kotlinx-coroutines-bom`
after Spring Boot BOM in `dependencyManagement`.

### Test Results

| Task | Result |
|------|--------|
| `:leader-spring-boot:aotTest` | **5/5 passing** (3.3s) |
| `:leader-spring-boot:test` | **321/321 passing** (1m 27s) |

### Verification

```bash
./gradlew :leader-spring-boot:aotTest :leader-spring-boot:test
```

### Lesson

See `docs/lessons/2026-05-16-spring-aot-library-module.md` for detailed analysis of
the coroutines ABI compatibility issue and Spring AOT library module setup guide.

Closes #256
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #256, milestone `0.1.0`, assignee `debop`
- PR: #284, head `8e705d1f91d1d7c3766000fa0c589fa1b359986a`, milestone `0.1.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
