### PR TITLE
fix: prevent Hazelcast TTL rewrites after takeover

### DIFF
--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElector.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElector.kt
@@ -62,7 +62,7 @@ class HazelcastLeaderElector private constructor(
     override fun <T> runIfLeader(lockName: String, action: () -> T): T? {
         lockName.requireNotBlank("lockName")
 
-        val lock = HazelcastLock(lockMap, lockName)
+        val lock = HazelcastLock(lockMap, lockName, LOCK_MAP_NAME, hazelcast::newTransactionContext)
         log.debug { "Leader 승격을 요청합니다 ... lockName=$lockName" }
 
         val acquired = lock.tryLock(options.waitTime, options.leaseTime)
@@ -95,11 +95,9 @@ class HazelcastLeaderElector private constructor(
             return AopScopeAccess.withPushedSync(handle) { action() }
         } finally {
             watchdog.close()
-            if (lock.isHeldByCurrentInstance()) {
-                runCatching { lock.unlock(options.minLeaseTime, acquiredAtNanos) }
-                    .onSuccess { log.debug { "Leader 권한을 반납했습니다. lockName=$lockName" } }
-                    .onFailure { e -> log.error(e) { "Fail to release lock. lockName=$lockName" } }
-            }
+            runCatching { lock.unlock(options.minLeaseTime, acquiredAtNanos) }
+                .onSuccess { log.debug { "Leader 권한을 반납했습니다. lockName=$lockName" } }
+                .onFailure { e -> log.error(e) { "Fail to release lock. lockName=$lockName" } }
         }
     }
 
@@ -115,7 +113,7 @@ class HazelcastLeaderElector private constructor(
     ): CompletableFuture<T?> {
         lockName.requireNotBlank("lockName")
 
-        val lock = HazelcastLock(lockMap, lockName)
+        val lock = HazelcastLock(lockMap, lockName, LOCK_MAP_NAME, hazelcast::newTransactionContext)
 
         return CompletableFuture
             .supplyAsync({ lock.tryLock(options.waitTime, options.leaseTime) }, executor)
@@ -143,11 +141,9 @@ class HazelcastLeaderElector private constructor(
                         }
                     actionFuture.whenCompleteAsync({ _, _ ->
                         watchdog.close()
-                        if (lock.isHeldByCurrentInstance()) {
-                            runCatching { lock.unlock(options.minLeaseTime, acquiredAtNanos) }
-                                .onSuccess { log.debug { "비동기 Leader 권한을 반납했습니다. lockName=$lockName" } }
-                                .onFailure { e -> log.error(e) { "Fail to release lock (async). lockName=$lockName" } }
-                        }
+                        runCatching { lock.unlock(options.minLeaseTime, acquiredAtNanos) }
+                            .onSuccess { log.debug { "비동기 Leader 권한을 반납했습니다. lockName=$lockName" } }
+                            .onFailure { e -> log.error(e) { "Fail to release lock (async). lockName=$lockName" } }
                     }, executor)
                 }
             }, executor)

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElector.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElector.kt
@@ -90,7 +90,7 @@ class HazelcastLeaderGroupElector private constructor(
 
         for (slot in 0 until maxLeaders) {
             val slotKeyValue = slotKey(lockName, slot)
-            val lock = HazelcastLock(lockMap, slotKeyValue)
+            val lock = HazelcastLock(lockMap, slotKeyValue, LOCK_MAP_NAME, hazelcast::newTransactionContext)
             if (lock.tryLock(slotWaitTime, leaseTime)) {
                 acquiredLock = lock
                 acquiredSlot = slot
@@ -138,11 +138,9 @@ class HazelcastLeaderGroupElector private constructor(
             }
         } finally {
             watchdog.close()
-            if (lock.isHeldByCurrentInstance()) {
-                runCatching { lock.unlock(minLeaseTime, acquiredAtNanos) }
-                    .onSuccess { log.debug { "리더 그룹 슬롯을 반납했습니다. lockName=$lockName, slot=$slot" } }
-                    .onFailure { e -> log.error(e) { "Fail to release group slot. lockName=$lockName, slot=$slot" } }
-            }
+            runCatching { lock.unlock(minLeaseTime, acquiredAtNanos) }
+                .onSuccess { log.debug { "리더 그룹 슬롯을 반납했습니다. lockName=$lockName, slot=$slot" } }
+                .onFailure { e -> log.error(e) { "Fail to release group slot. lockName=$lockName, slot=$slot" } }
         }
     }
 
@@ -158,7 +156,9 @@ class HazelcastLeaderGroupElector private constructor(
         return CompletableFuture.supplyAsync({
             (0 until maxLeaders)
                 .asSequence()
-                .map { slot -> HazelcastLock(lockMap, slotKey(lockName, slot)) to slot }
+                .map { slot ->
+                    HazelcastLock(lockMap, slotKey(lockName, slot), LOCK_MAP_NAME, hazelcast::newTransactionContext) to slot
+                }
                 .firstOrNull { (lock, _) -> lock.tryLock(slotWaitTime, leaseTime) }
         }, executor).thenComposeAsync({ acquired ->
             if (acquired == null) {
@@ -181,11 +181,9 @@ class HazelcastLeaderGroupElector private constructor(
                     }
                 actionFuture.whenCompleteAsync({ _, _ ->
                     watchdog.close()
-                    if (lock.isHeldByCurrentInstance()) {
-                        runCatching { lock.unlock(minLeaseTime, acquiredAtNanos) }
-                            .onSuccess { log.debug { "비동기 리더 그룹 슬롯을 반납했습니다. lockName=$lockName, slot=$slot" } }
-                            .onFailure { e -> log.error(e) { "Fail to release group slot (async). lockName=$lockName, slot=$slot" } }
-                    }
+                    runCatching { lock.unlock(minLeaseTime, acquiredAtNanos) }
+                        .onSuccess { log.debug { "비동기 리더 그룹 슬롯을 반납했습니다. lockName=$lockName, slot=$slot" } }
+                        .onFailure { e -> log.error(e) { "Fail to release group slot (async). lockName=$lockName, slot=$slot" } }
                 }, executor)
             }
         }, executor)

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderElector.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderElector.kt
@@ -70,7 +70,12 @@ class HazelcastSuspendLeaderElector private constructor(
     override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? {
         lockName.requireNotBlank("lockName")
 
-        val lock = HazelcastSuspendLock(lockMap, lockName)
+        val lock = HazelcastSuspendLock(
+            lockMap = lockMap,
+            lockKey = lockName,
+            transactionMapName = HazelcastLeaderElector.LOCK_MAP_NAME,
+            transactionContextProvider = hazelcast::newTransactionContext,
+        )
         log.debug { "Leader 승격을 요청합니다 (suspend) ... lockName=$lockName" }
 
         val acquired = lock.tryLock(options.waitTime, options.leaseTime)
@@ -107,15 +112,13 @@ class HazelcastSuspendLeaderElector private constructor(
             // NonCancellable: 코루틴 취소 시에도 watchdog close + 락 해제가 중단되지 않도록 보호
             withContext(NonCancellable) {
                 watchdog.close()
-                if (lock.isHeldByCurrentInstance()) {
-                    try {
-                        lock.unlock(options.minLeaseTime, acquiredAtNanos)
-                        log.debug { "Leader 권한을 반납했습니다 (suspend). lockName=$lockName" }
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        log.warn(e) { "Fail to release lock (suspend). lockName=$lockName" }
-                    }
+                try {
+                    lock.unlock(options.minLeaseTime, acquiredAtNanos)
+                    log.debug { "Leader 권한을 반납했습니다 (suspend). lockName=$lockName" }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log.warn(e) { "Fail to release lock (suspend). lockName=$lockName" }
                 }
             }
         }

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderGroupElector.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderGroupElector.kt
@@ -94,7 +94,12 @@ class HazelcastSuspendLeaderGroupElector private constructor(
         for (slot in 0 until maxLeaders) {
             currentCoroutineContext().ensureActive()
             val slotKeyValue = slotKey(lockName, slot)
-            val lock = HazelcastSuspendLock(lockMap, slotKeyValue)
+            val lock = HazelcastSuspendLock(
+                lockMap = lockMap,
+                lockKey = slotKeyValue,
+                transactionMapName = HazelcastLeaderGroupElector.LOCK_MAP_NAME,
+                transactionContextProvider = hazelcast::newTransactionContext,
+            )
             if (lock.tryLock(slotWaitTime, leaseTime)) {
                 acquiredLock = lock
                 acquiredSlot = slot
@@ -139,15 +144,13 @@ class HazelcastSuspendLeaderGroupElector private constructor(
             // NonCancellable: 코루틴 취소 시에도 watchdog close + release 가 중단되지 않도록 보호
             withContext(NonCancellable) {
                 watchdog.close()
-                if (lock.isHeldByCurrentInstance()) {
-                    try {
-                        lock.unlock(minLeaseTime, acquiredAtNanos)
-                        log.debug { "리더 그룹 슬롯을 반납했습니다 (suspend). lockName=$lockName, slot=$slot" }
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        log.warn(e) { "그룹 슬롯 해제 실패 (suspend). lockName=$lockName, slot=$slot" }
-                    }
+                try {
+                    lock.unlock(minLeaseTime, acquiredAtNanos)
+                    log.debug { "리더 그룹 슬롯을 반납했습니다 (suspend). lockName=$lockName, slot=$slot" }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log.warn(e) { "그룹 슬롯 해제 실패 (suspend). lockName=$lockName, slot=$slot" }
                 }
             }
         }

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/lock/HazelcastLock.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/lock/HazelcastLock.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.hazelcast.lock
 
 import com.hazelcast.core.HazelcastException
 import com.hazelcast.map.IMap
+import com.hazelcast.transaction.TransactionContext
 import io.bluetape4k.codec.Base58
 import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.remainingMinLeaseTime
@@ -31,6 +32,8 @@ import kotlin.time.Duration
 class HazelcastLock(
     private val lockMap: IMap<String, String>,
     val lockKey: String,
+    private val transactionMapName: String? = null,
+    private val transactionContextProvider: (() -> TransactionContext)? = null,
 ) {
     companion object: KLogging() {
         private const val RETRY_DELAY_MS = 50L
@@ -81,7 +84,7 @@ class HazelcastLock(
     /**
      * Releases the lock held by the current instance.
      *
-     * Validates token ownership before atomically removing the entry.
+     * Validates token ownership in a Hazelcast transaction before rewriting TTL or removing the entry.
      * Logs a warning on token mismatch (e.g., the lease expired and another node re-acquired the lock).
      */
     fun unlock(
@@ -89,15 +92,17 @@ class HazelcastLock(
         acquiredAtNanos: Long = System.nanoTime(),
     ) {
         val remaining = remainingMinLeaseTime(acquiredAtNanos, minLeaseTime)
-        val released = if (remaining > Duration.ZERO) {
-            if (isHeldByCurrentInstance()) {
-                lockMap.set(lockKey, token, remaining.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        val released = withOwnedTransaction(
+            onTransactionUnavailable = { releaseDirectly(remaining) },
+            onNotHeld = { false },
+        ) { txMap ->
+            if (remaining > Duration.ZERO) {
+                txMap.put(lockKey, token, remaining.inWholeMilliseconds, TimeUnit.MILLISECONDS)
                 true
             } else {
-                false
+                txMap.remove(lockKey)
+                true
             }
-        } else {
-            lockMap.remove(lockKey, token)
         }
         if (released) {
             log.debug { "Lock 해제 성공: lockKey=$lockKey" }
@@ -111,8 +116,9 @@ class HazelcastLock(
      * — T12 PR 7 (Issue #79).
      *
      * ## Behavior / Contract
-     * - Step 1: atomically validates that the entry value matches our token using [IMap.replace] (CAS).
-     * - Step 2: on token match, updates the TTL with [IMap.setTtl].
+     * - Step 1: opens a Hazelcast transaction and reads [lockKey] with `getForUpdate`.
+     * - Step 2: validates that the entry value still matches our token.
+     * - Step 3: on token match, rewrites the same token with a new TTL via transactional `put`.
      * - Token mismatch or not held → [ExtendOutcome.NotHeld]
      * - Successful renewal → [ExtendOutcome.Extended] (`observedExpireAt = now + leaseTime` — best-effort)
      * - [HazelcastException] → [ExtendOutcome.BackendError]
@@ -121,42 +127,80 @@ class HazelcastLock(
      * Hazelcast IMap automatically evicts entries on TTL expiry, so [IMap.replace] returns `false`
      * for expired entries → NotHeld.
      *
-     * ## Design Note — Why replace+setTtl Instead of EntryProcessor
+     * ## Design Note — Why Transaction Instead of EntryProcessor
      * In Hazelcast client-server mode, a custom `EntryProcessor` requires class deployment to the
      * server JVM ([UserCodeDeployment] or pre-deployment on the server side). The Hazelcast server in
      * bluetape4k-testcontainers uses a vanilla image, so the class cannot be found and a
      * `HazelcastSerializationException(ClassNotFoundException)` is thrown.
-     * Instead, the same token-guard semantics are achieved using built-in atomic primitives
-     * ([IMap.replace] CAS + [IMap.setTtl]).
-     *
-     * ## Race Window (Acceptable)
-     * An entry may expire during the sub-millisecond window between `replace` and `setTtl`.
-     * In that case `setTtl` returns `false` → treated as NotHeld.
-     * A theoretical race exists where our `setTtl` arrives after another instance takes over and
-     * refreshes that instance's TTL, but this window is extremely narrow — immediately after `replace`
-     * passes token validation.
+     * Instead, token validation and TTL rewrite use Hazelcast's built-in transactional map API,
+     * so a stale owner cannot refresh a successor entry between validation and TTL update.
      */
     fun extendDetailed(leaseTime: Duration): ExtendOutcome {
         val leaseMs = leaseTime.inWholeMilliseconds
         val nowMs = System.currentTimeMillis()
         return try {
-            // 1) CAS — value 가 우리 토큰일 때만 (no-op replace) 성공
-            val matched = lockMap.replace(lockKey, token, token)
-            if (!matched) {
-                log.debug { "Hazelcast extend NotHeld (token mismatch / 만료): lockKey=$lockKey" }
-                ExtendOutcome.NotHeld
-            } else {
-                // 2) TTL 갱신
-                val updated = lockMap.setTtl(lockKey, leaseMs, TimeUnit.MILLISECONDS)
-                if (updated) {
-                    ExtendOutcome.Extended(Instant.ofEpochMilli(nowMs + leaseMs))
-                } else {
-                    log.debug { "Hazelcast extend NotHeld (setTtl 실패 — race window): lockKey=$lockKey" }
+            withOwnedTransaction(
+                onTransactionUnavailable = { extendDirectly(leaseMs, nowMs) },
+                onNotHeld = {
+                    log.debug { "Hazelcast extend NotHeld (token mismatch / 만료): lockKey=$lockKey" }
                     ExtendOutcome.NotHeld
-                }
+                },
+            ) {
+                it.put(lockKey, token, leaseMs, TimeUnit.MILLISECONDS)
+                ExtendOutcome.Extended(Instant.ofEpochMilli(nowMs + leaseMs))
             }
         } catch (e: HazelcastException) {
             ExtendOutcome.BackendError(e)
+        }
+    }
+
+    private inline fun <T> withOwnedTransaction(
+        onTransactionUnavailable: () -> T,
+        onNotHeld: () -> T,
+        block: (com.hazelcast.transaction.TransactionalMap<String, String>) -> T,
+    ): T {
+        val provider = transactionContextProvider ?: return onTransactionUnavailable()
+        val context = provider()
+        context.beginTransaction()
+        return try {
+            val txMap = context.getMap<String, String>(transactionMapName ?: lockMap.name)
+            if (txMap.getForUpdate(lockKey) != token) {
+                context.commitTransaction()
+                onNotHeld()
+            } else {
+                val result = block(txMap)
+                context.commitTransaction()
+                result
+            }
+        } catch (e: Throwable) {
+            runCatching { context.rollbackTransaction() }
+            throw e
+        }
+    }
+
+    private fun releaseDirectly(remaining: Duration): Boolean {
+        if (lockMap[lockKey] != token) {
+            return false
+        }
+        return if (remaining > Duration.ZERO) {
+            lockMap.set(lockKey, token, remaining.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+            true
+        } else {
+            lockMap.remove(lockKey, token)
+        }
+    }
+
+    private fun extendDirectly(leaseMs: Long, nowMs: Long): ExtendOutcome {
+        if (lockMap[lockKey] != token) {
+            log.debug { "Hazelcast extend NotHeld (token mismatch / 만료): lockKey=$lockKey" }
+            return ExtendOutcome.NotHeld
+        }
+        val updated = lockMap.setTtl(lockKey, leaseMs, TimeUnit.MILLISECONDS)
+        return if (updated) {
+            ExtendOutcome.Extended(Instant.ofEpochMilli(nowMs + leaseMs))
+        } else {
+            log.debug { "Hazelcast extend NotHeld (setTtl 실패): lockKey=$lockKey" }
+            ExtendOutcome.NotHeld
         }
     }
 }

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/lock/HazelcastSuspendLock.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/lock/HazelcastSuspendLock.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.hazelcast.lock
 
 import com.hazelcast.core.HazelcastException
 import com.hazelcast.map.IMap
+import com.hazelcast.transaction.TransactionContext
 import io.bluetape4k.codec.Base58
 import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.remainingMinLeaseTime
@@ -34,6 +35,8 @@ import kotlin.time.Duration.Companion.milliseconds
 class HazelcastSuspendLock(
     private val lockMap: IMap<String, String>,
     val lockKey: String,
+    private val transactionMapName: String? = null,
+    private val transactionContextProvider: (() -> TransactionContext)? = null,
 ) {
     companion object: KLoggingChannel() {
         private const val RETRY_DELAY_MS = 50L
@@ -87,7 +90,7 @@ class HazelcastSuspendLock(
     /**
      * Releases the lock held by the current instance.
      *
-     * Verifies token ownership and then removes it atomically.
+     * Verifies token ownership in a Hazelcast transaction before rewriting TTL or removing the entry.
      * Logs a warning if the token does not match (e.g., the lease expired and another node re-acquired the lock).
      */
     suspend fun unlock(
@@ -95,15 +98,17 @@ class HazelcastSuspendLock(
         acquiredAtNanos: Long = System.nanoTime(),
     ) = withContext(Dispatchers.IO) {
         val remaining = remainingMinLeaseTime(acquiredAtNanos, minLeaseTime)
-        val released = if (remaining > Duration.ZERO) {
-            if (lockMap[lockKey] == token) {
-                lockMap.set(lockKey, token, remaining.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        val released = withOwnedTransaction(
+            onTransactionUnavailable = { releaseDirectly(remaining) },
+            onNotHeld = { false },
+        ) { txMap ->
+            if (remaining > Duration.ZERO) {
+                txMap.put(lockKey, token, remaining.inWholeMilliseconds, TimeUnit.MILLISECONDS)
                 true
             } else {
-                false
+                txMap.remove(lockKey)
+                true
             }
-        } else {
-            lockMap.remove(lockKey, token)
         }
         if (released) {
             log.debug { "Lock 해제 성공 (suspend): lockKey=$lockKey" }
@@ -116,28 +121,74 @@ class HazelcastSuspendLock(
      * Atomically extends the lock TTL by [leaseTime] and returns an [ExtendOutcome] (suspend) — T12 PR 7 (Issue #79).
      *
      * Since Hazelcast IMap is a blocking API, it is wrapped with `withContext(Dispatchers.IO)` to suspend.
-     * Behavior and contract are identical to [HazelcastLock.extendDetailed] (R6 — IMap auto-evict blocks expired-doc revival).
+     * Behavior and contract are identical to [HazelcastLock.extendDetailed].
      */
     suspend fun extendDetailed(leaseTime: Duration): ExtendOutcome = withContext(Dispatchers.IO) {
         val leaseMs = leaseTime.inWholeMilliseconds
         val nowMs = System.currentTimeMillis()
         try {
-            // 1) CAS — value 가 우리 토큰일 때만 (no-op replace) 성공
-            val matched = lockMap.replace(lockKey, token, token)
-            if (!matched) {
-                log.debug { "Hazelcast extend NotHeld (suspend): lockKey=$lockKey" }
-                ExtendOutcome.NotHeld
-            } else {
-                val updated = lockMap.setTtl(lockKey, leaseMs, TimeUnit.MILLISECONDS)
-                if (updated) {
-                    ExtendOutcome.Extended(Instant.ofEpochMilli(nowMs + leaseMs))
-                } else {
-                    log.debug { "Hazelcast extend NotHeld (setTtl 실패 — race, suspend): lockKey=$lockKey" }
+            withOwnedTransaction(
+                onTransactionUnavailable = { extendDirectly(leaseMs, nowMs) },
+                onNotHeld = {
+                    log.debug { "Hazelcast extend NotHeld (suspend): lockKey=$lockKey" }
                     ExtendOutcome.NotHeld
-                }
+                },
+            ) {
+                it.put(lockKey, token, leaseMs, TimeUnit.MILLISECONDS)
+                ExtendOutcome.Extended(Instant.ofEpochMilli(nowMs + leaseMs))
             }
         } catch (e: HazelcastException) {
             ExtendOutcome.BackendError(e)
+        }
+    }
+
+    private inline fun <T> withOwnedTransaction(
+        onTransactionUnavailable: () -> T,
+        onNotHeld: () -> T,
+        block: (com.hazelcast.transaction.TransactionalMap<String, String>) -> T,
+    ): T {
+        val provider = transactionContextProvider ?: return onTransactionUnavailable()
+        val context = provider()
+        context.beginTransaction()
+        return try {
+            val txMap = context.getMap<String, String>(transactionMapName ?: lockMap.name)
+            if (txMap.getForUpdate(lockKey) != token) {
+                context.commitTransaction()
+                onNotHeld()
+            } else {
+                val result = block(txMap)
+                context.commitTransaction()
+                result
+            }
+        } catch (e: Throwable) {
+            runCatching { context.rollbackTransaction() }
+            throw e
+        }
+    }
+
+    private fun releaseDirectly(remaining: Duration): Boolean {
+        if (lockMap[lockKey] != token) {
+            return false
+        }
+        return if (remaining > Duration.ZERO) {
+            lockMap.set(lockKey, token, remaining.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+            true
+        } else {
+            lockMap.remove(lockKey, token)
+        }
+    }
+
+    private fun extendDirectly(leaseMs: Long, nowMs: Long): ExtendOutcome {
+        if (lockMap[lockKey] != token) {
+            log.debug { "Hazelcast extend NotHeld (suspend): lockKey=$lockKey" }
+            return ExtendOutcome.NotHeld
+        }
+        val updated = lockMap.setTtl(lockKey, leaseMs, TimeUnit.MILLISECONDS)
+        return if (updated) {
+            ExtendOutcome.Extended(Instant.ofEpochMilli(nowMs + leaseMs))
+        } else {
+            log.debug { "Hazelcast extend NotHeld (setTtl 실패, suspend): lockKey=$lockKey" }
+            ExtendOutcome.NotHeld
         }
     }
 }

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendCancellationSafetyTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendCancellationSafetyTest.kt
@@ -10,18 +10,24 @@ class HazelcastSuspendCancellationSafetyTest {
     fun `suspend elector unlock failure handling rethrows CancellationException`() {
         val source = sourceText("HazelcastSuspendLeaderElector.kt")
 
-        source.contains("catch (e: CancellationException) {\n                        throw e\n                    } catch (e: Exception)").shouldBeTrue()
+        source.rethrowsCancellationBeforeBroadCatch().shouldBeTrue()
     }
 
     @Test
     fun `suspend group elector unlock failure handling rethrows CancellationException`() {
         val source = sourceText("HazelcastSuspendLeaderGroupElector.kt")
 
-        source.contains("catch (e: CancellationException) {\n                        throw e\n                    } catch (e: Exception)").shouldBeTrue()
+        source.rethrowsCancellationBeforeBroadCatch().shouldBeTrue()
     }
 
     private fun sourceText(fileName: String): String =
         Path.of("src/main/kotlin/io/bluetape4k/leader/hazelcast", fileName)
             .toFile()
             .readText()
+
+    private fun String.rethrowsCancellationBeforeBroadCatch(): Boolean {
+        val cancellationCatch = indexOf("catch (e: CancellationException) {\n                    throw e\n                }")
+        val broadCatch = indexOf("catch (e: Exception)", startIndex = cancellationCatch.coerceAtLeast(0))
+        return cancellationCatch >= 0 && broadCatch > cancellationCatch
+    }
 }

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/contract/HazelcastExtendDelegateReferenceTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/contract/HazelcastExtendDelegateReferenceTest.kt
@@ -29,9 +29,9 @@ import kotlin.time.Duration.Companion.seconds
  * - sync group ([HazelcastLeaderGroupElector])
  * - suspend group ([HazelcastSuspendLeaderGroupElector])
  *
- * Hazelcast `IMap.replace(K, ourToken, ourToken) + IMap.setTtl(K, leaseMs)` built-in atomic chain 으로
+ * Hazelcast transactional `getForUpdate(K) + put(K, ourToken, leaseMs)` built-in path 으로
  * 토큰 일치 + TTL 갱신이 수행됩니다. acquire 직후 (lease 미만료) 항상 Extended 가 반환됩니다.
- * race window 등 세부사항은 [io.bluetape4k.leader.hazelcast.lock.HazelcastLock.extendDetailed] KDoc 참고.
+ * 세부사항은 [io.bluetape4k.leader.hazelcast.lock.HazelcastLock.extendDetailed] KDoc 참고.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class HazelcastExtendDelegateReferenceTest: AbstractHazelcastLeaderTest() {

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/lock/HazelcastLockOwnerAtomicTtlTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/lock/HazelcastLockOwnerAtomicTtlTest.kt
@@ -1,0 +1,193 @@
+package io.bluetape4k.leader.hazelcast.lock
+
+import com.hazelcast.map.IMap
+import com.hazelcast.transaction.TransactionContext
+import com.hazelcast.transaction.TransactionalMap
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.ExtendOutcome
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.Runs
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HazelcastLockOwnerAtomicTtlTest {
+
+    private val mapName = "owner-atomic-locks"
+    private val lockMap = mockk<IMap<String, String>>(relaxed = true)
+    private val suspendLockMap = mockk<IMap<String, String>>(relaxed = true)
+    private val transactionContext = mockk<TransactionContext>(relaxed = true)
+    private val suspendTransactionContext = mockk<TransactionContext>(relaxed = true)
+    private val transactionMap = mockk<TransactionalMap<String, String>>(relaxed = true)
+    private val suspendTransactionMap = mockk<TransactionalMap<String, String>>(relaxed = true)
+
+    @BeforeEach
+    fun beforeEach() {
+        clearMocks(lockMap, suspendLockMap, transactionContext, suspendTransactionContext, transactionMap, suspendTransactionMap)
+    }
+
+    @Test
+    fun `unlock minLeaseTime rewrite is guarded by Hazelcast transaction`() {
+        val lockKey = "hazelcast-owner-atomic-unlock"
+        val lock = HazelcastLock(lockMap, lockKey, mapName) { transactionContext }
+        val token = lock.tokenForTest()
+        val acquiredAtNanos = System.nanoTime()
+
+        prepareTransaction(lockKey, token)
+        every { transactionMap.put(lockKey, token, any<Long>(), TimeUnit.MILLISECONDS) } returns token
+
+        lock.unlock(30.seconds, acquiredAtNanos)
+
+        verifyOrder {
+            transactionContext.beginTransaction()
+            transactionContext.getMap<String, String>(mapName)
+            transactionMap.getForUpdate(lockKey)
+            transactionMap.put(lockKey, token, any<Long>(), TimeUnit.MILLISECONDS)
+            transactionContext.commitTransaction()
+        }
+        verify(exactly = 0) { lockMap.remove(lockKey, token) }
+    }
+
+    @Test
+    fun `unlock minLeaseTime takeover returns NotHeld and does not rewrite successor token`() {
+        val lockKey = "hazelcast-owner-atomic-unlock-takeover"
+        val lock = HazelcastLock(lockMap, lockKey, mapName) { transactionContext }
+        val successorToken = "successor-token"
+
+        prepareTransaction(lockKey, successorToken)
+
+        lock.unlock(30.seconds, System.nanoTime())
+
+        verifyOrder {
+            transactionContext.beginTransaction()
+            transactionContext.getMap<String, String>(mapName)
+            transactionMap.getForUpdate(lockKey)
+            transactionContext.commitTransaction()
+        }
+        verify(exactly = 0) { transactionMap.put(lockKey, any<String>(), any<Long>(), TimeUnit.MILLISECONDS) }
+        verify(exactly = 0) { transactionMap.remove(lockKey) }
+        verify(exactly = 0) { lockMap.set(lockKey, any<String>(), any<Long>(), TimeUnit.MILLISECONDS) }
+        verify(exactly = 0) { lockMap.remove(lockKey, any<String>()) }
+    }
+
+    @Test
+    fun `extendDetailed TTL rewrite is guarded by Hazelcast transaction`() {
+        val lockKey = "hazelcast-owner-atomic-extend"
+        val lock = HazelcastLock(lockMap, lockKey, mapName) { transactionContext }
+        val token = lock.tokenForTest()
+
+        prepareTransaction(lockKey, token)
+        every { transactionMap.put(lockKey, token, 30.seconds.inWholeMilliseconds, TimeUnit.MILLISECONDS) } returns token
+
+        val outcome = lock.extendDetailed(30.seconds)
+
+        outcome.shouldBeInstanceOf<ExtendOutcome.Extended>()
+        verifyOrder {
+            transactionContext.beginTransaction()
+            transactionContext.getMap<String, String>(mapName)
+            transactionMap.getForUpdate(lockKey)
+            transactionMap.put(lockKey, token, 30.seconds.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+            transactionContext.commitTransaction()
+        }
+        verify(exactly = 0) { lockMap.replace(lockKey, token, token) }
+        verify(exactly = 0) { lockMap.setTtl(lockKey, any<Long>(), TimeUnit.MILLISECONDS) }
+    }
+
+    @Test
+    fun `extendDetailed takeover returns NotHeld and does not refresh successor TTL`() {
+        val lockKey = "hazelcast-owner-atomic-extend-takeover"
+        val lock = HazelcastLock(lockMap, lockKey, mapName) { transactionContext }
+        val successorToken = "successor-token"
+
+        prepareTransaction(lockKey, successorToken)
+
+        val outcome = lock.extendDetailed(30.seconds)
+
+        outcome shouldBeEqualTo ExtendOutcome.NotHeld
+        verifyOrder {
+            transactionContext.beginTransaction()
+            transactionContext.getMap<String, String>(mapName)
+            transactionMap.getForUpdate(lockKey)
+            transactionContext.commitTransaction()
+        }
+        verify(exactly = 0) { transactionMap.put(lockKey, any<String>(), any<Long>(), TimeUnit.MILLISECONDS) }
+        verify(exactly = 0) { lockMap.setTtl(lockKey, any<Long>(), TimeUnit.MILLISECONDS) }
+        verify(exactly = 0) { lockMap.replace(lockKey, any<String>(), any<String>()) }
+    }
+
+    @Test
+    fun `suspend extendDetailed takeover returns NotHeld and does not refresh successor TTL`() = runSuspendIO {
+        val lockKey = "hazelcast-owner-atomic-suspend-extend-takeover"
+        val lock = HazelcastSuspendLock(suspendLockMap, lockKey, mapName) { suspendTransactionContext }
+        val successorToken = "successor-token"
+
+        prepareSuspendTransaction(lockKey, successorToken)
+
+        val outcome = lock.extendDetailed(30.seconds)
+
+        outcome shouldBeEqualTo ExtendOutcome.NotHeld
+        verifyOrder {
+            suspendTransactionContext.beginTransaction()
+            suspendTransactionContext.getMap<String, String>(mapName)
+            suspendTransactionMap.getForUpdate(lockKey)
+            suspendTransactionContext.commitTransaction()
+        }
+        verify(exactly = 0) { suspendTransactionMap.put(lockKey, any<String>(), any<Long>(), TimeUnit.MILLISECONDS) }
+        verify(exactly = 0) { suspendLockMap.setTtl(lockKey, any<Long>(), TimeUnit.MILLISECONDS) }
+        verify(exactly = 0) { suspendLockMap.replace(lockKey, any<String>(), any<String>()) }
+    }
+
+    @Test
+    fun `suspend unlock minLeaseTime takeover does not rewrite successor token`() = runSuspendIO {
+        val lockKey = "hazelcast-owner-atomic-suspend-unlock-takeover"
+        val lock = HazelcastSuspendLock(suspendLockMap, lockKey, mapName) { suspendTransactionContext }
+        val successorToken = "successor-token"
+
+        prepareSuspendTransaction(lockKey, successorToken)
+
+        lock.unlock(30.seconds, System.nanoTime())
+
+        verifyOrder {
+            suspendTransactionContext.beginTransaction()
+            suspendTransactionContext.getMap<String, String>(mapName)
+            suspendTransactionMap.getForUpdate(lockKey)
+            suspendTransactionContext.commitTransaction()
+        }
+        verify(exactly = 0) { suspendTransactionMap.put(lockKey, any<String>(), any<Long>(), TimeUnit.MILLISECONDS) }
+        verify(exactly = 0) { suspendTransactionMap.remove(lockKey) }
+        verify(exactly = 0) { suspendLockMap.set(lockKey, any<String>(), any<Long>(), TimeUnit.MILLISECONDS) }
+        verify(exactly = 0) { suspendLockMap.remove(lockKey, any<String>()) }
+    }
+
+    private fun prepareTransaction(lockKey: String, observedToken: String) {
+        every { transactionContext.beginTransaction() } just Runs
+        every { transactionContext.getMap<String, String>(mapName) } returns transactionMap
+        every { transactionMap.getForUpdate(lockKey) } returns observedToken
+        every { transactionContext.commitTransaction() } just Runs
+        every { transactionContext.rollbackTransaction() } just Runs
+    }
+
+    private fun prepareSuspendTransaction(lockKey: String, observedToken: String) {
+        every { suspendTransactionContext.beginTransaction() } just Runs
+        every { suspendTransactionContext.getMap<String, String>(mapName) } returns suspendTransactionMap
+        every { suspendTransactionMap.getForUpdate(lockKey) } returns observedToken
+        every { suspendTransactionContext.commitTransaction() } just Runs
+        every { suspendTransactionContext.rollbackTransaction() } just Runs
+    }
+
+    private fun HazelcastLock.tokenForTest(): String {
+        val tokenField = HazelcastLock::class.java.getDeclaredField("token")
+        tokenField.isAccessible = true
+        return tokenField.get(this) as String
+    }
+}


### PR DESCRIPTION
## Summary

Closes #515

PR #549의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: prevent Hazelcast TTL rewrites after takeover`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary
- Use Hazelcast transactional map getForUpdate + TTL put for owner-guarded release and extend operations.
- Remove caller-side isHeld release prechecks so stale owners return NotHeld without mutating successor entries.
- Add forced owner-takeover regression tests for sync and suspend Hazelcast locks.

Fixes #515

## Validation
- ./gradlew :bluetape4k-leader-hazelcast:compileKotlin :bluetape4k-leader-hazelcast:compileTestKotlin --no-parallel --no-daemon --console=plain
- ./gradlew :bluetape4k-leader-hazelcast:test --tests 'io.bluetape4k.leader.hazelcast.lock.HazelcastLockOwnerAtomicTtlTest' --tests 'io.bluetape4k.leader.hazelcast.contract.HazelcastLockExtenderContractTest' --tests 'io.bluetape4k.leader.hazelcast.contract.HazelcastGroupLockExtenderContractTest' --tests 'io.bluetape4k.leader.hazelcast.contract.HazelcastExtendDelegateReferenceTest' --no-parallel --no-daemon --console=plain --rerun-tasks
- ./gradlew :bluetape4k-leader-hazelcast:test --no-parallel --no-daemon --console=plain (109 tests, 0 failures)
- git diff --check

## DoD Status
- [x] Issue #515 metadata checked: milestone 0.5.0, labels bug/integration/test, assignee debop.
- [x] Stale owners return NotHeld and do not call setTtl/replace or rewrite successor TTL in regression tests.
- [x] minLease release paths validate owner inside the same Hazelcast transaction before TTL rewrite/remove.
- [x] Sync, async, suspend, and group elector release paths use the lock's owner-guarded release instead of a separate isHeld precheck.
- [x] Required Hazelcast module test command passes.
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #515, milestone `0.5.0`, assignee `debop`
- PR: #549, head `e8b13786b4659db103c7c5ae49157b9fb6e4d804`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
