### PR TITLE
fix: refresh Nightly snapshot metadata

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,8 +2,8 @@ name: Nightly
 
 on:
   schedule:
-    - cron: '0 19 * * 1-6'  # Daily smoke, UTC 19:00 (KST 04:00) Mon-Sat
-    - cron: '0 19 * * 0'    # Weekly full, UTC 19:00 (KST 04:00) Sunday
+    - cron: '19 19 * * 1-6'  # Daily smoke, UTC 19:19 (KST 04:19) Mon-Sat
+    - cron: '19 19 * * 0'    # Weekly full, UTC 19:19 (KST 04:19) Sunday
   workflow_dispatch:
     inputs:
       scope:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -51,11 +51,11 @@ jobs:
         with:
           gradle-version: wrapper
       - name: Build (compile only)
-        run: ./gradlew build -x test -x koverVerify --parallel
+        run: ./gradlew --refresh-dependencies build -x test -x koverVerify --parallel
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       - name: Detekt static analysis
-        run: ./gradlew detekt --parallel
+        run: ./gradlew --refresh-dependencies detekt --parallel
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       - name: Upload detekt report
@@ -85,7 +85,7 @@ jobs:
       - name: Test leader-core
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-core:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-core:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -93,7 +93,7 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-core:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-core:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -131,7 +131,7 @@ jobs:
       - name: Test leader-redis-lettuce
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-redis-lettuce:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-redis-lettuce:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -141,7 +141,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-redis-lettuce:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-redis-lettuce:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -179,7 +179,7 @@ jobs:
       - name: Test leader-redis-redisson
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-redis-redisson:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-redis-redisson:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -189,7 +189,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-redis-redisson:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-redis-redisson:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -225,7 +225,7 @@ jobs:
       - name: Test leader-exposed-core (H2)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-exposed-core:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -234,7 +234,7 @@ jobs:
           LEADER_TEST_DB: "H2"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -272,7 +272,7 @@ jobs:
       - name: Test leader-exposed-core (PostgreSQL)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-exposed-core:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -283,7 +283,7 @@ jobs:
           LEADER_TEST_DB: "POSTGRESQL"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -321,7 +321,7 @@ jobs:
       - name: Test leader-exposed-core (MySQL 8)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-exposed-core:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -332,7 +332,7 @@ jobs:
           LEADER_TEST_DB: "MYSQL_V8"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -368,7 +368,7 @@ jobs:
       - name: Test leader-exposed-jdbc (H2)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-exposed-jdbc:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -377,7 +377,7 @@ jobs:
           LEADER_TEST_DB: "H2"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -415,7 +415,7 @@ jobs:
       - name: Test leader-exposed-jdbc (PostgreSQL)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-exposed-jdbc:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -426,7 +426,7 @@ jobs:
           LEADER_TEST_DB: "POSTGRESQL"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -464,7 +464,7 @@ jobs:
       - name: Test leader-exposed-jdbc (MySQL 8)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-exposed-jdbc:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -475,7 +475,7 @@ jobs:
           LEADER_TEST_DB: "MYSQL_V8"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -511,7 +511,7 @@ jobs:
       - name: Test leader-exposed-r2dbc (H2)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-exposed-r2dbc:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -520,7 +520,7 @@ jobs:
           LEADER_TEST_DB: "H2"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -557,7 +557,7 @@ jobs:
       - name: Test leader-exposed-r2dbc (PostgreSQL)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-exposed-r2dbc:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -568,7 +568,7 @@ jobs:
           LEADER_TEST_DB: "POSTGRESQL"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -605,7 +605,7 @@ jobs:
       - name: Test leader-exposed-r2dbc (MySQL 8)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-exposed-r2dbc:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -616,7 +616,7 @@ jobs:
           LEADER_TEST_DB: "MYSQL_V8"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -654,7 +654,7 @@ jobs:
       - name: Test leader-mongodb
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-mongodb:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-mongodb:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -664,7 +664,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-mongodb:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-mongodb:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -702,7 +702,7 @@ jobs:
       - name: Test leader-dynamodb
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-dynamodb:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-dynamodb:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -712,7 +712,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-dynamodb:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-dynamodb:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -750,7 +750,7 @@ jobs:
       - name: Test leader-etcd
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-etcd:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-etcd:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -760,7 +760,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-etcd:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-etcd:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -796,7 +796,7 @@ jobs:
       - name: Test leader-consul
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-consul:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-consul:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -806,7 +806,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-consul:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-consul:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -844,7 +844,7 @@ jobs:
       - name: Test leader-k8s unit and K3s group slots
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-k8s:test :bluetape4k-leader-k8s:k8sTest --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-k8s:test :bluetape4k-leader-k8s:k8sTest --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -854,7 +854,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-k8s:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-k8s:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -892,7 +892,7 @@ jobs:
       - name: Test leader-hazelcast
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-hazelcast:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-hazelcast:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -902,7 +902,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-hazelcast:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-hazelcast:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -940,7 +940,7 @@ jobs:
       - name: Test leader-zookeeper
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-zookeeper:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-zookeeper:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -950,7 +950,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-zookeeper:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-zookeeper:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -986,7 +986,7 @@ jobs:
       - name: Test leader-micrometer
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-micrometer:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-micrometer:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -994,7 +994,7 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-micrometer:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-micrometer:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -1032,7 +1032,7 @@ jobs:
       - name: Test leader-spring-boot
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-spring-boot:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-spring-boot:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1042,7 +1042,7 @@ jobs:
           DOCKER_HOST: 'unix:///var/run/docker.sock'
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-spring-boot:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-spring-boot:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -1080,7 +1080,7 @@ jobs:
       - name: Test leader-ktor
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-ktor:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-ktor:test --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1090,7 +1090,7 @@ jobs:
           DOCKER_HOST: 'unix:///var/run/docker.sock'
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-ktor:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-ktor:koverXmlReport --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()

--- a/docs/lessons/2026-06-04-nightly-snapshot-refresh.md
+++ b/docs/lessons/2026-06-04-nightly-snapshot-refresh.md
@@ -1,0 +1,22 @@
+# Nightly Snapshot Refresh
+
+## Context
+
+Nightly restores Gradle caches and consumes mutable bluetape4k Central snapshot artifacts.
+Stale snapshot metadata can make module jobs fail before tests execute.
+
+## Decision
+
+Pass `--refresh-dependencies` to Nightly Gradle invocations so snapshot metadata
+is rechecked on every scheduled or manually dispatched run.
+
+## Outcome
+
+Nightly keeps cache reuse for build state while avoiding stale Maven snapshot
+metadata during dependency resolution.
+
+## Verification
+
+- `actionlint .github/workflows/nightly-tests.yml`
+- `git diff --check`
+

--- a/docs/lessons/2026-06-04-nightly-snapshot-refresh.md
+++ b/docs/lessons/2026-06-04-nightly-snapshot-refresh.md
@@ -3,20 +3,21 @@
 ## Context
 
 Nightly restores Gradle caches and consumes mutable bluetape4k Central snapshot artifacts.
-Stale snapshot metadata can make module jobs fail before tests execute.
+Stale snapshot metadata or simultaneous Central snapshot metadata requests can
+make module jobs fail before tests execute.
 
 ## Decision
 
-Pass `--refresh-dependencies` to Nightly Gradle invocations so snapshot metadata
-is rechecked on every scheduled or manually dispatched run.
+Pass `--refresh-dependencies` to Nightly Gradle invocations and stagger the
+scheduled cron minute so snapshot metadata is rechecked without starting every
+downstream repository at the same time.
 
 ## Outcome
 
-Nightly keeps cache reuse for build state while avoiding stale Maven snapshot
-metadata during dependency resolution.
+Nightly keeps cache reuse for build state, refreshes mutable metadata, and
+reduces scheduled cross-repository Central snapshot contention.
 
 ## Verification
 
 - `actionlint .github/workflows/nightly-tests.yml`
 - `git diff --check`
-


### PR DESCRIPTION
## Summary

Closes #468

PR #469의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: refresh Nightly snapshot metadata`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

This PR hardens the Nightly workflow against recurring failures while resolving mutable bluetape4k Central snapshot dependencies.

## Background

Several downstream Nightly workflows failed while resolving io.github.bluetape4k:*:1.11.0-SNAPSHOT metadata from Central snapshots. The failures appeared before repository tests ran, so the mitigation belongs in the workflow dependency-resolution path rather than in module test code.

A manual same-time fan-out also reproduced Central snapshot 403 behavior, which showed that stale Gradle metadata was not the only risk. Scheduled downstream Nightly jobs should not all refresh mutable snapshot metadata at the same minute.

## Work Done

- Added --refresh-dependencies to Nightly Gradle invocations so restored Gradle caches cannot keep stale snapshot metadata.
- Staggered this repository schedule to minute 19 in the 19:00 UTC Nightly window.
- Added a repo-local lesson documenting the recurrence rule for future workflow changes.

## Validation

- actionlint .github/workflows/nightly-tests.yml: PASS
- git diff --check: PASS
- Gradle invocation audit: PASS, zero ./gradlew calls missing --refresh-dependencies in the Nightly workflow
- PR CI: PASS / CLEAN

## Follow-up Evidence

- The simultaneous manual full Nightly fan-out reproduced Central snapshot 403 in bluetape4k-graph, so the final merged fix includes both dependency refresh and schedule staggering.
- experimental was explicitly excluded from this sweep.

Closes #468

## Metadata

- PR: #469
- Merge commit: 86607a88f5a37f4ceeef212fb0d1613de1f9bc28
- URL: https://github.com/bluetape4k/bluetape4k-leader/pull/469
- Assignee: debop

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| Root-cause check | PASS | Snapshot metadata failures identified in prior Nightly logs |
| Workflow fix | PASS | Nightly Gradle calls refresh dependencies |
| Recurrence guard | PASS | Scheduled minute staggered across downstream repos |
| Static validation | PASS | actionlint and git diff --check passed |
| CI gate | PASS | PR status checks were CLEAN before merge |
| Merge/local sync | PASS | Merged to develop and local develop fast-forwarded |

Final status: merged
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #468, milestone `0.5.0`, assignee `debop`
- PR: #469, head `352629dde3bbcca559fbac81b3c64e636223c836`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
