### PR TITLE
fix: constrain zookeeper path and api contracts

### DIFF
--- a/docs/review/2026-07-04-zookeeper-api-review.md
+++ b/docs/review/2026-07-04-zookeeper-api-review.md
@@ -1,0 +1,54 @@
+# ZooKeeper API 7-Tier Review
+
+Date: 2026-07-04
+Scope: issues #571, #572, and #581, milestone 0.5.0
+
+## Modules Reviewed
+
+- `leader-zookeeper`: path construction, CuratorFramework convenience overloads, suspend owner dispatcher lifecycle.
+- `leader-consul`: public option validation.
+
+## 7-Tier Result
+
+1. Correctness: PASS
+   - ZooKeeper lock names now pass the shared `validateLockName()` contract before becoming znode path segments.
+   - Base paths are normalized and validated with Curator path rules before concatenation.
+
+2. API and Contract Compatibility: PASS
+   - Existing string-based convenience overloads remain source-compatible and delegate to the typed path overloads.
+   - `ZooKeeperElectionPath` provides a single typed argument for new call sites that want to avoid positional string swaps.
+
+3. Concurrency and Cancellation: PASS
+   - Suspend single-leader election no longer creates a single-thread executor per `runIfLeader` call.
+   - A bounded reusable owner-dispatcher pool preserves Curator's same-thread acquire/release constraint without blocking release behind waiting acquisitions.
+   - Cancellation propagation and `NonCancellable` release behavior are preserved.
+
+4. Backend Ownership Safety: PASS
+   - Invalid slash, traversal-like, empty-segment, and reserved lock names cannot escape the configured ZooKeeper namespace.
+   - Existing valid root and trailing-slash base-path behavior is preserved.
+
+5. Tests: PASS
+   - Added invalid ZooKeeper lock/base path regressions.
+   - Added typed overload coverage for sync, async, suspend, and group convenience APIs.
+   - Added suspend owner-dispatcher reuse coverage and reran the full ZooKeeper module test suite.
+   - Added Consul option validation regressions for session name, lease range, and lock delay.
+
+6. Security and Observability: PASS
+   - No new token or credential logging.
+   - Path validation fails before Curator znode creation, preventing namespace escape attempts.
+
+7. Maintainability: PASS
+   - Changes stay within ZooKeeper and Consul API/validation surfaces.
+   - Lifecycle ownership is documented on `ZooKeeperSuspendLeaderElector` and its factory.
+
+## Validation Evidence
+
+- `./gradlew :bluetape4k-leader-consul:compileKotlin :bluetape4k-leader-consul:compileTestKotlin :bluetape4k-leader-zookeeper:compileKotlin :bluetape4k-leader-zookeeper:compileTestKotlin --warning-mode all`
+- `./gradlew :bluetape4k-leader-consul:test --tests 'io.bluetape4k.leader.consul.ConsulLeaderElectionOptionsTest' :bluetape4k-leader-zookeeper:test --tests 'io.bluetape4k.leader.zookeeper.ZooKeeperApiCoverageTest' --warning-mode all`
+- `./gradlew :bluetape4k-leader-zookeeper:test --tests 'io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderElectorTest.SuspendedJobTester - 코루틴 job 경합에서 단일 리더만 실행된다' --warning-mode all`
+- `./gradlew :bluetape4k-leader-zookeeper:test --warning-mode all`
+- `git diff --check`
+
+## Deferred Verification
+
+Full repository test is intentionally deferred until the complete stacked issue train is implemented, per the requested workflow.

--- a/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElectionOptions.kt
+++ b/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElectionOptions.kt
@@ -3,6 +3,9 @@ package io.bluetape4k.leader.consul
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.consul.internal.ConsulLeaderPaths
+import io.bluetape4k.support.requireGe
+import io.bluetape4k.support.requireLe
+import io.bluetape4k.support.requireNotBlank
 import java.io.Serializable
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -27,20 +30,10 @@ data class ConsulLeaderElectionOptions(
 
     init {
         ConsulLeaderPaths.validatePrefix(keyPrefix)
-        require(sessionNamePrefix.isNotBlank()) {
-            "sessionNamePrefix must not be blank."
-        }
-        require(leaderOptions.leaseTime >= MinLeaseTime) {
-            "leaderOptions.leaseTime must be at least $MinLeaseTime for Consul Session TTL. " +
-                "leaseTime=${leaderOptions.leaseTime}"
-        }
-        require(leaderOptions.leaseTime <= MaxLeaseTime) {
-            "leaderOptions.leaseTime must be at most $MaxLeaseTime for Consul Session TTL. " +
-                "leaseTime=${leaderOptions.leaseTime}"
-        }
-        require(lockDelay >= Duration.ZERO) {
-            "lockDelay must be non-negative. lockDelay=$lockDelay"
-        }
+        sessionNamePrefix.requireNotBlank("sessionNamePrefix")
+        leaderOptions.leaseTime.requireGe(MinLeaseTime, "leaderOptions.leaseTime")
+        leaderOptions.leaseTime.requireLe(MaxLeaseTime, "leaderOptions.leaseTime")
+        lockDelay.requireGe(Duration.ZERO, "lockDelay")
     }
 
     companion object {
@@ -81,20 +74,16 @@ data class ConsulLeaderGroupElectionOptions(
 
     init {
         ConsulLeaderPaths.validatePrefix(keyPrefix)
-        require(sessionNamePrefix.isNotBlank()) {
-            "sessionNamePrefix must not be blank."
-        }
-        require(leaderGroupOptions.leaseTime >= ConsulLeaderElectionOptions.MinLeaseTime) {
-            "leaderGroupOptions.leaseTime must be at least ${ConsulLeaderElectionOptions.MinLeaseTime} " +
-                "for Consul Session TTL. leaseTime=${leaderGroupOptions.leaseTime}"
-        }
-        require(leaderGroupOptions.leaseTime <= ConsulLeaderElectionOptions.MaxLeaseTime) {
-            "leaderGroupOptions.leaseTime must be at most ${ConsulLeaderElectionOptions.MaxLeaseTime} " +
-                "for Consul Session TTL. leaseTime=${leaderGroupOptions.leaseTime}"
-        }
-        require(lockDelay >= Duration.ZERO) {
-            "lockDelay must be non-negative. lockDelay=$lockDelay"
-        }
+        sessionNamePrefix.requireNotBlank("sessionNamePrefix")
+        leaderGroupOptions.leaseTime.requireGe(
+            ConsulLeaderElectionOptions.MinLeaseTime,
+            "leaderGroupOptions.leaseTime",
+        )
+        leaderGroupOptions.leaseTime.requireLe(
+            ConsulLeaderElectionOptions.MaxLeaseTime,
+            "leaderGroupOptions.leaseTime",
+        )
+        lockDelay.requireGe(Duration.ZERO, "lockDelay")
     }
 
     companion object {

--- a/leader-consul/src/test/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElectionOptionsTest.kt
+++ b/leader-consul/src/test/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElectionOptionsTest.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeLessOrEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.consul.internal.ConsulLeaderPaths
 import io.bluetape4k.leader.consul.internal.ConsulSessionTtl
 import org.junit.jupiter.api.Test
@@ -53,6 +54,29 @@ class ConsulLeaderElectionOptionsTest {
         }
         assertFailsWith<IllegalArgumentException> {
             ConsulLeaderElectionOptions(sessionNamePrefix = " ")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            ConsulLeaderGroupElectionOptions(sessionNamePrefix = " ")
+        }
+    }
+
+    @Test
+    fun `validates Consul timing options with standard helpers`() {
+        assertFailsWith<IllegalArgumentException> {
+            ConsulLeaderElectionOptions(lockDelay = (-1).seconds)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            ConsulLeaderGroupElectionOptions(lockDelay = (-1).seconds)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            ConsulLeaderGroupElectionOptions(
+                leaderGroupOptions = LeaderGroupElectionOptions(leaseTime = 9.seconds),
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            ConsulLeaderGroupElectionOptions(
+                leaderGroupOptions = LeaderGroupElectionOptions(leaseTime = 86_401.seconds),
+            )
         }
     }
 

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperLeaderElector.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperLeaderElector.kt
@@ -166,12 +166,33 @@ class ZooKeeperLeaderElector private constructor(
  * Runs a leader-elected action using the ZooKeeper [CuratorFramework].
  */
 inline fun <T> CuratorFramework.runIfLeader(
+    path: ZooKeeperElectionPath,
+    options: LeaderElectionOptions = LeaderElectionOptions.Default,
+    crossinline action: () -> T,
+): T? =
+    ZooKeeperLeaderElector(this, path.basePath, options).runIfLeader(path.lockName) { action() }
+
+/**
+ * Runs a leader-elected action using the ZooKeeper [CuratorFramework].
+ */
+inline fun <T> CuratorFramework.runIfLeader(
     lockName: String,
     basePath: String = ZooKeeperLeaderElector.DEFAULT_BASE_PATH,
     options: LeaderElectionOptions = LeaderElectionOptions.Default,
     crossinline action: () -> T,
 ): T? =
-    ZooKeeperLeaderElector(this, basePath, options).runIfLeader(lockName) { action() }
+    runIfLeader(ZooKeeperElectionPath(lockName, basePath), options, action)
+
+/**
+ * Runs an async leader-elected action using the ZooKeeper [CuratorFramework].
+ */
+fun <T> CuratorFramework.runAsyncIfLeader(
+    path: ZooKeeperElectionPath,
+    executor: Executor = VirtualThreadExecutor,
+    options: LeaderElectionOptions = LeaderElectionOptions.Default,
+    action: () -> CompletableFuture<T>,
+): CompletableFuture<T?> =
+    ZooKeeperLeaderElector(this, path.basePath, options).runAsyncIfLeader(path.lockName, executor, action)
 
 /**
  * Runs an async leader-elected action using the ZooKeeper [CuratorFramework].
@@ -183,4 +204,4 @@ fun <T> CuratorFramework.runAsyncIfLeader(
     options: LeaderElectionOptions = LeaderElectionOptions.Default,
     action: () -> CompletableFuture<T>,
 ): CompletableFuture<T?> =
-    ZooKeeperLeaderElector(this, basePath, options).runAsyncIfLeader(lockName, executor, action)
+    runAsyncIfLeader(ZooKeeperElectionPath(lockName, basePath), executor, options, action)

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperLeaderGroupElector.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperLeaderGroupElector.kt
@@ -177,12 +177,33 @@ class ZooKeeperLeaderGroupElector private constructor(
  * Runs a multi-leader election action using a ZooKeeper [CuratorFramework].
  */
 inline fun <T> CuratorFramework.runIfLeaderGroup(
+    path: ZooKeeperElectionPath,
+    options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
+    crossinline action: () -> T,
+): T? =
+    ZooKeeperLeaderGroupElector(this, options, path.basePath).runIfLeader(path.lockName) { action() }
+
+/**
+ * Runs a multi-leader election action using a ZooKeeper [CuratorFramework].
+ */
+inline fun <T> CuratorFramework.runIfLeaderGroup(
     lockName: String,
     options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
     basePath: String = ZooKeeperLeaderGroupElector.DEFAULT_BASE_PATH,
     crossinline action: () -> T,
 ): T? =
-    ZooKeeperLeaderGroupElector(this, options, basePath).runIfLeader(lockName) { action() }
+    runIfLeaderGroup(ZooKeeperElectionPath(lockName, basePath), options, action)
+
+/**
+ * Runs an async multi-leader election action using a ZooKeeper [CuratorFramework].
+ */
+fun <T> CuratorFramework.runAsyncIfLeaderGroup(
+    path: ZooKeeperElectionPath,
+    executor: Executor = VirtualThreadExecutor,
+    options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
+    action: () -> CompletableFuture<T>,
+): CompletableFuture<T?> =
+    ZooKeeperLeaderGroupElector(this, options, path.basePath).runAsyncIfLeader(path.lockName, executor, action)
 
 /**
  * Runs an async multi-leader election action using a ZooKeeper [CuratorFramework].
@@ -194,4 +215,4 @@ fun <T> CuratorFramework.runAsyncIfLeaderGroup(
     basePath: String = ZooKeeperLeaderGroupElector.DEFAULT_BASE_PATH,
     action: () -> CompletableFuture<T>,
 ): CompletableFuture<T?> =
-    ZooKeeperLeaderGroupElector(this, options, basePath).runAsyncIfLeader(lockName, executor, action)
+    runAsyncIfLeaderGroup(ZooKeeperElectionPath(lockName, basePath), executor, options, action)

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperPaths.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperPaths.kt
@@ -1,18 +1,74 @@
 package io.bluetape4k.leader.zookeeper
 
+import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.support.requireNotBlank
+import org.apache.curator.utils.PathUtils
+import java.io.Serializable
+
+/**
+ * Typed ZooKeeper election path used by convenience overloads to avoid positional string mistakes.
+ *
+ * ## Behavior / Contract
+ * - [lockName] is validated with the common leader lock-name contract and must be one safe znode segment.
+ * - [basePath] is normalized to a valid ZooKeeper path before election znodes are created below it.
+ *
+ * ```kotlin
+ * val path = ZooKeeperElectionPath.single("daily-job")
+ * curator.runIfLeader(path) { runJob() }
+ * ```
+ */
+data class ZooKeeperElectionPath(
+    val lockName: String,
+    val basePath: String,
+): Serializable {
+
+    init {
+        ZooKeeperPaths.validateBasePath(basePath)
+        validateLockName(lockName)
+    }
+
+    companion object {
+        /**
+         * Creates a path descriptor for single-leader elections.
+         */
+        @JvmStatic
+        fun single(
+            lockName: String,
+            basePath: String = ZooKeeperLeaderElector.DEFAULT_BASE_PATH,
+        ): ZooKeeperElectionPath =
+            ZooKeeperElectionPath(lockName, basePath)
+
+        /**
+         * Creates a path descriptor for multi-leader group elections.
+         */
+        @JvmStatic
+        fun group(
+            lockName: String,
+            basePath: String = ZooKeeperLeaderGroupElector.DEFAULT_BASE_PATH,
+        ): ZooKeeperElectionPath =
+            ZooKeeperElectionPath(lockName, basePath)
+
+        private const val serialVersionUID = 1L
+    }
+}
 
 internal object ZooKeeperPaths {
 
     fun electionPath(basePath: String, lockName: String): String {
-        basePath.requireNotBlank("basePath")
-        lockName.requireNotBlank("lockName")
+        val normalizedBase = validateBasePath(basePath)
+        validateLockName(lockName)
 
-        val normalizedBase = basePath.trimEnd('/').ifBlank { "/" }
         return if (normalizedBase == "/") {
             "/$lockName"
         } else {
             "$normalizedBase/$lockName"
         }
+    }
+
+    fun validateBasePath(basePath: String): String {
+        basePath.requireNotBlank("basePath")
+        val normalizedBase = basePath.trimEnd('/').ifBlank { "/" }
+        PathUtils.validatePath(normalizedBase)
+        return normalizedBase
     }
 }

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderElector.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderElector.kt
@@ -14,22 +14,28 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 import org.apache.curator.framework.CuratorFramework
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * ZooKeeper suspend single-leader election implementation based on Apache Curator's inter-process mutex recipe.
  *
  * ## Behavior / Contract
  * - Uses the same Curator mutex recipe as the blocking [ZooKeeperLeaderElector] to mutually exclude the same [lockName].
- * - Since the Curator mutex has a thread-owner constraint, acquire/release is performed on a per-call single-thread dispatcher.
+ * - Since the Curator mutex has a thread-owner constraint, acquire/release is performed on a bounded pool of reusable
+ *   single-thread owner dispatchers owned by this elector instance. Each call keeps one owner lane until release.
  * - Even during cancellation, releases the lock inside `withContext(NonCancellable)` and re-propagates [CancellationException].
  * - [LeaderElectionOptions.leaseTime] is not used as a ZooKeeper TTL; session termination/expiry is the automatic release boundary.
+ * - Call [close] when the elector is no longer used. Convenience extension functions close their one-shot elector
+ *   automatically.
  *
  * ## ExtendDelegate Integration (T13 PR 8 / Issue #79)
  *
@@ -54,12 +60,19 @@ class ZooKeeperSuspendLeaderElector private constructor(
     private val client: CuratorFramework,
     private val basePath: String,
     private val options: LeaderElectionOptions,
-): SuspendLeaderElector {
+): SuspendLeaderElector, AutoCloseable {
+
+    private val ownerDispatchers = ZooKeeperOwnerDispatcherPool(
+        size = OwnerDispatcherPoolSize,
+        threadNamePrefix = "zookeeper-suspend-leader-owner",
+    )
 
     companion object: KLoggingChannel() {
         const val DEFAULT_BASE_PATH = "/leader-election"
         internal const val ZOOKEEPER_SUSPEND_FACTORY_BEAN_NAME = "zookeeper-suspend-leader-elector"
         internal val ERROR_CLASSIFIER = CompositeBackendErrorClassifier(ZooKeeperBackendErrorClassifier)
+        private const val OwnerDispatcherPoolSize = 8
+        private val OwnerThreadIds = AtomicInteger()
 
         @JvmStatic
         operator fun invoke(
@@ -70,98 +83,153 @@ class ZooKeeperSuspendLeaderElector private constructor(
             ZooKeeperSuspendLeaderElector(client, basePath, options)
     }
 
-    override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? {
+    override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? =
+        ownerDispatchers.withOwner { ownerDispatcher ->
+            runWithOwnerDispatcher(lockName, ownerDispatcher, action)
+        }
+
+    private suspend fun <T> runWithOwnerDispatcher(
+        lockName: String,
+        ownerDispatcher: ExecutorCoroutineDispatcher,
+        action: suspend () -> T,
+    ): T? {
         val path = ZooKeeperPaths.electionPath(basePath, lockName)
         val mutex = ZooKeeperOwnedInterProcessMutex(client, path)
-        val ownerDispatcher = Executors.newSingleThreadExecutor { task ->
-            Thread(task, "zookeeper-suspend-leader-$lockName").apply {
-                isDaemon = true
-            }
-        }.asCoroutineDispatcher()
 
+        log.debug { "ZooKeeper suspend leader lock 획득을 요청합니다. path=$path" }
+        val acquired = try {
+            runInterruptible(ownerDispatcher) {
+                mutex.acquire(options.waitTime.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "ZooKeeper suspend leader lock 획득 실패. path=$path" }
+            return null
+        }
+
+        if (!acquired) {
+            log.debug { "ZooKeeper suspend leader lock 획득 실패 (timeout). path=$path" }
+            return null
+        }
+
+        log.debug { "ZooKeeper suspend leader lock 획득 성공. path=$path" }
+
+        var watchdog: AutoCloseable? = null
         try {
-            log.debug { "ZooKeeper suspend leader lock 획득을 요청합니다. path=$path" }
-            val acquired = try {
-                runInterruptible(ownerDispatcher) {
-                    mutex.acquire(options.waitTime.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                log.warn(e) { "ZooKeeper suspend leader lock 획득 실패. path=$path" }
+            val lockPath = runInterruptible(ownerDispatcher) {
+                mutex.currentThreadLockPath()
+            }
+            if (lockPath == null) {
+                log.warn { "ZooKeeper suspend leader lock path 조회 실패. path=$path" }
                 return null
             }
 
-            if (!acquired) {
-                log.debug { "ZooKeeper suspend leader lock 획득 실패 (timeout). path=$path" }
-                return null
+            val acquiredAtNanos = System.nanoTime()
+            val delegate = ZooKeeperSuspendLockExtendDelegate(client, mutex, path, lockPath)
+            val identity = LockIdentity(
+                lockName = lockName,
+                kind = LockIdentity.AnnotationKind.SINGLE,
+                factoryBeanName = ZOOKEEPER_SUSPEND_FACTORY_BEAN_NAME,
+            )
+            val handle = LeaderLockHandle.real(
+                identity = identity,
+                token = lockName,
+                acquiredAtNanos = acquiredAtNanos,
+                extendDelegate = delegate,
+            )
+            // R16 enforce: ZK 는 TTL 없음 — autoExtend 강제 비활성화 (사용자 설정 무시 + WARN)
+            if (options.autoExtend) {
+                log.warn {
+                    "ZooKeeper 는 TTL 이 없는 세션 기반 락 — autoExtend=true 설정이 무시됩니다. " +
+                        "ZK 세션 keepalive 가 lease 역할을 대신합니다. lockName=$lockName"
+                }
             }
+            watchdog = LeaderLeaseAutoExtender.start(
+                enabled = false,
+                leaseTime = options.leaseTime,
+                delegate = delegate,
+                classifier = ERROR_CLASSIFIER,
+            )
 
-            log.debug { "ZooKeeper suspend leader lock 획득 성공. path=$path" }
-
-            var watchdog: AutoCloseable? = null
-            try {
-                val lockPath = runInterruptible(ownerDispatcher) {
-                    mutex.currentThreadLockPath()
-                }
-                if (lockPath == null) {
-                    log.warn { "ZooKeeper suspend leader lock path 조회 실패. path=$path" }
-                    return null
-                }
-
-                val acquiredAtNanos = System.nanoTime()
-                val delegate = ZooKeeperSuspendLockExtendDelegate(client, mutex, path, lockPath)
-                val identity = LockIdentity(
-                    lockName = lockName,
-                    kind = LockIdentity.AnnotationKind.SINGLE,
-                    factoryBeanName = ZOOKEEPER_SUSPEND_FACTORY_BEAN_NAME,
-                )
-                val handle = LeaderLockHandle.real(
-                    identity = identity,
-                    token = lockName,
-                    acquiredAtNanos = acquiredAtNanos,
-                    extendDelegate = delegate,
-                )
-                // R16 enforce: ZK 는 TTL 없음 — autoExtend 강제 비활성화 (사용자 설정 무시 + WARN)
-                if (options.autoExtend) {
-                    log.warn {
-                        "ZooKeeper 는 TTL 이 없는 세션 기반 락 — autoExtend=true 설정이 무시됩니다. " +
-                            "ZK 세션 keepalive 가 lease 역할을 대신합니다. lockName=$lockName"
-                    }
-                }
-                watchdog = LeaderLeaseAutoExtender.start(
-                    enabled = false,
-                    leaseTime = options.leaseTime,
-                    delegate = delegate,
-                    classifier = ERROR_CLASSIFIER,
-                )
-
-                return withContext(AopScopeAccess.createLockHandleElement(handle)) {
-                    action()
-                }
-            } finally {
-                // NonCancellable: 코루틴 취소 시에도 watchdog close + 락 해제가 중단되지 않도록 보호
-                withContext(NonCancellable) {
-                    try {
-                        watchdog?.close()
-                    } catch (e: Exception) {
-                        log.warn(e) { "ZooKeeper suspend watchdog close 실패. path=$path" }
-                    }
-                    try {
-                        runInterruptible(ownerDispatcher) {
-                            mutex.release()
-                        }
-                        log.debug { "ZooKeeper suspend leader lock 반납 완료. path=$path" }
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        log.warn(e) { "ZooKeeper suspend leader lock 반납 실패. path=$path" }
-                    }
-                }
+            return withContext(AopScopeAccess.createLockHandleElement(handle)) {
+                action()
             }
         } finally {
-            ownerDispatcher.close()
+            // NonCancellable: 코루틴 취소 시에도 watchdog close + 락 해제가 중단되지 않도록 보호
+            withContext(NonCancellable) {
+                try {
+                    watchdog?.close()
+                } catch (e: Exception) {
+                    log.warn(e) { "ZooKeeper suspend watchdog close 실패. path=$path" }
+                }
+                try {
+                    runInterruptible(ownerDispatcher) {
+                        mutex.release()
+                    }
+                    log.debug { "ZooKeeper suspend leader lock 반납 완료. path=$path" }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log.warn(e) { "ZooKeeper suspend leader lock 반납 실패. path=$path" }
+                }
+            }
         }
+    }
+
+    override fun close() {
+        ownerDispatchers.close()
+    }
+
+    private class ZooKeeperOwnerDispatcherPool(
+        size: Int,
+        threadNamePrefix: String,
+    ): AutoCloseable {
+        private val dispatchers: List<ExecutorCoroutineDispatcher> =
+            List(size) {
+                Executors.newSingleThreadExecutor { task ->
+                    Thread(task, "$threadNamePrefix-${OwnerThreadIds.incrementAndGet()}").apply {
+                        isDaemon = true
+                    }
+                }.asCoroutineDispatcher()
+            }
+        private val available = Channel<ExecutorCoroutineDispatcher>(capacity = size)
+
+        init {
+            dispatchers.forEach { dispatcher ->
+                available.trySend(dispatcher).getOrThrow()
+            }
+        }
+
+        suspend fun <T> withOwner(block: suspend (ExecutorCoroutineDispatcher) -> T): T {
+            val dispatcher = available.receive()
+            return try {
+                block(dispatcher)
+            } finally {
+                available.trySend(dispatcher).getOrThrow()
+            }
+        }
+
+        override fun close() {
+            available.close()
+            dispatchers.forEach { it.close() }
+        }
+    }
+}
+
+/**
+ * Runs a suspend leader election action using a ZooKeeper [CuratorFramework].
+ */
+suspend inline fun <T> CuratorFramework.suspendRunIfLeader(
+    path: ZooKeeperElectionPath,
+    options: LeaderElectionOptions = LeaderElectionOptions.Default,
+    crossinline action: suspend () -> T,
+): T? {
+    val elector = ZooKeeperSuspendLeaderElector(this, path.basePath, options)
+    return try {
+        elector.runIfLeader(path.lockName) { action() }
+    } finally {
+        elector.close()
     }
 }
 
@@ -174,4 +242,4 @@ suspend inline fun <T> CuratorFramework.suspendRunIfLeader(
     options: LeaderElectionOptions = LeaderElectionOptions.Default,
     crossinline action: suspend () -> T,
 ): T? =
-    ZooKeeperSuspendLeaderElector(this, basePath, options).runIfLeader(lockName) { action() }
+    suspendRunIfLeader(ZooKeeperElectionPath(lockName, basePath), options, action)

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderElectorFactory.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderElectorFactory.kt
@@ -1,12 +1,14 @@
 package io.bluetape4k.leader.zookeeper
 
 import io.bluetape4k.leader.LeaderElectionOptions
-import io.bluetape4k.leader.coroutines.SuspendLeaderElector
 import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
 import org.apache.curator.framework.CuratorFramework
 
 /**
  * Factory for [ZooKeeperSuspendLeaderElector].
+ *
+ * Created electors own a reusable single-thread ZooKeeper owner dispatcher.
+ * Close the returned [ZooKeeperSuspendLeaderElector] when it is no longer used.
  *
  * @param client Shared Curator client. Lifecycle managed by the caller.
  * @param basePath Base path for suspend leader election znodes
@@ -16,6 +18,6 @@ class ZooKeeperSuspendLeaderElectorFactory(
     private val basePath: String = ZooKeeperSuspendLeaderElector.DEFAULT_BASE_PATH,
 ): SuspendLeaderElectorFactory {
 
-    override suspend fun create(options: LeaderElectionOptions): SuspendLeaderElector =
+    override suspend fun create(options: LeaderElectionOptions): ZooKeeperSuspendLeaderElector =
         ZooKeeperSuspendLeaderElector(client, basePath, options)
 }

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderGroupElector.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderGroupElector.kt
@@ -167,9 +167,19 @@ class ZooKeeperSuspendLeaderGroupElector private constructor(
  * Runs a suspend multi-leader election action using a ZooKeeper [CuratorFramework].
  */
 suspend inline fun <T> CuratorFramework.suspendRunIfLeaderGroup(
+    path: ZooKeeperElectionPath,
+    options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
+    crossinline action: suspend () -> T,
+): T? =
+    ZooKeeperSuspendLeaderGroupElector(this, options, path.basePath).runIfLeader(path.lockName) { action() }
+
+/**
+ * Runs a suspend multi-leader election action using a ZooKeeper [CuratorFramework].
+ */
+suspend inline fun <T> CuratorFramework.suspendRunIfLeaderGroup(
     lockName: String,
     options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
     basePath: String = ZooKeeperSuspendLeaderGroupElector.DEFAULT_BASE_PATH,
     crossinline action: suspend () -> T,
 ): T? =
-    ZooKeeperSuspendLeaderGroupElector(this, options, basePath).runIfLeader(lockName) { action() }
+    suspendRunIfLeaderGroup(ZooKeeperElectionPath(lockName, basePath), options, action)

--- a/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperApiCoverageTest.kt
+++ b/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperApiCoverageTest.kt
@@ -1,10 +1,13 @@
 package io.bluetape4k.leader.zookeeper
 
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import kotlinx.coroutines.test.runTest
-import io.bluetape4k.assertions.shouldBeEqualTo
 import org.junit.jupiter.api.Test
+import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
 import kotlin.time.Duration.Companion.seconds
 
@@ -17,19 +20,40 @@ class ZooKeeperApiCoverageTest: AbstractZooKeeperLeaderTest() {
         val groupOptions = LeaderGroupElectionOptions(maxLeaders = 2, waitTime = 5.seconds)
 
         curator.runIfLeader(lockName) { "blocking" } shouldBeEqualTo "blocking"
+        curator.runIfLeader(ZooKeeperElectionPath.single("${lockName}-typed")) {
+            "blocking-typed"
+        } shouldBeEqualTo "blocking-typed"
+
         curator.runAsyncIfLeader("${lockName}-async") {
             CompletableFuture.completedFuture("async")
         }.join() shouldBeEqualTo "async"
+        curator.runAsyncIfLeader(ZooKeeperElectionPath.single("${lockName}-async-typed")) {
+            CompletableFuture.completedFuture("async-typed")
+        }.join() shouldBeEqualTo "async-typed"
 
         curator.runIfLeaderGroup(groupName, groupOptions) { "group" } shouldBeEqualTo "group"
+        curator.runIfLeaderGroup(ZooKeeperElectionPath.group("${groupName}-typed"), groupOptions) {
+            "group-typed"
+        } shouldBeEqualTo "group-typed"
+
         curator.runAsyncIfLeaderGroup("${groupName}-async", options = groupOptions) {
             CompletableFuture.completedFuture("group-async")
         }.join() shouldBeEqualTo "group-async"
+        curator.runAsyncIfLeaderGroup(ZooKeeperElectionPath.group("${groupName}-async-typed"), options = groupOptions) {
+            CompletableFuture.completedFuture("group-async-typed")
+        }.join() shouldBeEqualTo "group-async-typed"
 
         curator.suspendRunIfLeader("${lockName}-suspend") { "suspend" } shouldBeEqualTo "suspend"
+        curator.suspendRunIfLeader(ZooKeeperElectionPath.single("${lockName}-suspend-typed")) {
+            "suspend-typed"
+        } shouldBeEqualTo "suspend-typed"
+
         curator.suspendRunIfLeaderGroup("${groupName}-suspend", groupOptions) {
             "group-suspend"
         } shouldBeEqualTo "group-suspend"
+        curator.suspendRunIfLeaderGroup(ZooKeeperElectionPath.group("${groupName}-suspend-typed"), groupOptions) {
+            "group-suspend-typed"
+        } shouldBeEqualTo "group-suspend-typed"
     }
 
     @Test
@@ -45,9 +69,12 @@ class ZooKeeperApiCoverageTest: AbstractZooKeeperLeaderTest() {
             .create(groupOptions)
             .runIfLeader(randomName()) { "group-factory" } shouldBeEqualTo "group-factory"
 
-        ZooKeeperSuspendLeaderElectorFactory(curator)
-            .create(singleOptions)
-            .runIfLeader(randomName()) { "suspend-factory" } shouldBeEqualTo "suspend-factory"
+        val suspendElector = ZooKeeperSuspendLeaderElectorFactory(curator).create(singleOptions)
+        try {
+            suspendElector.runIfLeader(randomName()) { "suspend-factory" } shouldBeEqualTo "suspend-factory"
+        } finally {
+            suspendElector.close()
+        }
 
         ZooKeeperSuspendLeaderGroupElectorFactory(curator)
             .create(groupOptions)
@@ -78,5 +105,54 @@ class ZooKeeperApiCoverageTest: AbstractZooKeeperLeaderTest() {
         val result = curator.runIfLeader(randomName(), basePath = "/") { "root" }
 
         result shouldBeEqualTo "root"
+    }
+
+    @Test
+    fun `ZooKeeper path construction rejects unsafe lock name segments`() {
+        listOf("a/b", "../escape", "a//b", ".", "..", " lock").forEach { lockName ->
+            assertFailsWith<IllegalArgumentException> {
+                ZooKeeperPaths.electionPath("/leader-election", lockName)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                ZooKeeperElectionPath.single(lockName)
+            }
+        }
+    }
+
+    @Test
+    fun `ZooKeeper path construction validates and normalizes base path`() {
+        ZooKeeperPaths.electionPath("/leader-election/", "daily-job") shouldBeEqualTo "/leader-election/daily-job"
+        ZooKeeperPaths.electionPath("/", "daily-job") shouldBeEqualTo "/daily-job"
+
+        listOf("leader-election", "/leader-election//nested", "/leader-election/../escape").forEach { basePath ->
+            assertFailsWith<IllegalArgumentException> {
+                ZooKeeperPaths.electionPath(basePath, "daily-job")
+            }
+            assertFailsWith<IllegalArgumentException> {
+                ZooKeeperElectionPath.single("daily-job", basePath)
+            }
+        }
+    }
+
+    @Test
+    fun `suspend elector reuses owner dispatcher across runIfLeader calls`() = runTest {
+        val election = ZooKeeperSuspendLeaderElector(curator)
+        try {
+            repeat(3) { index ->
+                election.runIfLeader("${randomName()}-$index") { "ok" } shouldBeEqualTo "ok"
+            }
+        } finally {
+            election.close()
+        }
+
+        val source = Path.of(
+            "src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderElector.kt",
+        ).toFile().readText()
+        val runStart = source.indexOf("private suspend fun <T> runWithOwnerDispatcher")
+        val closeStart = source.indexOf("override fun close()", startIndex = runStart)
+        val runBody = source.substring(runStart, closeStart)
+
+        source.contains("private class ZooKeeperOwnerDispatcherPool").shouldBeTrue()
+        (!runBody.contains("Executors.newSingleThreadExecutor")).shouldBeTrue()
     }
 }

--- a/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderElectorTest.kt
+++ b/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperSuspendLeaderElectorTest.kt
@@ -25,9 +25,13 @@ class ZooKeeperSuspendLeaderElectorTest: AbstractZooKeeperLeaderTest() {
     fun `runIfLeader - 리더로 선출되어 suspend action 을 실행하고 결과를 반환한다`() = runTest {
         val election = ZooKeeperSuspendLeaderElector(curator)
 
-        val result = election.runIfLeader(randomName()) {
-            delay(10.milliseconds)
-            "hello"
+        val result = try {
+            election.runIfLeader(randomName()) {
+                delay(10.milliseconds)
+                "hello"
+            }
+        } finally {
+            election.close()
         }
 
         result shouldBeEqualTo "hello"
@@ -55,6 +59,7 @@ class ZooKeeperSuspendLeaderElectorTest: AbstractZooKeeperLeaderTest() {
             val result = election.runIfLeader(lockName) { "should-skip" }
             result.shouldBeNull()
         } finally {
+            election.close()
             release.countDown()
             holder.shutdownNow()
         }
@@ -65,8 +70,12 @@ class ZooKeeperSuspendLeaderElectorTest: AbstractZooKeeperLeaderTest() {
         val lockName = randomName()
         val election = ZooKeeperSuspendLeaderElector(curator)
 
-        runCatching { election.runIfLeader(lockName) { error("boom") } }
-        val result = election.runIfLeader(lockName) { "recovered" }
+        val result = try {
+            runCatching { election.runIfLeader(lockName) { error("boom") } }
+            election.runIfLeader(lockName) { "recovered" }
+        } finally {
+            election.close()
+        }
 
         result shouldBeEqualTo "recovered"
     }
@@ -88,25 +97,29 @@ class ZooKeeperSuspendLeaderElectorTest: AbstractZooKeeperLeaderTest() {
         val peakConcurrent = AtomicInteger(0)
         val executed = AtomicInteger(0)
 
-        SuspendedJobTester()
-            .workers(8)
-            .rounds(16)
-            .add {
-                election.runIfLeader(lockName) {
-                    val current = currentConcurrent.incrementAndGet()
-                    peakConcurrent.updateAndGet { max(it, current) }
-                    try {
-                        executed.incrementAndGet()
-                        delay(10.milliseconds)
-                    } finally {
-                        currentConcurrent.decrementAndGet()
+        try {
+            SuspendedJobTester()
+                .workers(12)
+                .rounds(16)
+                .add {
+                    election.runIfLeader(lockName) {
+                        val current = currentConcurrent.incrementAndGet()
+                        peakConcurrent.updateAndGet { max(it, current) }
+                        try {
+                            executed.incrementAndGet()
+                            delay(10.milliseconds)
+                        } finally {
+                            currentConcurrent.decrementAndGet()
+                        }
                     }
                 }
-            }
-            .run()
+                .run()
 
-        executed.get() shouldBeGreaterThan 0
-        peakConcurrent.get() shouldBeLessOrEqualTo 1
+            executed.get() shouldBeGreaterThan 0
+            peakConcurrent.get() shouldBeLessOrEqualTo 1
+        } finally {
+            election.close()
+        }
     }
 
     private fun String.cleanupScopeStartsImmediatelyAfterAcquire(): Boolean {


### PR DESCRIPTION
## Summary

PR #585의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: constrain zookeeper path and api contracts`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary
- Validate ZooKeeper lock names as safe single znode segments and validate/normalize base paths before constructing Curator paths.
- Add `ZooKeeperElectionPath` typed overloads for sync, async, suspend, and group convenience APIs while keeping existing string overloads compatible.
- Reuse a bounded pool of suspend owner dispatchers across `runIfLeader` calls and document close lifecycle.
- Align Consul option validation with repo-standard helper APIs.

## Stack
- Base PR: #584 (`fix/leader-0.5-acquisition-cleanup`)
- This PR resolves: #571, #572, #581
- Stacked for the 0.5.0 issue train.

## Validation
- `./gradlew :bluetape4k-leader-consul:compileKotlin :bluetape4k-leader-consul:compileTestKotlin :bluetape4k-leader-zookeeper:compileKotlin :bluetape4k-leader-zookeeper:compileTestKotlin --warning-mode all`
- `./gradlew :bluetape4k-leader-consul:test --tests 'io.bluetape4k.leader.consul.ConsulLeaderElectionOptionsTest' :bluetape4k-leader-zookeeper:test --tests 'io.bluetape4k.leader.zookeeper.ZooKeeperApiCoverageTest' --warning-mode all`
- `./gradlew :bluetape4k-leader-zookeeper:test --tests 'io.bluetape4k.leader.zookeeper.ZooKeeperSuspendLeaderElectorTest.SuspendedJobTester - 코루틴 job 경합에서 단일 리더만 실행된다' --warning-mode all`
- `./gradlew :bluetape4k-leader-zookeeper:test --warning-mode all`
- `git diff --check`

## DoD Status
- [x] ZooKeeper lock names cannot escape the configured namespace via slash, traversal-like, empty-segment, or reserved path forms.
- [x] Existing string overloads remain compatible and typed path overloads are available for safer call sites.
- [x] Suspend ZooKeeper single-leader election reuses bounded owner dispatchers without per-call executor creation or contention deadlock.
- [x] Consul public option validation uses project helper APIs.
- [x] 7-tier review artifact added at `docs/review/2026-07-04-zookeeper-api-review.md`.
- [x] PR metadata mirrors issues #571, #572, and #581: milestone `0.5.0`, assignee `debop`, labels `bug`, `security`, `test`, `performance`, `refactor`, `maintenance`.

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #585, head `b1d7095a30775f51badfc265e6da898816b2093b`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
