### PR TITLE
fix: harden Exposed JDBC cancellation and timeout budgets

### DIFF
--- a/docs/lessons/2026-05-20-exposed-jdbc-cancellation-timeouts.md
+++ b/docs/lessons/2026-05-20-exposed-jdbc-cancellation-timeouts.md
@@ -1,0 +1,35 @@
+# Exposed JDBC cancellation and timeout budgets
+
+## Context
+
+Issues #304, #305, and #306 shared the same Exposed JDBC lock/elector surface:
+blocking transaction cleanup paths swallowed `CancellationException` through
+`runCatching`, and lock acquisition retry loops used wall-clock time for local
+timeouts.
+
+## Decision
+
+Use explicit `try/catch` around transaction-backed best-effort paths so
+`CancellationException` is always rethrown before generic fallback logging.
+Keep database lease timestamps on wall-clock `Instant`, but measure local
+`tryLock` retry budgets with a small `MonotonicDeadline` helper based on
+`System.nanoTime`.
+
+## Outcome
+
+Single-lock and group-lock retry loops now resist wall-clock jumps, while DB
+cleanup/status failures keep the previous best-effort behavior for non-
+cancellation exceptions.
+
+## Verification
+
+- `./gradlew :bluetape4k-leader-exposed-jdbc:test --tests 'io.bluetape4k.leader.exposed.jdbc.lock.MonotonicDeadlineTest' --no-build-cache --stacktrace`
+  - 4 passing
+- `./gradlew :bluetape4k-leader-exposed-jdbc:test --no-build-cache --stacktrace`
+  - 231 passing
+
+## Future Guidance
+
+Do not use `runCatching` around suspend-aware or cancellation-sensitive Kotlin
+paths. For distributed locks, keep persisted lease expiry comparable across JVMs
+with wall-clock timestamps, but keep local wait budgets monotonic.

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElector.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElector.kt
@@ -108,22 +108,25 @@ class ExposedJdbcLeaderGroupElector private constructor(
      *
      * Returns `0` on DB error (best-effort; no exception propagation).
      */
-    override fun activeCount(lockName: String): Int = runCatching {
-        transaction(db) {
-            val now = Instant.now()
-            LeaderGroupLockTable
-                .selectAll()
-                .where {
-                    (LeaderGroupLockTable.lockName eq lockName) and
-                        (LeaderGroupLockTable.lockedUntil greater now)
-                }
-                .count()
-                .toInt()
+    override fun activeCount(lockName: String): Int =
+        try {
+            transaction(db) {
+                val now = Instant.now()
+                LeaderGroupLockTable
+                    .selectAll()
+                    .where {
+                        (LeaderGroupLockTable.lockName eq lockName) and
+                            (LeaderGroupLockTable.lockedUntil greater now)
+                    }
+                    .count()
+                    .toInt()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "activeCount DB 오류 (0 반환): lockName=$lockName" }
+            0
         }
-    }.getOrElse { e ->
-        log.warn(e) { "activeCount DB 오류 (0 반환): lockName=$lockName" }
-        0
-    }
 
     /** Number of slots immediately available for [lockName]. */
     override fun availableSlots(lockName: String): Int = maxLeaders - activeCount(lockName)
@@ -242,9 +245,14 @@ class ExposedJdbcLeaderGroupElector private constructor(
                     actionSucceeded -> effectiveKey?.let { historyRecorder?.recordCompleted(it, finishedAt, durationMs) }
                     capturedError != null -> effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, capturedError) }
                 }
-                runCatching { lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos) }
-                    .onSuccess { log.debug { "그룹 슬롯을 반납했습니다. lockName=$lockName, slot=$slot" } }
-                    .onFailure { e -> log.warn(e) { "그룹 슬롯 해제 실패. lockName=$lockName, slot=$slot" } }
+                try {
+                    lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos)
+                    log.debug { "그룹 슬롯을 반납했습니다. lockName=$lockName, slot=$slot" }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log.warn(e) { "그룹 슬롯 해제 실패. lockName=$lockName, slot=$slot" }
+                }
             }
         }
 
@@ -331,8 +339,13 @@ class ExposedJdbcLeaderGroupElector private constructor(
                         val finishedAt = Instant.now()
                         val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                         effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, e) }
-                        runCatching { lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos) }
-                            .onFailure { ex -> log.warn(ex) { "슬롯 해제 실패 (action 오류 경로). slot=$slot" } }
+                        try {
+                            lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos)
+                        } catch (ex: CancellationException) {
+                            throw ex
+                        } catch (ex: Exception) {
+                            log.warn(ex) { "슬롯 해제 실패 (action 오류 경로). slot=$slot" }
+                        }
                         return@thenComposeAsync CompletableFuture.failedFuture(e)
                     }
 
@@ -347,9 +360,14 @@ class ExposedJdbcLeaderGroupElector private constructor(
                         throwable is CancellationException -> { /* skip */ }
                         else -> effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, throwable) }
                     }
-                    runCatching { lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos) }
-                        .onSuccess { log.debug { "비동기 그룹 슬롯 반납. lockName=$lockName, slot=$slot" } }
-                        .onFailure { e -> log.warn(e) { "비동기 슬롯 해제 실패. lockName=$lockName, slot=$slot" } }
+                    try {
+                        lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos)
+                        log.debug { "비동기 그룹 슬롯 반납. lockName=$lockName, slot=$slot" }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log.warn(e) { "비동기 슬롯 해제 실패. lockName=$lockName, slot=$slot" }
+                    }
                 }, executor)
             }
         }, executor)

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLock.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLock.kt
@@ -64,7 +64,7 @@ internal class ExposedJdbcGroupLock internal constructor(
      * @return `true` when the lock is acquired, `false` on contention or timeout, `null` on DB error
      */
     fun tryLock(waitTime: Duration, leaseTime: Duration): Boolean? {
-        val deadline = System.currentTimeMillis() + waitTime.inWholeMilliseconds.coerceAtLeast(0L)
+        val deadline = MonotonicDeadline.fromNow(waitTime)
         var attempt = 0
 
         do {
@@ -82,7 +82,7 @@ internal class ExposedJdbcGroupLock internal constructor(
                 return true
             }
 
-            val remaining = deadline - System.currentTimeMillis()
+            val remaining = deadline.remainingMillisForSleep()
             if (remaining > 0L) {
                 try {
                     Thread.sleep(retryStrategy.delayMs(attempt++, remaining))
@@ -92,7 +92,7 @@ internal class ExposedJdbcGroupLock internal constructor(
                     return false
                 }
             }
-        } while (System.currentTimeMillis() < deadline)
+        } while (deadline.hasTimeRemaining())
 
         log.debug { "그룹 슬롯 락 획득 실패 (타임아웃): lockName=$lockName, slot=$slot" }
         return false
@@ -161,26 +161,29 @@ internal class ExposedJdbcGroupLock internal constructor(
      *
      * Returns `false` when the lease has expired and another instance has re-acquired the slot.
      */
-    fun isHeldByCurrentInstance(): Boolean = runCatching {
-        val lockNameVal = lockName
-        val slotVal = slot
-        val tokenVal = token
-        transaction(db) {
-            val now = Instant.now()
-            !LeaderGroupLockTable
-                .selectAll()
-                .where {
-                    (LeaderGroupLockTable.lockName eq lockNameVal) and
-                        (LeaderGroupLockTable.slot eq slotVal) and
-                        (LeaderGroupLockTable.token eq tokenVal) and
-                        (LeaderGroupLockTable.lockedUntil greater now)
-                }
-                .empty()
+    fun isHeldByCurrentInstance(): Boolean =
+        try {
+            val lockNameVal = lockName
+            val slotVal = slot
+            val tokenVal = token
+            transaction(db) {
+                val now = Instant.now()
+                !LeaderGroupLockTable
+                    .selectAll()
+                    .where {
+                        (LeaderGroupLockTable.lockName eq lockNameVal) and
+                            (LeaderGroupLockTable.slot eq slotVal) and
+                            (LeaderGroupLockTable.token eq tokenVal) and
+                            (LeaderGroupLockTable.lockedUntil greater now)
+                    }
+                    .empty()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "isHeldByCurrentInstance DB 오류 (false 반환): lockName=$lockName, slot=$slot" }
+            false
         }
-    }.getOrElse { e ->
-        log.warn(e) { "isHeldByCurrentInstance DB 오류 (false 반환): lockName=$lockName, slot=$slot" }
-        false
-    }
 
     /**
      * Releases the slot lock held by the current instance.
@@ -196,7 +199,7 @@ internal class ExposedJdbcGroupLock internal constructor(
         val tokenVal = this@ExposedJdbcGroupLock.token
         val remaining = remainingMinLeaseTime(acquiredAtNanos, minLeaseTime)
 
-        runCatching {
+        try {
             val matched = transaction(db) {
                 if (remaining > Duration.ZERO) {
                     LeaderGroupLockTable.update(
@@ -221,7 +224,9 @@ internal class ExposedJdbcGroupLock internal constructor(
             } else {
                 log.debug { "그룹 슬롯 해제 성공: lockName=$lockName, slot=$slot" }
             }
-        }.onFailure { e ->
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
             log.warn(e) { "그룹 슬롯 해제 중 DB 오류: lockName=$lockName, slot=$slot" }
         }
     }

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcLock.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcLock.kt
@@ -63,7 +63,7 @@ internal class ExposedJdbcLock internal constructor(
      * @return `true` when the lock is acquired, `false` on timeout or error
      */
     fun tryLock(waitTime: Duration, leaseTime: Duration): Boolean {
-        val deadline = System.currentTimeMillis() + waitTime.inWholeMilliseconds.coerceAtLeast(0L)
+        val deadline = MonotonicDeadline.fromNow(waitTime)
         var attempt = 0
 
         do {
@@ -81,7 +81,7 @@ internal class ExposedJdbcLock internal constructor(
                 return true
             }
 
-            val remaining = deadline - System.currentTimeMillis()
+            val remaining = deadline.remainingMillisForSleep()
             if (remaining > 0L) {
                 // sleep은 transaction 바깥에서만 호출 (HikariCP 풀 고갈 방지)
                 // InterruptedException 발생 시 interrupt flag 복원 후 false 반환 (never-throws 계약)
@@ -93,7 +93,7 @@ internal class ExposedJdbcLock internal constructor(
                     return false
                 }
             }
-        } while (System.currentTimeMillis() < deadline)
+        } while (deadline.hasTimeRemaining())
 
         log.debug { "락 획득 실패 (타임아웃): lockName=$lockName" }
         return false
@@ -157,22 +157,25 @@ internal class ExposedJdbcLock internal constructor(
      *
      * Returns `false` when the lease has expired and another instance has re-acquired the lock.
      */
-    fun isHeldByCurrentInstance(): Boolean = runCatching {
-        transaction(db) {
-            val now = Instant.now()
-            !LeaderLockTable
-                .selectAll()
-                .where {
-                    (LeaderLockTable.lockName eq lockName) and
-                            (LeaderLockTable.token eq token) and
-                            (LeaderLockTable.lockedUntil greater now)
-                }
-                .empty()
+    fun isHeldByCurrentInstance(): Boolean =
+        try {
+            transaction(db) {
+                val now = Instant.now()
+                !LeaderLockTable
+                    .selectAll()
+                    .where {
+                        (LeaderLockTable.lockName eq lockName) and
+                                (LeaderLockTable.token eq token) and
+                                (LeaderLockTable.lockedUntil greater now)
+                    }
+                    .empty()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "isHeldByCurrentInstance DB 오류 (false 반환): lockName=$lockName" }
+            false
         }
-    }.getOrElse { e ->
-        log.warn(e) { "isHeldByCurrentInstance DB 오류 (false 반환): lockName=$lockName" }
-        false
-    }
 
     /**
      * Releases the lock held by the current instance.
@@ -187,7 +190,7 @@ internal class ExposedJdbcLock internal constructor(
         val tokenVal = this@ExposedJdbcLock.token
         val remaining = remainingMinLeaseTime(acquiredAtNanos, minLeaseTime)
 
-        runCatching {
+        try {
             val matched = transaction(db) {
                 if (remaining > Duration.ZERO) {
                     LeaderLockTable.update(
@@ -206,7 +209,9 @@ internal class ExposedJdbcLock internal constructor(
             } else {
                 log.debug { "락 해제 성공: lockName=$lockName, token=${token.take(8)}" }
             }
-        }.onFailure { e ->
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
             log.warn(e) { "락 해제 중 DB 오류: lockName=$lockName" }
         }
     }

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/MonotonicDeadline.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/MonotonicDeadline.kt
@@ -1,0 +1,41 @@
+package io.bluetape4k.leader.exposed.jdbc.lock
+
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+
+/**
+ * Monotonic timeout budget for local retry loops.
+ *
+ * Database lease timestamps remain wall-clock based because other JVMs compare
+ * them through the database. Local wait budgets use [System.nanoTime] so wall
+ * clock adjustments do not extend or shorten a caller's `tryLock` wait.
+ */
+internal class MonotonicDeadline private constructor(
+    private val deadlineNanos: Long,
+    private val ticker: () -> Long,
+) {
+
+    fun remainingNanos(): Long = deadlineNanos - ticker()
+
+    fun remainingMillisForSleep(): Long {
+        val remainingNanos = remainingNanos()
+        if (remainingNanos <= 0L) {
+            return 0L
+        }
+        // RetryStrategy and Thread.sleep accept milliseconds; keep a positive
+        // sub-millisecond budget observable as one last sleep window.
+        return TimeUnit.NANOSECONDS.toMillis(remainingNanos).coerceAtLeast(1L)
+    }
+
+    fun hasTimeRemaining(): Boolean = remainingNanos() > 0L
+
+    companion object {
+        fun fromNow(
+            waitTime: Duration,
+            ticker: () -> Long = System::nanoTime,
+        ): MonotonicDeadline {
+            val timeoutNanos = waitTime.inWholeNanoseconds.coerceAtLeast(0L)
+            return MonotonicDeadline(ticker() + timeoutNanos, ticker)
+        }
+    }
+}

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/MonotonicDeadlineTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/MonotonicDeadlineTest.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.leader.exposed.jdbc.lock
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.milliseconds
+
+class MonotonicDeadlineTest {
+
+    @Test
+    fun `remainingMillisForSleep - 단조 시간 경과량으로 남은 시간을 계산한다`() {
+        var tickerNanos = 1_000_000_000L
+        val deadline = MonotonicDeadline.fromNow(100.milliseconds) { tickerNanos }
+
+        deadline.remainingMillisForSleep() shouldBeEqualTo 100L
+        deadline.hasTimeRemaining().shouldBeTrue()
+
+        tickerNanos += 40.milliseconds.inWholeNanoseconds
+
+        deadline.remainingMillisForSleep() shouldBeEqualTo 60L
+        deadline.hasTimeRemaining().shouldBeTrue()
+
+        tickerNanos += 60.milliseconds.inWholeNanoseconds
+
+        deadline.remainingMillisForSleep() shouldBeEqualTo 0L
+        deadline.hasTimeRemaining().shouldBeFalse()
+    }
+
+    @Test
+    fun `remainingMillisForSleep - sub millisecond budget keeps one millisecond sleep window`() {
+        var tickerNanos = 1_000_000L
+        val deadline = MonotonicDeadline.fromNow(1.milliseconds) { tickerNanos }
+
+        tickerNanos += 999_500L
+
+        deadline.remainingNanos() shouldBeEqualTo 500L
+        deadline.remainingMillisForSleep() shouldBeEqualTo 1L
+        deadline.hasTimeRemaining().shouldBeTrue()
+    }
+
+    @Test
+    fun `fromNow - zero wait time is already expired`() {
+        val deadline = MonotonicDeadline.fromNow(0.milliseconds) { 42L }
+
+        deadline.remainingMillisForSleep() shouldBeEqualTo 0L
+        deadline.hasTimeRemaining().shouldBeFalse()
+    }
+
+    @Test
+    fun `fromNow - negative wait time is already expired`() {
+        val deadline = MonotonicDeadline.fromNow((-1).milliseconds) { 42L }
+
+        deadline.remainingMillisForSleep() shouldBeEqualTo 0L
+        deadline.hasTimeRemaining().shouldBeFalse()
+    }
+}


### PR DESCRIPTION
## Summary

Closes #304
Closes #305
Closes #306

PR #317의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: harden Exposed JDBC cancellation and timeout budgets`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

- Replace cancellation-sensitive `runCatching` wrappers in Exposed JDBC lock/elector DB paths with explicit `CancellationException` rethrow.
- Move local `tryLock` wait budgets for single and group JDBC locks from wall-clock millis to a shared monotonic deadline helper.
- Add boundary tests for monotonic wait calculation and record the lesson for future lock timeout changes.

Fixes #304.
Fixes #305.
Fixes #306.

## Verification

- `./gradlew :bluetape4k-leader-exposed-jdbc:compileKotlin :bluetape4k-leader-exposed-jdbc:compileTestKotlin --no-build-cache --stacktrace`
- `./gradlew :bluetape4k-leader-exposed-jdbc:test --tests 'io.bluetape4k.leader.exposed.jdbc.lock.*' --no-build-cache --stacktrace`\n- `./gradlew :bluetape4k-leader-exposed-jdbc:test --tests 'io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderGroupElectionTest' --no-build-cache --stacktrace`\n- `./gradlew :bluetape4k-leader-exposed-jdbc:test --tests 'io.bluetape4k.leader.exposed.jdbc.lock.MonotonicDeadlineTest' --no-build-cache --stacktrace`\n- `./gradlew :bluetape4k-leader-exposed-jdbc:test --no-build-cache --stacktrace`\n\n## Review Notes\n\n- Claude advisor review: SHIP, no P0/P1 findings.\n- In-session review: no blocking findings; `git diff --check` clean.\n- Existing compile warnings remain in unrelated/pre-existing code: redundant `@ConsistentCopyVisibility` in `leader-core`, deprecated Exposed migration helper in `ExposedJdbcSchemaInitializer`.\n
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #304, #305, #306, milestone `0.1.1`, assignee `debop`
- PR: #317, head `9ed5cf4ca6c856659128ab2f0b76567babb2990d`, milestone `0.1.1`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
