### PR TITLE
fix: isolate Spring Boot backend test clients

### DIFF
--- a/docs/lessons/2026-07-02-issue-519-spring-boot-container-isolation.md
+++ b/docs/lessons/2026-07-02-issue-519-spring-boot-container-isolation.md
@@ -1,0 +1,24 @@
+# Lessons Learned — Issue 519 Spring Boot Testcontainer Isolation (2026-07-02)
+
+**Related issue**: #519
+**Affected module**: `bluetape4k-leader-spring-boot`
+
+## L1: Fault-injection tests must not hold shared backend clients
+
+### Problem
+
+`FailOpenRunIntegrationTest` verified `FAIL_OPEN_RUN` behavior with a Redis/ToxiProxy fault-injection path, while the same class also held a shared `RedisServer.Launcher.redis` client and connection through companion lazy properties. Later Spring Boot auto-configuration tests also cached Lettuce and Mongo clients in static lazy properties. A full module run could then observe stale backend connections or a not-started shared container state after the fault-injection scenario.
+
+### Lesson
+
+Keep singleton Testcontainers launchers as backend providers only. Do not cache mutable backend clients or connections in static test properties when Spring contexts or network fault injection are involved. Let the Spring test context own clients and connections through beans with explicit destroy methods, and use non-reusable, test-owned containers for fault-injection scenarios that mutate connectivity.
+
+### Verification
+
+- `./gradlew :bluetape4k-leader-spring-boot:compileTestKotlin --no-daemon --console=plain --warning-mode all`
+- `./gradlew :bluetape4k-leader-spring-boot:test --tests 'io.bluetape4k.leader.spring.aop.FailOpenRunIntegrationTest' --tests 'io.bluetape4k.leader.spring.aop.autoconfigure.LettuceAopFactoryAutoConfigurationTest' --tests 'io.bluetape4k.leader.spring.aop.autoconfigure.MongoAopFactoryAutoConfigurationTest' --tests 'io.bluetape4k.leader.spring.aop.autoconfigure.RedissonAopFactoryAutoConfigurationTest' --no-build-cache --rerun-tasks --no-parallel --no-daemon --console=plain --warning-mode all`
+- `./gradlew :bluetape4k-leader-spring-boot:test --no-build-cache --rerun-tasks --no-parallel --no-daemon --console=plain --warning-mode all`
+
+### Future Guard
+
+If a test changes container connectivity, proxy state, or backend process lifecycle, it should not reuse shared launcher clients. `MultithreadingTester` is not the right proof for this class of failure because the risk is external Testcontainers/Spring context lifecycle ordering, not an in-process thread-safety race; verify it with real Gradle Testcontainers runs instead.

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/FailOpenRunIntegrationTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/FailOpenRunIntegrationTest.kt
@@ -12,7 +12,6 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.closeSafe
 import io.bluetape4k.testcontainers.infra.ToxiproxyServer
 import io.bluetape4k.testcontainers.storage.RedisServer
-import io.bluetape4k.utils.ShutdownQueue
 import io.lettuce.core.RedisClient
 import io.lettuce.core.SetArgs
 import io.lettuce.core.api.StatefulRedisConnection
@@ -23,6 +22,7 @@ import io.mockk.mockk
 import io.bluetape4k.assertions.shouldBeEqualTo
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.reflect.MethodSignature
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -49,19 +49,9 @@ class FailOpenRunIntegrationTest {
         private const val CONTENTION_LOCK = "fail-open-it-contention"
         private const val BACKEND_LOCK = "fail-open-it-backend"
 
-        private val redis = RedisServer.Launcher.redis
-
-        private val client: RedisClient by lazy {
-            RedisClient.create(redis.url).also {
-                ShutdownQueue.register { runCatching { it.shutdown() } }
-            }
-        }
-
-        private val connection: StatefulRedisConnection<String, String> by lazy {
-            client.connect(StringCodec.UTF8).also {
-                ShutdownQueue.register { it.closeSafe() }
-            }
-        }
+        private val redis = RedisServer(reuse = false).also { it.start() }
+        private val client: RedisClient = RedisClient.create(redis.url)
+        private val connection: StatefulRedisConnection<String, String> = client.connect(StringCodec.UTF8)
     }
 
     // ── 경쟁 시나리오용 ──
@@ -89,6 +79,13 @@ class FailOpenRunIntegrationTest {
     @BeforeEach
     fun setUp() {
         clearMocks(signature, pjp, beanSelector)
+    }
+
+    @AfterAll
+    fun tearDown() {
+        runCatching { connection.closeSafe() }
+        runCatching { client.shutdown() }
+        runCatching { redis.close() }
     }
 
     private fun configureJoinPoint(method: java.lang.reflect.Method, target: Any) {
@@ -155,11 +152,11 @@ class FailOpenRunIntegrationTest {
     fun `FAIL_OPEN_RUN - ToxiProxy 장애 주입으로 Redis 차단 시 본문 실행`() {
         // ToxiProxy → Redis 연결을 별도 Docker 네트워크에서 구성 후 프록시 삭제로 장애 주입
         Network.newNetwork().use { network ->
-            RedisServer()
+            RedisServer(reuse = false)
                 .withNetwork(network)
                 .withNetworkAliases("redis")
                 .use { redisContainer ->
-                    ToxiproxyServer()
+                    ToxiproxyServer(reuse = false)
                         .withNetwork(network)
                         .use { toxiproxy ->
                             redisContainer.start()

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/autoconfigure/LettuceAopFactoryAutoConfigurationTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/autoconfigure/LettuceAopFactoryAutoConfigurationTest.kt
@@ -10,9 +10,7 @@ import io.bluetape4k.leader.lettuce.LettuceSuspendLeaderElectorFactory
 import io.bluetape4k.leader.lettuce.LettuceSuspendLeaderGroupElectorFactory
 import io.bluetape4k.leader.spring.LeaderTestApplication
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.support.closeSafe
 import io.bluetape4k.testcontainers.storage.RedisServer
-import io.bluetape4k.utils.ShutdownQueue
 import io.lettuce.core.RedisClient
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.codec.StringCodec
@@ -42,24 +40,16 @@ class LettuceAopFactoryAutoConfigurationTest {
 
     companion object : KLogging() {
         val redis = RedisServer.Launcher.redis
-
-        val redisClient: RedisClient by lazy {
-            RedisClient.create(redis.url).also {
-                ShutdownQueue.register { runCatching { it.shutdown() } }
-            }
-        }
-
-        val redisConnection: StatefulRedisConnection<String, String> by lazy {
-            redisClient.connect(StringCodec.UTF8).also {
-                ShutdownQueue.register { it.closeSafe() }
-            }
-        }
     }
 
     @TestConfiguration
     open class TestConfig {
-        @Bean
-        fun statefulRedisConnection(): StatefulRedisConnection<String, String> = redisConnection
+        @Bean(destroyMethod = "shutdown")
+        fun redisClient(): RedisClient = RedisClient.create(redis.url)
+
+        @Bean(destroyMethod = "close")
+        fun statefulRedisConnection(redisClient: RedisClient): StatefulRedisConnection<String, String> =
+            redisClient.connect(StringCodec.UTF8)
     }
 
     @Autowired

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/autoconfigure/MongoAopFactoryAutoConfigurationTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/autoconfigure/MongoAopFactoryAutoConfigurationTest.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.leader.spring.aop.autoconfigure
 
+import com.mongodb.client.MongoClient
+import com.mongodb.kotlin.client.coroutine.MongoClient as CoroutineMongoClient
 import io.bluetape4k.leader.LeaderElectorFactory
 import io.bluetape4k.leader.LeaderGroupElectorFactory
 import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
@@ -12,7 +14,6 @@ import io.bluetape4k.leader.mongodb.lock.MongoLock
 import io.bluetape4k.leader.spring.LeaderTestApplication
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.testcontainers.storage.MongoDBServer
-import io.bluetape4k.utils.ShutdownQueue
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import org.bson.Document
 import org.junit.jupiter.api.Test
@@ -23,6 +24,8 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
+
+private const val LEADER_AOP_AUTOCONFIG_DB = "leader_aop_autoconfig_test"
 
 /**
  * [LeaderAopFactoryAutoConfiguration.MongoFactoryConfig] / [LeaderAopFactoryAutoConfiguration.MongoSuspendFactoryConfig]
@@ -41,40 +44,37 @@ class MongoAopFactoryAutoConfigurationTest {
 
     companion object : KLogging() {
         val mongoServer = MongoDBServer.Launcher.mongoDB
-
-        val mongoClient by lazy {
-            MongoDBServer.Launcher.getClient().also {
-                ShutdownQueue.register { it.close() }
-            }
-        }
-
-        val coroutineMongoClient by lazy {
-            MongoDBServer.Launcher.getCoroutineClient().also {
-                ShutdownQueue.register { it.close() }
-            }
-        }
-
-        private val db by lazy { mongoClient.getDatabase("leader_aop_autoconfig_test") }
-        private val coroutineDb by lazy { coroutineMongoClient.getDatabase("leader_aop_autoconfig_test") }
     }
 
     @TestConfiguration
     open class TestConfig {
+        @Bean(destroyMethod = "close")
+        fun mongoClient(): MongoClient =
+            MongoDBServer.Launcher.getClient(mongoServer.url)
+
+        @Bean(destroyMethod = "close")
+        fun coroutineMongoClient(): CoroutineMongoClient =
+            MongoDBServer.Launcher.getCoroutineClient(mongoServer.url)
+
         @Bean(name = ["leaderLockMongoCollection"])
-        fun leaderLockMongoCollection(): com.mongodb.client.MongoCollection<Document> =
-            db.getCollection(MongoLock.LOCK_COLLECTION_NAME)
+        fun leaderLockMongoCollection(mongoClient: MongoClient): com.mongodb.client.MongoCollection<Document> =
+            mongoClient.getDatabase(LEADER_AOP_AUTOCONFIG_DB).getCollection(MongoLock.LOCK_COLLECTION_NAME)
 
         @Bean(name = ["leaderGroupLockMongoCollection"])
-        fun leaderGroupLockMongoCollection(): com.mongodb.client.MongoCollection<Document> =
-            db.getCollection(MongoLock.GROUP_LOCK_COLLECTION_NAME)
+        fun leaderGroupLockMongoCollection(mongoClient: MongoClient): com.mongodb.client.MongoCollection<Document> =
+            mongoClient.getDatabase(LEADER_AOP_AUTOCONFIG_DB).getCollection(MongoLock.GROUP_LOCK_COLLECTION_NAME)
 
         @Bean(name = ["leaderLockMongoCoroutineCollection"])
-        fun leaderLockMongoCoroutineCollection(): com.mongodb.kotlin.client.coroutine.MongoCollection<Document> =
-            coroutineDb.getCollection(MongoLock.LOCK_COLLECTION_NAME)
+        fun leaderLockMongoCoroutineCollection(
+            coroutineMongoClient: CoroutineMongoClient,
+        ): com.mongodb.kotlin.client.coroutine.MongoCollection<Document> =
+            coroutineMongoClient.getDatabase(LEADER_AOP_AUTOCONFIG_DB).getCollection(MongoLock.LOCK_COLLECTION_NAME)
 
         @Bean(name = ["leaderGroupLockMongoCoroutineCollection"])
-        fun leaderGroupLockMongoCoroutineCollection(): com.mongodb.kotlin.client.coroutine.MongoCollection<Document> =
-            coroutineDb.getCollection(MongoLock.GROUP_LOCK_COLLECTION_NAME)
+        fun leaderGroupLockMongoCoroutineCollection(
+            coroutineMongoClient: CoroutineMongoClient,
+        ): com.mongodb.kotlin.client.coroutine.MongoCollection<Document> =
+            coroutineMongoClient.getDatabase(LEADER_AOP_AUTOCONFIG_DB).getCollection(MongoLock.GROUP_LOCK_COLLECTION_NAME)
     }
 
     @Autowired


### PR DESCRIPTION
## Summary

Closes #519

PR #553의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: isolate Spring Boot backend test clients`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
Fixes #519

## Background

The Spring Boot integration module could fail a full test run after the `FAIL_OPEN_RUN` ToxiProxy scenario. The failing evidence pointed to stale backend client state: Lettuce/Redisson connection failures against shared Redis and a MongoDB container-not-started failure in later auto-configuration tests.

## What This Solves

This PR isolates mutable test backend resources from shared singleton launchers:

- `FailOpenRunIntegrationTest` now owns its Redis client/connection lifecycle and uses non-reusable Redis/ToxiProxy containers for fault injection.
- Lettuce auto-configuration tests now let the Spring context create and destroy Redis client/connection beans.
- Mongo auto-configuration tests now let the Spring context create and destroy Mongo clients instead of caching them in companion lazy properties.
- A lesson records the rule that fault-injection tests must not hold shared backend clients.

## Validation Notes

- `MultithreadingTester` was not used because this failure is external Testcontainers/Spring context lifecycle ordering, not in-process thread safety. The verification uses real Gradle Testcontainers runs instead.
- CodeGraph review context reported low risk and 0 impacted nodes for the changed test/docs files.
- Local review found P0/P1 = 0.

## DoD Status

| Step | Status | Evidence |
|------|--------|----------|
| Step 1 - Review | PASS | Issue #519 evidence confirmed shared client/container lifecycle risk in `FailOpenRunIntegrationTest`, Lettuce auto-config test, and Mongo auto-config test. |
| Step 2 - Issue | PASS | Fixes #519, milestone 0.5.0, labels bug/integration/test/spring. |
| Step 3 - Fix | PASS | Commit `e0207c7` isolates fault-injection containers and moves Lettuce/Mongo clients to Spring-owned beans. |
| Step 4 - Test | PASS | `:bluetape4k-leader-spring-boot:compileTestKotlin` succeeded. |
| Step 4 - Targeted Test | PASS | 4-class subset executed 27 tests successfully, then repeated successfully after the full module run. |
| Step 4 - Full Test | PASS | `:bluetape4k-leader-spring-boot:test --no-build-cache --rerun-tasks --no-parallel --no-daemon --console=plain --warning-mode all` executed 335 tests successfully. |
| Step 5 - Lessons | PASS | `docs/lessons/2026-07-02-issue-519-spring-boot-container-isolation.md`. |
| Step 6 - PR Metadata | PASS | Assignee `debop`; milestone `0.5.0`; labels `bug`, `integration`, `test`, `spring`. |
| Step 7 - Review | PASS | P0/P1 = 0; CodeGraph review context risk low / impacted nodes 0. |
| Step 8 - CI Gate | PASS | PR #553 checks: CI Status, Build, Coverage, `Test / leader-spring-boot (Testcontainers)`, gitleaks, wrapper validation, and dependency submission passed; unrelated matrix jobs skipped. |

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #519, milestone `0.5.0`, assignee `debop`
- PR: #553, head `e0207c7ffa742dfeedc11df106da22afe29ab7f0`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
