### PR TITLE
docs: use published dependency coordinates

### DIFF
--- a/examples/batch-scheduler/README.ko.md
+++ b/examples/batch-scheduler/README.ko.md
@@ -78,8 +78,7 @@ if (result == null) {
 
 ```kotlin
 dependencies {
-    implementation(project(":leader-redis-lettuce"))
-    implementation(project(":examples:batch-scheduler"))
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-redis-lettuce:${bluetape4kVersion}")
 }
 ```
 

--- a/examples/batch-scheduler/README.md
+++ b/examples/batch-scheduler/README.md
@@ -79,8 +79,7 @@ Or directly: run `BatchSchedulerDemo.main()` from your IDE. Spawns 3 simulated i
 
 ```kotlin
 dependencies {
-    implementation(project(":leader-redis-lettuce"))
-    implementation(project(":examples:batch-scheduler"))
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-redis-lettuce:${bluetape4kVersion}")
 }
 ```
 

--- a/examples/cache-warmer/README.ko.md
+++ b/examples/cache-warmer/README.ko.md
@@ -87,8 +87,7 @@ log.info { "warmed=${result.warmed} skipped=${result.skipped} failed=${result.fa
 
 ```kotlin
 dependencies {
-    implementation(project(":leader-hazelcast"))
-    implementation(project(":examples:cache-warmer"))
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-hazelcast:${bluetape4kVersion}")
 }
 ```
 

--- a/examples/cache-warmer/README.md
+++ b/examples/cache-warmer/README.md
@@ -92,8 +92,7 @@ that each partition is warmed exactly once across the cluster.
 
 ```kotlin
 dependencies {
-    implementation(project(":leader-hazelcast"))
-    implementation(project(":examples:cache-warmer"))
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-hazelcast:${bluetape4kVersion}")
 }
 ```
 

--- a/examples/dynamodb-export/README.ko.md
+++ b/examples/dynamodb-export/README.ko.md
@@ -98,8 +98,7 @@ Demo는 Testcontainers로 DynamoDB Local을 시작하고 lock table과 export ta
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-leader-dynamodb"))
-    implementation(project(":examples:dynamodb-export"))
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-dynamodb:${bluetape4kVersion}")
 }
 ```
 

--- a/examples/dynamodb-export/README.md
+++ b/examples/dynamodb-export/README.md
@@ -98,8 +98,7 @@ simulates two nodes competing for the same scheduled export lock.
 
 ```kotlin
 dependencies {
-    implementation(project(":bluetape4k-leader-dynamodb"))
-    implementation(project(":examples:dynamodb-export"))
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-dynamodb:${bluetape4kVersion}")
 }
 ```
 

--- a/examples/ktor-app/README.ko.md
+++ b/examples/ktor-app/README.ko.md
@@ -144,8 +144,8 @@ PORT=8081 REDIS_URL=redis://localhost:6379 ./gradlew :examples:ktor-app:run
 
 ```kotlin
 dependencies {
-    implementation(project(":leader-ktor"))
-    implementation(project(":leader-redis-lettuce"))
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-ktor:${bluetape4kVersion}")
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-redis-lettuce:${bluetape4kVersion}")
 
     implementation("io.github.bluetape4k:bluetape4k-ktor-core")
     implementation("io.lettuce:lettuce-core")

--- a/examples/ktor-app/README.md
+++ b/examples/ktor-app/README.md
@@ -144,8 +144,8 @@ PORT=8081 REDIS_URL=redis://localhost:6379 ./gradlew :examples:ktor-app:run
 
 ```kotlin
 dependencies {
-    implementation(project(":leader-ktor"))
-    implementation(project(":leader-redis-lettuce"))
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-ktor:${bluetape4kVersion}")
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-redis-lettuce:${bluetape4kVersion}")
 
     implementation("io.github.bluetape4k:bluetape4k-ktor-core")
     implementation("io.lettuce:lettuce-core")

--- a/examples/migration-gate/README.ko.md
+++ b/examples/migration-gate/README.ko.md
@@ -92,8 +92,7 @@ H2 in-memory DB + 3 pod 시뮬레이션. 1 Migrated + 2 AlreadyApplied 출력.
 
 ```kotlin
 dependencies {
-    implementation(project(":leader-exposed-jdbc"))
-    implementation(project(":examples:migration-gate"))
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-exposed-jdbc:${bluetape4kVersion}")
 }
 ```
 

--- a/examples/migration-gate/README.md
+++ b/examples/migration-gate/README.md
@@ -92,8 +92,7 @@ H2 in-memory DB + 3 pod simulation. Outputs 1 Migrated + 2 AlreadyApplied.
 
 ```kotlin
 dependencies {
-    implementation(project(":leader-exposed-jdbc"))
-    implementation(project(":examples:migration-gate"))
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-exposed-jdbc:${bluetape4kVersion}")
 }
 ```
 

--- a/examples/prometheus-dashboard/README.ko.md
+++ b/examples/prometheus-dashboard/README.ko.md
@@ -91,9 +91,9 @@ max by (lock_name) (leader_aop_active)
 
 ```kotlin
 dependencies {
-    implementation(project(":leader-spring-boot"))
-    implementation(project(":leader-micrometer"))
-    implementation(project(":leader-redis-lettuce"))
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-spring-boot:${bluetape4kVersion}")
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-micrometer:${bluetape4kVersion}")
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-redis-lettuce:${bluetape4kVersion}")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("io.micrometer:micrometer-registry-prometheus")
 }

--- a/examples/prometheus-dashboard/README.md
+++ b/examples/prometheus-dashboard/README.md
@@ -93,9 +93,9 @@ multi-instance deployments. The gauge is JVM-local, so `sum` can over-count.
 
 ```kotlin
 dependencies {
-    implementation(project(":leader-spring-boot"))
-    implementation(project(":leader-micrometer"))
-    implementation(project(":leader-redis-lettuce"))
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-spring-boot:${bluetape4kVersion}")
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-micrometer:${bluetape4kVersion}")
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-redis-lettuce:${bluetape4kVersion}")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("io.micrometer:micrometer-registry-prometheus")
 }

--- a/examples/tenant-aggregator/README.ko.md
+++ b/examples/tenant-aggregator/README.ko.md
@@ -96,8 +96,7 @@ H2 R2DBC in-memory DB 를 공유하는 3개 in-process 집계기를 6초간 poll
 
 ```kotlin
 dependencies {
-    implementation(project(":leader-exposed-r2dbc"))
-    implementation(project(":examples:tenant-aggregator"))
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-exposed-r2dbc:${bluetape4kVersion}")
 
     // R2DBC 드라이버 (택일)
     runtimeOnly(libs.r2dbc.h2)         // demo / tests

--- a/examples/tenant-aggregator/README.md
+++ b/examples/tenant-aggregator/README.md
@@ -96,8 +96,7 @@ Spins up 3 in-process aggregator instances against a shared H2 R2DBC database, p
 
 ```kotlin
 dependencies {
-    implementation(project(":leader-exposed-r2dbc"))
-    implementation(project(":examples:tenant-aggregator"))
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-exposed-r2dbc:${bluetape4kVersion}")
 
     // R2DBC driver (pick one)
     runtimeOnly(libs.r2dbc.h2)         // demo / tests

--- a/examples/webhook-poller/README.ko.md
+++ b/examples/webhook-poller/README.ko.md
@@ -97,8 +97,7 @@ MONGO_URL=mongodb://localhost:27017 ./gradlew :examples:webhook-poller:run
 
 ```kotlin
 dependencies {
-    implementation(project(":leader-mongodb"))
-    implementation(project(":examples:webhook-poller"))
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-mongodb:${bluetape4kVersion}")
 }
 ```
 

--- a/examples/webhook-poller/README.md
+++ b/examples/webhook-poller/README.md
@@ -97,8 +97,7 @@ Inserts 10 fake events into a fresh collection, then runs 3 pollers concurrently
 
 ```kotlin
 dependencies {
-    implementation(project(":leader-mongodb"))
-    implementation(project(":examples:webhook-poller"))
+    implementation("io.github.bluetape4k.leader:bluetape4k-leader-mongodb:${bluetape4kVersion}")
 }
 ```
 

--- a/leader-exposed-core/README.ko.md
+++ b/leader-exposed-core/README.ko.md
@@ -101,7 +101,7 @@ validateLockName("-bad-start")       // IllegalArgumentException
 
 ```kotlin
 // 프로덕션
-api(project(":leader-core"))
+api("io.github.bluetape4k.leader:bluetape4k-leader-core:${bluetape4kVersion}")
 api(libs.exposed.core)
 api(libs.exposed.java.time)
 compileOnly(libs.exposed.dao)

--- a/leader-exposed-core/README.md
+++ b/leader-exposed-core/README.md
@@ -101,7 +101,7 @@ Rules:
 
 ```kotlin
 // Production
-api(project(":leader-core"))
+api("io.github.bluetape4k.leader:bluetape4k-leader-core:${bluetape4kVersion}")
 api(libs.exposed.core)
 api(libs.exposed.java.time)
 compileOnly(libs.exposed.dao)


### PR DESCRIPTION
## Summary

PR #510의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `docs: use published dependency coordinates`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Replace README dependency snippets that used internal Gradle `project(\":...\")` references with user-facing dependency guidance.

## Background

Public README dependency sections should be usable from consumer builds. Internal Gradle project paths only work inside this repository checkout, so they are misleading when shown as installation snippets.

## Work Done

- Updated README dependency examples to use published Maven coordinates where the referenced module is published.
- Removed or clarified repository-only example wiring where no published artifact is intended.
- Kept the change documentation-only.

## Validation

- `rg 'project\(\":' -g 'README*.md' .`: PASS, no matches.
- `git diff --check`: PASS.
- Changed scope: 18 files changed, 24 insertions(+), 36 deletions(-).

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| R - Route | PASS | Type E documentation maintenance; README dependency snippets only. |
| D - Discover | PASS | Found README snippets that assumed repository-local Gradle project paths. |
| C - Apply | PASS | Replaced install snippets with Maven coordinates or clarified repository-internal support code. |
| V - Verify | PASS | Targeted `rg` found no README `project(\":...\")` references; `git diff --check` passed. |
| 6-E - Scope | PASS | Documentation-only; no source, build logic, or generated assets changed. |

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #510, head `82761fc5aa80ff0d2c9a9988c7153112e3b1b059`, milestone `0.4.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
