### PR TITLE
Expose lease expiry metadata in leader events

### DIFF
--- a/docs/lessons/2026-05-29-issue-411-lease-expiry-metadata.md
+++ b/docs/lessons/2026-05-29-issue-411-lease-expiry-metadata.md
@@ -1,0 +1,45 @@
+# Lessons — Issue 411 lease expiry metadata
+
+Date: 2026-05-29
+Issue: #411
+Branch: feat/411-lease-expiry-metadata
+
+## Context
+
+`LeaderLease` and several backend state snapshots already exposed `leaseUntil`, but listener callbacks and
+`LeaderElectionEvent.Elected` did not carry a coherent lease snapshot.
+
+## Decision
+
+Keep the existing `onElected(lockName)` callback for source compatibility and add `onElected(lockName, leader)`.
+Use `LeaderElectionEvent.Elected.fromLease()` to copy `LeaderLease.auditLeaderId` and `LeaderLease.leaseUntil`
+into the existing `leaderId` and `leaseExpiry` fields while preserving the full optional lease snapshot.
+
+## Outcome
+
+Local blocking and suspend electors now pass best-effort `LeaderLease` metadata to listeners and lifecycle events.
+Decorator electors read the delegate state immediately after acquisition and emit metadata when the delegate can
+report it. `leaderStateFlow()` uses the full event lease snapshot when present and falls back to legacy
+`leaderId`/`leaseExpiry` fields for older event shapes.
+
+## Verification
+
+- 7-Tier review found that group listener decorators could misreport aggregate `state().leaders.firstOrNull()` as
+  current-slot metadata. Fixed by emitting `null` for group decorators unless the exact acquired lease is known.
+- `./gradlew :bluetape4k-leader-core:test --tests "io.bluetape4k.leader.LeaderElectionEventTest" --tests "io.bluetape4k.leader.LeaderElectionListenerTest" --tests "io.bluetape4k.leader.coroutines.LeaderStateFlowExtTest" --no-daemon` passed: 49 tests.
+- `git diff --check` passed.
+- `./gradlew build -x test -x k8sTest --no-daemon` passed.
+- `./gradlew build -x test --no-daemon` failed only in `:bluetape4k-leader-k8s:k8sTest` and
+  `:examples:k8s-operator:k8sTest` after the K3s API endpoint refused connections on `localhost:34491`.
+- Retried the K3s lane sequentially with
+  `./gradlew :bluetape4k-leader-k8s:k8sTest :examples:k8s-operator:k8sTest --no-daemon --max-workers=1`;
+  it passed with 13 `leader-k8s` tests and 2 `examples:k8s-operator` tests.
+- After the 7-Tier fix, a fresh sequential K3s lane rerun failed once in
+  `KubernetesLeaseSuspendLeaderElectorK3sTest.watchdog auto extends lease during long suspend action` with
+  `Expected <null> to equal to "reacquired"`. The same single test passed on immediate retry, so record this as
+  a watchdog/K3s lifecycle flake to watch before PR merge.
+
+## Future Guard
+
+When core event metadata changes, update both the callback API and Flow projection tests. Treat lease expiry as
+observability metadata only; ownership decisions must remain on backend atomic acquire paths.

--- a/leader-core/README.ko.md
+++ b/leader-core/README.ko.md
@@ -51,16 +51,20 @@ async/가상 스레드 API는 예외 완료됩니다(`join()`에서는 cancellat
 `LeaderElectionListenerRegistry` 구현체는 `addListener`, `removeListener`로 생명주기 callback을 등록할 수 있습니다.
 
 - `onElected(lockName)`: 보호된 작업이 시작되기 직전
+- `onElected(lockName, leader)`: best-effort 소유자와 lease 만료 metadata가 필요한 구현체용 callback
 - `onRevoked(lockName)`: 현재 호출이 보유하던 락 또는 슬롯을 반납한 직후
 - `onSkipped(lockName)`: 리더십을 획득하지 못해 작업을 실행하지 않을 때
 
 suspend elector는 같은 생명주기를 `LeaderElectionEventPublisher.events`의 hot `Flow<LeaderElectionEvent>` stream으로도 제공합니다.
+`LeaderElectionEvent.Elected`도 같은 선택적 `LeaderLease` snapshot을 포함합니다. Backend가 정확한 만료 시각을
+보고할 수 없으면 `leader.leaseUntil`과 `leaseExpiry`는 `null`입니다. 이 값은 관측 metadata이며, 소유권 판단은
+항상 backend의 원자적 acquire path를 사용하세요.
 
 ```kotlin
 val election = LocalLeaderElector()
 val handle = election.addListener(object : LeaderElectionListener {
-    override fun onElected(lockName: String) {
-        println("elected: $lockName")
+    override fun onElected(lockName: String, leader: LeaderLease?) {
+        println("elected: $lockName until ${leader?.leaseUntil ?: "unknown"}")
     }
 })
 

--- a/leader-core/README.md
+++ b/leader-core/README.md
@@ -53,16 +53,20 @@ wrapping the cancellation; `isCancelled()` is not guaranteed). Blocking APIs als
 `LeaderElectionListenerRegistry` implementations support `addListener` and `removeListener` for lifecycle callbacks:
 
 - `onElected(lockName)` before the guarded action starts
+- `onElected(lockName, leader)` for implementations that need best-effort owner and lease expiry metadata
 - `onRevoked(lockName)` after the held lock or slot is released by the current call
 - `onSkipped(lockName)` when the action is not run because leadership was not acquired
 
 For suspend electors, `LeaderElectionEventPublisher.events` exposes the same lifecycle as a hot `Flow<LeaderElectionEvent>`.
+`LeaderElectionEvent.Elected` carries the same optional `LeaderLease` snapshot. `leader.leaseUntil` and
+`leaseExpiry` are `null` when a backend cannot report a precise expiry; treat them as observability metadata,
+not as an ownership decision.
 
 ```kotlin
 val election = LocalLeaderElector()
 val handle = election.addListener(object : LeaderElectionListener {
-    override fun onElected(lockName: String) {
-        println("elected: $lockName")
+    override fun onElected(lockName: String, leader: LeaderLease?) {
+        println("elected: $lockName until ${leader?.leaseUntil ?: "unknown"}")
     }
 })
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionListener.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderElectionListener.kt
@@ -12,6 +12,7 @@ import java.util.concurrent.CopyOnWriteArrayList
  *
  * ## Behavior / Contract
  * - [onElected] is called immediately before the user action runs, after this call acquires a leader or group slot.
+ *   Implementations that need owner or expiry metadata should override [onElected] with [LeaderLease].
  * - [onSkipped] is called when a leader or group slot could not be acquired within the wait time and the user action is skipped.
  * - [onRevoked] is called after this call releases the leadership or slot it held — not on external lease-loss detection.
  * - Ordinary listener exceptions are logged and ignored so they do not affect the leader action result.
@@ -28,6 +29,17 @@ interface LeaderElectionListener {
 
     /** Called when a leader or group slot is acquired. */
     fun onElected(lockName: String) = Unit
+
+    /**
+     * Called when a leader or group slot is acquired, with a best-effort lease snapshot.
+     *
+     * Backends that cannot report precise expiry pass `null` or a [LeaderLease] whose
+     * [LeaderLease.leaseUntil] is `null`. This callback is for observability only; callers must still use the
+     * backend's atomic acquire path to decide ownership.
+     */
+    fun onElected(lockName: String, leader: LeaderLease?) {
+        onElected(lockName)
+    }
 
     /** Called after leadership or a group slot is released. */
     fun onRevoked(lockName: String) = Unit
@@ -50,18 +62,30 @@ sealed interface LeaderElectionEvent {
      * Leader or group slot acquisition event.
      *
      * ## Behavior / Contract
-     * - [leaderId] is the identity of the node that won the election. Populated by local electors
-     *   and backends that carry identity; `null` when identity is unavailable (e.g. decorator path).
-     * - [leaseExpiry] is the absolute time at which the lease expires. Currently always `null`;
-     *   reserved for future backend implementations that can report expiry at election time.
+     * - [leader] is the full lease snapshot when the backend can report it at election time.
+     * - [leaderId] is the elected audit identity. When [leader] is present, this should match
+     *   [LeaderLease.auditLeaderId].
+     * - [leaseExpiry] is the absolute time at which the lease expires. When [leader] is present, this should
+     *   match [LeaderLease.leaseUntil].
+     * - `null` leader or expiry means the backend could not report precise metadata for this event.
      */
     data class Elected @JvmOverloads constructor(
         override val lockName: String,
         val leaderId: String? = null,
         val leaseExpiry: Instant? = null,
+        val leader: LeaderLease? = null,
     ) : LeaderElectionEvent, Serializable {
         companion object {
-            private const val serialVersionUID = 1L
+            private const val serialVersionUID = 2L
+
+            /** Creates an elected event from a best-effort [LeaderLease] snapshot. */
+            fun fromLease(lockName: String, leader: LeaderLease?): Elected =
+                Elected(
+                    lockName = lockName,
+                    leaderId = leader?.auditLeaderId,
+                    leaseExpiry = leader?.leaseUntil,
+                    leader = leader,
+                )
         }
     }
 
@@ -124,8 +148,8 @@ open class LeaderElectionListenerSupport : LeaderElectionListenerRegistry {
         listeners.remove(listener)
 
     /** Dispatches an elected event to all registered listeners. */
-    fun notifyElected(lockName: String) {
-        notify(lockName, "onElected") { it.onElected(lockName) }
+    fun notifyElected(lockName: String, leader: LeaderLease? = null) {
+        notify(lockName, "onElected") { it.onElected(lockName, leader) }
     }
 
     /** Dispatches a revoked event to all registered listeners. */

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/ListeningLeaderElectors.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/ListeningLeaderElectors.kt
@@ -53,8 +53,9 @@ class ListeningLeaderElector(
         var elected = false
         val result = delegate.runIfLeader(lockName) {
             elected = true
-            listeners.notifyElected(lockName)
-            eventSubject.tryEmit(LeaderElectionEvent.Elected(lockName))
+            val leader = delegate.state(lockName).leader
+            listeners.notifyElected(lockName, leader)
+            eventSubject.tryEmit(LeaderElectionEvent.Elected.fromLease(lockName, leader))
             try {
                 action()
             } finally {
@@ -77,8 +78,9 @@ class ListeningLeaderElector(
         val elected = AtomicBoolean(false)
         return delegate.runAsyncIfLeader(lockName, executor) {
             elected.set(true)
-            listeners.notifyElected(lockName)
-            eventSubject.tryEmit(LeaderElectionEvent.Elected(lockName))
+            val leader = delegate.state(lockName).leader
+            listeners.notifyElected(lockName, leader)
+            eventSubject.tryEmit(LeaderElectionEvent.Elected.fromLease(lockName, leader))
             try {
                 action().whenComplete { _, _ ->
                     listeners.notifyRevoked(lockName)
@@ -142,8 +144,8 @@ class ListeningLeaderGroupElector(
         var elected = false
         val result = delegate.runIfLeader(lockName) {
             elected = true
-            listeners.notifyElected(lockName)
-            eventSubject.tryEmit(LeaderElectionEvent.Elected(lockName))
+            listeners.notifyElected(lockName, null)
+            eventSubject.tryEmit(LeaderElectionEvent.Elected.fromLease(lockName, null))
             try {
                 action()
             } finally {
@@ -166,8 +168,8 @@ class ListeningLeaderGroupElector(
         val elected = AtomicBoolean(false)
         return delegate.runAsyncIfLeader(lockName, executor) {
             elected.set(true)
-            listeners.notifyElected(lockName)
-            eventSubject.tryEmit(LeaderElectionEvent.Elected(lockName))
+            listeners.notifyElected(lockName, null)
+            eventSubject.tryEmit(LeaderElectionEvent.Elected.fromLease(lockName, null))
             try {
                 action().whenComplete { _, _ ->
                     listeners.notifyRevoked(lockName)

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LeaderStateFlowExt.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LeaderStateFlowExt.kt
@@ -28,9 +28,8 @@ import kotlinx.coroutines.launch
  * ## Behavior / Contract
  * - Initial value is [LeaderState.empty] for [lockName].
  * - [LeaderElectionEvent.Elected] transitions to [LeaderState.occupied]:
- *   `auditLeaderId` is taken from [LeaderElectionEvent.Elected.leaderId] when available,
- *   falling back to [LeaderNodeId.Default]; `leaseUntil` is taken from
- *   [LeaderElectionEvent.Elected.leaseExpiry].
+ *   [LeaderElectionEvent.Elected.leader] is used when present. Older events without a lease snapshot
+ *   use [LeaderElectionEvent.Elected.leaderId] and [LeaderElectionEvent.Elected.leaseExpiry].
  * - [LeaderElectionEvent.Revoked] transitions back to [LeaderState.empty].
  * - [LeaderElectionEvent.Skipped] produces no state transition.
  * - This is a single-leader projection. For group electors with `maxLeaders > 1`, use
@@ -126,10 +125,10 @@ private fun LeaderElectionEvent.toLeaderState(lockName: String): LeaderState =
     when (this) {
         is LeaderElectionEvent.Elected -> LeaderState.occupied(
             lockName,
-            LeaderLease(
+            leader ?: LeaderLease(
                 auditLeaderId = leaderId ?: LeaderNodeId.Default,
                 leaseUntil = leaseExpiry,
-            )
+            ),
         )
 
         is LeaderElectionEvent.Revoked -> LeaderState.empty(lockName)

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/ListeningSuspendLeaderElectors.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/ListeningSuspendLeaderElectors.kt
@@ -35,8 +35,9 @@ class ListeningSuspendLeaderElector(
         var elected = false
         val result = delegate.runIfLeader(lockName) {
             elected = true
-            listeners.notifyElected(lockName)
-            eventSubject.emit(LeaderElectionEvent.Elected(lockName))
+            val leader = delegate.state(lockName).leader
+            listeners.notifyElected(lockName, leader)
+            eventSubject.emit(LeaderElectionEvent.Elected.fromLease(lockName, leader))
             try {
                 action()
             } finally {
@@ -84,8 +85,8 @@ class ListeningSuspendLeaderGroupElector(
         var elected = false
         val result = delegate.runIfLeader(lockName) {
             elected = true
-            listeners.notifyElected(lockName)
-            eventSubject.emit(LeaderElectionEvent.Elected(lockName))
+            listeners.notifyElected(lockName, null)
+            eventSubject.emit(LeaderElectionEvent.Elected.fromLease(lockName, null))
             try {
                 action()
             } finally {

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElector.kt
@@ -158,7 +158,7 @@ class LocalSuspendLeaderElector(
         }
         val startedAtNanos = System.nanoTime()
         val token = Base58.randomString(8)
-        states.acquireSingle(lockName, auditLeaderId = auditLeaderId, nodeId = nodeId, leaseTime = options.leaseTime)
+        val lease = states.acquireSingle(lockName, auditLeaderId = auditLeaderId, nodeId = nodeId, leaseTime = options.leaseTime)
 
         val identity = LockIdentity(
             lockName = lockName,
@@ -188,8 +188,8 @@ class LocalSuspendLeaderElector(
             auditLeaderId = auditLeaderId,
         )
         val watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime, delegate)
-        listeners.notifyElected(lockName)
-        eventSubject.emit(LeaderElectionEvent.Elected(lockName, leaderId = auditLeaderId))
+        listeners.notifyElected(lockName, lease)
+        eventSubject.emit(LeaderElectionEvent.Elected.fromLease(lockName, lease))
         return try {
             withContext(LockHandleElement(handle)) {
                 action()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderGroupElector.kt
@@ -280,8 +280,8 @@ class LocalSuspendLeaderGroupElector private constructor(
             auditLeaderId = auditLeaderId,
         )
         val watchdog = LeaderLeaseAutoExtender.start(false, options.leaseTime, delegate)
-        listeners.notifyElected(lockName)
-        eventSubject.emit(LeaderElectionEvent.Elected(lockName, leaderId = auditLeaderId))
+        listeners.notifyElected(lockName, lease)
+        eventSubject.emit(LeaderElectionEvent.Elected.fromLease(lockName, lease))
         return try {
             withContext(LockHandleElement(handle)) {
                 action()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderElector.kt
@@ -149,7 +149,7 @@ abstract class AbstractLocalLeaderElector(
         }
         val startedAtNanos = System.nanoTime()
         val token = Base58.randomString(8)
-        states.acquireSingle(lockName, auditLeaderId = auditLeaderId, nodeId = nodeId, leaseTime = options.leaseTime)
+        val lease = states.acquireSingle(lockName, auditLeaderId = auditLeaderId, nodeId = nodeId, leaseTime = options.leaseTime)
 
         val identity = LockIdentity(
             lockName = lockName,
@@ -181,7 +181,7 @@ abstract class AbstractLocalLeaderElector(
             auditLeaderId = auditLeaderId,
         )
         val watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime, delegate)
-        listeners.notifyElected(lockName)
+        listeners.notifyElected(lockName, lease)
         return try {
             LockStateHolder.withPushed(handle) { action() }
         } finally {

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/AbstractLocalLeaderGroupElector.kt
@@ -190,7 +190,7 @@ abstract class AbstractLocalLeaderGroupElector(
             auditLeaderId = auditLeaderId,
         )
         val watchdog = LeaderLeaseAutoExtender.start(false, options.leaseTime, delegate)
-        listeners.notifyElected(lockName)
+        listeners.notifyElected(lockName, lease)
         return try {
             LockStateHolder.withPushed(handle) {
                 CaptureScope.runWithCapture(handle) {

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionEventTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionEventTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.io.ByteArrayInputStream
@@ -20,6 +21,7 @@ class LeaderElectionEventTest {
         event.lockName shouldBeEqualTo "my-lock"
         event.leaderId.shouldBeNull()
         event.leaseExpiry.shouldBeNull()
+        event.leader.shouldBeNull()
     }
 
     @Test
@@ -29,6 +31,7 @@ class LeaderElectionEventTest {
         event.lockName shouldBeEqualTo "my-lock"
         event.leaderId shouldBeEqualTo "node-1"
         event.leaseExpiry.shouldBeNull()
+        event.leader.shouldBeNull()
     }
 
     @Test
@@ -39,6 +42,26 @@ class LeaderElectionEventTest {
         event.lockName shouldBeEqualTo "my-lock"
         event.leaderId shouldBeEqualTo "node-1"
         event.leaseExpiry shouldBeEqualTo expiry
+        event.leader.shouldBeNull()
+    }
+
+    @Test
+    fun `Elected - fromLease copies lease metadata`() {
+        val electedAt = Instant.parse("2025-06-01T00:00:00Z")
+        val expiry = electedAt.plusSeconds(30)
+        val lease = LeaderLease(
+            auditLeaderId = "node-1",
+            electedAt = electedAt,
+            leaseUntil = expiry,
+            nodeId = "host-a",
+        )
+
+        val event = LeaderElectionEvent.Elected.fromLease("my-lock", lease)
+
+        event.lockName shouldBeEqualTo "my-lock"
+        event.leaderId shouldBeEqualTo "node-1"
+        event.leaseExpiry shouldBeEqualTo expiry
+        event.leader.shouldNotBeNull() shouldBeEqualTo lease
     }
 
     @Test
@@ -58,6 +81,7 @@ class LeaderElectionEventTest {
         deserialized.lockName shouldBeEqualTo "my-lock"
         deserialized.leaderId shouldBeEqualTo "node-1"
         deserialized.leaseExpiry shouldBeEqualTo expiry
+        deserialized.leader.shouldBeNull()
     }
 
     @Test
@@ -75,15 +99,17 @@ class LeaderElectionEventTest {
         deserialized shouldBeEqualTo original
         deserialized.leaderId.shouldBeNull()
         deserialized.leaseExpiry.shouldBeNull()
+        deserialized.leader.shouldBeNull()
     }
 
     @Test
-    fun `Elected - data class equality considers leaderId and leaseExpiry`() {
+    fun `Elected - data class equality considers lease metadata`() {
         val expiry = Instant.parse("2025-06-01T00:00:00Z")
+        val lease = LeaderLease("node-1", leaseUntil = expiry)
 
-        val a = LeaderElectionEvent.Elected("lock", leaderId = "node-1", leaseExpiry = expiry)
-        val b = LeaderElectionEvent.Elected("lock", leaderId = "node-1", leaseExpiry = expiry)
-        val c = LeaderElectionEvent.Elected("lock", leaderId = "node-2", leaseExpiry = expiry)
+        val a = LeaderElectionEvent.Elected.fromLease("lock", lease)
+        val b = LeaderElectionEvent.Elected.fromLease("lock", lease)
+        val c = LeaderElectionEvent.Elected("lock", leaderId = "node-1", leaseExpiry = expiry)
         val d = LeaderElectionEvent.Elected("lock")
 
         a shouldBeEqualTo b

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionListenerTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderElectionListenerTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.coroutines.LocalSuspendLeaderElector
 import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
@@ -39,6 +40,23 @@ class LeaderElectionListenerTest {
         handle.close()
         election.runIfLeader("listener-job") { "done-again" }
         listener.events shouldBeEqualTo listOf("elected:listener-job", "revoked:listener-job")
+    }
+
+    @Test
+    fun `LocalLeaderElector - 선출 callback 에 lease expiry metadata 를 전달한다`() {
+        val election = LocalLeaderElector(
+            LeaderElectionOptions(nodeId = "node-a", leaseTime = 500.milliseconds)
+        )
+        val listener = RecordingLeaseListener()
+        election.addListener(listener)
+
+        val result = election.runIfLeader("listener-metadata-job") { "done" }
+
+        result shouldBeEqualTo "done"
+        val lease = listener.electedLeases.single().shouldNotBeNull()
+        lease.auditLeaderId shouldBeEqualTo "node-a"
+        lease.nodeId shouldBeEqualTo "node-a"
+        lease.leaseUntil.shouldNotBeNull()
     }
 
     @Test
@@ -241,6 +259,25 @@ class LeaderElectionListenerTest {
     }
 
     @Test
+    fun `ListeningLeaderGroupElector - aggregate state lease 를 현재 slot metadata 로 발행하지 않는다`() = runSuspendIO {
+        val preexisting = LeaderLease("other-node", leaseUntil = java.time.Instant.now().plusSeconds(60), slot = 0)
+        val election = StubLeaderGroupElector(elected = true, leaders = listOf(preexisting)).withListeners()
+        val collected = async(start = CoroutineStart.UNDISPATCHED) {
+            withTimeout(2_000.milliseconds) {
+                election.events.take(2).toList()
+            }
+        }
+
+        val result = election.runIfLeader("decorated-group-aggregate-job") { "done" }
+
+        result shouldBeEqualTo "done"
+        val event = collected.await()[0] as LeaderElectionEvent.Elected
+        event.leader shouldBeEqualTo null
+        event.leaderId shouldBeEqualTo null
+        event.leaseExpiry shouldBeEqualTo null
+    }
+
+    @Test
     fun `ListeningLeaderGroupElector - delegate skip 을 listener 이벤트로 발행한다`() {
         val listener = RecordingListener()
         val election = StubLeaderGroupElector(elected = false).withListeners(listener)
@@ -394,10 +431,13 @@ class LeaderElectionListenerTest {
         }
 
         result shouldBeEqualTo "done"
-        collected.await() shouldBeEqualTo listOf(
-            LeaderElectionEvent.Elected("suspend-event-job", leaderId = LeaderNodeId.Default),
-            LeaderElectionEvent.Revoked("suspend-event-job"),
-        )
+        val events = collected.await()
+        val elected = events[0] as LeaderElectionEvent.Elected
+        elected.lockName shouldBeEqualTo "suspend-event-job"
+        elected.leaderId shouldBeEqualTo LeaderNodeId.Default
+        elected.leader.shouldNotBeNull()
+        elected.leaseExpiry.shouldNotBeNull()
+        events[1] shouldBeEqualTo LeaderElectionEvent.Revoked("suspend-event-job")
     }
 
     @Test
@@ -477,6 +517,14 @@ class LeaderElectionListenerTest {
         }
     }
 
+    private class RecordingLeaseListener: LeaderElectionListener {
+        val electedLeases = CopyOnWriteArrayList<LeaderLease?>()
+
+        override fun onElected(lockName: String, leader: LeaderLease?) {
+            electedLeases += leader
+        }
+    }
+
     private class StubLeaderElector(
         private val elected: Boolean,
     ): LeaderElector {
@@ -503,6 +551,7 @@ class LeaderElectionListenerTest {
 
     private class StubLeaderGroupElector(
         private val elected: Boolean,
+        private val leaders: List<LeaderLease> = emptyList(),
     ): LeaderGroupElector {
 
         override val maxLeaders: Int = 2
@@ -512,7 +561,7 @@ class LeaderElectionListenerTest {
         override fun availableSlots(lockName: String): Int = 1
 
         override fun state(lockName: String): LeaderGroupState =
-            LeaderGroupState(lockName, maxLeaders, activeCount(lockName))
+            LeaderGroupState(lockName, maxLeaders, activeCount(lockName), leaders)
 
         override fun <T> runIfLeader(lockName: String, action: () -> T): T? =
             if (elected) action() else null

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LeaderStateFlowExtTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LeaderStateFlowExtTest.kt
@@ -9,6 +9,7 @@ import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.LeaderElectionEvent
 import io.bluetape4k.leader.LeaderElectionEventPublisher
 import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.LeaderLease
 import io.bluetape4k.leader.LeaderNodeId
 import io.bluetape4k.leader.LeaderState
 import kotlinx.coroutines.CoroutineScope
@@ -135,6 +136,24 @@ class LeaderStateFlowExtTest {
 
             flow.value.isOccupied.shouldBeTrue()
             flow.value.leader?.leaseUntil shouldBeEqualTo expiry
+        }
+    }
+
+    @Test
+    fun `Elected with leader lease uses full lease snapshot`() = runSuspendIO {
+        val electedAt = Instant.now()
+        val lease = LeaderLease(
+            auditLeaderId = "token-2",
+            electedAt = electedAt,
+            leaseUntil = electedAt.plusSeconds(60),
+            nodeId = "node-2",
+        )
+
+        withStateFlow { publisher, flow ->
+            publisher.emit(LeaderElectionEvent.Elected.fromLease("my-lock", lease))
+            flow.first { it.isOccupied }
+
+            flow.value.leader shouldBeEqualTo lease
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #411

PR #430의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `Expose lease expiry metadata in leader events`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
Fixes #411.

## Summary
- Adds a source-compatible elected callback that can receive an optional `LeaderLease` snapshot.
- Carries elected lease metadata through `LeaderElectionEvent.Elected` and `leaderStateFlow()` while preserving legacy `leaderId` / `leaseExpiry` fallback behavior.
- Updates local sync/suspend electors to emit exact acquired lease metadata and keeps group decorator metadata unknown unless the exact lease is available.
- Updates English/Korean README docs and records the lesson for future leader event metadata changes.

## Review Notes
- Formal 7-Tier review found a P1 risk where group listener decorators could misreport aggregate `state().leaders.firstOrNull()` as current-slot metadata. The PR fixes that by emitting `null` in decorator group paths unless the exact acquired lease is known.
- Lease expiry is observability metadata only; ownership decisions remain on backend atomic acquire paths.

## Validation
- `./gradlew :bluetape4k-leader-core:test --tests "io.bluetape4k.leader.LeaderElectionEventTest" --tests "io.bluetape4k.leader.LeaderElectionListenerTest" --tests "io.bluetape4k.leader.coroutines.LeaderStateFlowExtTest" --no-daemon` passed: 49 tests.
- `./gradlew build -x test -x k8sTest --no-daemon` passed.
- `git diff --check` passed.
- Sequential K3s lane passed before the 7-Tier follow-up fix: `./gradlew :bluetape4k-leader-k8s:k8sTest :examples:k8s-operator:k8sTest --no-daemon --max-workers=1` with 13 `leader-k8s` tests and 2 `examples:k8s-operator` tests.
- After the 7-Tier fix, the full sequential K3s lane had one watchdog flake: `KubernetesLeaseSuspendLeaderElectorK3sTest.watchdog auto extends lease during long suspend action` failed once with `Expected <null> to equal to "reacquired"`; the same single test passed on immediate retry.

## DoD
- Tier 1 Functional/API: PASS.
- Tier 2 Concurrency/K3s: WATCH due pass-after-retry watchdog flake.
- Tier 3 Compatibility/Docs: PASS.
- Tier 4 Test Coverage: PASS for changed core behavior.
- Tier 5 Code Quality: PASS.
- Tier 6 CI/Environment: WATCH due K3s lifecycle signal.
- Tier 7 Release/Operations: PASS; no publish or migration action required.

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #411, milestone `0.3.0`, assignee `debop`
- PR: #430, head `9bee48c3a04e0a3a8b03428b0cac22d4a06c6e08`, milestone `0.3.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
