### PR TITLE
feat(k8s): add Lease-per-slot group leader election

### DIFF
--- a/docs/lessons/2026-05-29-issue-404-k8s-group-lease-slots.md
+++ b/docs/lessons/2026-05-29-issue-404-k8s-group-lease-slots.md
@@ -1,0 +1,39 @@
+# Lessons — Issue 404 Kubernetes Lease-per-slot group election
+
+Date: 2026-05-29
+Issue: #404
+Branch: feat/404-k8s-group-lease-slots
+
+## Context
+
+`leader-k8s` already had safe single-Lease election with a per-acquisition fencing token, but group election was
+excluded until a Lease-per-slot model could preserve owner-conditional release and extension.
+
+## Decision
+
+Use one Kubernetes Lease per group slot named `<lockName>-slot-<slotIndex>`. Reuse `KubernetesLeaseLock` for each
+slot so group election inherits the existing resource-version compare-and-set, holder fencing token, release, state
+mapping, and extension delegate behavior.
+
+Add `KubernetesLeaseGroupOptions` rather than changing `leader-core` group options. Do not add group `autoExtend`
+in this PR because group auto-extension deserves a separate core-level contract. While running K3s verification,
+fix the existing watchdog close path so release waits for an in-flight extension before backend cleanup.
+
+## Outcome
+
+The implementation adds blocking/async and suspend group electors, slot state mapping into `LeaderGroupState`, K3s
+coverage for group acquisition and cleanup behavior, and README documentation in English and Korean.
+
+## Verification
+
+- `./gradlew :bluetape4k-leader-k8s:compileKotlin :bluetape4k-leader-k8s:compileTestKotlin :bluetape4k-leader-k8s:test --no-daemon` passed.
+- First `./gradlew :bluetape4k-leader-k8s:k8sTest --no-daemon --max-workers=1` run passed the new group tests but exposed the existing suspend watchdog close race.
+- `./gradlew :bluetape4k-leader-core:test --tests "io.bluetape4k.leader.LeaderLeaseAutoExtenderTest" --tests "io.bluetape4k.leader.LeaderLeaseAutoExtenderDelegateTest" --no-daemon` passed.
+- `./gradlew :bluetape4k-leader-k8s:k8sTest --no-daemon --max-workers=1` passed after the watchdog close fix.
+- `./gradlew build -x test -x k8sTest --no-daemon` passed.
+- `git diff --check` passed.
+
+## Future Guard
+
+For Kubernetes group election, keep correctness on per-slot Lease ownership checks. `LeaderGroupState` is only an
+observability snapshot and must not become an acquisition gate.

--- a/docs/superpowers/plans/2026-05-29-issue-404-k8s-group-lease-slots-plan.md
+++ b/docs/superpowers/plans/2026-05-29-issue-404-k8s-group-lease-slots-plan.md
@@ -1,0 +1,78 @@
+# Issue 404 Kubernetes Lease-per-slot group election plan
+
+## Scope
+
+Implement the approved Lease-per-slot group election design for `leader-k8s`.
+
+Branch: `feat/404-k8s-group-lease-slots`
+Worktree: `.worktrees/feat-404-k8s-group-lease-slots`
+Base: `origin/develop` at `a8f0942f`
+
+## Tasks
+
+1. Add shared group support types.
+   - Add `KubernetesLeaseGroupOptions`.
+   - Add internal slot name and group state helpers.
+   - Reuse `KubernetesLeaseLock`, `KubernetesLeaseLockExtendDelegate`, and `KubernetesLeaseStateMapper`.
+
+2. Implement blocking group elector.
+   - Add `KubernetesLeaseLeaderGroupElector`.
+   - Implement `activeCount`, `availableSlots`, and `state`.
+   - Implement `runIfLeader(lockName)`, `runIfLeader(slot)`, and `runIfLeaderResult(slot)`.
+   - Add `KubernetesClient.runIfLeaderGroup` and `runAsyncIfLeaderGroup` extensions.
+
+3. Implement suspend group elector.
+   - Add `KubernetesLeaseSuspendLeaderGroupElector`.
+   - Wrap acquire/release/state calls in `Dispatchers.IO`.
+   - Release in `NonCancellable + Dispatchers.IO`.
+   - Add `KubernetesClient.suspendRunIfLeaderGroup` extension.
+
+4. Add K3s integration tests.
+   - Blocking group acquire up to `maxLeaders`.
+   - Extra contender skipped while all slots are occupied.
+   - Release/reacquire.
+   - Expired slot takeover.
+   - Slot audit identity appears in state and result.
+   - Suspend cancellation cleanup.
+   - Cleanup helper deletes all derived slot Leases.
+
+5. Update docs and lesson.
+   - Update `leader-k8s/README.md`.
+   - Update `leader-k8s/README.ko.md`.
+   - Add `docs/lessons/2026-05-29-issue-404-k8s-group-lease-slots.md`.
+
+6. Verify.
+   - `./gradlew :bluetape4k-leader-k8s:compileKotlin :bluetape4k-leader-k8s:compileTestKotlin --no-daemon`
+   - `./gradlew :bluetape4k-leader-k8s:test --no-daemon`
+   - `./gradlew :bluetape4k-leader-k8s:k8sTest --no-daemon --max-workers=1`
+   - `./gradlew build -x test -x k8sTest --no-daemon`
+   - `git diff --check`
+
+7. Review and publish.
+   - Run local 7-Tier code review on the implementation diff.
+   - Fix any P0/P1 findings and rerun affected tests.
+   - Commit with Lore protocol.
+   - Push and open PR for `#404` with K3s evidence and any flake notes.
+
+## Risk Controls
+
+- Do not change `leader-core` interfaces unless implementation proves impossible without it.
+- Do not run separate Testcontainers Gradle processes concurrently.
+- Treat state as observability only.
+- Preserve caller ownership of `KubernetesClient`.
+- Keep normal production release non-deleting.
+
+## Step 3-R Plan Review
+
+| Tier | Scope | P0 | P1 | P2 | P3 | Notes |
+|---|---|---:|---:|---:|---:|---|
+| 1 Security | RBAC and input validation | 0 | 0 | 0 | 0 | Slot Lease names are derived and validated; no secret annotations added. |
+| 2 Ops/SRE | lifecycle and cleanup | 0 | 0 | 0 | 0 | Cleanup helper limited to tests/docs; production release preserves Lease records. |
+| 3 Structure | module boundaries | 0 | 0 | 0 | 0 | Implementation stays in `leader-k8s`; core API unchanged. |
+| 4 Kotlin/API | sync/async/suspend parity | 0 | 0 | 0 | 0 | Blocking and suspend electors both planned; async bridge covered by blocking elector. |
+| 5 Tests/types | behavior coverage | 0 | 0 | 0 | 0 | Every acceptance criterion maps to a named K3s test. |
+| 6 Performance/stability | retry budget and K3s sequencing | 0 | 0 | 0 | 0 | Sequential K3s command named; random slot start in design. |
+| 7 Docs/release | README, lesson, PR evidence | 0 | 0 | 0 | 0 | English/Korean docs and lesson included. |
+
+Step 3-R status: PASS. P0 = 0, P1 = 0.
+

--- a/docs/superpowers/plans/2026-05-29-issue-404-k8s-group-lease-slots-plan.md
+++ b/docs/superpowers/plans/2026-05-29-issue-404-k8s-group-lease-slots-plan.md
@@ -75,4 +75,3 @@ Base: `origin/develop` at `a8f0942f`
 | 7 Docs/release | README, lesson, PR evidence | 0 | 0 | 0 | 0 | English/Korean docs and lesson included. |
 
 Step 3-R status: PASS. P0 = 0, P1 = 0.
-

--- a/docs/superpowers/specs/2026-05-29-issue-404-k8s-group-lease-slots-design.md
+++ b/docs/superpowers/specs/2026-05-29-issue-404-k8s-group-lease-slots-design.md
@@ -92,8 +92,10 @@ Release and auto-extension are per acquired slot:
 
 - release calls `KubernetesLeaseLock.unlock(minLeaseTime, acquiredAtNanos)`;
 - release is owner-conditional and does not affect other slots;
-- auto-extension uses one `KubernetesLeaseLockExtendDelegate` bound to the acquired slot lock;
-- watchdog is disabled by default unless group options enable it, matching core option behavior;
+- lock-handle extension uses one `KubernetesLeaseLockExtendDelegate` bound to the acquired slot lock;
+- automatic watchdog extension is not introduced for group electors in this PR because core
+  `LeaderGroupElectionOptions` has no `autoExtend` contract. This PR fixes the existing watchdog close race for
+  single-election paths, but keeps group auto-extension as a separate contract decision;
 - suspend cleanup runs in `NonCancellable + Dispatchers.IO`.
 
 ## State Mapping
@@ -151,4 +153,3 @@ Tests and operational cleanup may delete all derived slot Lease names. README gu
 | 7 Docs/release | README, lesson, CI evidence | 0 | 0 | 0 | 0 | Existing leader-k8s CI/Nightly lanes should cover changed module. |
 
 Step 2-R status: PASS. P0 = 0, P1 = 0.
-

--- a/docs/superpowers/specs/2026-05-29-issue-404-k8s-group-lease-slots-design.md
+++ b/docs/superpowers/specs/2026-05-29-issue-404-k8s-group-lease-slots-design.md
@@ -1,0 +1,154 @@
+# Issue 404 Kubernetes Lease-per-slot group election design
+
+## Context
+
+Issue #404 extends `leader-k8s` from single Kubernetes Lease leader election to bounded group election.
+Issue #335 intentionally excluded group semantics until a safe Lease-per-slot model was designed.
+Issue #411 now exposes elected lease metadata to observers, which makes group state snapshots more useful.
+
+Existing `leader-k8s` single election already has the required safety primitives:
+
+- a per-acquisition fencing token in `spec.holderIdentity`;
+- audit and physical node identity in bluetape4k annotations;
+- Kubernetes optimistic concurrency through `metadata.resourceVersion`;
+- owner-conditional release and extension;
+- K3s-backed integration tests.
+
+## Goals
+
+1. Add blocking and suspend Kubernetes group electors:
+   - `KubernetesLeaseLeaderGroupElector : LeaderGroupElector`;
+   - `KubernetesLeaseSuspendLeaderGroupElector : SuspendLeaderGroupElector`.
+2. Represent each group slot as one Kubernetes Lease object.
+3. Preserve owner-conditional acquire, release, and extension for every slot.
+4. Report group state with active count and per-slot `LeaderLease` snapshots.
+5. Document group naming, RBAC, cleanup, and operational behavior in English and Korean READMEs.
+6. Cover acquire, contention, release/reacquire, expiry takeover, cancellation cleanup, and state mapping with K3s tests.
+
+## Non-Goals
+
+- Do not change `leader-core` group interfaces.
+- Do not use Kubernetes `LeaseCandidate` or control-plane coordinated leader election APIs.
+- Do not delete Lease objects on normal release. Group slots follow the single-Lease behavior: release clears holder identity or shortens the lease while preserving operator-visible Lease records.
+- Do not add Spring AOP group stream support. Issue #410 owns those semantics.
+- Do not add Nightly/CI workflow changes unless the new tests need a new job. Existing `leader-k8s` K3s coverage already runs in the affected module lane.
+
+## Public API
+
+Add `KubernetesLeaseLeaderGroupElector`:
+
+- constructor parameters: caller-owned `KubernetesClient`, `KubernetesLeaseGroupOptions`, and optional `Clock`;
+- implements blocking `runIfLeader(lockName)`, `runIfLeader(slot)`, result variants, inherited async bridge, and group state methods;
+- extension functions:
+  - `KubernetesClient.runIfLeaderGroup(...)`;
+  - `KubernetesClient.runAsyncIfLeaderGroup(...)`.
+
+Add `KubernetesLeaseSuspendLeaderGroupElector`:
+
+- constructor parameters: caller-owned `KubernetesClient`, `KubernetesLeaseGroupOptions`, and optional `Clock`;
+- wraps Fabric8 calls in `Dispatchers.IO`;
+- releases in `NonCancellable + Dispatchers.IO` and rethrows coroutine cancellation;
+- extension function:
+  - `KubernetesClient.suspendRunIfLeaderGroup(...)`.
+
+Add `KubernetesLeaseGroupOptions`:
+
+- wraps `LeaderGroupElectionOptions`;
+- carries the Kubernetes namespace and retry delay;
+- validates `maxLeaders`, namespace, and retry delay;
+- keeps single-election options unchanged for source compatibility.
+
+## Lease Naming
+
+Each logical group lock owns one Lease per slot:
+
+```text
+<lockName>-slot-<slotIndex>
+```
+
+where `slotIndex` is `0 until maxLeaders`.
+
+Because Kubernetes Lease names are DNS-1123 labels with a 63-character limit, the group lock name must leave room
+for the longest slot suffix. The implementation validates the derived Lease name before acquisition. If the user
+passes a lock name that cannot produce valid slot Lease names, the elector fails fast with `IllegalArgumentException`.
+
+## Acquisition Model
+
+For each acquisition attempt:
+
+1. Pick a random start slot to reduce slot-0 hotspots.
+2. Visit each slot at most once.
+3. Allocate the remaining `waitTime` across the remaining slots so one contended slot cannot consume the entire budget.
+4. Create a fresh `KubernetesLeaseLock` for the derived slot Lease name and a fresh owner token.
+5. Try to acquire that slot Lease using the existing single-Lease lock algorithm.
+6. If acquired, run the action with a `LeaderLockHandle` whose identity kind is `GROUP`, `groupParams.maxLeaders` is set, and `slotId` is the acquired slot index.
+7. If no slot is acquired before the deadline, return `null` / `LeaderRunResult.Skipped`.
+
+This model intentionally reuses the single-Lease fencing token and resource-version compare-and-set behavior.
+
+## Release and Extension
+
+Release and auto-extension are per acquired slot:
+
+- release calls `KubernetesLeaseLock.unlock(minLeaseTime, acquiredAtNanos)`;
+- release is owner-conditional and does not affect other slots;
+- auto-extension uses one `KubernetesLeaseLockExtendDelegate` bound to the acquired slot lock;
+- watchdog is disabled by default unless group options enable it, matching core option behavior;
+- suspend cleanup runs in `NonCancellable + Dispatchers.IO`.
+
+## State Mapping
+
+`state(lockName)` maps every slot Lease into `LeaderLease` snapshots:
+
+- absent, blank-holder, and expired slot Leases are ignored;
+- occupied slot Leases map through `KubernetesLeaseStateMapper`;
+- each returned lease sets `slot = slotIndex`;
+- `activeCount = leaders.size`;
+- `availableSlots = maxLeaders - activeCount`.
+
+State remains observability-only. Acquisition and release correctness depends only on per-slot owner-conditional Kubernetes updates.
+
+## Cleanup
+
+Normal release does not delete slot Lease resources.
+
+Tests and operational cleanup may delete all derived slot Lease names. README guidance must state that RBAC needs
+`get`, `create`, `update`, `patch`, and usually `delete` for test/cleanup tooling; production electors do not need
+`delete` for normal action lifecycle.
+
+## Failure and Cancellation Contracts
+
+- Contention returns `null` / `Skipped`.
+- Action exceptions propagate for `runIfLeader` and become `ActionFailed` for result APIs after election.
+- Java `CancellationException`, Kotlin `CancellationException`, and `InterruptedException` keep existing propagation semantics.
+- Kubernetes `409 Conflict` is contention and retry input, not a user-visible failure.
+- Cleanup failures are logged and swallowed after the action result is determined.
+
+## Verification Requirements
+
+- Compile and targeted unit tests for `leader-k8s`.
+- K3s tests for:
+  - multiple concurrent acquisitions up to `maxLeaders`;
+  - extra contender skipped when all slots are occupied;
+  - release/reacquire;
+  - expired slot takeover;
+  - slot audit identity and state lease metadata;
+  - suspend cancellation cleanup;
+  - group slot cleanup helper.
+- Sequential Testcontainers/K3s verification.
+- Full compile/build lane excluding heavyweight tests before PR if K3s has already run.
+
+## Step 2-R Design Review
+
+| Tier | Scope | P0 | P1 | P2 | P3 | Notes |
+|---|---|---:|---:|---:|---:|---|
+| 1 Security | Lease names, annotations, RBAC | 0 | 0 | 0 | 0 | No secret data added; names validated as DNS-1123 labels. |
+| 2 Ops/SRE | cleanup, diagnosis, K3s lifecycle | 0 | 0 | 1 | 0 | Keep pass-after-retry K3s flake visible in PR if it recurs. |
+| 3 Structure | core API and module boundary | 0 | 0 | 0 | 0 | No `leader-core` API change needed. |
+| 4 Kotlin/API | options, constructors, extension functions | 0 | 0 | 0 | 0 | Mirrors existing K8s and etcd group patterns. |
+| 5 Tests/types | group state, cancellation, result APIs | 0 | 0 | 0 | 0 | Tests explicitly named in verification requirements. |
+| 6 Performance/stability | slot scan, retry budget, watchdog | 0 | 0 | 0 | 0 | Random start slot avoids persistent slot-0 hotspot. |
+| 7 Docs/release | README, lesson, CI evidence | 0 | 0 | 0 | 0 | Existing leader-k8s CI/Nightly lanes should cover changed module. |
+
+Step 2-R status: PASS. P0 = 0, P1 = 0.
+

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt
@@ -191,7 +191,7 @@ object LeaderLeaseAutoExtender : KLogging() {
         val futureRef = AtomicReference<ScheduledFuture<*>?>(null)
         // Capture async mode at start() call time — subsequent configure() calls don't affect running watchdogs.
         val capturedAsyncExtend = asyncExtendEnabled
-        val extendInFlight: AtomicBoolean? = if (capturedAsyncExtend) AtomicBoolean(false) else null
+        val extendInFlight = AtomicBoolean(false)
 
         val doTick: () -> Unit = doTick@{
             if (closed.get()) {
@@ -244,7 +244,7 @@ object LeaderLeaseAutoExtender : KLogging() {
 
         // When async mode is enabled: dispatch each tick onto a virtual thread so that a slow backend
         // cannot block the shared scheduler. The extendInFlight guard prevents overlapping extends.
-        val tickRunnable: Runnable = if (capturedAsyncExtend && extendInFlight != null) {
+        val tickRunnable: Runnable = if (capturedAsyncExtend) {
             Runnable {
                 if (extendInFlight.compareAndSet(false, true)) {
                     Thread.ofVirtual()
@@ -255,7 +255,15 @@ object LeaderLeaseAutoExtender : KLogging() {
                 }
             }
         } else {
-            Runnable { doTick() }
+            Runnable {
+                if (extendInFlight.compareAndSet(false, true)) {
+                    try {
+                        doTick()
+                    } finally {
+                        extendInFlight.set(false)
+                    }
+                }
+            }
         }
 
         val future = try {
@@ -274,6 +282,7 @@ object LeaderLeaseAutoExtender : KLogging() {
         return AutoCloseable {
             if (closed.compareAndSet(false, true)) {
                 future.cancel(false)
+                waitForInFlightExtend(extendInFlight)
             }
         }
     }
@@ -374,6 +383,7 @@ object LeaderLeaseAutoExtender : KLogging() {
         return AutoCloseable {
             if (closed.compareAndSet(false, true)) {
                 future.cancel(false)
+                waitForInFlightExtend(extendInFlight)
                 cancelScopeIfIdle()
             }
         }
@@ -392,6 +402,23 @@ object LeaderLeaseAutoExtender : KLogging() {
     }
 
     private val MIN_RENEWAL_PERIOD = 25.milliseconds
+    private const val CLOSE_WAIT_TIMEOUT_MILLIS = 5_000L
+    private const val CLOSE_WAIT_POLL_MILLIS = 5L
+
+    private fun waitForInFlightExtend(extendInFlight: AtomicBoolean) {
+        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(CLOSE_WAIT_TIMEOUT_MILLIS)
+        while (extendInFlight.get() && System.nanoTime() < deadline) {
+            try {
+                Thread.sleep(CLOSE_WAIT_POLL_MILLIS)
+            } catch (e: InterruptedException) {
+                Thread.currentThread().interrupt()
+                return
+            }
+        }
+        if (extendInFlight.get()) {
+            log.warn { "leader.lease.auto-extend.close timed out while waiting for in-flight extend" }
+        }
+    }
 
     private fun handleOutcome(
         outcome: ExtendOutcome,

--- a/leader-k8s/README.ko.md
+++ b/leader-k8s/README.ko.md
@@ -4,7 +4,8 @@
 
 `bluetape4k-leader` 의 Kubernetes Lease 백엔드입니다. Kubernetes 기본
 `coordination.k8s.io/v1` Lease API 를 사용하므로 Redis, MongoDB, ZooKeeper,
-커스텀 CRD 없이 Kubernetes 안에서 단일 active worker 를 선출할 수 있습니다.
+커스텀 CRD 없이 Kubernetes 안에서 단일 active worker 또는 제한된 수의 worker 그룹을
+선출할 수 있습니다.
 
 ## Architecture
 
@@ -24,13 +25,25 @@
 이 설계는 같은 JVM 또는 같은 Pod 안의 두 elector 가 동일한 `nodeId` 만으로 소유권을
 잘못 공유하지 않게 합니다.
 
+그룹 리더 선출은 slot 마다 하나의 Lease 를 사용합니다.
+
+```text
+<lockName>-slot-<slotIndex>
+```
+
+각 slot 은 단일 Lease 선출과 같은 fencing token 및 owner-conditional update 의미를
+유지합니다. 그룹 state 는 관측용 metadata 이며, correctness 는 Kubernetes Lease
+소유권 검사에만 의존합니다.
+
 ## Core Features
 
 - Blocking / async `LeaderElector` 구현
 - Coroutine-native `SuspendLeaderElector` 구현
+- Lease-per-slot 기반 blocking / async `LeaderGroupElector` 구현
+- Coroutine-native `SuspendLeaderGroupElector` 구현
 - Kubernetes `resourceVersion` 기반 owner-conditional release / extension
 - `renewTime + leaseDurationSeconds` 기준 만료 Lease takeover
-- Lease metadata 와 annotation 에서 `LeaderState` snapshot 생성
+- Lease metadata 와 annotation 에서 `LeaderState`, `LeaderGroupState` snapshot 생성
 - 짧은 action 뒤에도 잠시 leadership 을 유지하는 `minLeaseTime` 지원
 - `k8sTest` 태스크의 K3s 기반 통합 테스트
 
@@ -82,6 +95,31 @@ val future = elector.runAsyncIfLeader("webhook-poller") {
 }
 ```
 
+Group 사용:
+
+```kotlin
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.k8s.KubernetesLeaseGroupOptions
+import io.bluetape4k.leader.k8s.KubernetesLeaseLeaderGroupElector
+
+val groupElector = KubernetesLeaseLeaderGroupElector(
+    client = client,
+    options = KubernetesLeaseGroupOptions(
+        namespace = "operators",
+        leaderGroupOptions = LeaderGroupElectionOptions(
+            maxLeaders = 4,
+            nodeId = "worker-0",
+            waitTime = 2.seconds,
+            leaseTime = 30.seconds,
+        ),
+    ),
+)
+
+groupElector.runIfLeader("partition-worker") {
+    processPartition()
+}
+```
+
 ## Configuration
 
 | 옵션 | 타입 | 기본값 | 설명 |
@@ -93,12 +131,20 @@ val future = elector.runAsyncIfLeader("webhook-poller") {
 | `leaderOptions.nodeId` | `String` | process-level default | audit node id annotation |
 | `leaderOptions.minLeaseTime` | `Duration` | `0.seconds` | 빠른 action 뒤 최소 leadership 유지 시간 |
 | `leaderOptions.autoExtend` | `Boolean` | `false` | action 실행 중 active Lease 자동 연장 |
+| `leaderGroupOptions.maxLeaders` | `Int` | `2` | 그룹 선출에서 허용하는 최대 active Lease slot 수 |
+| `leaderGroupOptions.waitTime` | `Duration` | `5.seconds` | 그룹 slot 획득 최대 대기 시간 |
+| `leaderGroupOptions.leaseTime` | `Duration` | `60.seconds` | 각 그룹 slot 에 기록하는 Lease duration |
+| `leaderGroupOptions.nodeId` | `String` | process-level default | 그룹 slot audit node id annotation |
+| `leaderGroupOptions.minLeaseTime` | `Duration` | `0.seconds` | 빠른 group action 뒤 최소 slot 유지 시간 |
 
 `lockName` 은 Kubernetes DNS-1123 label 이어야 하며 Lease 이름 제한인 63자를 넘을 수 없습니다.
+그룹 선출에서는 파생 이름인 `<lockName>-slot-<slotIndex>` 도 이 제한을 만족해야 합니다.
 
 ## RBAC
 
 애플리케이션 service account 는 선택한 namespace 안의 Lease 접근 권한이 필요합니다.
+production elector 는 정상 release 중 Lease 를 삭제하지 않지만, `delete` 는 테스트와
+운영 cleanup 도구에 유용합니다.
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/leader-k8s/README.md
+++ b/leader-k8s/README.md
@@ -4,8 +4,8 @@
 
 Kubernetes Lease backend for `bluetape4k-leader`. It uses the native
 `coordination.k8s.io/v1` Lease API, so applications running in Kubernetes can
-elect exactly one active worker without adding Redis, MongoDB, ZooKeeper, or a
-custom CRD.
+elect exactly one active worker, or a bounded group of workers, without adding
+Redis, MongoDB, ZooKeeper, or a custom CRD.
 
 ## Architecture
 
@@ -25,13 +25,25 @@ kept in annotations:
 This prevents two electors in the same JVM or Pod from treating the same
 `nodeId` as ownership authority.
 
+Group leader election uses one Lease per slot:
+
+```text
+<lockName>-slot-<slotIndex>
+```
+
+Each slot keeps the same fencing-token and owner-conditional update semantics as
+single-Lease election. Group state is observability metadata only; correctness
+stays on Kubernetes Lease ownership checks.
+
 ## Core Features
 
 - Blocking and async `LeaderElector` implementation
 - Coroutine-native `SuspendLeaderElector` implementation
+- Blocking and async `LeaderGroupElector` implementation using Lease-per-slot
+- Coroutine-native `SuspendLeaderGroupElector` implementation
 - Owner-conditional release and extension using Kubernetes `resourceVersion`
 - Expired Lease takeover based on `renewTime + leaseDurationSeconds`
-- `LeaderState` snapshots mapped from Lease metadata and annotations
+- `LeaderState` and `LeaderGroupState` snapshots mapped from Lease metadata and annotations
 - `minLeaseTime` support for short actions that must keep leadership briefly
 - K3s-backed integration tests under `k8sTest`
 
@@ -83,6 +95,31 @@ val future = elector.runAsyncIfLeader("webhook-poller") {
 }
 ```
 
+Group usage:
+
+```kotlin
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.k8s.KubernetesLeaseGroupOptions
+import io.bluetape4k.leader.k8s.KubernetesLeaseLeaderGroupElector
+
+val groupElector = KubernetesLeaseLeaderGroupElector(
+    client = client,
+    options = KubernetesLeaseGroupOptions(
+        namespace = "operators",
+        leaderGroupOptions = LeaderGroupElectionOptions(
+            maxLeaders = 4,
+            nodeId = "worker-0",
+            waitTime = 2.seconds,
+            leaseTime = 30.seconds,
+        ),
+    ),
+)
+
+groupElector.runIfLeader("partition-worker") {
+    processPartition()
+}
+```
+
 ## Configuration
 
 | Option | Type | Default | Description |
@@ -94,14 +131,21 @@ val future = elector.runAsyncIfLeader("webhook-poller") {
 | `leaderOptions.nodeId` | `String` | process-level default | Audit node id annotation |
 | `leaderOptions.minLeaseTime` | `Duration` | `0.seconds` | Minimum leadership hold time after quick actions |
 | `leaderOptions.autoExtend` | `Boolean` | `false` | Extends the active Lease while the action runs |
+| `leaderGroupOptions.maxLeaders` | `Int` | `2` | Maximum active Lease slots for group election |
+| `leaderGroupOptions.waitTime` | `Duration` | `5.seconds` | Maximum time to acquire any group slot |
+| `leaderGroupOptions.leaseTime` | `Duration` | `60.seconds` | Lease duration for each group slot |
+| `leaderGroupOptions.nodeId` | `String` | process-level default | Audit node id annotation for group slots |
+| `leaderGroupOptions.minLeaseTime` | `Duration` | `0.seconds` | Minimum slot hold time after quick group actions |
 
 `lockName` must be a Kubernetes DNS-1123 label and must fit the Lease name limit
-(63 characters).
+(63 characters). For group election, the derived `<lockName>-slot-<slotIndex>`
+names must also fit this limit.
 
 ## RBAC
 
 The service account running the application needs Lease access in the selected
-namespace:
+namespace. Production electors do not delete Leases during normal release, but
+`delete` is useful for test and operator cleanup tooling:
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseGroupOptions.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseGroupOptions.kt
@@ -1,0 +1,47 @@
+package io.bluetape4k.leader.k8s
+
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.support.requireGt
+import io.bluetape4k.support.requireNotBlank
+import java.io.Serializable
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Options for Kubernetes Lease-backed group leader election.
+ *
+ * ## Behavior / Contract
+ * - [leaderGroupOptions] controls max leaders, wait time, lease duration, node identity, and minimum lease time.
+ * - [namespace] stores one `coordination.k8s.io/v1` Lease per group slot.
+ * - [retryDelay] bounds full-jitter retry sleeps after contention or Kubernetes resource-version conflicts.
+ *
+ * ```kotlin
+ * val options = KubernetesLeaseGroupOptions(
+ *     namespace = "operators",
+ *     leaderGroupOptions = LeaderGroupElectionOptions(maxLeaders = 4),
+ * )
+ * ```
+ */
+data class KubernetesLeaseGroupOptions(
+    val leaderGroupOptions: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
+    val namespace: String = "default",
+    val retryDelay: Duration = 50.milliseconds,
+) : Serializable {
+
+    init {
+        namespace.requireNotBlank("namespace")
+        retryDelay.requireGt(Duration.ZERO, "retryDelay")
+    }
+
+    val maxLeaders: Int get() = leaderGroupOptions.maxLeaders
+
+    companion object {
+        /**
+         * Default group options instance using namespace `default` and [LeaderGroupElectionOptions.Default].
+         */
+        @JvmField
+        val Default = KubernetesLeaseGroupOptions()
+
+        private const val serialVersionUID = 1L
+    }
+}

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderGroupElector.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderGroupElector.kt
@@ -1,0 +1,333 @@
+package io.bluetape4k.leader.k8s
+
+import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
+import io.bluetape4k.leader.AopScopeAccess
+import io.bluetape4k.leader.LeaderGroupElector
+import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.LeaderLease
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LeaderSlot
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.k8s.internal.KubernetesLeaseLock
+import io.bluetape4k.leader.k8s.internal.KubernetesLeaseLockExtendDelegate
+import io.bluetape4k.leader.k8s.internal.KubernetesLeaseGroupAcquisitionDeadline
+import io.bluetape4k.leader.k8s.internal.KubernetesLeaseNames
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
+import io.fabric8.kubernetes.client.KubernetesClient
+import java.time.Clock
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.Executor
+import java.util.concurrent.ThreadLocalRandom
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Blocking and async group leader election backed by one Kubernetes Lease per group slot.
+ *
+ * ## Behavior / Contract
+ * - At most [maxLeaders] actions run concurrently for a logical `lockName`.
+ * - Each slot is represented as a separate Kubernetes Lease named `<lockName>-slot-<index>`.
+ * - Release and extension are owner-conditional for the acquired slot Lease.
+ * - The supplied [KubernetesClient] is caller-owned and is never closed by this elector.
+ *
+ * ```kotlin
+ * val election = KubernetesLeaseLeaderGroupElector(
+ *     client,
+ *     KubernetesLeaseGroupOptions(leaderGroupOptions = LeaderGroupElectionOptions(maxLeaders = 3)),
+ * )
+ * val result = election.runIfLeader("partition-worker") {
+ *     processPartition()
+ * }
+ * ```
+ */
+class KubernetesLeaseLeaderGroupElector @JvmOverloads constructor(
+    private val client: KubernetesClient,
+    val options: KubernetesLeaseGroupOptions = KubernetesLeaseGroupOptions.Default,
+    private val clock: Clock = Clock.systemUTC(),
+) : LeaderGroupElector {
+
+    companion object : KLogging() {
+        internal const val K8S_GROUP_FACTORY_BEAN_NAME = "kubernetes-lease-leader-group-elector"
+    }
+
+    override val maxLeaders: Int = options.maxLeaders
+
+    override fun activeCount(lockName: String): Int =
+        state(lockName).activeCount
+
+    override fun availableSlots(lockName: String): Int =
+        state(lockName).availableSlots
+
+    override fun state(lockName: String): LeaderGroupState {
+        val leaders = currentLeaders(lockName)
+        return LeaderGroupState(lockName, maxLeaders, leaders.size, leaders)
+    }
+
+    override fun <T> runIfLeader(lockName: String, action: () -> T): T? =
+        runWithGroupSlot(lockName, null, action)
+
+    override fun <T> runIfLeader(slot: LeaderSlot, action: () -> T): T? =
+        runWithGroupSlot(slot.lockName, slot.leaderId, action)
+
+    override fun <T> runIfLeaderResult(slot: LeaderSlot, action: () -> T): LeaderRunResult<T> {
+        var elected = false
+        val value = try {
+            runWithGroupSlot(slot.lockName, slot.leaderId) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
+        }
+        return if (elected) LeaderRunResult.Elected(value, leaderId = slot.leaderId) else LeaderRunResult.Skipped
+    }
+
+    override fun <T> runAsyncIfLeader(
+        lockName: String,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> =
+        runAsyncWithGroupSlot(lockName, null, executor, action)
+
+    override fun <T> runAsyncIfLeader(
+        slot: LeaderSlot,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> =
+        runAsyncWithGroupSlot(slot.lockName, slot.leaderId, executor, action)
+
+    override fun <T> runAsyncIfLeaderResult(
+        slot: LeaderSlot,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<LeaderRunResult<T>> {
+        var elected = false
+        return runAsyncWithGroupSlot(slot.lockName, slot.leaderId, executor) {
+            elected = true
+            action()
+        }.handle { value, failure ->
+            val cause = failure.unwrapCompletionException()
+            when {
+                cause is CancellationException -> throw cause
+                cause != null && elected -> LeaderRunResult.ActionFailed(cause)
+                cause != null -> throw cause
+                elected -> LeaderRunResult.Elected(value, leaderId = slot.leaderId)
+                else -> LeaderRunResult.Skipped
+            }
+        }
+    }
+
+    private fun <T> runWithGroupSlot(lockName: String, auditLeaderId: String?, action: () -> T): T? {
+        val acquired = acquire(lockName, auditLeaderId) ?: return null
+        val lock = acquired.lock
+        val delegate = KubernetesLeaseLockExtendDelegate(lock)
+        val handle = handle(lockName, lock, acquired.slot, acquired.acquiredAtNanos, delegate, auditLeaderId)
+        val watchdog = LeaderLeaseAutoExtender.start(
+            enabled = false,
+            leaseTime = options.leaderGroupOptions.leaseTime,
+            delegate = delegate,
+            classifier = KubernetesLeaseLeaderElector.ERROR_CLASSIFIER,
+        )
+
+        return try {
+            AopScopeAccess.withPushedSync(handle) {
+                AopScopeAccess.setCapture(handle)
+                try {
+                    action()
+                } finally {
+                    AopScopeAccess.clearCapture()
+                }
+            }
+        } finally {
+            watchdog.close()
+            release(lock, acquired.acquiredAtNanos, lockName, acquired.slot)
+        }
+    }
+
+    private fun <T> runAsyncWithGroupSlot(
+        lockName: String,
+        auditLeaderId: String?,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> =
+        CompletableFuture.supplyAsync({ acquire(lockName, auditLeaderId) }, executor)
+            .thenComposeAsync({ acquired ->
+                if (acquired == null) {
+                    CompletableFuture.completedFuture(null)
+                } else {
+                    runAcquiredAsync(lockName, acquired, auditLeaderId, executor, action)
+                }
+            }, executor)
+
+    private fun <T> runAcquiredAsync(
+        lockName: String,
+        acquired: AcquiredSlot,
+        auditLeaderId: String?,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> {
+        val lock = acquired.lock
+        val delegate = KubernetesLeaseLockExtendDelegate(lock)
+        val watchdog = LeaderLeaseAutoExtender.start(
+            enabled = false,
+            leaseTime = options.leaderGroupOptions.leaseTime,
+            delegate = delegate,
+            classifier = KubernetesLeaseLeaderElector.ERROR_CLASSIFIER,
+        )
+        val actionFuture = try {
+            val handle = handle(lockName, lock, acquired.slot, acquired.acquiredAtNanos, delegate, auditLeaderId)
+            AopScopeAccess.withPushedSync(handle) { action() }
+        } catch (e: Exception) {
+            watchdog.close()
+            release(lock, acquired.acquiredAtNanos, lockName, acquired.slot)
+            return CompletableFuture.failedFuture(e)
+        }
+
+        return actionFuture.handleAsync({ value, failure ->
+            watchdog.close()
+            release(lock, acquired.acquiredAtNanos, lockName, acquired.slot)
+            val cause = failure.unwrapCompletionException()
+            if (cause != null) {
+                throw cause
+            }
+            value
+        }, executor)
+    }
+
+    private fun acquire(lockName: String, auditLeaderId: String?): AcquiredSlot? {
+        val deadline = KubernetesLeaseGroupAcquisitionDeadline.fromNow(options.leaderGroupOptions.waitTime)
+        val startSlot = ThreadLocalRandom.current().nextInt(maxLeaders)
+
+        for (attempt in 0 until maxLeaders) {
+            val slot = (startSlot + attempt) % maxLeaders
+            val remaining = deadline.remaining()
+            if (attempt > 0 && remaining <= Duration.ZERO) {
+                break
+            }
+            val slotBudget = slotBudget(remaining, maxLeaders - attempt)
+            val lock = newSlotLock(lockName, slot, auditLeaderId)
+            if (lock.tryLock(slotBudget, options.leaderGroupOptions.leaseTime)) {
+                log.debug { "Kubernetes Lease group slot acquired. lockName=$lockName, slot=$slot" }
+                return AcquiredSlot(slot, lock, System.nanoTime())
+            }
+        }
+
+        log.debug { "Kubernetes Lease group acquisition skipped. lockName=$lockName" }
+        return null
+    }
+
+    private fun currentLeaders(lockName: String): List<LeaderLease> =
+        (0 until maxLeaders).mapNotNull { slot ->
+            runCatching {
+                newSlotLock(lockName, slot, null)
+                    .state()
+                    .leader
+                    ?.copy(slot = slot)
+            }.getOrElse { e ->
+                log.warn(e) { "Kubernetes Lease group state query failed. lockName=$lockName, slot=$slot" }
+                null
+            }
+        }
+
+    private fun handle(
+        lockName: String,
+        lock: KubernetesLeaseLock,
+        slot: Int,
+        acquiredAtNanos: Long,
+        delegate: KubernetesLeaseLockExtendDelegate,
+        auditLeaderId: String?,
+    ): LeaderLockHandle.Real =
+        LeaderLockHandle.real(
+            identity = LockIdentity(
+                lockName = lockName,
+                kind = LockIdentity.AnnotationKind.GROUP,
+                factoryBeanName = K8S_GROUP_FACTORY_BEAN_NAME,
+                groupParams = LockIdentity.GroupParams(maxLeaders),
+            ),
+            token = lock.ownerToken,
+            acquiredAtNanos = acquiredAtNanos,
+            slotId = slot.toString(),
+            extendDelegate = delegate,
+            auditLeaderId = auditLeaderId ?: lock.ownerToken,
+        )
+
+    private fun release(
+        lock: KubernetesLeaseLock,
+        acquiredAtNanos: Long,
+        lockName: String,
+        slot: Int,
+    ): Boolean =
+        try {
+            lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos)
+        } catch (e: Exception) {
+            log.warn(e) { "Failed to release Kubernetes Lease group slot. lockName=$lockName, slot=$slot" }
+            false
+        }
+
+    private fun newSlotLock(lockName: String, slot: Int, auditLeaderId: String?): KubernetesLeaseLock {
+        val ownerToken = KubernetesLeaseLock.newOwnerToken()
+        return KubernetesLeaseLock(
+            client = client,
+            namespace = options.namespace,
+            lockName = KubernetesLeaseNames.groupSlotLeaseName(lockName, slot, maxLeaders),
+            ownerToken = ownerToken,
+            auditLeaderId = auditLeaderId ?: ownerToken,
+            nodeId = options.leaderGroupOptions.nodeId,
+            retryDelay = options.retryDelay,
+            clock = clock,
+        )
+    }
+
+    private fun slotBudget(remaining: Duration, remainingSlots: Int): Duration {
+        if (remaining <= Duration.ZERO) {
+            return Duration.ZERO
+        }
+        return (remaining.inWholeMilliseconds / remainingSlots)
+            .coerceAtLeast(1L)
+            .milliseconds
+    }
+
+    private data class AcquiredSlot(
+        val slot: Int,
+        val lock: KubernetesLeaseLock,
+        val acquiredAtNanos: Long,
+    )
+}
+
+private fun Throwable?.unwrapCompletionException(): Throwable? =
+    if (this is CompletionException && cause != null) cause else this
+
+/**
+ * Runs [action] only when this client acquires one Kubernetes Lease group slot.
+ */
+inline fun <T> KubernetesClient.runIfLeaderGroup(
+    lockName: String,
+    options: KubernetesLeaseGroupOptions = KubernetesLeaseGroupOptions.Default,
+    crossinline action: () -> T,
+): T? =
+    KubernetesLeaseLeaderGroupElector(this, options).runIfLeader(lockName) { action() }
+
+/**
+ * Runs [action] asynchronously only when this client acquires one Kubernetes Lease group slot.
+ */
+fun <T> KubernetesClient.runAsyncIfLeaderGroup(
+    lockName: String,
+    options: KubernetesLeaseGroupOptions = KubernetesLeaseGroupOptions.Default,
+    executor: Executor = VirtualThreadExecutor,
+    action: () -> CompletableFuture<T>,
+): CompletableFuture<T?> =
+    KubernetesLeaseLeaderGroupElector(this, options).runAsyncIfLeader(lockName, executor, action)

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseSuspendLeaderGroupElector.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseSuspendLeaderGroupElector.kt
@@ -1,0 +1,236 @@
+package io.bluetape4k.leader.k8s
+
+import io.bluetape4k.leader.AopScopeAccess
+import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.LeaderLease
+import io.bluetape4k.leader.LeaderLeaseAutoExtender
+import io.bluetape4k.leader.LeaderLockHandle
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LeaderSlot
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
+import io.bluetape4k.leader.k8s.internal.KubernetesLeaseLock
+import io.bluetape4k.leader.k8s.internal.KubernetesLeaseLockExtendDelegate
+import io.bluetape4k.leader.k8s.internal.KubernetesLeaseGroupAcquisitionDeadline
+import io.bluetape4k.leader.k8s.internal.KubernetesLeaseNames
+import io.bluetape4k.logging.coroutines.KLoggingChannel
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
+import io.fabric8.kubernetes.client.KubernetesClient
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import java.time.Clock
+import java.util.concurrent.ThreadLocalRandom
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Coroutine group leader election backed by one Kubernetes Lease per group slot.
+ *
+ * ## Behavior / Contract
+ * - Fabric8 client calls are wrapped in [Dispatchers.IO].
+ * - Cancellation is rethrown after owner-conditional slot release in a [NonCancellable] cleanup section.
+ * - The supplied [KubernetesClient] is caller-owned and is never closed by this elector.
+ *
+ * ```kotlin
+ * val election = KubernetesLeaseSuspendLeaderGroupElector(client)
+ * election.runIfLeader("partition-worker") {
+ *     processPartitionSuspend()
+ * }
+ * ```
+ */
+class KubernetesLeaseSuspendLeaderGroupElector @JvmOverloads constructor(
+    private val client: KubernetesClient,
+    val options: KubernetesLeaseGroupOptions = KubernetesLeaseGroupOptions.Default,
+    private val clock: Clock = Clock.systemUTC(),
+) : SuspendLeaderGroupElector {
+
+    companion object : KLoggingChannel() {
+        internal const val K8S_SUSPEND_GROUP_FACTORY_BEAN_NAME = "kubernetes-lease-suspend-leader-group-elector"
+    }
+
+    override val maxLeaders: Int = options.maxLeaders
+
+    override fun activeCount(lockName: String): Int =
+        state(lockName).activeCount
+
+    override fun availableSlots(lockName: String): Int =
+        state(lockName).availableSlots
+
+    override fun state(lockName: String): LeaderGroupState {
+        val leaders = currentLeaders(lockName)
+        return LeaderGroupState(lockName, maxLeaders, leaders.size, leaders)
+    }
+
+    override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? =
+        runWithGroupSlot(lockName, null, action)
+
+    override suspend fun <T> runIfLeader(slot: LeaderSlot, action: suspend () -> T): T? =
+        runWithGroupSlot(slot.lockName, slot.leaderId, action)
+
+    override suspend fun <T> runIfLeaderResultSuspend(
+        slot: LeaderSlot,
+        action: suspend () -> T,
+    ): LeaderRunResult<T> {
+        var elected = false
+        val value = try {
+            runWithGroupSlot(slot.lockName, slot.leaderId) {
+                elected = true
+                action()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (elected) {
+                return LeaderRunResult.ActionFailed(e)
+            }
+            throw e
+        }
+        return if (elected) LeaderRunResult.Elected(value, leaderId = slot.leaderId) else LeaderRunResult.Skipped
+    }
+
+    private suspend fun <T> runWithGroupSlot(
+        lockName: String,
+        auditLeaderId: String?,
+        action: suspend () -> T,
+    ): T? {
+        currentCoroutineContext().ensureActive()
+        val acquired = withContext(Dispatchers.IO) {
+            acquire(lockName, auditLeaderId)
+        } ?: return null
+
+        val lock = acquired.lock
+        val delegate = KubernetesLeaseLockExtendDelegate(lock)
+        val handle = handle(lockName, lock, acquired.slot, acquired.acquiredAtNanos, delegate, auditLeaderId)
+        val watchdog = LeaderLeaseAutoExtender.start(
+            enabled = false,
+            leaseTime = options.leaderGroupOptions.leaseTime,
+            delegate = delegate,
+            classifier = KubernetesLeaseLeaderElector.ERROR_CLASSIFIER,
+        )
+
+        try {
+            return withContext(AopScopeAccess.createLockHandleElement(handle)) {
+                AopScopeAccess.setCapture(handle)
+                try {
+                    action()
+                } finally {
+                    AopScopeAccess.clearCapture()
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } finally {
+            withContext(NonCancellable + Dispatchers.IO) {
+                watchdog.close()
+                try {
+                    lock.unlock(options.leaderGroupOptions.minLeaseTime, acquired.acquiredAtNanos)
+                    log.debug { "Kubernetes Lease group slot released (suspend). lockName=$lockName, slot=${acquired.slot}" }
+                } catch (e: Exception) {
+                    log.warn(e) {
+                        "Failed to release Kubernetes Lease group slot (suspend). lockName=$lockName, slot=${acquired.slot}"
+                    }
+                }
+            }
+        }
+    }
+
+    private fun acquire(lockName: String, auditLeaderId: String?): AcquiredSlot? {
+        val deadline = KubernetesLeaseGroupAcquisitionDeadline.fromNow(options.leaderGroupOptions.waitTime)
+        val startSlot = ThreadLocalRandom.current().nextInt(maxLeaders)
+
+        for (attempt in 0 until maxLeaders) {
+            val slot = (startSlot + attempt) % maxLeaders
+            val remaining = deadline.remaining()
+            if (attempt > 0 && remaining <= Duration.ZERO) {
+                break
+            }
+            val lock = newSlotLock(lockName, slot, auditLeaderId)
+            if (lock.tryLock(slotBudget(remaining, maxLeaders - attempt), options.leaderGroupOptions.leaseTime)) {
+                log.debug { "Kubernetes Lease group slot acquired (suspend). lockName=$lockName, slot=$slot" }
+                return AcquiredSlot(slot, lock, System.nanoTime())
+            }
+        }
+
+        log.debug { "Kubernetes Lease group acquisition skipped (suspend). lockName=$lockName" }
+        return null
+    }
+
+    private fun currentLeaders(lockName: String): List<LeaderLease> =
+        (0 until maxLeaders).mapNotNull { slot ->
+            runCatching {
+                newSlotLock(lockName, slot, null)
+                    .state()
+                    .leader
+                    ?.copy(slot = slot)
+            }.getOrElse { e ->
+                log.warn(e) { "Kubernetes Lease group state query failed (suspend). lockName=$lockName, slot=$slot" }
+                null
+            }
+        }
+
+    private fun handle(
+        lockName: String,
+        lock: KubernetesLeaseLock,
+        slot: Int,
+        acquiredAtNanos: Long,
+        delegate: KubernetesLeaseLockExtendDelegate,
+        auditLeaderId: String?,
+    ): LeaderLockHandle.Real =
+        LeaderLockHandle.real(
+            identity = LockIdentity(
+                lockName = lockName,
+                kind = LockIdentity.AnnotationKind.GROUP,
+                factoryBeanName = K8S_SUSPEND_GROUP_FACTORY_BEAN_NAME,
+                groupParams = LockIdentity.GroupParams(maxLeaders),
+            ),
+            token = lock.ownerToken,
+            acquiredAtNanos = acquiredAtNanos,
+            slotId = slot.toString(),
+            extendDelegate = delegate,
+            auditLeaderId = auditLeaderId ?: lock.ownerToken,
+        )
+
+    private fun newSlotLock(lockName: String, slot: Int, auditLeaderId: String?): KubernetesLeaseLock {
+        val ownerToken = KubernetesLeaseLock.newOwnerToken()
+        return KubernetesLeaseLock(
+            client = client,
+            namespace = options.namespace,
+            lockName = KubernetesLeaseNames.groupSlotLeaseName(lockName, slot, maxLeaders),
+            ownerToken = ownerToken,
+            auditLeaderId = auditLeaderId ?: ownerToken,
+            nodeId = options.leaderGroupOptions.nodeId,
+            retryDelay = options.retryDelay,
+            clock = clock,
+        )
+    }
+
+    private fun slotBudget(remaining: Duration, remainingSlots: Int): Duration {
+        if (remaining <= Duration.ZERO) {
+            return Duration.ZERO
+        }
+        return (remaining.inWholeMilliseconds / remainingSlots)
+            .coerceAtLeast(1L)
+            .milliseconds
+    }
+
+    private data class AcquiredSlot(
+        val slot: Int,
+        val lock: KubernetesLeaseLock,
+        val acquiredAtNanos: Long,
+    )
+}
+
+/**
+ * Runs [action] only when this client acquires one Kubernetes Lease group slot in a coroutine.
+ */
+suspend fun <T> KubernetesClient.suspendRunIfLeaderGroup(
+    lockName: String,
+    options: KubernetesLeaseGroupOptions = KubernetesLeaseGroupOptions.Default,
+    action: suspend () -> T,
+): T? =
+    KubernetesLeaseSuspendLeaderGroupElector(this, options).runIfLeader(lockName) { action() }

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/internal/KubernetesLeaseGroupAcquisitionDeadline.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/internal/KubernetesLeaseGroupAcquisitionDeadline.kt
@@ -1,0 +1,16 @@
+package io.bluetape4k.leader.k8s.internal
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
+
+internal class KubernetesLeaseGroupAcquisitionDeadline private constructor(
+    private val expiresAtNanos: Long,
+) {
+    fun remaining(): Duration =
+        (expiresAtNanos - System.nanoTime()).coerceAtLeast(0L).nanoseconds
+
+    companion object {
+        fun fromNow(waitTime: Duration): KubernetesLeaseGroupAcquisitionDeadline =
+            KubernetesLeaseGroupAcquisitionDeadline(System.nanoTime() + waitTime.inWholeNanoseconds.coerceAtLeast(0L))
+    }
+}

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/internal/KubernetesLeaseNames.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/internal/KubernetesLeaseNames.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.k8s.internal
 
 import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requireInRange
 
 internal object KubernetesLeaseNames {
     private val Dns1123Label = Regex("[a-z0-9]([-a-z0-9]*[a-z0-9])?")
@@ -13,5 +14,12 @@ internal object KubernetesLeaseNames {
         require(Dns1123Label.matches(lockName)) {
             "lockName must be a DNS-1123 label for Kubernetes Lease name. lockName=$lockName"
         }
+    }
+
+    fun groupSlotLeaseName(lockName: String, slot: Int, maxLeaders: Int): String {
+        slot.requireInRange(0, maxLeaders - 1, "slot")
+        val leaseName = "$lockName-slot-$slot"
+        validateLeaseName(leaseName)
+        return leaseName
     }
 }

--- a/leader-k8s/src/test/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderGroupElectorK3sTest.kt
+++ b/leader-k8s/src/test/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderGroupElectorK3sTest.kt
@@ -1,0 +1,184 @@
+package io.bluetape4k.leader.k8s
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LeaderSlot
+import io.bluetape4k.leader.k8s.internal.KubernetesLeaseLock
+import io.bluetape4k.leader.k8s.internal.KubernetesLeaseNames
+import io.bluetape4k.testcontainers.infra.K3sServer
+import io.fabric8.kubernetes.client.KubernetesClient
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Clock
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+@Tag("k8s")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KubernetesLeaseLeaderGroupElectorK3sTest {
+
+    companion object {
+        private const val NAMESPACE = "default"
+
+        private val k3s: K3sServer by lazy { K3sServer.Launcher.k3s }
+    }
+
+    @Test
+    fun `runIfLeader acquires up to max leaders and releases for reacquire`() {
+        k3s.kubernetesClient().use { client ->
+            val lockName = randomLockName()
+            withCleanGroupLeases(client, lockName, maxLeaders = 2) {
+                val first = elector(client, nodeId = "node-a", maxLeaders = 2)
+                val second = elector(client, nodeId = "node-b", maxLeaders = 2)
+                val third = elector(client, nodeId = "node-c", maxLeaders = 2)
+
+                val result = first.runIfLeader(lockName) {
+                    val nested = second.runIfLeader(lockName) {
+                        val state = first.state(lockName)
+                        state.activeCount shouldBeEqualTo 2
+                        state.leaders.size shouldBeEqualTo 2
+                        third.runIfLeader(lockName) { "third" }.shouldBeNull()
+                        "second"
+                    }
+                    nested shouldBeEqualTo "second"
+                    "first"
+                }
+                val reacquired = third.runIfLeader(lockName) { "reacquired" }
+
+                result shouldBeEqualTo "first"
+                reacquired shouldBeEqualTo "reacquired"
+                first.state(lockName).activeCount shouldBeEqualTo 0
+            }
+        }
+    }
+
+    @Test
+    fun `slot leader id is written as group audit identity`() {
+        k3s.kubernetesClient().use { client ->
+            val lockName = randomLockName()
+            withCleanGroupLeases(client, lockName, maxLeaders = 2) {
+                val leaderId = "audit-node-a"
+                val election = elector(client, nodeId = "node-a", maxLeaders = 2)
+
+                val result = election.runIfLeaderResult(LeaderSlot(lockName, leaderId)) {
+                    val state = election.state(lockName)
+
+                    state.activeCount shouldBeEqualTo 1
+                    state.leaders.any {
+                        it.auditLeaderId == leaderId && it.nodeId == "node-a" && it.slot != null
+                    }.shouldBeTrue()
+                    "done"
+                }
+
+                (result is LeaderRunResult.Elected).shouldBeTrue()
+                (result as LeaderRunResult.Elected).value shouldBeEqualTo "done"
+                result.leaderId shouldBeEqualTo leaderId
+            }
+        }
+    }
+
+    @Test
+    fun `expired group slot is taken over by another owner`() {
+        k3s.kubernetesClient().use { client ->
+            val lockName = randomLockName()
+            withCleanGroupLeases(client, lockName, maxLeaders = 1) {
+                val staleLock = KubernetesLeaseLock(
+                    client = client,
+                    namespace = NAMESPACE,
+                    lockName = KubernetesLeaseNames.groupSlotLeaseName(lockName, slot = 0, maxLeaders = 1),
+                    ownerToken = "owner-a-${Base58.randomString(8).lowercase()}",
+                    auditLeaderId = "node-a",
+                    nodeId = "node-a",
+                    retryDelay = 10.milliseconds,
+                    clock = Clock.systemUTC(),
+                )
+
+                staleLock.tryLock(waitTime = 100.milliseconds, leaseTime = 1.seconds).shouldBeTrue()
+                Thread.sleep(1_250L)
+
+                val result = elector(client, nodeId = "node-b", maxLeaders = 1).runIfLeader(lockName) { "node-b" }
+
+                result shouldBeEqualTo "node-b"
+            }
+        }
+    }
+
+    @Test
+    fun `async failure releases group slot for next attempt`() {
+        k3s.kubernetesClient().use { client ->
+            val lockName = randomLockName()
+            withCleanGroupLeases(client, lockName, maxLeaders = 1) {
+                val election = elector(client, nodeId = "node-a", maxLeaders = 1)
+
+                assertFailsWith<CompletionException> {
+                    election.runAsyncIfLeader(lockName, VirtualThreadExecutor) {
+                        CompletableFuture.failedFuture<Int>(IllegalStateException("boom"))
+                    }.join()
+                }
+
+                val result = election.runAsyncIfLeader(lockName, VirtualThreadExecutor) {
+                    CompletableFuture.completedFuture("recovered")
+                }.get(5, TimeUnit.SECONDS)
+                result shouldBeEqualTo "recovered"
+            }
+        }
+    }
+
+    private fun elector(
+        client: KubernetesClient,
+        nodeId: String,
+        maxLeaders: Int,
+        waitTime: Duration = 200.milliseconds,
+        leaseTime: Duration = 1.seconds,
+    ): KubernetesLeaseLeaderGroupElector =
+        KubernetesLeaseLeaderGroupElector(
+            client,
+            KubernetesLeaseGroupOptions(
+                namespace = NAMESPACE,
+                retryDelay = 10.milliseconds,
+                leaderGroupOptions = LeaderGroupElectionOptions(
+                    maxLeaders = maxLeaders,
+                    waitTime = waitTime,
+                    leaseTime = leaseTime,
+                    nodeId = nodeId,
+                ),
+            ),
+        )
+
+    private fun randomLockName(): String =
+        "k8s-${Base58.randomString(10).lowercase()}"
+
+    private inline fun withCleanGroupLeases(
+        client: KubernetesClient,
+        lockName: String,
+        maxLeaders: Int,
+        block: () -> Unit,
+    ) {
+        deleteGroupLeases(client, lockName, maxLeaders)
+        try {
+            block()
+        } finally {
+            deleteGroupLeases(client, lockName, maxLeaders)
+        }
+    }
+
+    private fun deleteGroupLeases(client: KubernetesClient, lockName: String, maxLeaders: Int) {
+        repeat(maxLeaders) { slot ->
+            client.leases()
+                .inNamespace(NAMESPACE)
+                .withName(KubernetesLeaseNames.groupSlotLeaseName(lockName, slot, maxLeaders))
+                .delete()
+        }
+    }
+}

--- a/leader-k8s/src/test/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseSuspendLeaderGroupElectorK3sTest.kt
+++ b/leader-k8s/src/test/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseSuspendLeaderGroupElectorK3sTest.kt
@@ -1,0 +1,158 @@
+package io.bluetape4k.leader.k8s
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LeaderSlot
+import io.bluetape4k.leader.k8s.internal.KubernetesLeaseNames
+import io.bluetape4k.testcontainers.infra.K3sServer
+import io.fabric8.kubernetes.client.KubernetesClient
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+@Tag("k8s")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class KubernetesLeaseSuspendLeaderGroupElectorK3sTest {
+
+    companion object {
+        private const val NAMESPACE = "default"
+
+        private val k3s: K3sServer by lazy { K3sServer.Launcher.k3s }
+    }
+
+    @Test
+    fun `runIfLeader acquires up to max leaders in suspend group`() = runSuspendIO {
+        k3s.kubernetesClient().use { client ->
+            val lockName = randomLockName()
+            withCleanGroupLeases(client, lockName, maxLeaders = 2) {
+                val first = elector(client, nodeId = "node-a", maxLeaders = 2)
+                val second = elector(client, nodeId = "node-b", maxLeaders = 2)
+                val third = elector(client, nodeId = "node-c", maxLeaders = 2)
+
+                val result = first.runIfLeader(lockName) {
+                    val nested = second.runIfLeader(lockName) {
+                        first.state(lockName).activeCount shouldBeEqualTo 2
+                        third.runIfLeader(lockName) { "third" }.shouldBeNull()
+                        "second"
+                    }
+                    nested shouldBeEqualTo "second"
+                    "first"
+                }
+                val reacquired = third.runIfLeader(lockName) { "reacquired" }
+
+                result shouldBeEqualTo "first"
+                reacquired shouldBeEqualTo "reacquired"
+                first.state(lockName).activeCount shouldBeEqualTo 0
+            }
+        }
+    }
+
+    @Test
+    fun `runIfLeaderResultSuspend writes group slot leader id as audit identity`() = runSuspendIO {
+        k3s.kubernetesClient().use { client ->
+            val lockName = randomLockName()
+            withCleanGroupLeases(client, lockName, maxLeaders = 2) {
+                val leaderId = "audit-node-a"
+                val election = elector(client, nodeId = "node-a", maxLeaders = 2)
+
+                val result = election.runIfLeaderResultSuspend(LeaderSlot(lockName, leaderId)) {
+                    val state = election.state(lockName)
+
+                    state.activeCount shouldBeEqualTo 1
+                    state.leaders.any {
+                        it.auditLeaderId == leaderId && it.nodeId == "node-a" && it.slot != null
+                    }.shouldBeTrue()
+                    "done"
+                }
+
+                (result is LeaderRunResult.Elected).shouldBeTrue()
+                (result as LeaderRunResult.Elected).value shouldBeEqualTo "done"
+                result.leaderId shouldBeEqualTo leaderId
+            }
+        }
+    }
+
+    @Test
+    fun `cancellation releases group slot in NonCancellable cleanup`() = runSuspendIO {
+        k3s.kubernetesClient().use { client ->
+            val lockName = randomLockName()
+            withCleanGroupLeases(client, lockName, maxLeaders = 1) {
+                val election = elector(client, nodeId = "node-a", maxLeaders = 1)
+
+                kotlin.runCatching {
+                    withTimeout(100.milliseconds) {
+                        election.runIfLeader(lockName) {
+                            delay(1.seconds)
+                        }
+                    }
+                }.onFailure { e ->
+                    if (e !is TimeoutCancellationException) {
+                        throw e
+                    }
+                }
+
+                val result = election.runIfLeader(lockName) { "recovered" }
+                result shouldBeEqualTo "recovered"
+            }
+        }
+    }
+
+    private fun elector(
+        client: KubernetesClient,
+        nodeId: String,
+        maxLeaders: Int,
+        waitTime: Duration = 200.milliseconds,
+        leaseTime: Duration = 1.seconds,
+    ): KubernetesLeaseSuspendLeaderGroupElector =
+        KubernetesLeaseSuspendLeaderGroupElector(
+            client,
+            KubernetesLeaseGroupOptions(
+                namespace = NAMESPACE,
+                retryDelay = 10.milliseconds,
+                leaderGroupOptions = LeaderGroupElectionOptions(
+                    maxLeaders = maxLeaders,
+                    waitTime = waitTime,
+                    leaseTime = leaseTime,
+                    nodeId = nodeId,
+                ),
+            ),
+        )
+
+    private fun randomLockName(): String =
+        "k8s-${Base58.randomString(10).lowercase()}"
+
+    private inline fun withCleanGroupLeases(
+        client: KubernetesClient,
+        lockName: String,
+        maxLeaders: Int,
+        block: () -> Unit,
+    ) {
+        deleteGroupLeases(client, lockName, maxLeaders)
+        try {
+            block()
+        } finally {
+            deleteGroupLeases(client, lockName, maxLeaders)
+        }
+    }
+
+    private fun deleteGroupLeases(client: KubernetesClient, lockName: String, maxLeaders: Int) {
+        repeat(maxLeaders) { slot ->
+            client.leases()
+                .inNamespace(NAMESPACE)
+                .withName(KubernetesLeaseNames.groupSlotLeaseName(lockName, slot, maxLeaders))
+                .delete()
+        }
+    }
+}

--- a/leader-k8s/src/test/kotlin/io/bluetape4k/leader/k8s/internal/KubernetesLeaseSupportTest.kt
+++ b/leader-k8s/src/test/kotlin/io/bluetape4k/leader/k8s/internal/KubernetesLeaseSupportTest.kt
@@ -21,6 +21,18 @@ class KubernetesLeaseSupportTest {
     }
 
     @Test
+    fun `group slot lease name must leave room for suffix`() {
+        KubernetesLeaseNames.groupSlotLeaseName("daily-job", slot = 1, maxLeaders = 3) shouldBeEqualTo "daily-job-slot-1"
+
+        assertFailsWith<IllegalArgumentException> {
+            KubernetesLeaseNames.groupSlotLeaseName("x".repeat(60), slot = 1, maxLeaders = 3)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            KubernetesLeaseNames.groupSlotLeaseName("daily-job", slot = 3, maxLeaders = 3)
+        }
+    }
+
+    @Test
     fun `duration converts to ceiling seconds`() {
         1.milliseconds.toLeaseDurationSeconds("leaseTime") shouldBeEqualTo 1
         999.milliseconds.toLeaseDurationSeconds("leaseTime") shouldBeEqualTo 1


### PR DESCRIPTION
## Summary

Closes #404

PR #431의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `feat(k8s): add Lease-per-slot group leader election`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Fixes #404.

Adds Kubernetes Lease-per-slot group leader election for blocking, async, and coroutine APIs. Each logical group slot maps to its own `coordination.k8s.io/v1` Lease so release, extension delegate wiring, expiry takeover, and state snapshots keep the existing owner-conditional single-Lease safety model.

Also fixes the shared `LeaderLeaseAutoExtender.close()` path to wait for an in-flight extension before backend release. K3s verification exposed that pre-existing race in the single suspend watchdog test.

## DoD / 7-Tier Review

| Tier | Result | Evidence |
| --- | --- | --- |
| 1 Security | PASS | Per-slot Lease names are DNS-1123 validated; no secrets or new privileged APIs. |
| 2 Ops/SRE | PASS | Owner-conditional release, cancellation cleanup, expiry takeover, and K3s cleanup paths verified. |
| 3 Architecture | PASS | Reuses `KubernetesLeaseLock` rather than introducing a separate ownership model. |
| 4 Kotlin/API | PASS | Public API has KDoc; suspend Fabric8 calls run on `Dispatchers.IO`; cancellation is rethrown. |
| 5 Tests | PASS | New K3s coverage for sync, async, suspend, state/audit identity, expiry, failure, cancellation, and reacquire. |
| 6 Performance/Stability | PASS | Slot scan is bounded by `maxLeaders`; wait budget is bounded; watchdog close wait is capped. |
| 7 Docs/Release | PASS | README and README.ko document group usage, naming, options, and RBAC cleanup note; lesson added. |

P0: 0. P1: 0.

## Verification

- `./gradlew :bluetape4k-leader-k8s:compileKotlin :bluetape4k-leader-k8s:compileTestKotlin :bluetape4k-leader-k8s:test --no-daemon`
- `./gradlew :bluetape4k-leader-core:test --tests "io.bluetape4k.leader.LeaderLeaseAutoExtenderTest" --tests "io.bluetape4k.leader.LeaderLeaseAutoExtenderDelegateTest" --no-daemon`
- `./gradlew :bluetape4k-leader-k8s:k8sTest --no-daemon --max-workers=1`
- `./gradlew build -x test -x k8sTest --no-daemon`
- `git diff --cached --check`

## Notes

The first K3s pass after group tests exposed an existing single suspend watchdog close race. The final K3s run passed after the core close fix.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #404, milestone `0.3.0`, assignee `debop`
- PR: #431, head `607ddf596fd1f43be1deeefe865779ef2635d4e6`, milestone `0.3.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
