### PR TITLE
fix: preserve suspend cancellation propagation

### DIFF
--- a/docs/review/2026-07-04-suspend-cancellation-review.md
+++ b/docs/review/2026-07-04-suspend-cancellation-review.md
@@ -1,0 +1,55 @@
+# Suspend cancellation review
+
+Date: 2026-07-04
+
+Scope:
+- Issues: #568, #569
+- Modules: `leader-core`, `leader-exposed-r2dbc`, `leader-redis-lettuce`, `leader-redis-redisson`
+- Packages:
+  - `io.bluetape4k.leader.local`
+  - `io.bluetape4k.leader.exposed.r2dbc.lock`
+  - `io.bluetape4k.leader.lettuce`
+  - `io.bluetape4k.leader.redisson`
+
+## Findings
+
+1. `ExposedR2dbcLock.isHeldByCurrentInstance()` and `unlock()` wrapped `suspendTransaction` with `runCatching`.
+   This converted coroutine cancellation into a logged fallback result.
+2. `ExposedR2dbcGroupLock.isHeldByCurrentInstance()` and `unlock()` had the same suspend `runCatching` pattern.
+3. Suspend strategic electors logged `updateResult` failures through `runCatching`, which could also swallow cancellation while recording success or failure.
+4. Synchronous strategic electors still use `runCatching`, but they do not call suspend APIs and are outside the coroutine-cancellation scope of this review.
+
+## Changes
+
+- Replaced suspend `runCatching` blocks with explicit `try/catch`.
+- Re-throw `CancellationException` before non-cancellation error handling.
+- Catch `Exception` for backend/logged fallbacks instead of broad `Throwable`.
+- Extracted package-internal cancellation-preserving helpers so regression tests can force cancellation and non-cancellation failures directly.
+- Kept previous non-cancellation fallback behavior:
+  - R2DBC `isHeldByCurrentInstance()` returns `false` on DB errors.
+  - R2DBC `unlock()` logs backend errors without deleting another owner's lock.
+  - Strategic elector result-update errors are logged without hiding the action result unless cancellation occurs.
+
+## Pattern Review
+
+- `bluetape4k-code-patterns`: PASS
+  - No `runCatching` around suspend calls remains in the affected suspend paths.
+  - `CancellationException` is rethrown before generic exception handling.
+  - No production `runBlocking` added.
+  - No `!!` added.
+  - No public API shape changed.
+
+## Verification
+
+- `./gradlew :bluetape4k-leader-core:compileKotlin :bluetape4k-leader-core:compileTestKotlin :bluetape4k-leader-exposed-r2dbc:compileKotlin :bluetape4k-leader-exposed-r2dbc:compileTestKotlin :bluetape4k-leader-redis-lettuce:compileKotlin :bluetape4k-leader-redis-lettuce:compileTestKotlin :bluetape4k-leader-redis-redisson:compileKotlin :bluetape4k-leader-redis-redisson:compileTestKotlin --warning-mode all`
+  - PASS, `BUILD SUCCESSFUL in 13s`.
+- `./gradlew :bluetape4k-leader-core:test --tests 'io.bluetape4k.leader.local.LocalStrategicSuspendLeaderElectorTest' --warning-mode all`
+  - PASS, 14 tests.
+- `./gradlew :bluetape4k-leader-exposed-r2dbc:test --tests 'io.bluetape4k.leader.exposed.r2dbc.lock.R2dbcLockCancellationTest' --tests 'io.bluetape4k.leader.exposed.r2dbc.lock.ExposedR2dbcLockTest' --tests 'io.bluetape4k.leader.exposed.r2dbc.lock.ExposedR2dbcGroupLockTest' --warning-mode all --rerun-tasks`
+  - PASS, 74 tests across H2, PostgreSQL, and MySQL, including `R2dbcLockCancellationTest`.
+- `./gradlew :bluetape4k-leader-redis-lettuce:test --tests 'io.bluetape4k.leader.lettuce.LettuceStrategicSuspendLeaderElectorTest' --warning-mode all`
+  - PASS, 17 tests.
+- `./gradlew :bluetape4k-leader-redis-redisson:test --tests 'io.bluetape4k.leader.redisson.RedissonStrategicSuspendLeaderElectorTest' --warning-mode all`
+  - PASS, 11 tests.
+- Static scan:
+  - `runCatching` remains only in synchronous strategic elector implementations for this search pattern.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElector.kt
@@ -84,15 +84,44 @@ class LocalStrategicSuspendLeaderElector(
 
         return try {
             val value = action()
-            runCatching { updateResult(lockName, nodeId, CandidateResult.SUCCESS) }
-                .onFailure { log.warn(it) { "[$lockName] successCount 업데이트 실패 — 무시됨" } }
+            updateStrategicResultPreservingCancellation(
+                lockName = lockName,
+                result = CandidateResult.SUCCESS,
+                update = { updateResult(lockName, nodeId, CandidateResult.SUCCESS) },
+                onFailure = { e, message -> log.warn(e) { message } },
+            )
             value
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            runCatching { updateResult(lockName, nodeId, CandidateResult.FAILURE) }
-                .onFailure { log.warn(it) { "[$lockName] failureCount 업데이트 실패 — 무시됨" } }
+            updateStrategicResultPreservingCancellation(
+                lockName = lockName,
+                result = CandidateResult.FAILURE,
+                update = { updateResult(lockName, nodeId, CandidateResult.FAILURE) },
+                onFailure = { e, message -> log.warn(e) { message } },
+            )
             throw e
         }
     }
 }
+
+internal suspend fun updateStrategicResultPreservingCancellation(
+    lockName: String,
+    result: CandidateResult,
+    update: suspend () -> Unit,
+    onFailure: (Exception, String) -> Unit,
+) {
+    try {
+        update()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        onFailure(e, "[$lockName] ${result.logFieldName} 업데이트 실패 — 무시됨")
+    }
+}
+
+private val CandidateResult.logFieldName: String
+    get() = when (this) {
+        CandidateResult.SUCCESS -> "successCount"
+        CandidateResult.FAILURE -> "failureCount"
+    }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElectorTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElectorTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.local
 
 import io.bluetape4k.codec.Base58
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.LeaderElectionException
 import io.bluetape4k.leader.strategy.CandidateInfo
@@ -8,6 +9,7 @@ import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
 import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
 import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -95,6 +97,42 @@ class LocalStrategicSuspendLeaderElectorTest {
         caughtCancellation.shouldBeTrue()
         val candidate = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
         candidate.failureCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `updateResult cancellation - CancellationException 재전파`() = runSuspendIO {
+        val cancellation = CancellationException("cancel update")
+
+        val thrown = assertFailsWith<CancellationException> {
+            updateStrategicResultPreservingCancellation(
+                lockName = lockName,
+                result = CandidateResult.SUCCESS,
+                update = { throw cancellation },
+                onFailure = { _, _ -> error("CancellationException must not be handled as a backend failure") },
+            )
+        }
+
+        thrown shouldBeEqualTo cancellation
+    }
+
+    @Test
+    fun `updateResult exception - 일반 예외는 fallback 으로 처리`() = runSuspendIO {
+        val failure = IllegalStateException("update failed")
+        var handledFailure: Exception? = null
+        var handledMessage: String? = null
+
+        updateStrategicResultPreservingCancellation(
+            lockName = lockName,
+            result = CandidateResult.FAILURE,
+            update = { throw failure },
+            onFailure = { e, message ->
+                handledFailure = e
+                handledMessage = message
+            },
+        )
+
+        handledFailure shouldBeEqualTo failure
+        handledMessage shouldBeEqualTo "[$lockName] failureCount 업데이트 실패 — 무시됨"
     }
 
     @Test

--- a/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcGroupLock.kt
+++ b/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcGroupLock.kt
@@ -174,23 +174,26 @@ internal class ExposedR2dbcGroupLock internal constructor(
      *
      * Returns `false` if the lease has expired and another instance has re-acquired it.
      */
-    suspend fun isHeldByCurrentInstance(): Boolean = runCatching {
-        suspendTransaction(db) {
-            val now = Instant.now()
-            !LeaderGroupLockTable
-                .selectAll()
-                .where {
-                    (LeaderGroupLockTable.lockName eq lockName) and
-                            (LeaderGroupLockTable.slot eq slot) and
-                            (LeaderGroupLockTable.token eq token) and
-                            (LeaderGroupLockTable.lockedUntil greater now)
-                }
-                .empty()
+    suspend fun isHeldByCurrentInstance(): Boolean =
+        runR2dbcLockOperationPreservingCancellation(
+            onFailure = { e ->
+                log.warn(e) { "isHeldByCurrentInstance DB 오류 (false 반환): lockName=$lockName, slot=$slot" }
+                false
+            },
+        ) {
+            suspendTransaction(db) {
+                val now = Instant.now()
+                !LeaderGroupLockTable
+                    .selectAll()
+                    .where {
+                        (LeaderGroupLockTable.lockName eq lockName) and
+                                (LeaderGroupLockTable.slot eq slot) and
+                                (LeaderGroupLockTable.token eq token) and
+                                (LeaderGroupLockTable.lockedUntil greater now)
+                    }
+                    .empty()
+            }
         }
-    }.getOrElse { e ->
-        log.warn(e) { "isHeldByCurrentInstance DB 오류 (false 반환): lockName=$lockName, slot=$slot" }
-        false
-    }
 
     /**
      * Releases the slot lock held by the current instance.
@@ -206,7 +209,11 @@ internal class ExposedR2dbcGroupLock internal constructor(
         val tokenVal = this@ExposedR2dbcGroupLock.token
         val remaining = remainingMinLeaseTime(acquiredAtNanos, minLeaseTime)
 
-        runCatching {
+        runR2dbcLockOperationPreservingCancellation(
+            onFailure = { e ->
+                log.warn(e) { "그룹 슬롯 해제 중 DB 오류: lockName=$lockName, slot=$slot" }
+            },
+        ) {
             val matched = suspendTransaction(db) {
                 if (remaining > Duration.ZERO) {
                     LeaderGroupLockTable.update(
@@ -231,8 +238,6 @@ internal class ExposedR2dbcGroupLock internal constructor(
             } else {
                 log.debug { "그룹 슬롯 해제 성공: lockName=$lockName, slot=$slot" }
             }
-        }.onFailure { e ->
-            log.warn(e) { "그룹 슬롯 해제 중 DB 오류: lockName=$lockName, slot=$slot" }
         }
     }
 

--- a/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcLock.kt
+++ b/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcLock.kt
@@ -172,22 +172,25 @@ internal class ExposedR2dbcLock internal constructor(
      *
      * Returns `false` if the lease has expired and another instance has re-acquired it.
      */
-    suspend fun isHeldByCurrentInstance(): Boolean = runCatching {
-        suspendTransaction(db) {
-            val now = currentTime()
-            !LeaderLockTable
-                .selectAll()
-                .where {
-                    (LeaderLockTable.lockName eq lockName) and
-                            (LeaderLockTable.token eq token) and
-                            (LeaderLockTable.lockedUntil greater now)
-                }
-                .empty()
+    suspend fun isHeldByCurrentInstance(): Boolean =
+        runR2dbcLockOperationPreservingCancellation(
+            onFailure = { e ->
+                log.warn(e) { "isHeldByCurrentInstance DB 오류 (false 반환): lockName=$lockName" }
+                false
+            },
+        ) {
+            suspendTransaction(db) {
+                val now = currentTime()
+                !LeaderLockTable
+                    .selectAll()
+                    .where {
+                        (LeaderLockTable.lockName eq lockName) and
+                                (LeaderLockTable.token eq token) and
+                                (LeaderLockTable.lockedUntil greater now)
+                    }
+                    .empty()
+            }
         }
-    }.getOrElse { e ->
-        log.warn(e) { "isHeldByCurrentInstance DB 오류 (false 반환): lockName=$lockName" }
-        false
-    }
 
     /**
      * Releases the lock held by the current instance.
@@ -203,7 +206,11 @@ internal class ExposedR2dbcLock internal constructor(
         val tokenVal = this@ExposedR2dbcLock.token
         val remaining = remainingMinLeaseTime(acquiredAtNanos, minLeaseTime)
 
-        runCatching {
+        runR2dbcLockOperationPreservingCancellation(
+            onFailure = { e ->
+                log.warn(e) { "락 해제 중 DB 오류: lockName=$lockName" }
+            },
+        ) {
             val matched = suspendTransaction(db) {
                 if (remaining > Duration.ZERO) {
                     val now = currentTime()
@@ -223,8 +230,6 @@ internal class ExposedR2dbcLock internal constructor(
             } else {
                 log.debug { "락 해제 성공: lockName=$lockName, token=${token.take(8)}" }
             }
-        }.onFailure { e ->
-            log.warn(e) { "락 해제 중 DB 오류: lockName=$lockName" }
         }
     }
 
@@ -278,6 +283,18 @@ internal class ExposedR2dbcLock internal constructor(
     private suspend fun R2dbcTransaction.currentTime(): Instant =
         if (useDbTime) dbCurrentTimestamp() else Instant.now()
 }
+
+internal suspend fun <T> runR2dbcLockOperationPreservingCancellation(
+    onFailure: (Exception) -> T,
+    operation: suspend () -> T,
+): T =
+    try {
+        operation()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        onFailure(e)
+    }
 
 private suspend fun R2dbcTransaction.dbCurrentTimestamp(): Instant =
     exec("SELECT CURRENT_TIMESTAMP") { row -> row.get(0).toInstant() }

--- a/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/R2dbcLockCancellationTest.kt
+++ b/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/R2dbcLockCancellationTest.kt
@@ -1,0 +1,46 @@
+package io.bluetape4k.leader.exposed.r2dbc.lock
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.Test
+
+class R2dbcLockCancellationTest {
+
+    @Test
+    fun `R2DBC lock operation - CancellationException 재전파`() = runSuspendIO {
+        val cancellation = CancellationException("cancel r2dbc")
+
+        val thrown = assertFailsWith<CancellationException> {
+            runR2dbcLockOperationPreservingCancellation(
+                onFailure = { error("CancellationException must not be handled as a DB failure") },
+            ) {
+                throw cancellation
+            }
+        }
+
+        thrown shouldBeEqualTo cancellation
+    }
+
+    @Test
+    fun `R2DBC lock operation - 일반 예외는 fallback 으로 처리`() = runSuspendIO {
+        val failure = IllegalStateException("db failed")
+        var handled = false
+
+        val result = runR2dbcLockOperationPreservingCancellation(
+            onFailure = { e ->
+                handled = true
+                e shouldBeEqualTo failure
+                false
+            },
+        ) {
+            throw failure
+        }
+
+        result.shouldBeFalse()
+        handled.shouldBeTrue()
+    }
+}

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElector.kt
@@ -94,15 +94,44 @@ class LettuceStrategicSuspendLeaderElector(
 
         return try {
             val value = action()
-            runCatching { updateResult(lockName, nodeId, CandidateResult.SUCCESS) }
-                .onFailure { log.warn(it) { "[$lockName] successCount 업데이트 실패 — 무시됨" } }
+            updateStrategicResultPreservingCancellation(
+                lockName = lockName,
+                result = CandidateResult.SUCCESS,
+                update = { updateResult(lockName, nodeId, CandidateResult.SUCCESS) },
+                onFailure = { e, message -> log.warn(e) { message } },
+            )
             value
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            runCatching { updateResult(lockName, nodeId, CandidateResult.FAILURE) }
-                .onFailure { log.warn(it) { "[$lockName] failureCount 업데이트 실패 — 무시됨" } }
+            updateStrategicResultPreservingCancellation(
+                lockName = lockName,
+                result = CandidateResult.FAILURE,
+                update = { updateResult(lockName, nodeId, CandidateResult.FAILURE) },
+                onFailure = { e, message -> log.warn(e) { message } },
+            )
             throw e
         }
     }
 }
+
+internal suspend fun updateStrategicResultPreservingCancellation(
+    lockName: String,
+    result: CandidateResult,
+    update: suspend () -> Unit,
+    onFailure: (Exception, String) -> Unit,
+) {
+    try {
+        update()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        onFailure(e, "[$lockName] ${result.logFieldName} 업데이트 실패 — 무시됨")
+    }
+}
+
+private val CandidateResult.logFieldName: String
+    get() = when (this) {
+        CandidateResult.SUCCESS -> "successCount"
+        CandidateResult.FAILURE -> "failureCount"
+    }

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElectorTest.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
 import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
 import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -186,6 +187,44 @@ class LettuceStrategicSuspendLeaderElectorTest: AbstractLettuceLeaderTest() {
 
         val candidate = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
         candidate.failureCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `updateResult cancellation - CancellationException 재전파`() = runSuspendIO {
+        val lockName = randomName()
+        val cancellation = CancellationException("cancel lettuce update")
+
+        val thrown = assertFailsWith<CancellationException> {
+            updateStrategicResultPreservingCancellation(
+                lockName = lockName,
+                result = CandidateResult.SUCCESS,
+                update = { throw cancellation },
+                onFailure = { _, _ -> error("CancellationException must not be handled as a Redis failure") },
+            )
+        }
+
+        thrown shouldBeEqualTo cancellation
+    }
+
+    @Test
+    fun `updateResult exception - 일반 예외는 fallback 으로 처리`() = runSuspendIO {
+        val lockName = randomName()
+        val failure = IllegalStateException("lettuce update failed")
+        var handledFailure: Exception? = null
+        var handledMessage: String? = null
+
+        updateStrategicResultPreservingCancellation(
+            lockName = lockName,
+            result = CandidateResult.FAILURE,
+            update = { throw failure },
+            onFailure = { e, message ->
+                handledFailure = e
+                handledMessage = message
+            },
+        )
+
+        handledFailure shouldBeEqualTo failure
+        handledMessage shouldBeEqualTo "[$lockName] failureCount 업데이트 실패 — 무시됨"
     }
 
     @Test

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElector.kt
@@ -81,15 +81,44 @@ class RedissonStrategicSuspendLeaderElector(
 
         return try {
             val value = action()
-            runCatching { updateResult(lockName, nodeId, CandidateResult.SUCCESS) }
-                .onFailure { log.warn(it) { "[$lockName] successCount 업데이트 실패 — 무시됨" } }
+            updateStrategicResultPreservingCancellation(
+                lockName = lockName,
+                result = CandidateResult.SUCCESS,
+                update = { updateResult(lockName, nodeId, CandidateResult.SUCCESS) },
+                onFailure = { e, message -> log.warn(e) { message } },
+            )
             value
         } catch (e: CancellationException) {
             throw e
         } catch (e: Throwable) {
-            runCatching { updateResult(lockName, nodeId, CandidateResult.FAILURE) }
-                .onFailure { log.warn(it) { "[$lockName] failureCount 업데이트 실패 — 무시됨" } }
+            updateStrategicResultPreservingCancellation(
+                lockName = lockName,
+                result = CandidateResult.FAILURE,
+                update = { updateResult(lockName, nodeId, CandidateResult.FAILURE) },
+                onFailure = { e, message -> log.warn(e) { message } },
+            )
             throw e
         }
     }
 }
+
+internal suspend fun updateStrategicResultPreservingCancellation(
+    lockName: String,
+    result: CandidateResult,
+    update: suspend () -> Unit,
+    onFailure: (Exception, String) -> Unit,
+) {
+    try {
+        update()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        onFailure(e, "[$lockName] ${result.logFieldName} 업데이트 실패 — 무시됨")
+    }
+}
+
+private val CandidateResult.logFieldName: String
+    get() = when (this) {
+        CandidateResult.SUCCESS -> "successCount"
+        CandidateResult.FAILURE -> "failureCount"
+    }

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElectorTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElectorTest.kt
@@ -4,9 +4,11 @@ import io.bluetape4k.junit5.awaitility.untilSuspending
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.LeaderElectionException
 import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
 import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
 import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -100,6 +102,44 @@ class RedissonStrategicSuspendLeaderElectorTest: AbstractRedissonLeaderTest() {
         val candidate = node1.listCandidates(lockName).firstOrNull { it.nodeId == "node-1" }
         candidate.shouldNotBeNull()
         candidate.failureCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `updateResult cancellation - CancellationException 재전파`() = runSuspendIO {
+        val lockName = randomName()
+        val cancellation = CancellationException("cancel redisson update")
+
+        val thrown = assertFailsWith<CancellationException> {
+            updateStrategicResultPreservingCancellation(
+                lockName = lockName,
+                result = CandidateResult.SUCCESS,
+                update = { throw cancellation },
+                onFailure = { _, _ -> error("CancellationException must not be handled as a Redis failure") },
+            )
+        }
+
+        thrown shouldBeEqualTo cancellation
+    }
+
+    @Test
+    fun `updateResult exception - 일반 예외는 fallback 으로 처리`() = runSuspendIO {
+        val lockName = randomName()
+        val failure = IllegalStateException("redisson update failed")
+        var handledFailure: Exception? = null
+        var handledMessage: String? = null
+
+        updateStrategicResultPreservingCancellation(
+            lockName = lockName,
+            result = CandidateResult.FAILURE,
+            update = { throw failure },
+            onFailure = { e, message ->
+                handledFailure = e
+                handledMessage = message
+            },
+        )
+
+        handledFailure shouldBeEqualTo failure
+        handledMessage shouldBeEqualTo "[$lockName] failureCount 업데이트 실패 — 무시됨"
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #568
Closes #569

PR #583의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: preserve suspend cancellation propagation`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
Stacked on #582 (`fix/leader-0.5-core-contracts`).

Fixes #568.
Fixes #569.

## Summary
- Preserves `CancellationException` in suspend R2DBC lock operations before generic fallback handling.
- Preserves `CancellationException` in suspend strategic elector `updateResult` paths for local, Lettuce, and Redisson backends.
- Adds direct cancellation/fallback regressions for affected helpers and strategic electors.
- Records module/package review evidence in `docs/review/2026-07-04-suspend-cancellation-review.md`.

## 7-Tier Review
- Tier 1 Correctness: PASS - suspend cancellation is rethrown and ordinary exceptions still use the existing fallback semantics.
- Tier 2 API/Contracts: PASS - no public API contract or signature drift.
- Tier 3 Concurrency/Coroutines: PASS - broad exception handling now preserves structured coroutine cancellation.
- Tier 4 Persistence/Backends: PASS - R2DBC lock transaction wrappers keep backend fallback behavior for non-cancellation failures.
- Tier 5 Tests: PASS - targeted cancellation and fallback regressions added for core, R2DBC, Lettuce, and Redisson paths.
- Tier 6 Security/Observability: PASS - no token/logging surface added; existing warning paths are retained for non-cancellation failures.
- Tier 7 Maintainability: PASS - helper names encode the cancellation-first contract and avoid new dependency or module churn.

## Validation
- `./gradlew :bluetape4k-leader-core:compileKotlin :bluetape4k-leader-core:compileTestKotlin :bluetape4k-leader-exposed-r2dbc:compileKotlin :bluetape4k-leader-exposed-r2dbc:compileTestKotlin :bluetape4k-leader-redis-lettuce:compileKotlin :bluetape4k-leader-redis-lettuce:compileTestKotlin :bluetape4k-leader-redis-redisson:compileKotlin :bluetape4k-leader-redis-redisson:compileTestKotlin --warning-mode all`
- `./gradlew :bluetape4k-leader-core:test --tests io.bluetape4k.leader.local.LocalStrategicSuspendLeaderElectorTest --warning-mode all`
- `./gradlew :bluetape4k-leader-exposed-r2dbc:test --tests io.bluetape4k.leader.exposed.r2dbc.lock.R2dbcLockCancellationTest --tests io.bluetape4k.leader.exposed.r2dbc.lock.ExposedR2dbcLockTest --tests io.bluetape4k.leader.exposed.r2dbc.lock.ExposedR2dbcGroupLockTest --warning-mode all --rerun-tasks`
- `./gradlew :bluetape4k-leader-redis-lettuce:test --tests io.bluetape4k.leader.lettuce.LettuceStrategicSuspendLeaderElectorTest --warning-mode all`
- `./gradlew :bluetape4k-leader-redis-redisson:test --tests io.bluetape4k.leader.redisson.RedissonStrategicSuspendLeaderElectorTest --warning-mode all`
- `git diff --check`

## DoD Status
- [x] Issues #568 and #569 are implemented in the second stacked PR branch.
- [x] PR metadata is intended to mirror milestone `0.5.0`, assignee `debop`, and focused bug/test/maintenance labels.
- [x] Full repository test remains deferred until the complete stacked issue train is implemented, per requested workflow.

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #568, #569, milestone `0.5.0`, assignee `debop`
- PR: #583, head `ed520bfe6cd0003deaf02af699213ce950ede1d7`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
