### PR TITLE
fix: keep async acquisition waits off caller executors

### DIFF
--- a/docs/lessons/2026-05-20-async-acquisition-nonblocking.md
+++ b/docs/lessons/2026-05-20-async-acquisition-nonblocking.md
@@ -1,0 +1,42 @@
+# Async acquisition should keep caller executors free
+
+## Context
+
+Issue #320 tightened `CompletableFuture` leader acquisition after the
+monotonic-deadline fixes. Some async electors returned futures but still wrapped
+blocking `tryLock(waitTime, leaseTime)` loops in caller executors, so retry
+waits could occupy the supplied executor under contention.
+
+## Decision
+
+Describe this as a CPU-bounded async boundary, not IO-native non-blocking for
+every backend.
+
+- Lettuce single-leader acquisition can use native Lettuce async Redis commands.
+- MongoDB `MongoCollection` uses the sync driver here, so each database attempt
+  is still blocking I/O. Isolate those attempts on `VirtualThreadExecutor` and
+  schedule retry waits with `CompletableFuture.delayedExecutor`.
+- Do not claim Mongo sync-driver acquisition is IO non-blocking. The guarantee
+  is that caller-provided action executors are not retained by acquisition retry
+  sleeps.
+
+## Outcome
+
+`MongoLeaderElector`, `MongoLeaderGroupElector`, and `LettuceLeaderElector`
+async paths no longer wrap blocking wait-loop `tryLock` calls in caller
+executors. New contention tests use a single-thread caller executor and prove a
+marker task can run while acquisition waits for timeout.
+
+## Verification
+
+- `./gradlew :bluetape4k-leader-mongodb:compileKotlin :bluetape4k-leader-mongodb:compileTestKotlin --no-build-cache --stacktrace`
+- `./gradlew :bluetape4k-leader-redis-lettuce:compileKotlin :bluetape4k-leader-redis-lettuce:compileTestKotlin --no-build-cache --stacktrace`
+- `./gradlew :bluetape4k-leader-mongodb:test --no-build-cache --stacktrace`
+- `./gradlew :bluetape4k-leader-redis-lettuce:test --no-build-cache --stacktrace`
+
+## Future Guard
+
+When changing async leader-elector paths, check both the acquisition attempt and
+the retry wait. Virtual threads are acceptable for isolating sync-driver
+blocking I/O, but retry waits should use timer/delay mechanisms instead of
+sleeping inside caller executors.

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElector.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElector.kt
@@ -148,8 +148,8 @@ class MongoLeaderElector private constructor(
         validateMongoLockName(lockName)
         val lock = MongoLock(collection, lockName, options.retryDelay)
 
-        return CompletableFuture
-            .supplyAsync({ lock.tryLock(options.leaderOptions.waitTime, options.leaderOptions.leaseTime) }, executor)
+        return lock
+            .tryLockAsync(options.leaderOptions.waitTime, options.leaderOptions.leaseTime)
             .thenComposeAsync({ acquired ->
                 if (!acquired) {
                     log.debug { "리더 승격 실패 (슬롯 없음, 비동기). lockName=$lockName" }

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderGroupElector.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderGroupElector.kt
@@ -23,6 +23,7 @@ import java.util.Date
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import kotlin.random.Random
+import kotlin.time.Duration
 
 /**
  * Multi-leader group election implementation using a MongoDB slot-based distributed semaphore.
@@ -170,15 +171,7 @@ class MongoLeaderGroupElector private constructor(
         val perSlotWait = options.leaderGroupOptions.waitTime / maxLeaders
         val start = Random.nextInt(maxLeaders)
 
-        return CompletableFuture.supplyAsync({
-            (0 until maxLeaders)
-                .asSequence()
-                .map { i ->
-                    val slot = (start + i) % maxLeaders
-                    MongoLock(groupCollection, slotKey(lockName, slot), options.retryDelay) to slot
-                }
-                .firstOrNull { (lock, _) -> lock.tryLock(perSlotWait, leaseTime) }
-        }, executor).thenComposeAsync({ acquired ->
+        return acquireSlotAsync(lockName, start, perSlotWait, leaseTime).thenComposeAsync({ acquired ->
             if (acquired == null) {
                 log.debug { "리더 그룹 슬롯 획득 실패 (비동기). lockName=$lockName" }
                 CompletableFuture.completedFuture(null)
@@ -205,6 +198,32 @@ class MongoLeaderGroupElector private constructor(
                 }, executor)
             }
         }, executor)
+    }
+
+    private fun acquireSlotAsync(
+        lockName: String,
+        start: Int,
+        perSlotWait: Duration,
+        leaseTime: Duration,
+    ): CompletableFuture<Pair<MongoLock, Int>?> {
+        fun attempt(offset: Int): CompletableFuture<Pair<MongoLock, Int>?> {
+            if (offset >= maxLeaders) {
+                return CompletableFuture.completedFuture(null)
+            }
+
+            val slot = (start + offset) % maxLeaders
+            val lock = MongoLock(groupCollection, slotKey(lockName, slot), options.retryDelay)
+            return lock.tryLockAsync(perSlotWait, leaseTime)
+                .thenCompose { acquired ->
+                    if (acquired) {
+                        CompletableFuture.completedFuture(lock to slot)
+                    } else {
+                        attempt(offset + 1)
+                    }
+                }
+        }
+
+        return attempt(0)
     }
 }
 

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/lock/MongoLock.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/lock/MongoLock.kt
@@ -13,6 +13,7 @@ import com.mongodb.client.model.Indexes
 import com.mongodb.client.model.ReturnDocument
 import com.mongodb.client.model.Updates
 import io.bluetape4k.codec.Base58
+import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
 import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.remainingMinLeaseTime
 import io.bluetape4k.leader.mongodb.internal.MonotonicDeadline
@@ -22,13 +23,15 @@ import io.bluetape4k.logging.error
 import io.bluetape4k.logging.warn
 import org.bson.Document
 import java.time.Instant
+import java.util.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import java.util.*
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit
-import kotlin.random.Random
 
 /**
  * Token-based distributed lock backed by MongoDB `findOneAndUpdate` upsert + TTL index.
@@ -101,10 +104,17 @@ class MongoLock private constructor(
 
     internal val token: String = Base58.randomString(22)
 
+    private enum class AcquireResult {
+        ACQUIRED,
+        CONTENDED,
+        FAILED,
+    }
+
     /**
      * Attempts to acquire the lock within [waitTime]. Returns `true` on success, `false` on timeout or error.
      *
-     * This function never throws. All MongoDB exceptions are handled by returning `false`.
+     * This is a blocking API: retry waits use [Thread.sleep]. Use [tryLockAsync] from CompletableFuture paths so
+     * retry waits do not occupy executor threads.
      *
      * @param waitTime Maximum wait time for lock acquisition
      * @param leaseTime Maximum lock hold (TTL) duration
@@ -114,50 +124,13 @@ class MongoLock private constructor(
         val deadline = MonotonicDeadline.fromNow(waitTime)
 
         do {
-            val result: Document? = try {
-                collection.findOneAndUpdate(
-                    Filters.and(
-                        Filters.eq("_id", lockKey),
-                        Filters.lt("expireAt", Date())
-                    ),
-                    Updates.combine(
-                        Updates.set("token", token),
-                        Updates.set("expireAt", Date(System.currentTimeMillis() + leaseTime.inWholeMilliseconds))
-                    ),
-                    FindOneAndUpdateOptions().upsert(true).returnDocument(ReturnDocument.AFTER)
-                )
-            } catch (e: MongoCommandException) {
-                when (e.errorCode) {
-                    11000 -> null  // Duplicate Key — 유효한 락이 이미 존재, 재시도
-                    13, 18 -> {
-                        log.error(e) { "MongoDB 인증 오류 (code=${e.errorCode}) 발생: lockKey=$lockKey" }
-                        return false
-                    }
-                    else -> {
-                        log.warn(e) { "MongoDB 커맨드 오류 (code=${e.errorCode}) 발생: lockKey=$lockKey" }
-                        return false
-                    }
+            when (tryAcquireOnce(leaseTime)) {
+                AcquireResult.ACQUIRED -> {
+                    log.debug { "락 획득 성공: lockKey=$lockKey" }
+                    return true
                 }
-            } catch (e: MongoWriteException) {
-                if (e.code == 11000) null  // Duplicate Key — 재시도
-                else {
-                    log.warn(e) { "MongoDB 쓰기 오류 (code=${e.code}) 발생: lockKey=$lockKey" }
-                    return false
-                }
-            } catch (e: MongoTimeoutException) {
-                log.warn(e) { "MongoDB 타임아웃 발생: lockKey=$lockKey" }
-                return false
-            } catch (e: MongoSecurityException) {
-                log.error(e) { "MongoDB 보안 오류 발생: lockKey=$lockKey" }
-                return false
-            } catch (e: MongoException) {
-                log.warn(e) { "MongoDB 오류 발생: lockKey=$lockKey" }
-                return false
-            }
-
-            if (result?.getString("token") == token) {
-                log.debug { "락 획득 성공: lockKey=$lockKey" }
-                return true
+                AcquireResult.CONTENDED -> Unit
+                AcquireResult.FAILED -> return false
             }
 
             if (deadline.hasTimeRemaining()) {
@@ -172,6 +145,97 @@ class MongoLock private constructor(
 
         log.debug { "락 획득 실패 (타임아웃): lockKey=$lockKey" }
         return false
+    }
+
+    /**
+     * Attempts to acquire the lock without occupying [executor] threads for retry waits.
+     *
+     * The MongoDB sync driver still performs each individual database operation on [executor], which defaults to
+     * [VirtualThreadExecutor]. Retry delays are scheduled with [CompletableFuture.delayedExecutor] instead of
+     * sleeping inside the executor thread.
+     */
+    fun tryLockAsync(
+        waitTime: Duration,
+        leaseTime: Duration,
+        executor: Executor = VirtualThreadExecutor,
+    ): CompletableFuture<Boolean> {
+        val deadline = MonotonicDeadline.fromNow(waitTime)
+
+        fun attempt(): CompletableFuture<Boolean> {
+            return CompletableFuture.supplyAsync({ tryAcquireOnce(leaseTime) }, executor)
+                .thenCompose { result ->
+                    when (result) {
+                        AcquireResult.ACQUIRED -> {
+                            log.debug { "락 획득 성공 (async): lockKey=$lockKey" }
+                            CompletableFuture.completedFuture(true)
+                        }
+                        AcquireResult.FAILED -> CompletableFuture.completedFuture(false)
+                        AcquireResult.CONTENDED -> {
+                            if (!deadline.hasTimeRemaining()) {
+                                log.debug { "락 획득 실패 (타임아웃, async): lockKey=$lockKey" }
+                                CompletableFuture.completedFuture(false)
+                            } else {
+                                val jitter = Random.nextLong(1, retryDelay.inWholeMilliseconds.coerceAtLeast(2))
+                                val delayMillis = deadline.remainingMillisForDelay(jitter)
+                                val delayed = CompletableFuture.delayedExecutor(delayMillis, TimeUnit.MILLISECONDS)
+                                CompletableFuture.runAsync({}, delayed).thenCompose { attempt() }
+                            }
+                        }
+                    }
+                }
+        }
+
+        return attempt()
+    }
+
+    private fun tryAcquireOnce(leaseTime: Duration): AcquireResult {
+        val result: Document? = try {
+            collection.findOneAndUpdate(
+                Filters.and(
+                    Filters.eq("_id", lockKey),
+                    Filters.lt("expireAt", Date())
+                ),
+                Updates.combine(
+                    Updates.set("token", token),
+                    Updates.set("expireAt", Date(System.currentTimeMillis() + leaseTime.inWholeMilliseconds))
+                ),
+                FindOneAndUpdateOptions().upsert(true).returnDocument(ReturnDocument.AFTER)
+            )
+        } catch (e: MongoCommandException) {
+            return when (e.errorCode) {
+                11000 -> AcquireResult.CONTENDED  // Duplicate Key — 유효한 락이 이미 존재, 재시도
+                13, 18 -> {
+                    log.error(e) { "MongoDB 인증 오류 (code=${e.errorCode}) 발생: lockKey=$lockKey" }
+                    AcquireResult.FAILED
+                }
+                else -> {
+                    log.warn(e) { "MongoDB 커맨드 오류 (code=${e.errorCode}) 발생: lockKey=$lockKey" }
+                    AcquireResult.FAILED
+                }
+            }
+        } catch (e: MongoWriteException) {
+            return if (e.code == 11000) {
+                AcquireResult.CONTENDED  // Duplicate Key — 재시도
+            } else {
+                log.warn(e) { "MongoDB 쓰기 오류 (code=${e.code}) 발생: lockKey=$lockKey" }
+                AcquireResult.FAILED
+            }
+        } catch (e: MongoTimeoutException) {
+            log.warn(e) { "MongoDB 타임아웃 발생: lockKey=$lockKey" }
+            return AcquireResult.FAILED
+        } catch (e: MongoSecurityException) {
+            log.error(e) { "MongoDB 보안 오류 발생: lockKey=$lockKey" }
+            return AcquireResult.FAILED
+        } catch (e: MongoException) {
+            log.warn(e) { "MongoDB 오류 발생: lockKey=$lockKey" }
+            return AcquireResult.FAILED
+        }
+
+        return if (result?.getString("token") == token) {
+            AcquireResult.ACQUIRED
+        } else {
+            AcquireResult.CONTENDED
+        }
     }
 
     /**

--- a/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElectionTest.kt
+++ b/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElectionTest.kt
@@ -15,12 +15,14 @@ import io.bluetape4k.leader.mongodb.lock.MongoLock
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import java.util.concurrent.CompletionException
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
 
 class MongoLeaderElectionTest: AbstractMongoLeaderTest() {
 
@@ -253,6 +255,37 @@ class MongoLeaderElectionTest: AbstractMongoLeaderTest() {
         }.get(5, TimeUnit.SECONDS)
 
         result shouldBeEqualTo "async 성공"
+    }
+
+    @Test
+    fun `runAsyncIfLeader - 경합 retry 대기는 executor thread 를 점유하지 않는다`() {
+        val lockName = randomName()
+        val holderLock = MongoLock(lockCollection, lockName)
+        holderLock.tryLock(100.milliseconds, 2.seconds).shouldBeTrue()
+        val executor = Executors.newSingleThreadExecutor()
+        val election = MongoLeaderElector(
+            lockCollection,
+            MongoLeaderElectionOptions(
+                leaderOptions = LeaderElectionOptions(
+                    waitTime = 700.milliseconds,
+                    leaseTime = 2.seconds,
+                ),
+                retryDelay = 100.milliseconds,
+            )
+        )
+
+        try {
+            val contender = election.runAsyncIfLeader(lockName, executor) {
+                CompletableFuture.completedFuture("unexpected")
+            }
+            val marker = CompletableFuture.supplyAsync({ "executor-free" }, executor)
+
+            marker.get(300, TimeUnit.MILLISECONDS) shouldBeEqualTo "executor-free"
+            contender.get(2, TimeUnit.SECONDS).shouldBeNull()
+        } finally {
+            holderLock.unlock()
+            executor.shutdownNow()
+        }
     }
 
     @Test

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElector.kt
@@ -175,14 +175,9 @@ class LettuceLeaderElector @JvmOverloads constructor(
         lockName.requireNotBlank("lockName")
 
         val lock = LettuceLock(connection, lockName, options.leaseTime)
-        return CompletableFuture.supplyAsync({
-            val acquired = lock.tryLock(options.waitTime, options.leaseTime)
+        return lock.tryLockAsync(options.waitTime, options.leaseTime).thenComposeAsync({ acquired ->
             if (!acquired) {
                 log.debug { "리더 선출 실패 (슬롯 없음, async): lockName=$lockName" }
-            }
-            acquired
-        }, executor).thenCompose { acquired ->
-            if (!acquired) {
                 CompletableFuture.completedFuture(null)
             } else {
                 val startedAt = Instant.now()
@@ -204,35 +199,52 @@ class LettuceLeaderElector @JvmOverloads constructor(
                 val effectiveKey: LeaderHistoryKey? = key ?: record?.let { LeaderHistoryKey(lockName = lockName, token = token) }
 
                 log.debug { "리더 선출 성공 (async): lockName=$lockName" }
-                try {
-                    action().whenComplete { _, throwable ->
-                        watchdog.close()
-                        val finishedAt = Instant.now()
-                        val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
-                        when {
-                            throwable == null -> effectiveKey?.let { historyRecorder?.recordCompleted(it, finishedAt, durationMs) }
-                            throwable is java.util.concurrent.CancellationException -> { /* cancelled — no audit */ }
-                            else -> effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, throwable) }
-                        }
-                        runCatching {
-                            if (lock.isHeldByCurrentInstance()) {
-                                lock.unlock(options.minLeaseTime, acquiredAtNanos)
-                            }
-                        }.onFailure { log.warn(it) { "Fail to release lock. lockName=$lockName" } }
-                    }
+                val actionFuture: CompletableFuture<T> = try {
+                    action()
                 } catch (e: Throwable) {
-                    watchdog.close()
-                    val finishedAt = Instant.now()
-                    val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
-                    effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, e) }
-                    runCatching {
-                        if (lock.isHeldByCurrentInstance()) {
-                            lock.unlock(options.minLeaseTime, acquiredAtNanos)
-                        }
-                    }.onFailure { log.warn(it) { "Fail to release lock. lockName=$lockName" } }
-                    CompletableFuture.failedFuture(e)
+                    return@thenComposeAsync releaseAndPropagate<T>(
+                        lock, lockName, watchdog, acquiredAtNanos, effectiveKey, e, null
+                    )
+                }
+
+                actionFuture.handle<Pair<T?, Throwable?>> { value, error ->
+                    Pair(value, error)
+                }.thenCompose { (value, error) ->
+                    releaseAndPropagate(lock, lockName, watchdog, acquiredAtNanos, effectiveKey, error, value)
                 }
             }
+        }, executor)
+    }
+
+    private fun <T> releaseAndPropagate(
+        lock: LettuceLock,
+        lockName: String,
+        watchdog: AutoCloseable,
+        acquiredAtNanos: Long,
+        historyKey: LeaderHistoryKey?,
+        error: Throwable?,
+        value: T?,
+    ): CompletableFuture<T?> {
+        watchdog.close()
+        val finishedAt = Instant.now()
+        val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
+        when {
+            error == null -> historyKey?.let { historyRecorder?.recordCompleted(it, finishedAt, durationMs) }
+            error is java.util.concurrent.CancellationException -> { /* cancelled — no audit */ }
+            else -> historyKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, error) }
         }
+
+        return lock.unlockAsync(options.minLeaseTime, acquiredAtNanos)
+            .exceptionally { releaseError ->
+                log.warn(releaseError) { "Fail to release lock. lockName=$lockName" }
+                Unit
+            }
+            .thenCompose {
+                if (error != null) {
+                    CompletableFuture.failedFuture(error)
+                } else {
+                    CompletableFuture.completedFuture<T?>(value)
+                }
+            }
     }
 }

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElectionTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElectionTest.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.leader.LeaderElectionException
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
+import io.bluetape4k.leader.lettuce.lock.LettuceLock
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
@@ -19,6 +20,8 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 class LettuceLeaderElectionTest: AbstractLettuceLeaderTest() {
@@ -173,6 +176,33 @@ class LettuceLeaderElectionTest: AbstractLettuceLeaderTest() {
         }.get()
         r1 shouldBeEqualTo 1
         r2 shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `비동기 리더 선출 - 경합 retry 대기는 executor thread 를 점유하지 않는다`() {
+        val holderLock = LettuceLock(connection, lockName)
+        holderLock.tryLock(waitTime = 100.milliseconds, leaseTime = 2.seconds).shouldBeTrue()
+        val executor = Executors.newSingleThreadExecutor()
+        val contender = LettuceLeaderElector(
+            connection,
+            LeaderElectionOptions(
+                waitTime = 700.milliseconds,
+                leaseTime = 2.seconds,
+            )
+        )
+
+        try {
+            val result = contender.runAsyncIfLeader(lockName, executor) {
+                CompletableFuture.completedFuture("unexpected")
+            }
+            val marker = CompletableFuture.supplyAsync({ "executor-free" }, executor)
+
+            marker.get(300, TimeUnit.MILLISECONDS) shouldBeEqualTo "executor-free"
+            result.get(2, TimeUnit.SECONDS).shouldBeNull()
+        } finally {
+            holderLock.unlock()
+            executor.shutdownNow()
+        }
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary

Closes #320

PR #321의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: keep async acquisition waits off caller executors`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

- Fixes #320.
- Moves Lettuce single-leader async acquisition from blocking `tryLock(...)` wrapped in `CompletableFuture.supplyAsync` to the existing native async Lettuce lock path.
- Adds `MongoLock.tryLockAsync(...)` for `CompletableFuture` paths: sync-driver MongoDB attempts run on `VirtualThreadExecutor`, while retry waits use `CompletableFuture.delayedExecutor` instead of sleeping caller executors.
- Routes Mongo single/group async electors through async acquisition and adds contention tests proving the caller-supplied executor remains available during retry wait.
- Captures the terminology guard in `docs/lessons/2026-05-20-async-acquisition-nonblocking.md`.

## Terminology

This PR targets a CPU-bounded async boundary, not IO-native non-blocking for every backend.

- MongoDB still uses the sync driver in these APIs, so each database attempt remains blocking I/O isolated on virtual threads.
- Mongo retry waits are scheduled and do not occupy caller executors.
- Lettuce uses native async Redis commands where available.

## Verification

- [x] `./gradlew :bluetape4k-leader-mongodb:compileKotlin :bluetape4k-leader-mongodb:compileTestKotlin :bluetape4k-leader-redis-lettuce:compileKotlin :bluetape4k-leader-redis-lettuce:compileTestKotlin :bluetape4k-leader-mongodb:test :bluetape4k-leader-redis-lettuce:test --no-build-cache --no-parallel --stacktrace`
  - MongoDB module: 121 passing.
  - Lettuce was initially up-to-date in the combined invocation.
- [x] `./gradlew :bluetape4k-leader-redis-lettuce:test --rerun-tasks --no-build-cache --no-parallel --stacktrace`
  - Lettuce module: 213 passing.
- [x] `git diff --check`
- [x] Static grep: no async elector path wraps blocking `tryLock` in `CompletableFuture.supplyAsync`; remaining `supplyAsync` is the Mongo sync-driver attempt isolated in `MongoLock.tryLockAsync`.

## Review Notes

- IntelliJ diagnostics were not available because this worktree project is not open in IntelliJ.
- Codex CLI review was skipped per user instruction for this session.
- Claude CLI review was attempted but timed out without producing findings; local Tier-4 review found no P0/P1 issues.

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #320, milestone `0.1.1`, assignee `debop`
- PR: #321, head `9dbc42b7445e450b5d06cd3b1af6b45e6d246160`, milestone `0.1.1`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
