### PR TITLE
docs: add Configuration section to leader-consul README and clarify etcd cleanup timeout

### DIFF
--- a/leader-consul/README.ko.md
+++ b/leader-consul/README.ko.md
@@ -87,6 +87,42 @@ bluetape4k:
       lock-delay: 0s
 ```
 
+## Configuration
+
+### `ConsulEndpoint`
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `baseUrl` | `URI` | — | Consul HTTP API base URL, 예: `http://localhost:8500` |
+| `datacenter` | `String?` | `null` | 선택적 target datacenter |
+| `aclToken` | `String?` | `null` | 모든 요청에 전송되는 선택적 ACL token |
+| `requestTimeout` | `Duration` | `5.seconds` | 요청당 HTTP 타임아웃. lock acquire, 상태 읽기, session 갱신, lock 해제, session 삭제 등 모든 blocking wait 을 제어합니다. |
+
+### `ConsulLeaderElectionOptions`
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `leaderOptions.waitTime` | `Duration` | `5.seconds` | lock 획득 최대 시간 예산 |
+| `leaderOptions.leaseTime` | `Duration` | `60.seconds` | Consul Session TTL. `[10.seconds, 86_400.seconds]` 범위 필수. |
+| `leaderOptions.nodeId` | `String` | 프로세스 기본값 | core 계약과 공유되는 감사 노드 ID |
+| `leaderOptions.minLeaseTime` | `Duration` | `0.seconds` | 빠른 action 이후 최소 리더십 유지 시간 |
+| `leaderOptions.autoExtend` | `Boolean` | `false` | action 실행 중 Consul session 자동 갱신 여부 |
+| `keyPrefix` | `String` | `bluetape4k/leader` | Consul KV key prefix |
+| `sessionNamePrefix` | `String` | `bluetape4k-leader` | 생성되는 Consul session 이름 prefix |
+| `lockDelay` | `Duration` | `0.seconds` | Consul session lock delay. 0이면 TTL 만료 후 즉시 재획득 가능. 중복 실행이 안전하지 않은 경우 idempotent action 또는 외부 fencing token 을 사용하세요. |
+
+### `ConsulLeaderGroupElectionOptions`
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `leaderGroupOptions.maxLeaders` | `Int` | `2` | 동시 group leader 최대 수 |
+| `leaderGroupOptions.waitTime` | `Duration` | `5.seconds` | group slot 획득 최대 시간 예산 |
+| `leaderGroupOptions.leaseTime` | `Duration` | `60.seconds` | group slot 용 Consul Session TTL. `[10.seconds, 86_400.seconds]` 범위 필수. |
+| `leaderGroupOptions.minLeaseTime` | `Duration` | `0.seconds` | 빠른 action 이후 최소 group-slot 유지 시간 |
+| `keyPrefix` | `String` | `bluetape4k/leader` | group lock key 용 Consul KV key prefix |
+| `sessionNamePrefix` | `String` | `bluetape4k-leader` | 생성되는 Consul session 이름 prefix |
+| `lockDelay` | `Duration` | `0.seconds` | `ConsulLeaderElectionOptions.lockDelay` 참조 |
+
 ## Dependency
 
 ```kotlin

--- a/leader-consul/README.md
+++ b/leader-consul/README.md
@@ -88,6 +88,42 @@ bluetape4k:
       lock-delay: 0s
 ```
 
+## Configuration
+
+### `ConsulEndpoint`
+
+| Property | Type | Default | Description |
+| --- | --- | --- | --- |
+| `baseUrl` | `URI` | — | Consul HTTP API base URL, e.g. `http://localhost:8500` |
+| `datacenter` | `String?` | `null` | Optional target datacenter |
+| `aclToken` | `String?` | `null` | Optional ACL token sent with every request |
+| `requestTimeout` | `Duration` | `5.seconds` | Per-request HTTP timeout. Governs all blocking waits: lock acquire, state read, session renew, lock release, and session destroy. |
+
+### `ConsulLeaderElectionOptions`
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `leaderOptions.waitTime` | `Duration` | `5.seconds` | Maximum time budget for lock acquisition |
+| `leaderOptions.leaseTime` | `Duration` | `60.seconds` | Consul Session TTL. Must be in `[10.seconds, 86_400.seconds]`. |
+| `leaderOptions.nodeId` | `String` | process-level default | Audit node ID shared with core contracts |
+| `leaderOptions.minLeaseTime` | `Duration` | `0.seconds` | Minimum leadership hold time after quick actions |
+| `leaderOptions.autoExtend` | `Boolean` | `false` | Renews the Consul session while the action runs |
+| `keyPrefix` | `String` | `bluetape4k/leader` | Consul KV key prefix |
+| `sessionNamePrefix` | `String` | `bluetape4k-leader` | Prefix for created Consul session names |
+| `lockDelay` | `Duration` | `0.seconds` | Consul session lock delay. Zero allows immediate reacquire after TTL expiry; use idempotent actions or external fencing tokens when duplicate execution is unsafe. |
+
+### `ConsulLeaderGroupElectionOptions`
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `leaderGroupOptions.maxLeaders` | `Int` | `2` | Maximum number of concurrent group leaders |
+| `leaderGroupOptions.waitTime` | `Duration` | `5.seconds` | Maximum time budget for group slot acquisition |
+| `leaderGroupOptions.leaseTime` | `Duration` | `60.seconds` | Consul Session TTL for group slots. Must be in `[10.seconds, 86_400.seconds]`. |
+| `leaderGroupOptions.minLeaseTime` | `Duration` | `0.seconds` | Minimum group-slot hold time after quick actions |
+| `keyPrefix` | `String` | `bluetape4k/leader` | Consul KV key prefix for group lock keys |
+| `sessionNamePrefix` | `String` | `bluetape4k-leader` | Prefix for created Consul session names |
+| `lockDelay` | `Duration` | `0.seconds` | See `ConsulLeaderElectionOptions.lockDelay`. |
+
 ## Dependency
 
 ```kotlin

--- a/leader-etcd/README.ko.md
+++ b/leader-etcd/README.ko.md
@@ -127,8 +127,8 @@ publisher.events.collect { event ->
 | 옵션 | 타입 | 기본값 | 설명 |
 | --- | --- | --- | --- |
 | `keyPrefix` | `String` | `/bluetape4k/leader` | lock key 를 저장할 absolute etcd key prefix |
-| `retryDelay` | `Duration` | `50.milliseconds` | jetcd queued lock 을 직접 쓰지 않는 retry API 용 예약 옵션 |
-| `leaderOptions.waitTime` | `Duration` | `5.seconds` | lease grant 와 lock 획득 전체 최대 대기 시간 |
+| `retryDelay` | `Duration` | `50.milliseconds` | cleanup wait floor: unlock 과 lease revoke 는 `max(waitTime, retryDelay)` 만큼 대기. jetcd queued lock 외 retry API 용 예약 옵션이기도 함. |
+| `leaderOptions.waitTime` | `Duration` | `5.seconds` | lease grant, lock 획득, cleanup (unlock/lease revoke 는 `max(waitTime, retryDelay)` 대기) 전체 최대 시간 예산 |
 | `leaderOptions.leaseTime` | `Duration` | `60.seconds` | etcd lease TTL |
 | `leaderOptions.nodeId` | `String` | process-level default | core 계약과 공유하는 audit node id |
 | `leaderOptions.minLeaseTime` | `Duration` | `0.seconds` | 빠른 action 뒤 최소 leadership 유지 시간 |

--- a/leader-etcd/README.md
+++ b/leader-etcd/README.md
@@ -129,8 +129,8 @@ publisher.events.collect { event ->
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
 | `keyPrefix` | `String` | `/bluetape4k/leader` | Absolute etcd key prefix for lock keys |
-| `retryDelay` | `Duration` | `50.milliseconds` | Reserved for retrying APIs that do not use jetcd queued locks directly |
-| `leaderOptions.waitTime` | `Duration` | `5.seconds` | Maximum time budget for lease grant plus lock acquisition |
+| `retryDelay` | `Duration` | `50.milliseconds` | Cleanup wait floor: unlock and lease revoke block for `max(waitTime, retryDelay)`. Also reserved for retrying APIs outside jetcd queued locks. |
+| `leaderOptions.waitTime` | `Duration` | `5.seconds` | Maximum time budget for lease grant, lock acquisition, and cleanup (unlock and lease revoke block for `max(waitTime, retryDelay)`) |
 | `leaderOptions.leaseTime` | `Duration` | `60.seconds` | etcd lease TTL |
 | `leaderOptions.nodeId` | `String` | process-level default | Audit node id shared with core contracts |
 | `leaderOptions.minLeaseTime` | `Duration` | `0.seconds` | Minimum leadership hold time after quick actions |


### PR DESCRIPTION
## Summary

PR #388의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `docs: add Configuration section to leader-consul README and clarify etcd cleanup timeout`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Add a `## Configuration` section to `leader-consul/README.md` (and `README.ko.md`) documenting the three configuration types that were missing from module documentation:

- `ConsulEndpoint` — all four properties including `requestTimeout` which now governs all blocking Consul waits after [#372](https://github.com/bluetape4k/bluetape4k-leader/issues/372)
- `ConsulLeaderElectionOptions` — all election options with Consul-specific constraints (Session TTL range, lockDelay semantics)
- `ConsulLeaderGroupElectionOptions` — all group election options

Update `leader-etcd/README.md` (and `README.ko.md`) configuration table to reflect that `waitTime` and `retryDelay` jointly govern the cleanup wait budget (`max(waitTime, retryDelay)`) after [#373](https://github.com/bluetape4k/bluetape4k-leader/issues/373).

## Changed files

| File | Change |
|------|--------|
| `leader-consul/README.md` | Added `## Configuration` section (3 tables) |
| `leader-consul/README.ko.md` | Same in Korean |
| `leader-etcd/README.md` | Updated `retryDelay` and `leaderOptions.waitTime` descriptions |
| `leader-etcd/README.ko.md` | Same in Korean |

## Verification

```
git diff --check  # no whitespace errors
```

Documentation-only change; no compilation or test run required.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #388, head `8bfc21f62be47b11c79487e6cc88a400d6ec686a`, milestone `0.2.2`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
