### PR TITLE
fix: harden backend namespace safety

### DIFF
--- a/docs/review/2026-07-04-backend-namespace-safety-review.md
+++ b/docs/review/2026-07-04-backend-namespace-safety-review.md
@@ -1,0 +1,57 @@
+# Backend Namespace Safety Review
+
+Issue: #579
+Milestone: 0.5.0
+
+## Scope
+
+- `bluetape4k-leader-mongodb`
+- `bluetape4k-leader-dynamodb`
+- `bluetape4k-leader-redis-lettuce`
+- `bluetape4k-leader-redis-redisson`
+- `bluetape4k-leader-hazelcast`
+- `examples/ktor-app`
+- `examples/prometheus-dashboard`
+
+## 7-Tier Findings
+
+### Tier 1 - Correctness
+
+- Mongo history collection namespace and TTL are validated at configuration construction time.
+- DynamoDB table names and key prefixes are validated before key composition or client calls.
+- Redis and Hazelcast single-election lock names now share the core `validateLockName` contract before backend calls.
+
+### Tier 2 - Security
+
+- Redis URL logging no longer exposes credentials from `REDIS_URL`.
+- Prometheus dashboard defaults to `REDACT` lock-name tags instead of raw labels.
+- Redis hash-tag manipulation through Lettuce slot group lock names is rejected before key construction.
+
+### Tier 3 - Concurrency
+
+- No locking or coroutine ownership semantics changed; validation is performed before acquiring backend locks.
+
+### Tier 4 - API
+
+- Existing public APIs are preserved.
+- Invalid namespace values now fail early with `IllegalArgumentException`.
+
+### Tier 5 - Observability
+
+- Metric tag defaults are safer for tenant/user-derived lock names.
+- Startup logging remains useful while redacting Redis credentials.
+
+### Tier 6 - Tests
+
+- Added pure validation tests for MongoDB and DynamoDB options.
+- Added backend-boundary validation tests for Lettuce, Redisson, and Hazelcast.
+- Added example-level regression tests for Redis URL redaction and Prometheus lock-name tag defaults.
+
+### Tier 7 - Documentation
+
+- Prometheus dashboard README files now match the safe `REDACT` default and describe when `HASH` or `RAW` may be used.
+
+## Validation
+
+- `./gradlew :bluetape4k-leader-mongodb:test --tests 'io.bluetape4k.leader.mongodb.history.MongoHistoryConfigTest' :bluetape4k-leader-dynamodb:test --tests 'io.bluetape4k.leader.dynamodb.DynamoDbLeaderOptionsValidationTest' :bluetape4k-leader-redis-lettuce:test --tests 'io.bluetape4k.leader.lettuce.semaphore.LettuceSlotTokenGroupTest.slot key rejects Redis hash-tag manipulation in lock name' :bluetape4k-leader-redis-redisson:test --tests 'io.bluetape4k.leader.redisson.RedissonLeaderElectionTest.lock name validation rejects Redis namespace manipulation before backend calls' :bluetape4k-leader-hazelcast:test --tests 'io.bluetape4k.leader.hazelcast.HazelcastLeaderElectionTest.lock name validation rejects map namespace manipulation before backend calls' :examples:ktor-app:test --tests 'io.bluetape4k.leader.examples.ktor.KtorAppTest.Redis URL redaction*' :examples:prometheus-dashboard:test --tests 'io.bluetape4k.leader.examples.prometheus.PrometheusAssetsTest.application config redacts lock name metric tags by default' --no-build-cache`
+- `git diff --check`

--- a/examples/ktor-app/src/main/kotlin/io/bluetape4k/leader/examples/ktor/KtorAppMain.kt
+++ b/examples/ktor-app/src/main/kotlin/io/bluetape4k/leader/examples/ktor/KtorAppMain.kt
@@ -23,6 +23,7 @@ import io.ktor.server.routing.routing
 import io.lettuce.core.RedisClient
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.codec.StringCodec
+import java.net.URI
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
@@ -66,7 +67,7 @@ object KtorAppMain: KLogging() {
     fun main(args: Array<String>) {
         val redisUrl = System.getenv(ENV_REDIS_URL) ?: DEFAULT_REDIS_URL
         val port = System.getenv(ENV_PORT)?.toIntOrNull() ?: DEFAULT_PORT
-        log.info { "KtorAppMain 시작 — redisUrl=$redisUrl, port=$port" }
+        log.info { "KtorAppMain 시작 — redisUrl=${redactRedisUrlForLog(redisUrl)}, port=$port" }
 
         val client = RedisClient.create(redisUrl).also {
             ShutdownQueue.register { runCatching { it.shutdown() } }
@@ -80,6 +81,16 @@ object KtorAppMain: KLogging() {
         }.start(wait = true)
     }
 }
+
+internal fun redactRedisUrlForLog(redisUrl: String): String =
+    runCatching {
+        val uri = URI(redisUrl)
+        if (uri.userInfo == null) {
+            redisUrl
+        } else {
+            URI(uri.scheme, "redacted", uri.host, uri.port, uri.path, uri.query, uri.fragment).toString()
+        }
+    }.getOrElse { "<invalid-redis-url>" }
 
 /**
  * Ktor 애플리케이션 모듈 — 플러그인 install + 라우트 + 백그라운드 leader scheduled job 을 구성한다.

--- a/examples/ktor-app/src/test/kotlin/io/bluetape4k/leader/examples/ktor/KtorAppTest.kt
+++ b/examples/ktor-app/src/test/kotlin/io/bluetape4k/leader/examples/ktor/KtorAppTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.leader.examples.ktor
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.coroutines.runSuspendIO
@@ -41,6 +42,20 @@ class KtorAppTest: AbstractKtorAppTest() {
         private val AWAIT_TIMEOUT = 15.seconds
 
         private val objectMapper = ObjectMapper()
+    }
+
+    @Test
+    fun `Redis URL redaction removes credentials from startup log value`() {
+        val redacted = redactRedisUrlForLog("redis://user:secret@localhost:6379/0")
+
+        redacted shouldBeEqualTo "redis://redacted@localhost:6379/0"
+        redacted.contains("user").shouldBeFalse()
+        redacted.contains("secret").shouldBeFalse()
+    }
+
+    @Test
+    fun `Redis URL redaction handles malformed values without leaking input`() {
+        redactRedisUrlForLog("redis://user:secret@[bad-host") shouldBeEqualTo "<invalid-redis-url>"
     }
 
     @Test

--- a/examples/prometheus-dashboard/README.ko.md
+++ b/examples/prometheus-dashboard/README.ko.md
@@ -54,7 +54,8 @@ curl http://localhost:8080/actuator/prometheus | grep leader_aop
 `DEMO_REDIS_URL`이 없으면 `bootRun`은 Testcontainers Redis를 사용합니다.
 demo는 로컬 `ObservationHandler`로 leader observation도 로그에 남깁니다. 끄려면 `DEMO_OBSERVATION_LOGGING_HANDLER_ENABLED=false`를 지정하세요.
 
-이 예제는 하나의 정적 job 이름만 사용하므로 raw metric lock label을 명시적으로 켭니다.
+이 예제는 metric lock label을 기본적으로 `REDACT`로 둡니다. raw label 없이 제한된 상관관계만
+필요하면 `HASH`를 사용하고, `RAW`는 정적 job 이름만 쓰는 로컬 데모 profile에서만 켜세요.
 
 ```yaml
 bluetape4k:
@@ -63,10 +64,10 @@ bluetape4k:
       metrics:
         tags:
           lock-name:
-            mode: RAW
+            mode: REDACT
 ```
 
-실제 서비스에서 lock name에 tenant, user, request, 무제한 job identifier가 들어간다면 기본 `REDACT` 모드를 유지하세요. raw label 없이 제한된 상관관계만 필요하면 `HASH`를 사용합니다.
+실제 서비스에서 lock name에 tenant, user, request, 무제한 job identifier가 들어간다면 `REDACT`를 유지하세요.
 
 ## Observation Tracing Demo
 

--- a/examples/prometheus-dashboard/README.md
+++ b/examples/prometheus-dashboard/README.md
@@ -54,7 +54,8 @@ curl http://localhost:8080/actuator/prometheus | grep leader_aop
 `bootRun` uses Testcontainers Redis unless `DEMO_REDIS_URL` is set.
 The demo also logs leader observations from a local `ObservationHandler`; disable it with `DEMO_OBSERVATION_LOGGING_HANDLER_ENABLED=false`.
 
-The example opts into raw metric lock labels because it uses one static job name:
+The example keeps metric lock labels redacted by default. Use `HASH` when a dashboard needs bounded
+correlation without raw labels, and reserve `RAW` for profile-gated local demos with static job names.
 
 ```yaml
 bluetape4k:
@@ -63,10 +64,10 @@ bluetape4k:
       metrics:
         tags:
           lock-name:
-            mode: RAW
+            mode: REDACT
 ```
 
-Keep the default `REDACT` mode in real services when lock names contain tenant, user, request, or unbounded job identifiers. Use `HASH` when a dashboard needs bounded correlation without raw labels.
+Keep `REDACT` in real services when lock names contain tenant, user, request, or unbounded job identifiers.
 
 ## Observation Tracing Demo
 

--- a/examples/prometheus-dashboard/src/main/resources/application.yml
+++ b/examples/prometheus-dashboard/src/main/resources/application.yml
@@ -37,7 +37,7 @@ bluetape4k:
         enabled: true
         tags:
           lock-name:
-            mode: RAW
+            mode: REDACT
     observability:
       tracing:
         enabled: true

--- a/examples/prometheus-dashboard/src/test/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusAssetsTest.kt
+++ b/examples/prometheus-dashboard/src/test/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusAssetsTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.leader.examples.prometheus
 
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -63,6 +64,14 @@ class PrometheusAssetsTest {
     }
 
     @Test
+    fun `application config redacts lock name metric tags by default`() {
+        val config = applicationConfigPath.readText()
+
+        config.contains("mode: REDACT").shouldBeTrue()
+        config.contains("mode: RAW").shouldBeFalse()
+    }
+
+    @Test
     fun `readme files document alerts runbooks and diagram`() {
         val english = englishReadmePath.readText()
         val korean = koreanReadmePath.readText()
@@ -89,6 +98,7 @@ class PrometheusAssetsTest {
         private val docsImageRoot = projectRoot.resolve("docs/images/readme-diagrams")
 
         private val prometheusConfigPath = exampleRoot.resolve("provisioning/prometheus/prometheus.yml")
+        private val applicationConfigPath = exampleRoot.resolve("src/main/resources/application.yml")
         private val prometheusRulesPath = exampleRoot.resolve("provisioning/prometheus/rules/leader-alerts.yml")
         private val grafanaDashboardPath =
             exampleRoot.resolve("provisioning/grafana/dashboards/leader-dashboard.json")

--- a/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbLeaderElectionOptions.kt
+++ b/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbLeaderElectionOptions.kt
@@ -1,8 +1,8 @@
 package io.bluetape4k.leader.dynamodb
 
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.dynamodb.internal.DynamoDbKeys
 import io.bluetape4k.support.requireGt
-import io.bluetape4k.support.requireNotBlank
 import java.io.Serializable
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -31,8 +31,8 @@ data class DynamoDbLeaderElectionOptions(
 ) : Serializable {
 
     init {
-        tableName.requireNotBlank("tableName")
-        keyPrefix.requireNotBlank("keyPrefix")
+        DynamoDbKeys.validateTableName(tableName)
+        DynamoDbKeys.validateKeyPrefix(keyPrefix)
         retryDelay.requireGt(Duration.ZERO, "retryDelay")
         ttlPadding.requireGt(Duration.ZERO, "ttlPadding")
         require(clockSkewTolerance >= Duration.ZERO) { "clockSkewTolerance must be >= 0: $clockSkewTolerance" }

--- a/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbLeaderGroupElectionOptions.kt
+++ b/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbLeaderGroupElectionOptions.kt
@@ -1,8 +1,8 @@
 package io.bluetape4k.leader.dynamodb
 
 import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.dynamodb.internal.DynamoDbKeys
 import io.bluetape4k.support.requireGt
-import io.bluetape4k.support.requireNotBlank
 import java.io.Serializable
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -30,8 +30,8 @@ data class DynamoDbLeaderGroupElectionOptions(
     val maxLeaders: Int get() = leaderGroupOptions.maxLeaders
 
     init {
-        tableName.requireNotBlank("tableName")
-        keyPrefix.requireNotBlank("keyPrefix")
+        DynamoDbKeys.validateTableName(tableName)
+        DynamoDbKeys.validateKeyPrefix(keyPrefix)
         retryDelay.requireGt(Duration.ZERO, "retryDelay")
         ttlPadding.requireGt(Duration.ZERO, "ttlPadding")
         require(clockSkewTolerance >= Duration.ZERO) { "clockSkewTolerance must be >= 0: $clockSkewTolerance" }

--- a/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/internal/DynamoDbKeys.kt
+++ b/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/internal/DynamoDbKeys.kt
@@ -4,6 +4,21 @@ import io.bluetape4k.leader.validateLockName
 
 internal object DynamoDbKeys {
     private const val SlotMarker = "#slot-"
+    private val TableNamePattern = Regex("^[a-zA-Z0-9_.-]{3,255}$")
+    private val KeyPrefixPattern = Regex("^[a-zA-Z0-9][a-zA-Z0-9_:-]{0,127}$")
+
+    fun validateTableName(tableName: String) {
+        require(TableNamePattern.matches(tableName)) {
+            "tableName must be 3-255 chars and contain only [a-zA-Z0-9_.-]: $tableName"
+        }
+    }
+
+    fun validateKeyPrefix(keyPrefix: String) {
+        require(KeyPrefixPattern.matches(keyPrefix)) {
+            "keyPrefix must be 1-128 chars, start with alphanumeric, and contain only [a-zA-Z0-9_:-]: $keyPrefix"
+        }
+        require(!keyPrefix.contains(SlotMarker)) { "keyPrefix must not contain '$SlotMarker': $keyPrefix" }
+    }
 
     fun validateUserLockName(lockName: String) {
         validateLockName(lockName)

--- a/leader-dynamodb/src/test/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbLeaderOptionsValidationTest.kt
+++ b/leader-dynamodb/src/test/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbLeaderOptionsValidationTest.kt
@@ -1,0 +1,29 @@
+package io.bluetape4k.leader.dynamodb
+
+import io.bluetape4k.assertions.assertFailsWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DynamoDbLeaderOptionsValidationTest {
+
+    @Test
+    fun `single leader options validate table namespace before client calls`() {
+        assertFailsWith<IllegalArgumentException> {
+            DynamoDbLeaderElectionOptions(tableName = "ab")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            DynamoDbLeaderElectionOptions(tableName = "bad/table")
+        }
+    }
+
+    @Test
+    fun `group leader options validate key prefix before slot key composition`() {
+        assertFailsWith<IllegalArgumentException> {
+            DynamoDbLeaderGroupElectionOptions(keyPrefix = "/tenant")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            DynamoDbLeaderGroupElectionOptions(keyPrefix = "tenant#slot-0")
+        }
+    }
+}

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElector.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElector.kt
@@ -12,10 +12,10 @@ import io.bluetape4k.leader.hazelcast.internal.HazelcastBackendErrorClassifier
 import io.bluetape4k.leader.hazelcast.internal.HazelcastLockExtendDelegate
 import io.bluetape4k.leader.hazelcast.lock.HazelcastLock
 import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
+import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.error
-import io.bluetape4k.support.requireNotBlank
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 
@@ -60,7 +60,7 @@ class HazelcastLeaderElector private constructor(
     private val lockMap: IMap<String, String> = hazelcast.getMap(LOCK_MAP_NAME)
 
     override fun <T> runIfLeader(lockName: String, action: () -> T): T? {
-        lockName.requireNotBlank("lockName")
+        validateLockName(lockName)
 
         val lock = HazelcastLock(lockMap, lockName, LOCK_MAP_NAME, hazelcast::newTransactionContext)
         log.debug { "Leader 승격을 요청합니다 ... lockName=$lockName" }
@@ -111,7 +111,7 @@ class HazelcastLeaderElector private constructor(
         executor: Executor,
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
-        lockName.requireNotBlank("lockName")
+        validateLockName(lockName)
 
         val lock = HazelcastLock(lockMap, lockName, LOCK_MAP_NAME, hazelcast::newTransactionContext)
 
@@ -158,7 +158,7 @@ inline fun <T> HazelcastInstance.runIfLeader(
     options: LeaderElectionOptions = LeaderElectionOptions.Default,
     crossinline action: () -> T,
 ): T? {
-    jobName.requireNotBlank("jobName")
+    validateLockName(jobName)
     return HazelcastLeaderElector(this, options).runIfLeader(jobName) { action() }
 }
 
@@ -171,6 +171,6 @@ inline fun <T> HazelcastInstance.runAsyncIfLeader(
     options: LeaderElectionOptions = LeaderElectionOptions.Default,
     crossinline action: () -> CompletableFuture<T>,
 ): CompletableFuture<T?> {
-    jobName.requireNotBlank("jobName")
+    validateLockName(jobName)
     return HazelcastLeaderElector(this, options).runAsyncIfLeader(jobName, executor) { action() }
 }

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderElector.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastSuspendLeaderElector.kt
@@ -13,10 +13,10 @@ import io.bluetape4k.leader.hazelcast.internal.HazelcastSuspendLockExtendDelegat
 import io.bluetape4k.leader.hazelcast.lock.HazelcastSuspendLock
 import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
 import io.bluetape4k.leader.internal.SuspendExtendDelegate
+import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
-import io.bluetape4k.support.requireNotBlank
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
@@ -68,7 +68,7 @@ class HazelcastSuspendLeaderElector private constructor(
     private val lockMap: IMap<String, String> = hazelcast.getMap(HazelcastLeaderElector.LOCK_MAP_NAME)
 
     override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? {
-        lockName.requireNotBlank("lockName")
+        validateLockName(lockName)
 
         val lock = HazelcastSuspendLock(
             lockMap = lockMap,
@@ -134,6 +134,6 @@ suspend inline fun <T> HazelcastInstance.suspendRunIfLeader(
     options: LeaderElectionOptions = LeaderElectionOptions.Default,
     crossinline action: suspend () -> T,
 ): T? {
-    jobName.requireNotBlank("jobName")
+    validateLockName(jobName)
     return HazelcastSuspendLeaderElector(this, options).runIfLeader(jobName) { action() }
 }

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElectionTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElectionTest.kt
@@ -2,15 +2,16 @@ package io.bluetape4k.leader.hazelcast
 
 import io.bluetape4k.concurrent.futureOf
 import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeGreaterThan
-import io.bluetape4k.assertions.shouldBeNull
-import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
@@ -26,6 +27,15 @@ import kotlin.time.Duration.Companion.seconds
 class HazelcastLeaderElectionTest: AbstractHazelcastLeaderTest() {
 
     companion object: KLogging()
+
+    @Test
+    fun `lock name validation rejects map namespace manipulation before backend calls`() {
+        val election = HazelcastLeaderElector(hazelcastClient)
+
+        assertFailsWith<IllegalArgumentException> {
+            election.runIfLeader("tenant{other}") { "should-not-run" }
+        }
+    }
 
     @Test
     fun `runIfLeader - 리더로 선출되어 action 을 실행하고 결과를 반환한다`() {

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/history/MongoHistoryConfig.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/history/MongoHistoryConfig.kt
@@ -9,13 +9,13 @@ import java.io.Serializable
  * ## Properties
  * - [collectionName]: MongoDB collection name for history records. Defaults to
  *   [DEFAULT_COLLECTION_NAME].
- * - [ttlDays]: TTL index expiry in days. A value ≤ 0 disables the TTL index;
+ * - [ttlDays]: TTL index expiry in days. A value of `0` disables the TTL index;
  *   the `leader.history.mongodb.ttl.disabled` gauge will read `1.0` in that case.
  *
  * ## Behavior / Contract
  * - TTL index is the primary retention mechanism in MongoDB; `deleteOlderThan()`
  *   is a supplementary immediate-purge helper.
- * - When [ttlDays] ≤ 0, data accumulates indefinitely unless the caller invokes
+ * - When [ttlDays] is `0`, data accumulates indefinitely unless the caller invokes
  *   `deleteOlderThan()` explicitly.
  */
 data class MongoHistoryConfig(
@@ -23,10 +23,26 @@ data class MongoHistoryConfig(
     val ttlDays: Long = DEFAULT_TTL_DAYS,
 ) : Serializable {
 
+    init {
+        validateMongoHistoryCollectionName(collectionName)
+        require(ttlDays >= 0) { "ttlDays must be >= 0. Use 0 to disable TTL index. ttlDays=$ttlDays" }
+    }
+
     companion object : KLogging() {
         private const val serialVersionUID = 1L
 
         const val DEFAULT_COLLECTION_NAME = "bluetape4k_leader_history"
         const val DEFAULT_TTL_DAYS = 90L
+    }
+}
+
+private fun validateMongoHistoryCollectionName(collectionName: String) {
+    require(collectionName.isNotBlank()) { "collectionName must not be blank" }
+    require(collectionName.length <= 120) { "collectionName.length must be <= 120: ${collectionName.length}" }
+    require(!collectionName.startsWith("system.")) {
+        "collectionName must not use MongoDB reserved system namespace: $collectionName"
+    }
+    require(collectionName.none { it == '\u0000' || it == '$' }) {
+        "collectionName must not contain MongoDB reserved null or '$' characters: $collectionName"
     }
 }

--- a/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/history/MongoHistoryConfigTest.kt
+++ b/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/history/MongoHistoryConfigTest.kt
@@ -1,0 +1,29 @@
+package io.bluetape4k.leader.mongodb.history
+
+import io.bluetape4k.assertions.assertFailsWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MongoHistoryConfigTest {
+
+    @Test
+    fun `history collection name rejects reserved MongoDB namespaces`() {
+        assertFailsWith<IllegalArgumentException> {
+            MongoHistoryConfig(collectionName = "system.profile")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            MongoHistoryConfig(collectionName = "leader\$history")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            MongoHistoryConfig(collectionName = "")
+        }
+    }
+
+    @Test
+    fun `history TTL must be non-negative`() {
+        assertFailsWith<IllegalArgumentException> {
+            MongoHistoryConfig(ttlDays = -1)
+        }
+    }
+}

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/semaphore/LettuceSlotTokenGroup.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/semaphore/LettuceSlotTokenGroup.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.lettuce.internal.MonotonicDeadline
 import io.bluetape4k.leader.lettuce.script.RedisScript
 import io.bluetape4k.leader.lettuce.script.RedisScriptRunner
+import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
@@ -210,7 +211,7 @@ return 0
     }
 
     init {
-        lockName.requireNotBlank("lockName")
+        validateLockName(lockName)
         maxLeaders.requirePositiveNumber("maxLeaders")
     }
 

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/semaphore/LettuceSlotTokenGroupTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/semaphore/LettuceSlotTokenGroupTest.kt
@@ -35,6 +35,13 @@ class LettuceSlotTokenGroupTest: AbstractLettuceLeaderTest() {
         group = LettuceSlotTokenGroup(connection, lockName, MAX_LEADERS)
     }
 
+    @Test
+    fun `slot key rejects Redis hash-tag manipulation in lock name`() {
+        assertFailsWith<IllegalArgumentException> {
+            LettuceSlotTokenGroup(connection, "tenant{other}", MAX_LEADERS)
+        }
+    }
+
     @AfterEach
     fun teardown() {
         connection.sync().del(group.slotKey)

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElector.kt
@@ -13,10 +13,10 @@ import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
 import io.bluetape4k.leader.redisson.internal.RedissonBackendErrorClassifier
 import io.bluetape4k.leader.redisson.internal.RedissonLockExtendDelegate
 import io.bluetape4k.leader.remainingMinLeaseTime
+import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.error
-import io.bluetape4k.support.requireNotBlank
 import org.redisson.api.RLock
 import org.redisson.api.RedissonClient
 import org.redisson.client.RedisException
@@ -104,7 +104,7 @@ class RedissonLeaderElector private constructor(
     }
 
     private fun <T> runImpl(lockName: String, auditLeaderId: String?, action: () -> T): T? {
-        lockName.requireNotBlank("lockName")
+        validateLockName(lockName)
 
         val lock: RLock = redissonClient.getLock(lockName)
 
@@ -197,7 +197,7 @@ class RedissonLeaderElector private constructor(
         executor: Executor,
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
-        lockName.requireNotBlank("lockName")
+        validateLockName(lockName)
 
         val lock: RLock = redissonClient.getLock(lockName)
 
@@ -357,7 +357,7 @@ inline fun <T> RedissonClient.runIfLeader(
     options: LeaderElectionOptions = LeaderElectionOptions.Default,
     crossinline action: () -> T,
 ): T? {
-    jobName.requireNotBlank("jobName")
+    validateLockName(jobName)
     val leaderElection = RedissonLeaderElector(this, options)
     return leaderElection.runIfLeader(jobName) { action() }
 }
@@ -371,7 +371,7 @@ inline fun <T> RedissonClient.runAsyncIfLeader(
     options: LeaderElectionOptions = LeaderElectionOptions.Default,
     crossinline action: () -> CompletableFuture<T>,
 ): CompletableFuture<T?> {
-    jobName.requireNotBlank("jobName")
+    validateLockName(jobName)
     val leaderElection = RedissonLeaderElector(this, options)
     return leaderElection.runAsyncIfLeader(jobName, executor) { action() }
 }

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderElector.kt
@@ -13,10 +13,10 @@ import io.bluetape4k.leader.internal.SuspendExtendDelegate
 import io.bluetape4k.leader.redisson.internal.RedissonBackendErrorClassifier
 import io.bluetape4k.leader.redisson.internal.RedissonSuspendLockExtendDelegate
 import io.bluetape4k.leader.remainingMinLeaseTime
+import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
-import io.bluetape4k.support.requireNotBlank
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
@@ -53,7 +53,7 @@ suspend inline fun <T> RedissonClient.suspendRunIfLeader(
     options: LeaderElectionOptions = LeaderElectionOptions.Default,
     crossinline action: suspend () -> T,
 ): T? {
-    jobName.requireNotBlank("jobName")
+    validateLockName(jobName)
 
     val leaderElection = RedissonSuspendLeaderElector(this, options)
     return leaderElection.runIfLeader(jobName) { action() }
@@ -160,7 +160,7 @@ class RedissonSuspendLeaderElector private constructor(
     }
 
     private suspend fun <T> runImpl(lockName: String, auditLeaderId: String?, action: suspend () -> T): T? {
-        lockName.requireNotBlank("lockName")
+        validateLockName(lockName)
 
         val lock: RLock = redissonClient.getLock(lockName)
 

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElectionTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElectionTest.kt
@@ -35,6 +35,15 @@ class RedissonLeaderElectionTest: AbstractRedissonLeaderTest() {
     companion object: KLogging()
 
     @Test
+    fun `lock name validation rejects Redis namespace manipulation before backend calls`() {
+        val leaderElection = RedissonLeaderElector(redissonClient)
+
+        assertFailsWith<IllegalArgumentException> {
+            leaderElection.runIfLeader("tenant{other}") { "should-not-run" }
+        }
+    }
+
+    @Test
     fun `run action if leader`() {
         val lockName = randomName()
         val leaderElection = RedissonLeaderElector(redissonClient)


### PR DESCRIPTION
## Summary

Closes #579

PR #591의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `fix: harden backend namespace safety`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

- Fixes #579.
- Validates MongoDB history collection names and non-negative TTL settings before sink/index usage.
- Validates DynamoDB table names and key prefixes before key construction or client calls.
- Applies the shared lock-name contract to Redis/Hazelcast single-election APIs before backend acquisition.
- Redacts Redis credentials in the Ktor example startup log.
- Switches the Prometheus dashboard lock-name metric tag default to `REDACT` and updates EN/KO docs.

## Review Notes

- Added `docs/review/2026-07-04-backend-namespace-safety-review.md` with a module-scoped 7-tier review summary.
- This PR stacks on #590 (`fix/leader-0.5-doc-parity`).
- The final stacked PR #592 pins the Prometheus dashboard redaction sentinel and carries the full repository test result.

## Validation

- `./gradlew :bluetape4k-leader-mongodb:test --tests 'io.bluetape4k.leader.mongodb.history.MongoHistoryConfigTest' :bluetape4k-leader-dynamodb:test --tests 'io.bluetape4k.leader.dynamodb.DynamoDbLeaderOptionsValidationTest' :bluetape4k-leader-redis-lettuce:test --tests 'io.bluetape4k.leader.lettuce.semaphore.LettuceSlotTokenGroupTest.slot key rejects Redis hash-tag manipulation in lock name' :bluetape4k-leader-redis-redisson:test --tests 'io.bluetape4k.leader.redisson.RedissonLeaderElectionTest.lock name validation rejects Redis namespace manipulation before backend calls' :bluetape4k-leader-hazelcast:test --tests 'io.bluetape4k.leader.hazelcast.HazelcastLeaderElectionTest.lock name validation rejects map namespace manipulation before backend calls' :examples:ktor-app:test --tests 'io.bluetape4k.leader.examples.ktor.KtorAppTest.Redis URL redaction*' :examples:prometheus-dashboard:test --tests 'io.bluetape4k.leader.examples.prometheus.PrometheusAssetsTest.application config redacts lock name metric tags by default' --no-build-cache`
- `./gradlew test --no-build-cache --rerun-tasks` on final stacked PR #592 branch: `BUILD SUCCESSFUL in 6m 54s`; `189 actionable tasks: 189 executed`.
- `git diff --check`
- Static scan: no remaining Prometheus `mode: RAW` config/docs except the regression assertion that rejects it.

## DoD Status

- [x] Issue #579 assigned to `debop` and scoped to milestone `0.5.0`.
- [x] PR assignee, labels, and milestone mirror the issue metadata.
- [x] Backend namespace validation is enforced before backend calls/key construction.
- [x] Example logging and metric-tag defaults avoid secret/raw lock-name leakage.
- [x] Targeted tests pass.
- [x] Full repository test suite passed on the final stacked PR #592 branch.

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #579, milestone `0.5.0`, assignee `debop`
- PR: #591, head `27984fddff705039163ab48a3dcc6eafa3fbea79`, milestone `0.5.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
