### PR TITLE
fix: preserve Redisson async slot leader identity

### DIFF
--- a/docs/lessons/2026-07-01-issue-512-redisson-async-slot-identity.md
+++ b/docs/lessons/2026-07-01-issue-512-redisson-async-slot-identity.md
@@ -1,0 +1,42 @@
+# Lessons Learned - Issue 512 Redisson Async Slot Identity (2026-07-01)
+
+## Context
+
+Issue #512 found that Redisson async `LeaderSlot` APIs inherited the default
+bridge path. Blocking and suspend APIs preserved `slot.leaderId`, but async
+single/group result APIs could return `LeaderRunResult.Elected(..., leaderId =
+null)` and emit bridge warnings.
+
+## Decision
+
+Mirror the Lettuce async slot identity fix in Redisson single/group electors by
+overriding both slot variants:
+
+- `runAsyncIfLeader(slot, ...)`
+- `runAsyncIfLeaderResult(slot, ...)`
+
+Single-lock async execution pushes a real `LeaderLockHandle` while creating the
+async action. Group async execution also writes `slot.leaderId` into the
+Redisson audit map for the acquired permit and removes that entry during async
+cleanup.
+
+## Outcome
+
+The failing async contract tests reproduced the issue first, then passed after
+the Redisson implementation change.
+
+Validation evidence:
+
+- `./gradlew :bluetape4k-leader-redis-redisson:test --tests '*RedissonAsyncLeader*LeaderIdContractTest' --no-parallel`
+- `./gradlew :bluetape4k-leader-redis-redisson:test --no-parallel`
+- Test XML summary: 198 tests, 0 failures, 0 errors, 0 skipped.
+
+## Future Guard
+
+When a backend implements slot-aware blocking or suspend APIs, verify async
+slot APIs separately. Default bridge methods deliberately warn and drop
+`leaderId`; backend modules must override both async slot variants to preserve
+audit identity.
+
+Do not broaden Redisson async slot identity fixes into release-completion
+ordering changes unless the active issue explicitly covers that behavior.

--- a/docs/review/2026-07-01-issue-512-redisson-async-slot-identity-review.md
+++ b/docs/review/2026-07-01-issue-512-redisson-async-slot-identity-review.md
@@ -1,0 +1,28 @@
+# Issue 512 Review - Redisson Async Slot Identity
+
+## Scope
+
+- `leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElector.kt`
+- `leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElector.kt`
+- Redisson async single/group contract subclasses
+
+## Review Result
+
+P0/P1 findings: 0
+
+## Checks
+
+| Tier | Result | Evidence |
+|---|---|---|
+| Correctness | PASS | `runAsyncIfLeader(slot)` now overrides the bridge default and routes through an audit-aware internal path. |
+| Result contract | PASS | `runAsyncIfLeaderResult(slot)` returns `LeaderRunResult.Elected(..., leaderId = slot.leaderId)` when the action runs, including null-returning actions. |
+| Backend audit path | PASS | Redisson group async acquire writes `auditLeaderId` into the audit map and removes it during async cleanup. |
+| Release semantics | PASS | Existing Redisson async release behavior remains unchanged; release-completion ordering is tracked separately by issue #514. |
+| Exception semantics | PASS | Action failures still become `LeaderRunResult.ActionFailed`; cancellation is rethrown rather than wrapped. Backend failures before election still complete exceptionally. |
+| Bridge warning regression | PASS | New contract tests assert `LeaderElectorBridgeLog` slot/result counters stay at zero. |
+| Test coverage | PASS | `./gradlew :bluetape4k-leader-redis-redisson:test --no-parallel` passed, 198 tests, 0 failures, 0 errors, 0 skipped. |
+
+## Tooling Notes
+
+- CodeGraph did not resolve the Redisson async implementation node in this worktree, so this review used direct diff inspection plus targeted source checks.
+- IntelliJ diagnostics MCP was not available in this session; Gradle compile/test was used as the fallback diagnostic gate.

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElector.kt
@@ -22,9 +22,11 @@ import org.redisson.api.RedissonClient
 import org.redisson.client.RedisException
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Elects a single leader among multiple processes/threads using a Redisson distributed lock.
@@ -160,6 +162,40 @@ class RedissonLeaderElector private constructor(
         lockName: String,
         executor: Executor,
         action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> =
+        runAsyncImpl(lockName, auditLeaderId = null, executor, action)
+
+    override fun <T> runAsyncIfLeader(
+        slot: LeaderSlot,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> =
+        runAsyncImpl(slot.lockName, auditLeaderId = slot.leaderId, executor, action)
+
+    override fun <T> runAsyncIfLeaderResult(
+        slot: LeaderSlot,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<LeaderRunResult<T>> {
+        val elected = AtomicBoolean(false)
+        return runAsyncIfLeader(slot, executor) {
+            elected.set(true)
+            action()
+        }.handle { value, failure ->
+            when {
+                failure != null && elected.get() -> failure.toActionFailedResult()
+                failure != null -> throw failure.asCompletionException()
+                elected.get() -> LeaderRunResult.Elected(value, leaderId = slot.leaderId)
+                else -> LeaderRunResult.Skipped
+            }
+        }
+    }
+
+    private fun <T> runAsyncImpl(
+        lockName: String,
+        auditLeaderId: String?,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
         lockName.requireNotBlank("lockName")
 
@@ -174,7 +210,7 @@ class RedissonLeaderElector private constructor(
                 .tryLockAsync(waitTimeMills, leaseTimeMills, TimeUnit.MILLISECONDS, currentThreadId)
                 .thenComposeAsync({ acquired ->
                     if (acquired) {
-                        executeActionAsync(lock, currentThreadId, executor, System.nanoTime(), action)
+                        executeActionAsync(lock, auditLeaderId, currentThreadId, executor, System.nanoTime(), action)
                     } else {
                         log.debug { "Leader 승격 실패 (슬롯 없음). lock=$lockName" }
                         CompletableFuture.completedFuture(null)
@@ -191,10 +227,11 @@ class RedissonLeaderElector private constructor(
     /**
      * Executes the asynchronous [action] while holding the lock and releases the lock on completion (success or failure).
      *
-     * Aligned with the Lettuce pattern — handle push is not performed on the async path (AOP scope supports sync/suspend only).
+     * Aligned with the Lettuce path by pushing a real leader handle while creating the asynchronous action.
      */
-    private inline fun <T> executeActionAsync(
+    private fun <T> executeActionAsync(
         lock: RLock,
+        auditLeaderId: String?,
         currentThreadId: Long,
         executor: Executor,
         acquiredAtNanos: Long,
@@ -202,6 +239,19 @@ class RedissonLeaderElector private constructor(
     ): CompletableFuture<T?> {
         val lockName = lock.name
         val delegate = RedissonLockExtendDelegate(redissonClient, lock, currentThreadId)
+        val identity = LockIdentity(
+            lockName = lockName,
+            kind = LockIdentity.AnnotationKind.SINGLE,
+            factoryBeanName = REDISSON_FACTORY_BEAN_NAME,
+        )
+        val handle = LeaderLockHandle.real(
+            identity = identity,
+            token = lockName,
+            acquiredAtNanos = acquiredAtNanos,
+            acquiringThreadId = currentThreadId,
+            extendDelegate = delegate,
+            auditLeaderId = auditLeaderId,
+        )
         val watchdog = LeaderLeaseAutoExtender.start(
             options.autoExtend,
             options.leaseTime,
@@ -210,7 +260,9 @@ class RedissonLeaderElector private constructor(
         )
         log.debug { "Leader로 승격하여 비동기 작업을 수행합니다. lock=$lockName, threadId=$currentThreadId" }
 
-        val actionFuture = runCatching { action() }
+        val actionFuture = runCatching {
+            AopScopeAccess.withPushedSync(handle) { action() }
+        }
             .getOrElse { error ->
                 watchdog.close()
                 releaseLockAsync(lock, currentThreadId, acquiredAtNanos)
@@ -222,6 +274,20 @@ class RedissonLeaderElector private constructor(
             releaseLockAsync(lock, currentThreadId, acquiredAtNanos)
         }, executor)
     }
+
+    private fun Throwable.unwrapCompletionCause(): Throwable =
+        (this as? CompletionException)?.cause ?: this
+
+    private fun Throwable.toActionFailedResult(): LeaderRunResult.ActionFailed {
+        val cause = unwrapCompletionCause()
+        if (cause is CancellationException) {
+            throw cause
+        }
+        return LeaderRunResult.ActionFailed(cause)
+    }
+
+    private fun Throwable.asCompletionException(): CompletionException =
+        this as? CompletionException ?: CompletionException(this)
 
     private fun releaseLock(lock: RLock, acquiredAtNanos: Long) {
         val remaining = remainingMinLeaseTime(acquiredAtNanos, options.minLeaseTime)

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElector.kt
@@ -26,8 +26,10 @@ import org.redisson.api.RedissonClient
 import org.redisson.client.RedisException
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration
 
 /**
@@ -207,6 +209,40 @@ class RedissonLeaderGroupElector private constructor(
         lockName: String,
         executor: Executor,
         action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> =
+        runAsyncImpl(lockName, auditLeaderId = null, executor, action)
+
+    override fun <T> runAsyncIfLeader(
+        slot: LeaderSlot,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> =
+        runAsyncImpl(slot.lockName, auditLeaderId = slot.leaderId, executor, action)
+
+    override fun <T> runAsyncIfLeaderResult(
+        slot: LeaderSlot,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<LeaderRunResult<T>> {
+        val elected = AtomicBoolean(false)
+        return runAsyncIfLeader(slot, executor) {
+            elected.set(true)
+            action()
+        }.handle { value, failure ->
+            when {
+                failure != null && elected.get() -> failure.toActionFailedResult()
+                failure != null -> throw failure.asCompletionException()
+                elected.get() -> LeaderRunResult.Elected(value, leaderId = slot.leaderId)
+                else -> LeaderRunResult.Skipped
+            }
+        }
+    }
+
+    private fun <T> runAsyncImpl(
+        lockName: String,
+        auditLeaderId: String?,
+        executor: Executor,
+        action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
         return try {
             lockName.requireNotBlank("lockName")
@@ -227,7 +263,7 @@ class RedissonLeaderGroupElector private constructor(
                     } else {
                         // Codex P2: acquire 성공 후 startedAtNanos 캡처
                         val startedAtNanos = System.nanoTime()
-                        executeAsync(semaphore, lockName, permitId, startedAtNanos, action)
+                        executeAsync(semaphore, lockName, permitId, auditLeaderId, startedAtNanos, action)
                     }
                 }, executor)
         } catch (e: Throwable) {
@@ -240,23 +276,83 @@ class RedissonLeaderGroupElector private constructor(
         semaphore: RPermitExpirableSemaphore,
         lockName: String,
         permitId: String,
+        auditLeaderId: String?,
         startedAtNanos: Long,
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
         log.debug { "슬롯 획득 성공 (async). lockName=$lockName, permitId=$permitId" }
 
+        val auditMap = getAuditMap(lockName)
+        if (auditLeaderId != null) {
+            runCatching {
+                auditMap.fastPut(permitId, auditLeaderId)
+                auditMap.expire(java.time.Duration.ofMillis(leaseTime.inWholeMilliseconds + AUDIT_MAP_TTL_PADDING_MS))
+            }.onFailure { log.warn(it) { "Failed to write audit map. lockName=$lockName, permitId=$permitId" } }
+        }
+
+        val delegate = RedissonSemaphoreExtendDelegate(semaphore, permitId)
+        val identity = LockIdentity(
+            lockName = lockName,
+            kind = LockIdentity.AnnotationKind.GROUP,
+            factoryBeanName = REDISSON_GROUP_FACTORY_BEAN_NAME,
+            groupParams = LockIdentity.GroupParams(maxLeaders),
+        )
+        val handle = LeaderLockHandle.real(
+            identity = identity,
+            token = permitId,
+            acquiredAtNanos = startedAtNanos,
+            slotId = permitId,
+            extendDelegate = delegate,
+            auditLeaderId = auditLeaderId,
+        )
+
         val actionFuture: CompletableFuture<T> = try {
-            action()
+            AopScopeAccess.withPushedSync(handle) {
+                AopScopeAccess.setCapture(handle)
+                try {
+                    action()
+                } finally {
+                    AopScopeAccess.clearCapture()
+                }
+            }
         } catch (e: Throwable) {
+            removeAuditEntry(auditMap, permitId, auditLeaderId, lockName)
             releaseOrExtendAsync(semaphore, permitId, startedAtNanos, lockName)
             return failedCompletableFutureOf(e)
         }
 
         return actionFuture.handle<T?> { value, error ->
+            removeAuditEntry(auditMap, permitId, auditLeaderId, lockName)
             releaseOrExtendAsync(semaphore, permitId, startedAtNanos, lockName)
             if (error != null) throw error else value
         }
     }
+
+    private fun removeAuditEntry(
+        auditMap: RMap<String, String>,
+        permitId: String,
+        auditLeaderId: String?,
+        lockName: String,
+    ) {
+        if (auditLeaderId != null) {
+            runCatching { auditMap.fastRemove(permitId) }
+                .onFailure { log.warn(it) { "Failed to remove audit map. lockName=$lockName, permitId=$permitId" } }
+        }
+    }
+
+    private fun Throwable.unwrapCompletionCause(): Throwable =
+        (this as? CompletionException)?.cause ?: this
+
+    private fun Throwable.toActionFailedResult(): LeaderRunResult.ActionFailed {
+        val cause = unwrapCompletionCause()
+        if (cause is CancellationException) {
+            throw cause
+        }
+        return LeaderRunResult.ActionFailed(cause)
+    }
+
+    private fun Throwable.asCompletionException(): CompletionException =
+        this as? CompletionException ?: CompletionException(this)
 
     private fun releaseOrExtend(
         semaphore: RPermitExpirableSemaphore,

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/contract/RedissonAsyncLeaderElectorLeaderIdContractTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/contract/RedissonAsyncLeaderElectorLeaderIdContractTest.kt
@@ -1,0 +1,25 @@
+package io.bluetape4k.leader.redisson.contract
+
+import io.bluetape4k.leader.AsyncLeaderElector
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.contract.AbstractAsyncLeaderElectorLeaderIdContractTest
+import io.bluetape4k.leader.redisson.AbstractRedissonLeaderTest
+import io.bluetape4k.leader.redisson.RedissonLeaderElector
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [AbstractAsyncLeaderElectorLeaderIdContractTest] Redisson backend implementation.
+ *
+ * Verifies slot-aware audit identity propagation for async [RedissonLeaderElector].
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RedissonAsyncLeaderElectorLeaderIdContractTest : AbstractAsyncLeaderElectorLeaderIdContractTest() {
+
+    companion object : KLogging() {
+        val redis = AbstractRedissonLeaderTest.redis
+    }
+
+    override fun createElector(options: LeaderElectionOptions): AsyncLeaderElector =
+        RedissonLeaderElector(AbstractRedissonLeaderTest.redissonClient, options)
+}

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/contract/RedissonAsyncLeaderGroupElectorLeaderIdContractTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/contract/RedissonAsyncLeaderGroupElectorLeaderIdContractTest.kt
@@ -1,0 +1,25 @@
+package io.bluetape4k.leader.redisson.contract
+
+import io.bluetape4k.leader.AsyncLeaderGroupElector
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.contract.AbstractAsyncLeaderGroupElectorLeaderIdContractTest
+import io.bluetape4k.leader.redisson.AbstractRedissonLeaderTest
+import io.bluetape4k.leader.redisson.RedissonLeaderGroupElector
+import io.bluetape4k.logging.KLogging
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * [AbstractAsyncLeaderGroupElectorLeaderIdContractTest] Redisson backend implementation.
+ *
+ * Verifies slot-aware audit identity propagation for async [RedissonLeaderGroupElector].
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RedissonAsyncLeaderGroupElectorLeaderIdContractTest : AbstractAsyncLeaderGroupElectorLeaderIdContractTest() {
+
+    companion object : KLogging() {
+        val redis = AbstractRedissonLeaderTest.redis
+    }
+
+    override fun createElector(options: LeaderGroupElectionOptions): AsyncLeaderGroupElector =
+        RedissonLeaderGroupElector(AbstractRedissonLeaderTest.redissonClient, options)
+}


### PR DESCRIPTION
## Summary

Closes #512

PR #546의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: preserve Redisson async slot leader identity`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Fixes #512.

Redisson async slot APIs now preserve `LeaderSlot.leaderId` instead of falling through the default async bridge. The single-lock and group electors override the slot-aware async methods, return `LeaderRunResult.Elected(..., leaderId = slot.leaderId)`, and keep the Redisson group audit map aligned with the acquired permit lifecycle.

## Changes

- Override Redisson single/group `runAsyncIfLeader(slot, ...)` and `runAsyncIfLeaderResult(slot, ...)`.
- Push a real leader handle while creating Redisson async actions so slot identity is available to action-scoped logic.
- Add Redisson async single/group contract tests for leaderId propagation and bridge-warning suppression.
- Add implementation review and lesson notes for the issue.

## Verification

- `git diff --check`
- `./gradlew :bluetape4k-leader-redis-redisson:test --tests '*RedissonAsyncLeader*LeaderIdContractTest' --no-parallel`
- `./gradlew :bluetape4k-leader-redis-redisson:test --no-parallel`
- Test XML summary: 198 tests, 0 failures, 0 errors, 0 skipped.

## Review Notes

- P0/P1 review findings: 0.
- Redisson async release-completion ordering is intentionally unchanged; issue #514 tracks that separate behavior.
- IntelliJ diagnostics were unavailable in this session, so Gradle compile/test served as the diagnostic fallback.

## DoD Status

- Issue #512 acceptance criteria: PASS.
- Redisson single async slot result preserves `leaderId`: PASS.
- Redisson group async slot result preserves `leaderId`: PASS.
- Default async bridge warning regression coverage: PASS.
- PR metadata mirrors issue milestone, assignee, and labels: PASS.

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #512, milestone `0.5.0`, assignee `debop`
- PR: #546, head `76016265c299b402deb466ee415546fb1a1bd51c`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
