### PR TITLE
refactor: share DynamoDB Local test launcher

### DIFF
--- a/docs/lessons/2026-05-24-issue-367-dynamodb-local-launcher.md
+++ b/docs/lessons/2026-05-24-issue-367-dynamodb-local-launcher.md
@@ -1,0 +1,42 @@
+# Issue 367 DynamoDB Local Launcher
+
+## Context
+
+`leader-dynamodb` carried a private `DynamoDbLocalContainer` even after the
+shared `DynamoDbLocalServer` fixture was added to `bluetape4k-testcontainers`.
+
+## Decision
+
+Consume the `1.9.2-SNAPSHOT` bluetape4k catalog and use
+`DynamoDbLocalServer.Launcher.dynamoDb` from the integration test base.
+
+## Outcome
+
+The leader repository no longer duplicates the DynamoDB Local image, port, and
+command wiring. Test lifecycle now follows the shared launcher pattern, where
+the singleton container is registered in `ShutdownQueue` and client resources
+remain owned by the leader tests.
+
+The temporary `1.9.2-SNAPSHOT` catalog is acceptable for this branch because the
+root build already sets `resolutionStrategy.cacheChangingModulesFor(0,
+TimeUnit.SECONDS)`. No matching `bluetape4k-exposed 1.9.2-SNAPSHOT` existed at
+implementation time, so exposed-module binary compatibility was checked by
+compiling the exposed leader test sources with the current catalog pair.
+`DynamoDbLocalServer` still pins `amazon/dynamodb-local:2.6.1`, matching the
+private container it replaces.
+
+## Verification
+
+- `./gradlew :bluetape4k-leader-dynamodb:compileTestKotlin --refresh-dependencies --no-configuration-cache`
+- `./gradlew :bluetape4k-leader-dynamodb:test --tests 'io.bluetape4k.leader.dynamodb.DynamoDbLeaderElectorIntegrationTest' --no-configuration-cache`
+- `./gradlew :bluetape4k-leader-exposed-core:compileTestKotlin :bluetape4k-leader-exposed-jdbc:compileTestKotlin :bluetape4k-leader-exposed-r2dbc:compileTestKotlin --no-configuration-cache`
+
+## Future Guard
+
+Before replacing private test containers with shared launchers, verify the
+snapshot or release artifact contains the new helper class. Snapshot metadata can
+exist before the latest develop merge has been published.
+
+Before cutting the next leader release, re-pin `bluetape4k` from
+`1.9.2-SNAPSHOT` to the corresponding GA catalog and align `bluetape4k-exposed`
+when its matching version exists.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k = "1.9.1"  # https://central.sonatype.com/artifact/io.github.bluetape4k/bluetape4k-bom
+bluetape4k = "1.9.2-SNAPSHOT"  # https://central.sonatype.com/artifact/io.github.bluetape4k/bluetape4k-bom
 bluetape4k-exposed = "1.9.1"  # https://mvnrepository.com/artifact/io.github.bluetape4k.exposed/bluetape4k-exposed-bom
 
 kotlin = "2.3.21"  # https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-bom

--- a/leader-dynamodb/src/test/kotlin/io/bluetape4k/leader/dynamodb/AbstractDynamoDbLeaderTest.kt
+++ b/leader-dynamodb/src/test/kotlin/io/bluetape4k/leader/dynamodb/AbstractDynamoDbLeaderTest.kt
@@ -1,12 +1,11 @@
 package io.bluetape4k.leader.dynamodb
 
 import io.bluetape4k.codec.Base58
+import io.bluetape4k.testcontainers.aws.DynamoDbLocalServer
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.TestInstance
-import org.testcontainers.containers.GenericContainer
-import org.testcontainers.utility.DockerImageName
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
@@ -19,16 +18,13 @@ import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement
 import software.amazon.awssdk.services.dynamodb.model.KeyType
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType
 import software.amazon.awssdk.services.dynamodb.model.TimeToLiveSpecification
-import java.net.URI
 
 @Tag("integration")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 abstract class AbstractDynamoDbLeaderTest {
 
     companion object {
-        private const val DYNAMODB_PORT = 8000
-
-        private val container = DynamoDbLocalContainer()
+        private val container = DynamoDbLocalServer.Launcher.dynamoDb
         private lateinit var syncClient: DynamoDbClient
         private lateinit var asyncClient: DynamoDbAsyncClient
         private lateinit var sharedTableName: String
@@ -36,18 +32,20 @@ abstract class AbstractDynamoDbLeaderTest {
         @BeforeAll
         @JvmStatic
         fun startDynamoDb() {
-            container.start()
-            val endpoint = URI.create("http://${container.host}:${container.getMappedPort(DYNAMODB_PORT)}")
-            val credentials = StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test"))
+            val endpoint = container.awsEndpoint
+            val credentials = StaticCredentialsProvider.create(
+                AwsBasicCredentials.create(container.awsAccessKey, container.awsSecretKey),
+            )
+            val region = Region.of(container.regionName)
             syncClient = DynamoDbClient.builder()
                 .endpointOverride(endpoint)
                 .credentialsProvider(credentials)
-                .region(Region.US_EAST_1)
+                .region(region)
                 .build()
             asyncClient = DynamoDbAsyncClient.builder()
                 .endpointOverride(endpoint)
                 .credentialsProvider(credentials)
-                .region(Region.US_EAST_1)
+                .region(region)
                 .build()
             sharedTableName = "leader_${Base58.randomString(12)}"
             createTable(syncClient, sharedTableName)
@@ -62,7 +60,6 @@ abstract class AbstractDynamoDbLeaderTest {
             if (::syncClient.isInitialized) {
                 syncClient.close()
             }
-            container.stop()
         }
 
         private fun createTable(client: DynamoDbClient, tableName: String) {
@@ -109,11 +106,4 @@ abstract class AbstractDynamoDbLeaderTest {
     protected fun randomName(): String =
         "leader-test-${Base58.randomString(8)}"
 
-    private class DynamoDbLocalContainer :
-        GenericContainer<DynamoDbLocalContainer>(DockerImageName.parse("amazon/dynamodb-local:2.6.1")) {
-        init {
-            withExposedPorts(DYNAMODB_PORT)
-            withCommand("-jar", "DynamoDBLocal.jar", "-inMemory", "-sharedDb")
-        }
-    }
 }


### PR DESCRIPTION
## Summary

Closes #367

PR #370의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `refactor: share DynamoDB Local test launcher`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
Closes #367.

## Summary

- Bump the bluetape4k catalog to `1.9.2-SNAPSHOT` so leader can consume the new shared `DynamoDbLocalServer` fixture.
- Replace the private `DynamoDbLocalContainer` in `AbstractDynamoDbLeaderTest` with `DynamoDbLocalServer.Launcher.dynamoDb`.
- Keep AWS endpoint, credentials, region, image, and lifecycle ownership in the shared testcontainers helper.
- Add a lesson documenting the transitional SNAPSHOT state and release-time GA re-pin requirement.

## Snapshot / Compatibility Notes

- Verified Maven Central snapshot `bluetape4k-testcontainers:1.9.2-20260524.020928-2` contains `io/bluetape4k/testcontainers/aws/DynamoDbLocalServer.class`.
- Root build already sets `resolutionStrategy.cacheChangingModulesFor(0, TimeUnit.SECONDS)`, so changing SNAPSHOT modules are not cached across resolutions.
- `DynamoDbLocalServer` pins `amazon/dynamodb-local:2.6.1`, matching the private fixture this PR removes.
- No `bluetape4k-exposed 1.9.2-SNAPSHOT` exists yet; current `bluetape4k-exposed 1.9.1` compatibility was checked by compiling the exposed leader test sources.
- Before the next leader release, re-pin `bluetape4k` to the matching GA catalog and align `bluetape4k-exposed` when available.

## Verification

- `./gradlew :bluetape4k-leader-dynamodb:compileTestKotlin --refresh-dependencies --no-configuration-cache`
- `./gradlew :bluetape4k-leader-dynamodb:test --tests 'io.bluetape4k.leader.dynamodb.DynamoDbLeaderElectorIntegrationTest' --no-configuration-cache`
- `./gradlew :bluetape4k-leader-exposed-core:compileTestKotlin :bluetape4k-leader-exposed-jdbc:compileTestKotlin :bluetape4k-leader-exposed-r2dbc:compileTestKotlin --no-configuration-cache`
- `git diff --check`
- Claude advisor rerun artifact: `.omx/artifacts/claude-issue-367-dynamodb-local-launcher-rerun-20260524112011.md` (`P0=0`, `P1=0`)

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #367, milestone `0.2.2`, assignee `debop`
- PR: #370, head `c2a519e9c927e75e182376d42aae3bf56b82984f`, milestone `0.2.2`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
