### PR TITLE
fix: add overflow saturation guard to ExposedJdbc MonotonicDeadline

### DIFF
--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/MonotonicDeadline.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/MonotonicDeadline.kt
@@ -34,8 +34,15 @@ internal class MonotonicDeadline private constructor(
             waitTime: Duration,
             ticker: () -> Long = System::nanoTime,
         ): MonotonicDeadline {
+            val now = ticker()
             val timeoutNanos = waitTime.inWholeNanoseconds.coerceAtLeast(0L)
-            return MonotonicDeadline(ticker() + timeoutNanos, ticker)
+            val deadlineNanos =
+                if (Long.MAX_VALUE - timeoutNanos < now) {
+                    Long.MAX_VALUE
+                } else {
+                    now + timeoutNanos
+                }
+            return MonotonicDeadline(deadlineNanos, ticker)
         }
     }
 }

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/MonotonicDeadlineTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/MonotonicDeadlineTest.kt
@@ -54,4 +54,19 @@ class MonotonicDeadlineTest {
         deadline.remainingMillisForSleep() shouldBeEqualTo 0L
         deadline.hasTimeRemaining().shouldBeFalse()
     }
+
+    @Test
+    fun `fromNow - huge wait time saturates deadline instead of overflowing`() {
+        var tickerNanos = Long.MAX_VALUE - 10L
+        val deadline = MonotonicDeadline.fromNow(100.milliseconds) { tickerNanos }
+
+        deadline.remainingNanos() shouldBeEqualTo 10L
+        deadline.remainingMillisForSleep() shouldBeEqualTo 1L
+        deadline.hasTimeRemaining().shouldBeTrue()
+
+        tickerNanos += 10L
+
+        deadline.remainingNanos() shouldBeEqualTo 0L
+        deadline.hasTimeRemaining().shouldBeFalse()
+    }
 }


### PR DESCRIPTION
## Summary

PR #322의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: add overflow saturation guard to ExposedJdbc MonotonicDeadline`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Problem

`ExposedJdbcLock.tryLock` and `ExposedJdbcGroupLock.tryLock` could silently skip
their entire wait budget on long-running JVMs where `System.nanoTime()` is close
to `Long.MAX_VALUE`.

`MonotonicDeadline.fromNow` computed the deadline as:

```kotlin
MonotonicDeadline(ticker() + timeoutNanos, ticker)
```

When `ticker()` is near `Long.MAX_VALUE` the addition overflows to a large
negative number. `hasTimeRemaining()` returns `false` immediately, so every
`tryLock` call returns without acquiring the lock — with no error and no log.

## Root Cause

The sibling `leader-redis-lettuce` and `leader-mongodb` backends already apply a
saturation guard (introduced in the same bug-fix round). The `leader-exposed-jdbc`
variant introduced in the same commit was not brought to parity.

## Fix

Apply `Long.MAX_VALUE` saturation in `MonotonicDeadline.fromNow`, matching the
Lettuce and MongoDB implementations exactly:

```kotlin
val deadlineNanos =
    if (Long.MAX_VALUE - timeoutNanos < now) {
        Long.MAX_VALUE
    } else {
        now + timeoutNanos
    }
```

## Test

Added overflow saturation test to `MonotonicDeadlineTest` mirroring the tests
already present in `leader-redis-lettuce` and `leader-mongodb`.

## Verification

```
./gradlew :bluetape4k-leader-exposed-jdbc:test \
    --tests "io.bluetape4k.leader.exposed.jdbc.lock.MonotonicDeadlineTest"
```

Detected by automated daily review job (2026-05-21).

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #322, head `3bd379a9ebb6ebd0864edce642aca080395caa96`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
