### PR TITLE
fix: upgrade KubernetesLeaseLockExtendDelegate to SuspendExtendDelegate

### DIFF
--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseSuspendLeaderElector.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseSuspendLeaderElector.kt
@@ -123,9 +123,9 @@ class KubernetesLeaseSuspendLeaderElector @JvmOverloads constructor(
                 try {
                     lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos)
                     log.debug { "Kubernetes Lease released (suspend). lockName=$lockName" }
-                } catch (e: CancellationException) {
-                    throw e
                 } catch (e: Exception) {
+                    // Inside NonCancellable, CancellationException from the backend is a backend error,
+                    // not coroutine cancellation. Log and swallow to complete cleanup.
                     log.warn(e) { "Failed to release Kubernetes Lease (suspend). lockName=$lockName" }
                 }
             }

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/internal/KubernetesLeaseLockExtendDelegate.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/internal/KubernetesLeaseLockExtendDelegate.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.leader.k8s.internal
 
 import io.bluetape4k.leader.ExtendOutcome
-import io.bluetape4k.leader.internal.ExtendDelegate
+import io.bluetape4k.leader.internal.SuspendExtendDelegate
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
@@ -10,13 +10,27 @@ import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 
+/**
+ * Extend delegate for the Kubernetes Lease backend.
+ *
+ * ## Behavior / Contract
+ *
+ * Implements [SuspendExtendDelegate] so that [io.bluetape4k.leader.LeaderLeaseAutoExtender] selects
+ * the suspend watchdog overload and dispatches all Fabric8 I/O into [Dispatchers.IO].
+ *
+ * The sync [extend] and [isHeld] overrides keep the blocking elector ([KubernetesLeaseLeaderElector])
+ * functional without going through `runBlocking`.
+ */
 internal class KubernetesLeaseLockExtendDelegate(
     private val lock: KubernetesLeaseLock,
-) : ExtendDelegate {
+) : SuspendExtendDelegate {
     private val lastDeadline = AtomicReference(Instant.EPOCH)
 
     override val lastExtendDeadline: AtomicReference<Instant> get() = lastDeadline
 
+    // Overridden explicitly so that the blocking elector (KubernetesLeaseLeaderElector) continues to
+    // call Fabric8 I/O correctly. SuspendExtendDelegate.extend() defaults to BackendError, which
+    // would break the sync watchdog.
     override fun extend(lockAtMostFor: Duration): ExtendOutcome =
         lock.extendDetailed(lockAtMostFor)
 
@@ -27,6 +41,12 @@ internal class KubernetesLeaseLockExtendDelegate(
         }
     }
 
+    // Overridden explicitly for the same reason as extend() above.
     override fun isHeld(): Boolean =
         lock.isHeldByCurrentInstance()
+
+    override suspend fun isHeldSuspend(): Boolean =
+        withContext(Dispatchers.IO) {
+            lock.isHeldByCurrentInstance()
+        }
 }


### PR DESCRIPTION
## Summary

Related to #349

PR #346의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: upgrade KubernetesLeaseLockExtendDelegate to SuspendExtendDelegate`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Fixes a bug where `KubernetesLeaseLockExtendDelegate` implemented `ExtendDelegate`
instead of `SuspendExtendDelegate`. This caused `LeaderLeaseAutoExtender` to select
the **sync** watchdog overload, dispatching blocking Fabric8 HTTP I/O directly onto the
shared `ScheduledThreadPoolExecutor` watchdog thread rather than `Dispatchers.IO`.

### Root Cause

Every other suspend backend (`LettuceSuspendLockExtendDelegate`,
`RedissonSuspendLockExtendDelegate`, `MongoSuspendLockExtendDelegate`,
`HazelcastSuspendLockExtendDelegate`, `ExposedR2dbcSuspendLockExtendDelegate`) implements
`SuspendExtendDelegate`. The Kubernetes backend missed this, causing the wrong watchdog
overload to be selected and blocking the watchdog scheduler thread pool.

Secondary consequence: `LeaderLockHandle.Real.isStillHeldSuspend()` fell back to blocking
`isHeld()` instead of the coroutine-safe `isHeldSuspend()`.

### Changes

**`KubernetesLeaseLockExtendDelegate`**
- Now implements `SuspendExtendDelegate` instead of `ExtendDelegate`
- Adds `isHeldSuspend()` backed by `withContext(Dispatchers.IO)`
- Overrides `extend()` and `isHeld()` explicitly so `KubernetesLeaseLeaderElector`
  (blocking elector) continues to work without change

**`KubernetesLeaseSuspendLeaderElector`**
- Removes spurious `catch (e: CancellationException) { throw e }` inside the
  `withContext(NonCancellable)` cleanup block. Inside `NonCancellable`, a
  `CancellationException` from the backend is a backend error, not coroutine
  cancellation — it should be logged and swallowed to complete cleanup.

## Test Plan

- `KubernetesLeaseSuspendLeaderElectorK3sTest` — existing K3s integration tests cover
  the acquire/release path through the corrected watchdog overload
- `KubernetesLeaseLeaderElectorK3sTest` — blocking elector unchanged; sync extend/isHeld
  still routes through the explicit overrides

## Verification

Detected by automated daily code review (scheduled job, 2026-05-22).
CI must pass before merge.

## Linked Issues
- Related to #349: watchdog auto-extend behavior covered by the Kubernetes suspend K3s test follow-up.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #349, milestone `0.2.0`, assignee `debop`
- PR: #346, head `d53cac3b62dfae8e54b852b462dc3afbddf70363`, milestone `0.2.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
