### PR TITLE
docs(spring): define group stream rejection contract

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -494,7 +494,8 @@ Stream 반환 규칙:
 - 길거나 무한에 가까운 stream에는 `autoExtend = true`를 사용하세요.
 - lease window 안에 끝나는 것이 확실한 stream에만 `streamBounded = true`를 사용하세요.
 - 안전하지 않은 `Flux` / `Flow` 시그니처는 validator와 subscription/collection 시점에 빠르게 실패합니다.
-- `@LeaderGroupElection`은 `T?`, `suspend T?`, `Mono<T>`를 지원하며, group lease extension 의미가 정의되기 전까지 `Flux` / `Flow` group stream은 거부됩니다.
+- `@LeaderGroupElection`은 `T?`, `suspend T?`, `Mono<T>`를 지원합니다.
+- `@LeaderGroupElection` `Flux<T>` / `Flow<T>` stream은 0.3.0 범위 밖입니다. slot별 group lease extension 의미가 정의되지 않았으므로 startup validation과 subscription/collection 시점에 다시 거부됩니다.
 
 ### `failureMode`
 

--- a/README.md
+++ b/README.md
@@ -491,7 +491,8 @@ Stream return rules:
 - Use `autoExtend = true` for long-running or unbounded streams.
 - Use `streamBounded = true` only when the stream is known to finish within the lease window.
 - Unsafe `Flux` / `Flow` signatures fail fast in the validator and at subscription/collection time.
-- `@LeaderGroupElection` supports `T?`, `suspend T?`, and `Mono<T>`; `Flux` / `Flow` group streams are rejected until group lease extension semantics are defined.
+- `@LeaderGroupElection` supports `T?`, `suspend T?`, and `Mono<T>`.
+- `@LeaderGroupElection` `Flux<T>` / `Flow<T>` streams are out of scope for 0.3.0. They are rejected in startup validation and again at subscription/collection time because group lease extension is not defined per slot.
 
 ### `failureMode`
 

--- a/docs/lessons/2026-05-29-issue-410-spring-group-stream-semantics.md
+++ b/docs/lessons/2026-05-29-issue-410-spring-group-stream-semantics.md
@@ -1,0 +1,23 @@
+# Issue 410 Spring Group Stream Semantics
+
+## Context
+
+Single-leader AOP supports `Flux` and Kotlin `Flow` by holding the lock for the subscription or collection lifecycle. Group election does not yet define slot-scoped auto-extension for long-lived streams.
+
+## Decision
+
+Keep `@LeaderGroupElection` `Flux<T>` and `Flow<T>` out of scope for 0.3.0. They must fail startup validation in strict mode and be rejected again by the aspect at subscription or collection time without calling the method body.
+
+## Outcome
+
+The public KDoc and README locale set now match the implementation: group AOP supports sync, suspend, and `Mono`, while group streams remain unsupported until per-slot extension semantics are designed.
+
+## Verification
+
+- `./gradlew :bluetape4k-leader-core:compileKotlin :bluetape4k-leader-spring-boot:compileKotlin --no-daemon` passed.
+- `./gradlew :bluetape4k-leader-spring-boot:test --tests 'io.bluetape4k.leader.spring.aop.LeaderGroupElectionAspectSuspendMonoTest' --tests 'io.bluetape4k.leader.spring.aop.validator.LeaderAnnotationValidatorBeanPostProcessorTest' --no-daemon` passed with 42 tests.
+- `git diff --check` passed.
+
+## Future Guard
+
+Do not enable group `Flux` / `Flow` only by relaxing the validator. First design slot-scoped lease extension, cancellation cleanup, metrics, and fail-open semantics.

--- a/docs/superpowers/plans/2026-05-29-issue-410-spring-group-stream-semantics-plan.md
+++ b/docs/superpowers/plans/2026-05-29-issue-410-spring-group-stream-semantics-plan.md
@@ -1,0 +1,38 @@
+# Implementation Plan - Issue #410 Spring group stream semantics
+
+## Scope
+
+Define and publish the 0.3.0 contract for `@LeaderGroupElection` stream return types. This is a design and safety-documentation PR with small test/KDoc reinforcement, not a group stream implementation.
+
+## Tasks
+
+| ID | Task | Acceptance |
+| --- | --- | --- |
+| T1 | Write the design spec. | Spec states whether group `Flux` / `Flow` is in scope for 0.3.0 and defines lifecycle/rejection semantics. |
+| T2 | Update public `LeaderGroupElection` KDoc. | KDoc says sync, suspend, and `Mono` are supported; group `Flux` / `Flow` are unsupported and rejected. |
+| T3 | Update README locale set. | `README.md` and `README.ko.md` explain that group streams are out of scope for 0.3.0 and rejected twice. |
+| T4 | Strengthen tests. | Validator covers group `Flow` startup failure; aspect tests verify unsupported group `Flux` / `Flow` do not call `pjp.proceed()`. |
+| T5 | Add lesson entry. | Lesson records the contract and future implementation guard. |
+| T6 | Verify targeted Spring Boot tests and diff hygiene. | `leader-spring-boot` targeted tests and `git diff --check` pass. |
+
+## Verification Commands
+
+```bash
+./gradlew :bluetape4k-leader-core:compileKotlin :bluetape4k-leader-spring-boot:compileKotlin --no-daemon
+./gradlew :bluetape4k-leader-spring-boot:test --tests 'io.bluetape4k.leader.spring.aop.LeaderGroupElectionAspectSuspendMonoTest' --tests 'io.bluetape4k.leader.spring.aop.validator.LeaderAnnotationValidatorBeanPostProcessorTest' --no-daemon
+git diff --check
+```
+
+## Step 3-R Plan Review
+
+| Tier | Verdict | Evidence |
+| --- | --- | --- |
+| 1 Security | PASS | Plan keeps unsupported stream body unexecuted and avoids fail-open stream execution. |
+| 2 Ops/SRE | PASS | Rejection semantics are explicit and observable as startup/runtime failure. |
+| 3 Architecture | PASS | No new group auto-extension API is introduced before slot semantics are designed. |
+| 4 Kotlin/API | PASS | Public API remains source-compatible; KDoc correction matches existing implementation. |
+| 5 Tests | PASS | Tests cover validator and runtime no-body behavior for both `Flux` and `Flow`. |
+| 6 Performance/Stability | PASS | No backend acquisition on unsupported streams; no hot-path implementation change. |
+| 7 Docs/Release | PASS | README locale set, spec, plan, and lesson are covered. |
+
+P0: 0. P1: 0. P2: 0. P3: 0.

--- a/docs/superpowers/specs/2026-05-29-issue-410-spring-group-stream-semantics-design.md
+++ b/docs/superpowers/specs/2026-05-29-issue-410-spring-group-stream-semantics-design.md
@@ -1,0 +1,74 @@
+# Design Spec - Issue #410 Spring group stream semantics
+
+## Context
+
+`@LeaderElection` supports `Flux<T>` and Kotlin `Flow<T>` because single-leader streams can either opt into watchdog-style extension with `autoExtend=true` or declare a finite stream with `streamBounded=true`.
+
+`@LeaderGroupElection` supports sync `T?`, `suspend T?`, and `Mono<T>`, but it does not expose group auto-extension. A group stream would need one acquired slot to stay valid until subscription cancellation, completion, or error, and the cleanup path must release that exact slot. Without a slot-scoped extension contract, allowing `Flux<T>` or `Flow<T>` would risk releasing before stream termination or holding an expired slot while downstream still observes elected execution.
+
+## Decision
+
+Group `Flux<T>` and Kotlin `Flow<T>` support is out of scope for 0.3.0.
+
+The 0.3.0 public contract is:
+
+- `@LeaderGroupElection` may protect sync `T?`, `suspend T?`, and Reactor `Mono<T>` methods.
+- `@LeaderGroupElection` methods returning `Flux<T>` or `Flow<T>` are unsafe signatures.
+- Strict startup validation must fail for group `Flux<T>` and group `Flow<T>`.
+- Non-strict startup validation may warn, but runtime must still reject the stream at subscription or collection time.
+- Runtime rejection must not call the method body, must not acquire a group slot, and must surface `LeaderGroupElectionException`.
+
+## Lifecycle Semantics
+
+For supported group return types:
+
+- Sync: acquire one slot before body execution and release after the body returns or throws.
+- Suspend: acquire one slot before coroutine body execution and release in the suspend elector cleanup path.
+- Mono: defer acquisition until subscription and release after the `Mono` completes, errors, or is cancelled.
+
+For unsupported group streams:
+
+- `Flux<T>` returns a cold error `Flux`.
+- `Flow<T>` returns a cold error `Flow`.
+- Subscription or collection fails before `pjp.proceed()` is called.
+- No fail-open branch is allowed for unsupported group streams, because fail-open would execute a stream without a lease contract while appearing to be under group election.
+
+## Unsafe Signatures
+
+These must continue to fail validation:
+
+```kotlin
+@LeaderGroupElection(name = "group-events", maxLeaders = 3)
+fun groupEvents(): Flux<Event>
+
+@LeaderGroupElection(name = "group-flow", maxLeaders = 3)
+fun groupFlow(): Flow<Event>
+```
+
+`@LeaderElection` stream rules do not transfer to group election. In particular, `streamBounded` exists only on `@LeaderElection`, and `autoExtend` is not available on `@LeaderGroupElection` in 0.3.0.
+
+## Future Implementation Shape
+
+A future group stream feature must first add slot-scoped extension semantics:
+
+- one acquired group slot per subscription or collection;
+- watchdog extension tied to that slot identity;
+- release of the same slot on complete, error, and cancellation;
+- metrics that distinguish unsupported stream rejection, contention skip, backend failure, and body failure;
+- tests for per-subscription acquisition, downstream cancellation, body error, backend error, fail-open policy, and slot cleanup.
+
+Until that exists, group streams remain rejected even if validation is configured as non-strict.
+
+## Step 2-R Local 7-Tier Review
+
+| Tier | Verdict | Evidence |
+| --- | --- | --- |
+| 1 Security | PASS | Unsupported streams do not execute user code without a lease and introduce no new input surface. |
+| 2 Ops/SRE | PASS | Contract prefers fail-fast startup/runtime errors over ambiguous long-lived slot ownership. |
+| 3 Architecture | PASS | Keeps group election on existing slot model; avoids adding group auto-extension in 0.3.0. |
+| 4 Kotlin/API | PASS | No new public annotation property; KDoc clarifies existing supported return shapes. |
+| 5 Tests | PASS | Existing tests cover runtime rejection; this work adds group Flow validator coverage and no-body verification. |
+| 6 Performance/Stability | PASS | Rejection is cold and performs no backend acquisition or stream collection. |
+| 7 Docs/Release | PASS | README locale set and KDoc are updated to reflect the 0.3.0 contract. |
+
+P0: 0. P1: 0. P2: 0. P3: 0.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/annotation/LeaderGroupElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/annotation/LeaderGroupElection.kt
@@ -6,7 +6,11 @@ package io.bluetape4k.leader.annotation
  * ## Behavior
  * - On method call, attempts to acquire one of [maxLeaders] slots using [name]. If successful, runs the body;
  *   otherwise branches according to [failureMode].
- * - Supports sync `T?` return only. suspend / `Mono<T>` / `Flow<T>` are planned for follow-up [#80].
+ * - Supports sync `T?`, `suspend T?`, and Reactor `Mono<T>` return types.
+ * - Reactor `Flux<T>` and Kotlin `Flow<T>` return types are intentionally unsupported in 0.3.0.
+ *   Group stream execution would require per-slot lease extension semantics across subscription,
+ *   cancellation, completion, and error paths. Unsafe stream signatures fail validation and are
+ *   also rejected by the runtime aspect at subscription or collection time.
  * - Startup fails if [maxLeaders] ≤ 1 (use [LeaderElection] for single-leader).
  *
  * ## Usage Example

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectSuspendMonoTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectSuspendMonoTest.kt
@@ -14,6 +14,7 @@ import io.bluetape4k.logging.KLogging
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeNull
@@ -352,6 +353,7 @@ class LeaderGroupElectionAspectSuspendMonoTest {
         val flux = aspect.aroundLeader(pjp) as Flux<*>
 
         assertFailsWith<LeaderGroupElectionException> { flux.collectList().block() }
+        verify(exactly = 0) { pjp.proceed() }
     }
 
     @Test
@@ -362,5 +364,6 @@ class LeaderGroupElectionAspectSuspendMonoTest {
         val flow = aspect.aroundLeader(pjp) as Flow<*>
 
         assertFailsWith<LeaderGroupElectionException> { flow.toList() }
+        verify(exactly = 0) { pjp.proceed() }
     }
 }

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessorTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/validator/LeaderAnnotationValidatorBeanPostProcessorTest.kt
@@ -223,6 +223,16 @@ class LeaderAnnotationValidatorBeanPostProcessorTest {
     }
 
     @Test
+    fun `LeaderGroupElection Flow 반환 타입 strict true - startup fail`() {
+        class SampleFlow {
+            @LeaderGroupElection(name = "group-flow-job", maxLeaders = 3)
+            open fun process(): Flow<String> = flowOf("ok")
+        }
+        val bpp = LeaderAnnotationValidatorBeanPostProcessor(strict = true, spel = spel)
+        assertFailsWith<IllegalStateException> { bpp.postProcessAfterInitialization(SampleFlow(), "sample") }
+    }
+
+    @Test
     fun `composed bounded stream - AliasFor streamBounded 통과`() {
         class SampleComposedStream {
             @ComposedBoundedLeaderStream(name = "alias-stream-job")


### PR DESCRIPTION
## Summary

Closes #410

PR #433의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `docs(spring): define group stream rejection contract`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Closes #410.

This PR defines the 0.3.0 public contract for `@LeaderGroupElection` stream return types:

- Keeps group `Flux<T>` / Kotlin `Flow<T>` out of scope for 0.3.0.
- Documents that group AOP supports sync, suspend, and `Mono<T>` only for now.
- Pins unsafe group stream behavior: strict startup validation fails, and runtime rejects again at subscription/collection time without calling the method body.
- Adds a design spec, implementation plan, lesson, README locale updates, KDoc correction, and targeted tests.

## DoD / 7-Tier Review

| Tier | Result | Evidence |
| --- | --- | --- |
| 1 Security | PASS | Unsupported streams do not execute user code without a lease and add no new input surface. |
| 2 Ops/SRE | PASS | Fail-fast startup/runtime rejection avoids ambiguous long-lived group slot ownership. |
| 3 Architecture | PASS | No group stream API is enabled before slot-scoped extension semantics exist. |
| 4 Kotlin/API | PASS | Source-compatible KDoc clarification; no new annotation property. |
| 5 Tests | PASS | Validator now covers group Flow; aspect tests verify group Flux/Flow do not call `pjp.proceed()`. |
| 6 Performance/Stability | PASS | Runtime rejection remains cold and performs no backend acquisition. |
| 7 Docs/Release | PASS | README/README.ko, spec, plan, and lesson updated. |

P0: 0. P1: 0.

## Verification

- `./gradlew :bluetape4k-leader-core:compileKotlin :bluetape4k-leader-spring-boot:compileKotlin --no-daemon`
- `./gradlew :bluetape4k-leader-spring-boot:test --tests 'io.bluetape4k.leader.spring.aop.LeaderGroupElectionAspectSuspendMonoTest' --tests 'io.bluetape4k.leader.spring.aop.validator.LeaderAnnotationValidatorBeanPostProcessorTest' --no-daemon` (42 tests)
- `git diff --check`

## Notes

An initial local compile command used stale short module paths (`:leader-core`, `:leader-spring-boot`) and failed before execution. The verification above uses the correct repository module paths.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #410, milestone `0.3.0`, assignee `debop`
- PR: #433, head `b3b6cc69a0cc49dbd3446ec26d0aac6ce49e0f82`, milestone `0.3.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
