### PR TITLE
fix: isolate Fabric8 Vert.x runtime for K3s tests

### DIFF
--- a/docs/lessons/2026-06-04-issue-480-leader-k8s-vertx-runtime.md
+++ b/docs/lessons/2026-06-04-issue-480-leader-k8s-vertx-runtime.md
@@ -1,0 +1,32 @@
+# Issue 480 Leader K8s Vert.x Runtime
+
+## Context
+
+Post-merge Nightly cleared the Central snapshot metadata failures, but the
+Leader K8s K3s job still failed all tests with
+`NoSuchMethodError: WebClientOptions.setMaxPoolSize(int)`.
+
+## Decision
+
+Keep the repository's default Vert.x 5 line intact and isolate only
+`leader-k8s` test runtime to Fabric8-compatible Vert.x 4.5.27 and Netty
+4.1.133.Final. This mirrors the benchmark module's Kubernetes runtime isolation
+instead of downgrading other preview backends.
+
+## Outcome
+
+The K3s test runtime should now use the Vert.x 4 HTTP client API expected by
+Fabric8 Kubernetes client 7.7.x.
+
+## Verification
+
+- `./gradlew :bluetape4k-leader-k8s:dependencyInsight --configuration testRuntimeClasspath --dependency io.vertx:vertx-web-client --no-daemon` selected `io.vertx:vertx-web-client:4.5.27`.
+- `./gradlew :bluetape4k-leader-k8s:dependencyInsight --configuration testRuntimeClasspath --dependency io.vertx:vertx-core --no-daemon` selected `io.vertx:vertx-core:4.5.27`.
+- `./gradlew :bluetape4k-leader-k8s:dependencyInsight --configuration testRuntimeClasspath --dependency io.netty:netty-common --no-daemon` selected `io.netty:netty-common:4.1.133.Final`.
+- `./gradlew :bluetape4k-leader-k8s:k8sTest --no-daemon --no-configuration-cache` passed with 20 K3s tests on 2026-06-04.
+
+## Future Guard
+
+When Fabric8 and etcd can share the same Vert.x line, remove this local runtime
+pin together with the benchmark Kubernetes pin. Until then, do not rely on the
+repo-wide Vert.x version for K3s-backed tests.

--- a/leader-k8s/build.gradle.kts
+++ b/leader-k8s/build.gradle.kts
@@ -2,6 +2,37 @@ configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }
 
+val fabric8VertxVersion = "4.5.27"
+val fabric8NettyVersion = "4.1.133.Final"
+
+configurations.named("testRuntimeClasspath") {
+    // Fabric8 7.7.x uses the Vert.x 4 HTTP client API; keep the K3s test runtime isolated from repo-wide Vert.x 5.
+    resolutionStrategy.eachDependency {
+        when (requested.group) {
+            "io.netty" -> useVersion(fabric8NettyVersion)
+            "io.vertx" -> useVersion(fabric8VertxVersion)
+        }
+    }
+    resolutionStrategy.force(
+        "io.netty:netty-all:$fabric8NettyVersion",
+        "io.netty:netty-buffer:$fabric8NettyVersion",
+        "io.netty:netty-codec:$fabric8NettyVersion",
+        "io.netty:netty-codec-dns:$fabric8NettyVersion",
+        "io.netty:netty-codec-http:$fabric8NettyVersion",
+        "io.netty:netty-codec-http2:$fabric8NettyVersion",
+        "io.netty:netty-codec-socks:$fabric8NettyVersion",
+        "io.netty:netty-common:$fabric8NettyVersion",
+        "io.netty:netty-handler:$fabric8NettyVersion",
+        "io.netty:netty-handler-proxy:$fabric8NettyVersion",
+        "io.netty:netty-resolver:$fabric8NettyVersion",
+        "io.netty:netty-resolver-dns:$fabric8NettyVersion",
+        "io.netty:netty-transport:$fabric8NettyVersion",
+        "io.vertx:vertx-core:$fabric8VertxVersion",
+        "io.vertx:vertx-web-client:$fabric8VertxVersion",
+        "io.vertx:vertx-web-common:$fabric8VertxVersion",
+    )
+}
+
 dependencies {
     api(project(":bluetape4k-leader-core"))
     api(libs.fabric8.kubernetes.client)


### PR DESCRIPTION
## Summary

Closes #480

PR #481의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: isolate Fabric8 Vert.x runtime for K3s tests`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

- Isolate `leader-k8s` test runtime to Fabric8-compatible Vert.x 4.5.27 and Netty 4.1.133.Final.
- Preserve the repository-wide Vert.x 5 line for other preview backend paths.
- Record the Nightly failure diagnosis and guardrail in `docs/lessons/2026-06-04-issue-480-leader-k8s-vertx-runtime.md`.

Fixes #480.

## Root Cause

Post-merge Nightly run 26981853581 cleared the Central snapshot metadata failures, but the Leader K8s job still failed with:

- `NoSuchMethodError: WebClientOptions.setMaxPoolSize(int)`
- Fabric8 `VertxHttpClientBuilder` on the K3s test runtime

Dependency insight showed Fabric8 requested `io.vertx:vertx-web-client:4.5.27`, but Gradle resolved it to `5.1.0`. Fabric8 Kubernetes client 7.7.x expects the Vert.x 4 HTTP client API.

## Validation

- `./gradlew :bluetape4k-leader-k8s:dependencyInsight --configuration testRuntimeClasspath --dependency io.vertx:vertx-web-client --no-daemon`
- `./gradlew :bluetape4k-leader-k8s:dependencyInsight --configuration testRuntimeClasspath --dependency io.vertx:vertx-core --no-daemon`
- `./gradlew :bluetape4k-leader-k8s:dependencyInsight --configuration testRuntimeClasspath --dependency io.netty:netty-common --no-daemon`
- `./gradlew :bluetape4k-leader-k8s:k8sTest --no-daemon --no-configuration-cache`

## DoD Status

- [x] K3s runtime selects `vertx-web-client:4.5.27`.
- [x] K3s runtime selects `vertx-core:4.5.27`.
- [x] K3s runtime selects `netty-common:4.1.133.Final`.
- [x] `leader-k8s` K3s tests pass locally: 20 passing.
- [x] PR body populated and structured with DoD status.

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #480, milestone `0.4.0`, assignee `debop`
- PR: #481, head `b70d946a58414d7ae1f0cb2f0417ef5228ac2ead`, milestone `0.4.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
