### PR TITLE
fix: decouple acquisition cleanup from caller execution

### DIFF
--- a/docs/review/2026-07-04-acquisition-cleanup-review.md
+++ b/docs/review/2026-07-04-acquisition-cleanup-review.md
@@ -1,0 +1,73 @@
+# Acquisition Cleanup 7-Tier Review
+
+Date: 2026-07-04
+Scope: issues #566 and #567, milestone 0.5.0
+
+## Modules Reviewed
+
+- `leader-consul`: async single and group cleanup callbacks.
+- `leader-k8s`: async single/group cleanup callbacks and suspend single acquisition cleanup.
+- `leader-exposed-jdbc`: async single and group cleanup callbacks.
+- `leader-mongodb`: async single/group cleanup callbacks and suspend single acquisition cleanup.
+- `leader-hazelcast`: async single/group cleanup callbacks and suspend single acquisition cleanup.
+- `leader-redis-lettuce`: suspend single acquisition cleanup.
+- `leader-redis-redisson`: suspend single acquisition cleanup.
+- `leader-exposed-r2dbc`: suspend single acquisition cleanup.
+- `leader-zookeeper`: suspend single acquisition cleanup.
+
+## 7-Tier Result
+
+1. Correctness: PASS
+   - Async cleanup is attached with direct completion callbacks so caller executor shutdown after action start cannot skip release/watchdog close.
+   - Suspend electors enter cleanup scope immediately after successful acquisition, before audit, handle, watchdog, or action setup can suspend.
+
+2. API and Contract Compatibility: PASS
+   - No public type, constructor, or method signature changes.
+   - `CompletableFuture` action result/failure propagation remains delegated to the action future.
+
+3. Concurrency and Cancellation: PASS
+   - Coroutine cancellation still propagates.
+   - Mandatory release runs under existing `NonCancellable` cleanup blocks.
+   - Watchdog cleanup is null-safe when cancellation happens before watchdog creation.
+
+4. Backend Ownership Safety: PASS
+   - Existing owner/token/thread-id release checks are preserved.
+   - Backend-specific `minLeaseTime` release behavior is unchanged.
+
+5. Tests: PASS
+   - Added Consul fake-client async regression where caller executor shutdown cannot skip release/destroy cleanup.
+   - Added Kubernetes K3s async regression and source-structure suspend guard.
+   - Added Exposed JDBC async regression across H2, PostgreSQL, and MySQL.
+   - Added Mongo async and suspend regressions for executor shutdown and `recordAcquired` cancellation.
+   - Added Hazelcast async single/group regressions where caller executor is shut down before action future completion.
+   - Added Lettuce suspend regression where `recordAcquired` cancellation happens after lock acquisition but before action start, then the next contender reacquires.
+   - Added Exposed R2DBC suspend regression across H2, PostgreSQL, and MySQL.
+   - Added Redisson and ZooKeeper source-structure guards for immediate post-acquisition cleanup scope.
+
+6. Security and Observability: PASS
+   - No new token, credential, or owner payload logging.
+   - Existing cleanup failure logging paths are retained.
+
+7. Maintainability: PASS
+   - Changes are local to the affected elector patterns.
+   - No dependency, module, or public API churn.
+
+## Validation Evidence
+
+- `./gradlew :bluetape4k-leader-consul:compileKotlin :bluetape4k-leader-consul:compileTestKotlin :bluetape4k-leader-k8s:compileKotlin :bluetape4k-leader-k8s:compileTestKotlin :bluetape4k-leader-exposed-jdbc:compileKotlin :bluetape4k-leader-exposed-jdbc:compileTestKotlin :bluetape4k-leader-mongodb:compileKotlin :bluetape4k-leader-mongodb:compileTestKotlin :bluetape4k-leader-hazelcast:compileKotlin :bluetape4k-leader-hazelcast:compileTestKotlin :bluetape4k-leader-redis-lettuce:compileKotlin :bluetape4k-leader-redis-lettuce:compileTestKotlin :bluetape4k-leader-redis-redisson:compileKotlin :bluetape4k-leader-redis-redisson:compileTestKotlin :bluetape4k-leader-exposed-r2dbc:compileKotlin :bluetape4k-leader-exposed-r2dbc:compileTestKotlin :bluetape4k-leader-zookeeper:compileKotlin :bluetape4k-leader-zookeeper:compileTestKotlin --warning-mode all`
+- `./gradlew :bluetape4k-leader-consul:test --tests 'io.bluetape4k.leader.consul.ConsulLeaderElectorDelegationTest.runAsyncIfLeader cleanup runs after caller executor shutdown' --warning-mode all`
+- `./gradlew :bluetape4k-leader-k8s:test --tests 'io.bluetape4k.leader.k8s.KubernetesLeaseSuspendCancellationSafetyTest.suspend elector opens cleanup scope immediately after acquisition' --warning-mode all`
+- `./gradlew :bluetape4k-leader-k8s:k8sTest --tests 'io.bluetape4k.leader.k8s.KubernetesLeaseLeaderElectorK3sTest.async cleanup runs after caller executor shutdown' --warning-mode all`
+- `./gradlew :bluetape4k-leader-exposed-jdbc:test --tests 'io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderElectionTest.runAsyncIfLeader - caller executor shutdown 후 action 완료되어도 cleanup 이 실행된다' --warning-mode all`
+- `./gradlew :bluetape4k-leader-mongodb:test --tests 'io.bluetape4k.leader.mongodb.MongoLeaderElectionTest.runAsyncIfLeader - caller executor shutdown 후 action 완료되어도 cleanup 이 실행된다' --tests 'io.bluetape4k.leader.mongodb.MongoSuspendLeaderElectorTest.runIfLeader - recordAcquired 취소 후에도 lock 이 해제되어 다음 호출이 성공한다' --warning-mode all`
+- `./gradlew :bluetape4k-leader-hazelcast:test --tests 'io.bluetape4k.leader.hazelcast.HazelcastLeaderElectionTest.runAsyncIfLeader - caller executor shutdown 후 action 완료되어도 cleanup 이 실행된다' --tests 'io.bluetape4k.leader.hazelcast.HazelcastLeaderGroupElectionTest.runAsyncIfLeader - caller executor shutdown 후 action 완료되어도 그룹 슬롯 cleanup 이 실행된다' --warning-mode all`
+- `./gradlew :bluetape4k-leader-hazelcast:test --tests 'io.bluetape4k.leader.hazelcast.HazelcastSuspendCancellationSafetyTest.suspend elector unlock failure handling rethrows CancellationException' --warning-mode all`
+- `./gradlew :bluetape4k-leader-redis-lettuce:test --tests 'io.bluetape4k.leader.lettuce.LettuceSuspendLeaderElectorTest.runIfLeader - recordAcquired 취소 후에도 lock 이 해제되어 다음 호출이 성공한다' --warning-mode all`
+- `./gradlew :bluetape4k-leader-exposed-r2dbc:test --tests 'io.bluetape4k.leader.exposed.r2dbc.ExposedR2DbcSuspendLeaderElectorTest.runIfLeader - recordAcquired 취소 후에도 lock 이 해제되어 다음 호출이 성공한다' --warning-mode all`
+- `./gradlew :bluetape4k-leader-redis-redisson:test --tests 'io.bluetape4k.leader.redisson.RedissonSuspendLeaderElectorTest.suspend elector opens cleanup scope immediately after acquisition' :bluetape4k-leader-zookeeper:test --tests 'io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderElectorTest.suspend elector opens cleanup scope immediately after acquisition' --warning-mode all`
+- `git diff --check`
+- `rg -n "whenCompleteAsync|handleAsync" leader-consul/src/main/kotlin leader-k8s/src/main/kotlin leader-exposed-jdbc/src/main/kotlin leader-mongodb/src/main/kotlin leader-hazelcast/src/main/kotlin` returned no matches.
+
+## Deferred Verification
+
+Full repository test is intentionally deferred until the complete stacked issue train is implemented, per the requested workflow.

--- a/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElector.kt
+++ b/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElector.kt
@@ -204,7 +204,7 @@ class ConsulLeaderElector private constructor(
             return CompletableFuture.failedFuture(e)
         }
 
-        return actionFuture.handleAsync({ value, failure ->
+        return actionFuture.handle { value, failure ->
             watchdog.close()
             release(handle)
             val cause = failure.unwrapCompletionException()
@@ -212,7 +212,7 @@ class ConsulLeaderElector private constructor(
                 throw CompletionException(cause)
             }
             value
-        }, executor)
+        }
     }
 
     private fun acquire(lockName: String, auditLeaderId: String?): ConsulLeaseHandle? {

--- a/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderGroupElector.kt
+++ b/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderGroupElector.kt
@@ -214,7 +214,7 @@ class ConsulLeaderGroupElector private constructor(
             return CompletableFuture.failedFuture(e)
         }
 
-        return actionFuture.handleAsync({ value, failure ->
+        return actionFuture.handle { value, failure ->
             watchdog.close()
             release(handle)
             val cause = failure.unwrapCompletionException()
@@ -222,7 +222,7 @@ class ConsulLeaderGroupElector private constructor(
                 throw CompletionException(cause)
             }
             value
-        }, executor)
+        }
     }
 
     private fun acquire(lockName: String, auditLeaderId: String?): ConsulLeaseHandle? {

--- a/leader-consul/src/test/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElectorDelegationTest.kt
+++ b/leader-consul/src/test/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElectorDelegationTest.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.LeaderElectionException
 import io.bluetape4k.leader.LeaderGroupElectionOptions
@@ -23,6 +24,8 @@ import java.time.Instant
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -239,6 +242,42 @@ class ConsulLeaderElectorDelegationTest {
         failure.cause.shouldBeInstanceOf<CancellationException>()
         client.releaseCalls shouldBeEqualTo 1
         client.destroyCalls shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `runAsyncIfLeader cleanup runs after caller executor shutdown`() {
+        val client = FakeConsulLockClient()
+        val elector = ConsulLeaderElector.create(
+            client,
+            ConsulLeaderElectionOptions(
+                leaderOptions = LeaderElectionOptions(
+                    waitTime = Duration.ZERO,
+                    leaseTime = 10.seconds,
+                    autoExtend = true,
+                ),
+            ),
+        )
+        val executor = Executors.newSingleThreadExecutor()
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>()
+
+        try {
+            val resultFuture = elector.runAsyncIfLeader("lock-a", executor) {
+                actionStarted.countDown()
+                actionFuture
+            }
+            actionStarted.await(3, TimeUnit.SECONDS).shouldBeTrue()
+            executor.shutdown()
+
+            actionFuture.complete("done")
+
+            resultFuture.get(3, TimeUnit.SECONDS) shouldBeEqualTo "done"
+            elector.runIfLeader("lock-a") { "reacquired" } shouldBeEqualTo "reacquired"
+            client.releaseCalls shouldBeEqualTo 2
+            client.destroyCalls shouldBeEqualTo 2
+        } finally {
+            executor.shutdownNow()
+        }
     }
 
     @Test

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElector.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElector.kt
@@ -254,7 +254,7 @@ class ExposedJdbcLeaderElector private constructor(
                             return@thenComposeAsync CompletableFuture.completedFuture(null)
                         }
 
-                    actionFuture.whenCompleteAsync({ _, throwable ->
+                    actionFuture.whenComplete { _, throwable ->
                         watchdog.close()
                         val finishedAt = Instant.now()
                         val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
@@ -271,7 +271,7 @@ class ExposedJdbcLeaderElector private constructor(
                         runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos) }
                             .onSuccess { log.debug { "비동기 리더 권한을 반납했습니다. lockName=$lockName" } }
                             .onFailure { e -> log.warn(e) { "비동기 락 해제 실패. lockName=$lockName" } }
-                    }, executor)
+                    }
                 }
             }, executor)
     }

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElector.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElector.kt
@@ -349,7 +349,7 @@ class ExposedJdbcLeaderGroupElector private constructor(
                         return@thenComposeAsync CompletableFuture.failedFuture(e)
                     }
 
-                actionFuture.whenCompleteAsync({ _, throwable ->
+                actionFuture.whenComplete { _, throwable ->
                     watchdog.close()
                     val finishedAt = Instant.now()
                     val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
@@ -368,7 +368,7 @@ class ExposedJdbcLeaderGroupElector private constructor(
                     } catch (e: Exception) {
                         log.warn(e) { "비동기 슬롯 해제 실패. lockName=$lockName, slot=$slot" }
                     }
-                }, executor)
+                }
             }
         }, executor)
     }

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElectionTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElectionTest.kt
@@ -20,6 +20,7 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.assertions.shouldBeTrue
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -32,6 +33,8 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -383,6 +386,43 @@ class ExposedJdbcLeaderElectionTest: AbstractExposedJdbcLeaderTest() {
                 .count()
         }
         failedCount shouldBeEqualTo 1L
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - caller executor shutdown 후 action 완료되어도 cleanup 이 실행된다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val election = ExposedJdbcLeaderElector(
+            db,
+            ExposedJdbcLeaderElectionOptions(
+                leaderOptions = LeaderElectionOptions(
+                    waitTime = 2.seconds,
+                    leaseTime = 10.seconds,
+                    autoExtend = true,
+                ),
+            ),
+        )
+        val executor = Executors.newSingleThreadExecutor()
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>()
+
+        try {
+            val resultFuture = election.runAsyncIfLeader(lockName, executor) {
+                actionStarted.countDown()
+                actionFuture
+            }
+            actionStarted.await(3, TimeUnit.SECONDS).shouldBeTrue()
+            executor.shutdown()
+
+            actionFuture.complete("done")
+
+            resultFuture.get(3, TimeUnit.SECONDS) shouldBeEqualTo "done"
+            election.runIfLeader(lockName) { "reacquired" } shouldBeEqualTo "reacquired"
+        } finally {
+            executor.shutdownNow()
+        }
     }
 
     @ParameterizedTest

--- a/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderElector.kt
+++ b/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderElector.kt
@@ -122,43 +122,44 @@ class ExposedR2DbcSuspendLeaderElector private constructor(
 
         log.debug { "리더로 승격하여 작업을 수행합니다. lockName=$lockName" }
 
-        val startedAt = Instant.now()
         val acquiredAtNanos = System.nanoTime()
-
-        val delegate: SuspendExtendDelegate = ExposedR2dbcSuspendLockExtendDelegate(lock)
-        val identity = LockIdentity(
-            lockName = lockName,
-            kind = LockIdentity.AnnotationKind.SINGLE,
-            factoryBeanName = EXPOSED_R2DBC_SUSPEND_FACTORY_BEAN_NAME,
-        )
-        val handle = LeaderLockHandle.real(
-            identity = identity,
-            token = lock.token,
-            acquiredAtNanos = acquiredAtNanos,
-            extendDelegate = delegate,
-        )
-        val watchdog = LeaderLeaseAutoExtender.start(
-            options.leaderOptions.autoExtend,
-            options.leaderOptions.leaseTime,
-            delegate,
-            ERROR_CLASSIFIER,
-        )
-
-        val record = historyRecorder?.let {
-            LeaderLockHistoryRecord(
-                lockName = lockName,
-                token = lock.token,
-                kind = LockIdentity.AnnotationKind.SINGLE,
-                acquiredAt = startedAt,
-                lockedUntil = startedAt.plusMillis(options.leaderOptions.leaseTime.inWholeMilliseconds),
-                nodeId = options.lockOwner,
-            )
-        }
-        val key = record?.let { historyRecorder.recordAcquired(it) }
-        val effectiveKey: LeaderHistoryKey? =
-            key ?: record?.let { LeaderHistoryKey(lockName = lockName, token = lock.token) }
+        var watchdog: AutoCloseable? = null
 
         try {
+            val startedAt = Instant.now()
+            val delegate: SuspendExtendDelegate = ExposedR2dbcSuspendLockExtendDelegate(lock)
+            val identity = LockIdentity(
+                lockName = lockName,
+                kind = LockIdentity.AnnotationKind.SINGLE,
+                factoryBeanName = EXPOSED_R2DBC_SUSPEND_FACTORY_BEAN_NAME,
+            )
+            val handle = LeaderLockHandle.real(
+                identity = identity,
+                token = lock.token,
+                acquiredAtNanos = acquiredAtNanos,
+                extendDelegate = delegate,
+            )
+            watchdog = LeaderLeaseAutoExtender.start(
+                options.leaderOptions.autoExtend,
+                options.leaderOptions.leaseTime,
+                delegate,
+                ERROR_CLASSIFIER,
+            )
+
+            val record = historyRecorder?.let {
+                LeaderLockHistoryRecord(
+                    lockName = lockName,
+                    token = lock.token,
+                    kind = LockIdentity.AnnotationKind.SINGLE,
+                    acquiredAt = startedAt,
+                    lockedUntil = startedAt.plusMillis(options.leaderOptions.leaseTime.inWholeMilliseconds),
+                    nodeId = options.lockOwner,
+                )
+            }
+            val key = record?.let { historyRecorder.recordAcquired(it) }
+            val effectiveKey: LeaderHistoryKey? =
+                key ?: record?.let { LeaderHistoryKey(lockName = lockName, token = lock.token) }
+
             return try {
                 val result = withContext(AopScopeAccess.createLockHandleElement(handle)) {
                     action()
@@ -178,7 +179,7 @@ class ExposedR2DbcSuspendLeaderElector private constructor(
         } finally {
             // NonCancellable: 코루틴 취소 시에도 watchdog close + 락 해제가 중단되지 않도록 보호
             withContext(NonCancellable) {
-                watchdog.close()
+                watchdog?.close()
                 try {
                     lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos)
                     log.debug { "리더 권한을 반납했습니다. lockName=$lockName" }

--- a/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderElectorTest.kt
+++ b/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderElectorTest.kt
@@ -8,9 +8,13 @@ import io.bluetape4k.leader.exposed.r2dbc.history.ExposedSuspendLeaderHistorySin
 import io.bluetape4k.leader.exposed.retry.RetryStrategy
 import io.bluetape4k.leader.exposed.tables.LeaderLockHistoryTable
 import io.bluetape4k.leader.exposed.tables.LeaderLockTable
+import io.bluetape4k.leader.history.LeaderHistoryKey
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
+import io.bluetape4k.leader.history.SuspendLeaderHistorySink
 import io.bluetape4k.leader.history.SuspendSafeLeaderHistoryRecorder
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
@@ -26,11 +30,11 @@ import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
 import io.bluetape4k.assertions.assertFailsWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import java.time.Instant
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.time.Duration.Companion.milliseconds
 
 class ExposedR2DbcSuspendLeaderElectorTest: AbstractExposedR2dbcLeaderTest() {
 
@@ -144,6 +148,37 @@ class ExposedR2DbcSuspendLeaderElectorTest: AbstractExposedR2dbcLeaderTest() {
         val result = election.runIfLeader(lockName) { "recovered" }
         result shouldBeEqualTo "recovered"
     }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runIfLeader - recordAcquired 취소 후에도 lock 이 해제되어 다음 호출이 성공한다`(testDB: TestR2dbcDB) =
+        runSuspendIO {
+            val db = setupDb(testDB)
+            cleanTables(db)
+            val lockName = randomName()
+            val options = ExposedR2dbcLeaderElectionOptions(
+                leaderOptions = LeaderElectionOptions(
+                    waitTime = 2.seconds,
+                    leaseTime = 10.seconds,
+                ),
+                retryStrategy = RetryStrategy.Jitter(),
+            )
+            val cancelingRecorder = SuspendSafeLeaderHistoryRecorder(CancelOnAcquiredHistorySink)
+            val election = ExposedR2DbcSuspendLeaderElector(db, options, cancelingRecorder)
+
+            assertFailsWith<CancellationException> {
+                election.runIfLeader(lockName) { "should-not-run" }
+            }
+
+            val rowCount = suspendTransaction(db) {
+                LeaderLockTable
+                    .selectAll()
+                    .where { LeaderLockTable.lockName eq lockName }
+                    .count()
+            }
+            rowCount shouldBeEqualTo 0L
+            ExposedR2DbcSuspendLeaderElector(db, options).runIfLeader(lockName) { "reacquired" } shouldBeEqualTo "reacquired"
+        }
 
     @ParameterizedTest
     @MethodSource("enableDialects")
@@ -309,5 +344,23 @@ class ExposedR2DbcSuspendLeaderElectorTest: AbstractExposedR2dbcLeaderTest() {
                 .count()
         }
         failedCount shouldBeGreaterOrEqualTo 1L
+    }
+
+    private object CancelOnAcquiredHistorySink: SuspendLeaderHistorySink {
+        override suspend fun recordAcquired(record: LeaderLockHistoryRecord): LeaderHistoryKey? {
+            throw CancellationException("cancel after acquire")
+        }
+
+        override suspend fun recordCompleted(key: LeaderHistoryKey, finishedAt: Instant, durationMs: Long) {
+        }
+
+        override suspend fun recordFailed(
+            key: LeaderHistoryKey,
+            finishedAt: Instant,
+            durationMs: Long,
+            errorType: String?,
+            errorMessage: String?,
+        ) {
+        }
     }
 }

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElector.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElector.kt
@@ -139,12 +139,12 @@ class HazelcastLeaderElector private constructor(
                                 .onFailure { e -> log.error(e) { "Fail to release lock on action error (async). lockName=$lockName" } }
                             return@thenComposeAsync CompletableFuture.failedFuture(error)
                         }
-                    actionFuture.whenCompleteAsync({ _, _ ->
+                    actionFuture.whenComplete { _, _ ->
                         watchdog.close()
                         runCatching { lock.unlock(options.minLeaseTime, acquiredAtNanos) }
                             .onSuccess { log.debug { "비동기 Leader 권한을 반납했습니다. lockName=$lockName" } }
                             .onFailure { e -> log.error(e) { "Fail to release lock (async). lockName=$lockName" } }
-                    }, executor)
+                    }
                 }
             }, executor)
     }

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElector.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElector.kt
@@ -179,12 +179,12 @@ class HazelcastLeaderGroupElector private constructor(
                             .onFailure { ex -> log.error(ex) { "Fail to release group slot on action error (async). lockName=$lockName, slot=$slot" } }
                         return@thenComposeAsync CompletableFuture.failedFuture(e)
                     }
-                actionFuture.whenCompleteAsync({ _, _ ->
+                actionFuture.whenComplete { _, _ ->
                     watchdog.close()
                     runCatching { lock.unlock(minLeaseTime, acquiredAtNanos) }
                         .onSuccess { log.debug { "비동기 리더 그룹 슬롯을 반납했습니다. lockName=$lockName, slot=$slot" } }
                         .onFailure { e -> log.error(e) { "Fail to release group slot (async). lockName=$lockName, slot=$slot" } }
-                }, executor)
+                }
             }
         }, executor)
     }

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderElector.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderElector.kt
@@ -85,33 +85,34 @@ class HazelcastSuspendLeaderElector private constructor(
         }
 
         val acquiredAtNanos = System.nanoTime()
-        val delegate: SuspendExtendDelegate = HazelcastSuspendLockExtendDelegate(lock)
-        val identity = LockIdentity(
-            lockName = lockName,
-            kind = LockIdentity.AnnotationKind.SINGLE,
-            factoryBeanName = HAZELCAST_SUSPEND_FACTORY_BEAN_NAME,
-        )
-        val handle = LeaderLockHandle.real(
-            identity = identity,
-            token = lockName,
-            acquiredAtNanos = acquiredAtNanos,
-            extendDelegate = delegate,
-        )
-        val watchdog = LeaderLeaseAutoExtender.start(
-            options.autoExtend,
-            options.leaseTime,
-            delegate,
-            ERROR_CLASSIFIER,
-        )
-        log.debug { "Leader로 승격하여 suspend 작업을 수행합니다. lockName=$lockName" }
+        var watchdog: AutoCloseable? = null
         try {
+            val delegate: SuspendExtendDelegate = HazelcastSuspendLockExtendDelegate(lock)
+            val identity = LockIdentity(
+                lockName = lockName,
+                kind = LockIdentity.AnnotationKind.SINGLE,
+                factoryBeanName = HAZELCAST_SUSPEND_FACTORY_BEAN_NAME,
+            )
+            val handle = LeaderLockHandle.real(
+                identity = identity,
+                token = lockName,
+                acquiredAtNanos = acquiredAtNanos,
+                extendDelegate = delegate,
+            )
+            watchdog = LeaderLeaseAutoExtender.start(
+                options.autoExtend,
+                options.leaseTime,
+                delegate,
+                ERROR_CLASSIFIER,
+            )
+            log.debug { "Leader로 승격하여 suspend 작업을 수행합니다. lockName=$lockName" }
             return withContext(AopScopeAccess.createLockHandleElement(handle)) {
                 action()
             }
         } finally {
             // NonCancellable: 코루틴 취소 시에도 watchdog close + 락 해제가 중단되지 않도록 보호
             withContext(NonCancellable) {
-                watchdog.close()
+                watchdog?.close()
                 try {
                     lock.unlock(options.minLeaseTime, acquiredAtNanos)
                     log.debug { "Leader 권한을 반납했습니다 (suspend). lockName=$lockName" }

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElectionTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElectionTest.kt
@@ -10,6 +10,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
@@ -190,6 +191,34 @@ class HazelcastLeaderElectionTest: AbstractHazelcastLeaderTest() {
         val result = election.runAsyncIfLeader(lockName) { futureOf { 99 } }
             .get(3, TimeUnit.SECONDS)
         result shouldBeEqualTo 99
+    }
+
+    @Test
+    fun `runAsyncIfLeader - caller executor shutdown 후 action 완료되어도 cleanup 이 실행된다`() {
+        val lockName = randomName()
+        val election = HazelcastLeaderElector(
+            hazelcastClient,
+            LeaderElectionOptions(waitTime = 2.seconds, leaseTime = 10.seconds, autoExtend = true),
+        )
+        val executor = Executors.newSingleThreadExecutor()
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<Int>()
+
+        try {
+            val resultFuture = election.runAsyncIfLeader(lockName, executor) {
+                actionStarted.countDown()
+                actionFuture
+            }
+            actionStarted.await(3, TimeUnit.SECONDS).shouldBeTrue()
+            executor.shutdown()
+
+            actionFuture.complete(7)
+
+            resultFuture.get(3, TimeUnit.SECONDS) shouldBeEqualTo 7
+            election.runIfLeader(lockName) { "reacquired" } shouldBeEqualTo "reacquired"
+        } finally {
+            executor.shutdownNow()
+        }
     }
 
     @Test

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElectionTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElectionTest.kt
@@ -16,6 +16,7 @@ import io.bluetape4k.logging.debug
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -178,6 +179,34 @@ class HazelcastLeaderGroupElectionTest: AbstractHazelcastLeaderTest() {
         }
         val result = election.runAsyncIfLeader(lockName) { futureOf { "복구 성공" } }.join()
         result shouldBeEqualTo "복구 성공"
+    }
+
+    @Test
+    fun `runAsyncIfLeader - caller executor shutdown 후 action 완료되어도 그룹 슬롯 cleanup 이 실행된다`() {
+        val lockName = randomName()
+        val singleElection = HazelcastLeaderGroupElector(
+            hazelcastClient,
+            LeaderGroupElectionOptions(maxLeaders = 1, waitTime = 2.seconds, leaseTime = 10.seconds),
+        )
+        val executor = Executors.newSingleThreadExecutor()
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>()
+
+        try {
+            val resultFuture = singleElection.runAsyncIfLeader(lockName, executor) {
+                actionStarted.countDown()
+                actionFuture
+            }
+            actionStarted.await(3, TimeUnit.SECONDS).shouldBeTrue()
+            executor.shutdown()
+
+            actionFuture.complete("done")
+
+            resultFuture.get(3, TimeUnit.SECONDS) shouldBeEqualTo "done"
+            singleElection.runIfLeader(lockName) { "reacquired" } shouldBeEqualTo "reacquired"
+        } finally {
+            executor.shutdownNow()
+        }
     }
 
     @Test

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendCancellationSafetyTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendCancellationSafetyTest.kt
@@ -11,6 +11,7 @@ class HazelcastSuspendCancellationSafetyTest {
         val source = sourceText("HazelcastSuspendLeaderElector.kt")
 
         source.rethrowsCancellationBeforeBroadCatch().shouldBeTrue()
+        source.cleanupScopeStartsImmediatelyAfterAcquire().shouldBeTrue()
     }
 
     @Test
@@ -29,5 +30,22 @@ class HazelcastSuspendCancellationSafetyTest {
         val cancellationCatch = indexOf("catch (e: CancellationException) {\n                    throw e\n                }")
         val broadCatch = indexOf("catch (e: Exception)", startIndex = cancellationCatch.coerceAtLeast(0))
         return cancellationCatch >= 0 && broadCatch > cancellationCatch
+    }
+
+    private fun String.cleanupScopeStartsImmediatelyAfterAcquire(): Boolean {
+        val acquiredAt = indexOf("val acquiredAtNanos = System.nanoTime()")
+        val cleanupScope = indexOf("var watchdog: AutoCloseable? = null", startIndex = acquiredAt.coerceAtLeast(0))
+        val tryStart = indexOf("try {", startIndex = cleanupScope.coerceAtLeast(0))
+        val watchdogStart = indexOf("LeaderLeaseAutoExtender.start", startIndex = tryStart.coerceAtLeast(0))
+        val finallyStart = indexOf("} finally {", startIndex = watchdogStart.coerceAtLeast(0))
+        val watchdogClose = indexOf("watchdog?.close()", startIndex = finallyStart.coerceAtLeast(0))
+        val unlock = indexOf("lock.unlock(options.minLeaseTime, acquiredAtNanos)", startIndex = watchdogClose.coerceAtLeast(0))
+        return listOf(acquiredAt, cleanupScope, tryStart, watchdogStart, finallyStart, watchdogClose, unlock).all { it >= 0 } &&
+            acquiredAt < cleanupScope &&
+            cleanupScope < tryStart &&
+            tryStart < watchdogStart &&
+            watchdogStart < finallyStart &&
+            finallyStart < watchdogClose &&
+            watchdogClose < unlock
     }
 }

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderElector.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderElector.kt
@@ -192,7 +192,7 @@ class KubernetesLeaseLeaderElector @JvmOverloads constructor(
             return CompletableFuture.failedFuture(e)
         }
 
-        return actionFuture.handleAsync({ value, failure ->
+        return actionFuture.handle { value, failure ->
             watchdog.close()
             release(lock, acquiredAtNanos, lockName)
             val cause = failure.unwrapCompletionException()
@@ -200,7 +200,7 @@ class KubernetesLeaseLeaderElector @JvmOverloads constructor(
                 throw cause
             }
             value
-        }, executor)
+        }
     }
 
     private fun release(

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderGroupElector.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderGroupElector.kt
@@ -197,7 +197,7 @@ class KubernetesLeaseLeaderGroupElector @JvmOverloads constructor(
             return CompletableFuture.failedFuture(e)
         }
 
-        return actionFuture.handleAsync({ value, failure ->
+        return actionFuture.handle { value, failure ->
             watchdog.close()
             release(lock, acquired.acquiredAtNanos, lockName, acquired.slot)
             val cause = failure.unwrapCompletionException()
@@ -205,7 +205,7 @@ class KubernetesLeaseLeaderGroupElector @JvmOverloads constructor(
                 throw cause
             }
             value
-        }, executor)
+        }
     }
 
     private fun acquire(lockName: String, auditLeaderId: String?): AcquiredSlot? {

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseSuspendLeaderElector.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseSuspendLeaderElector.kt
@@ -92,26 +92,27 @@ class KubernetesLeaseSuspendLeaderElector @JvmOverloads constructor(
         }
 
         val acquiredAtNanos = System.nanoTime()
-        val delegate = KubernetesLeaseLockExtendDelegate(lock)
-        val handle = LeaderLockHandle.real(
-            identity = LockIdentity(
-                lockName = lockName,
-                kind = LockIdentity.AnnotationKind.SINGLE,
-                factoryBeanName = K8S_SUSPEND_FACTORY_BEAN_NAME,
-            ),
-            token = lock.ownerToken,
-            acquiredAtNanos = acquiredAtNanos,
-            extendDelegate = delegate,
-            auditLeaderId = auditLeaderId ?: lock.ownerToken,
-        )
-        val watchdog = LeaderLeaseAutoExtender.start(
-            options.leaderOptions.autoExtend,
-            options.leaderOptions.leaseTime,
-            delegate,
-            KubernetesLeaseLeaderElector.ERROR_CLASSIFIER,
-        )
+        var watchdog: AutoCloseable? = null
 
         try {
+            val delegate = KubernetesLeaseLockExtendDelegate(lock)
+            val handle = LeaderLockHandle.real(
+                identity = LockIdentity(
+                    lockName = lockName,
+                    kind = LockIdentity.AnnotationKind.SINGLE,
+                    factoryBeanName = K8S_SUSPEND_FACTORY_BEAN_NAME,
+                ),
+                token = lock.ownerToken,
+                acquiredAtNanos = acquiredAtNanos,
+                extendDelegate = delegate,
+                auditLeaderId = auditLeaderId ?: lock.ownerToken,
+            )
+            watchdog = LeaderLeaseAutoExtender.start(
+                options.leaderOptions.autoExtend,
+                options.leaderOptions.leaseTime,
+                delegate,
+                KubernetesLeaseLeaderElector.ERROR_CLASSIFIER,
+            )
             return withContext(AopScopeAccess.createLockHandleElement(handle)) {
                 action()
             }
@@ -119,7 +120,7 @@ class KubernetesLeaseSuspendLeaderElector @JvmOverloads constructor(
             throw e
         } finally {
             withContext(NonCancellable + Dispatchers.IO) {
-                watchdog.close()
+                watchdog?.close()
                 try {
                     lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos)
                     log.debug { "Kubernetes Lease released (suspend). lockName=$lockName" }

--- a/leader-k8s/src/test/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderElectorK3sTest.kt
+++ b/leader-k8s/src/test/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderElectorK3sTest.kt
@@ -18,8 +18,10 @@ import org.junit.jupiter.api.TestInstance
 import java.time.Clock
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -162,6 +164,35 @@ class KubernetesLeaseLeaderElectorK3sTest {
     }
 
     @Test
+    fun `async cleanup runs after caller executor shutdown`() {
+        k3s.kubernetesClient().use { client ->
+            val lockName = randomLockName()
+            withCleanLease(client, lockName) {
+                val election = elector(client, nodeId = "node-a", autoExtend = true)
+                val executor = Executors.newSingleThreadExecutor()
+                val actionStarted = CountDownLatch(1)
+                val actionFuture = CompletableFuture<String>()
+
+                try {
+                    val resultFuture = election.runAsyncIfLeader(lockName, executor) {
+                        actionStarted.countDown()
+                        actionFuture
+                    }
+                    actionStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                    executor.shutdown()
+
+                    actionFuture.complete("done")
+
+                    resultFuture.get(5, TimeUnit.SECONDS) shouldBeEqualTo "done"
+                    elector(client, nodeId = "node-b").runIfLeader(lockName) { "reacquired" } shouldBeEqualTo "reacquired"
+                } finally {
+                    executor.shutdownNow()
+                }
+            }
+        }
+    }
+
+    @Test
     fun `async result propagates cancellation and releases lease`() {
         k3s.kubernetesClient().use { client ->
             val lockName = randomLockName()
@@ -186,6 +217,7 @@ class KubernetesLeaseLeaderElectorK3sTest {
         nodeId: String,
         waitTime: Duration = 150.milliseconds,
         leaseTime: Duration = 1.seconds,
+        autoExtend: Boolean = false,
     ): KubernetesLeaseLeaderElector =
         KubernetesLeaseLeaderElector(
             client,
@@ -196,6 +228,7 @@ class KubernetesLeaseLeaderElectorK3sTest {
                     waitTime = waitTime,
                     leaseTime = leaseTime,
                     nodeId = nodeId,
+                    autoExtend = autoExtend,
                 ),
             ),
         )

--- a/leader-k8s/src/test/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseSuspendCancellationSafetyTest.kt
+++ b/leader-k8s/src/test/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseSuspendCancellationSafetyTest.kt
@@ -1,0 +1,34 @@
+package io.bluetape4k.leader.k8s
+
+import io.bluetape4k.assertions.shouldBeTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+
+class KubernetesLeaseSuspendCancellationSafetyTest {
+
+    @Test
+    fun `suspend elector opens cleanup scope immediately after acquisition`() {
+        val source = Path.of("src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseSuspendLeaderElector.kt")
+            .toFile()
+            .readText()
+
+        source.cleanupScopeStartsImmediatelyAfterAcquire().shouldBeTrue()
+    }
+
+    private fun String.cleanupScopeStartsImmediatelyAfterAcquire(): Boolean {
+        val acquiredAt = indexOf("val acquiredAtNanos = System.nanoTime()")
+        val cleanupScope = indexOf("var watchdog: AutoCloseable? = null", startIndex = acquiredAt.coerceAtLeast(0))
+        val tryStart = indexOf("try {", startIndex = cleanupScope.coerceAtLeast(0))
+        val watchdogStart = indexOf("LeaderLeaseAutoExtender.start", startIndex = tryStart.coerceAtLeast(0))
+        val finallyStart = indexOf("} finally {", startIndex = watchdogStart.coerceAtLeast(0))
+        val watchdogClose = indexOf("watchdog?.close()", startIndex = finallyStart.coerceAtLeast(0))
+        val unlock = indexOf("lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos)", startIndex = watchdogClose.coerceAtLeast(0))
+        return listOf(acquiredAt, cleanupScope, tryStart, watchdogStart, finallyStart, watchdogClose, unlock).all { it >= 0 } &&
+            acquiredAt < cleanupScope &&
+            cleanupScope < tryStart &&
+            tryStart < watchdogStart &&
+            watchdogStart < finallyStart &&
+            finallyStart < watchdogClose &&
+            watchdogClose < unlock
+    }
+}

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElector.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElector.kt
@@ -189,7 +189,7 @@ class MongoLeaderElector private constructor(
                                 .onFailure { ex -> log.warn(ex) { "락 해제 실패 (action 오류 경로). lockName=$lockName" } }
                             return@thenComposeAsync CompletableFuture.failedFuture(e)
                         }
-                    actionFuture.whenCompleteAsync({ _, throwable ->
+                    actionFuture.whenComplete { _, throwable ->
                         watchdog.close()
                         val finishedAt = Instant.now()
                         val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
@@ -205,7 +205,7 @@ class MongoLeaderElector private constructor(
                         runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos) }
                             .onSuccess { log.debug { "비동기 리더 권한을 반납했습니다. lockName=$lockName" } }
                             .onFailure { e -> log.warn(e) { "비동기 락 해제 실패. lockName=$lockName" } }
-                    }, executor)
+                    }
                 }
             }, executor)
     }

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderGroupElector.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderGroupElector.kt
@@ -217,7 +217,7 @@ class MongoLeaderGroupElector private constructor(
                             .onFailure { ex -> log.warn(ex) { "그룹 슬롯 해제 실패 (action 오류 경로). lockName=$lockName, slot=$slot" } }
                         return@thenComposeAsync CompletableFuture.failedFuture(e)
                     }
-                actionFuture.whenCompleteAsync({ _, throwable ->
+                actionFuture.whenComplete { _, throwable ->
                     val finishedAt = Instant.now()
                     val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
                     if (throwable == null) {
@@ -229,7 +229,7 @@ class MongoLeaderGroupElector private constructor(
                     runCatching { lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos) }
                         .onSuccess { log.debug { "비동기 그룹 슬롯을 반납했습니다. lockName=$lockName, slot=$slot" } }
                         .onFailure { e -> log.warn(e) { "비동기 그룹 슬롯 해제 실패. lockName=$lockName, slot=$slot" } }
-                }, executor)
+                }
             }
         }, executor)
     }

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderElector.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderElector.kt
@@ -82,42 +82,44 @@ class MongoSuspendLeaderElector private constructor(
             return null
         }
 
-        val startedAt = Instant.now()
         val acquiredAtNanos = System.nanoTime()
-        val delegate: SuspendExtendDelegate = MongoSuspendLockExtendDelegate(lock)
-        val identity = LockIdentity(
-            lockName = lockName,
-            kind = LockIdentity.AnnotationKind.SINGLE,
-            factoryBeanName = MONGO_SUSPEND_FACTORY_BEAN_NAME,
-        )
-        val handle = LeaderLockHandle.real(
-            identity = identity,
-            token = lock.token,
-            acquiredAtNanos = acquiredAtNanos,
-            extendDelegate = delegate,
-        )
-        val watchdog = LeaderLeaseAutoExtender.start(
-            options.leaderOptions.autoExtend,
-            options.leaderOptions.leaseTime,
-            delegate,
-            ERROR_CLASSIFIER,
-        )
-
-        val record = historyRecorder?.let {
-            LeaderLockHistoryRecord(
-                lockName = lockName,
-                token = lock.token,
-                kind = LockIdentity.AnnotationKind.SINGLE,
-                acquiredAt = startedAt,
-                lockedUntil = startedAt.plusMillis(options.leaderOptions.leaseTime.inWholeMilliseconds),
-            )
-        }
-        val key = record?.let { historyRecorder.recordAcquired(it) }
-        val effectiveKey: LeaderHistoryKey? =
-            key ?: record?.let { LeaderHistoryKey(lockName = lockName, token = lock.token) }
+        var watchdog: AutoCloseable? = null
 
         log.debug { "리더로 승격하여 suspend 작업을 수행합니다. lockName=$lockName" }
         try {
+            val startedAt = Instant.now()
+            val delegate: SuspendExtendDelegate = MongoSuspendLockExtendDelegate(lock)
+            val identity = LockIdentity(
+                lockName = lockName,
+                kind = LockIdentity.AnnotationKind.SINGLE,
+                factoryBeanName = MONGO_SUSPEND_FACTORY_BEAN_NAME,
+            )
+            val handle = LeaderLockHandle.real(
+                identity = identity,
+                token = lock.token,
+                acquiredAtNanos = acquiredAtNanos,
+                extendDelegate = delegate,
+            )
+            watchdog = LeaderLeaseAutoExtender.start(
+                options.leaderOptions.autoExtend,
+                options.leaderOptions.leaseTime,
+                delegate,
+                ERROR_CLASSIFIER,
+            )
+
+            val record = historyRecorder?.let {
+                LeaderLockHistoryRecord(
+                    lockName = lockName,
+                    token = lock.token,
+                    kind = LockIdentity.AnnotationKind.SINGLE,
+                    acquiredAt = startedAt,
+                    lockedUntil = startedAt.plusMillis(options.leaderOptions.leaseTime.inWholeMilliseconds),
+                )
+            }
+            val key = record?.let { historyRecorder.recordAcquired(it) }
+            val effectiveKey: LeaderHistoryKey? =
+                key ?: record?.let { LeaderHistoryKey(lockName = lockName, token = lock.token) }
+
             return try {
                 val result = withContext(AopScopeAccess.createLockHandleElement(handle)) {
                     action()
@@ -137,7 +139,7 @@ class MongoSuspendLeaderElector private constructor(
         } finally {
             // NonCancellable: 코루틴 취소 시에도 watchdog close + 락 해제가 중단되지 않도록 보호
             withContext(NonCancellable) {
-                watchdog.close()
+                watchdog?.close()
                 try {
                     lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos)
                     log.debug { "리더 권한을 반납했습니다 (suspend). lockName=$lockName" }

--- a/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElectionTest.kt
+++ b/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElectionTest.kt
@@ -17,6 +17,7 @@ import io.bluetape4k.logging.debug
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -301,6 +302,40 @@ class MongoLeaderElectionTest: AbstractMongoLeaderTest() {
 
         val result = election.runIfLeader(lockName) { "복구 성공" }
         result shouldBeEqualTo "복구 성공"
+    }
+
+    @Test
+    fun `runAsyncIfLeader - caller executor shutdown 후 action 완료되어도 cleanup 이 실행된다`() {
+        val lockName = randomName()
+        val election = MongoLeaderElector(
+            lockCollection,
+            MongoLeaderElectionOptions(
+                leaderOptions = LeaderElectionOptions(
+                    waitTime = 2.seconds,
+                    leaseTime = 10.seconds,
+                    autoExtend = true,
+                ),
+            ),
+        )
+        val executor = Executors.newSingleThreadExecutor()
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>()
+
+        try {
+            val resultFuture = election.runAsyncIfLeader(lockName, executor) {
+                actionStarted.countDown()
+                actionFuture
+            }
+            actionStarted.await(3, TimeUnit.SECONDS).shouldBeTrue()
+            executor.shutdown()
+
+            actionFuture.complete("done")
+
+            resultFuture.get(3, TimeUnit.SECONDS) shouldBeEqualTo "done"
+            election.runIfLeader(lockName) { "reacquired" } shouldBeEqualTo "reacquired"
+        } finally {
+            executor.shutdownNow()
+        }
     }
 
     @Test

--- a/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderElectorTest.kt
+++ b/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoSuspendLeaderElectorTest.kt
@@ -9,9 +9,14 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.LeaderElectionException
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.history.LeaderHistoryKey
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
+import io.bluetape4k.leader.history.SuspendLeaderHistorySink
+import io.bluetape4k.leader.history.SuspendSafeLeaderHistoryRecorder
 import io.bluetape4k.leader.mongodb.lock.MongoSuspendLock
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -19,6 +24,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
+import java.time.Instant
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -173,6 +179,21 @@ class MongoSuspendLeaderElectorTest: AbstractMongoLeaderTest() {
     }
 
     @Test
+    fun `runIfLeader - recordAcquired 취소 후에도 lock 이 해제되어 다음 호출이 성공한다`() = runSuspendIO {
+        val lockName = randomName()
+        val cancelingRecorder = SuspendSafeLeaderHistoryRecorder(CancelOnAcquiredHistorySink)
+        val election = MongoSuspendLeaderElector(coroutineLockCollection, historyRecorder = cancelingRecorder)
+
+        assertFailsWith<CancellationException> {
+            election.runIfLeader(lockName) { "should-not-run" }
+        }
+
+        val doc = lockCollection.find(Filters.eq("_id", lockName)).first()
+        doc.shouldBeNull()
+        MongoSuspendLeaderElector(coroutineLockCollection).runIfLeader(lockName) { "reacquired" } shouldBeEqualTo "reacquired"
+    }
+
+    @Test
     fun `runIfLeader - 반복 실행 시 매번 성공한다`() = runSuspendIO {
         val election = MongoSuspendLeaderElector(coroutineLockCollection)
         val lockName = randomName()
@@ -189,5 +210,23 @@ class MongoSuspendLeaderElectorTest: AbstractMongoLeaderTest() {
         io.bluetape4k.leader.mongodb.lock.MongoSuspendLock.resetEnsuredFor(namespace)
 
         io.bluetape4k.leader.mongodb.lock.MongoSuspendLock.ensureIndexes(coroutineLockCollection)
+    }
+
+    private object CancelOnAcquiredHistorySink: SuspendLeaderHistorySink {
+        override suspend fun recordAcquired(record: LeaderLockHistoryRecord): LeaderHistoryKey? {
+            throw CancellationException("cancel after acquire")
+        }
+
+        override suspend fun recordCompleted(key: LeaderHistoryKey, finishedAt: Instant, durationMs: Long) {
+        }
+
+        override suspend fun recordFailed(
+            key: LeaderHistoryKey,
+            finishedAt: Instant,
+            durationMs: Long,
+            errorType: String?,
+            errorMessage: String?,
+        ) {
+        }
     }
 }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElector.kt
@@ -108,39 +108,41 @@ class LettuceSuspendLeaderElector(
             log.debug { "리더 선출 실패 (슬롯 없음, suspend): lockName=$lockName" }
             return null
         }
-        val startedAt = Instant.now()
         val acquiredAtNanos = System.nanoTime()
         val token = lock.currentToken() ?: error("token missing after tryLock — lockName=$lockName")
-        val delegate: SuspendExtendDelegate = LettuceSuspendLockExtendDelegate(lock)
-        val identity = LockIdentity(
-            lockName = lockName,
-            kind = LockIdentity.AnnotationKind.SINGLE,
-            factoryBeanName = LETTUCE_SUSPEND_FACTORY_BEAN_NAME,
-        )
-        val handle = LeaderLockHandle.real(
-            identity = identity,
-            token = token,
-            acquiredAtNanos = acquiredAtNanos,
-            extendDelegate = delegate,
-            auditLeaderId = auditLeaderId,
-        )
-        val watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime, delegate, ERROR_CLASSIFIER)
-
-        val record = historyRecorder?.let {
-            LeaderLockHistoryRecord(
-                lockName = lockName,
-                token = token,
-                kind = LockIdentity.AnnotationKind.SINGLE,
-                acquiredAt = startedAt,
-                lockedUntil = startedAt.plusMillis(options.leaseTime.inWholeMilliseconds),
-            )
-        }
-        val key = record?.let { historyRecorder.recordAcquired(it) }
-        val effectiveKey: LeaderHistoryKey? =
-            key ?: record?.let { LeaderHistoryKey(lockName = lockName, token = token) }
+        var watchdog: AutoCloseable? = null
 
         log.debug { "리더 선출 성공 (suspend): lockName=$lockName" }
         try {
+            val startedAt = Instant.now()
+            val delegate: SuspendExtendDelegate = LettuceSuspendLockExtendDelegate(lock)
+            val identity = LockIdentity(
+                lockName = lockName,
+                kind = LockIdentity.AnnotationKind.SINGLE,
+                factoryBeanName = LETTUCE_SUSPEND_FACTORY_BEAN_NAME,
+            )
+            val handle = LeaderLockHandle.real(
+                identity = identity,
+                token = token,
+                acquiredAtNanos = acquiredAtNanos,
+                extendDelegate = delegate,
+                auditLeaderId = auditLeaderId,
+            )
+            watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime, delegate, ERROR_CLASSIFIER)
+
+            val record = historyRecorder?.let {
+                LeaderLockHistoryRecord(
+                    lockName = lockName,
+                    token = token,
+                    kind = LockIdentity.AnnotationKind.SINGLE,
+                    acquiredAt = startedAt,
+                    lockedUntil = startedAt.plusMillis(options.leaseTime.inWholeMilliseconds),
+                )
+            }
+            val key = record?.let { historyRecorder.recordAcquired(it) }
+            val effectiveKey: LeaderHistoryKey? =
+                key ?: record?.let { LeaderHistoryKey(lockName = lockName, token = token) }
+
             return try {
                 val result = withContext(AopScopeAccess.createLockHandleElement(handle)) {
                     action()
@@ -160,7 +162,7 @@ class LettuceSuspendLeaderElector(
         } finally {
             // NonCancellable: 코루틴 취소 시에도 lease 정리가 중단되지 않도록 보호
             withContext(NonCancellable) {
-                watchdog.close()
+                watchdog?.close()
                 try {
                     if (lock.isHeldByCurrentInstance()) {
                         lock.unlock(options.minLeaseTime, acquiredAtNanos)

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendLeaderElectorTest.kt
@@ -6,6 +6,10 @@ import io.bluetape4k.leader.LeaderElectionException
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
+import io.bluetape4k.leader.history.LeaderHistoryKey
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
+import io.bluetape4k.leader.history.SuspendLeaderHistorySink
+import io.bluetape4k.leader.history.SuspendSafeLeaderHistoryRecorder
 import io.bluetape4k.logging.KLogging
 import kotlinx.coroutines.delay
 import io.bluetape4k.assertions.shouldBeEqualTo
@@ -19,6 +23,7 @@ import io.bluetape4k.assertions.assertFailsWith
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import java.time.Instant
 import java.util.concurrent.CancellationException
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -90,6 +95,18 @@ class LettuceSuspendLeaderElectorTest: AbstractLettuceLeaderTest() {
             thrown.message shouldBeEqualTo cancellation.message
         }
 
+    @Test
+    fun `runIfLeader - recordAcquired 취소 후에도 lock 이 해제되어 다음 호출이 성공한다`() = runSuspendIO {
+        val cancelingRecorder = SuspendSafeLeaderHistoryRecorder(CancelOnAcquiredHistorySink)
+        val election = LettuceSuspendLeaderElector(connection, options, cancelingRecorder)
+
+        assertFailsWith<CancellationException> {
+            election.runIfLeader(lockName) { "should-not-run" }
+        }
+
+        suspendElection.runIfLeader(lockName) { "reacquired" } shouldBeEqualTo "reacquired"
+    }
+
     // =========================================================================
     // 확장 함수
     // =========================================================================
@@ -155,5 +172,23 @@ class LettuceSuspendLeaderElectorTest: AbstractLettuceLeaderTest() {
             .run()
 
         counter.get() shouldBeGreaterOrEqualTo 1
+    }
+
+    private object CancelOnAcquiredHistorySink: SuspendLeaderHistorySink {
+        override suspend fun recordAcquired(record: LeaderLockHistoryRecord): LeaderHistoryKey? {
+            throw CancellationException("cancel after acquire")
+        }
+
+        override suspend fun recordCompleted(key: LeaderHistoryKey, finishedAt: Instant, durationMs: Long) {
+        }
+
+        override suspend fun recordFailed(
+            key: LeaderHistoryKey,
+            finishedAt: Instant,
+            durationMs: Long,
+            errorType: String?,
+            errorMessage: String?,
+        ) {
+        }
     }
 }

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElector.kt
@@ -179,35 +179,36 @@ class RedissonSuspendLeaderElector private constructor(
                 return null
             }
             val acquiredAtNanos = System.nanoTime()
-            val delegate: SuspendExtendDelegate = RedissonSuspendLockExtendDelegate(redissonClient, lock, lockId)
-            val identity = LockIdentity(
-                lockName = lockName,
-                kind = LockIdentity.AnnotationKind.SINGLE,
-                factoryBeanName = REDISSON_SUSPEND_FACTORY_BEAN_NAME,
-            )
-            val handle = LeaderLockHandle.real(
-                identity = identity,
-                token = lockName,
-                acquiredAtNanos = acquiredAtNanos,
-                acquiringThreadId = lockId,
-                extendDelegate = delegate,
-                auditLeaderId = auditLeaderId,
-            )
-            val watchdog = LeaderLeaseAutoExtender.start(
-                options.autoExtend,
-                options.leaseTime,
-                delegate,
-                ERROR_CLASSIFIER,
-            )
-            log.debug { "Leader로 승격되어 작업을 수행합니다. lock=$lockName, lockId=$lockId" }
+            var watchdog: AutoCloseable? = null
             try {
+                val delegate: SuspendExtendDelegate = RedissonSuspendLockExtendDelegate(redissonClient, lock, lockId)
+                val identity = LockIdentity(
+                    lockName = lockName,
+                    kind = LockIdentity.AnnotationKind.SINGLE,
+                    factoryBeanName = REDISSON_SUSPEND_FACTORY_BEAN_NAME,
+                )
+                val handle = LeaderLockHandle.real(
+                    identity = identity,
+                    token = lockName,
+                    acquiredAtNanos = acquiredAtNanos,
+                    acquiringThreadId = lockId,
+                    extendDelegate = delegate,
+                    auditLeaderId = auditLeaderId,
+                )
+                watchdog = LeaderLeaseAutoExtender.start(
+                    options.autoExtend,
+                    options.leaseTime,
+                    delegate,
+                    ERROR_CLASSIFIER,
+                )
+                log.debug { "Leader로 승격되어 작업을 수행합니다. lock=$lockName, lockId=$lockId" }
                 return withContext(AopScopeAccess.createLockHandleElement(handle)) {
                     action()
                 }
             } finally {
                 // NonCancellable: 코루틴 취소 시에도 lease 정리가 중단되지 않도록 보호
                 withContext(NonCancellable) {
-                    watchdog.close()
+                    watchdog?.close()
                     if (lock.isHeldByThread(lockId)) {
                         try {
                             releaseLock(lock, lockId, acquiredAtNanos)

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElectorTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElectorTest.kt
@@ -15,6 +15,7 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
+import java.nio.file.Path
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -139,6 +140,15 @@ class RedissonSuspendLeaderElectorTest: AbstractRedissonLeaderTest() {
             thrown.message shouldBeEqualTo cancellation.message
         }
 
+    @Test
+    fun `suspend elector opens cleanup scope immediately after acquisition`() {
+        val source = Path.of("src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElector.kt")
+            .toFile()
+            .readText()
+
+        source.cleanupScopeStartsImmediatelyAfterAcquire().shouldBeTrue()
+    }
+
     /**
      * [SuspendedJobTester]를 사용하여 짧은 `waitTime` 환경에서 여러 코루틴이 동시에
      * [RedissonSuspendLeaderElector.runIfLeader]를 호출할 때,
@@ -174,5 +184,22 @@ class RedissonSuspendLeaderElectorTest: AbstractRedissonLeaderTest() {
 
     private suspend fun randomDelay(from: Long = 5L, until: Long = 10L) {
         delay(Random.nextLong(from, until).milliseconds)
+    }
+
+    private fun String.cleanupScopeStartsImmediatelyAfterAcquire(): Boolean {
+        val acquiredAt = indexOf("val acquiredAtNanos = System.nanoTime()")
+        val cleanupScope = indexOf("var watchdog: AutoCloseable? = null", startIndex = acquiredAt.coerceAtLeast(0))
+        val tryStart = indexOf("try {", startIndex = cleanupScope.coerceAtLeast(0))
+        val watchdogStart = indexOf("LeaderLeaseAutoExtender.start", startIndex = tryStart.coerceAtLeast(0))
+        val finallyStart = indexOf("} finally {", startIndex = watchdogStart.coerceAtLeast(0))
+        val watchdogClose = indexOf("watchdog?.close()", startIndex = finallyStart.coerceAtLeast(0))
+        val release = indexOf("releaseLock(lock, lockId, acquiredAtNanos)", startIndex = watchdogClose.coerceAtLeast(0))
+        return listOf(acquiredAt, cleanupScope, tryStart, watchdogStart, finallyStart, watchdogClose, release).all { it >= 0 } &&
+            acquiredAt < cleanupScope &&
+            cleanupScope < tryStart &&
+            tryStart < watchdogStart &&
+            watchdogStart < finallyStart &&
+            finallyStart < watchdogClose &&
+            watchdogClose < release
     }
 }

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderElector.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderElector.kt
@@ -99,51 +99,43 @@ class ZooKeeperSuspendLeaderElector private constructor(
 
             log.debug { "ZooKeeper suspend leader lock 획득 성공. path=$path" }
 
-            val lockPath = runInterruptible(ownerDispatcher) {
-                mutex.currentThreadLockPath()
-            }
-            if (lockPath == null) {
-                log.warn { "ZooKeeper suspend leader lock path 조회 실패. path=$path" }
-                withContext(NonCancellable) {
-                    try {
-                        runInterruptible(ownerDispatcher) {
-                            mutex.release()
-                        }
-                    } catch (e: Exception) {
-                        log.warn(e) { "ZooKeeper suspend leader lock path 조회 실패 후 반납 실패. path=$path" }
+            var watchdog: AutoCloseable? = null
+            try {
+                val lockPath = runInterruptible(ownerDispatcher) {
+                    mutex.currentThreadLockPath()
+                }
+                if (lockPath == null) {
+                    log.warn { "ZooKeeper suspend leader lock path 조회 실패. path=$path" }
+                    return null
+                }
+
+                val acquiredAtNanos = System.nanoTime()
+                val delegate = ZooKeeperSuspendLockExtendDelegate(client, mutex, path, lockPath)
+                val identity = LockIdentity(
+                    lockName = lockName,
+                    kind = LockIdentity.AnnotationKind.SINGLE,
+                    factoryBeanName = ZOOKEEPER_SUSPEND_FACTORY_BEAN_NAME,
+                )
+                val handle = LeaderLockHandle.real(
+                    identity = identity,
+                    token = lockName,
+                    acquiredAtNanos = acquiredAtNanos,
+                    extendDelegate = delegate,
+                )
+                // R16 enforce: ZK 는 TTL 없음 — autoExtend 강제 비활성화 (사용자 설정 무시 + WARN)
+                if (options.autoExtend) {
+                    log.warn {
+                        "ZooKeeper 는 TTL 이 없는 세션 기반 락 — autoExtend=true 설정이 무시됩니다. " +
+                            "ZK 세션 keepalive 가 lease 역할을 대신합니다. lockName=$lockName"
                     }
                 }
-                return null
-            }
+                watchdog = LeaderLeaseAutoExtender.start(
+                    enabled = false,
+                    leaseTime = options.leaseTime,
+                    delegate = delegate,
+                    classifier = ERROR_CLASSIFIER,
+                )
 
-            val acquiredAtNanos = System.nanoTime()
-            val delegate = ZooKeeperSuspendLockExtendDelegate(client, mutex, path, lockPath)
-            val identity = LockIdentity(
-                lockName = lockName,
-                kind = LockIdentity.AnnotationKind.SINGLE,
-                factoryBeanName = ZOOKEEPER_SUSPEND_FACTORY_BEAN_NAME,
-            )
-            val handle = LeaderLockHandle.real(
-                identity = identity,
-                token = lockName,
-                acquiredAtNanos = acquiredAtNanos,
-                extendDelegate = delegate,
-            )
-            // R16 enforce: ZK 는 TTL 없음 — autoExtend 강제 비활성화 (사용자 설정 무시 + WARN)
-            if (options.autoExtend) {
-                log.warn {
-                    "ZooKeeper 는 TTL 이 없는 세션 기반 락 — autoExtend=true 설정이 무시됩니다. " +
-                        "ZK 세션 keepalive 가 lease 역할을 대신합니다. lockName=$lockName"
-                }
-            }
-            val watchdog = LeaderLeaseAutoExtender.start(
-                enabled = false,
-                leaseTime = options.leaseTime,
-                delegate = delegate,
-                classifier = ERROR_CLASSIFIER,
-            )
-
-            try {
                 return withContext(AopScopeAccess.createLockHandleElement(handle)) {
                     action()
                 }
@@ -151,7 +143,7 @@ class ZooKeeperSuspendLeaderElector private constructor(
                 // NonCancellable: 코루틴 취소 시에도 watchdog close + 락 해제가 중단되지 않도록 보호
                 withContext(NonCancellable) {
                     try {
-                        watchdog.close()
+                        watchdog?.close()
                     } catch (e: Exception) {
                         log.warn(e) { "ZooKeeper suspend watchdog close 실패. path=$path" }
                     }

--- a/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderElectorTest.kt
+++ b/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderElectorTest.kt
@@ -8,7 +8,9 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeLessOrEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
+import java.nio.file.Path
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -70,6 +72,15 @@ class ZooKeeperSuspendLeaderElectorTest: AbstractZooKeeperLeaderTest() {
     }
 
     @Test
+    fun `suspend elector opens cleanup scope immediately after acquisition`() {
+        val source = Path.of("src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderElector.kt")
+            .toFile()
+            .readText()
+
+        source.cleanupScopeStartsImmediatelyAfterAcquire().shouldBeTrue()
+    }
+
+    @Test
     fun `SuspendedJobTester - 코루틴 job 경합에서 단일 리더만 실행된다`() = runTest {
         val lockName = randomName()
         val election = ZooKeeperSuspendLeaderElector(curator)
@@ -96,5 +107,22 @@ class ZooKeeperSuspendLeaderElectorTest: AbstractZooKeeperLeaderTest() {
 
         executed.get() shouldBeGreaterThan 0
         peakConcurrent.get() shouldBeLessOrEqualTo 1
+    }
+
+    private fun String.cleanupScopeStartsImmediatelyAfterAcquire(): Boolean {
+        val acquired = indexOf("log.debug { \"ZooKeeper suspend leader lock 획득 성공. path=${'$'}path\" }")
+        val cleanupScope = indexOf("var watchdog: AutoCloseable? = null", startIndex = acquired.coerceAtLeast(0))
+        val tryStart = indexOf("try {", startIndex = cleanupScope.coerceAtLeast(0))
+        val watchdogStart = indexOf("LeaderLeaseAutoExtender.start", startIndex = tryStart.coerceAtLeast(0))
+        val finallyStart = indexOf("} finally {", startIndex = watchdogStart.coerceAtLeast(0))
+        val watchdogClose = indexOf("watchdog?.close()", startIndex = finallyStart.coerceAtLeast(0))
+        val release = indexOf("mutex.release()", startIndex = watchdogClose.coerceAtLeast(0))
+        return listOf(acquired, cleanupScope, tryStart, watchdogStart, finallyStart, watchdogClose, release).all { it >= 0 } &&
+            acquired < cleanupScope &&
+            cleanupScope < tryStart &&
+            tryStart < watchdogStart &&
+            watchdogStart < finallyStart &&
+            finallyStart < watchdogClose &&
+            watchdogClose < release
     }
 }


### PR DESCRIPTION
## Summary

PR #584의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: decouple acquisition cleanup from caller execution`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary
- Decouple async release/watchdog cleanup from caller executors by attaching cleanup directly to action future completion.
- Open suspend cleanup scopes immediately after successful backend acquisition so cancellation during handle/history/watchdog setup still releases locks.
- Add backend-specific regressions and a 7-tier review artifact for issues #566 and #567.

## Stack
- Base PR: #583 (`fix/leader-0.5-suspend-cancellation`)
- This PR resolves: #566, #567
- Stacked for the 0.5.0 issue train.

## Validation
- `./gradlew :bluetape4k-leader-consul:compileKotlin :bluetape4k-leader-consul:compileTestKotlin :bluetape4k-leader-k8s:compileKotlin :bluetape4k-leader-k8s:compileTestKotlin :bluetape4k-leader-exposed-jdbc:compileKotlin :bluetape4k-leader-exposed-jdbc:compileTestKotlin :bluetape4k-leader-mongodb:compileKotlin :bluetape4k-leader-mongodb:compileTestKotlin :bluetape4k-leader-hazelcast:compileKotlin :bluetape4k-leader-hazelcast:compileTestKotlin :bluetape4k-leader-redis-lettuce:compileKotlin :bluetape4k-leader-redis-lettuce:compileTestKotlin :bluetape4k-leader-redis-redisson:compileKotlin :bluetape4k-leader-redis-redisson:compileTestKotlin :bluetape4k-leader-exposed-r2dbc:compileKotlin :bluetape4k-leader-exposed-r2dbc:compileTestKotlin :bluetape4k-leader-zookeeper:compileKotlin :bluetape4k-leader-zookeeper:compileTestKotlin --warning-mode all`
- `./gradlew :bluetape4k-leader-consul:test --tests 'io.bluetape4k.leader.consul.ConsulLeaderElectorDelegationTest.runAsyncIfLeader cleanup runs after caller executor shutdown' :bluetape4k-leader-hazelcast:test --tests 'io.bluetape4k.leader.hazelcast.HazelcastLeaderElectionTest.runAsyncIfLeader - caller executor shutdown 후 action 완료되어도 cleanup 이 실행된다' --tests 'io.bluetape4k.leader.hazelcast.HazelcastLeaderGroupElectionTest.runAsyncIfLeader - caller executor shutdown 후 action 완료되어도 그룹 슬롯 cleanup 이 실행된다' --tests 'io.bluetape4k.leader.hazelcast.HazelcastSuspendCancellationSafetyTest.suspend elector unlock failure handling rethrows CancellationException' :bluetape4k-leader-redis-lettuce:test --tests 'io.bluetape4k.leader.lettuce.LettuceSuspendLeaderElectorTest.runIfLeader - recordAcquired 취소 후에도 lock 이 해제되어 다음 호출이 성공한다' --warning-mode all`
- `./gradlew :bluetape4k-leader-k8s:test --tests 'io.bluetape4k.leader.k8s.KubernetesLeaseSuspendCancellationSafetyTest.suspend elector opens cleanup scope immediately after acquisition' --warning-mode all`
- `./gradlew :bluetape4k-leader-k8s:k8sTest --tests 'io.bluetape4k.leader.k8s.KubernetesLeaseLeaderElectorK3sTest.async cleanup runs after caller executor shutdown' --warning-mode all`
- `./gradlew :bluetape4k-leader-exposed-jdbc:test --tests 'io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderElectionTest.runAsyncIfLeader - caller executor shutdown 후 action 완료되어도 cleanup 이 실행된다' --warning-mode all`
- `./gradlew :bluetape4k-leader-mongodb:test --tests 'io.bluetape4k.leader.mongodb.MongoLeaderElectionTest.runAsyncIfLeader - caller executor shutdown 후 action 완료되어도 cleanup 이 실행된다' --tests 'io.bluetape4k.leader.mongodb.MongoSuspendLeaderElectorTest.runIfLeader - recordAcquired 취소 후에도 lock 이 해제되어 다음 호출이 성공한다' --warning-mode all`
- `./gradlew :bluetape4k-leader-exposed-r2dbc:test --tests 'io.bluetape4k.leader.exposed.r2dbc.ExposedR2DbcSuspendLeaderElectorTest.runIfLeader - recordAcquired 취소 후에도 lock 이 해제되어 다음 호출이 성공한다' --warning-mode all`
- `./gradlew :bluetape4k-leader-redis-redisson:test --tests 'io.bluetape4k.leader.redisson.RedissonSuspendLeaderElectorTest.suspend elector opens cleanup scope immediately after acquisition' :bluetape4k-leader-zookeeper:test --tests 'io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderElectorTest.suspend elector opens cleanup scope immediately after acquisition' --warning-mode all`
- `git diff --check`
- `rg -n "whenCompleteAsync|handleAsync" leader-consul/src/main/kotlin leader-k8s/src/main/kotlin leader-exposed-jdbc/src/main/kotlin leader-mongodb/src/main/kotlin leader-hazelcast/src/main/kotlin` returned no matches.

## DoD Status
- [x] Async cleanup no longer depends on caller executor availability after action start.
- [x] Suspend cleanup scopes start immediately after backend acquisition.
- [x] Regression coverage added for direct backend behavior and source-structure guards where direct cancellation hooks are not practical.
- [x] 7-tier review artifact added at `docs/review/2026-07-04-acquisition-cleanup-review.md`.
- [x] PR metadata mirrors issues #566 and #567: milestone `0.5.0`, assignee `debop`, labels `bug`, `integration`, `test`.

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #584, head `d1f850c27f0662edd5bc7eb57e9e2ae6f076f5f8`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
