### PR TITLE
JDK 25 테스트 런타임을 virtual-thread-jdk25로 정렬한다 (#676)

### DIFF
--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -127,7 +127,7 @@ dependencies {
     add("benchmarkImplementation", project(":bluetape4k-leader-micrometer"))
 
     add("benchmarkImplementation", bt4k.bluetape4k.testcontainers)
-    add("benchmarkImplementation", bt4k.bluetape4k.virtualthread.jdk21)
+    add("benchmarkImplementation", bt4k.bluetape4k.virtualthread.jdk25)
     add("benchmarkImplementation", bt4k.h2.v2)
     add("benchmarkImplementation", bt4k.postgresql)
     add("benchmarkImplementation", bt4k.mysql.connector.j)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,6 +94,10 @@ val centralSnapshotsParallelism: Int = providers
 val projectGroup = providers.gradleProperty("projectGroup").get()
 val baseVersion = providers.gradleProperty("baseVersion").get()
 val snapshotVersion = providers.gradleProperty("snapshotVersion").get()
+val bluetape4kVirtualThreadJdk25Version = providers
+    .gradleProperty("bluetape4kVirtualThreadJdk25Version")
+    .orElse("1.13.0-SNAPSHOT")
+    .get()
 
 fun Project.isNonPublishedProject(): Boolean =
     path == ":examples" || path.startsWith(":examples:") || path == ":benchmark"
@@ -537,6 +541,29 @@ if (detektRequested) {
             dependsOn(detektProductionSourceGuard)
             dependsOn(moduleDetektTasks)
             finalizedBy(reportMerge)
+        }
+    }
+}
+
+subprojects {
+    configurations.configureEach {
+        exclude(
+            group = "io.github.bluetape4k",
+            module = "bluetape4k-virtualthread-jdk21",
+        )
+        resolutionStrategy.force(
+            "io.github.bluetape4k:bluetape4k-virtualthread-api:$bluetape4kVirtualThreadJdk25Version",
+            "io.github.bluetape4k:bluetape4k-virtualthread-jdk25:$bluetape4kVirtualThreadJdk25Version",
+        )
+        resolutionStrategy.eachDependency {
+            if (requested.group == "io.github.bluetape4k" &&
+                requested.name in setOf(
+                    "bluetape4k-virtualthread-api",
+                    "bluetape4k-virtualthread-jdk25",
+                )) {
+                useVersion(bluetape4kVirtualThreadJdk25Version)
+                because("JDK 25 runtime uses one matching virtual-thread API/provider snapshot")
+            }
         }
     }
 }

--- a/examples/virtual-thread-runner/build.gradle.kts
+++ b/examples/virtual-thread-runner/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
 
     implementation(bt4k.bluetape4k.logging)
 
+    runtimeOnly(bt4k.bluetape4k.virtualthread.jdk25)
     runtimeOnly(bt4k.logback)
 
     testImplementation(bt4k.bluetape4k.junit5)

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,6 +46,11 @@ signing.gnupg.executable=/opt/homebrew/bin/gpg
 
 # Shared bluetape4k ecosystem catalog version
 
+# 현재 leader library에는 JDK 21 compatibility island를 유지하는 모듈이 없다.
+# 중앙 immutable catalog가 일치하는 release train을 승격할 때까지
+# JDK 25 provider는 1.13.0 snapshot line에서 게시된다.
+bluetape4kVirtualThreadJdk25Version=1.13.0-SNAPSHOT
+
 # Maven Central Snapshots publish parallelism
 centralSnapshotsParallelism=4
 

--- a/leader-core/build.gradle.kts
+++ b/leader-core/build.gradle.kts
@@ -9,7 +9,7 @@ configurations {
 dependencies {
     api(bt4k.bluetape4k.core)
     api(bt4k.bluetape4k.idgenerators)
-    compileOnly(bt4k.bluetape4k.virtualthread.jdk21)
+    compileOnly(bt4k.bluetape4k.virtualthread.jdk25)
     testImplementation(bt4k.bluetape4k.junit5)
 
     implementation(bt4k.bluetape4k.coroutines)

--- a/leader-etcd/build.gradle.kts
+++ b/leader-etcd/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     testImplementation(testFixtures(project(":bluetape4k-leader-core")))
     testImplementation(bt4k.bluetape4k.junit5)
     testImplementation(bt4k.bluetape4k.testcontainers)
-    testImplementation(bt4k.bluetape4k.virtualthread.jdk21)
+    testImplementation(bt4k.bluetape4k.virtualthread.jdk25)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit.jupiter)

--- a/leader-exposed-core/build.gradle.kts
+++ b/leader-exposed-core/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 
     // Test — Multi-DB (H2, PostgreSQL, MySQL)
     testImplementation(bt4k.bluetape4k.junit5)
-    testImplementation(bt4k.bluetape4k.virtualthread.jdk21)
+    testImplementation(bt4k.bluetape4k.virtualthread.jdk25)
     testImplementation(bt4k.bluetape4k.exposed.jdbc.tests)
 
     testImplementation(bt4k.exposed.jdbc)

--- a/leader-exposed-jdbc/build.gradle.kts
+++ b/leader-exposed-jdbc/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 
     testImplementation(bt4k.bluetape4k.junit5)
     testImplementation(bt4k.bluetape4k.testcontainers)
-    testImplementation(bt4k.bluetape4k.virtualthread.jdk21)
+    testImplementation(bt4k.bluetape4k.virtualthread.jdk25)
     testImplementation(bt4k.bluetape4k.exposed.jdbc.tests)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(bt4k.h2.v2)

--- a/leader-hazelcast/build.gradle.kts
+++ b/leader-hazelcast/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     implementation(bt4k.bluetape4k.coroutines)
     testImplementation(bt4k.bluetape4k.junit5)
     testImplementation(bt4k.bluetape4k.testcontainers)
-    testImplementation(bt4k.bluetape4k.virtualthread.jdk21)
+    testImplementation(bt4k.bluetape4k.virtualthread.jdk25)
 
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.testcontainers)

--- a/leader-micrometer/build.gradle.kts
+++ b/leader-micrometer/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
     api(libs.micrometer.core)
     api(libs.micrometer.observation)
 
-    testImplementation(bt4k.bluetape4k.virtualthread.jdk21)
+    testImplementation(bt4k.bluetape4k.virtualthread.jdk25)
     testImplementation(bt4k.bluetape4k.junit5)
     testImplementation(bt4k.bluetape4k.testcontainers)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/leader-mongodb/build.gradle.kts
+++ b/leader-mongodb/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
     compileOnly(bt4k.mongodb.driver.kotlin.coroutine)
     compileOnly(libs.micrometer.core)
 
-    testImplementation(bt4k.bluetape4k.virtualthread.jdk21)
+    testImplementation(bt4k.bluetape4k.virtualthread.jdk25)
     testImplementation(bt4k.bluetape4k.junit5)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(bt4k.mongodb.driver.kotlin.coroutine)

--- a/leader-redis-lettuce/build.gradle.kts
+++ b/leader-redis-lettuce/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation(bt4k.bluetape4k.junit5)
     testImplementation(bt4k.bluetape4k.testcontainers)
-    testImplementation(bt4k.bluetape4k.virtualthread.jdk21)
+    testImplementation(bt4k.bluetape4k.virtualthread.jdk25)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit.jupiter)

--- a/leader-redis-redisson/build.gradle.kts
+++ b/leader-redis-redisson/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation(bt4k.bluetape4k.junit5)
     testImplementation(bt4k.bluetape4k.testcontainers)
-    testImplementation(bt4k.bluetape4k.virtualthread.jdk21)
+    testImplementation(bt4k.bluetape4k.virtualthread.jdk25)
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit.jupiter)
 

--- a/leader-spring-boot/build.gradle.kts
+++ b/leader-spring-boot/build.gradle.kts
@@ -142,7 +142,7 @@ dependencies {
     testImplementation("org.springframework:spring-webflux")
     testImplementation("jakarta.servlet:jakarta.servlet-api")
     testImplementation(bt4k.springmockk)
-    testImplementation(bt4k.bluetape4k.virtualthread.jdk21)
+    testImplementation(bt4k.bluetape4k.virtualthread.jdk25)
     testImplementation(project(":bluetape4k-leader-consul"))
     testImplementation(project(":bluetape4k-leader-dynamodb"))
     testImplementation(bt4k.bluetape4k.testcontainers)

--- a/leader-zookeeper/build.gradle.kts
+++ b/leader-zookeeper/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
 
     testImplementation(testFixtures(project(":bluetape4k-leader-core")))
 
-    testImplementation(bt4k.bluetape4k.virtualthread.jdk21)
+    testImplementation(bt4k.bluetape4k.virtualthread.jdk25)
     testImplementation(bt4k.bluetape4k.junit5)
     testImplementation(bt4k.bluetape4k.testcontainers)
     testImplementation(libs.kotlinx.coroutines.test)


### PR DESCRIPTION
## Summary

Closes #676

PR #685의 historical body를 현재 workflow canonical PR template로 정규화합니다.
대상 제목: `JDK 25 테스트 런타임을 virtual-thread-jdk25로 정렬한다 (#676)`
## Background

이 PR은 MERGED 상태이며 코드와 PR head는 변경하지 않고 GitHub metadata와 본문 구조만 정리합니다. 연결 이슈와 milestone/assignee 기준을 live metadata에서 다시 확인했습니다.
## What This Solves

- PR 본문에서 연결 이슈, milestone, assignee, head, CI 범위를 템플릿의 고정된 위치에서 확인할 수 있습니다.
- 실제 GitHub assignee/milestone과 본문 Metadata를 같은 기준으로 맞춥니다.
## Work Done

- 연결 이슈의 milestone을 PR에 mirror하고 기본 assignee `debop`을 보완했습니다.
- 기존 본문은 Historical PR Body 블록에 보존하고 active Metadata를 canonical 3줄 형식으로 재작성했습니다.

### Historical PR Body (보존)

````
## 요약

- 모든 library/benchmark Gradle 선언을 `virtualthread-jdk25`로 정렬했습니다.
- 중앙 immutable catalog가 1.12.1인 동안 `1.13.0-SNAPSHOT` API/provider를 함께 선택하도록 임시 resolution bridge를 추가했습니다.
- `virtual-thread-runner` 예제에 JDK25 provider runtime dependency를 명시했습니다.

## 검증

- `./gradlew test --continue --no-daemon --no-configuration-cache --console=plain`
- Hazelcast, Lettuce, Redisson, ZooKeeper virtual-thread targeted tests
- `./gradlew compileKotlin --continue --no-daemon --no-configuration-cache --console=plain`
- `dependencyInsight`: provider `1.13.0-SNAPSHOT`, runtimeElements, JVM 25 variant

## 확인 필요

- Detekt는 현재 플러그인이 `--jvm-target 25`를 지원하지 않아 #677 범위의 기존 오류가 남아 있습니다.
- JDK25 provider snapshot bridge는 중앙 catalog가 1.13.x release train을 승격하면 제거해야 합니다.
- Nightly dispatch는 merge 전 별도 실행이 필요합니다.

Closes #676
````
## Validation

- `gh api --paginate repos/bluetape4k/bluetape4k-leader/pulls?state=closed`: PASS (live inventory)
- `gh api repos/bluetape4k/bluetape4k-leader/issues/{issue}`: PASS (연결 이슈 milestone/assignee read-back)
- `canonical PR body structural audit`: PASS (8개 H2 순서, exact Metadata 3줄, 최종 DoD)
- `repository code CI`: N/A (코드와 PR head를 변경하지 않은 metadata/body-only repair)
## Review Notes

- P0/P1: 0 (metadata/body 정규화 범위)
- P2/P3: 없음
- Review evidence: live issue/PR metadata snapshot, PATCH response, 전체 PR read-back
## Metadata

- Issue: #676, milestone `0.6.0`, assignee `debop`
- PR: #685, head `abfcec2c856af4cb836b8fd8bf2b9a91b94331e1`, milestone `0.6.0`, assignee `debop`
- CI: N/A (닫힌 PR의 metadata/body만 갱신했으며 코드와 PR head는 변경하지 않음)
## DoD Status

Required checks: 4/4; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
| --- | --- | --- | --- | --- |
| PR-META-01 | Issue metadata read-back | PASS | live linked issue API | none |
| PR-META-02 | PR assignee/milestone synchronization | PASS | live PR issue API after PATCH | none |
| PR-BODY-01 | Canonical structure and exact Metadata lines | PASS | full closed-PR structural audit | none |
| PR-BODY-02 | Historical body preservation | PASS | Historical PR Body block + rollback manifest | none |
| PR-BODY-03 | Historical CI rerun | N/A | code/head unchanged | no code CI rerun |

Final status: DONE (닫힌 MERGED PR metadata 및 본문 정규화 완료)
Unchecked required items: none
