### PR TITLE
chore: resolve Dependabot security dependency alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Updated the `bluetape4k-exposed` test helper reference from `1.9.2-SNAPSHOT`
   to the published `1.9.2` release.
+- Aligned the AWS SDK BOM with the central `bluetape4k-dependencies` catalog.
+
+### Fixed
+
+- Applied central catalog-managed Netty 4.1, Protobuf, Fabric8, and Vert.x 4
+  dependency overrides for Dependabot security alerts. (#389)
 
 ---
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -257,15 +257,36 @@ subprojects {
             mavenBom(rootLibs.micrometer.bom.get().toString())
             mavenBom(rootLibs.testcontainers.bom.get().toString())
             mavenBom(rootLibs.aws2.bom.get().toString())
+            mavenBom("io.netty:netty-bom:${bt4kVersion("netty")}")
+            mavenBom("com.google.protobuf:protobuf-bom:${bt4kVersion("protobuf")}")
+            mavenBom("io.vertx:vertx-dependencies:${bt4kVersion("vertx")}")
         }
     
         dependencies {
             dependency("com.hazelcast:hazelcast:${bt4kVersion("hazelcast")}")
+            dependency("com.google.protobuf:protobuf-java:${bt4kVersion("protobuf")}")
+            dependency("io.netty:netty-codec-http:${bt4kVersion("netty")}")
+            dependency("io.netty:netty-codec-http2:${bt4kVersion("netty")}")
+            dependency("io.vertx:vertx-core:${bt4kVersion("vertx")}")
             dependency("com.mysql:mysql-connector-j:${bt4kVersion("mysql-connector-j")}")
             dependency("org.postgresql:postgresql:${bt4kVersion("postgresql")}")
             dependency("io.r2dbc:r2dbc-h2:${bt4kVersion("r2dbc-h2")}")
             dependency("org.redisson:redisson:${bt4kVersion("redisson")}")
             dependency("org.slf4j:slf4j-api:${bt4kVersion("slf4j")}")
+        }
+    }
+
+    if (path in setOf(":bluetape4k-leader-k8s", ":examples:k8s-lease", ":examples:k8s-operator")) {
+        dependencyManagement {
+            imports {
+                mavenBom("io.netty:netty-bom:${bt4kVersion("netty4")}")
+                mavenBom("io.vertx:vertx-dependencies:${bt4kVersion("vertx4")}")
+            }
+            dependencies {
+                dependency("io.netty:netty-codec-http:${bt4kVersion("netty4")}")
+                dependency("io.netty:netty-codec-http2:${bt4kVersion("netty4")}")
+                dependency("io.vertx:vertx-core:${bt4kVersion("vertx4")}")
+            }
         }
     }
 

--- a/docs/lessons/2026-05-26-issue-389-dependabot-security-overrides.md
+++ b/docs/lessons/2026-05-26-issue-389-dependabot-security-overrides.md
@@ -1,0 +1,34 @@
+# Issue 389 Dependabot Security Overrides
+
+## Context
+
+Issue #389 reported open Dependabot alerts for transitive Netty, Protobuf,
+Vert.x, and Jackson artifacts on the default branch.
+
+## Decision
+
+Keep common external library versions in `bluetape4k-dependencies` and use
+central catalog aliases from `leader` dependency management for the security
+override surface.
+
+## Outcome
+
+`leader` now imports central Netty 4.1, Protobuf, and Vert.x 4 BOMs and
+constrains the alerted modules through `bt4kVersion(...)`. Fabric8 was updated
+to the central catalog's 7.7.0 line, and the local AWS SDK BOM drift was also
+aligned to the central catalog.
+
+## Verification
+
+- Dependency sync updated `aws2` from `2.44.9` to `2.44.12`.
+- Gradle dependency management now reads Netty, Protobuf, and Vert.x versions
+  from the imported `bt4k` catalog.
+- `./gradlew build -x test -x k8sTest` passed.
+- Dependency insight confirmed K8s/Fabric8 resolves Netty `4.1.133.Final` and
+  Vert.x `4.5.27`, while Redisson resolves Netty `4.2.13.Final`.
+
+## Future Notes
+
+Do not add repo-local security pins for common external libraries. Add the
+missing alias to `bluetape4k-dependencies`, then consume it through the `bt4k`
+catalog in downstream repos.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ mongo-driver = "5.7.0"  # https://mvnrepository.com/artifact/org.mongodb/mongodb
 
 curator = "5.9.0"  # https://mvnrepository.com/artifact/org.apache.curator/curator-recipes
 jetcd = "0.8.6"  # https://mvnrepository.com/artifact/io.etcd/jetcd-core
-aws2 = "2.44.9"  # https://mvnrepository.com/artifact/software.amazon.awssdk/bom
+aws2 = "2.44.12"  # https://mvnrepository.com/artifact/software.amazon.awssdk/bom
 
 micrometer = "1.16.5"  # https://mvnrepository.com/artifact/io.micrometer/micrometer-bom
 
@@ -41,7 +41,7 @@ mockk = "1.14.9"  # https://mvnrepository.com/artifact/io.mockk/mockk
 springmockk = "5.0.1"  # https://mvnrepository.com/artifact/com.ninja-squad/springmockk
 awaitility = "4.3.0"  # https://mvnrepository.com/artifact/org.awaitility/awaitility-kotlin
 testcontainers = "2.0.5"  # https://mvnrepository.com/artifact/org.testcontainers/testcontainers-bom
-fabric8-kubernetes-client = "7.6.1"  # https://mvnrepository.com/artifact/io.fabric8/kubernetes-client
+fabric8-kubernetes-client = "7.7.0"  # https://mvnrepository.com/artifact/io.fabric8/kubernetes-client
 
 hikaricp = "7.0.2"                  # https://mvnrepository.com/artifact/com.zaxxer/HikariCP
 r2dbc-postgresql = "1.1.1.RELEASE"  # https://mvnrepository.com/artifact/org.postgresql/r2dbc-postgresql

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-    .orElse("catalog/2026-05-26-00")
+    .orElse("catalog/2026-05-26-01")
     .get()
 
 fun resolveBluetape4kDependenciesCatalogFile(): File {


### PR DESCRIPTION
## Summary

Closes #389

PR #395의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `chore: resolve Dependabot security dependency alerts`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary
- Use the central catalog tag `catalog/2026-05-26-01` from `bluetape4k-dependencies` PR #82.
- Apply central Netty, Protobuf, and Vert.x dependency management for issue #389.
- Keep Fabric8/K8s on the central Netty 4.1 + Vert.x 4 compatibility line while non-K8s paths use Netty 4.2 + Vert.x 5.
- Align local AWS SDK and Fabric8 catalog versions with `bluetape4k-dependencies`.
- Record the decision in `docs/lessons`.

Closes #389.

## Verification
- `curl` check for the `catalog/2026-05-26-01` central aliases.
- `./gradlew -q :bluetape4k-leader-k8s:dependencyInsight --configuration testRuntimeClasspath --dependency netty-common`
- `./gradlew -q :bluetape4k-leader-k8s:dependencyInsight --configuration testRuntimeClasspath --dependency vertx-core`
- `./gradlew -q :bluetape4k-leader-redis-redisson:dependencyInsight --configuration testRuntimeClasspath --dependency netty-codec-http2`
- `./gradlew build -x test -x k8sTest`

## Notes
- `:examples:k8s-lease:k8sTest` passed during validation.
- `:bluetape4k-leader-k8s:k8sTest` no longer has Vert.x/Netty ABI failures, but the local run hit K3s localhost connection-refused cleanup failures, so full K8s integration remains environment-sensitive.

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #389, milestone `0.2.2`, assignee `debop`
- PR: #395, head `d01b71941047b5b9cba1f535d2a3dd31169eea16`, milestone `0.2.2`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
