### PR TITLE
fix: harden Kubernetes Lease validation and ops manifests

### DIFF
--- a/docs/review/2026-07-04-kubernetes-validation-ops-review.md
+++ b/docs/review/2026-07-04-kubernetes-validation-ops-review.md
@@ -1,0 +1,55 @@
+# Kubernetes Validation and Ops 7-Tier Review
+
+Date: 2026-07-04
+Scope: issue #575, milestone 0.5.0
+
+## Modules Reviewed
+
+- `leader-k8s`: Lease namespace and name validation contracts.
+- `examples/k8s-lease`: client-side validation before Fabric8 Lease calls.
+- `examples/k8s-operator`: RBAC, Deployment, README, and manifest regression checks.
+
+## 7-Tier Result
+
+1. Correctness: PASS
+   - Kubernetes namespace values are validated as DNS-1123 labels before electors use them.
+   - Example Lease names now fail fast before Fabric8 create, read, update, or delete calls.
+
+2. API and Contract Compatibility: PASS
+   - No public elector method signatures changed.
+   - Validation remains inside existing option/example construction and call boundaries.
+
+3. Concurrency and Cancellation: PASS
+   - No acquisition, release, watchdog, async, or coroutine cleanup path was changed.
+   - Existing K3s acquisition/release tests still pass.
+
+4. Backend Ownership Safety: PASS
+   - Invalid namespace and Lease names are rejected client-side instead of being passed to Kubernetes.
+   - The operator runtime Role no longer grants Lease `delete`.
+
+5. Tests: PASS
+   - Added negative tests for invalid namespace and Lease names.
+   - Added manifest tests for least-privilege RBAC, stable image tag, and startup/liveness/readiness probes.
+   - Ran affected unit and K3s-backed checks.
+
+6. Security and Observability: PASS
+   - Runtime operator permissions are reduced to `get`, `create`, `update`, and `patch`.
+   - Deployment no longer uses a mutable `latest` tag.
+   - Probe behavior is documented in English and Korean README files.
+
+7. Maintainability: PASS
+   - Namespace validation lives beside existing Kubernetes Lease name validation.
+   - Manifest expectations are locked in a small dedicated test class.
+
+## Validation Evidence
+
+- `./gradlew :bluetape4k-leader-k8s:compileKotlin :bluetape4k-leader-k8s:compileTestKotlin :examples:k8s-lease:compileKotlin :examples:k8s-lease:compileTestKotlin :examples:k8s-operator:compileKotlin :examples:k8s-operator:compileTestKotlin --warning-mode all`
+- `./gradlew :bluetape4k-leader-k8s:test --tests 'io.bluetape4k.leader.k8s.internal.KubernetesLeaseSupportTest' :examples:k8s-lease:test --tests 'io.bluetape4k.leader.examples.k8slease.K8sLeaseValidationTest' :examples:k8s-operator:test --tests 'io.bluetape4k.leader.examples.k8soperator.OperatorManifestTest' --tests 'io.bluetape4k.leader.examples.k8soperator.OperatorControllerTest' --warning-mode all`
+- `./gradlew :bluetape4k-leader-k8s:k8sTest :examples:k8s-lease:k8sTest :examples:k8s-operator:k8sTest --warning-mode all`
+- `./gradlew :examples:k8s-lease:k8sTest --tests 'io.bluetape4k.leader.examples.k8slease.K8sLeaseLeaderElectionExampleTest' --warning-mode all`
+- `rg -n "namespace\\.requireNotBlank\\(\"namespace\"\\)|leaseName\\.requireNotBlank\\(\"leaseName\"\\)|:latest|\"delete\"|delete" leader-k8s/src/main examples/k8s-lease/src/main examples/k8s-operator/k8s examples/k8s-operator/README.md examples/k8s-operator/README.ko.md -g '*.kt' -g '*.yaml' -g '*.md'`
+- `git diff --check`
+
+## Deferred Verification
+
+Full repository test is intentionally deferred until the complete stacked issue train is implemented, per the requested workflow.

--- a/examples/k8s-lease/src/main/kotlin/io/bluetape4k/leader/examples/k8slease/K8sLeaseLeaderElectionExample.kt
+++ b/examples/k8s-lease/src/main/kotlin/io/bluetape4k/leader/examples/k8slease/K8sLeaseLeaderElectionExample.kt
@@ -31,7 +31,7 @@ class K8sLeaseLeaderElectionExample(
 ) {
 
     init {
-        namespace.requireNotBlank("namespace")
+        validateKubernetesNamespace(namespace)
         require(!leaseDuration.isNegative && !leaseDuration.isZero) {
             "leaseDuration must be positive. leaseDuration=$leaseDuration"
         }
@@ -39,6 +39,7 @@ class K8sLeaseLeaderElectionExample(
 
     companion object: KLogging() {
         private const val CONFLICT_STATUS = 409
+        private val DNS_1123_LABEL = Regex("[a-z0-9]([-a-z0-9]*[a-z0-9])?")
 
         @JvmStatic
         fun main(args: Array<String>) {
@@ -47,7 +48,7 @@ class K8sLeaseLeaderElectionExample(
     }
 
     fun tryAcquire(leaseName: String, holderIdentity: String): LeaseAttempt {
-        leaseName.requireNotBlank("leaseName")
+        validateLeaseName(leaseName)
         holderIdentity.requireNotBlank("holderIdentity")
 
         val now = now()
@@ -81,7 +82,7 @@ class K8sLeaseLeaderElectionExample(
     }
 
     fun release(leaseName: String, holderIdentity: String): Boolean {
-        leaseName.requireNotBlank("leaseName")
+        validateLeaseName(leaseName)
         holderIdentity.requireNotBlank("holderIdentity")
 
         val current = lease(leaseName) ?: return false
@@ -104,7 +105,7 @@ class K8sLeaseLeaderElectionExample(
     }
 
     fun delete(leaseName: String) {
-        leaseName.requireNotBlank("leaseName")
+        validateLeaseName(leaseName)
         client.leases().inNamespace(namespace).withName(leaseName).delete()
     }
 
@@ -167,6 +168,26 @@ class K8sLeaseLeaderElectionExample(
     }
 
     private fun now(): ZonedDateTime = ZonedDateTime.now(clock)
+
+    private fun validateKubernetesNamespace(namespace: String) {
+        namespace.requireNotBlank("namespace")
+        require(namespace.length <= 63) {
+            "namespace must be at most 63 characters for Kubernetes namespace name. namespace=$namespace"
+        }
+        require(DNS_1123_LABEL.matches(namespace)) {
+            "namespace must be a DNS-1123 label for Kubernetes namespace name. namespace=$namespace"
+        }
+    }
+
+    private fun validateLeaseName(leaseName: String) {
+        leaseName.requireNotBlank("leaseName")
+        require(leaseName.length <= 63) {
+            "leaseName must be at most 63 characters for Kubernetes Lease name. leaseName=$leaseName"
+        }
+        require(DNS_1123_LABEL.matches(leaseName)) {
+            "leaseName must be a DNS-1123 label for Kubernetes Lease name. leaseName=$leaseName"
+        }
+    }
 }
 
 enum class LeaseOutcome {

--- a/examples/k8s-lease/src/test/kotlin/io/bluetape4k/leader/examples/k8slease/K8sLeaseValidationTest.kt
+++ b/examples/k8s-lease/src/test/kotlin/io/bluetape4k/leader/examples/k8slease/K8sLeaseValidationTest.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.leader.examples.k8slease
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.fabric8.kubernetes.client.KubernetesClientBuilder
+import org.junit.jupiter.api.Test
+
+class K8sLeaseValidationTest {
+
+    @Test
+    fun `Lease example validates namespace and lease names before client calls`() {
+        KubernetesClientBuilder().build().use { client ->
+            assertFailsWith<IllegalArgumentException> {
+                K8sLeaseLeaderElectionExample(client = client, namespace = "InvalidNamespace")
+            }
+
+            val example = K8sLeaseLeaderElectionExample(client = client, namespace = "default")
+            assertFailsWith<IllegalArgumentException> {
+                example.tryAcquire("InvalidLease", "node-a")
+            }
+            assertFailsWith<IllegalArgumentException> {
+                example.release("lease_name", "node-a")
+            }
+            assertFailsWith<IllegalArgumentException> {
+                example.delete("x".repeat(64))
+            }
+        }
+    }
+}

--- a/examples/k8s-operator/README.ko.md
+++ b/examples/k8s-operator/README.ko.md
@@ -76,5 +76,16 @@ kubectl apply -f k8s/deployment.yaml
 kubectl logs deploy/bluetape4k-k8s-operator -f
 ```
 
-ServiceAccount에는 대상 namespace의 `coordination.k8s.io/leases`에 대해
-`get`, `create`, `update`, `patch`, `delete` 권한이 필요합니다.
+런타임 ServiceAccount에는 대상 namespace의 `coordination.k8s.io/leases`에 대해
+`get`, `create`, `update`, `patch` 권한만 필요합니다. Lease 삭제는 운영 중인
+operator 권한이 아니라 관리자/테스트 정리 권한으로 분리합니다.
+
+예제 Deployment는 `latest` 대신 안정적인 `0.5.0` 이미지 태그를 사용합니다. 실제
+환경에서는 직접 빌드한 immutable tag나 digest로 교체하세요.
+
+Probe 계약은 다음과 같습니다.
+
+- `startupProbe`는 Spring Boot actuator endpoint가 준비될 때까지 liveness 판단을
+  늦춥니다.
+- `livenessProbe`는 actuator health endpoint가 응답하지 않는 pod를 재시작합니다.
+- `readinessProbe`는 시작 또는 복구 중인 pod를 service routing에서 제외합니다.

--- a/examples/k8s-operator/README.md
+++ b/examples/k8s-operator/README.md
@@ -76,5 +76,19 @@ kubectl apply -f k8s/deployment.yaml
 kubectl logs deploy/bluetape4k-k8s-operator -f
 ```
 
-The service account needs `get`, `create`, `update`, `patch`, and `delete` on
-`coordination.k8s.io/leases` in the target namespace.
+The runtime service account needs only `get`, `create`, `update`, and `patch`
+on `coordination.k8s.io/leases` in the target namespace. Lease deletion is an
+admin/test cleanup concern and is intentionally not granted to the running
+operator.
+
+The example Deployment uses a stable `0.5.0` image tag instead of `latest`.
+Replace it with the immutable tag or digest you build for your own registry.
+
+The probe contract is:
+
+- `startupProbe` waits for the Spring Boot actuator endpoint before Kubernetes
+  applies liveness decisions.
+- `livenessProbe` restarts a pod whose actuator health endpoint stops
+  responding.
+- `readinessProbe` keeps non-ready pods out of service routing while the
+  operator starts or recovers.

--- a/examples/k8s-operator/k8s/deployment.yaml
+++ b/examples/k8s-operator/k8s/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: bluetape4k-k8s-operator
       containers:
         - name: operator
-          image: ghcr.io/bluetape4k/bluetape4k-k8s-operator:latest
+          image: ghcr.io/bluetape4k/bluetape4k-k8s-operator:0.5.0
           imagePullPolicy: IfNotPresent
           env:
             - name: POD_NAMESPACE
@@ -31,6 +31,18 @@ spec:
           ports:
             - name: actuator
               containerPort: 8080
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: actuator
+            failureThreshold: 12
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: actuator
+            initialDelaySeconds: 30
+            periodSeconds: 20
           readinessProbe:
             httpGet:
               path: /actuator/health

--- a/examples/k8s-operator/k8s/rbac.yaml
+++ b/examples/k8s-operator/k8s/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    verbs: ["get", "create", "update", "patch", "delete"]
+    verbs: ["get", "create", "update", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/examples/k8s-operator/src/test/kotlin/io/bluetape4k/leader/examples/k8soperator/OperatorManifestTest.kt
+++ b/examples/k8s-operator/src/test/kotlin/io/bluetape4k/leader/examples/k8soperator/OperatorManifestTest.kt
@@ -1,0 +1,36 @@
+package io.bluetape4k.leader.examples.k8soperator
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldContain
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.nio.file.Files
+import java.nio.file.Path
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class OperatorManifestTest {
+
+    @Test
+    fun `runtime role does not grant lease delete`() {
+        val rbac = readManifest("rbac.yaml")
+
+        rbac shouldContain """resources: ["leases"]"""
+        rbac shouldContain """verbs: ["get", "create", "update", "patch"]"""
+        rbac.contains("delete").shouldBeFalse()
+    }
+
+    @Test
+    fun `deployment uses stable image reference and full probe contract`() {
+        val deployment = readManifest("deployment.yaml")
+
+        deployment shouldContain "image: ghcr.io/bluetape4k/bluetape4k-k8s-operator:0.5.0"
+        deployment.contains(":latest").shouldBeFalse()
+        deployment shouldContain "startupProbe:"
+        deployment shouldContain "livenessProbe:"
+        deployment shouldContain "readinessProbe:"
+        deployment shouldContain "path: /actuator/health"
+    }
+
+    private fun readManifest(fileName: String): String =
+        Files.readString(Path.of("k8s", fileName))
+}

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseGroupOptions.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseGroupOptions.kt
@@ -1,8 +1,8 @@
 package io.bluetape4k.leader.k8s
 
 import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.k8s.internal.KubernetesLeaseNames
 import io.bluetape4k.support.requireGt
-import io.bluetape4k.support.requireNotBlank
 import java.io.Serializable
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -29,7 +29,7 @@ data class KubernetesLeaseGroupOptions(
 ) : Serializable {
 
     init {
-        namespace.requireNotBlank("namespace")
+        KubernetesLeaseNames.validateNamespace(namespace)
         retryDelay.requireGt(Duration.ZERO, "retryDelay")
     }
 

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseOptions.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseOptions.kt
@@ -1,8 +1,8 @@
 package io.bluetape4k.leader.k8s
 
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.k8s.internal.KubernetesLeaseNames
 import io.bluetape4k.support.requireGt
-import io.bluetape4k.support.requireNotBlank
 import java.io.Serializable
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -28,7 +28,7 @@ data class KubernetesLeaseOptions(
     val retryDelay: Duration = 50.milliseconds,
 ) : Serializable {
     init {
-        namespace.requireNotBlank("namespace")
+        KubernetesLeaseNames.validateNamespace(namespace)
         retryDelay.requireGt(Duration.ZERO, "retryDelay")
     }
 

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/internal/KubernetesLeaseNames.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/internal/KubernetesLeaseNames.kt
@@ -6,6 +6,16 @@ import io.bluetape4k.support.requireInRange
 internal object KubernetesLeaseNames {
     private val Dns1123Label = Regex("[a-z0-9]([-a-z0-9]*[a-z0-9])?")
 
+    fun validateNamespace(namespace: String) {
+        namespace.requireNotBlank("namespace")
+        require(namespace.length <= 63) {
+            "namespace must be at most 63 characters for Kubernetes namespace name. namespace=$namespace"
+        }
+        require(Dns1123Label.matches(namespace)) {
+            "namespace must be a DNS-1123 label for Kubernetes namespace name. namespace=$namespace"
+        }
+    }
+
     fun validateLeaseName(lockName: String) {
         lockName.requireNotBlank("lockName")
         require(lockName.length <= 63) {

--- a/leader-k8s/src/test/kotlin/io/bluetape4k/leader/k8s/internal/KubernetesLeaseSupportTest.kt
+++ b/leader-k8s/src/test/kotlin/io/bluetape4k/leader/k8s/internal/KubernetesLeaseSupportTest.kt
@@ -2,11 +2,38 @@ package io.bluetape4k.leader.k8s.internal
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.leader.k8s.KubernetesLeaseGroupOptions
+import io.bluetape4k.leader.k8s.KubernetesLeaseOptions
 import org.junit.jupiter.api.Test
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class KubernetesLeaseSupportTest {
+
+    @Test
+    fun `namespace must be DNS-1123 label`() {
+        KubernetesLeaseNames.validateNamespace("operator-system")
+
+        assertFailsWith<IllegalArgumentException> {
+            KubernetesLeaseNames.validateNamespace("OperatorSystem")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            KubernetesLeaseNames.validateNamespace("operator_system")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            KubernetesLeaseNames.validateNamespace("x".repeat(64))
+        }
+    }
+
+    @Test
+    fun `options reject invalid namespace`() {
+        assertFailsWith<IllegalArgumentException> {
+            KubernetesLeaseOptions(namespace = "OperatorSystem")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            KubernetesLeaseGroupOptions(namespace = "operator_system")
+        }
+    }
 
     @Test
     fun `lease name must be DNS-1123 label`() {


### PR DESCRIPTION
## Summary

Closes #575

PR #589의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: harden Kubernetes Lease validation and ops manifests`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary
- Validate Kubernetes namespaces as DNS-1123 labels in `leader-k8s` options.
- Add fail-fast namespace and Lease-name validation to the k8s Lease example.
- Harden the operator example manifests by removing runtime Lease delete, pinning the image tag, and adding startup/liveness/readiness probes.
- Update EN/KO README probe and RBAC documentation and add manifest regression tests.

Fixes #575

## Validation
- `./gradlew :bluetape4k-leader-k8s:compileKotlin :bluetape4k-leader-k8s:compileTestKotlin :examples:k8s-lease:compileKotlin :examples:k8s-lease:compileTestKotlin :examples:k8s-operator:compileKotlin :examples:k8s-operator:compileTestKotlin --warning-mode all`
- `./gradlew :bluetape4k-leader-k8s:test --tests 'io.bluetape4k.leader.k8s.internal.KubernetesLeaseSupportTest' :examples:k8s-lease:test --tests 'io.bluetape4k.leader.examples.k8slease.K8sLeaseValidationTest' :examples:k8s-operator:test --tests 'io.bluetape4k.leader.examples.k8soperator.OperatorManifestTest' --tests 'io.bluetape4k.leader.examples.k8soperator.OperatorControllerTest' --warning-mode all`
- `./gradlew :bluetape4k-leader-k8s:k8sTest :examples:k8s-lease:k8sTest :examples:k8s-operator:k8sTest --warning-mode all`
- `./gradlew :examples:k8s-lease:k8sTest --tests 'io.bluetape4k.leader.examples.k8slease.K8sLeaseLeaderElectionExampleTest' --warning-mode all`
- `rg -n "namespace\.requireNotBlank\(\"namespace\"\)|leaseName\.requireNotBlank\(\"leaseName\"\)|:latest|\"delete\"|delete" leader-k8s/src/main examples/k8s-lease/src/main examples/k8s-operator/k8s examples/k8s-operator/README.md examples/k8s-operator/README.ko.md -g '*.kt' -g '*.yaml' -g '*.md'`
- `git diff --check`

## DoD Status
- PASS: Kubernetes namespace values now use DNS-1123 validation in library options.
- PASS: k8s Lease example rejects invalid namespace and Lease names before Fabric8 calls.
- PASS: operator manifest is delete-free at runtime, avoids `latest`, and defines startup/liveness/readiness probes.
- PASS: English and Korean README files describe RBAC and probe contracts.
- DEFERRED: Full repository test will run after the remaining stacked milestone issues are implemented, per workflow request.

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #575, milestone `0.5.0`, assignee `debop`
- PR: #589, head `f1c35a2e8dff018518a23d2a6e833a4a8483ab67`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
