### PR TITLE
ci: pin Kotlin for CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,6 +28,12 @@ jobs:
         with:
           languages: ${{ matrix.language }}
 
+      - name: Pin Kotlin for CodeQL extractor
+        if: matrix.language == 'java-kotlin'
+        run: |
+          perl -0pi -e 's/kotlin = "2\.4\.0"/kotlin = "2.3.21"/' gradle/libs.versions.toml
+          grep -n 'kotlin = "2.3.21"' gradle/libs.versions.toml
+
       - name: Setup JDK 21
         if: matrix.language == 'java-kotlin'
         uses: actions/setup-java@v5


### PR DESCRIPTION
## Summary

PR #593의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `ci: pin Kotlin for CodeQL analysis`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## Summary

- Pin Kotlin to 2.3.21 only inside the CodeQL java-kotlin analysis job.
- Keep the repository Gradle version catalog on Kotlin 2.4.0 for normal builds.
- Verify the temporary runner-side catalog rewrite before the CodeQL Gradle build starts.

## Rationale

CodeQL Java/Kotlin extractor support can lag Kotlin 2.4.x. This keeps project builds on Kotlin 2.4.0 while allowing CodeQL analysis to build with the latest known supported Kotlin line.

## Validation

- `actionlint .github/workflows/codeql.yml`
- `git diff --check`

## DoD Status

| Step | Status | Evidence |
|---|---:|---|
| Scope | PASS | Changed only `.github/workflows/codeql.yml` |
| CodeQL Kotlin pin | PASS | `java-kotlin` job rewrites `kotlin = "2.4.0"` to `2.3.21` in the runner workspace |
| Repository Kotlin version | PASS | Source catalog remains Kotlin 2.4.0 outside the workflow job |
| Workflow lint | PASS | `actionlint .github/workflows/codeql.yml` |
| Whitespace check | PASS | `git diff --check` |

````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: N/A, milestone `N/A`, assignee `N/A`
- PR: #593, head `613d24c310c4e776170e8d935a988767ac89b72b`, milestone `N/A`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
