### PR TITLE
perf: bound dynamodb group state lookup

### DIFF
--- a/docs/review/2026-07-04-dynamodb-slot-state-review.md
+++ b/docs/review/2026-07-04-dynamodb-slot-state-review.md
@@ -1,0 +1,54 @@
+# DynamoDB Slot State 7-Tier Review
+
+Date: 2026-07-04
+Scope: issue #573, milestone 0.5.0
+
+## Modules Reviewed
+
+- `leader-dynamodb`: group state and active-count lookup paths.
+
+## 7-Tier Result
+
+1. Correctness: PASS
+   - Group state now reads deterministic slot keys for `0 until maxLeaders`.
+   - Missing and expired slot rows are excluded from the returned `LeaderLease` list.
+
+2. API and Contract Compatibility: PASS
+   - Public elector APIs and option models are unchanged.
+   - `state()` and `activeCount()` retain the same empty, partial, full, and released-slot semantics.
+
+3. Concurrency and Cancellation: PASS
+   - No acquisition, release, watchdog, or coroutine cancellation paths were changed.
+   - Async-backed suspend state reads still use the same client boundary, now through bounded batch get calls.
+
+4. Backend Ownership Safety: PASS
+   - Lookup is limited to deterministic group slot keys derived from the validated logical lock name.
+   - No table-wide prefix scan remains on the group state hot path.
+
+5. Tests: PASS
+   - Added internal client tests for deterministic slot keys, expired-slot filtering, missing slots, batch chunking at 100 keys, unprocessed-key retry, and zero scan calls.
+   - Existing DynamoDB group integration tests cover empty, occupied, full, release, and reacquire behavior.
+
+6. Security and Observability: PASS
+   - No credential or token logging changes.
+   - The lookup no longer pages through unrelated table rows.
+
+7. Maintainability: PASS
+   - Batch lookup behavior is centralized in `DynamoDbLockClient`.
+   - Electors only pass the group prefix and `maxLeaders`, keeping key derivation in the DynamoDB internal package.
+
+## Validation Evidence
+
+- `./gradlew :bluetape4k-leader-dynamodb:compileKotlin :bluetape4k-leader-dynamodb:compileTestKotlin --warning-mode all`
+- `./gradlew :bluetape4k-leader-dynamodb:test --tests 'io.bluetape4k.leader.dynamodb.internal.DynamoDbLockClientStateLookupTest' --tests 'io.bluetape4k.leader.dynamodb.DynamoDbLeaderGroupElectorIntegrationTest' --tests 'io.bluetape4k.leader.dynamodb.DynamoDbSuspendLeaderGroupElectorIntegrationTest' --warning-mode all`
+- `./gradlew :bluetape4k-leader-dynamodb:test --warning-mode all`
+- `rg -n "ScanRequest|\\.scan\\(" leader-dynamodb/src/main leader-dynamodb/src/test -g '*.kt'`
+- `git diff --check`
+
+## Retry Note
+
+The first full DynamoDB module run exposed one timing-sensitive existing watchdog integration failure. The failing test passed when rerun directly, and the full module passed on the next run with 27 passing tests.
+
+## Deferred Verification
+
+Full repository test is intentionally deferred until the complete stacked issue train is implemented, per the requested workflow.

--- a/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbLeaderGroupElector.kt
+++ b/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbLeaderGroupElector.kt
@@ -45,7 +45,7 @@ class DynamoDbLeaderGroupElector(
 
     override fun state(lockName: String): LeaderGroupState {
         DynamoDbKeys.validateUserLockName(lockName)
-        val leases = lockClient.activeGroupLeases(DynamoDbKeys.groupPrefix(options.keyPrefix, lockName))
+        val leases = lockClient.activeGroupLeases(DynamoDbKeys.groupPrefix(options.keyPrefix, lockName), maxLeaders)
         return LeaderGroupState(lockName, maxLeaders, leases.size.coerceAtMost(maxLeaders), leases)
     }
 

--- a/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbSuspendLeaderGroupElector.kt
+++ b/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbSuspendLeaderGroupElector.kt
@@ -42,7 +42,7 @@ class DynamoDbSuspendLeaderGroupElector(
 
     override fun state(lockName: String): LeaderGroupState {
         DynamoDbKeys.validateUserLockName(lockName)
-        val leases = lockClient.activeGroupLeases(DynamoDbKeys.groupPrefix(options.keyPrefix, lockName))
+        val leases = lockClient.activeGroupLeases(DynamoDbKeys.groupPrefix(options.keyPrefix, lockName), maxLeaders)
         return LeaderGroupState(lockName, maxLeaders, leases.size.coerceAtMost(maxLeaders), leases)
     }
 

--- a/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/internal/DynamoDbLockClient.kt
+++ b/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/internal/DynamoDbLockClient.kt
@@ -10,11 +10,12 @@ import io.bluetape4k.logging.warn
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemRequest
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
 import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest
+import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest
-import software.amazon.awssdk.services.dynamodb.model.ScanRequest
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest
 import java.time.Instant
 import java.util.UUID
@@ -42,6 +43,7 @@ internal class DynamoDbLockClient(
         private const val OwnerAttr = "#ownerId"
         private const val LeaseAttr = "#leaseExpiry"
         private const val TtlAttr = "#ttl"
+        private const val BatchGetLimit = 100
 
         fun newOwnerId(): String = UUID.randomUUID().toString()
     }
@@ -295,41 +297,48 @@ internal class DynamoDbLockClient(
         }
     }
 
-    fun activeGroupLeases(prefix: String): List<LeaderLease> {
+    fun activeGroupLeases(prefix: String, maxLeaders: Int): List<LeaderLease> {
         val now = nowMillis()
-        val request = ScanRequest.builder()
-            .tableName(tableName)
-            .filterExpression("begins_with($LockNameAttr, :prefix) AND $LeaseAttr > :now")
-            .expressionAttributeNames(mapOf(LockNameAttr to LockName, LeaseAttr to LeaseExpiry))
-            .expressionAttributeValues(mapOf(":prefix" to s(prefix), ":now" to n(now)))
-            .build()
-        val items = scanAll(request)
+        val keys = (0 until maxLeaders).map { slot -> "$prefix$slot" }
+        val items = batchRead(keys)
         return items.mapNotNull { item ->
             val ownerId = item[OwnerId]?.s() ?: return@mapNotNull null
             val auditLeaderId = item[AuditLeaderId]?.s() ?: ownerId
             val nodeId = item[NodeId]?.s()
             val leaseExpiry = item[LeaseExpiry]?.n()?.toLongOrNull() ?: return@mapNotNull null
+            if (leaseExpiry <= now) {
+                return@mapNotNull null
+            }
             val slot = item[LockName]?.s()?.substringAfterLast("#slot-", "")?.toIntOrNull()
             LeaderLease(auditLeaderId, leaseUntil = Instant.ofEpochMilli(leaseExpiry), slot = slot, nodeId = nodeId)
         }
     }
 
-    private fun scanAll(request: ScanRequest): List<Map<String, AttributeValue>> {
+    private fun batchRead(keys: List<String>): List<Map<String, AttributeValue>> {
         val items = mutableListOf<Map<String, AttributeValue>>()
-        var nextKey: Map<String, AttributeValue>? = null
-        do {
-            val pageRequest = request.toBuilder().apply {
-                if (!nextKey.isNullOrEmpty()) {
-                    exclusiveStartKey(nextKey)
+        keys.chunked(BatchGetLimit).forEach { chunk ->
+            var requestItems = batchRequestItems(chunk)
+            do {
+                val response = syncClient?.batchGetItem(BatchGetItemRequest.builder().requestItems(requestItems).build())
+                    ?: requireNotNull(asyncClient) { "DynamoDB client is required" }
+                        .batchGetItem(BatchGetItemRequest.builder().requestItems(requestItems).build())
+                        .join()
+                items += response.responses()[tableName].orEmpty()
+                requestItems = response.unprocessedKeys().filterValues { tableKeys ->
+                    !tableKeys.keys().isNullOrEmpty()
                 }
-            }.build()
-            val response = syncClient?.scan(pageRequest)
-                ?: requireNotNull(asyncClient) { "DynamoDB client is required" }.scan(pageRequest).join()
-            items += response.items()
-            nextKey = response.lastEvaluatedKey().takeUnless { it.isNullOrEmpty() }
-        } while (nextKey != null)
+            } while (requestItems.isNotEmpty())
+        }
         return items
     }
+
+    private fun batchRequestItems(keys: List<String>): Map<String, KeysAndAttributes> =
+        mapOf(
+            tableName to KeysAndAttributes.builder()
+                .consistentRead(true)
+                .keys(keys.map { key -> mapOf(LockName to s(key)) })
+                .build(),
+        )
 
     private data class LockRecord(
         val ownerId: String,

--- a/leader-dynamodb/src/test/kotlin/io/bluetape4k/leader/dynamodb/internal/DynamoDbLockClientStateLookupTest.kt
+++ b/leader-dynamodb/src/test/kotlin/io/bluetape4k/leader/dynamodb/internal/DynamoDbLockClientStateLookupTest.kt
@@ -1,0 +1,154 @@
+package io.bluetape4k.leader.dynamodb.internal
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemRequest
+import software.amazon.awssdk.services.dynamodb.model.BatchGetItemResponse
+import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes
+import software.amazon.awssdk.services.dynamodb.model.ScanRequest
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DynamoDbLockClientStateLookupTest {
+
+    @Test
+    fun `activeGroupLeases reads deterministic slot keys without scan`() {
+        val client = mockk<DynamoDbClient>()
+        val request = slot<BatchGetItemRequest>()
+        val now = 1_000L
+        val tableName = "leader-locks"
+        val prefix = "leader/group/orders#slot-"
+        val lockClient = DynamoDbLockClient(tableName, syncClient = client, nowMillis = { now })
+
+        every { client.batchGetItem(capture(request)) } returns BatchGetItemResponse.builder()
+            .responses(
+                mapOf(
+                    tableName to listOf(
+                        item("${prefix}0", ownerId = "owner-a", auditLeaderId = "audit-a", nodeId = "node-a", expiresAt = 5_000L),
+                        item("${prefix}1", ownerId = "owner-b", auditLeaderId = "audit-b", nodeId = "node-b", expiresAt = 999L),
+                    ),
+                ),
+            )
+            .unprocessedKeys(emptyMap())
+            .build()
+
+        val leases = lockClient.activeGroupLeases(prefix, maxLeaders = 3)
+
+        leases.size shouldBeEqualTo 1
+        leases.single().auditLeaderId shouldBeEqualTo "audit-a"
+        leases.single().nodeId shouldBeEqualTo "node-a"
+        leases.single().slot shouldBeEqualTo 0
+        request.captured.requestedKeys(tableName) shouldBeEqualTo listOf("${prefix}0", "${prefix}1", "${prefix}2")
+        verify(exactly = 1) { client.batchGetItem(any<BatchGetItemRequest>()) }
+        verify(exactly = 0) { client.scan(any<ScanRequest>()) }
+    }
+
+    @Test
+    fun `activeGroupLeases chunks slot lookup at DynamoDB batch get limit`() {
+        val client = mockk<DynamoDbClient>()
+        val requests = mutableListOf<BatchGetItemRequest>()
+        val tableName = "leader-locks"
+        val prefix = "leader/group/orders#slot-"
+        val lockClient = DynamoDbLockClient(tableName, syncClient = client, nowMillis = { 1_000L })
+
+        every { client.batchGetItem(any<BatchGetItemRequest>()) } answers {
+            requests += invocation.args[0] as BatchGetItemRequest
+            BatchGetItemResponse.builder()
+                .responses(emptyMap())
+                .unprocessedKeys(emptyMap())
+                .build()
+        }
+
+        lockClient.activeGroupLeases(prefix, maxLeaders = 250) shouldBeEqualTo emptyList()
+
+        requests.map { it.requestedKeys(tableName).size } shouldBeEqualTo listOf(100, 100, 50)
+        requests.flatMap { it.requestedKeys(tableName) }.toSet().size shouldBeEqualTo 250
+        verify(exactly = 3) { client.batchGetItem(any<BatchGetItemRequest>()) }
+        verify(exactly = 0) { client.scan(any<ScanRequest>()) }
+    }
+
+    @Test
+    fun `activeGroupLeases retries unprocessed slot keys`() {
+        val client = mockk<DynamoDbClient>()
+        val requests = mutableListOf<BatchGetItemRequest>()
+        val tableName = "leader-locks"
+        val prefix = "leader/group/orders#slot-"
+        val lockClient = DynamoDbLockClient(tableName, syncClient = client, nowMillis = { 1_000L })
+
+        var attempt = 0
+        every { client.batchGetItem(any<BatchGetItemRequest>()) } answers {
+            requests += invocation.args[0] as BatchGetItemRequest
+            attempt += 1
+            if (attempt == 1) {
+                BatchGetItemResponse.builder()
+                    .responses(emptyMap())
+                    .unprocessedKeys(
+                        mapOf(
+                            tableName to KeysAndAttributes.builder()
+                                .consistentRead(true)
+                                .keys(listOf(mapOf(DynamoDbLockClient.LockName to s("${prefix}0"))))
+                                .build(),
+                        ),
+                    )
+                    .build()
+            } else {
+                BatchGetItemResponse.builder()
+                    .responses(
+                        mapOf(
+                            tableName to listOf(
+                                item(
+                                    "${prefix}0",
+                                    ownerId = "owner-a",
+                                    auditLeaderId = "audit-a",
+                                    nodeId = "node-a",
+                                    expiresAt = 5_000L,
+                                ),
+                            ),
+                        ),
+                    )
+                    .unprocessedKeys(emptyMap())
+                    .build()
+            }
+        }
+
+        val leases = lockClient.activeGroupLeases(prefix, maxLeaders = 1)
+
+        leases.single().auditLeaderId shouldBeEqualTo "audit-a"
+        requests.map { it.requestedKeys(tableName) } shouldBeEqualTo listOf(listOf("${prefix}0"), listOf("${prefix}0"))
+        verify(exactly = 2) { client.batchGetItem(any<BatchGetItemRequest>()) }
+        verify(exactly = 0) { client.scan(any<ScanRequest>()) }
+    }
+
+    private fun BatchGetItemRequest.requestedKeys(tableName: String): List<String> =
+        requestItems()[tableName]
+            ?.keys()
+            .orEmpty()
+            .mapNotNull { key -> key[DynamoDbLockClient.LockName]?.s() }
+
+    private fun item(
+        lockName: String,
+        ownerId: String,
+        auditLeaderId: String,
+        nodeId: String,
+        expiresAt: Long,
+    ): Map<String, AttributeValue> =
+        mapOf(
+            DynamoDbLockClient.LockName to s(lockName),
+            DynamoDbLockClient.OwnerId to s(ownerId),
+            DynamoDbLockClient.AuditLeaderId to s(auditLeaderId),
+            DynamoDbLockClient.NodeId to s(nodeId),
+            DynamoDbLockClient.LeaseExpiry to n(expiresAt),
+        )
+
+    private fun s(value: String): AttributeValue =
+        AttributeValue.builder().s(value).build()
+
+    private fun n(value: Long): AttributeValue =
+        AttributeValue.builder().n(value.toString()).build()
+}


### PR DESCRIPTION
## Summary

Closes #573

PR #587의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `perf: bound dynamodb group state lookup`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

- Replace DynamoDB group state table scan with deterministic slot-key BatchGetItem lookup.
- Chunk slot lookup at DynamoDB's 100-key batch limit and retry unprocessed keys.
- Filter missing and expired slot rows locally while preserving group state semantics.
- Add internal client tests proving zero scan calls and bounded request counts.

Fixes #573

## Validation

- ./gradlew :bluetape4k-leader-dynamodb:compileKotlin :bluetape4k-leader-dynamodb:compileTestKotlin --warning-mode all
- ./gradlew :bluetape4k-leader-dynamodb:test --tests 'io.bluetape4k.leader.dynamodb.internal.DynamoDbLockClientStateLookupTest' --tests 'io.bluetape4k.leader.dynamodb.DynamoDbLeaderGroupElectorIntegrationTest' --tests 'io.bluetape4k.leader.dynamodb.DynamoDbSuspendLeaderGroupElectorIntegrationTest' --warning-mode all
- ./gradlew :bluetape4k-leader-dynamodb:test --warning-mode all
- rg -n "ScanRequest|\.scan\(" leader-dynamodb/src/main leader-dynamodb/src/test -g '*.kt'
- git diff --check

## DoD Status

- [x] Issue scope reviewed against milestone 0.5.0.
- [x] 7-Tier review artifact added at docs/review/2026-07-04-dynamodb-slot-state-review.md.
- [x] state() and activeCount() no longer use table scans for deterministic group slots.
- [x] Tests cover missing, partial, expired, full, chunked, and unprocessed-key lookup behavior.
- [x] DynamoDB module tests pass.
- [x] Full repository test remains deferred until the full stacked issue train is complete, per request.

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #573, milestone `0.5.0`, assignee `debop`
- PR: #587, head `92680482c5ebf23a7df7558d3125366e8efc65ea`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
