### PR TITLE
build: prevent stale Nightly Gradle cache

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -50,6 +50,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
       - name: Build (compile only)
         run: ./gradlew --refresh-dependencies build -x test -x koverVerify --parallel
         env:
@@ -81,6 +82,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-core
         run: |
@@ -127,6 +129,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-redis-lettuce
         run: |
@@ -175,6 +178,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-redis-redisson
         run: |
@@ -221,6 +225,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-exposed-core (H2)
         run: |
@@ -268,6 +273,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-exposed-core (PostgreSQL)
         run: |
@@ -317,6 +323,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-exposed-core (MySQL 8)
         run: |
@@ -364,6 +371,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-exposed-jdbc (H2)
         run: |
@@ -411,6 +419,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-exposed-jdbc (PostgreSQL)
         run: |
@@ -460,6 +469,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-exposed-jdbc (MySQL 8)
         run: |
@@ -507,6 +517,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-exposed-r2dbc (H2)
         run: |
@@ -553,6 +564,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-exposed-r2dbc (PostgreSQL)
         run: |
@@ -601,6 +613,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-exposed-r2dbc (MySQL 8)
         run: |
@@ -650,6 +663,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-mongodb
         run: |
@@ -698,6 +712,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-dynamodb
         run: |
@@ -746,6 +761,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-etcd
         run: |
@@ -792,6 +808,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-consul
         run: |
@@ -840,6 +857,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-k8s unit and K3s group slots
         run: |
@@ -888,6 +906,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-hazelcast
         run: |
@@ -936,6 +955,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-zookeeper
         run: |
@@ -982,6 +1002,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-micrometer
         run: |
@@ -1028,6 +1049,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-spring-boot
         run: |
@@ -1076,6 +1098,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
+          cache-disabled: true
           cache-read-only: true
       - name: Test leader-ktor
         run: |

--- a/docs/lessons/2026-06-04-issue-472-nightly-gradle-cache.md
+++ b/docs/lessons/2026-06-04-issue-472-nightly-gradle-cache.md
@@ -1,0 +1,22 @@
+# 2026-06-04 Issue 472 Nightly Gradle Cache
+
+## Context
+
+Nightly builds across bluetape4k repositories intermittently resolved managed dependencies as `group:artifact:.` on GitHub runners.
+
+## Decision
+
+Disable `gradle/actions/setup-gradle` cache restore/write for Nightly jobs so scheduled runs do not reuse stale dependency-management state.
+
+## Outcome
+
+Every Nightly `setup-gradle` block now sets `cache-disabled: true` while keeping explicit Gradle dependency refresh.
+
+## Verification
+
+- Audited `.github/workflows/nightly-tests.yml`: setup-gradle blocks match cache-disabled blocks.
+- Planned validation: `actionlint`, `git diff --check`.
+
+## Future Rule
+
+When a Nightly workflow uses snapshot or BOM-managed bluetape4k dependencies, keep Gradle action cache disabled unless a fresh CI proof shows cache restore cannot replay stale metadata.


### PR DESCRIPTION
## Summary

Closes #472

PR #473의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `build: prevent stale Nightly Gradle cache`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary
- Closes #472.
- Disable Gradle action caching for every Nightly setup-gradle step.
- Add a short lesson documenting the stale dependency metadata failure mode.

## Background
Recent bluetape4k Nightly runs resolved managed dependencies as group:artifact:. even with --refresh-dependencies. The common risk is stale Gradle action state being restored into scheduled snapshot/BOM builds.

## Work Done
- Added cache-disabled: true to all gradle/actions/setup-gradle@v6 blocks in .github/workflows/nightly-tests.yml.
- Preserved existing --refresh-dependencies and --no-configuration-cache Gradle command behavior.
- Added docs/lessons/2026-06-04-issue-472-nightly-gradle-cache.md.

## Validation
- actionlint .github/workflows/nightly-tests.yml
- git diff --check
- Audited Nightly setup-gradle blocks: every block has cache-disabled: true.

## DoD
- Nightly no longer restores or writes Gradle action cache state.
- The recurrence rule is documented for future workflow edits.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #472, milestone `0.5.0`, assignee `debop`
- PR: #473, head `aba60cea5c9aac276bd3399456aaf44ffffbe711`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
