### PR TITLE
fix: prevent stale ZooKeeper session extension

### DIFF
--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperLeaderElector.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperLeaderElector.kt
@@ -10,20 +10,20 @@ import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
 import io.bluetape4k.leader.zookeeper.internal.ZooKeeperBackendErrorClassifier
 import io.bluetape4k.leader.zookeeper.internal.ZooKeeperLockExtendDelegate
+import io.bluetape4k.leader.zookeeper.internal.ZooKeeperOwnedInterProcessMutex
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import org.apache.curator.framework.CuratorFramework
-import org.apache.curator.framework.recipes.locks.InterProcessMutex
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
 
 /**
- * ZooKeeper single-leader election implementation based on Apache Curator [InterProcessMutex].
+ * ZooKeeper single-leader election implementation based on Apache Curator's inter-process mutex recipe.
  *
  * ## Behavior / Contract
- * - Creates an [InterProcessMutex] at the ZooKeeper path for each [lockName] and attempts acquisition
+ * - Creates a Curator mutex at the ZooKeeper path for each [lockName] and attempts acquisition
  *   for up to [LeaderElectionOptions.waitTime].
  * - Returns `null` without executing [action] if acquisition fails.
  * - Executes [action] on successful acquisition and always calls `release()` in a `finally` block.
@@ -72,7 +72,7 @@ class ZooKeeperLeaderElector private constructor(
 
     override fun <T> runIfLeader(lockName: String, action: () -> T): T? {
         val path = ZooKeeperPaths.electionPath(basePath, lockName)
-        val mutex = InterProcessMutex(client, path)
+        val mutex = ZooKeeperOwnedInterProcessMutex(client, path)
 
         log.debug { "ZooKeeper leader lock 획득을 요청합니다. path=$path" }
         val acquired = try {
@@ -93,8 +93,19 @@ class ZooKeeperLeaderElector private constructor(
 
         log.debug { "ZooKeeper leader lock 획득 성공. path=$path" }
 
+        val lockPath = mutex.currentThreadLockPath()
+        if (lockPath == null) {
+            log.warn { "ZooKeeper leader lock path 조회 실패. path=$path" }
+            try {
+                mutex.release()
+            } catch (e: Exception) {
+                log.warn(e) { "ZooKeeper leader lock path 조회 실패 후 반납 실패. path=$path" }
+            }
+            return null
+        }
+
         val acquiredAtNanos = System.nanoTime()
-        val delegate = ZooKeeperLockExtendDelegate(mutex, path)
+        val delegate = ZooKeeperLockExtendDelegate(client, mutex, path, lockPath)
         val identity = LockIdentity(
             lockName = lockName,
             kind = LockIdentity.AnnotationKind.SINGLE,

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperLeaderGroupElector.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperLeaderGroupElector.kt
@@ -111,7 +111,7 @@ class ZooKeeperLeaderGroupElector private constructor(
 
         val acquiredAtNanos = System.nanoTime()
         val slotKey = path
-        val delegate = ZooKeeperSlotExtendDelegate(slotKey)
+        val delegate = ZooKeeperSlotExtendDelegate(client, slotKey, lease.nodeName)
         val identity = LockIdentity(
             lockName = lockName,
             kind = LockIdentity.AnnotationKind.GROUP,

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderElector.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderElector.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.leader.coroutines.SuspendLeaderElector
 import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
 import io.bluetape4k.leader.zookeeper.internal.ZooKeeperBackendErrorClassifier
+import io.bluetape4k.leader.zookeeper.internal.ZooKeeperOwnedInterProcessMutex
 import io.bluetape4k.leader.zookeeper.internal.ZooKeeperSuspendLockExtendDelegate
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
@@ -18,15 +19,14 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 import org.apache.curator.framework.CuratorFramework
-import org.apache.curator.framework.recipes.locks.InterProcessMutex
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 /**
- * ZooKeeper suspend single-leader election implementation based on Apache Curator [InterProcessMutex].
+ * ZooKeeper suspend single-leader election implementation based on Apache Curator's inter-process mutex recipe.
  *
  * ## Behavior / Contract
- * - Uses the same [InterProcessMutex] recipe as the blocking [ZooKeeperLeaderElector] to mutually exclude the same [lockName].
+ * - Uses the same Curator mutex recipe as the blocking [ZooKeeperLeaderElector] to mutually exclude the same [lockName].
  * - Since the Curator mutex has a thread-owner constraint, acquire/release is performed on a per-call single-thread dispatcher.
  * - Even during cancellation, releases the lock inside `withContext(NonCancellable)` and re-propagates [CancellationException].
  * - [LeaderElectionOptions.leaseTime] is not used as a ZooKeeper TTL; session termination/expiry is the automatic release boundary.
@@ -72,7 +72,7 @@ class ZooKeeperSuspendLeaderElector private constructor(
 
     override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? {
         val path = ZooKeeperPaths.electionPath(basePath, lockName)
-        val mutex = InterProcessMutex(client, path)
+        val mutex = ZooKeeperOwnedInterProcessMutex(client, path)
         val ownerDispatcher = Executors.newSingleThreadExecutor { task ->
             Thread(task, "zookeeper-suspend-leader-$lockName").apply {
                 isDaemon = true
@@ -99,8 +99,25 @@ class ZooKeeperSuspendLeaderElector private constructor(
 
             log.debug { "ZooKeeper suspend leader lock 획득 성공. path=$path" }
 
+            val lockPath = runInterruptible(ownerDispatcher) {
+                mutex.currentThreadLockPath()
+            }
+            if (lockPath == null) {
+                log.warn { "ZooKeeper suspend leader lock path 조회 실패. path=$path" }
+                withContext(NonCancellable) {
+                    try {
+                        runInterruptible(ownerDispatcher) {
+                            mutex.release()
+                        }
+                    } catch (e: Exception) {
+                        log.warn(e) { "ZooKeeper suspend leader lock path 조회 실패 후 반납 실패. path=$path" }
+                    }
+                }
+                return null
+            }
+
             val acquiredAtNanos = System.nanoTime()
-            val delegate = ZooKeeperSuspendLockExtendDelegate(mutex, path)
+            val delegate = ZooKeeperSuspendLockExtendDelegate(client, mutex, path, lockPath)
             val identity = LockIdentity(
                 lockName = lockName,
                 kind = LockIdentity.AnnotationKind.SINGLE,

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderGroupElector.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderGroupElector.kt
@@ -110,7 +110,7 @@ class ZooKeeperSuspendLeaderGroupElector private constructor(
 
         val acquiredAtNanos = System.nanoTime()
         val slotKey = path
-        val delegate = ZooKeeperSuspendSlotExtendDelegate(slotKey)
+        val delegate = ZooKeeperSuspendSlotExtendDelegate(client, slotKey, lease.nodeName)
         val identity = LockIdentity(
             lockName = lockName,
             kind = LockIdentity.AnnotationKind.GROUP,

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperLockExtendDelegate.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperLockExtendDelegate.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.internal.ExtendDelegate
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
+import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.recipes.locks.InterProcessMutex
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
@@ -18,12 +19,11 @@ import kotlin.time.Duration
  * as an ephemeral znode and is valid only while the ZK session is alive. Therefore `extend(d)` means
  * **session-held liveness check** rather than lease renewal (R3-F11).
  *
- * - [extend]: returns [ExtendOutcome.Extended] (observedExpireAt = [Instant.MAX]) if
- *   `mutex.isAcquiredInThisProcess()` is `true`; returns [ExtendOutcome.NotHeld] if `false`.
- *   Backend exceptions are wrapped as [ExtendOutcome.BackendError].
- * - [extendSuspend]: `isAcquiredInThisProcess()` is a local counter check — non-blocking, no
- *   `withContext(IO)` needed. Only adds `CancellationException` re-propagation.
- * - [isHeld]: delegates directly to `mutex.isAcquiredInThisProcess()`.
+ * - [extend]: returns [ExtendOutcome.Extended] (observedExpireAt = [Instant.MAX]) only if Curator still
+ *   reports a local acquisition and the acquired ephemeral znode still exists in ZooKeeper. Returns
+ *   [ExtendOutcome.NotHeld] when ownership is no longer positively observable.
+ * - [extendSuspend]: follows the same backend ownership check.
+ * - [isHeld]: returns false when the local mutex state or backend znode check says the lock is no longer held.
  * - [lastExtendDeadline]: single `AtomicReference(Instant.EPOCH)` instance (R2 mitigation interface
  *   compatibility — cosmetic in ZK since the watchdog is disabled, but [LockExtender.extendActiveLockDetailed]
  *   calls `set` on it).
@@ -35,8 +35,10 @@ import kotlin.time.Duration
  * The [extend] method on this delegate is called only via the user-driven `LockExtender.extendActiveLock` path.
  */
 internal class ZooKeeperLockExtendDelegate(
+    private val client: CuratorFramework,
     private val mutex: InterProcessMutex,
     private val lockKey: String,
+    private val lockPath: String,
 ): ExtendDelegate {
 
     companion object: KLogging()
@@ -53,7 +55,7 @@ internal class ZooKeeperLockExtendDelegate(
 
     override fun isHeld(): Boolean =
         try {
-            mutex.isAcquiredInThisProcess
+            isBackendHeld()
         } catch (e: Exception) {
             log.warn(e) { "ZooKeeper isHeld failed. lockKey=$lockKey" }
             false
@@ -61,10 +63,13 @@ internal class ZooKeeperLockExtendDelegate(
 
     private fun doExtend(): ExtendOutcome =
         try {
-            if (mutex.isAcquiredInThisProcess) ExtendOutcome.Extended(Instant.MAX)
+            if (isBackendHeld()) ExtendOutcome.Extended(Instant.MAX)
             else ExtendOutcome.NotHeld
         } catch (e: Exception) {
             log.warn(e) { "ZooKeeper extend (passthrough) failed. lockKey=$lockKey" }
             ExtendOutcome.BackendError(e)
         }
+
+    private fun isBackendHeld(): Boolean =
+        mutex.isAcquiredInThisProcess && ZooKeeperOwnershipProbe.isLiveNode(client, lockPath)
 }

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperOwnedInterProcessMutex.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperOwnedInterProcessMutex.kt
@@ -1,0 +1,12 @@
+package io.bluetape4k.leader.zookeeper.internal
+
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.framework.recipes.locks.InterProcessMutex
+
+internal class ZooKeeperOwnedInterProcessMutex(
+    client: CuratorFramework,
+    path: String,
+): InterProcessMutex(client, path) {
+
+    fun currentThreadLockPath(): String? = getLockPath()
+}

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperOwnershipProbe.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperOwnershipProbe.kt
@@ -1,0 +1,19 @@
+package io.bluetape4k.leader.zookeeper.internal
+
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.framework.imps.CuratorFrameworkState
+import org.apache.curator.utils.ZKPaths
+
+internal object ZooKeeperOwnershipProbe {
+
+    fun isLiveNode(client: CuratorFramework, nodePath: String): Boolean {
+        if (client.state != CuratorFrameworkState.STARTED) return false
+        if (!client.zookeeperClient.isConnected) return false
+        return client.checkExists().forPath(nodePath) != null
+    }
+
+    fun leaseNodePath(slotKey: String, leaseNodeName: String): String =
+        ZKPaths.makePath(ZKPaths.makePath(slotKey, LEASES_NODE), leaseNodeName)
+
+    private const val LEASES_NODE = "leases"
+}

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperSlotExtendDelegate.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperSlotExtendDelegate.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.internal.ExtendDelegate
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
+import org.apache.curator.framework.CuratorFramework
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
@@ -18,24 +19,25 @@ import kotlin.time.Duration
  * A `Lease` from [org.apache.curator.framework.recipes.locks.InterProcessSemaphoreV2] is an
  * ephemeral znode with no TTL. It is only released by `Lease.close()` or session expiry.
  *
- * - [extend] / [extendSuspend]: while the delegate is alive (i.e., the handle is pushed into scope),
- *   returns [ExtendOutcome.Extended] (observedExpireAt = [Instant.MAX]). After the elector calls
- *   [markReleased] in `finally`, returns [ExtendOutcome.NotHeld] (defensive — guards against races
- *   where extend is called after handle pop).
- * - [isHeld]: delegates directly to the [released] state. `true` = not yet released.
+ * - [extend] / [extendSuspend]: returns [ExtendOutcome.Extended] (observedExpireAt = [Instant.MAX]) only while
+ *   the delegate is alive and the lease ephemeral znode still exists in ZooKeeper.
+ * - [isHeld]: returns false after [markReleased] or when the lease node is no longer positively observable.
  *
- * `Lease` has no liveness-query API, so the elector explicitly signals state transition via [markReleased].
+ * `Lease` only exposes the acquired node name, so the elector passes it to this delegate for backend liveness checks.
  *
  * ## R16 Enforcement
  * Group elector always uses `autoExtend=false` (no option available) — watchdog disabled.
  * The [extend] method on this delegate is called only via the user-driven `LockExtender.extendActiveLock` path.
  */
 internal class ZooKeeperSlotExtendDelegate(
+    private val client: CuratorFramework,
     private val slotKey: String,
+    leaseNodeName: String,
 ): ExtendDelegate {
 
     companion object: KLogging()
 
+    private val leasePath = ZooKeeperOwnershipProbe.leaseNodePath(slotKey, leaseNodeName)
     private val released = AtomicBoolean(false)
 
     private val _lastExtendDeadline = AtomicReference(Instant.EPOCH)
@@ -55,14 +57,23 @@ internal class ZooKeeperSlotExtendDelegate(
 
     override suspend fun extendSuspend(lockAtMostFor: Duration): ExtendOutcome = doExtend()
 
-    override fun isHeld(): Boolean = !released.get()
+    override fun isHeld(): Boolean =
+        try {
+            isBackendHeld()
+        } catch (e: Exception) {
+            log.warn(e) { "ZooKeeper group isHeld failed. slotKey=$slotKey" }
+            false
+        }
 
     private fun doExtend(): ExtendOutcome =
         try {
-            if (released.get()) ExtendOutcome.NotHeld
-            else ExtendOutcome.Extended(Instant.MAX)
+            if (isBackendHeld()) ExtendOutcome.Extended(Instant.MAX)
+            else ExtendOutcome.NotHeld
         } catch (e: Exception) {
             log.warn(e) { "ZooKeeper group extend (passthrough) failed. slotKey=$slotKey" }
             ExtendOutcome.BackendError(e)
         }
+
+    private fun isBackendHeld(): Boolean =
+        !released.get() && ZooKeeperOwnershipProbe.isLiveNode(client, leasePath)
 }

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperSuspendLockExtendDelegate.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperSuspendLockExtendDelegate.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.leader.internal.ExtendDelegate
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.CancellationException
+import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.framework.recipes.locks.InterProcessMutex
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicReference
@@ -18,10 +19,9 @@ import kotlin.time.Duration
  * ZooKeeper uses **session-based locks** with no TTL concept. `extend(d)` means
  * **session-held liveness check**, not lease extension (R3-F11).
  *
- * - [extend] / [extendSuspend]: checks `mutex.isAcquiredInThisProcess()` (Curator local counter — non-blocking)
- *   and returns [ExtendOutcome.Extended] (observedExpireAt = [Instant.MAX]) or [ExtendOutcome.NotHeld] accordingly.
- * - [extendSuspend] checks a local counter, so `withContext(IO)` wrapping is unnecessary — only re-propagates CancellationException.
- * - [isHeld]: delegates directly to `isAcquiredInThisProcess`.
+ * - [extend] / [extendSuspend]: return [ExtendOutcome.Extended] (observedExpireAt = [Instant.MAX]) only if
+ *   Curator still reports a local acquisition and the acquired ephemeral znode still exists in ZooKeeper.
+ * - [isHeld]: returns false when ownership is no longer positively observable in ZooKeeper.
  *
  * Token-based lock (session-bound) — no thread affinity.
  *
@@ -29,8 +29,10 @@ import kotlin.time.Duration
  * The elector forces `enabled=false` when calling [io.bluetape4k.leader.LeaderLeaseAutoExtender.start].
  */
 internal class ZooKeeperSuspendLockExtendDelegate(
+    private val client: CuratorFramework,
     private val mutex: InterProcessMutex,
     private val lockKey: String,
+    private val lockPath: String,
 ): ExtendDelegate {
 
     companion object: KLoggingChannel()
@@ -52,7 +54,7 @@ internal class ZooKeeperSuspendLockExtendDelegate(
 
     override fun isHeld(): Boolean =
         try {
-            mutex.isAcquiredInThisProcess
+            isBackendHeld()
         } catch (e: Exception) {
             log.warn(e) { "ZooKeeperSuspend isHeld failed. lockKey=$lockKey" }
             false
@@ -60,10 +62,13 @@ internal class ZooKeeperSuspendLockExtendDelegate(
 
     private fun doExtend(): ExtendOutcome =
         try {
-            if (mutex.isAcquiredInThisProcess) ExtendOutcome.Extended(Instant.MAX)
+            if (isBackendHeld()) ExtendOutcome.Extended(Instant.MAX)
             else ExtendOutcome.NotHeld
         } catch (e: Exception) {
             log.warn(e) { "ZooKeeperSuspend extend (passthrough) failed. lockKey=$lockKey" }
             ExtendOutcome.BackendError(e)
         }
+
+    private fun isBackendHeld(): Boolean =
+        mutex.isAcquiredInThisProcess && ZooKeeperOwnershipProbe.isLiveNode(client, lockPath)
 }

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperSuspendSlotExtendDelegate.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/internal/ZooKeeperSuspendSlotExtendDelegate.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.leader.internal.ExtendDelegate
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.CancellationException
+import org.apache.curator.framework.CuratorFramework
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
@@ -16,20 +17,22 @@ import kotlin.time.Duration
  *
  * ## Behavior / Contract (PASSTHROUGH — Spec §6 row 12)
  *
- * - [extend] / [extendSuspend]: returns [ExtendOutcome.Extended] (observedExpireAt = [Instant.MAX]) while the delegate is alive.
- *   Returns [ExtendOutcome.NotHeld] after the elector calls [markReleased] in `finally`.
- * - [extendSuspend] performs a local atomic check — `withContext(IO)` is not needed.
- * - [isHeld]: delegates directly to the [released] state.
+ * - [extend] / [extendSuspend]: returns [ExtendOutcome.Extended] (observedExpireAt = [Instant.MAX]) only while
+ *   the delegate is alive and the lease ephemeral znode still exists in ZooKeeper.
+ * - [isHeld]: returns false after [markReleased] or when the lease node is no longer positively observable.
  *
  * ## R16 enforce
  * Group elector always uses `autoExtend=false` — watchdog is disabled.
  */
 internal class ZooKeeperSuspendSlotExtendDelegate(
+    private val client: CuratorFramework,
     private val slotKey: String,
+    leaseNodeName: String,
 ): ExtendDelegate {
 
     companion object: KLoggingChannel()
 
+    private val leasePath = ZooKeeperOwnershipProbe.leaseNodePath(slotKey, leaseNodeName)
     private val released = AtomicBoolean(false)
 
     private val _lastExtendDeadline = AtomicReference(Instant.EPOCH)
@@ -51,14 +54,23 @@ internal class ZooKeeperSuspendSlotExtendDelegate(
             ExtendOutcome.BackendError(e)
         }
 
-    override fun isHeld(): Boolean = !released.get()
+    override fun isHeld(): Boolean =
+        try {
+            isBackendHeld()
+        } catch (e: Exception) {
+            log.warn(e) { "ZooKeeperSuspend group isHeld failed. slotKey=$slotKey" }
+            false
+        }
 
     private fun doExtend(): ExtendOutcome =
         try {
-            if (released.get()) ExtendOutcome.NotHeld
-            else ExtendOutcome.Extended(Instant.MAX)
+            if (isBackendHeld()) ExtendOutcome.Extended(Instant.MAX)
+            else ExtendOutcome.NotHeld
         } catch (e: Exception) {
             log.warn(e) { "ZooKeeperSuspend group extend (passthrough) failed. slotKey=$slotKey" }
             ExtendOutcome.BackendError(e)
         }
+
+    private fun isBackendHeld(): Boolean =
+        !released.get() && ZooKeeperOwnershipProbe.isLiveNode(client, leasePath)
 }

--- a/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/contract/ZooKeeperExtendDelegateReferenceTest.kt
+++ b/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/contract/ZooKeeperExtendDelegateReferenceTest.kt
@@ -1,12 +1,14 @@
 package io.bluetape4k.leader.zookeeper.contract
 
 import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.codec.Base58
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.AopScopeAccess
 import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderLockHandle
 import io.bluetape4k.leader.LockAssert
 import io.bluetape4k.leader.LockExtender
 import io.bluetape4k.leader.zookeeper.AbstractZooKeeperLeaderTest
@@ -15,6 +17,7 @@ import io.bluetape4k.leader.zookeeper.ZooKeeperLeaderGroupElector
 import io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderElector
 import io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderGroupElector
 import io.bluetape4k.logging.coroutines.KLoggingChannel
+import org.apache.curator.utils.ZKPaths
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.time.Instant
@@ -46,6 +49,20 @@ class ZooKeeperExtendDelegateReferenceTest: AbstractZooKeeperLeaderTest() {
     companion object: KLoggingChannel()
 
     private fun randomLockName(): String = "extdelref-zk-${Base58.randomString(8)}"
+
+    private fun deleteChildren(path: String) {
+        curator.children.forPath(path)
+            .forEach { child -> curator.delete().forPath(ZKPaths.makePath(path, child)) }
+    }
+
+    private fun deleteSingleLockNode(lockName: String) {
+        deleteChildren(ZKPaths.makePath(ZooKeeperLeaderElector.DEFAULT_BASE_PATH, lockName))
+    }
+
+    private fun deleteGroupLeaseNode(lockName: String) {
+        val groupPath = ZKPaths.makePath(ZooKeeperLeaderGroupElector.DEFAULT_BASE_PATH, lockName)
+        deleteChildren(ZKPaths.makePath(groupPath, "leases"))
+    }
 
     @Test
     fun `sync single — extendActiveLockDetailed returns Extended inside body (passthrough)`() {
@@ -130,5 +147,71 @@ class ZooKeeperExtendDelegateReferenceTest: AbstractZooKeeperLeaderTest() {
         }
 
         outcomes.forEach { it.shouldBeInstanceOf<ExtendOutcome.Extended>() }
+    }
+
+    @Test
+    fun `sync single — extendActiveLockDetailed returns NotHeld after lock znode loss`() {
+        val elector = ZooKeeperLeaderElector(curator)
+        val lockName = randomLockName()
+
+        var outcome: ExtendOutcome? = null
+        elector.runIfLeader(lockName) {
+            val handle = AopScopeAccess.peekSyncMatching(lockName) as LeaderLockHandle.Real
+            deleteSingleLockNode(lockName)
+            handle.isStillHeld().shouldBeFalse()
+            outcome = LockExtender.extendActiveLockDetailed(60.seconds)
+        }
+
+        outcome.shouldBeInstanceOf<ExtendOutcome.NotHeld>()
+    }
+
+    @Test
+    fun `suspend single — extendActiveLockDetailedSuspend returns NotHeld after lock znode loss`() = runSuspendIO {
+        val elector = ZooKeeperSuspendLeaderElector(curator)
+        val lockName = randomLockName()
+
+        var outcome: ExtendOutcome? = null
+        elector.runIfLeader(lockName) {
+            deleteSingleLockNode(lockName)
+            outcome = LockExtender.extendActiveLockDetailedSuspend(60.seconds)
+        }
+
+        outcome.shouldBeInstanceOf<ExtendOutcome.NotHeld>()
+    }
+
+    @Test
+    fun `sync group — extendActiveLockDetailed returns NotHeld after lease znode loss`() {
+        val elector = ZooKeeperLeaderGroupElector(
+            curator,
+            LeaderGroupElectionOptions(maxLeaders = 2),
+        )
+        val lockName = randomLockName()
+
+        var outcome: ExtendOutcome? = null
+        elector.runIfLeader(lockName) {
+            val handle = AopScopeAccess.peekSyncMatching(lockName) as LeaderLockHandle.Real
+            deleteGroupLeaseNode(lockName)
+            handle.isStillHeld().shouldBeFalse()
+            outcome = LockExtender.extendActiveLockDetailed(60.seconds)
+        }
+
+        outcome.shouldBeInstanceOf<ExtendOutcome.NotHeld>()
+    }
+
+    @Test
+    fun `suspend group — extendActiveLockDetailedSuspend returns NotHeld after lease znode loss`() = runSuspendIO {
+        val elector = ZooKeeperSuspendLeaderGroupElector(
+            curator,
+            LeaderGroupElectionOptions(maxLeaders = 2),
+        )
+        val lockName = randomLockName()
+
+        var outcome: ExtendOutcome? = null
+        elector.runIfLeader(lockName) {
+            deleteGroupLeaseNode(lockName)
+            outcome = LockExtender.extendActiveLockDetailedSuspend(60.seconds)
+        }
+
+        outcome.shouldBeInstanceOf<ExtendOutcome.NotHeld>()
     }
 }


### PR DESCRIPTION
## Summary

Closes #516

PR #550의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: prevent stale ZooKeeper session extension`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary
- Require ZooKeeper extend delegates to verify backend ephemeral-node ownership before returning `Extended(Instant.MAX)`.
- Capture the Curator mutex owner znode path at acquisition time for sync and suspend single-lock electors.
- Pass group lease node names into sync and suspend slot delegates so deleted lease znodes return `NotHeld`.

Closes #516

## Tests
- `./gradlew :bluetape4k-leader-zookeeper:test --tests '*ZooKeeperExtendDelegateReferenceTest*' --no-parallel --no-daemon --console=plain`
- `./gradlew :bluetape4k-leader-zookeeper:test --no-parallel --no-daemon --console=plain`
- `./gradlew :bluetape4k-leader-zookeeper:compileKotlin :bluetape4k-leader-zookeeper:compileTestKotlin --warning-mode all --no-parallel --no-daemon --console=plain`
- `git diff --check`

## DoD Status
- [x] Issue #516 metadata checked: assignee `debop`, milestone `0.5.0`, labels `bug`, `integration`, `test`.
- [x] Added regression tests for sync/suspend single lock and sync/suspend group lease znode loss while the action body is active.
- [x] `extendActiveLock*` returns `NotHeld` after backend ownership loss for single-lock and group paths.
- [x] `isHeld` path verified for sync single/group through `LeaderLockHandle.Real.isStillHeld()` after znode loss.
- [x] ZooKeeper module compile/test verification passed locally with `--no-parallel`.

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #516, milestone `0.5.0`, assignee `debop`
- PR: #550, head `09eb6adf231beba3ac47583b01dcfb8c38ed2373`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
