### PR TITLE
fix: preserve Lettuce async slot leader identity

### DIFF
--- a/docs/lessons/2026-07-01-issue-511-lettuce-async-slot-identity.md
+++ b/docs/lessons/2026-07-01-issue-511-lettuce-async-slot-identity.md
@@ -1,0 +1,37 @@
+# Lessons Learned - Issue 511 Lettuce Async Slot Identity (2026-07-01)
+
+## Context
+
+Issue #511 found that Lettuce async `LeaderSlot` APIs inherited the default
+bridge path. Blocking and suspend APIs preserved `slot.leaderId`, but async
+single/group result APIs could return `LeaderRunResult.Elected(..., leaderId =
+null)` and emit bridge warnings.
+
+## Decision
+
+Add async slot identity contract fixtures in `leader-core` test fixtures and
+make Lettuce single/group async electors override both slot variants:
+
+- `runAsyncIfLeader(slot, ...)`
+- `runAsyncIfLeaderResult(slot, ...)`
+
+Group async acquire must pass `slot.leaderId` into `tryAcquireAsync` so Redis
+slot metadata matches sync and suspend behavior.
+
+## Outcome
+
+The failing async contract tests reproduced the issue first, then passed after
+the Lettuce implementation change.
+
+Validation evidence:
+
+- `./gradlew :bluetape4k-leader-redis-lettuce:test --tests '*LettuceAsyncLeader*LeaderIdContractTest' --no-parallel`
+- `./gradlew :bluetape4k-leader-redis-lettuce:test --no-parallel`
+- Test XML summary: 221 tests, 0 failures, 0 errors, 0 skipped.
+
+## Future Guard
+
+When a backend implements slot-aware blocking or suspend APIs, verify async
+slot APIs separately. Default bridge methods deliberately warn and drop
+`leaderId`; backend modules must override both async slot variants to preserve
+audit identity.

--- a/docs/review/2026-07-01-issue-511-lettuce-async-slot-identity-review.md
+++ b/docs/review/2026-07-01-issue-511-lettuce-async-slot-identity-review.md
@@ -1,0 +1,29 @@
+# Issue 511 Review - Lettuce Async Slot Identity
+
+## Scope
+
+- `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElector.kt`
+- `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElector.kt`
+- async slot identity contract fixtures in `leader-core/src/testFixtures`
+- Lettuce async single/group contract subclasses
+
+## Review Result
+
+P0/P1 findings: 0
+
+## Checks
+
+| Tier | Result | Evidence |
+|---|---|---|
+| Correctness | PASS | `runAsyncIfLeader(slot)` now overrides the bridge default and routes through an audit-aware internal path. |
+| Result contract | PASS | `runAsyncIfLeaderResult(slot)` returns `LeaderRunResult.Elected(..., leaderId = slot.leaderId)` when the action runs, including null-returning actions. |
+| Backend audit path | PASS | Group async acquire now passes `auditLeaderId` into `LettuceSlotTokenGroup.tryAcquireAsync`, matching sync and suspend paths. |
+| Release semantics | PASS | Existing async release-after-action behavior remains in `releaseAndPropagate`; lock/slot release is still awaited before outer completion. |
+| Exception semantics | PASS | Action failures still become `LeaderRunResult.ActionFailed`; cancellation is rethrown rather than wrapped. Backend failures before election still complete exceptionally. |
+| Bridge warning regression | PASS | New contract tests assert `LeaderElectorBridgeLog` slot/result counters stay at zero. |
+| Test coverage | PASS | `./gradlew :bluetape4k-leader-redis-lettuce:test --no-parallel` passed, 221 tests, 0 failures, 0 errors, 0 skipped. |
+
+## Tooling Notes
+
+- CodeGraph reported low risk but did not resolve new test fixture nodes in this worktree, so this review used direct diff inspection plus targeted source checks.
+- IntelliJ diagnostics MCP was not available in this session; Gradle compile/test was used as the fallback diagnostic gate.

--- a/leader-core/src/testFixtures/kotlin/io/bluetape4k/leader/contract/AbstractAsyncLeaderElectorLeaderIdContractTest.kt
+++ b/leader-core/src/testFixtures/kotlin/io/bluetape4k/leader/contract/AbstractAsyncLeaderElectorLeaderIdContractTest.kt
@@ -1,0 +1,85 @@
+package io.bluetape4k.leader.contract
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.leader.AsyncLeaderElector
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LeaderSlot
+import io.bluetape4k.leader.identity.LeaderElectorBridgeLog
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Backend-agnostic contract for [AsyncLeaderElector] slot-aware audit identity propagation.
+ *
+ * ## Verified contracts
+ * - `runAsyncIfLeaderResult(slot)` -> [LeaderRunResult.Elected.leaderId] == `slot.leaderId`
+ * - Correct async slot overrides do not trigger [LeaderElectorBridgeLog]
+ *
+ * Subclasses implement [createElector] to supply the backend-specific [AsyncLeaderElector].
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractAsyncLeaderElectorLeaderIdContractTest {
+
+    companion object : KLogging()
+
+    protected abstract fun createElector(options: LeaderElectionOptions): AsyncLeaderElector
+
+    private val defaultElector: AsyncLeaderElector by lazy {
+        createElector(LeaderElectionOptions.Default)
+    }
+
+    @BeforeEach
+    fun resetBridgeLog() {
+        LeaderElectorBridgeLog.setGlobal(LeaderElectorBridgeLog())
+    }
+
+    private fun slot(leaderId: String = "node-a") =
+        LeaderSlot("lock-${Base58.randomString(8)}", leaderId)
+
+    @Test
+    fun `runAsyncIfLeaderResult(slot) - Elected 반환 및 leaderId 전파`() {
+        val s = slot("async-audit-node")
+        val result = defaultElector.runAsyncIfLeaderResult(s) {
+            CompletableFuture.completedFuture("done")
+        }.join()
+
+        result shouldBeInstanceOf LeaderRunResult.Elected::class
+        (result as LeaderRunResult.Elected).value shouldBeEqualTo "done"
+        result.leaderId shouldBeEqualTo "async-audit-node"
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult(slot) - action null 반환해도 Elected with leaderId`() {
+        val s = slot("async-null-node")
+        val result = defaultElector.runAsyncIfLeaderResult<String?>(s) {
+            CompletableFuture.completedFuture(null)
+        }.join()
+
+        result shouldBeInstanceOf LeaderRunResult.Elected::class
+        (result as LeaderRunResult.Elected).leaderId shouldBeEqualTo "async-null-node"
+    }
+
+    @Test
+    fun `runAsyncIfLeader(slot) - bridge log 미호출`() {
+        defaultElector.runAsyncIfLeader(slot()) {
+            CompletableFuture.completedFuture(Unit)
+        }.join()
+
+        LeaderElectorBridgeLog.global().droppedAuditCount() shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult(slot) - result bridge log 미호출`() {
+        defaultElector.runAsyncIfLeaderResult(slot()) {
+            CompletableFuture.completedFuture(Unit)
+        }.join()
+
+        LeaderElectorBridgeLog.global().droppedResultBridgeCount() shouldBeEqualTo 0L
+    }
+}

--- a/leader-core/src/testFixtures/kotlin/io/bluetape4k/leader/contract/AbstractAsyncLeaderGroupElectorLeaderIdContractTest.kt
+++ b/leader-core/src/testFixtures/kotlin/io/bluetape4k/leader/contract/AbstractAsyncLeaderGroupElectorLeaderIdContractTest.kt
@@ -1,0 +1,85 @@
+package io.bluetape4k.leader.contract
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.leader.AsyncLeaderGroupElector
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LeaderSlot
+import io.bluetape4k.leader.identity.LeaderElectorBridgeLog
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Backend-agnostic contract for [AsyncLeaderGroupElector] slot-aware audit identity propagation.
+ *
+ * ## Verified contracts
+ * - `runAsyncIfLeaderResult(slot)` -> [LeaderRunResult.Elected.leaderId] == `slot.leaderId`
+ * - Correct async group slot overrides do not trigger [LeaderElectorBridgeLog]
+ *
+ * Subclasses implement [createElector] to supply the backend-specific [AsyncLeaderGroupElector].
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+abstract class AbstractAsyncLeaderGroupElectorLeaderIdContractTest {
+
+    companion object : KLogging()
+
+    protected abstract fun createElector(options: LeaderGroupElectionOptions): AsyncLeaderGroupElector
+
+    private val defaultElector: AsyncLeaderGroupElector by lazy {
+        createElector(LeaderGroupElectionOptions(maxLeaders = 2))
+    }
+
+    @BeforeEach
+    fun resetBridgeLog() {
+        LeaderElectorBridgeLog.setGlobal(LeaderElectorBridgeLog())
+    }
+
+    private fun slot(leaderId: String = "node-a") =
+        LeaderSlot("lock-${Base58.randomString(8)}", leaderId)
+
+    @Test
+    fun `runAsyncIfLeaderResult(slot) - Elected 반환 및 leaderId 전파`() {
+        val s = slot("async-group-audit-node")
+        val result = defaultElector.runAsyncIfLeaderResult(s) {
+            CompletableFuture.completedFuture("done")
+        }.join()
+
+        result shouldBeInstanceOf LeaderRunResult.Elected::class
+        (result as LeaderRunResult.Elected).value shouldBeEqualTo "done"
+        result.leaderId shouldBeEqualTo "async-group-audit-node"
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult(slot) - action null 반환해도 Elected with leaderId`() {
+        val s = slot("async-group-null-node")
+        val result = defaultElector.runAsyncIfLeaderResult<String?>(s) {
+            CompletableFuture.completedFuture(null)
+        }.join()
+
+        result shouldBeInstanceOf LeaderRunResult.Elected::class
+        (result as LeaderRunResult.Elected).leaderId shouldBeEqualTo "async-group-null-node"
+    }
+
+    @Test
+    fun `runAsyncIfLeader(slot) - bridge log 미호출`() {
+        defaultElector.runAsyncIfLeader(slot()) {
+            CompletableFuture.completedFuture(Unit)
+        }.join()
+
+        LeaderElectorBridgeLog.global().droppedAuditCount() shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult(slot) - result bridge log 미호출`() {
+        defaultElector.runAsyncIfLeaderResult(slot()) {
+            CompletableFuture.completedFuture(Unit)
+        }.join()
+
+        LeaderElectorBridgeLog.global().droppedResultBridgeCount() shouldBeEqualTo 0L
+    }
+}

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElector.kt
@@ -23,8 +23,10 @@ import io.lettuce.core.api.StatefulRedisConnection
 import kotlinx.coroutines.CancellationException
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Creates a [LettuceLeaderElector] instance from this [StatefulRedisConnection].
@@ -171,6 +173,40 @@ class LettuceLeaderElector @JvmOverloads constructor(
         lockName: String,
         executor: Executor,
         action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> =
+        runAsyncImpl(lockName, auditLeaderId = null, executor, action)
+
+    override fun <T> runAsyncIfLeader(
+        slot: LeaderSlot,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> =
+        runAsyncImpl(slot.lockName, auditLeaderId = slot.leaderId, executor, action)
+
+    override fun <T> runAsyncIfLeaderResult(
+        slot: LeaderSlot,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<LeaderRunResult<T>> {
+        val elected = AtomicBoolean(false)
+        return runAsyncIfLeader(slot, executor) {
+            elected.set(true)
+            action()
+        }.handle { value, failure ->
+            when {
+                failure != null && elected.get() -> failure.toActionFailedResult()
+                failure != null -> throw failure.asCompletionException()
+                elected.get() -> LeaderRunResult.Elected(value, leaderId = slot.leaderId)
+                else -> LeaderRunResult.Skipped
+            }
+        }
+    }
+
+    private fun <T> runAsyncImpl(
+        lockName: String,
+        auditLeaderId: String?,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
         lockName.requireNotBlank("lockName")
 
@@ -186,6 +222,18 @@ class LettuceLeaderElector @JvmOverloads constructor(
                 val delegate = LettuceLockExtendDelegate(lock)
                 val watchdog =
                     LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime, delegate, ERROR_CLASSIFIER)
+                val identity = LockIdentity(
+                    lockName = lockName,
+                    kind = LockIdentity.AnnotationKind.SINGLE,
+                    factoryBeanName = LETTUCE_FACTORY_BEAN_NAME,
+                )
+                val handle = LeaderLockHandle.real(
+                    identity = identity,
+                    token = token,
+                    acquiredAtNanos = acquiredAtNanos,
+                    extendDelegate = delegate,
+                    auditLeaderId = auditLeaderId,
+                )
 
                 val record = historyRecorder?.let {
                     LeaderLockHistoryRecord(
@@ -202,7 +250,7 @@ class LettuceLeaderElector @JvmOverloads constructor(
 
                 log.debug { "리더 선출 성공 (async): lockName=$lockName" }
                 val actionFuture: CompletableFuture<T> = try {
-                    action()
+                    AopScopeAccess.withPushedSync(handle) { action() }
                 } catch (e: Throwable) {
                     return@thenComposeAsync releaseAndPropagate<T>(
                         lock, lockName, watchdog, acquiredAtNanos, effectiveKey, e, null
@@ -217,6 +265,23 @@ class LettuceLeaderElector @JvmOverloads constructor(
             }
         }, executor)
     }
+
+    private fun Throwable.unwrapCompletionCause(): Throwable =
+        (this as? CompletionException)?.cause ?: this
+
+    private fun Throwable.toActionFailedResult(): LeaderRunResult.ActionFailed {
+        val cause = unwrapCompletionCause()
+        if (cause is CancellationException) {
+            throw cause
+        }
+        if (cause is java.util.concurrent.CancellationException) {
+            throw cause
+        }
+        return LeaderRunResult.ActionFailed(cause)
+    }
+
+    private fun Throwable.asCompletionException(): CompletionException =
+        this as? CompletionException ?: CompletionException(this)
 
     private fun <T> releaseAndPropagate(
         lock: LettuceLock,

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElector.kt
@@ -21,8 +21,10 @@ import io.bluetape4k.support.requireNotBlank
 import io.lettuce.core.api.StatefulRedisConnection
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Creates a [LettuceLeaderGroupElector] instance from a [StatefulRedisConnection].
@@ -169,21 +171,77 @@ class LettuceLeaderGroupElector(
         lockName: String,
         executor: Executor,
         action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> =
+        runAsyncImpl(lockName, auditLeaderId = null, executor, action)
+
+    override fun <T> runAsyncIfLeader(
+        slot: LeaderSlot,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> =
+        runAsyncImpl(slot.lockName, auditLeaderId = slot.leaderId, executor, action)
+
+    override fun <T> runAsyncIfLeaderResult(
+        slot: LeaderSlot,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<LeaderRunResult<T>> {
+        val elected = AtomicBoolean(false)
+        return runAsyncIfLeader(slot, executor) {
+            elected.set(true)
+            action()
+        }.handle { value, failure ->
+            when {
+                failure != null && elected.get() -> failure.toActionFailedResult()
+                failure != null -> throw failure.asCompletionException()
+                elected.get() -> LeaderRunResult.Elected(value, leaderId = slot.leaderId)
+                else -> LeaderRunResult.Skipped
+            }
+        }
+    }
+
+    private fun <T> runAsyncImpl(
+        lockName: String,
+        auditLeaderId: String?,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
         val slotGroup = getSlotGroup(lockName)
 
-        return slotGroup.tryAcquireAsync(options.waitTime, options.leaseTime).thenComposeAsync({ token ->
+        return slotGroup.tryAcquireAsync(options.waitTime, options.leaseTime, auditLeaderId ?: "").thenComposeAsync({ token ->
             if (token == null) {
                 log.debug { "리더 선출 실패 (슬롯 없음, async): lockName=$lockName" }
                 CompletableFuture.completedFuture<T?>(null)
             } else {
                 // Codex P2: acquire 성공 후 startedAtNanos 캡처
                 val startedAtNanos = System.nanoTime()
+                val delegate = LettuceSlotExtendDelegate(slotGroup, token)
+                val identity = LockIdentity(
+                    lockName = lockName,
+                    kind = LockIdentity.AnnotationKind.GROUP,
+                    factoryBeanName = LETTUCE_GROUP_FACTORY_BEAN_NAME,
+                    groupParams = LockIdentity.GroupParams(maxLeaders),
+                )
+                val handle = LeaderLockHandle.real(
+                    identity = identity,
+                    token = token,
+                    acquiredAtNanos = startedAtNanos,
+                    slotId = token,
+                    extendDelegate = delegate,
+                    auditLeaderId = auditLeaderId,
+                )
                 log.debug { "리더 선출 성공 (async): lockName=$lockName, token=$token" }
 
                 // Codex P2-2: action 결과(성공/실패)와 무관하게 release 완료까지 대기한 뒤 outer future 를 complete.
                 val actionFuture: CompletableFuture<T> = try {
-                    action()
+                    AopScopeAccess.withPushedSync(handle) {
+                        AopScopeAccess.setCapture(handle)
+                        try {
+                            action()
+                        } finally {
+                            AopScopeAccess.clearCapture()
+                        }
+                    }
                 } catch (e: Throwable) {
                     return@thenComposeAsync releaseAndPropagate<T>(slotGroup, lockName, token, startedAtNanos, e, null)
                 }
@@ -196,6 +254,20 @@ class LettuceLeaderGroupElector(
             }
         }, executor)
     }
+
+    private fun Throwable.unwrapCompletionCause(): Throwable =
+        (this as? CompletionException)?.cause ?: this
+
+    private fun Throwable.toActionFailedResult(): LeaderRunResult.ActionFailed {
+        val cause = unwrapCompletionCause()
+        if (cause is CancellationException) {
+            throw cause
+        }
+        return LeaderRunResult.ActionFailed(cause)
+    }
+
+    private fun Throwable.asCompletionException(): CompletionException =
+        this as? CompletionException ?: CompletionException(this)
 
     private fun <T> releaseAndPropagate(
         slotGroup: LettuceSlotTokenGroup,

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/contract/LettuceAsyncLeaderElectorLeaderIdContractTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/contract/LettuceAsyncLeaderElectorLeaderIdContractTest.kt
@@ -1,0 +1,25 @@
+package io.bluetape4k.leader.lettuce.contract
+
+import io.bluetape4k.leader.AsyncLeaderElector
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.contract.AbstractAsyncLeaderElectorLeaderIdContractTest
+import io.bluetape4k.leader.lettuce.AbstractLettuceLeaderTest
+import io.bluetape4k.leader.lettuce.LettuceLeaderElector
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [AbstractAsyncLeaderElectorLeaderIdContractTest] Lettuce backend implementation.
+ *
+ * Verifies slot-aware audit identity propagation for async [LettuceLeaderElector].
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LettuceAsyncLeaderElectorLeaderIdContractTest : AbstractAsyncLeaderElectorLeaderIdContractTest() {
+
+    companion object : KLogging() {
+        val redis = AbstractLettuceLeaderTest.redis
+    }
+
+    override fun createElector(options: LeaderElectionOptions): AsyncLeaderElector =
+        LettuceLeaderElector(AbstractLettuceLeaderTest.connection, options)
+}

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/contract/LettuceAsyncLeaderGroupElectorLeaderIdContractTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/contract/LettuceAsyncLeaderGroupElectorLeaderIdContractTest.kt
@@ -1,0 +1,25 @@
+package io.bluetape4k.leader.lettuce.contract
+
+import io.bluetape4k.leader.AsyncLeaderGroupElector
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.contract.AbstractAsyncLeaderGroupElectorLeaderIdContractTest
+import io.bluetape4k.leader.lettuce.AbstractLettuceLeaderTest
+import io.bluetape4k.leader.lettuce.LettuceLeaderGroupElector
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [AbstractAsyncLeaderGroupElectorLeaderIdContractTest] Lettuce backend implementation.
+ *
+ * Verifies slot-aware audit identity propagation for async [LettuceLeaderGroupElector].
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class LettuceAsyncLeaderGroupElectorLeaderIdContractTest : AbstractAsyncLeaderGroupElectorLeaderIdContractTest() {
+
+    companion object : KLogging() {
+        val redis = AbstractLettuceLeaderTest.redis
+    }
+
+    override fun createElector(options: LeaderGroupElectionOptions): AsyncLeaderGroupElector =
+        LettuceLeaderGroupElector(AbstractLettuceLeaderTest.connection, options)
+}


### PR DESCRIPTION
## Summary

Closes #511

PR #545의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: preserve Lettuce async slot leader identity`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
Fixes #511

## Summary

Lettuce async `LeaderSlot` calls now use explicit slot-aware overrides instead of the default bridge path. This preserves the audit/result identity contract for async single-lock and group-lock APIs.

## Background

Blocking and suspend Lettuce slot APIs already preserve `slot.leaderId`, but async slot APIs inherited the bridge defaults. That could return `LeaderRunResult.Elected(..., leaderId = null)` and increment bridge warning counters even when callers used the public `LeaderSlot` API.

## Work Done

- Added reusable async slot identity contract fixtures in `leader-core` test fixtures.
- Added Lettuce async single/group contract subclasses.
- Routed `LettuceLeaderElector.runAsyncIfLeader(slot, ...)` through an audit-aware internal async path.
- Routed `LettuceLeaderGroupElector.runAsyncIfLeader(slot, ...)` through group acquire with `auditLeaderId` so Redis slot metadata matches sync/suspend behavior.
- Added explicit `runAsyncIfLeaderResult(slot, ...)` implementations that return `LeaderRunResult.Elected(..., leaderId = slot.leaderId)`.
- Preserved existing release-after-action completion behavior.
- Added review and lesson artifacts.

## Validation

- `./gradlew :bluetape4k-leader-redis-lettuce:test --tests '*LettuceAsyncLeader*LeaderIdContractTest' --no-parallel`
- `./gradlew :bluetape4k-leader-redis-lettuce:test --no-parallel`
- `git diff --check`
- Targeted `rg` checks for slot override, bridge warning counters, and group `auditLeaderId` propagation.
- CodeGraph review context plus manual 7-tier equivalent review: P0/P1 = 0.

## DoD Status

| Step | Status | Evidence |
|---|---:|---|
| Review | PASS | Issue #511 source evidence confirmed against current Lettuce async code. |
| Fix | PASS | Async slot overrides added for Lettuce single/group electors. |
| Tests | PASS | Lettuce async contract tests passed; full `leader-redis-lettuce` test passed with 221 tests, 0 failures, 0 errors, 0 skipped. |
| Lessons | PASS | `docs/lessons/2026-07-01-issue-511-lettuce-async-slot-identity.md` committed. |
| Review artifact | PASS | `docs/review/2026-07-01-issue-511-lettuce-async-slot-identity-review.md`, P0/P1 = 0. |
| CI | PASS | GitHub Actions run 28520581259 passed: CI Status, Coverage Report, Build, leader-redis-lettuce, leader-core, leader-redis-redisson, leader-consul, leader-dynamodb, leader-etcd, leader-k8s, leader-ktor, and example tests; non-applicable matrix entries skipped. |
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #511, milestone `0.5.0`, assignee `debop`
- PR: #545, head `ec7c7c3a4e3ecead4eac6f5c92bf1d68d39aab06`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
