### PR TITLE
fix: restore K8s example runtime compatibility

### DIFF
--- a/.github/scripts/retry-snapshot-warmup.sh
+++ b/.github/scripts/retry-snapshot-warmup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: retry-snapshot-warmup.sh <gradle-args...>" >&2
+  exit 64
+fi
+
+max_attempts="${SNAPSHOT_WARMUP_ATTEMPTS:-5}"
+delay_seconds="${SNAPSHOT_WARMUP_DELAY_SECONDS:-30}"
+
+is_snapshot_metadata_failure() {
+  local log_file="$1"
+  grep -Eq \
+    "central\.sonatype\.com/repository/maven-snapshots|Unable to load Maven meta-data|Received status code 403" \
+    "$log_file"
+}
+
+for attempt in $(seq 1 "$max_attempts"); do
+  log_file="$(mktemp)"
+
+  set +e
+  ./gradlew "$@" 2>&1 | tee "$log_file"
+  status="${PIPESTATUS[0]}"
+  set -e
+
+  if [ "$status" -eq 0 ]; then
+    rm -f "$log_file"
+    exit 0
+  fi
+
+  if [ "$attempt" -lt "$max_attempts" ] && is_snapshot_metadata_failure "$log_file"; then
+    echo "SNAPSHOT metadata resolution failed; retrying warm-up attempt $((attempt + 1))/${max_attempts} after ${delay_seconds}s"
+    rm -f "$log_file"
+    sleep "$delay_seconds"
+    continue
+  fi
+
+  rm -f "$log_file"
+  exit "$status"
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [build, changes]
-    if: ${{ needs.changes.outputs['leader-ktor'] == 'true' || needs.changes.outputs['examples-ktor-app'] == 'true' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ needs.changes.outputs['leader-ktor'] == 'true' || needs.changes.outputs['leader-exposed'] == 'true' || needs.changes.outputs['examples-ktor-app'] == 'true' || needs.changes.outputs['examples-migration-gate'] == 'true' || needs.changes.outputs['examples-tenant-aggregator'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -290,13 +290,18 @@ jobs:
           gradle-version: wrapper
           cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
-      - name: Warm Ktor test SNAPSHOT dependencies
+      - name: Warm test SNAPSHOT dependencies
         run: |
-          for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-ktor:compileTestKotlin :examples:ktor-app:compileTestKotlin --no-configuration-cache --no-daemon && break
-            echo "Attempt $attempt failed"
-            [ $attempt -lt 5 ] && sleep 30 || exit 1
-          done
+          .github/scripts/retry-snapshot-warmup.sh \
+            :bluetape4k-leader-ktor:compileTestKotlin \
+            :bluetape4k-leader-exposed-core:compileTestKotlin \
+            :bluetape4k-leader-exposed-jdbc:compileTestKotlin \
+            :bluetape4k-leader-exposed-r2dbc:compileTestKotlin \
+            :examples:ktor-app:compileTestKotlin \
+            :examples:migration-gate:compileTestKotlin \
+            :examples:tenant-aggregator:compileTestKotlin \
+            --no-configuration-cache \
+            --no-daemon
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
 
@@ -507,7 +512,7 @@ jobs:
     name: Test / leader-exposed-jdbc (H2)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, changes]
+    needs: [build, changes, snapshot-warmup]
     if: ${{ needs.changes.outputs['leader-exposed'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v6
@@ -559,7 +564,7 @@ jobs:
     name: Test / leader-exposed-jdbc (PostgreSQL)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, changes]
+    needs: [build, changes, snapshot-warmup]
     if: ${{ needs.changes.outputs['leader-exposed'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v6
@@ -613,7 +618,7 @@ jobs:
     name: Test / leader-exposed-jdbc (MySQL 8)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, changes]
+    needs: [build, changes, snapshot-warmup]
     if: ${{ needs.changes.outputs['leader-exposed'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v6
@@ -668,7 +673,7 @@ jobs:
     name: Test / leader-exposed-r2dbc (H2)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, changes]
+    needs: [build, changes, snapshot-warmup]
     if: ${{ needs.changes.outputs['leader-exposed'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v6
@@ -714,7 +719,7 @@ jobs:
     name: Test / leader-exposed-r2dbc (PostgreSQL)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, changes]
+    needs: [build, changes, snapshot-warmup]
     if: ${{ needs.changes.outputs['leader-exposed'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v6
@@ -762,7 +767,7 @@ jobs:
     name: Test / leader-exposed-r2dbc (MySQL 8)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, changes]
+    needs: [build, changes, snapshot-warmup]
     if: ${{ needs.changes.outputs['leader-exposed'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v6
@@ -810,7 +815,7 @@ jobs:
     name: Test / examples-migration-gate
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, changes]
+    needs: [build, changes, snapshot-warmup]
     if: ${{ needs.changes.outputs['examples-migration-gate'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v6
@@ -918,7 +923,7 @@ jobs:
     name: Test / examples-tenant-aggregator
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build, changes]
+    needs: [build, changes, snapshot-warmup]
     if: ${{ needs.changes.outputs['examples-tenant-aggregator'] == 'true' || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -63,13 +63,14 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
-      - name: Warm examples-ktor-app test SNAPSHOT dependencies
+      - name: Warm example test SNAPSHOT dependencies
         run: |
-          for attempt in 1 2 3 4 5; do
-            ./gradlew :examples:ktor-app:compileTestKotlin --no-configuration-cache --no-daemon && break
-            echo "Attempt $attempt failed"
-            [ $attempt -lt 5 ] && sleep 30 || exit 1
-          done
+          .github/scripts/retry-snapshot-warmup.sh \
+            :examples:ktor-app:compileTestKotlin \
+            :examples:migration-gate:compileTestKotlin \
+            :examples:tenant-aggregator:compileTestKotlin \
+            --no-configuration-cache \
+            --no-daemon
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
 

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -81,7 +81,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: build
-    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -91,13 +90,26 @@ jobs:
       - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: wrapper
-      - name: Warm leader-ktor test SNAPSHOT dependencies
+      - name: Warm smoke test SNAPSHOT dependencies
         run: |
-          for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-ktor:compileTestKotlin --no-daemon --no-configuration-cache && break
-            echo "Attempt $attempt failed"
-            [ $attempt -lt 5 ] && sleep 30 || exit 1
-          done
+          .github/scripts/retry-snapshot-warmup.sh \
+            :bluetape4k-leader-exposed-core:compileTestKotlin \
+            :bluetape4k-leader-exposed-jdbc:compileTestKotlin \
+            :bluetape4k-leader-exposed-r2dbc:compileTestKotlin \
+            --no-configuration-cache \
+            --no-daemon
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+      - name: Warm full-scope test SNAPSHOT dependencies
+        if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+        run: |
+          .github/scripts/retry-snapshot-warmup.sh \
+            :bluetape4k-leader-ktor:compileTestKotlin \
+            :examples:ktor-app:compileTestKotlin \
+            :examples:migration-gate:compileTestKotlin \
+            :examples:tenant-aggregator:compileTestKotlin \
+            --no-configuration-cache \
+            --no-daemon
         env:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
 
@@ -246,7 +258,7 @@ jobs:
     name: Test / leader-exposed-core (H2)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, snapshot-warmup]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -293,7 +305,7 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, snapshot-warmup]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -342,7 +354,7 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, snapshot-warmup]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -389,7 +401,7 @@ jobs:
     name: Test / leader-exposed-jdbc (H2)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, snapshot-warmup]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -436,7 +448,7 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, snapshot-warmup]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -485,7 +497,7 @@ jobs:
 
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, snapshot-warmup]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -532,7 +544,7 @@ jobs:
     name: Test / leader-exposed-r2dbc (H2)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, snapshot-warmup]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -578,7 +590,7 @@ jobs:
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, snapshot-warmup]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -626,7 +638,7 @@ jobs:
     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: build
+    needs: [build, snapshot-warmup]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/docs/lessons/2026-06-06-issue-497-k8s-examples-vertx-runtime.md
+++ b/docs/lessons/2026-06-06-issue-497-k8s-examples-vertx-runtime.md
@@ -1,0 +1,39 @@
+# 2026-06-06 - Issue 497 K8s Examples Vert.x Runtime
+
+## Context
+
+Post-merge Examples workflow run 27054353270 still failed in the
+`examples-k8s-lease` and `examples-k8s-operator` jobs with
+`NoSuchMethodError: WebClientOptions.setMaxPoolSize(int)`. Issue #480 had fixed
+the `leader-k8s` module runtime, but the example modules kept resolving Fabric8
+Vert.x 4 requests to the repo-wide Vert.x 5 line.
+
+## Decision
+
+Apply the same Fabric8-compatible test runtime isolation to the two K3s-backed
+examples: Vert.x 4.5.27 and Netty 4.1.133.Final on `testRuntimeClasspath`.
+Keep the pin scoped to the examples instead of downgrading the repository-wide
+Vert.x default used by non-Kubernetes preview backends.
+
+## Outcome
+
+The example K3s tests now execute with the Vert.x 4 HTTP client API expected by
+Fabric8 Kubernetes client 7.7.x, matching the already-fixed `leader-k8s`
+runtime shape.
+
+## Verification
+
+- `./gradlew :examples:k8s-lease:dependencyInsight --configuration testRuntimeClasspath --dependency io.vertx:vertx-web-client --no-daemon` selected `io.vertx:vertx-web-client:4.5.27`.
+- `./gradlew :examples:k8s-operator:dependencyInsight --configuration testRuntimeClasspath --dependency io.vertx:vertx-web-client --no-daemon` selected `io.vertx:vertx-web-client:4.5.27`.
+- `./gradlew :examples:k8s-lease:dependencyInsight --configuration testRuntimeClasspath --dependency io.vertx:vertx-core --no-daemon` selected `io.vertx:vertx-core:4.5.27`.
+- `./gradlew :examples:k8s-operator:dependencyInsight --configuration testRuntimeClasspath --dependency io.vertx:vertx-core --no-daemon` selected `io.vertx:vertx-core:4.5.27`.
+- `./gradlew :examples:k8s-lease:dependencyInsight --configuration testRuntimeClasspath --dependency io.netty:netty-common --no-daemon` selected `io.netty:netty-common:4.1.133.Final`.
+- `./gradlew :examples:k8s-operator:dependencyInsight --configuration testRuntimeClasspath --dependency io.netty:netty-common --no-daemon` selected `io.netty:netty-common:4.1.133.Final`.
+- `./gradlew :examples:k8s-lease:k8sTest --no-daemon --no-configuration-cache` passed with one K3s test on 2026-06-06.
+- `./gradlew :examples:k8s-operator:k8sTest --no-daemon --no-configuration-cache` passed with two K3s tests on 2026-06-06.
+
+## Future Guidance
+
+When a runtime pin is needed for `leader-k8s`, check K3s-backed examples in the
+same pass. The Examples workflow runs those modules independently, so module
+tests can pass while example runtime classpaths still drift.

--- a/docs/lessons/2026-06-06-snapshot-metadata-403-warmup.md
+++ b/docs/lessons/2026-06-06-snapshot-metadata-403-warmup.md
@@ -1,0 +1,37 @@
+# 2026-06-06 - Snapshot Metadata 403 Warm-Up
+
+## Context
+
+The manually dispatched Examples workflow for issue #497 proved that both K8s
+example jobs passed, but `examples-tenant-aggregator` failed on Central
+SNAPSHOT metadata with HTTP 403 for
+`bluetape4k-exposed-r2dbc-tests:1.11.0-SNAPSHOT`. A failed job retry passed,
+confirming a transient metadata lookup problem rather than a test regression.
+
+## Decision
+
+Move Central SNAPSHOT retry handling into a dedicated warm-up script that
+retries only metadata-resolution failures. Expand CI, Examples, and Nightly
+warm-up scopes to cover exposed test fixtures as well as the existing Ktor
+SNAPSHOT consumers.
+
+## Outcome
+
+Ktor and exposed SNAPSHOT coordinates are warmed before dependent tests run.
+When Central returns metadata 403, the retry happens in the warm-up step instead
+of rerunning an already-started test job.
+
+## Verification
+
+- `bash -n .github/scripts/retry-snapshot-warmup.sh`
+- `actionlint .github/workflows/ci.yml .github/workflows/examples.yml .github/workflows/nightly-tests.yml`
+- `git diff --check`
+- GitHub Examples run 27055610835 passed after rerunning the failed
+  `examples-tenant-aggregator` job; the first failure was Central metadata 403,
+  while both K8s jobs passed before the retry.
+
+## Future Guidance
+
+When adding a test module that consumes bluetape4k SNAPSHOT artifacts, add its
+`compileTestKotlin` task to the relevant warm-up scope before relying on the
+test matrix retry loop.

--- a/examples/k8s-lease/build.gradle.kts
+++ b/examples/k8s-lease/build.gradle.kts
@@ -6,6 +6,37 @@ application {
     mainClass.set("io.bluetape4k.leader.examples.k8slease.K8sLeaseLeaderElectionExample")
 }
 
+val fabric8VertxVersion = "4.5.27"
+val fabric8NettyVersion = "4.1.133.Final"
+
+configurations.named("testRuntimeClasspath") {
+    // Fabric8 7.7.x uses the Vert.x 4 HTTP client API; keep K3s example tests isolated from repo-wide Vert.x 5.
+    resolutionStrategy.eachDependency {
+        when (requested.group) {
+            "io.netty" -> useVersion(fabric8NettyVersion)
+            "io.vertx" -> useVersion(fabric8VertxVersion)
+        }
+    }
+    resolutionStrategy.force(
+        "io.netty:netty-all:$fabric8NettyVersion",
+        "io.netty:netty-buffer:$fabric8NettyVersion",
+        "io.netty:netty-codec:$fabric8NettyVersion",
+        "io.netty:netty-codec-dns:$fabric8NettyVersion",
+        "io.netty:netty-codec-http:$fabric8NettyVersion",
+        "io.netty:netty-codec-http2:$fabric8NettyVersion",
+        "io.netty:netty-codec-socks:$fabric8NettyVersion",
+        "io.netty:netty-common:$fabric8NettyVersion",
+        "io.netty:netty-handler:$fabric8NettyVersion",
+        "io.netty:netty-handler-proxy:$fabric8NettyVersion",
+        "io.netty:netty-resolver:$fabric8NettyVersion",
+        "io.netty:netty-resolver-dns:$fabric8NettyVersion",
+        "io.netty:netty-transport:$fabric8NettyVersion",
+        "io.vertx:vertx-core:$fabric8VertxVersion",
+        "io.vertx:vertx-web-client:$fabric8VertxVersion",
+        "io.vertx:vertx-web-common:$fabric8VertxVersion",
+    )
+}
+
 dependencies {
     implementation(libs.bluetape4k.core)
     implementation(libs.fabric8.kubernetes.client)

--- a/examples/k8s-operator/build.gradle.kts
+++ b/examples/k8s-operator/build.gradle.kts
@@ -26,6 +26,37 @@ dependencyManagement {
     }
 }
 
+val fabric8VertxVersion = "4.5.27"
+val fabric8NettyVersion = "4.1.133.Final"
+
+configurations.named("testRuntimeClasspath") {
+    // Fabric8 7.7.x uses the Vert.x 4 HTTP client API; keep K3s example tests isolated from repo-wide Vert.x 5.
+    resolutionStrategy.eachDependency {
+        when (requested.group) {
+            "io.netty" -> useVersion(fabric8NettyVersion)
+            "io.vertx" -> useVersion(fabric8VertxVersion)
+        }
+    }
+    resolutionStrategy.force(
+        "io.netty:netty-all:$fabric8NettyVersion",
+        "io.netty:netty-buffer:$fabric8NettyVersion",
+        "io.netty:netty-codec:$fabric8NettyVersion",
+        "io.netty:netty-codec-dns:$fabric8NettyVersion",
+        "io.netty:netty-codec-http:$fabric8NettyVersion",
+        "io.netty:netty-codec-http2:$fabric8NettyVersion",
+        "io.netty:netty-codec-socks:$fabric8NettyVersion",
+        "io.netty:netty-common:$fabric8NettyVersion",
+        "io.netty:netty-handler:$fabric8NettyVersion",
+        "io.netty:netty-handler-proxy:$fabric8NettyVersion",
+        "io.netty:netty-resolver:$fabric8NettyVersion",
+        "io.netty:netty-resolver-dns:$fabric8NettyVersion",
+        "io.netty:netty-transport:$fabric8NettyVersion",
+        "io.vertx:vertx-core:$fabric8VertxVersion",
+        "io.vertx:vertx-web-client:$fabric8VertxVersion",
+        "io.vertx:vertx-web-common:$fabric8VertxVersion",
+    )
+}
+
 dependencies {
     implementation(project(":bluetape4k-leader-k8s"))
 


### PR DESCRIPTION
## Summary

Closes #497

PR #498의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: restore K8s example runtime compatibility`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

- Keep the K3s-backed example test runtime on Fabric8-compatible Vert.x 4.5.27 and Netty 4.1.133.Final.
- Apply the runtime isolation to both `examples:k8s-lease` and `examples:k8s-operator`.
- Retry Central SNAPSHOT metadata failures in a dedicated warm-up phase before exposed/Ktor tests run.
- Add a lesson entry so future K8s runtime fixes check examples together with `leader-k8s`.

Closes #497.

## Root Cause

Fabric8 Kubernetes client 7.7.x still requests Vert.x 4 HTTP client APIs, but the example `testRuntimeClasspath` was resolving those artifacts to the repository-wide Vert.x 5 line. The post-merge Examples workflow then failed with `NoSuchMethodError: WebClientOptions.setMaxPoolSize(int)`.

## Verification

- `./gradlew :examples:k8s-lease:dependencyInsight --configuration testRuntimeClasspath --dependency io.vertx:vertx-web-client --no-daemon`
- `./gradlew :examples:k8s-operator:dependencyInsight --configuration testRuntimeClasspath --dependency io.vertx:vertx-web-client --no-daemon`
- `./gradlew :examples:k8s-lease:dependencyInsight --configuration testRuntimeClasspath --dependency io.vertx:vertx-core --no-daemon`
- `./gradlew :examples:k8s-operator:dependencyInsight --configuration testRuntimeClasspath --dependency io.vertx:vertx-core --no-daemon`
- `./gradlew :examples:k8s-lease:dependencyInsight --configuration testRuntimeClasspath --dependency io.netty:netty-common --no-daemon`
- `./gradlew :examples:k8s-operator:dependencyInsight --configuration testRuntimeClasspath --dependency io.netty:netty-common --no-daemon`
- `./gradlew :examples:k8s-lease:k8sTest --no-daemon --no-configuration-cache`
- `./gradlew :examples:k8s-operator:k8sTest --no-daemon --no-configuration-cache`
- `.github/scripts/retry-snapshot-warmup.sh :examples:tenant-aggregator:compileTestKotlin --no-configuration-cache --no-daemon`
- `bash -n .github/scripts/retry-snapshot-warmup.sh`
- `actionlint .github/workflows/ci.yml .github/workflows/examples.yml .github/workflows/nightly-tests.yml`
- `git diff --check`

## DoD Status

| Step | Status | Evidence |
| --- | --- | --- |
| Issue reviewed | Done | #497 matched the post-merge Examples workflow failures in `examples-k8s-lease` and `examples-k8s-operator`. |
| Root cause confirmed | Done | Both example classpaths had resolved `io.vertx:vertx-web-client:4.5.27 -> 5.1.0` before the fix. |
| Runtime compatibility restored | Done | Both examples now select Vert.x 4.5.27 and Netty 4.1.133.Final on `testRuntimeClasspath`. |
| K3s examples verified | Done | `:examples:k8s-lease:k8sTest` passed with 1 test; `:examples:k8s-operator:k8sTest` passed with 2 tests. |
| Snapshot 403 handling narrowed | Done | Added warm-up retry script and expanded CI/Examples/Nightly warm-up coverage for exposed SNAPSHOT test fixtures. |
| Regression note captured | Done | Added `docs/lessons/2026-06-06-issue-497-k8s-examples-vertx-runtime.md` and `docs/lessons/2026-06-06-snapshot-metadata-403-warmup.md`. |

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #497, milestone `0.4.0`, assignee `debop`
- PR: #498, head `e4634f06e67d221370fcea9649da13b3fc45ea3a`, milestone `0.4.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
