### PR TITLE
docs: capture MongoDB suspend benchmark repeat

### DIFF
--- a/benchmark/README.ko.md
+++ b/benchmark/README.ko.md
@@ -42,6 +42,14 @@ lease extender와 비교합니다. 현재 Redisson elector는 항상 명시적 `
 - [`docs/benchmarks/2026-06-01-issue-422-redis-lease-extension-throughput.json`](../docs/benchmarks/2026-06-01-issue-422-redis-lease-extension-throughput.json)
 - [`docs/benchmarks/2026-06-01-issue-422-redis-lease-extension-average-time.json`](../docs/benchmarks/2026-06-01-issue-422-redis-lease-extension-average-time.json)
 
+Issue #414는 2026-06-05 같은 장비에서 노이즈가 컸던 suspend MongoDB
+`runIfLeader` 행을 Lettuce, Redisson, Hazelcast와 함께 반복 측정했습니다.
+기존과 같은 fork 1, thread 1, warmup 2회, measurement 3회 구성을 유지했고,
+MongoDB가 더 느리지만 짧은 측정 창에서는 좁은 tuning target으로 삼기에는
+여전히 노이즈가 크다는 점을 확인했습니다. 원본 JSON과 판단 기록은
+[`docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-repeat.md`](../docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-repeat.md)에
+보존했습니다.
+
 ## Charts
 
 분산 환경 backend 차트는 infrastructure backend 간 차이가 보이도록 local
@@ -198,7 +206,9 @@ source set에서 별도로 실행합니다.
 - benchmark setup은 측정 전 smoke `runIfLeader` check를 수행하므로,
   infrastructure 연결 실패가 잘못된 빠른 경로로 측정되지 않습니다.
 - 특히 DynamoDB, etcd, Kubernetes, suspend MongoDB처럼 노이즈가 큰 행은
-  최적화 판단 전에 반복 측정하세요.
+  최적화 판단 전에 반복 측정하세요. Issue #414는 짧은 측정 창에서 suspend
+  MongoDB가 안정적인 최적화 target이 아니라 여전히 노이즈가 큰 행임을
+  확인했습니다.
 
 ## Benchmark Classes
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -41,6 +41,13 @@ represented because the current Redisson electors always pass an explicit
 - [`docs/benchmarks/2026-06-01-issue-422-redis-lease-extension-throughput.json`](../docs/benchmarks/2026-06-01-issue-422-redis-lease-extension-throughput.json)
 - [`docs/benchmarks/2026-06-01-issue-422-redis-lease-extension-average-time.json`](../docs/benchmarks/2026-06-01-issue-422-redis-lease-extension-average-time.json)
 
+Issue #414 repeated the noisy suspend MongoDB `runIfLeader` row on 2026-06-05
+against Lettuce, Redisson, and Hazelcast. The repeated same-machine run kept the
+existing one-fork, one-thread, two-warmup, three-measurement shape and confirmed
+that MongoDB stayed slower but too noisy for a narrow tuning target. Raw JSON
+and the decision record are stored under
+[`docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-repeat.md`](../docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-repeat.md).
+
 ## Charts
 
 Distributed backend charts exclude the local and H2 rows so infrastructure
@@ -195,7 +202,8 @@ latest self-improve section above for issue #329 after numbers.
 - Benchmark setup performs a smoke `runIfLeader` check before measurement, so a
   failed infrastructure connection does not become a false fast-path row.
 - Repeat noisy rows, especially DynamoDB, etcd, Kubernetes, and suspend MongoDB,
-  before optimizing against them.
+  before optimizing against them. Issue #414 confirmed suspend MongoDB remains
+  a noisy row rather than a stable optimization target in short-window runs.
 
 ## Benchmark Classes
 

--- a/docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-average-time-run-1.json
+++ b/docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-average-time-run-1.json
@@ -1,0 +1,230 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "lettuce"
+        },
+        "primaryMetric" : {
+            "score" : 711.2464390731296,
+            "scoreError" : 269.69389245688296,
+            "scoreConfidence" : [
+                441.5525466162467,
+                980.9403315300126
+            ],
+            "scorePercentiles" : {
+                "0.0" : 695.4583039555864,
+                "50.0" : 713.5206113879003,
+                "90.0" : 724.7604018759018,
+                "95.0" : 724.7604018759018,
+                "99.0" : 724.7604018759018,
+                "99.9" : 724.7604018759018,
+                "99.99" : 724.7604018759018,
+                "99.999" : 724.7604018759018,
+                "99.9999" : 724.7604018759018,
+                "100.0" : 724.7604018759018
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    713.5206113879003,
+                    724.7604018759018,
+                    695.4583039555864
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "redisson"
+        },
+        "primaryMetric" : {
+            "score" : 689.1881603183792,
+            "scoreError" : 145.2614624829934,
+            "scoreConfidence" : [
+                543.9266978353858,
+                834.4496228013727
+            ],
+            "scorePercentiles" : {
+                "0.0" : 680.527068707483,
+                "50.0" : 690.8472126634549,
+                "90.0" : 696.1901995841996,
+                "95.0" : 696.1901995841996,
+                "99.0" : 696.1901995841996,
+                "99.9" : 696.1901995841996,
+                "99.99" : 696.1901995841996,
+                "99.999" : 696.1901995841996,
+                "99.9999" : 696.1901995841996,
+                "100.0" : 696.1901995841996
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    696.1901995841996,
+                    680.527068707483,
+                    690.8472126634549
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "mongo"
+        },
+        "primaryMetric" : {
+            "score" : 1324.2275103526772,
+            "scoreError" : 2903.1228417359066,
+            "scoreConfidence" : [
+                -1578.8953313832294,
+                4227.350352088584
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1163.7124814814815,
+                "50.0" : 1327.0347955145119,
+                "90.0" : 1481.9352540620384,
+                "95.0" : 1481.9352540620384,
+                "99.0" : 1481.9352540620384,
+                "99.9" : 1481.9352540620384,
+                "99.99" : 1481.9352540620384,
+                "99.999" : 1481.9352540620384,
+                "99.9999" : 1481.9352540620384,
+                "100.0" : 1481.9352540620384
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    1481.9352540620384,
+                    1327.0347955145119,
+                    1163.7124814814815
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "hazelcast"
+        },
+        "primaryMetric" : {
+            "score" : 741.2706679269155,
+            "scoreError" : 890.110984939106,
+            "scoreConfidence" : [
+                -148.84031701219044,
+                1631.3816528660213
+            ],
+            "scorePercentiles" : {
+                "0.0" : 703.3632251051894,
+                "50.0" : 724.1310086517664,
+                "90.0" : 796.3177700237907,
+                "95.0" : 796.3177700237907,
+                "99.0" : 796.3177700237907,
+                "99.9" : 796.3177700237907,
+                "99.99" : 796.3177700237907,
+                "99.999" : 796.3177700237907,
+                "99.9999" : 796.3177700237907,
+                "100.0" : 796.3177700237907
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    796.3177700237907,
+                    703.3632251051894,
+                    724.1310086517664
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]

--- a/docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-average-time-run-2.json
+++ b/docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-average-time-run-2.json
@@ -1,0 +1,230 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "lettuce"
+        },
+        "primaryMetric" : {
+            "score" : 675.3451070113247,
+            "scoreError" : 83.27719435913131,
+            "scoreConfidence" : [
+                592.0679126521934,
+                758.622301370456
+            ],
+            "scorePercentiles" : {
+                "0.0" : 670.3332494983277,
+                "50.0" : 676.4377112914132,
+                "90.0" : 679.2643602442333,
+                "95.0" : 679.2643602442333,
+                "99.0" : 679.2643602442333,
+                "99.9" : 679.2643602442333,
+                "99.99" : 679.2643602442333,
+                "99.999" : 679.2643602442333,
+                "99.9999" : 679.2643602442333,
+                "100.0" : 679.2643602442333
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    679.2643602442333,
+                    670.3332494983277,
+                    676.4377112914132
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "redisson"
+        },
+        "primaryMetric" : {
+            "score" : 731.0042953891189,
+            "scoreError" : 751.3511626912557,
+            "scoreConfidence" : [
+                -20.346867302136843,
+                1482.3554580803745
+            ],
+            "scorePercentiles" : {
+                "0.0" : 683.512411724608,
+                "50.0" : 752.6241566716642,
+                "90.0" : 756.8763177710844,
+                "95.0" : 756.8763177710844,
+                "99.0" : 756.8763177710844,
+                "99.9" : 756.8763177710844,
+                "99.99" : 756.8763177710844,
+                "99.999" : 756.8763177710844,
+                "99.9999" : 756.8763177710844,
+                "100.0" : 756.8763177710844
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    752.6241566716642,
+                    756.8763177710844,
+                    683.512411724608
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "mongo"
+        },
+        "primaryMetric" : {
+            "score" : 4716.787500843931,
+            "scoreError" : 39107.22301822812,
+            "scoreConfidence" : [
+                -34390.43551738419,
+                43824.01051907205
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2265.2071063348417,
+                "50.0" : 5647.059122905028,
+                "90.0" : 6238.096273291925,
+                "95.0" : 6238.096273291925,
+                "99.0" : 6238.096273291925,
+                "99.9" : 6238.096273291925,
+                "99.99" : 6238.096273291925,
+                "99.999" : 6238.096273291925,
+                "99.9999" : 6238.096273291925,
+                "100.0" : 6238.096273291925
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    6238.096273291925,
+                    5647.059122905028,
+                    2265.2071063348417
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "hazelcast"
+        },
+        "primaryMetric" : {
+            "score" : 762.326768286984,
+            "scoreError" : 591.6886473040406,
+            "scoreConfidence" : [
+                170.6381209829434,
+                1354.0154155910245
+            ],
+            "scorePercentiles" : {
+                "0.0" : 724.979905865315,
+                "50.0" : 778.5975344694035,
+                "90.0" : 783.4028645262333,
+                "95.0" : 783.4028645262333,
+                "99.0" : 783.4028645262333,
+                "99.9" : 783.4028645262333,
+                "99.99" : 783.4028645262333,
+                "99.999" : 783.4028645262333,
+                "99.9999" : 783.4028645262333,
+                "100.0" : 783.4028645262333
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    778.5975344694035,
+                    724.979905865315,
+                    783.4028645262333
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]

--- a/docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-average-time-run-3.json
+++ b/docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-average-time-run-3.json
@@ -1,0 +1,230 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "lettuce"
+        },
+        "primaryMetric" : {
+            "score" : 741.277395986941,
+            "scoreError" : 311.58894525865026,
+            "scoreConfidence" : [
+                429.6884507282907,
+                1052.8663412455912
+            ],
+            "scorePercentiles" : {
+                "0.0" : 730.5457055393586,
+                "50.0" : 732.3141238164603,
+                "90.0" : 760.9723586050038,
+                "95.0" : 760.9723586050038,
+                "99.0" : 760.9723586050038,
+                "99.9" : 760.9723586050038,
+                "99.99" : 760.9723586050038,
+                "99.999" : 760.9723586050038,
+                "99.9999" : 760.9723586050038,
+                "100.0" : 760.9723586050038
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    760.9723586050038,
+                    730.5457055393586,
+                    732.3141238164603
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "redisson"
+        },
+        "primaryMetric" : {
+            "score" : 730.3571948672549,
+            "scoreError" : 575.8761461273626,
+            "scoreConfidence" : [
+                154.48104873989223,
+                1306.2333409946175
+            ],
+            "scorePercentiles" : {
+                "0.0" : 694.5677772380292,
+                "50.0" : 742.2742336795252,
+                "90.0" : 754.2295736842105,
+                "95.0" : 754.2295736842105,
+                "99.0" : 754.2295736842105,
+                "99.9" : 754.2295736842105,
+                "99.99" : 754.2295736842105,
+                "99.999" : 754.2295736842105,
+                "99.9999" : 754.2295736842105,
+                "100.0" : 754.2295736842105
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    694.5677772380292,
+                    754.2295736842105,
+                    742.2742336795252
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "mongo"
+        },
+        "primaryMetric" : {
+            "score" : 5348.704559172819,
+            "scoreError" : 35069.351645984854,
+            "scoreConfidence" : [
+                -29720.647086812034,
+                40418.05620515767
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3236.8998090614887,
+                "50.0" : 5812.719653179191,
+                "90.0" : 6996.494215277778,
+                "95.0" : 6996.494215277778,
+                "99.0" : 6996.494215277778,
+                "99.9" : 6996.494215277778,
+                "99.99" : 6996.494215277778,
+                "99.999" : 6996.494215277778,
+                "99.9999" : 6996.494215277778,
+                "100.0" : 6996.494215277778
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    5812.719653179191,
+                    6996.494215277778,
+                    3236.8998090614887
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "avgt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "hazelcast"
+        },
+        "primaryMetric" : {
+            "score" : 700.0482757576691,
+            "scoreError" : 668.2981491965231,
+            "scoreConfidence" : [
+                31.750126561145976,
+                1368.3464249541921
+            ],
+            "scorePercentiles" : {
+                "0.0" : 659.1382845849803,
+                "50.0" : 711.1941790516631,
+                "90.0" : 729.8123636363637,
+                "95.0" : 729.8123636363637,
+                "99.0" : 729.8123636363637,
+                "99.9" : 729.8123636363637,
+                "99.99" : 729.8123636363637,
+                "99.999" : 729.8123636363637,
+                "99.9999" : 729.8123636363637,
+                "100.0" : 729.8123636363637
+            },
+            "scoreUnit" : "us/op",
+            "rawData" : [
+                [
+                    729.8123636363637,
+                    659.1382845849803,
+                    711.1941790516631
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]

--- a/docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-repeat.md
+++ b/docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-repeat.md
@@ -1,0 +1,135 @@
+# Issue #414 MongoDB suspend benchmark repeat - 2026-06-05
+
+Issue #414 repeated the noisy MongoDB suspend leader-election row against the
+same-machine Lettuce, Redisson, and Hazelcast suspend baselines. The goal was to
+separate repeatable backend overhead from short-window benchmark noise before
+opening a tuning task.
+
+Use this report for same-machine comparison only. It is not a release-grade
+performance claim.
+
+## Caveats
+
+- Only `SuspendBackendLeaderElectorBenchmark.runIfLeader` was measured.
+- The benchmark used the same one fork, one thread, two warmups, and three
+  one-second measurement iterations as the existing cross-backend baseline.
+- The generated Gradle `benchmarkBenchmark` and `benchmarkAverageTimeBenchmark`
+  tasks were verified first, but runtime filtering through `--args` replaces the
+  `kotlinx-benchmark` runner config path. The focused run therefore used the
+  official JVM benchmark JAR produced by `:benchmark:benchmarkBenchmarkJar`.
+- Each row starts its own Testcontainer in the JMH fork. Container startup is
+  outside measured iterations, but Docker and local resource pressure can still
+  affect short-window scores.
+- JMH ran on GraalVM JDK 25 because that was the active shell `JAVA_HOME` for
+  this repeat. Compare with the same JDK before making a before/after claim.
+
+## Environment
+
+| Field | Value |
+|---|---|
+| Date | 2026-06-05 |
+| Host | Apple M4 Pro, 12 CPUs, 48 GiB RAM |
+| OS | macOS 26.5.1 arm64 |
+| JDK | Oracle GraalVM 25.0.3 |
+| Gradle | 9.5.1 |
+| kotlinx-benchmark | 0.4.17 |
+| JMH | 1.37 |
+| Docker | Colima, Docker server 29.2.1, Ubuntu 24.04.4 LTS, 3905 MB |
+| Warmup | 2 iterations, 1 second each |
+| Measurement | 3 iterations, 1 second each |
+| Forks | 1 |
+| Threads | 1 |
+
+## Commands
+
+Task-name verification:
+
+```bash
+./gradlew :benchmark:tasks --all --no-daemon
+```
+
+JMH JAR generation:
+
+```bash
+./gradlew :benchmark:benchmarkBenchmarkJar --no-daemon --no-configuration-cache --rerun-tasks
+```
+
+Throughput repeat, run once per `run` value from 1 to 3:
+
+```bash
+java -jar benchmark/build/benchmarks/benchmark/jars/benchmark-benchmark-jmh-0.4.0-JMH.jar \
+  -foe true -bm thrpt -tu s -wi 2 -i 3 -w 1s -r 1s -f 1 \
+  -p backend=lettuce,redisson,mongo,hazelcast \
+  -rf json -rff docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-throughput-run-${run}.json \
+  '.*SuspendBackendLeaderElectorBenchmark.runIfLeader.*'
+```
+
+Average-time repeat, run once per `run` value from 1 to 3:
+
+```bash
+java -jar benchmark/build/benchmarks/benchmark/jars/benchmark-benchmark-jmh-0.4.0-JMH.jar \
+  -foe true -bm avgt -tu us -wi 2 -i 3 -w 1s -r 1s -f 1 \
+  -p backend=lettuce,redisson,mongo,hazelcast \
+  -rf json -rff docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-average-time-run-${run}.json \
+  '.*SuspendBackendLeaderElectorBenchmark.runIfLeader.*'
+```
+
+Machine-readable source artifacts:
+
+- [`2026-06-05-issue-414-mongodb-suspend-throughput-run-1.json`](./2026-06-05-issue-414-mongodb-suspend-throughput-run-1.json)
+- [`2026-06-05-issue-414-mongodb-suspend-throughput-run-2.json`](./2026-06-05-issue-414-mongodb-suspend-throughput-run-2.json)
+- [`2026-06-05-issue-414-mongodb-suspend-throughput-run-3.json`](./2026-06-05-issue-414-mongodb-suspend-throughput-run-3.json)
+- [`2026-06-05-issue-414-mongodb-suspend-average-time-run-1.json`](./2026-06-05-issue-414-mongodb-suspend-average-time-run-1.json)
+- [`2026-06-05-issue-414-mongodb-suspend-average-time-run-2.json`](./2026-06-05-issue-414-mongodb-suspend-average-time-run-2.json)
+- [`2026-06-05-issue-414-mongodb-suspend-average-time-run-3.json`](./2026-06-05-issue-414-mongodb-suspend-average-time-run-3.json)
+
+## Repeat Summary
+
+Higher is better for throughput. Lower is better for average time.
+
+| Backend | Throughput mean (ops/s) | Throughput run range (ops/s) | Mean JMH error (ops/s) | Average-time mean (us/op) | Average-time run range (us/op) | Mean JMH error (us/op) |
+|---|---:|---:|---:|---:|---:|---:|
+| lettuce | 1,459.312 | 1,437.426 - 1,485.930 | 752.101 | 709.290 | 675.345 - 741.277 | 221.520 |
+| redisson | 1,408.395 | 1,395.184 - 1,431.931 | 883.032 | 716.850 | 689.188 - 731.004 | 490.830 |
+| hazelcast | 1,406.936 | 1,378.012 - 1,441.799 | 695.930 | 734.549 | 700.048 - 762.327 | 716.699 |
+| mongo | 634.467 | 302.035 - 896.383 | 3,030.521 | 3,796.573 | 1,324.228 - 5,348.705 | 25,693.233 |
+
+## Per-Run Results
+
+### Throughput
+
+| Run | Lettuce (ops/s) | Redisson (ops/s) | Hazelcast (ops/s) | MongoDB (ops/s) |
+|---:|---:|---:|---:|---:|
+| 1 | 1,485.930 ± 726.394 | 1,398.071 ± 511.196 | 1,378.012 ± 287.418 | 896.383 ± 754.808 |
+| 2 | 1,454.580 ± 241.711 | 1,431.931 ± 797.288 | 1,400.998 ± 236.957 | 704.984 ± 3,923.388 |
+| 3 | 1,437.426 ± 1,288.199 | 1,395.184 ± 1,340.612 | 1,441.799 ± 1,563.414 | 302.035 ± 4,413.367 |
+
+### Average Time
+
+| Run | Lettuce (us/op) | Redisson (us/op) | Hazelcast (us/op) | MongoDB (us/op) |
+|---:|---:|---:|---:|---:|
+| 1 | 711.246 ± 269.694 | 689.188 ± 145.261 | 741.271 ± 890.111 | 1,324.228 ± 2,903.123 |
+| 2 | 675.345 ± 83.277 | 731.004 ± 751.351 | 762.327 ± 591.689 | 4,716.788 ± 39,107.223 |
+| 3 | 741.277 ± 311.589 | 730.357 ± 575.876 | 700.048 ± 668.298 | 5,348.705 ± 35,069.352 |
+
+## Decision
+
+No production tuning issue was opened from this repeat. MongoDB was consistently
+slower than the Redis and Hazelcast suspend rows, but the score and error range
+were too wide for a narrow optimization target:
+
+- Throughput fell from 896 ops/s to 302 ops/s across three repeats.
+- Average time moved from 1.3 ms/op to 5.3 ms/op across three repeats.
+- JMH error for MongoDB exceeded the measured score in the noisier repeats.
+
+Treat the current MongoDB suspend row as a noisy preview-backend comparison
+point. Before changing production code, rerun a longer profile with the same JDK,
+more measurement time, and optional MongoDB/client profiling so the bottleneck is
+stable enough to isolate.
+
+## Verification
+
+- `./gradlew :benchmark:tasks --all --no-daemon`
+- `./gradlew :benchmark:benchmarkBenchmarkJar --no-daemon --no-configuration-cache --rerun-tasks`
+- JMH throughput repeat, 3 runs, raw JSON linked above.
+- JMH average-time repeat, 3 runs, raw JSON linked above.

--- a/docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-throughput-run-1.json
+++ b/docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-throughput-run-1.json
@@ -1,0 +1,230 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "lettuce"
+        },
+        "primaryMetric" : {
+            "score" : 1485.9296197298863,
+            "scoreError" : 726.394430464372,
+            "scoreConfidence" : [
+                759.5351892655143,
+                2212.3240501942582
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1457.1438682345135,
+                "50.0" : 1469.2764074997303,
+                "90.0" : 1531.3685834554155,
+                "95.0" : 1531.3685834554155,
+                "99.0" : 1531.3685834554155,
+                "99.9" : 1531.3685834554155,
+                "99.99" : 1531.3685834554155,
+                "99.999" : 1531.3685834554155,
+                "99.9999" : 1531.3685834554155,
+                "100.0" : 1531.3685834554155
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1531.3685834554155,
+                    1469.2764074997303,
+                    1457.1438682345135
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "redisson"
+        },
+        "primaryMetric" : {
+            "score" : 1398.0708778215132,
+            "scoreError" : 511.195982133468,
+            "scoreConfidence" : [
+                886.8748956880452,
+                1909.2668599549813
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1365.7786501634707,
+                "50.0" : 1412.4704129967229,
+                "90.0" : 1415.9635703043464,
+                "95.0" : 1415.9635703043464,
+                "99.0" : 1415.9635703043464,
+                "99.9" : 1415.9635703043464,
+                "99.99" : 1415.9635703043464,
+                "99.999" : 1415.9635703043464,
+                "99.9999" : 1415.9635703043464,
+                "100.0" : 1415.9635703043464
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1415.9635703043464,
+                    1365.7786501634707,
+                    1412.4704129967229
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "mongo"
+        },
+        "primaryMetric" : {
+            "score" : 896.3834049815472,
+            "scoreError" : 754.808218922939,
+            "scoreConfidence" : [
+                141.5751860586082,
+                1651.1916239044863
+            ],
+            "scorePercentiles" : {
+                "0.0" : 850.2587155429933,
+                "50.0" : 908.6680717314092,
+                "90.0" : 930.2234276702388,
+                "95.0" : 930.2234276702388,
+                "99.0" : 930.2234276702388,
+                "99.9" : 930.2234276702388,
+                "99.99" : 930.2234276702388,
+                "99.999" : 930.2234276702388,
+                "99.9999" : 930.2234276702388,
+                "100.0" : 930.2234276702388
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    850.2587155429933,
+                    930.2234276702388,
+                    908.6680717314092
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "hazelcast"
+        },
+        "primaryMetric" : {
+            "score" : 1378.0121191518028,
+            "scoreError" : 287.41800325782185,
+            "scoreConfidence" : [
+                1090.5941158939809,
+                1665.4301224096248
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1363.4738695205988,
+                "50.0" : 1375.8113423681602,
+                "90.0" : 1394.7511455666493,
+                "95.0" : 1394.7511455666493,
+                "99.0" : 1394.7511455666493,
+                "99.9" : 1394.7511455666493,
+                "99.99" : 1394.7511455666493,
+                "99.999" : 1394.7511455666493,
+                "99.9999" : 1394.7511455666493,
+                "100.0" : 1394.7511455666493
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1363.4738695205988,
+                    1375.8113423681602,
+                    1394.7511455666493
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]

--- a/docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-throughput-run-2.json
+++ b/docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-throughput-run-2.json
@@ -1,0 +1,230 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "lettuce"
+        },
+        "primaryMetric" : {
+            "score" : 1454.5797428060703,
+            "scoreError" : 241.71050999650612,
+            "scoreConfidence" : [
+                1212.8692328095642,
+                1696.2902528025763
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1444.6755556094336,
+                "50.0" : 1449.434040716259,
+                "90.0" : 1469.6296320925182,
+                "95.0" : 1469.6296320925182,
+                "99.0" : 1469.6296320925182,
+                "99.9" : 1469.6296320925182,
+                "99.99" : 1469.6296320925182,
+                "99.999" : 1469.6296320925182,
+                "99.9999" : 1469.6296320925182,
+                "100.0" : 1469.6296320925182
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1444.6755556094336,
+                    1449.434040716259,
+                    1469.6296320925182
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "redisson"
+        },
+        "primaryMetric" : {
+            "score" : 1431.931052745299,
+            "scoreError" : 797.2876460218596,
+            "scoreConfidence" : [
+                634.6434067234394,
+                2229.2186987671585
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1400.7434597168779,
+                "50.0" : 1413.1683706091396,
+                "90.0" : 1481.8813279098797,
+                "95.0" : 1481.8813279098797,
+                "99.0" : 1481.8813279098797,
+                "99.9" : 1481.8813279098797,
+                "99.99" : 1481.8813279098797,
+                "99.999" : 1481.8813279098797,
+                "99.9999" : 1481.8813279098797,
+                "100.0" : 1481.8813279098797
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1400.7434597168779,
+                    1413.1683706091396,
+                    1481.8813279098797
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "mongo"
+        },
+        "primaryMetric" : {
+            "score" : 704.983571799442,
+            "scoreError" : 3923.3882715850964,
+            "scoreConfidence" : [
+                -3218.4046997856544,
+                4628.371843384539
+            ],
+            "scorePercentiles" : {
+                "0.0" : 456.7088457295794,
+                "50.0" : 824.8744364703822,
+                "90.0" : 833.3674331983644,
+                "95.0" : 833.3674331983644,
+                "99.0" : 833.3674331983644,
+                "99.9" : 833.3674331983644,
+                "99.99" : 833.3674331983644,
+                "99.999" : 833.3674331983644,
+                "99.9999" : 833.3674331983644,
+                "100.0" : 833.3674331983644
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    456.7088457295794,
+                    833.3674331983644,
+                    824.8744364703822
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "hazelcast"
+        },
+        "primaryMetric" : {
+            "score" : 1400.997873444326,
+            "scoreError" : 236.9573520322779,
+            "scoreConfidence" : [
+                1164.040521412048,
+                1637.9552254766038
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1387.0436318260981,
+                "50.0" : 1403.2148763404107,
+                "90.0" : 1412.7351121664688,
+                "95.0" : 1412.7351121664688,
+                "99.0" : 1412.7351121664688,
+                "99.9" : 1412.7351121664688,
+                "99.99" : 1412.7351121664688,
+                "99.999" : 1412.7351121664688,
+                "99.9999" : 1412.7351121664688,
+                "100.0" : 1412.7351121664688
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1403.2148763404107,
+                    1387.0436318260981,
+                    1412.7351121664688
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]

--- a/docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-throughput-run-3.json
+++ b/docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-throughput-run-3.json
@@ -1,0 +1,230 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "lettuce"
+        },
+        "primaryMetric" : {
+            "score" : 1437.42619197558,
+            "scoreError" : 1288.19919527251,
+            "scoreConfidence" : [
+                149.22699670306997,
+                2725.62538724809
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1357.448775411898,
+                "50.0" : 1463.6832340655333,
+                "90.0" : 1491.146566449309,
+                "95.0" : 1491.146566449309,
+                "99.0" : 1491.146566449309,
+                "99.9" : 1491.146566449309,
+                "99.99" : 1491.146566449309,
+                "99.999" : 1491.146566449309,
+                "99.9999" : 1491.146566449309,
+                "100.0" : 1491.146566449309
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1463.6832340655333,
+                    1491.146566449309,
+                    1357.448775411898
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "redisson"
+        },
+        "primaryMetric" : {
+            "score" : 1395.1840302521716,
+            "scoreError" : 1340.6122900930784,
+            "scoreConfidence" : [
+                54.571740159093224,
+                2735.79632034525
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1310.3841299768346,
+                "50.0" : 1435.0237060170143,
+                "90.0" : 1440.144254762666,
+                "95.0" : 1440.144254762666,
+                "99.0" : 1440.144254762666,
+                "99.9" : 1440.144254762666,
+                "99.99" : 1440.144254762666,
+                "99.999" : 1440.144254762666,
+                "99.9999" : 1440.144254762666,
+                "100.0" : 1440.144254762666
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1310.3841299768346,
+                    1435.0237060170143,
+                    1440.144254762666
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "mongo"
+        },
+        "primaryMetric" : {
+            "score" : 302.0347424387091,
+            "scoreError" : 4413.366602118849,
+            "scoreConfidence" : [
+                -4111.33185968014,
+                4715.401344557558
+            ],
+            "scorePercentiles" : {
+                "0.0" : 161.74080063871384,
+                "50.0" : 162.9942642666258,
+                "90.0" : 581.3691624107876,
+                "95.0" : 581.3691624107876,
+                "99.0" : 581.3691624107876,
+                "99.9" : 581.3691624107876,
+                "99.99" : 581.3691624107876,
+                "99.999" : 581.3691624107876,
+                "99.9999" : 581.3691624107876,
+                "100.0" : 581.3691624107876
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    161.74080063871384,
+                    162.9942642666258,
+                    581.3691624107876
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.bluetape4k.leader.benchmark.SuspendBackendLeaderElectorBenchmark.runIfLeader",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Library/Java/JavaVirtualMachines/graalvm-jdk-25/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.3",
+        "vmName" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vmVersion" : "25.0.3+9-LTS-jvmci-b01",
+        "warmupIterations" : 2,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 3,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "backend" : "hazelcast"
+        },
+        "primaryMetric" : {
+            "score" : 1441.7992267405443,
+            "scoreError" : 1563.4139605724363,
+            "scoreConfidence" : [
+                -121.61473383189195,
+                3005.2131873129806
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1342.848389885722,
+                "50.0" : 1490.6809962620346,
+                "90.0" : 1491.8682940738765,
+                "95.0" : 1491.8682940738765,
+                "99.0" : 1491.8682940738765,
+                "99.9" : 1491.8682940738765,
+                "99.99" : 1491.8682940738765,
+                "99.999" : 1491.8682940738765,
+                "99.9999" : 1491.8682940738765,
+                "100.0" : 1491.8682940738765
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1342.848389885722,
+                    1491.8682940738765,
+                    1490.6809962620346
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]

--- a/docs/lessons/2026-06-05-issue-414-mongodb-suspend-repeat.md
+++ b/docs/lessons/2026-06-05-issue-414-mongodb-suspend-repeat.md
@@ -1,0 +1,33 @@
+# Issue 414 MongoDB Suspend Benchmark Repeat
+
+## Context
+
+The suspend MongoDB `runIfLeader` benchmark row was marked noisy in the
+cross-backend baseline. Issue #414 asked for repeated same-machine evidence
+before deciding whether to open a tuning task.
+
+## Decision or Finding
+
+Three focused repeats against Lettuce, Redisson, and Hazelcast confirmed that
+MongoDB stays slower, but the short-window score range and JMH error are too
+wide for a narrow production optimization target.
+
+## Outcome
+
+No production code changed and no follow-up tuning issue was opened. The raw
+throughput and average-time JSON files plus the decision record are preserved in
+`docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-repeat.md`.
+
+## Verification
+
+- `./gradlew :benchmark:tasks --all --no-daemon`
+- `./gradlew :benchmark:benchmarkBenchmarkJar --no-daemon --no-configuration-cache --rerun-tasks`
+- JMH throughput repeat for `lettuce,redisson,mongo,hazelcast`, 3 runs.
+- JMH average-time repeat for `lettuce,redisson,mongo,hazelcast`, 3 runs.
+
+## Future Guidance
+
+For focused benchmark repeats, verify generated kotlinx-benchmark task names
+first. If runtime filters are needed, build the official benchmark JAR with
+Gradle and document why direct JMH execution is being used instead of the
+generated JavaExec task.


### PR DESCRIPTION
## Summary

Closes #414

PR #484의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `docs: capture MongoDB suspend benchmark repeat`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

- Repeat the noisy MongoDB suspend `runIfLeader` benchmark row against Lettuce, Redisson, and Hazelcast.
- Preserve three throughput JSON runs and three average-time JSON runs under `docs/benchmarks`.
- Document that MongoDB remains slower but too noisy in short-window runs to justify a narrow production tuning task.

## Evidence

- Throughput repeat mean: MongoDB 634.467 ops/s, Lettuce 1,459.312 ops/s, Redisson 1,408.395 ops/s, Hazelcast 1,406.936 ops/s.
- Average-time repeat mean: MongoDB 3,796.573 us/op, Lettuce 709.290 us/op, Redisson 716.850 us/op, Hazelcast 734.549 us/op.
- MongoDB varied from 302.035 to 896.383 ops/s and 1,324.228 to 5,348.705 us/op across three repeats, so no follow-up tuning issue was opened from this run.

## Validation

- `./gradlew :benchmark:tasks --all --no-daemon`
- `./gradlew :benchmark:benchmarkBenchmarkJar --no-daemon --no-configuration-cache --rerun-tasks`
- JMH throughput repeat, 3 runs, `lettuce,redisson,mongo,hazelcast`
- JMH average-time repeat, 3 runs, `lettuce,redisson,mongo,hazelcast`
- `jq empty docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-*.json`
- `git diff --check HEAD~1..HEAD`

Closes #414.

## DoD Status

| Gate | Status | Evidence |
|---|---|---|
| Issue scope | PASS | Repeated MongoDB suspend row and compared with Lettuce, Redisson, Hazelcast. |
| Raw artifacts | PASS | Six JSON files stored under `docs/benchmarks/2026-06-05-issue-414-*`. |
| Decision record | PASS | `docs/benchmarks/2026-06-05-issue-414-mongodb-suspend-repeat.md`. |
| README parity | PASS | Updated `benchmark/README.md` and `benchmark/README.ko.md`. |
| Lesson | PASS | Added `docs/lessons/2026-06-05-issue-414-mongodb-suspend-repeat.md`. |
| Local validation | PASS | Commands listed in Validation completed. |

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #414, milestone `0.4.0`, assignee `debop`
- PR: #484, head `5d00f920d2f7cf9927e120d89246595e0c21d393`, milestone `0.4.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
