### PR TITLE
build: harden Nightly dependency refresh

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -52,11 +52,11 @@ jobs:
           gradle-version: wrapper
           cache-disabled: true
       - name: Build (compile only)
-        run: ./gradlew --refresh-dependencies build -x test -x koverVerify --parallel
+        run: ./gradlew --refresh-dependencies build -x test -x koverVerify --parallel --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       - name: Detekt static analysis
-        run: ./gradlew --refresh-dependencies detekt --parallel
+        run: ./gradlew --refresh-dependencies detekt --parallel --no-configuration-cache
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       - name: Upload detekt report
@@ -87,7 +87,7 @@ jobs:
       - name: Test leader-core
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-core:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-core:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -95,7 +95,7 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-core:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-core:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -134,7 +134,7 @@ jobs:
       - name: Test leader-redis-lettuce
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-redis-lettuce:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-redis-lettuce:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -144,7 +144,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-redis-lettuce:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-redis-lettuce:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -183,7 +183,7 @@ jobs:
       - name: Test leader-redis-redisson
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-redis-redisson:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-redis-redisson:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -193,7 +193,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-redis-redisson:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-redis-redisson:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -230,7 +230,7 @@ jobs:
       - name: Test leader-exposed-core (H2)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -239,7 +239,7 @@ jobs:
           LEADER_TEST_DB: "H2"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -278,7 +278,7 @@ jobs:
       - name: Test leader-exposed-core (PostgreSQL)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -289,7 +289,7 @@ jobs:
           LEADER_TEST_DB: "POSTGRESQL"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -328,7 +328,7 @@ jobs:
       - name: Test leader-exposed-core (MySQL 8)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -339,7 +339,7 @@ jobs:
           LEADER_TEST_DB: "MYSQL_V8"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -376,7 +376,7 @@ jobs:
       - name: Test leader-exposed-jdbc (H2)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -385,7 +385,7 @@ jobs:
           LEADER_TEST_DB: "H2"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -424,7 +424,7 @@ jobs:
       - name: Test leader-exposed-jdbc (PostgreSQL)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -435,7 +435,7 @@ jobs:
           LEADER_TEST_DB: "POSTGRESQL"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -474,7 +474,7 @@ jobs:
       - name: Test leader-exposed-jdbc (MySQL 8)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -485,7 +485,7 @@ jobs:
           LEADER_TEST_DB: "MYSQL_V8"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -522,7 +522,7 @@ jobs:
       - name: Test leader-exposed-r2dbc (H2)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -531,7 +531,7 @@ jobs:
           LEADER_TEST_DB: "H2"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -569,7 +569,7 @@ jobs:
       - name: Test leader-exposed-r2dbc (PostgreSQL)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -580,7 +580,7 @@ jobs:
           LEADER_TEST_DB: "POSTGRESQL"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -618,7 +618,7 @@ jobs:
       - name: Test leader-exposed-r2dbc (MySQL 8)
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -629,7 +629,7 @@ jobs:
           LEADER_TEST_DB: "MYSQL_V8"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -668,7 +668,7 @@ jobs:
       - name: Test leader-mongodb
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-mongodb:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-mongodb:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -678,7 +678,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-mongodb:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-mongodb:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -717,7 +717,7 @@ jobs:
       - name: Test leader-dynamodb
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-dynamodb:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-dynamodb:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -727,7 +727,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-dynamodb:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-dynamodb:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -766,7 +766,7 @@ jobs:
       - name: Test leader-etcd
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-etcd:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-etcd:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -776,7 +776,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-etcd:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-etcd:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -813,7 +813,7 @@ jobs:
       - name: Test leader-consul
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-consul:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-consul:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -823,7 +823,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-consul:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-consul:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -862,7 +862,7 @@ jobs:
       - name: Test leader-k8s unit and K3s group slots
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-k8s:test :bluetape4k-leader-k8s:k8sTest --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-k8s:test :bluetape4k-leader-k8s:k8sTest --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -872,7 +872,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-k8s:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-k8s:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -911,7 +911,7 @@ jobs:
       - name: Test leader-hazelcast
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-hazelcast:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-hazelcast:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -921,7 +921,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-hazelcast:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-hazelcast:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -960,7 +960,7 @@ jobs:
       - name: Test leader-zookeeper
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-zookeeper:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-zookeeper:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -970,7 +970,7 @@ jobs:
           DOCKER_HOST: "unix:///var/run/docker.sock"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-zookeeper:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-zookeeper:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -1007,7 +1007,7 @@ jobs:
       - name: Test leader-micrometer
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-micrometer:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-micrometer:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1015,7 +1015,7 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-micrometer:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-micrometer:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -1054,7 +1054,7 @@ jobs:
       - name: Test leader-spring-boot
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-spring-boot:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-spring-boot:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1064,7 +1064,7 @@ jobs:
           DOCKER_HOST: 'unix:///var/run/docker.sock'
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-spring-boot:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-spring-boot:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()
@@ -1103,7 +1103,7 @@ jobs:
       - name: Test leader-ktor
         run: |
           for attempt in 1 2 3; do
-            ./gradlew --refresh-dependencies :bluetape4k-leader-ktor:test --no-daemon && break
+            ./gradlew --refresh-dependencies :bluetape4k-leader-ktor:test --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 3 ] && sleep 10 || exit 1
           done
@@ -1113,7 +1113,7 @@ jobs:
           DOCKER_HOST: 'unix:///var/run/docker.sock'
       - name: Generate Kover XML report
         if: always()
-        run: ./gradlew --refresh-dependencies :bluetape4k-leader-ktor:koverXmlReport --no-daemon
+        run: ./gradlew --refresh-dependencies :bluetape4k-leader-ktor:koverXmlReport --no-daemon --no-configuration-cache
         continue-on-error: true
       - name: Upload test results
         if: always()

--- a/docs/lessons/2026-06-04-issue-474-nightly-config-cache-catalog.md
+++ b/docs/lessons/2026-06-04-issue-474-nightly-config-cache-catalog.md
@@ -1,0 +1,21 @@
+# 2026-06-04 Issue 474 Nightly Config Cache And Catalog
+
+## Context
+
+Nightly workflows use snapshot and BOM-managed dependencies, so stale Gradle/configuration state can surface versionless dependency coordinates.
+
+## Decision
+
+Keep Nightly Gradle commands on `--no-configuration-cache` and keep local bluetape4k aliases versioned through their BOM ref.
+
+## Outcome
+
+Nightly commands no longer rely on configuration cache during dependency refresh, and repo-local catalog aliases avoid `group:artifact:.` coordinates.
+
+## Verification
+
+- Planned: `actionlint`, `git diff --check`, command audit, catalog alias audit.
+
+## Future Rule
+
+For Nightly jobs that refresh snapshots, disable both Gradle action cache and configuration cache unless a repo-specific proof says otherwise.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,18 +80,18 @@ jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.1.
 
 # bluetape4k
 bluetape4k-bom = { module = "io.github.bluetape4k:bluetape4k-bom", version.ref = "bluetape4k" }
-bluetape4k-core = { module = "io.github.bluetape4k:bluetape4k-core" }
-bluetape4k-coroutines = { module = "io.github.bluetape4k:bluetape4k-coroutines" }
-bluetape4k-idgenerators = { module = "io.github.bluetape4k:bluetape4k-idgenerators" }
-bluetape4k-logging = { module = "io.github.bluetape4k:bluetape4k-logging" }
-bluetape4k-junit5 = { module = "io.github.bluetape4k:bluetape4k-junit5" }
-bluetape4k-testcontainers = { module = "io.github.bluetape4k:bluetape4k-testcontainers" }
-bluetape4k-lettuce = { module = "io.github.bluetape4k:bluetape4k-lettuce" }
-bluetape4k-redisson = { module = "io.github.bluetape4k:bluetape4k-redisson" }
-bluetape4k-bucket4j = { module = "io.github.bluetape4k:bluetape4k-bucket4j" }
-bluetape4k-ktor-core = { module = "io.github.bluetape4k:bluetape4k-ktor-core" }
-bluetape4k-ktor-testing = { module = "io.github.bluetape4k:bluetape4k-ktor-testing" }
-bluetape4k-virtualthread-jdk21 = { module = "io.github.bluetape4k:bluetape4k-virtualthread-jdk21" }
+bluetape4k-core = { module = "io.github.bluetape4k:bluetape4k-core", version.ref = "bluetape4k-bom" }
+bluetape4k-coroutines = { module = "io.github.bluetape4k:bluetape4k-coroutines", version.ref = "bluetape4k-bom" }
+bluetape4k-idgenerators = { module = "io.github.bluetape4k:bluetape4k-idgenerators", version.ref = "bluetape4k-bom" }
+bluetape4k-logging = { module = "io.github.bluetape4k:bluetape4k-logging", version.ref = "bluetape4k-bom" }
+bluetape4k-junit5 = { module = "io.github.bluetape4k:bluetape4k-junit5", version.ref = "bluetape4k-bom" }
+bluetape4k-testcontainers = { module = "io.github.bluetape4k:bluetape4k-testcontainers", version.ref = "bluetape4k-bom" }
+bluetape4k-lettuce = { module = "io.github.bluetape4k:bluetape4k-lettuce", version.ref = "bluetape4k-bom" }
+bluetape4k-redisson = { module = "io.github.bluetape4k:bluetape4k-redisson", version.ref = "bluetape4k-bom" }
+bluetape4k-bucket4j = { module = "io.github.bluetape4k:bluetape4k-bucket4j", version.ref = "bluetape4k-bom" }
+bluetape4k-ktor-core = { module = "io.github.bluetape4k:bluetape4k-ktor-core", version.ref = "bluetape4k-bom" }
+bluetape4k-ktor-testing = { module = "io.github.bluetape4k:bluetape4k-ktor-testing", version.ref = "bluetape4k-bom" }
+bluetape4k-virtualthread-jdk21 = { module = "io.github.bluetape4k:bluetape4k-virtualthread-jdk21", version.ref = "bluetape4k-bom" }
 
 # bluetape4k Exposed test helpers
 bluetape4k-exposed-bom = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-bom", version.ref = "bluetape4k-exposed" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,18 +80,18 @@ jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.1.
 
 # bluetape4k
 bluetape4k-bom = { module = "io.github.bluetape4k:bluetape4k-bom", version.ref = "bluetape4k" }
-bluetape4k-core = { module = "io.github.bluetape4k:bluetape4k-core", version.ref = "bluetape4k-bom" }
-bluetape4k-coroutines = { module = "io.github.bluetape4k:bluetape4k-coroutines", version.ref = "bluetape4k-bom" }
-bluetape4k-idgenerators = { module = "io.github.bluetape4k:bluetape4k-idgenerators", version.ref = "bluetape4k-bom" }
-bluetape4k-logging = { module = "io.github.bluetape4k:bluetape4k-logging", version.ref = "bluetape4k-bom" }
-bluetape4k-junit5 = { module = "io.github.bluetape4k:bluetape4k-junit5", version.ref = "bluetape4k-bom" }
-bluetape4k-testcontainers = { module = "io.github.bluetape4k:bluetape4k-testcontainers", version.ref = "bluetape4k-bom" }
-bluetape4k-lettuce = { module = "io.github.bluetape4k:bluetape4k-lettuce", version.ref = "bluetape4k-bom" }
-bluetape4k-redisson = { module = "io.github.bluetape4k:bluetape4k-redisson", version.ref = "bluetape4k-bom" }
-bluetape4k-bucket4j = { module = "io.github.bluetape4k:bluetape4k-bucket4j", version.ref = "bluetape4k-bom" }
-bluetape4k-ktor-core = { module = "io.github.bluetape4k:bluetape4k-ktor-core", version.ref = "bluetape4k-bom" }
-bluetape4k-ktor-testing = { module = "io.github.bluetape4k:bluetape4k-ktor-testing", version.ref = "bluetape4k-bom" }
-bluetape4k-virtualthread-jdk21 = { module = "io.github.bluetape4k:bluetape4k-virtualthread-jdk21", version.ref = "bluetape4k-bom" }
+bluetape4k-core = { module = "io.github.bluetape4k:bluetape4k-core", version.ref = "bluetape4k" }
+bluetape4k-coroutines = { module = "io.github.bluetape4k:bluetape4k-coroutines", version.ref = "bluetape4k" }
+bluetape4k-idgenerators = { module = "io.github.bluetape4k:bluetape4k-idgenerators", version.ref = "bluetape4k" }
+bluetape4k-logging = { module = "io.github.bluetape4k:bluetape4k-logging", version.ref = "bluetape4k" }
+bluetape4k-junit5 = { module = "io.github.bluetape4k:bluetape4k-junit5", version.ref = "bluetape4k" }
+bluetape4k-testcontainers = { module = "io.github.bluetape4k:bluetape4k-testcontainers", version.ref = "bluetape4k" }
+bluetape4k-lettuce = { module = "io.github.bluetape4k:bluetape4k-lettuce", version.ref = "bluetape4k" }
+bluetape4k-redisson = { module = "io.github.bluetape4k:bluetape4k-redisson", version.ref = "bluetape4k" }
+bluetape4k-bucket4j = { module = "io.github.bluetape4k:bluetape4k-bucket4j", version.ref = "bluetape4k" }
+bluetape4k-ktor-core = { module = "io.github.bluetape4k:bluetape4k-ktor-core", version.ref = "bluetape4k" }
+bluetape4k-ktor-testing = { module = "io.github.bluetape4k:bluetape4k-ktor-testing", version.ref = "bluetape4k" }
+bluetape4k-virtualthread-jdk21 = { module = "io.github.bluetape4k:bluetape4k-virtualthread-jdk21", version.ref = "bluetape4k" }
 
 # bluetape4k Exposed test helpers
 bluetape4k-exposed-bom = { module = "io.github.bluetape4k.exposed:bluetape4k-exposed-bom", version.ref = "bluetape4k-exposed" }


### PR DESCRIPTION
## Summary

Closes #474

PR #475의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `build: harden Nightly dependency refresh`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary
Closes #474.

Harden the Nightly workflow so dependency refresh runs do not reuse stale Gradle setup state and local bluetape4k snapshot aliases always resolve with an explicit governed version key.

## Background
Recent Nightly runs exposed recurring failure modes: configuration-cache serialization or replay during refresh jobs, and local `io.github.bluetape4k:*` catalog aliases resolving with empty or invalid dependency versions in isolated CI jobs. Earlier cache-disabled PRs reduced one layer of stale setup state, but Gradle command lines and local catalog aliases still needed deterministic guards.

## Work Done
- Added `--no-configuration-cache` to Nightly Gradle command lines that run dependency refresh, build, detekt, tests, or summaries.
- Pointed local bluetape4k aliases at the existing bluetape4k version key.
- Added a concise lesson documenting the Nightly hardening rule for future workflow maintenance.

## Validation
- actionlint, git diff --check, version-ref audit, and isolated ./gradlew help --no-configuration-cache --no-daemon passed.
- Nightly audit: `missing_alias=0`, `missing_no_config_cache=0`, `missing_version_refs=0`, and no malformed `--no-configuration-cache` command patterns.

## Review Notes
P0/P1 review gate is clean for this workflow-only change. The branch changes are limited to Nightly workflow hardening, local version catalog alias guards where needed, and the matching lesson note.

## DoD Status
| Step | Status | Evidence |
|---|---|---|
| Issue | PASS | Closes #474, milestone `0.5.0`, assignee `debop` |
| Fix | PASS | Nightly Gradle commands and local catalog guards hardened on `fix/issue-474-nightly-config-cache-catalog` |
| Lessons | PASS | `docs/lessons/2026-06-04-issue-474-nightly-config-cache-catalog.md` |
| Local validation | PASS | actionlint, git diff --check, version-ref audit, and isolated ./gradlew help --no-configuration-cache --no-daemon passed.; Nightly audit passed before PR update |
| PR body | PASS | Created and updated with `--body-file`; live body verified after update |
| CI gate | PASS | GitHub checks completed SUCCESS or SKIPPED before merge |


````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #474, milestone `0.5.0`, assignee `debop`
- PR: #475, head `af79a79057f298afe8568c5d268d17be56e3a3d3`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
