### PR TITLE
fix: align Nightly full schedule condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' }}
 
       - name: Build (compile only)
-        run: ./gradlew build -x test -x koverVerify --parallel
+        run: ./gradlew build -x test -x koverVerify --parallel --refresh-dependencies --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
 
@@ -278,7 +278,7 @@ jobs:
       - name: Test leader-core
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-core:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-core:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -287,7 +287,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-core:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-core:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -326,7 +326,7 @@ jobs:
       - name: Test leader-micrometer
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-micrometer:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-micrometer:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -334,7 +334,7 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-micrometer:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-micrometer:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -374,7 +374,7 @@ jobs:
       - name: Test leader-redis-lettuce
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-redis-lettuce:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-redis-lettuce:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -385,7 +385,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-redis-lettuce:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-redis-lettuce:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -427,7 +427,7 @@ jobs:
       - name: Test leader-redis-redisson
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-redis-redisson:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-redis-redisson:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -438,7 +438,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-redis-redisson:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-redis-redisson:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -480,7 +480,7 @@ jobs:
       - name: Test leader-exposed-jdbc (H2)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-exposed-jdbc:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-exposed-jdbc:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -490,7 +490,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -532,7 +532,7 @@ jobs:
       - name: Test leader-exposed-jdbc (PostgreSQL)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-exposed-jdbc:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-exposed-jdbc:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -544,7 +544,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -586,7 +586,7 @@ jobs:
       - name: Test leader-exposed-jdbc (MySQL 8)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-exposed-jdbc:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-exposed-jdbc:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -598,7 +598,7 @@ jobs:
 
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
 
       - name: Upload test results
@@ -638,7 +638,7 @@ jobs:
       - name: Test leader-exposed-r2dbc (H2)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-exposed-r2dbc:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-exposed-r2dbc:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -647,7 +647,7 @@ jobs:
           LEADER_TEST_DB: "H2"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -684,7 +684,7 @@ jobs:
       - name: Test leader-exposed-r2dbc (PostgreSQL)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-exposed-r2dbc:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-exposed-r2dbc:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -695,7 +695,7 @@ jobs:
           LEADER_TEST_DB: "POSTGRESQL"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -732,7 +732,7 @@ jobs:
       - name: Test leader-exposed-r2dbc (MySQL 8)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-exposed-r2dbc:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-exposed-r2dbc:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -743,7 +743,7 @@ jobs:
           LEADER_TEST_DB: "MYSQL_V8"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -780,7 +780,7 @@ jobs:
       - name: Test examples-migration-gate
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :examples:migration-gate:test --no-daemon && break
+            ./gradlew :examples:migration-gate:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -816,7 +816,7 @@ jobs:
       - name: Test examples-webhook-poller
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :examples:webhook-poller:test --no-daemon && break
+            ./gradlew :examples:webhook-poller:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -852,7 +852,7 @@ jobs:
       - name: Test examples-cache-warmer
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :examples:cache-warmer:test --no-daemon && break
+            ./gradlew :examples:cache-warmer:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -888,7 +888,7 @@ jobs:
       - name: Test examples-tenant-aggregator
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :examples:tenant-aggregator:test --no-daemon && break
+            ./gradlew :examples:tenant-aggregator:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -924,7 +924,7 @@ jobs:
       - name: Test examples-batch-scheduler
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :examples:batch-scheduler:test --no-daemon && break
+            ./gradlew :examples:batch-scheduler:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -960,7 +960,7 @@ jobs:
       - name: Test examples-etcd-reconciler
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :examples:etcd-reconciler:test --no-daemon && break
+            ./gradlew :examples:etcd-reconciler:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -996,7 +996,7 @@ jobs:
       - name: Test examples-consul-maintenance
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :examples:consul-maintenance:test --no-daemon && break
+            ./gradlew :examples:consul-maintenance:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1032,7 +1032,7 @@ jobs:
       - name: Test examples-k8s-lease
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :examples:k8s-lease:test --no-daemon && break
+            ./gradlew :examples:k8s-lease:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1066,7 +1066,7 @@ jobs:
       - name: Test examples-k8s-operator
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :examples:k8s-operator:test --no-daemon && break
+            ./gradlew :examples:k8s-operator:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1100,7 +1100,7 @@ jobs:
       - name: Test examples-rate-limiter
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :examples:rate-limiter:test --no-daemon && break
+            ./gradlew :examples:rate-limiter:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1136,7 +1136,7 @@ jobs:
       - name: Test examples-strategic-election
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :examples:strategic-election:test --no-daemon && break
+            ./gradlew :examples:strategic-election:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1170,7 +1170,7 @@ jobs:
       - name: Test examples-virtual-thread-runner
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :examples:virtual-thread-runner:test --no-daemon && break
+            ./gradlew :examples:virtual-thread-runner:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1204,7 +1204,7 @@ jobs:
       - name: Test examples-redisson-watchdog
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :examples:redisson-watchdog:test --no-daemon && break
+            ./gradlew :examples:redisson-watchdog:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1240,7 +1240,7 @@ jobs:
       - name: Test examples-ktor-app
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :examples:ktor-app:test --no-daemon && break
+            ./gradlew :examples:ktor-app:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1276,7 +1276,7 @@ jobs:
       - name: Test examples-prometheus-dashboard
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :examples:prometheus-dashboard:processAot :examples:prometheus-dashboard:processTestAot :examples:prometheus-dashboard:test --no-daemon && break
+            ./gradlew :examples:prometheus-dashboard:processAot :examples:prometheus-dashboard:processTestAot :examples:prometheus-dashboard:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1312,7 +1312,7 @@ jobs:
       - name: Test leader-spring-boot
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-spring-boot:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-spring-boot:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1322,7 +1322,7 @@ jobs:
           DOCKER_HOST: 'unix:///var/run/docker.sock'
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-spring-boot:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-spring-boot:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -1359,7 +1359,7 @@ jobs:
       - name: Test leader-ktor
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-ktor:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-ktor:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1369,7 +1369,7 @@ jobs:
           DOCKER_HOST: 'unix:///var/run/docker.sock'
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-ktor:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-ktor:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -1406,7 +1406,7 @@ jobs:
       - name: Test leader-mongodb
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-mongodb:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-mongodb:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1416,7 +1416,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-mongodb:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-mongodb:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -1453,7 +1453,7 @@ jobs:
       - name: Test leader-dynamodb
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-dynamodb:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-dynamodb:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1463,7 +1463,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-dynamodb:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-dynamodb:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -1500,7 +1500,7 @@ jobs:
       - name: Test leader-etcd
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-etcd:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-etcd:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1510,7 +1510,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-etcd:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-etcd:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -1547,7 +1547,7 @@ jobs:
       - name: Test leader-consul
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-consul:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-consul:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1557,7 +1557,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-consul:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-consul:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -1594,7 +1594,7 @@ jobs:
       - name: Test leader-k8s
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-k8s:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-k8s:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1628,7 +1628,7 @@ jobs:
       - name: Test leader-hazelcast
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-hazelcast:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-hazelcast:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1638,7 +1638,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-hazelcast:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-hazelcast:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -1675,7 +1675,7 @@ jobs:
       - name: Test leader-zookeeper
         run: |
           for attempt in 1 2 3; do
-            ./gradlew :bluetape4k-leader-zookeeper:test --no-daemon && break
+            ./gradlew :bluetape4k-leader-zookeeper:test --refresh-dependencies --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1685,7 +1685,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew :bluetape4k-leader-zookeeper:koverXmlReport --no-daemon
+        run: ./gradlew :bluetape4k-leader-zookeeper:koverXmlReport --refresh-dependencies --no-configuration-cache --no-daemon
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -1720,7 +1720,7 @@ jobs:
           gradle-version: wrapper
           cache-read-only: true
       - name: Compile benchmark classes
-        run: ./gradlew :benchmark:compileBenchmarkKotlin --no-daemon --no-configuration-cache
+        run: ./gradlew :benchmark:compileBenchmarkKotlin --refresh-dependencies --no-configuration-cache --no-daemon
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
 

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -113,7 +113,7 @@ jobs:
   # ── leader-redis-lettuce (Testcontainers: Redis) ────────────────────────────
   test-redis-lettuce:
     name: Test / leader-redis-lettuce (Testcontainers)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -161,7 +161,7 @@ jobs:
   # ── leader-redis-redisson (Testcontainers: Redis) ───────────────────────────
   test-redis-redisson:
     name: Test / leader-redis-redisson (Testcontainers)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -254,7 +254,7 @@ jobs:
   # ── leader-exposed-core (PostgreSQL, Testcontainers) ───────────────────────
   test-exposed-core-postgresql:
     name: Test / leader-exposed-core (PostgreSQL)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -303,7 +303,7 @@ jobs:
   # ── leader-exposed-core (MySQL 8, Testcontainers) ──────────────────────────
   test-exposed-core-mysql:
     name: Test / leader-exposed-core (MySQL 8)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -397,7 +397,7 @@ jobs:
   # ── leader-exposed-jdbc (PostgreSQL, Testcontainers) ───────────────────────
   test-exposed-jdbc-postgresql:
     name: Test / leader-exposed-jdbc (PostgreSQL)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -446,7 +446,7 @@ jobs:
   # ── leader-exposed-jdbc (MySQL 8, Testcontainers) ──────────────────────────
   test-exposed-jdbc-mysql:
     name: Test / leader-exposed-jdbc (MySQL 8)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -540,7 +540,7 @@ jobs:
   # ── leader-exposed-r2dbc (PostgreSQL) ─────────────────────────────────────
   test-exposed-r2dbc-postgresql:
     name: Test / leader-exposed-r2dbc (PostgreSQL)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: build
@@ -588,7 +588,7 @@ jobs:
   # ── leader-exposed-r2dbc (MySQL 8) ────────────────────────────────────────
   test-exposed-r2dbc-mysql:
     name: Test / leader-exposed-r2dbc (MySQL 8)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: build
@@ -636,7 +636,7 @@ jobs:
   # ── leader-mongodb (Testcontainers: MongoDB) ────────────────────────────────
   test-mongodb:
     name: Test / leader-mongodb (Testcontainers)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -684,7 +684,7 @@ jobs:
   # ── 0.2.2 preview gate: DynamoDB Local runtime tests ──────────────────────
   test-leader-dynamodb:
     name: Test / leader-dynamodb (DynamoDB Local)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -732,7 +732,7 @@ jobs:
   # ── 0.2.2 preview gate: etcd Testcontainers runtime tests ────────────────
   test-leader-etcd:
     name: Test / leader-etcd (Testcontainers)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -826,7 +826,7 @@ jobs:
   # ── 0.3.0 preview gate: Kubernetes Lease K3s runtime tests, including group slots; full only ──
   test-leader-k8s:
     name: Test / leader-k8s (K3s + group slots)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -874,7 +874,7 @@ jobs:
   # ── leader-hazelcast (Testcontainers: Hazelcast) ────────────────────────────
   test-hazelcast:
     name: Test / leader-hazelcast (Testcontainers)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -922,7 +922,7 @@ jobs:
   # ── leader-zookeeper (Testcontainers: ZooKeeper) ───────────────────────────
   test-zookeeper:
     name: Test / leader-zookeeper (Testcontainers)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -1014,7 +1014,7 @@ jobs:
   # ── leader-spring-boot (Testcontainers: Redis + MongoDB + H2) ───────────────
   test-spring-boot:
     name: Test / leader-spring-boot (Testcontainers)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -1062,7 +1062,7 @@ jobs:
   # ── leader-ktor (Testcontainers: Redis) ────────────────────────────────────
   test-leader-ktor:
     name: Test / leader-ktor (Testcontainers)
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -1135,7 +1135,7 @@ jobs:
       - test-micrometer
       - test-spring-boot
       - test-leader-ktor
-    if: ${{ always() && ((github.event_name == 'schedule' && github.event.schedule == '0 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full')) }}
+    if: ${{ always() && ((github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full')) }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/docs/lessons/2026-06-04-nightly-full-schedule-condition.md
+++ b/docs/lessons/2026-06-04-nightly-full-schedule-condition.md
@@ -8,18 +8,29 @@ The Nightly cron minute was staggered to reduce Central snapshot metadata
 contention. Full-scope scheduled jobs still compared `github.event.schedule`
 against the old Sunday cron string, so weekly full jobs could be skipped.
 
+The follow-up PR also showed that CI can hit the same snapshot metadata failure
+path as Nightly when its Gradle commands do not use `--refresh-dependencies`.
+
 ## Decision
 
 Keep the staggered cron, and update full-scope job conditions to compare against
 the repository's current Sunday schedule.
+
+Apply the same snapshot refresh and GitHub runner configuration-cache avoidance
+to CI Gradle invocations so PR checks validate the branch under the same
+dependency-resolution policy expected from Nightly.
 
 ## Verification
 
 - `actionlint .github/workflows/nightly-tests.yml`
 - `git diff --check`
 - Schedule-condition audit: no old `0 19 * * 0` full-job condition remains.
+- CI/Nightly Gradle audit: every `./gradlew` call includes
+  `--refresh-dependencies`.
 
 ## Future Rule
 
 When changing a scheduled cron string, update every `github.event.schedule`
 comparison in the same workflow.
+When changing snapshot dependency policy, audit both `.github/workflows/ci.yml`
+and `.github/workflows/nightly-tests.yml`.

--- a/docs/lessons/2026-06-04-nightly-full-schedule-condition.md
+++ b/docs/lessons/2026-06-04-nightly-full-schedule-condition.md
@@ -1,0 +1,25 @@
+# Lessons Learned — Nightly full schedule condition (2026-06-04)
+
+**Related issue**: #470
+
+## Context
+
+The Nightly cron minute was staggered to reduce Central snapshot metadata
+contention. Full-scope scheduled jobs still compared `github.event.schedule`
+against the old Sunday cron string, so weekly full jobs could be skipped.
+
+## Decision
+
+Keep the staggered cron, and update full-scope job conditions to compare against
+the repository's current Sunday schedule.
+
+## Verification
+
+- `actionlint .github/workflows/nightly-tests.yml`
+- `git diff --check`
+- Schedule-condition audit: no old `0 19 * * 0` full-job condition remains.
+
+## Future Rule
+
+When changing a scheduled cron string, update every `github.event.schedule`
+comparison in the same workflow.


### PR DESCRIPTION
## Summary

Closes #470

PR #471의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: align Nightly full schedule condition`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary
- Align leader Nightly full-scope schedule checks with the staggered cron.
- Keep CI and Nightly snapshot dependency resolution fresh with `--refresh-dependencies`.
- Avoid GitHub runner configuration-cache serialization in CI Gradle commands that consume snapshot metadata.

## Background
The Nightly cron was staggered to reduce Central snapshot metadata contention, but full-scope scheduled jobs still compared `github.event.schedule` against the old Sunday cron. The follow-up PR also showed that PR CI can fail on the same stale snapshot metadata path when CI Gradle commands do not refresh dependencies.

## Work Done
- Updated full-scope `github.event.schedule` conditions to match the current Sunday cron.
- Added snapshot refresh to CI and Nightly Gradle invocations.
- Added configuration-cache avoidance to CI Gradle invocations.
- Recorded the schedule-condition and CI snapshot refresh rule in `docs/lessons/2026-06-04-nightly-full-schedule-condition.md`.

## Validation
- `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml`
- `git diff --check`
- YAML run-block audit: every CI/Nightly `./gradlew` command includes `--refresh-dependencies`.
- `./gradlew --refresh-dependencies --no-configuration-cache build -x test -x koverVerify --parallel --no-daemon`

## DoD Status
- [x] Issue-first tracking: closes #470.
- [x] PR body includes scope, cause, validation, and DoD.
- [x] CI and Nightly workflow changes were checked together.
- [x] Local compile-only validation passed with the same snapshot refresh/no configuration cache policy used by CI.

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #470, milestone `0.5.0`, assignee `debop`
- PR: #471, head `1b5665380a0b93bdc84a03757161e8ed8a7fabe1`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
