### PR TITLE
fix: replace runCatching with try/catch in suspend DynamoDB leader electors

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -53,5 +53,5 @@ centralSnapshotsParallelism=4
 # project version
 #
 projectGroup=io.github.bluetape4k.leader
-baseVersion=0.2.1
-snapshotVersion=
+baseVersion=0.2.2
+snapshotVersion=-SNAPSHOT

--- a/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbSuspendLeaderElector.kt
+++ b/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbSuspendLeaderElector.kt
@@ -119,10 +119,14 @@ class DynamoDbSuspendLeaderElector(
             runCatching { watchdog.close() }
                 .onFailure { e -> log.warn(e) { "DynamoDB suspend leader watchdog close failed. lockName=$lockName" } }
             withContext(NonCancellable) {
-                runCatching {
+                try {
                     lockClient.releaseAsync(lock, options.leaderOptions.minLeaseTime, acquiredAtNanos)
                         .awaitWithoutCancellingFuture { }
-                }.onFailure { e -> log.warn(e) { "DynamoDB suspend leader release failed. lockName=$lockName" } }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log.warn(e) { "DynamoDB suspend leader release failed. lockName=$lockName" }
+                }
             }
         }
     }

--- a/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbSuspendLeaderGroupElector.kt
+++ b/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbSuspendLeaderGroupElector.kt
@@ -136,10 +136,12 @@ class DynamoDbSuspendLeaderGroupElector(
                         log.warn(e) { "DynamoDB suspend group watchdog close failed. lockName=$lockName, slot=$slot" }
                     }
                 withContext(NonCancellable) {
-                    runCatching {
+                    try {
                         lockClient.releaseAsync(lock, options.leaderGroupOptions.minLeaseTime, acquiredAtNanos)
                             .awaitWithoutCancellingFuture { }
-                    }.onFailure { e ->
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
                         log.warn(e) { "DynamoDB suspend group slot release failed. lockName=$lockName, slot=$slot" }
                     }
                 }


### PR DESCRIPTION
## Summary

PR #364의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: replace runCatching with try/catch in suspend DynamoDB leader electors`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Replace `runCatching {}` wrapping suspend calls with explicit `try/catch` in both DynamoDB suspend leader electors.

## Problem

`runCatching {}` around suspend calls can swallow `CancellationException`, violating the project's coroutine contract (CLAUDE.md: "Do not use `runCatching {}` around suspend calls; it can swallow cancellation").

Affected files:
- `DynamoDbSuspendLeaderElector.kt` — `withContext(NonCancellable)` release block
- `DynamoDbSuspendLeaderGroupElector.kt` — `withContext(NonCancellable)` release block

## Fix

Replace with `try/catch` that explicitly rethrows `CancellationException` before the broad `Exception` handler. Reference pattern: `DynamoDbSuspendLockExtendDelegate.extendSuspend`.

## Verification

```
./gradlew :bluetape4k-leader-dynamodb:compileKotlin
```
Compilation clean (no errors, no new warnings).

## Related

Found during automated daily org scan code review of `leader-dynamodb` module (commit `1b3ad7e`).
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #364, head `d7bf9927e5fd4c150550e873053b49cb9ac82650`, milestone `0.2.2`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
