### PR TITLE
fix: make Redisson lock extension owner-atomic

### DIFF
--- a/docs/lessons/2026-07-01-issue-513-redisson-owner-atomic-extend.md
+++ b/docs/lessons/2026-07-01-issue-513-redisson-owner-atomic-extend.md
@@ -1,0 +1,24 @@
+# Issue 513 - Redisson Owner-Atomic Extend
+
+## Context
+
+Issue #513 exposed a race in Redisson single-lock extension: the old implementation checked owner state locally and renewed the key TTL in a separate Redis command.
+
+## Decision
+
+Use a shared internal helper that performs owner verification and TTL renewal in one Redis Lua script. The helper reflects Redisson's own `getLockName(long)` owner field and `getRawName()` raw Redis key name from the resolved Redisson 4.4.0 artifact.
+
+## Test Guard
+
+Keep MockK doubles as class-level fields and reset them in `@BeforeEach` with `clearMocks(...)`. Do not introduce method-local `mockk(...)` or `spyk(...)` in new bluetape4k tests unless the review evidence explicitly justifies why the object cannot be a normal fixture or real test object.
+
+## Outcome
+
+The sync and suspend delegates now share the same owner-atomic extend path. Regression coverage verifies that stale-owner results map to `WrongThread` or `NotHeld`, and full `leader-redis-redisson` tests pass serially.
+
+## Verification
+
+- `RedissonOwnerAtomicExtendDelegateTest`: `BUILD SUCCESSFUL in 13s`
+- Redisson extend contract tests: `BUILD SUCCESSFUL in 4s`
+- `:bluetape4k-leader-redis-redisson:test --no-parallel`: `BUILD SUCCESSFUL in 19s`
+- `git diff --check`: pass

--- a/docs/review/2026-07-01-issue-513-redisson-owner-atomic-extend-review.md
+++ b/docs/review/2026-07-01-issue-513-redisson-owner-atomic-extend-review.md
@@ -1,0 +1,42 @@
+# Issue 513 Review - Redisson Owner-Atomic Extend
+
+## Scope
+
+- Issue: #513, `P1: Redisson lock extension is not owner-atomic`
+- Module: `leader-redis-redisson`
+- Target behavior: replace check-then-expire renewal with a Redis-side owner check and TTL update.
+
+## Source Evidence
+
+- Resolved Redisson runtime is `org.redisson:redisson:4.4.0`.
+- `javap` against the local Redisson 4.4.0 artifact confirms:
+  - `org.redisson.RedissonBaseLock.getLockName(long)` exists and returns the owner hash field shape Redisson uses for lock ownership.
+  - `org.redisson.RedissonObject.getRawName()` exists and provides the raw Redis key name.
+- The implementation uses `redissonClient.getScript(StringCodec.INSTANCE)` so script arguments are encoded like Redisson lock owner fields instead of with the default object codec.
+
+## Code-Pattern Audit
+
+- MockK test doubles are class-level fields in `RedissonOwnerAtomicExtendDelegateTest`.
+- `@BeforeEach` resets the class-level mocks with `clearMocks(scriptClient, keys, script, scriptResult)`.
+- No method-local `mockk(...)` or `spyk(...)` remains in the new test.
+- Suspend regression test uses `runSuspendIO`, not `runTest`, because it exercises real Redisson/Testcontainers-backed objects.
+- Assertions use `bluetape4k-assertions`.
+- No ad hoc thread, executor, sleep, coroutine stress loop, `!!`, JUnit assertion API, or `kotlin.test` assertion API was introduced.
+
+## Verification
+
+- Pattern grep:
+  - Remaining `mockk(...)` matches are only class-level fields.
+  - Remaining `runCatching` match is an existing KDoc warning, not executable code.
+- `./gradlew :bluetape4k-leader-redis-redisson:test --tests '*RedissonOwnerAtomicExtendDelegateTest' --no-parallel`
+  - `BUILD SUCCESSFUL in 13s`
+- `./gradlew :bluetape4k-leader-redis-redisson:test --tests '*RedissonExtendDelegateReferenceTest' --tests '*RedissonLockExtenderContractTest' --tests '*RedissonSuspendLockExtenderContractTest' --no-parallel`
+  - `BUILD SUCCESSFUL in 4s`
+- `./gradlew :bluetape4k-leader-redis-redisson:test --no-parallel`
+  - `BUILD SUCCESSFUL in 19s`
+- `git diff --check`
+  - pass
+
+## Notes
+
+- The regression test simulates the race deterministically through `RScript` return values instead of adding stress loops. This fits the issue because the race is removed by one Redis Lua operation, and the existing contract tests cover sync/suspend extender behavior through the module's Redisson test infrastructure.

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/internal/RedissonLockExtendDelegate.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/internal/RedissonLockExtendDelegate.kt
@@ -19,7 +19,7 @@ import kotlin.time.Duration
  * [ExtendDelegate] for Redisson [RLock] (sync blocking) — T8 PR 3 (Issue #79).
  *
  * ## Behavior / Contract
- * - [extend]: owner-guarded — checks `lock.isHeldByThread(acquiringThreadId)` then calls `RKeys.expire(d, key)`.
+ * - [extend]: owner-atomic — verifies Redisson's owner hash field and renews key TTL in one Redis Lua script.
  *   Returns [ExtendOutcome.WrongThread] on thread mismatch (AC-8), [ExtendOutcome.NotHeld] when not holding the lock.
  *   Backend exceptions are wrapped as [ExtendOutcome.BackendError].
  * - [extendSuspend]: Redisson sync is blocking I/O, so dispatched with `withContext(Dispatchers.IO)` + `ensureActive()` (R9 / AC-21).
@@ -27,15 +27,9 @@ import kotlin.time.Duration
  * - [lastExtendDeadline]: single `AtomicReference(Instant.EPOCH)` instance — used for R2 watchdog skip.
  *
  * ## RLock TTL renewal mechanism
- * Redisson's [RLock] does not directly implement [org.redisson.api.RExpirable], so `lock.expire(d)`
- * cannot be called. Instead, the Redis key TTL is renewed directly via [RedissonClient.getKeys]
- * `expire(duration, keyName)` — the same mechanism used by Redisson's built-in watchdog.
- *
- * ## Owner-guard race window
- * A race window exists between the `isHeldByThread` check and the `expire(d)` call. If a takeover
- * occurs immediately after the check, the new owner's lease may be renewed in a narrow race.
- * This is explicitly documented as an acceptable race in this PR — for full atomicity, replace with
- * a hand-rolled Lua script (`HEXISTS` + `PEXPIRE`) in a follow-up PR.
+ * Redisson's [RLock] stores ownership in a Redis hash field named like `clientId:threadId`.
+ * The extend path uses the same owner field and performs `HEXISTS` + `PEXPIRE` in one Lua script,
+ * avoiding the check-then-expire race where a stale owner could renew a successor lock.
  *
  * AC-21: blocking backend [ExtendDelegate.extendSuspend] default is never called — this class overrides it explicitly.
  *
@@ -86,23 +80,7 @@ internal class RedissonLockExtendDelegate(
 
     private fun doExtend(lockAtMostFor: Duration): ExtendOutcome {
         return try {
-            // AC-8: thread-id mismatch / 미보유 → WrongThread / NotHeld
-            if (!lock.isHeldByThread(acquiringThreadId)) {
-                return if (lock.remainTimeToLive() >= 0L) {
-                    // 다른 owner 가 보유 — Redisson 의 lock 소유자 식별 단위 (thread id) 가 다르므로 WrongThread.
-                    ExtendOutcome.WrongThread
-                } else {
-                    ExtendOutcome.NotHeld
-                }
-            }
-            val javaDuration = java.time.Duration.ofNanos(lockAtMostFor.inWholeNanoseconds)
-            // RKeys.expire(Duration, vararg String) → 갱신된 key 개수 반환 (>= 1 이면 성공).
-            val updated = redissonClient.keys.expire(javaDuration, lock.name)
-            if (updated >= 1L) {
-                ExtendOutcome.Extended(Instant.now().plus(javaDuration))
-            } else {
-                ExtendOutcome.NotHeld
-            }
+            RedissonOwnerAtomicExtend.extend(redissonClient, lock, acquiringThreadId, lockAtMostFor)
         } catch (e: Exception) {
             log.warn(e) { "Redisson extend failed. lockName=${lock.name}, threadId=$acquiringThreadId" }
             ExtendOutcome.BackendError(e)

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/internal/RedissonOwnerAtomicExtend.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/internal/RedissonOwnerAtomicExtend.kt
@@ -1,0 +1,110 @@
+package io.bluetape4k.leader.redisson.internal
+
+import io.bluetape4k.leader.ExtendOutcome
+import kotlinx.coroutines.future.await
+import org.redisson.api.RLock
+import org.redisson.api.RScript
+import org.redisson.api.RedissonClient
+import org.redisson.client.codec.StringCodec
+import java.lang.reflect.Method
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration
+
+internal object RedissonOwnerAtomicExtend {
+
+    internal const val WRONG_THREAD_RESULT = -1L
+    internal const val NOT_HELD_RESULT = 0L
+
+    private const val OWNER_ATOMIC_EXTEND_SCRIPT = """
+        if (redis.call('exists', KEYS[1]) == 0) then
+            return 0
+        end
+        if (redis.call('hexists', KEYS[1], ARGV[1]) == 0) then
+            return -1
+        end
+        redis.call('pexpire', KEYS[1], ARGV[2])
+        local now = redis.call('time')
+        return now[1] * 1000 + math.floor(now[2] / 1000) + tonumber(ARGV[2])
+    """
+
+    private val lockNameMethodCache = ConcurrentHashMap<Class<*>, Method>()
+    private val rawNameMethodCache = ConcurrentHashMap<Class<*>, Method>()
+
+    fun extend(
+        redissonClient: RedissonClient,
+        lock: RLock,
+        acquiringThreadId: Long,
+        lockAtMostFor: Duration,
+    ): ExtendOutcome {
+        val leaseMillis = lockAtMostFor.inWholeMilliseconds.coerceAtLeast(1L)
+        val keyName = rawName(lock)
+        val result = redissonClient.getScript(StringCodec.INSTANCE).eval<Long>(
+            keyName,
+            RScript.Mode.READ_WRITE,
+            OWNER_ATOMIC_EXTEND_SCRIPT,
+            RScript.ReturnType.LONG,
+            listOf(keyName),
+            ownerField(lock, acquiringThreadId),
+            leaseMillis,
+        )
+        return result.toExtendOutcome()
+    }
+
+    suspend fun extendSuspend(
+        redissonClient: RedissonClient,
+        lock: RLock,
+        acquiringThreadId: Long,
+        lockAtMostFor: Duration,
+    ): ExtendOutcome {
+        val leaseMillis = lockAtMostFor.inWholeMilliseconds.coerceAtLeast(1L)
+        val keyName = rawName(lock)
+        val result = redissonClient.getScript(StringCodec.INSTANCE).evalAsync<Long>(
+            keyName,
+            RScript.Mode.READ_WRITE,
+            OWNER_ATOMIC_EXTEND_SCRIPT,
+            RScript.ReturnType.LONG,
+            listOf(keyName),
+            ownerField(lock, acquiringThreadId),
+            leaseMillis,
+        )
+            .toCompletableFuture()
+            .await()
+        return result.toExtendOutcome()
+    }
+
+    private fun Long.toExtendOutcome(): ExtendOutcome =
+        when (this) {
+            NOT_HELD_RESULT -> ExtendOutcome.NotHeld
+            WRONG_THREAD_RESULT -> ExtendOutcome.WrongThread
+            else -> ExtendOutcome.Extended(Instant.ofEpochMilli(this))
+        }
+
+    private fun ownerField(lock: RLock, acquiringThreadId: Long): String {
+        val method = lockNameMethodCache.computeIfAbsent(lock.javaClass) { type ->
+            findMethod(type, "getLockName", java.lang.Long.TYPE)
+        }
+        return method.invoke(lock, acquiringThreadId) as String
+    }
+
+    private fun rawName(lock: RLock): String {
+        val method = rawNameMethodCache.computeIfAbsent(lock.javaClass) { type ->
+            findMethod(type, "getRawName")
+        }
+        return method.invoke(lock) as String
+    }
+
+    private fun findMethod(type: Class<*>, name: String, vararg parameterTypes: Class<*>): Method {
+        var current: Class<*>? = type
+        while (current != null) {
+            try {
+                val method = current.getDeclaredMethod(name, *parameterTypes)
+                method.isAccessible = true
+                return method
+            } catch (_: NoSuchMethodException) {
+                current = current.superclass
+            }
+        }
+        error("Redisson RLock implementation does not expose $name(${parameterTypes.joinToString()}): ${type.name}")
+    }
+}

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/internal/RedissonSuspendLockExtendDelegate.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/internal/RedissonSuspendLockExtendDelegate.kt
@@ -7,7 +7,6 @@ import io.bluetape4k.logging.warn
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.future.await
 import kotlinx.coroutines.withContext
 import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
@@ -19,8 +18,7 @@ import kotlin.time.Duration
 /**
  * [SuspendExtendDelegate] for Redisson [RLock] (suspend variant) — T8 PR 3 (Issue #79).
  *
- * Redisson's async API is [java.util.concurrent.CompletableFuture]-based,
- * so it is bridged to suspend via `await()`.
+ * Redisson's async API is [java.util.concurrent.CompletableFuture]-based.
  *
  * ## Meaning of acquiringThreadId
  * Redisson's [RLock] identifies lock owners by a `long` identifier. The sync variant uses
@@ -31,12 +29,12 @@ import kotlin.time.Duration
  * simply compares the owner field without interpreting the semantic meaning of the long value.
  *
  * ## RLock TTL renewal mechanism
- * Redisson's [RLock] does not directly implement [org.redisson.api.RExpirable], so
- * `lock.expire(d)` / `lock.expireAsync(d)` cannot be called. Instead, the Redis key TTL is
- * renewed directly via [RedissonClient.getKeys] `expireAsync(name, ms, MILLISECONDS)`.
+ * Redisson's [RLock] stores ownership in a Redis hash field named like `clientId:threadId`.
+ * The extend path uses the same owner field and performs `HEXISTS` + `PEXPIRE` in one Lua script,
+ * avoiding the check-then-expire race where a stale owner could renew a successor lock.
  *
  * ## Behavior / Contract
- * - [extendSuspend]: owner-guarded — checks `lock.isHeldByThread(acquiringThreadId)` then calls `expireAsync(...).await()`.
+ * - [extendSuspend]: owner-atomic — verifies owner and renews key TTL in one Redis Lua script.
  *   Returns [ExtendOutcome.WrongThread] on owner-id mismatch (AC-8).
  * - [isHeldSuspend]: delegates to `lock.isHeldByThread(acquiringThreadId)` through the suspend contract.
  *
@@ -78,23 +76,6 @@ internal class RedissonSuspendLockExtendDelegate(
         }
 
     private suspend fun doExtendSuspend(lockAtMostFor: Duration): ExtendOutcome {
-        // AC-8: owner-id mismatch / 미보유 → WrongThread / NotHeld
-        if (!lock.isHeldByThread(acquiringThreadId)) {
-            return if (lock.remainTimeToLive() >= 0L) {
-                ExtendOutcome.WrongThread
-            } else {
-                ExtendOutcome.NotHeld
-            }
-        }
-        val javaDuration = java.time.Duration.ofNanos(lockAtMostFor.inWholeNanoseconds)
-        // RKeysAsync.expireAsync(Duration, vararg String) → 갱신된 key 개수 반환 (>= 1 이면 성공).
-        val updated = redissonClient.keys.expireAsync(javaDuration, lock.name)
-            .toCompletableFuture()
-            .await()
-        return if (updated >= 1L) {
-            ExtendOutcome.Extended(Instant.now().plus(javaDuration))
-        } else {
-            ExtendOutcome.NotHeld
-        }
+        return RedissonOwnerAtomicExtend.extendSuspend(redissonClient, lock, acquiringThreadId, lockAtMostFor)
     }
 }

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/internal/RedissonOwnerAtomicExtendDelegateTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/internal/RedissonOwnerAtomicExtendDelegateTest.kt
@@ -1,0 +1,88 @@
+package io.bluetape4k.leader.redisson.internal
+
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.redisson.AbstractRedissonLeaderTest
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.redisson.api.RFuture
+import org.redisson.api.RKeys
+import org.redisson.api.RScript
+import org.redisson.api.RedissonClient
+import org.redisson.client.codec.StringCodec
+import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration.Companion.seconds
+
+class RedissonOwnerAtomicExtendDelegateTest: AbstractRedissonLeaderTest() {
+
+    private val scriptClient = mockk<RedissonClient>()
+    private val keys = mockk<RKeys>()
+    private val script = mockk<RScript>()
+    private val scriptResult = mockk<RFuture<Long>>()
+
+    @BeforeEach
+    fun beforeEach() {
+        clearMocks(scriptClient, keys, script, scriptResult)
+
+        every { scriptClient.keys } returns keys
+        every { scriptClient.getScript(StringCodec.INSTANCE) } returns script
+    }
+
+    @Test
+    fun `sync extend returns WrongThread when atomic owner field check fails`() {
+        val lockName = "redisson-owner-atomic-sync"
+        val ownerId = 101L
+        val lock = AbstractRedissonLeaderTest.redissonClient.getLock(lockName)
+
+        every {
+            script.eval<Long>(
+                lockName,
+                RScript.Mode.READ_WRITE,
+                any(),
+                RScript.ReturnType.LONG,
+                any<List<Any>>(),
+                any(),
+                any(),
+            )
+        } returns RedissonOwnerAtomicExtend.WRONG_THREAD_RESULT
+
+        val outcome = RedissonLockExtendDelegate(scriptClient, lock, ownerId)
+            .extend(30.seconds)
+
+        outcome.shouldBeInstanceOf<ExtendOutcome.WrongThread>()
+        verify(exactly = 0) { keys.expire(any<java.time.Duration>(), lockName) }
+    }
+
+    @Test
+    fun `suspend extend returns NotHeld when owner key disappears during atomic extend`() = runSuspendIO {
+        val lockName = "redisson-owner-atomic-suspend"
+        val ownerId = 202L
+        val lock = AbstractRedissonLeaderTest.redissonClient.getLock(lockName)
+
+        every { scriptResult.toCompletableFuture() } returns CompletableFuture.completedFuture(
+            RedissonOwnerAtomicExtend.NOT_HELD_RESULT,
+        )
+        every {
+            script.evalAsync<Long>(
+                lockName,
+                RScript.Mode.READ_WRITE,
+                any(),
+                RScript.ReturnType.LONG,
+                any<List<Any>>(),
+                any(),
+                any(),
+            )
+        } returns scriptResult
+
+        val outcome = RedissonSuspendLockExtendDelegate(scriptClient, lock, ownerId)
+            .extendSuspend(30.seconds)
+
+        outcome.shouldBeInstanceOf<ExtendOutcome.NotHeld>()
+        verify(exactly = 0) { keys.expireAsync(any<java.time.Duration>(), lockName) }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #513

PR #547의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: make Redisson lock extension owner-atomic`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

Closes #513.

This PR replaces Redisson single-lock check-then-expire renewal with an owner-atomic Redis Lua script. The script verifies Redisson's owner hash field and updates TTL in one Redis-side operation, so a stale owner cannot renew a successor lock after ownership is lost.

## Changes

- Added `RedissonOwnerAtomicExtend` to share owner-atomic extend logic across sync and suspend delegates.
- Updated sync and suspend Redisson extend delegates to use the shared Lua path.
- Added deterministic regression coverage for `WrongThread` and `NotHeld` stale-owner outcomes.
- Added review and lesson artifacts documenting Redisson 4.4.0 source evidence and `$bluetape4k-code-patterns` audit results.

## Review Notes

- Redisson 4.4.0 local class evidence confirms `RedissonBaseLock.getLockName(long)` and `RedissonObject.getRawName()` exist.
- The script uses `redissonClient.getScript(StringCodec.INSTANCE)` so owner field arguments match Redisson lock hash fields.
- MockK doubles in the new test are class-level fields and reset in `@BeforeEach` with `clearMocks(...)`; no method-local `mockk(...)` or `spyk(...)` remains.
- No ad hoc thread, executor, sleep, coroutine stress loop, JUnit assertion API, `kotlin.test` assertion API, or `!!` was introduced.

## DoD Status

| Step | Status | Evidence |
|---|---|---|
| Issue metadata | PASS | Issue #513 is assigned to `debop`, milestone `0.5.0`, labels `bug`, `integration`, `test`. |
| Redisson source validation | PASS | Local Redisson 4.4.0 `javap` confirms `getLockName(long)` and `getRawName()` on the resolved artifact. |
| Code-pattern audit | PASS | Pattern grep leaves only class-level MockK fields and an existing KDoc warning line; method-local MockK doubles were removed. |
| Regression test | PASS | `./gradlew :bluetape4k-leader-redis-redisson:test --tests '*RedissonOwnerAtomicExtendDelegateTest' --no-parallel` -> `BUILD SUCCESSFUL in 13s`. |
| Contract tests | PASS | `./gradlew :bluetape4k-leader-redis-redisson:test --tests '*RedissonExtendDelegateReferenceTest' --tests '*RedissonLockExtenderContractTest' --tests '*RedissonSuspendLockExtenderContractTest' --no-parallel` -> `BUILD SUCCESSFUL in 4s`. |
| Module test | PASS | `./gradlew :bluetape4k-leader-redis-redisson:test --no-parallel` -> `BUILD SUCCESSFUL in 19s`. |
| Diff hygiene | PASS | `git diff --check` passed. |
| CI | PASS | CI run #28525342433 and `submit-gradle` passed; PR merge state is `CLEAN`. |

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #513, milestone `0.5.0`, assignee `debop`
- PR: #547, head `2c6b89a263d65cc23a533859db030a9fc1a2d936`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
