### PR TITLE
fix: honor etcd keepalive TTL when extending locks

### DIFF
--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/ExtendOutcome.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/ExtendOutcome.kt
@@ -41,6 +41,7 @@ sealed interface ExtendOutcome {
      * - Redisson: Redisson internal atomic — may use client clock → ±50ms
      * - MongoDB: server-side `$$NOW` aggregation → accurate
      * - Exposed JDBC/R2DBC: DB server time (`now()` SQL) → accurate
+     * - etcd: keep-alive response TTL from the server plus local receipt time → bounded by actual lease TTL
      * - ZooKeeper: no TTL concept — `Instant.MAX` (session-held liveness passthrough)
      *
      * Do not use as a precise deadline — intended for observability/logging only.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt
@@ -4,7 +4,6 @@ import io.bluetape4k.leader.coroutines.LockHandleElement
 import io.bluetape4k.leader.internal.LockStateHolder
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
-import java.time.Instant
 import kotlin.coroutines.coroutineContext
 import kotlin.time.Duration
 import kotlin.time.toKotlinDuration
@@ -43,7 +42,7 @@ import kotlin.time.toKotlinDuration
  * ## Concurrency (Watchdog × LockExtender)
  * - Both make atomic backend extend calls → race-free, but **last-write-wins**.
  * - Calling `extendActiveLock(d)` updates [io.bluetape4k.leader.internal.ExtendDelegate.lastExtendDeadline]
- *   → watchdog skips on the next tick if the user deadline is later (R2 mitigation).
+ *   to the backend-observed expiry → watchdog skips only while the renewed lease is still safely ahead (R2 mitigation).
  * - Disable watchdog if precise TTL protection is required (= ShedLock equivalent mode).
  *
  * ## ⚠️ Reactor non-suspend operators not supported (Step 3-P R5)
@@ -191,11 +190,11 @@ object LockExtender : KLogging() {
             return ExtendOutcome.NotHeld
         }
         val real = handle as LeaderLockHandle.Real
-        // ⚠️ Tier 8 T8-H1 — backend extend 호출 후 Extended 일 때만 lastExtendDeadline 갱신.
-        //   pre-extend 갱신 시 backend 가 NotHeld/BackendError 반환해도 watchdog 가 deadline 기준 skip → split-brain.
+        // Update only after a successful backend extend. Use the backend-observed expiry so watchdog skips
+        // never outlive the lease that was actually renewed.
         val outcome = real.extend(lockAtMostFor)
         if (outcome is ExtendOutcome.Extended) {
-            real.extendDelegate.lastExtendDeadline.set(Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds))
+            real.extendDelegate.lastExtendDeadline.set(outcome.observedExpireAt)
         }
         return outcome
     }
@@ -206,10 +205,11 @@ object LockExtender : KLogging() {
             return ExtendOutcome.NotHeld
         }
         val real = handle as LeaderLockHandle.Real
-        // ⚠️ Tier 8 T8-H1 — backend extend 호출 후 Extended 일 때만 lastExtendDeadline 갱신.
+        // Update only after a successful backend extend. Use the backend-observed expiry so watchdog skips
+        // never outlive the lease that was actually renewed.
         val outcome = real.extendSuspend(lockAtMostFor)
         if (outcome is ExtendOutcome.Extended) {
-            real.extendDelegate.lastExtendDeadline.set(Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds))
+            real.extendDelegate.lastExtendDeadline.set(outcome.observedExpireAt)
         }
         return outcome
     }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/ExtendDelegate.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/ExtendDelegate.kt
@@ -18,11 +18,12 @@ import kotlin.time.Duration
  * - `extend` calls the backend atomic extend — implemented by sync backends (Lettuce sync, Redisson, Hazelcast, Exposed JDBC, ZK).
  * - `extendSuspend` default calls sync `extend` directly — **blocking backends must override** using
  *   `withContext(Dispatchers.IO)` + `coroutineContext.ensureActive()` (R9 mitigation).
- * - `lastExtendDeadline` tracks the expire deadline at the time user calls `LockExtender.extendActiveLock(d)` (R2 mitigation).
+ * - `lastExtendDeadline` tracks the backend-observed expire deadline after `LockExtender.extendActiveLock(d)`
+ *   succeeds (R2 mitigation).
  *   If the Watchdog tick finds `now() + watchdogCadence < lastExtendDeadline.get()`, backend extend is skipped.
  *
  * ## R2 Watchdog skip semantics (Step 3-P)
- * User calls `extend(60s)` → `lastExtendDeadline = now + 60s` is updated.
+ * User calls `extend(60s)` → backend returns `Extended(observedExpireAt)` → `lastExtendDeadline = observedExpireAt`.
  * Watchdog cadence = leaseTime/3 (e.g. 10s for 30s lease). On tick, if `now + 10s < deadline`, skip.
  * → Prevents user-extended lease from being silently shortened by the watchdog (split-brain guard).
  */
@@ -49,7 +50,7 @@ interface ExtendDelegate {
     /**
      * Tracks the expire deadline of user explicit extend calls (R2 mitigation).
      *
-     * `LockExtender.extendActiveLock(d)` sets: `now() + d`.
+     * `LockExtender.extendActiveLock(d)` sets this to [ExtendOutcome.Extended.observedExpireAt].
      * Watchdog reads: if `now() + cadence < lastExtendDeadline.get()`, backend call is skipped.
      *
      * **Implementation rule**: must return the stored `AtomicReference<Instant>` instance.

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LockExtenderTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LockExtenderTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.leader.coroutines.LockHandleElement
 import io.bluetape4k.leader.internal.ExtendDelegate
@@ -239,24 +240,14 @@ class LockExtenderTest {
     // --- R2 mitigation: lastExtendDeadline update ---
 
     @Test
-    fun `extendActiveLock sets lastExtendDeadline to approximately now plus duration (R2)`() {
-        val delegate = FakeDelegate(ExtendOutcome.Extended(Instant.now()))
-        val beforeCall = Instant.now()
+    fun `extendActiveLock sets lastExtendDeadline to backend observed expireAt (R2)`() {
+        val observedExpireAt = Instant.now().plusSeconds(5)
+        val delegate = FakeDelegate(ExtendOutcome.Extended(observedExpireAt))
         LockStateHolder.withPushed(realHandle(delegate = delegate)) {
             LockExtender.extendActiveLock(60.seconds)
         }
-        val afterCall = Instant.now()
 
-        val deadline = delegate.lastExtendDeadline.get()
-        val expectedMin = beforeCall.plusSeconds(59)   // some tolerance
-        val expectedMax = afterCall.plusSeconds(61)    // some tolerance
-
-        assert(!deadline.isBefore(expectedMin)) {
-            "lastExtendDeadline=$deadline is before expected minimum=$expectedMin"
-        }
-        assert(!deadline.isAfter(expectedMax)) {
-            "lastExtendDeadline=$deadline is after expected maximum=$expectedMax"
-        }
+        delegate.lastExtendDeadline.get() shouldBeEqualTo observedExpireAt
     }
 
     // --- suspend variants ---
@@ -330,6 +321,21 @@ class LockExtenderTest {
         }
 
         delegate.lastExtendDeadline.get() shouldBeEqualTo Instant.EPOCH
+        delegate.suspendExtendCalls.get() shouldBeEqualTo 1
+        delegate.syncExtendCalls.get() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `extendActiveLockDetailedSuspend sets lastExtendDeadline to backend observed expireAt`() = runTest {
+        val observedExpireAt = Instant.now().plusSeconds(5)
+        val delegate = FakeSuspendDelegate(ExtendOutcome.Extended(observedExpireAt))
+
+        withContext(LockHandleElement(realHandle(delegate = delegate))) {
+            val outcome = LockExtender.extendActiveLockDetailedSuspend(60.seconds)
+            outcome.shouldBeInstanceOf<ExtendOutcome.Extended>()
+        }
+
+        delegate.lastExtendDeadline.get() shouldBeEqualTo observedExpireAt
         delegate.suspendExtendCalls.get() shouldBeEqualTo 1
         delegate.syncExtendCalls.get() shouldBeEqualTo 0
     }

--- a/leader-etcd/src/main/kotlin/io/bluetape4k/leader/etcd/internal/EtcdLockExtendDelegate.kt
+++ b/leader-etcd/src/main/kotlin/io/bluetape4k/leader/etcd/internal/EtcdLockExtendDelegate.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.leader.etcd.internal
 import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.internal.ExtendDelegate
 import io.bluetape4k.leader.internal.SuspendExtendDelegate
+import io.etcd.jetcd.lease.LeaseKeepAliveResponse
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.future.await
 import java.time.Instant
@@ -23,8 +24,7 @@ internal class EtcdLockExtendDelegate(
         }
 
         return runCatching {
-            lockClient.keepAliveOnce(handle.leaseId).get(10, TimeUnit.SECONDS)
-            ExtendOutcome.Extended(Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds))
+            lockClient.keepAliveOnce(handle.leaseId).get(10, TimeUnit.SECONDS).toExtendOutcome()
         }.getOrElse { e ->
             if (EtcdBackendErrorClassifier.isExpectedCleanup(e)) {
                 ExtendOutcome.NotHeld
@@ -36,8 +36,7 @@ internal class EtcdLockExtendDelegate(
 
     override fun isHeld(): Boolean =
         !handle.isReleased && runCatching {
-            lockClient.keepAliveOnce(handle.leaseId).get(10, TimeUnit.SECONDS)
-            true
+            lockClient.keepAliveOnce(handle.leaseId).get(10, TimeUnit.SECONDS).getTTL() > 0L
         }.getOrDefault(false)
 
     override val lastExtendDeadline: AtomicReference<Instant>
@@ -57,8 +56,7 @@ internal class EtcdSuspendLockExtendDelegate(
         }
 
         return try {
-            lockClient.keepAliveOnce(handle.leaseId).await()
-            ExtendOutcome.Extended(Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds))
+            lockClient.keepAliveOnce(handle.leaseId).await().toExtendOutcome()
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -72,8 +70,7 @@ internal class EtcdSuspendLockExtendDelegate(
 
     override suspend fun isHeldSuspend(): Boolean =
         !handle.isReleased && try {
-            lockClient.keepAliveOnce(handle.leaseId).await()
-            true
+            lockClient.keepAliveOnce(handle.leaseId).await().getTTL() > 0L
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -86,3 +83,12 @@ internal class EtcdSuspendLockExtendDelegate(
 
 private fun Throwable.asException(): Exception =
     this as? Exception ?: RuntimeException(this)
+
+private fun LeaseKeepAliveResponse.toExtendOutcome(): ExtendOutcome {
+    val ttlSeconds = getTTL()
+    return if (ttlSeconds > 0L) {
+        ExtendOutcome.Extended(Instant.now().plusSeconds(ttlSeconds))
+    } else {
+        ExtendOutcome.NotHeld
+    }
+}

--- a/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdLeaderElectorIntegrationTest.kt
+++ b/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdLeaderElectorIntegrationTest.kt
@@ -1,12 +1,18 @@
 package io.bluetape4k.leader.etcd
 
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeLessOrEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LockAssert
 import io.bluetape4k.leader.LockExtender
 import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -112,6 +118,31 @@ class EtcdLeaderElectorIntegrationTest: AbstractEtcdLeaderTest() {
             }
 
             extended shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `extendActiveLockDetailed reports etcd keepalive TTL instead of requested duration`() {
+        newClient().use { client ->
+            val options = EtcdLeaderElectionOptions(
+                leaderOptions = LeaderElectionOptions(waitTime = 2.seconds, leaseTime = 3.seconds),
+                keyPrefix = "/bluetape4k/leader/test/${randomName()}",
+            )
+            val elector = EtcdLeaderElector(client, options)
+
+            val outcome = checkNotNull(elector.runIfLeader(randomName()) {
+                val beforeExtend = Instant.now()
+                val result = LockExtender.extendActiveLockDetailed(60.seconds)
+                beforeExtend to result
+            })
+
+            val result = outcome.second
+            result.shouldBeInstanceOf<ExtendOutcome.Extended>()
+
+            val observedMillis = Duration.between(outcome.first, (result as ExtendOutcome.Extended).observedExpireAt)
+                .toMillis()
+            observedMillis shouldBeGreaterOrEqualTo 0L
+            observedMillis shouldBeLessOrEqualTo 6_000L
         }
     }
 

--- a/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdSuspendLeaderElectorIntegrationTest.kt
+++ b/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdSuspendLeaderElectorIntegrationTest.kt
@@ -2,8 +2,12 @@ package io.bluetape4k.leader.etcd
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeLessOrEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LockAssert
 import io.bluetape4k.leader.LockExtender
@@ -12,6 +16,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -110,6 +116,31 @@ class EtcdSuspendLeaderElectorIntegrationTest: AbstractEtcdLeaderTest() {
             }
 
             extended shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `extendActiveLockDetailedSuspend reports etcd keepalive TTL instead of requested duration`() = runSuspendIO {
+        newClient().use { client ->
+            val options = EtcdLeaderElectionOptions(
+                leaderOptions = LeaderElectionOptions(waitTime = 2.seconds, leaseTime = 3.seconds),
+                keyPrefix = "/bluetape4k/leader/test/${randomName()}",
+            )
+            val elector = EtcdSuspendLeaderElector(client, options)
+
+            val outcome = checkNotNull(elector.runIfLeader(randomName()) {
+                val beforeExtend = Instant.now()
+                val result = LockExtender.extendActiveLockDetailedSuspend(60.seconds)
+                beforeExtend to result
+            })
+
+            val result = outcome.second
+            result.shouldBeInstanceOf<ExtendOutcome.Extended>()
+
+            val observedMillis = Duration.between(outcome.first, (result as ExtendOutcome.Extended).observedExpireAt)
+                .toMillis()
+            observedMillis shouldBeGreaterOrEqualTo 0L
+            observedMillis shouldBeLessOrEqualTo 6_000L
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #517

PR #551의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: honor etcd keepalive TTL when extending locks`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary
- Fix etcd lock extension to compute `ExtendOutcome.Extended.observedExpireAt` from `LeaseKeepAliveResponse.getTTL()` instead of the caller-requested duration.
- Propagate backend-observed expiry into `ExtendDelegate.lastExtendDeadline` so watchdog skip windows cannot outlive the actual renewed lease.
- Add sync and suspend etcd integration coverage for short lease TTL with a long explicit extension request.

Fixes #517

## Verification
- RED check: `./gradlew :bluetape4k-leader-core:test --tests 'io.bluetape4k.leader.LockExtenderTest.extendActiveLock sets lastExtendDeadline to backend observed expireAt (R2)' --no-daemon --console=plain` failed before the fix because `lastExtendDeadline` was set to the requested 60s duration.
- `./gradlew :bluetape4k-leader-core:test --tests 'io.bluetape4k.leader.LockExtenderTest.extendActiveLock sets lastExtendDeadline to backend observed expireAt (R2)' --tests 'io.bluetape4k.leader.LockExtenderTest.extendActiveLockDetailedSuspend sets lastExtendDeadline to backend observed expireAt' --no-daemon --console=plain`
- `./gradlew :bluetape4k-leader-etcd:test --tests 'io.bluetape4k.leader.etcd.EtcdLeaderElectorIntegrationTest.extendActiveLockDetailed reports etcd keepalive TTL instead of requested duration' --tests 'io.bluetape4k.leader.etcd.EtcdSuspendLeaderElectorIntegrationTest.extendActiveLockDetailedSuspend reports etcd keepalive TTL instead of requested duration' --no-parallel --no-daemon --console=plain`
- `./gradlew :bluetape4k-leader-core:test :bluetape4k-leader-etcd:test --no-parallel --warning-mode all --no-daemon --console=plain`
- `git diff --check`

## Step DoD
| Step | Status | Evidence |
|---|---:|---|
| W: issue and baseline | PASS | #517 is open in milestone `0.5.0`, labels `bug`, `integration`, `test`, assignee `debop`; current code used requested duration for etcd observed expiry. |
| A: root cause | PASS | `EtcdLockExtendDelegate` ignored `LeaseKeepAliveResponse.getTTL()` and `LockExtender` overwrote `lastExtendDeadline` with `now + lockAtMostFor`. |
| F: fix | PASS | etcd sync/suspend delegates now return TTL-based observed expiry; common deadline propagation uses `Extended.observedExpireAt`. |
| 4-T: tests | PASS | Added core deadline propagation tests and etcd sync/suspend integration tests for 3s lease + 60s extension request. |
| 6-R: review | PASS | Local diff review done; CodeGraph detected 7 changed files and no registered affected flows. |
| README/docs | PASS | No README change needed; public API surface unchanged, KDoc contract updated. |
| Lessons | PASS | Narrow bug fix; issue, tests, commit, and PR capture the durable rule. |
| Validation | PASS | Core + etcd tests pass with `--no-parallel --warning-mode all`; `git diff --check` passes. |

## DoD Status
- [x] Sync etcd explicit extension uses server-reported keep-alive TTL.
- [x] Suspend etcd explicit extension uses server-reported keep-alive TTL.
- [x] Watchdog skip deadline is bounded by backend-observed expiry.
- [x] Targeted regression tests cover requested 60s extension over a shorter etcd lease.
- [x] PR metadata mirrors issue #517 milestone, labels, and assignee.

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #517, milestone `0.5.0`, assignee `debop`
- PR: #551, head `414b2a87aef5e2ca238266941eceecfaf973fc46`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
