### PR TITLE
release: 0.6.0 릴리스에서 JDK 25 snapshot 의존성을 차단한다

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,13 +150,18 @@ jobs:
           set -euo pipefail
           BASE=$(grep -E '^baseVersion=' gradle.properties | cut -d= -f2)
           SNAP=$(grep -E '^snapshotVersion=' gradle.properties | cut -d= -f2 || echo "")
-          echo "tag=$VERSION baseVersion=$BASE snapshotVersion='$SNAP'"
+          VTHREAD=$(grep -E '^bluetape4kVirtualThreadJdk25Version=' gradle.properties | cut -d= -f2)
+          echo "tag=$VERSION baseVersion=$BASE snapshotVersion='$SNAP' bluetape4kVirtualThreadJdk25Version='$VTHREAD'"
           if [[ "$BASE" != "$VERSION" ]]; then
             echo "::error::gradle.properties baseVersion ($BASE) does not match tag ($VERSION)"
             exit 1
           fi
           if [[ -n "$SNAP" ]]; then
             echo "::error::snapshotVersion must be empty for release. Got: '$SNAP'"
+            exit 1
+          fi
+          if [[ -z "$VTHREAD" || "$VTHREAD" == *-SNAPSHOT ]]; then
+            echo "::error::bluetape4kVirtualThreadJdk25Version은 릴리스에서 non-snapshot immutable 좌표여야 한다. 현재값: '$VTHREAD'"
             exit 1
           fi
 
@@ -169,6 +174,20 @@ jobs:
         with:
           gradle-version: wrapper
           cache-read-only: true
+
+      - name: Verify immutable JDK25 virtual-thread resolution
+        shell: bash
+        run: |
+          set -euo pipefail
+          resolution_file="$RUNNER_TEMP/virtualthread-dependencies.txt"
+          python3 scripts/ci/validate_release_preflight_test.py
+          ./gradlew :bluetape4k-leader-core:dependencies \
+            --configuration compileClasspath \
+            --no-daemon --no-configuration-cache --no-build-cache --console=plain \
+            | tee "$resolution_file"
+          python3 scripts/ci/validate_release_preflight.py \
+            --properties gradle.properties \
+            --resolution "$resolution_file"
 
       - name: Verify published binary compatibility
         shell: bash

--- a/docs/lessons/2026-08-14-issue-689-release-jdk25-immutable-dependency.md
+++ b/docs/lessons/2026-08-14-issue-689-release-jdk25-immutable-dependency.md
@@ -1,0 +1,43 @@
+# 릴리스 preflight에서 JDK 25 virtual-thread snapshot을 차단하기
+
+## 배경
+
+Issue #689는 `bluetape4k-leader`의 0.6.0 릴리스가
+`bluetape4k-virtualthread-api`와 `bluetape4k-virtualthread-jdk25`의
+변경 가능한 `1.13.0-SNAPSHOT` 해석에 의존하던 문제를 다룬다. 기존 release
+workflow는 `baseVersion`과 `snapshotVersion`만 검사했기 때문에 provider
+version property가 snapshot이어도 publish 단계까지 진행될 수 있었다.
+
+## 원인
+
+Gradle의 `central-snapshots` 저장소는 `1.13.0-SNAPSHOT`을 현재 timestamp
+build로 해석하지만, release preflight에는 그 resolved dependency가 snapshot인지
+확인하는 단계가 없었다. 따라서 태그와 프로젝트 버전이 일치해도 공급망 입력이
+재현 가능하다고 보장할 수 없었다.
+
+## 결정
+
+- release train의 기본 좌표를 `1.13.0-20260813.192107-9` immutable timestamp
+  coordinate로 고정한다.
+- 개발선에서 snapshot을 시험해야 하는 경우에만
+  `-Pbluetape4kVirtualThreadJdk25Version=1.13.0-SNAPSHOT`으로 명시적 override를
+  사용한다.
+- release workflow는 `-SNAPSHOT` 좌표를 즉시 거부하고, `leader-core`의
+  `compileClasspath` dependency graph에서 API/provider가 동일한 immutable
+  좌표로 해석되는지 별도 validator로 확인한다.
+
+## 검증
+
+- `scripts/ci/validate_release_preflight_test.py`가 snapshot 거부, 동일 좌표 API/provider
+  해석, snapshot resolution 거부를 검증한다.
+- release workflow는 실패 시 `::error::`를 출력하고 publish 단계 전에 종료한다.
+- 실제 Gradle dependency graph는 release 실행 시 `$RUNNER_TEMP/virtualthread-dependencies.txt`
+  로 보존되고 `tee`로 job log에도 남으며, validator가 선택된 API/provider 좌표를
+  다시 출력한다.
+
+## 향후 지침
+
+새 JDK 25 provider build를 채택할 때는 Maven Central Snapshots의 timestamp와
+API/provider POM 존재를 먼저 확인하고, `gradle.properties`의 immutable 좌표와
+release preflight 테스트를 함께 갱신한다. 개발 snapshot override를 release
+branch에 남기지 않는다.

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,8 +48,10 @@ signing.gnupg.executable=/opt/homebrew/bin/gpg
 
 # 현재 leader library에는 JDK 21 compatibility island를 유지하는 모듈이 없다.
 # 중앙 immutable catalog가 일치하는 release train을 승격할 때까지
-# JDK 25 provider는 1.13.0 snapshot line에서 게시된다.
-bluetape4kVirtualThreadJdk25Version=1.13.0-SNAPSHOT
+# 현재 release train은 Maven Central Snapshots의 immutable timestamp 좌표를 사용한다.
+# 개발선에서 새 snapshot을 시험할 때만 -Pbluetape4kVirtualThreadJdk25Version=1.13.0-SNAPSHOT을
+# 명시적으로 덮어쓸 수 있으며, release preflight는 해당 suffix를 fail-closed 한다.
+bluetape4kVirtualThreadJdk25Version=1.13.0-20260813.192107-9
 
 # Maven Central Snapshots publish parallelism
 centralSnapshotsParallelism=4

--- a/scripts/ci/validate_release_preflight.py
+++ b/scripts/ci/validate_release_preflight.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""릴리스 게시 전에 immutable virtual-thread 좌표를 검증한다."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+GROUP = "io.github.bluetape4k"
+REQUIRED_MODULES = (
+    "bluetape4k-virtualthread-api",
+    "bluetape4k-virtualthread-jdk25",
+)
+SNAPSHOT_SUFFIX = "-SNAPSHOT"
+
+
+def read_gradle_properties(path: Path) -> dict[str, str]:
+    properties: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        properties[key.strip()] = value.strip()
+    return properties
+
+
+def validate_provider_version(
+    properties: dict[str, str],
+) -> tuple[str | None, list[str]]:
+    version = properties.get("bluetape4kVirtualThreadJdk25Version", "").strip()
+    if not version:
+        return None, [
+            "릴리스에는 bluetape4kVirtualThreadJdk25Version이 필요하다",
+        ]
+    if version.endswith(SNAPSHOT_SUFFIX):
+        return version, [
+            "릴리스의 bluetape4kVirtualThreadJdk25Version은 -SNAPSHOT으로 끝날 수 없다: "
+            f"{version}",
+        ]
+    return version, []
+
+
+def validate_resolved_dependencies(
+    resolution: str,
+    expected_version: str,
+) -> list[str]:
+    errors: list[str] = []
+    for module in REQUIRED_MODULES:
+        coordinate_pattern = re.compile(
+            rf"{re.escape(GROUP)}:{re.escape(module)}:"
+            rf"(?P<requested>[^\s()]+)(?:\s+->\s+(?P<resolved>[^\s()]+))?"
+        )
+        versions = [
+            match.group("resolved") or match.group("requested")
+            for match in coordinate_pattern.finditer(resolution)
+        ]
+        if expected_version not in versions:
+            errors.append(
+                f"해석된 dependency에서 {GROUP}:{module}:{expected_version}을 찾을 수 없다"
+            )
+        snapshot_versions = sorted(
+            version for version in versions if version.endswith(SNAPSHOT_SUFFIX)
+        )
+        if snapshot_versions:
+            errors.append(
+                f"해석된 dependency {GROUP}:{module}에 snapshot 좌표가 남아 있다: "
+                + ", ".join(snapshot_versions)
+            )
+    return errors
+
+
+def validate(
+    properties_path: Path,
+    resolution_path: Path,
+) -> tuple[str | None, list[str]]:
+    version, errors = validate_provider_version(read_gradle_properties(properties_path))
+    if version is None:
+        return version, errors
+    errors.extend(
+        validate_resolved_dependencies(
+            resolution_path.read_text(encoding="utf-8"),
+            version,
+        )
+    )
+    return version, errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--properties", type=Path, required=True)
+    parser.add_argument("--resolution", type=Path, required=True)
+    args = parser.parse_args()
+
+    version, errors = validate(args.properties, args.resolution)
+    if errors:
+        for error in errors:
+            print(f"::error::{error}")
+        return 1
+
+    print(
+        "immutable JDK25 virtual-thread API/provider 해석 확인: "
+        f"{GROUP}:{REQUIRED_MODULES[0]}:{version}, "
+        f"{GROUP}:{REQUIRED_MODULES[1]}:{version}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/validate_release_preflight_test.py
+++ b/scripts/ci/validate_release_preflight_test.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""immutable JDK25 provider pin에 대한 release preflight 계약 테스트."""
+
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PROPERTIES = ROOT / "gradle.properties"
+WORKFLOW = ROOT / ".github/workflows/release.yml"
+sys.path.insert(0, str(Path(__file__).parent))
+
+from validate_release_preflight import (  # noqa: E402
+    validate_provider_version,
+    validate_resolved_dependencies,
+)
+
+
+class ReleasePreflightContractTest(unittest.TestCase):
+    def test_release_line_uses_an_immutable_jdk25_provider_coordinate(self) -> None:
+        properties = {
+            line.split("=", 1)[0]: line.split("=", 1)[1]
+            for line in PROPERTIES.read_text(encoding="utf-8").splitlines()
+            if "=" in line and not line.lstrip().startswith("#")
+        }
+        version = properties["bluetape4kVirtualThreadJdk25Version"]
+
+        self.assertNotRegex(version, re.compile(r"-SNAPSHOT$"))
+
+    def test_release_workflow_validates_the_resolved_provider_and_api(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("validate_release_preflight.py", workflow)
+        self.assertIn("--resolution", workflow)
+        self.assertRegex(
+            workflow,
+            re.compile(r"SNAPSHOT.*fail|fail.*SNAPSHOT", re.IGNORECASE | re.DOTALL),
+        )
+
+    def test_provider_validation_rejects_a_dev_snapshot(self) -> None:
+        version, errors = validate_provider_version(
+            {"bluetape4kVirtualThreadJdk25Version": "1.13.0-SNAPSHOT"}
+        )
+
+        self.assertEqual(version, "1.13.0-SNAPSHOT")
+        self.assertEqual(len(errors), 1)
+        self.assertIn("-SNAPSHOT으로 끝날 수 없다", errors[0])
+
+    def test_provider_validation_rejects_a_missing_coordinate(self) -> None:
+        version, errors = validate_provider_version({})
+
+        self.assertIsNone(version)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("필요하다", errors[0])
+
+    def test_resolution_validation_requires_the_same_immutable_api_and_provider(
+        self,
+    ) -> None:
+        resolution = """
+        +--- io.github.bluetape4k:bluetape4k-virtualthread-api:1.13.0-SNAPSHOT -> 1.13.0-20260813.192107-9
+        +--- io.github.bluetape4k:bluetape4k-virtualthread-jdk25:1.13.0-SNAPSHOT -> 1.13.0-20260813.192107-9
+        """
+
+        errors = validate_resolved_dependencies(
+            resolution,
+            "1.13.0-20260813.192107-9",
+        )
+
+        self.assertEqual(errors, [])
+
+    def test_resolution_validation_rejects_snapshot_output(self) -> None:
+        resolution = (
+            "io.github.bluetape4k:bluetape4k-virtualthread-api:1.13.0-SNAPSHOT\n"
+            "io.github.bluetape4k:bluetape4k-virtualthread-jdk25:1.13.0-SNAPSHOT\n"
+        )
+
+        errors = validate_resolved_dependencies(resolution, "1.13.0-SNAPSHOT")
+
+        self.assertEqual(len(errors), 2)
+        self.assertTrue(all("snapshot 좌표가 남아 있다" in error for error in errors))
+
+    def test_resolution_validation_rejects_a_different_immutable_coordinate(self) -> None:
+        resolution = (
+            "io.github.bluetape4k:bluetape4k-virtualthread-api:1.12.1\n"
+            "io.github.bluetape4k:bluetape4k-virtualthread-jdk25:1.12.1\n"
+        )
+
+        errors = validate_resolved_dependencies(
+            resolution,
+            "1.13.0-20260813.192107-9",
+        )
+
+        self.assertEqual(len(errors), 2)
+        self.assertTrue(all("찾을 수 없다" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #689

0.6.0 안정 릴리스가 mutable JDK 25 virtual-thread snapshot 좌표를 해석하지 않도록
immutable timestamp 좌표와 fail-closed release preflight를 도입합니다.

## Background

Epic #697의 `RELEASE-01` 작업으로, 릴리스용 `gradle.properties`가
`1.13.0-SNAPSHOT`을 가리키고 release workflow가 실제 provider 해석 결과를 검증하지
않던 공급망 재현성 공백을 해결합니다. 선행 `RELEASE-FAST #693`은 PR #706으로
병합되었고, 후행 `RELEASE-02`는 #663입니다.

## What This Solves

- 릴리스가 mutable `bluetape4k-virtualthread-api`/`bluetape4k-virtualthread-jdk25`
  snapshot 좌표에 의존하는 위험을 차단합니다.
- 요청 좌표가 snapshot이어도 실제 해석된 두 provider 좌표가 동일한 immutable
  timestamp 버전인지 release workflow에서 fail-closed로 검증합니다.
- 개발 환경의 snapshot override와 릴리스 환경의 immutable 검증 경계를 문서화합니다.

## Work Done

- `gradle.properties`: 릴리스 기본값을
  `1.13.0-20260813.192107-9`로 고정하고 개발용 명시적 override를 설명했습니다.
- `.github/workflows/release.yml`: snapshot 값을 거부하고 Gradle dependency graph를
  보존한 뒤 Python preflight validator를 실행하도록 했습니다.
- `scripts/ci/validate_release_preflight.py` 및 테스트: provider 버전과 실제
  `requested -> resolved` 해석을 검증하는 fail-closed contract를 추가했습니다.
- `docs/lessons/2026-08-14-issue-689-release-jdk25-immutable-dependency.md`:
  재발 방지 결정과 검증 절차를 기록했습니다.

## Validation

- `python3 scripts/ci/validate_release_preflight_test.py`: PASS (7 tests)
- `./gradlew :bluetape4k-leader-core:dependencies --configuration compileClasspath --no-daemon --no-configuration-cache --no-build-cache --console=plain`: PASS (두 provider 모두 `1.13.0-20260813.192107-9`로 해석)
- `./gradlew :bluetape4k-leader-core:test --no-daemon --no-configuration-cache --no-build-cache --console=plain`: PASS (`BUILD SUCCESSFUL`)
- `./gradlew build -x test --no-daemon --no-configuration-cache --no-build-cache --console=plain`: PASS (`BUILD SUCCESSFUL`)
- `./gradlew detekt --no-daemon --no-configuration-cache --no-build-cache --console=plain`: PASS (`BUILD SUCCESSFUL`)
- `actionlint .github/workflows/release.yml`: PASS
- `python3 -m py_compile scripts/ci/validate_release_preflight.py scripts/ci/validate_release_preflight_test.py`: PASS
- `git diff --check`: PASS
- Central snapshot POM HTTP 확인: PASS (API/provider POM 모두 `200`)

## Review Notes

- P0/P1: 0
- P2/P3: 없음
- Review evidence: 로컬 inline review 및 receipt run `20260814T125614Z-2c51f569`의 `issue689-verification-evidence.json`; 독립 review lane은 fresh evidence 없이 만료되어 PASS로 집계하지 않았고, hosted review thread는 0개입니다.

## Metadata

- Issue: #689, milestone `0.6.0`, assignee `debop`
- PR: #707, head `af3b4369c60b4a4c8be743ae12a984c4529b6aa5`, milestone `0.6.0`, assignee `debop`
- Labels: `bug`, `ci`, `build`
- CI: https://github.com/bluetape4k/bluetape4k-leader/actions/runs/31804881260 (exact head 46/46 SUCCESS, 실패·취소·pending 0)
- Merge: commit `a16a2b5361a267c1dd3186e58bd922180b1db9f8`, merged at `2026-08-14T13:49:32Z`

## Epic / Stacked PR Train

- Epic: #697 — `epic: 0.6.0 릴리스 재현성 공급망 및 CI 게이트`
- Train: `RELEASE-01`
- Issue: #689
- Base: `develop`
- Predecessor: `RELEASE-FAST #693` / merged PR #706 (historical prerequisite #690도 완료)
- Successor: `RELEASE-02 #663`, base `RELEASE-01`
- PR branch/head: `build/epic-release-01-jdk25` / `af3b4369c60b4a4c8be743ae12a984c4529b6aa5`
- PR base: `develop`
- Train relation: #693의 병합 결과를 기준으로 #689를 쌓고, #663이 이 PR 위에 이어집니다.

## DoD Status

Required checks: 24/24; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-01 - Root cause | snapshot provider 좌표와 release preflight 공백을 재현·확정 | PASS | Issue #689 live metadata, RED test | none |
| C-02 - Issue gate | 승인된 #689 범위와 Epic/Train 연결 확인 | PASS | `gh issue view 689` live read-back | none |
| C-03 - RED | 수정 전 contract 테스트 실패 확인 | PASS | current property/workflow 부재로 2 tests FAIL | none |
| C-04 - Fix | immutable 기본값·validator·workflow guard 구현 | PASS | commit `af3b4369c60b4a4c8be743ae12a984c4529b6aa5` | none |
| C-05 - GREEN / blast radius | targeted test와 module/build/detekt 검증 | PASS | Gradle test/build/detekt PASS | none |
| C-06 - Lesson | 한국어 재발 방지 lesson 작성 | PASS | `docs/lessons/2026-08-14-issue-689-release-jdk25-immutable-dependency.md` | GNO indexing은 integration 후 수행 |
| CG-01 - Authority | 구현·PR delivery 승인 범위 확인 | PASS | user-approved #689 plan, merge excluded | none |
| CG-02 - History / live evidence | GNO 탐색 후 live GitHub로 issue/train 확인 | PASS | GNO + `gh issue view 689/697` | none |
| CG-03 - Worktree | isolated worktree에서 작업·dirty worktree 보존 | PASS | `.worktrees/build/epic-release-01-jdk25` clean | none |
| CG-04 - Language / policy | 공개 산출물 한국어·코드 토큰 보존 | PASS | PR body/lesson/commit Korean | none |
| CG-05 - Kotlin patterns / deps | Kotlin scope·의존성 변경 위험 점검 | PASS | Kotlin source/dependency declarations unchanged except provider version | none |
| CG-06 - Docs / API contract | release workflow와 lesson 계약 확인 | PASS | workflow actionlint, lesson diff | none |
| CG-07 - Targeted proof | validator, resolution, POM, module checks 실행 | PASS | commands in `## Validation` | none |
| CG-08 - Heavyweight backend checks | backend/runtime 변경 여부에 따라 범위 판정 | N/A | release/Python/property scope; Testcontainers/runtime lifecycle 미변경 | none |
| CG-09 - Lesson indexing | lesson을 GNO collection에 반영 | PASS | `gno update`: 4 added, 2 updated; `gno search -c bluetape4k-docs` read-back 성공 | none |
| CG-10 - Final pre-PR | diff/path/commit/guard 최종 확인 | PASS | exact 5 paths, clean worktree, `git diff --check` | none |
| CG-11 - PR authority | target repo/base/head 명시 승인 확인 | PASS | repo `bluetape4k/bluetape4k-leader`, base `develop`, head branch approved | none |
| CG-12 - Exact head | pushed head와 local commit 일치 확인 | PASS | `git ls-remote`: `af3b4369c60b4a4c8be743ae12a984c4529b6aa5` | none |
| CG-12A - Guidance refresh | current AGENTS/skills/gates/template/issue 재독 | PASS | hashes unchanged; Issue #689 metadata no drift | none |
| CG-13 - PR create/read-back | PR를 생성하고 body/metadata를 live read-back | PASS | this PR exact head read-back | none |
| CG-14 - Hosted CI / review | exact head required checks와 review threads 확인 | PASS | run `31804881260`: 46/46 SUCCESS; failures/cancelled/pending 0; reviews/threads 0 | none |
| CG-15 - Merge readiness | mergeability·CI·threads 종합 | PASS | `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`, exact head `af3b4369c60b4a4c8be743ae12a984c4529b6aa5` | fresh merge approval remains separate |
| CG-16 - Merge approval | exact head 기준 별도 승인 획득 | PASS | 최신 사용자 승인 후 merge commit `a16a2b5361a267c1dd3186e58bd922180b1db9f8` 확인 | none |
| CG-17 - Merge | 승인된 PR만 merge | PASS | `gh pr view 707`: MERGED at `2026-08-14T13:49:32Z` | none |
| CG-18 - Sync / cleanup | develop sync 및 proven merged worktree 정리 | PASS | `git pull --ff-only`: `develop`=`origin/develop`=`a16a2b53`; merged feature worktree/branch 삭제; unrelated worktrees 보존 | none |

Final status: DONE (PR #707 merge, GNO indexing, develop sync, safe cleanup 완료; 후행 RELEASE-02 #663은 별도 train 작업입니다.)

Unchecked required items: none