### PR TITLE
fix: guard release catalog selection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ env:
   JAVA_VERSION: '21'
   JAVA_DISTRIBUTION: 'temurin'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-  BLUETAPE4K_DEPENDENCIES_CATALOG_REF: ${{ github.event.inputs.catalogRef || vars.BLUETAPE4K_DEPENDENCIES_CATALOG_REF || 'develop' }}
 
 jobs:
   resolve-version:
@@ -75,6 +74,73 @@ jobs:
         with:
           ref: ${{ needs.resolve-version.outputs.ref }}
           fetch-depth: 0
+
+      - name: Resolve dependencies catalog ref
+        id: catalog
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_CATALOG_REF: ${{ github.event.inputs.catalogRef || '' }}
+          REPOSITORY_CATALOG_REF: ${{ vars.BLUETAPE4K_DEPENDENCIES_CATALOG_REF || '' }}
+        run: |
+          set -euo pipefail
+          DEFAULT_CATALOG_REF=$(sed -nE 's/^[[:space:]]*\.orElse\("([^"]+)"\).*/\1/p' settings.gradle.kts | head -1)
+
+          if [[ -z "$DEFAULT_CATALOG_REF" ]]; then
+            echo "::error::Could not resolve checked-in bluetape4k-dependencies catalog default from settings.gradle.kts"
+            exit 1
+          fi
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && -n "$INPUT_CATALOG_REF" ]]; then
+            SELECTED_CATALOG_REF="$INPUT_CATALOG_REF"
+            CATALOG_SOURCE="workflow_dispatch input catalogRef"
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" && -n "$REPOSITORY_CATALOG_REF" ]]; then
+            SELECTED_CATALOG_REF="$REPOSITORY_CATALOG_REF"
+            CATALOG_SOURCE="repository variable BLUETAPE4K_DEPENDENCIES_CATALOG_REF"
+          else
+            SELECTED_CATALOG_REF="$DEFAULT_CATALOG_REF"
+            CATALOG_SOURCE="checked-in settings.gradle.kts default"
+          fi
+
+          if [[ "$EVENT_NAME" == "push" && -n "$REPOSITORY_CATALOG_REF" && "$REPOSITORY_CATALOG_REF" != "$DEFAULT_CATALOG_REF" ]]; then
+            echo "::notice::Ignoring repository catalog variable '$REPOSITORY_CATALOG_REF' for tag-triggered release. Using checked-in default '$DEFAULT_CATALOG_REF'."
+          fi
+
+          echo "BLUETAPE4K_DEPENDENCIES_CATALOG_REF=$SELECTED_CATALOG_REF" >> "$GITHUB_ENV"
+          {
+            echo "ref=$SELECTED_CATALOG_REF"
+            echo "source=$CATALOG_SOURCE"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "catalogRef=$SELECTED_CATALOG_REF"
+          echo "catalogSource=$CATALOG_SOURCE"
+          echo "checkedInDefault=$DEFAULT_CATALOG_REF"
+          echo "repositoryVariable=${REPOSITORY_CATALOG_REF:-<unset>}"
+
+      - name: Verify dependencies catalog aliases
+        shell: bash
+        run: |
+          set -euo pipefail
+          catalog_file="$RUNNER_TEMP/bluetape4k-libs.versions.toml"
+          catalog_url="https://raw.githubusercontent.com/bluetape4k/bluetape4k-dependencies/${BLUETAPE4K_DEPENDENCIES_CATALOG_REF}/gradle/libs.versions.toml"
+          required_aliases=(
+            "bluetape4k-bom"
+            "bluetape4k-exposed-bom"
+            "exposed-plugin"
+          )
+
+          echo "Fetching bluetape4k-dependencies catalog: $catalog_url"
+          curl -fsSL "$catalog_url" -o "$catalog_file"
+
+          for alias in "${required_aliases[@]}"; do
+            if ! grep -Eq "^[[:space:]]*${alias}[[:space:]]*=" "$catalog_file"; then
+              echo "::error::Catalog ref '${BLUETAPE4K_DEPENDENCIES_CATALOG_REF}' is missing required alias: ${alias}"
+              exit 1
+            fi
+          done
+
+          echo "Verified catalog aliases from ${BLUETAPE4K_DEPENDENCIES_CATALOG_REF}:"
+          grep -E '^[[:space:]]*(bluetape4k-bom|bluetape4k-exposed-bom|exposed-plugin)[[:space:]]*=' "$catalog_file"
 
       - name: Verify gradle.properties matches tag
         shell: bash

--- a/docs/lessons/2026-05-27-release-catalog-guard.md
+++ b/docs/lessons/2026-05-27-release-catalog-guard.md
@@ -1,0 +1,28 @@
+# Release Catalog Guard
+
+## Context
+
+The AWS 0.3.0 release exposed a shared release workflow risk: a stale GitHub
+repository variable can override the checked-in `settings.gradle.kts` catalog
+default before Gradle compiles build scripts.
+
+## Decision
+
+Stable tag releases use the checked-in catalog default. Manual dispatch can use
+an explicit `catalogRef` override, then the repository variable as an
+operational fallback.
+
+## Outcome
+
+The release workflow logs the selected catalog source and verifies required
+catalog aliases before Maven Central publish.
+
+## Verification
+
+Run `actionlint`, validate catalog selection branches locally, and check the
+current release catalog contains the required aliases.
+
+## Future Guidance
+
+Treat repository catalog variables as manual release overrides, not as the
+release train source of truth.


### PR DESCRIPTION
## Summary

Closes #398

PR #399의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: guard release catalog selection`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary
- keep tag-triggered releases on the checked-in bluetape4k-dependencies catalog default
- allow manual workflow dispatch to use an explicit catalogRef override path
- verify required catalog aliases before Maven Central publish
- document the release catalog override rule in docs/lessons

Closes #398

## Verification
- actionlint .github/workflows/release.yml
- git diff --check
- local tag-push catalog selection check with stale repository variable
- required-alias check against catalog/2026-05-26-01
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #398, milestone `0.2.2`, assignee `debop`
- PR: #399, head `8cddff77490611928b08c8d839310561077a5120`, milestone `0.2.2`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
