### PR TITLE
ci: 문서·매뉴얼·전역 설정 변경의 계약 검증 연결

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,28 +11,8 @@ on:
   workflow_dispatch:
   push:
     branches: [develop, main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - '.gitignore'
-      - '.editorconfig'
-      - '.gitleaks.toml'
-      - 'CHANGELOG.md'
-      - 'WIP.md'
-      - 'LICENSE'
-      - '.claude/**'
   pull_request:
     branches: [develop, main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - '.gitignore'
-      - '.editorconfig'
-      - '.gitleaks.toml'
-      - 'CHANGELOG.md'
-      - 'WIP.md'
-      - 'LICENSE'
-      - '.claude/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -89,6 +69,8 @@ jobs:
     timeout-minutes: 5
     needs: validate-wrapper
     outputs:
+      manual-contract: ${{ steps.filter.outputs.manual-contract }}
+      global-config: ${{ steps.filter.outputs.global-config }}
       dependency-graph: ${{ steps.filter.outputs.dependency-graph }}
       leader-core: ${{ steps.filter.outputs.leader-core }}
       leader-redis: ${{ steps.filter.outputs.leader-redis }}
@@ -127,6 +109,26 @@ jobs:
         id: filter
         with:
           filters: |
+            # Documentation/manual changes must run the release contract job.
+            manual-contract:
+              - '**.md'
+              - 'docs/**'
+              - 'scripts/manual/**'
+              - 'scripts/ci/**'
+              - 'README*'
+              - 'WIP.md'
+              - 'CHANGELOG.md'
+            # Build/workflow topology changes select representative/global checks.
+            global-config:
+              - '.github/workflows/**'
+              - 'settings.gradle.kts'
+              - 'build.gradle.kts'
+              - 'buildSrc/**'
+              - 'gradle/**'
+              - 'gradle.properties'
+              - 'gradlew'
+              - 'gradlew.bat'
+              - 'bluetape4k-leader-bom/**'
             # Gradle graph roots are conservatively fanned out to every contract test.
             dependency-graph:
               - 'settings.gradle.kts'
@@ -291,6 +293,35 @@ jobs:
           python3 scripts/ci/validate_leader_contract_matrix.py --static
           python3 scripts/ci/validate_leader_contract_matrix.py --self-test
           python3 scripts/compatibility/check_binary_api_test.py
+
+  # ── 2-B. 매뉴얼/릴리스 provenance 계약 검증 ─────────────────────────────
+  manual-contract:
+    name: Validate manual and release contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [changes]
+    if: always() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs['manual-contract'] == 'true' || needs.changes.outputs['global-config'] == 'true')
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-java@v5.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v6.3.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
+      - name: Validate manual, provenance, diagram, and changed-path contracts
+        env:
+          CI_WORKFLOW_PATH: .github/workflows/ci.yml
+          MANUAL_CONTRACT_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
+          MANUAL_CONTRACT_HEAD_REF: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: python3 scripts/ci/validate_manual_contract.py
 
   # ── 3. 전체 빌드 (테스트 제외) ───────────────────────────────────────────
   catalog-governance:
@@ -2015,6 +2046,7 @@ jobs:
       - build
       - changes
       - ci-contract
+      - manual-contract
       - test-core
       - test-micrometer
       - test-redis-lettuce

--- a/scripts/ci/validate_ci_fanout.py
+++ b/scripts/ci/validate_ci_fanout.py
@@ -15,6 +15,9 @@ from typing import Any
 
 DEFAULT_WORKFLOW = Path(".github/workflows/ci.yml")
 TEST_JOB_PREFIX = "test-"
+MANUAL_CONTRACT_JOB_ID = "manual-contract"
+MANUAL_CONTRACT_OUTPUT = "manual-contract"
+GLOBAL_CONFIG_OUTPUT = "global-config"
 REQUIRED_ROOT_PATHS = {
     "settings.gradle.kts",
     "build.gradle.kts",
@@ -107,6 +110,27 @@ def section_paths(workflow: str, section: str) -> set[str]:
     return paths
 
 
+def event_paths_ignore(workflow: str, event: str) -> set[str]:
+    """Return paths ignored by a top-level push/pull_request event."""
+
+    lines = workflow.splitlines()
+    event_start = next(
+        (i for i, line in enumerate(lines) if line == f"  {event}:"),
+        None,
+    )
+    if event_start is None:
+        return set()
+    event_indent = len(lines[event_start]) - len(lines[event_start].lstrip())
+    event_end = len(lines)
+    for index in range(event_start + 1, len(lines)):
+        line = lines[index]
+        if line.strip() and len(line) - len(line.lstrip()) <= event_indent:
+            event_end = index
+            break
+    block = "\n".join(lines[event_start:event_end])
+    return section_paths(block, "paths-ignore")
+
+
 def static_errors(workflow: str) -> list[str]:
     errors: list[str] = []
     specs = job_specs(workflow)
@@ -123,6 +147,47 @@ def static_errors(workflow: str) -> list[str]:
     )
     if not output_line:
         errors.append("changes.outputs is missing dependency-graph")
+
+    required_contract_outputs = {MANUAL_CONTRACT_OUTPUT, GLOBAL_CONFIG_OUTPUT}
+    missing_contract_outputs = required_contract_outputs - declared_outputs
+    if missing_contract_outputs:
+        errors.append(
+            "changes.outputs is missing: " + ", ".join(sorted(missing_contract_outputs))
+        )
+
+    for event in ("push", "pull_request"):
+        ignored = event_paths_ignore(workflow, event)
+        if ignored & {"**.md", "docs/**", "README*", "CHANGELOG.md", "WIP.md"}:
+            errors.append(
+                f"{event}.paths-ignore suppresses manual-contract changes: "
+                + ", ".join(sorted(ignored & {"**.md", "docs/**", "README*", "CHANGELOG.md", "WIP.md"}))
+            )
+
+    manual_filter_paths = section_paths(workflow, MANUAL_CONTRACT_OUTPUT)
+    required_manual_paths = {"**.md", "docs/**", "scripts/manual/**"}
+    missing_manual_paths = required_manual_paths - manual_filter_paths
+    if missing_manual_paths:
+        errors.append(
+            "manual-contract filter is missing: " + ", ".join(sorted(missing_manual_paths))
+        )
+
+    global_filter_paths = section_paths(workflow, GLOBAL_CONFIG_OUTPUT)
+    required_global_paths = {
+        ".github/workflows/**",
+        "settings.gradle.kts",
+        "build.gradle.kts",
+        "buildSrc/**",
+        "gradle/**",
+        "gradle.properties",
+        "gradlew",
+        "gradlew.bat",
+        "bluetape4k-leader-bom/**",
+    }
+    missing_global_paths = required_global_paths - global_filter_paths
+    if missing_global_paths:
+        errors.append(
+            "global-config filter is missing: " + ", ".join(sorted(missing_global_paths))
+        )
 
     dependency_paths = section_paths(workflow, "dependency-graph")
     missing_root = REQUIRED_ROOT_PATHS - dependency_paths
@@ -164,6 +229,20 @@ def static_errors(workflow: str) -> list[str]:
     if contract is None or "validate_ci_fanout.py --static" not in contract.block:
         errors.append("ci-contract does not invoke the static validator")
 
+    manual_contract = specs.get(MANUAL_CONTRACT_JOB_ID)
+    if manual_contract is None:
+        errors.append("manual-contract job is missing")
+    else:
+        if "needs:" not in manual_contract.block or "changes" not in manual_contract.block:
+            errors.append("manual-contract does not depend on changes")
+        for output in (MANUAL_CONTRACT_OUTPUT, GLOBAL_CONFIG_OUTPUT):
+            if f"needs.changes.outputs['{output}']" not in manual_contract.condition:
+                errors.append(f"manual-contract condition does not reference {output}")
+        if "workflow_dispatch" not in manual_contract.condition:
+            errors.append("manual-contract condition does not include workflow_dispatch")
+        if "validate_manual_contract.py" not in manual_contract.block:
+            errors.append("manual-contract does not invoke the manual validator")
+
     status = specs.get("ci-status")
     if status is None:
         errors.append("ci-status job is missing")
@@ -176,6 +255,8 @@ def static_errors(workflow: str) -> list[str]:
             errors.append("ci-status still treats skipped jobs as success")
         if "- ci-contract" not in status.block:
             errors.append("ci-status does not depend on ci-contract")
+        if f"- {MANUAL_CONTRACT_JOB_ID}" not in status.block:
+            errors.append("ci-status does not depend on manual-contract")
 
     return errors
 
@@ -216,6 +297,29 @@ def runtime_errors(needs: dict[str, Any], event_name: str, specs: dict[str, JobS
             report.append(f"{spec.job_id}: N/A (intended skip)")
         else:
             report.append(f"{spec.job_id}: N/A condition false, result={result}")
+
+    manual_spec = specs.get(MANUAL_CONTRACT_JOB_ID)
+    if manual_spec is not None:
+        expected = event_name == "workflow_dispatch" or any(
+            str(outputs.get(key, "false")).lower() == "true"
+            for key in manual_spec.output_keys
+        )
+        payload = needs.get(MANUAL_CONTRACT_JOB_ID)
+        if payload is None:
+            errors.append(f"missing runtime result for {MANUAL_CONTRACT_JOB_ID}")
+        else:
+            result = payload.get("result")
+            if expected and result == "skipped":
+                errors.append(
+                    f"{MANUAL_CONTRACT_JOB_ID} was skipped although its impact filter is true"
+                )
+                report.append(f"{MANUAL_CONTRACT_JOB_ID}: REQUIRED but skipped")
+            elif expected:
+                report.append(f"{MANUAL_CONTRACT_JOB_ID}: REQUIRED ({result})")
+            elif result == "skipped":
+                report.append(f"{MANUAL_CONTRACT_JOB_ID}: N/A (intended skip)")
+            else:
+                report.append(f"{MANUAL_CONTRACT_JOB_ID}: N/A condition false, result={result}")
     return errors, report
 
 
@@ -282,6 +386,7 @@ def run_self_test() -> int:
         "changes": {"result": "success", "outputs": {"dependency-graph": "true"}},
         "build": {"result": "success"},
         "ci-contract": {"result": "success"},
+        MANUAL_CONTRACT_JOB_ID: {"result": "success"},
     }
     base.update({job_id: {"result": "success"} for job_id in test_ids})
     broken = dict(base)
@@ -290,9 +395,27 @@ def run_self_test() -> int:
     if not any("test-core" in error and "skipped" in error for error in errors):
         print("self-test did not catch an impacted skipped job", file=sys.stderr)
         return 1
+    manual_broken = dict(base)
+    manual_broken["changes"] = {
+        "result": "success",
+        "outputs": {"dependency-graph": "false", MANUAL_CONTRACT_OUTPUT: "true", GLOBAL_CONFIG_OUTPUT: "false"},
+    }
+    manual_broken[MANUAL_CONTRACT_JOB_ID] = {"result": "skipped"}
+    errors, _ = runtime_errors(manual_broken, "pull_request", specs)
+    if not any(MANUAL_CONTRACT_JOB_ID in error and "skipped" in error for error in errors):
+        print("self-test did not catch an impacted manual contract skip", file=sys.stderr)
+        return 1
     n_a = dict(base)
-    n_a["changes"] = {"result": "success", "outputs": {"dependency-graph": "false"}}
+    n_a["changes"] = {
+        "result": "success",
+        "outputs": {
+            "dependency-graph": "false",
+            MANUAL_CONTRACT_OUTPUT: "false",
+            GLOBAL_CONFIG_OUTPUT: "false",
+        },
+    }
     n_a.update({job_id: {"result": "skipped"} for job_id in test_ids})
+    n_a[MANUAL_CONTRACT_JOB_ID] = {"result": "skipped"}
     errors, _ = runtime_errors(n_a, "pull_request", specs)
     if errors:
         print("self-test rejected intended N/A skips: " + "; ".join(errors), file=sys.stderr)

--- a/scripts/ci/validate_ci_fanout_test.py
+++ b/scripts/ci/validate_ci_fanout_test.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""CI fan-out validator contract tests."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from validate_ci_fanout import job_specs, runtime_errors, static_errors
+
+
+class ValidateCiFanoutContractTest(unittest.TestCase):
+    def test_static_contract_requires_manual_and_global_filters_and_job(self) -> None:
+        workflow = """
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+jobs:
+  changes:
+    outputs:
+      dependency-graph: ${{ steps.filter.outputs.dependency-graph }}
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            dependency-graph:
+              - 'settings.gradle.kts'
+  ci-contract:
+    needs: [changes]
+    steps:
+      - run: python3 scripts/ci/validate_ci_fanout.py --static
+  ci-status:
+    needs:
+      - ci-contract
+    steps: []
+"""
+
+        errors = static_errors(workflow)
+
+        self.assertTrue(any("manual-contract" in error for error in errors))
+        self.assertTrue(any("paths-ignore" in error for error in errors))
+
+    def test_impacted_manual_contract_cannot_be_skipped(self) -> None:
+        workflow = """
+jobs:
+  changes:
+    outputs:
+      manual-contract: ${{ steps.filter.outputs.manual-contract }}
+      global-config: ${{ steps.filter.outputs.global-config }}
+  manual-contract:
+    needs: [changes]
+    if: always() && (needs.changes.outputs['manual-contract'] == 'true' || needs.changes.outputs['global-config'] == 'true')
+"""
+        specs = job_specs(workflow)
+        needs = {
+            "changes": {
+                "result": "success",
+                "outputs": {"manual-contract": "true", "global-config": "false"},
+            },
+            "manual-contract": {"result": "skipped"},
+            "build": {"result": "success"},
+            "ci-contract": {"result": "success"},
+        }
+
+        errors, _ = runtime_errors(needs, "pull_request", specs)
+
+        self.assertTrue(any("manual-contract" in error and "skipped" in error for error in errors))
+
+    def test_unimpacted_manual_contract_skip_is_reported_as_na(self) -> None:
+        workflow = """
+jobs:
+  changes:
+    outputs:
+      manual-contract: ${{ steps.filter.outputs.manual-contract }}
+      global-config: ${{ steps.filter.outputs.global-config }}
+  manual-contract:
+    needs: [changes]
+    if: always() && (needs.changes.outputs['manual-contract'] == 'true' || needs.changes.outputs['global-config'] == 'true')
+"""
+        specs = job_specs(workflow)
+        needs = {
+            "changes": {
+                "result": "success",
+                "outputs": {"manual-contract": "false", "global-config": "false"},
+            },
+            "manual-contract": {"result": "skipped"},
+            "build": {"result": "success"},
+            "ci-contract": {"result": "success"},
+        }
+
+        errors, report = runtime_errors(needs, "pull_request", specs)
+
+        self.assertEqual(errors, [])
+        self.assertIn("manual-contract: N/A (intended skip)", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/validate_diagram_contract.py
+++ b/scripts/ci/validate_diagram_contract.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Validate changed SVG diagram XML, connector geometry, and arrowheads."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+NUMBER = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
+POINT_RE = re.compile(rf"({NUMBER})\s*,?\s*({NUMBER})")
+CSS_MARKER_RE = re.compile(r"\.([A-Za-z0-9_-]+)\s*\{[^}]*marker-end:\s*url\(#([^\)]+)\)", re.DOTALL)
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def numbers(value: str) -> list[float]:
+    return [float(token) for token in re.findall(NUMBER, value)]
+
+
+def marker_reference(value: str) -> str | None:
+    match = re.search(r"url\(#([^\)]+)\)", value)
+    return match.group(1) if match else None
+
+
+def css_marker_references(root: ET.Element) -> dict[str, str]:
+    styles = [element.text or "" for element in root.iter() if local_name(element.tag) == "style"]
+    return {class_name: marker_id for style in styles for class_name, marker_id in CSS_MARKER_RE.findall(style)}
+
+
+def validate_svg(path: Path) -> list[str]:
+    relative = path.as_posix()
+    errors: list[str] = []
+    try:
+        root = ET.parse(path).getroot()
+    except (ET.ParseError, OSError) as exc:
+        return [f"{relative}: invalid SVG XML: {exc}"]
+
+    if local_name(root.tag) != "svg":
+        errors.append(f"{relative}: root element is not svg")
+    view_box = numbers(root.attrib.get("viewBox", ""))
+    if len(view_box) != 4 or view_box[2] <= 0 or view_box[3] <= 0:
+        errors.append(f"{relative}: viewBox must contain positive width and height")
+    for element in root.iter():
+        if local_name(element.tag) in {"title", "desc"} and not (element.text or "").strip():
+            errors.append(f"{relative}: {local_name(element.tag)} must not be empty")
+    if not any(local_name(element.tag) == "title" for element in root.iter()):
+        errors.append(f"{relative}: accessible title missing")
+    if not any(local_name(element.tag) == "desc" for element in root.iter()):
+        errors.append(f"{relative}: accessible description missing")
+
+    markers = {
+        element.attrib.get("id"): element
+        for element in root.iter()
+        if local_name(element.tag) == "marker" and element.attrib.get("id")
+    }
+    class_markers = css_marker_references(root)
+
+    def effective_marker(element: ET.Element) -> str | None:
+        explicit = marker_reference(element.attrib.get("marker-end", ""))
+        if explicit:
+            return explicit
+        for class_name in element.attrib.get("class", "").split():
+            if class_name in class_markers:
+                return class_markers[class_name]
+        return None
+
+    directed = [
+        element
+        for element in root.iter()
+        if local_name(element.tag) in {"path", "line", "polyline", "polygon"}
+        and effective_marker(element) is not None
+    ]
+    for marker_id, marker in markers.items():
+        try:
+            width = float(marker.attrib.get("markerWidth", "0"))
+            height = float(marker.attrib.get("markerHeight", "0"))
+        except ValueError:
+            width = height = 0
+        if width <= 0 or height <= 0:
+            errors.append(f"{relative}: marker {marker_id} has non-positive dimensions")
+        if marker.attrib.get("markerUnits") != "userSpaceOnUse":
+            errors.append(f"{relative}: marker {marker_id} must use userSpaceOnUse units")
+        marker_paths = [element for element in marker.iter() if local_name(element.tag) == "path"]
+        if not marker_paths or not any("Z" in element.attrib.get("d", "").upper() for element in marker_paths):
+            errors.append(f"{relative}: marker {marker_id} has no closed arrowhead path")
+
+    for element in directed:
+        marker_id = effective_marker(element)
+        if marker_id not in markers:
+            errors.append(f"{relative}: directed element references unknown marker {marker_id!r}")
+        if local_name(element.tag) == "path":
+            points = [(float(match.group(1)), float(match.group(2))) for match in POINT_RE.finditer(element.attrib.get("d", ""))]
+            if len(points) < 2 or len(set(points)) < 2:
+                errors.append(f"{relative}: directed path {element.attrib.get('id', '<anonymous>')} has degenerate geometry")
+            if not re.search(r"[LHVCSQTAZ]", element.attrib.get("d", "").upper()):
+                errors.append(f"{relative}: directed path {element.attrib.get('id', '<anonymous>')} has no drawable segment")
+
+    return errors
+
+
+def changed_svg_paths(root: Path, base_ref: str | None, head_ref: str | None) -> list[Path]:
+    if not base_ref or not head_ref:
+        return []
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_ref}...{head_ref}", "--", "*.svg"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "git diff failed")
+    return [root / line for line in result.stdout.splitlines() if line.endswith(".svg") and (root / line).is_file()]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--base-ref")
+    parser.add_argument("--head-ref")
+    parser.add_argument("paths", nargs="*")
+    args = parser.parse_args()
+    root = args.root.resolve()
+    paths = [root / path for path in args.paths] if args.paths else changed_svg_paths(root, args.base_ref, args.head_ref)
+    if not paths:
+        print("Diagram XML/geometry/arrowhead contract: N/A (no changed SVG files)")
+        return 0
+    errors = [error for path in paths for error in validate_svg(path)]
+    if errors:
+        print("Diagram XML/geometry/arrowhead contract FAILED:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print(f"Diagram XML/geometry/arrowhead contract OK: {len(paths)} changed SVG file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/validate_diagram_contract_test.py
+++ b/scripts/ci/validate_diagram_contract_test.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Tests for changed SVG diagram contract validation."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from validate_diagram_contract import validate_svg
+
+
+class ValidateDiagramContractTest(unittest.TestCase):
+    def test_accepts_directed_svg_with_closed_arrowhead(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "diagram.svg"
+            path.write_text(
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">'
+                '<title>Title</title><desc>Description</desc><defs>'
+                '<marker id="arrow" markerWidth="14" markerHeight="14" markerUnits="userSpaceOnUse">'
+                '<path d="M 0 0 L 10 5 L 0 10 Z"/></marker></defs>'
+                '<path id="route" d="M 10 10 L 90 90" marker-end="url(#arrow)"/></svg>',
+                encoding="utf-8",
+            )
+
+            self.assertEqual(validate_svg(path), [])
+
+    def test_accepts_comma_separated_path_coordinates(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "diagram.svg"
+            path.write_text(
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">'
+                '<title>Title</title><desc>Description</desc><defs>'
+                '<marker id="arrow" markerWidth="14" markerHeight="14" markerUnits="userSpaceOnUse">'
+                '<path d="M0,0 L10,5 L0,10 Z"/></marker></defs>'
+                '<path id="route" d="M10,10L90,90" marker-end="url(#arrow)"/></svg>',
+                encoding="utf-8",
+            )
+
+            self.assertEqual(validate_svg(path), [])
+
+    def test_rejects_degenerate_connector_and_open_arrowhead(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "diagram.svg"
+            path.write_text(
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">'
+                '<title>Title</title><desc>Description</desc><defs>'
+                '<marker id="arrow" markerWidth="14" markerHeight="14" markerUnits="userSpaceOnUse">'
+                '<path d="M 0 0 L 0 0"/></marker></defs>'
+                '<path id="route" d="M 10 10 L 10 10" marker-end="url(#arrow)"/></svg>',
+                encoding="utf-8",
+            )
+
+            errors = validate_svg(path)
+
+            self.assertTrue(any("degenerate geometry" in error for error in errors))
+            self.assertTrue(any("closed arrowhead" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/validate_manual_contract.py
+++ b/scripts/ci/validate_manual_contract.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Run the reproducible manual, release provenance, and diagram CI contract."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+INVENTORY = ROOT / "build/manual/module-inventory.json"
+RELEASE_INVENTORY = ROOT / "build/manual/release-module-inventory.json"
+MANIFEST = ROOT / "docs/manual/manifest.yaml"
+RELEASE_COUNT = int(os.environ.get("MANUAL_RELEASE_EXPECTED_COUNT", "35"))
+
+
+def manifest_value(name: str) -> str:
+    pattern = re.compile(rf"^{re.escape(name)}:\s*([^#\s]+)\s*$", re.MULTILINE)
+    match = pattern.search(MANIFEST.read_text(encoding="utf-8"))
+    if not match:
+        raise ValueError(f"manual manifest is missing {name}")
+    return match.group(1)
+
+
+def run(command: list[str], *, env: dict[str, str] | None = None) -> None:
+    rendered = " ".join(command)
+    print(f"[manual-contract] RUN {rendered}")
+    process = subprocess.run(
+        command,
+        cwd=ROOT,
+        env=env,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if process.stdout:
+        print(process.stdout, end="")
+    if process.returncode != 0:
+        raise RuntimeError(f"command failed ({process.returncode}): {rendered}")
+
+
+def main() -> int:
+    try:
+        release_ref = manifest_value("releaseRef")
+        release_commit = manifest_value("releaseCommit")
+        print(
+            "[manual-contract] release provenance target: "
+            f"{release_ref} ({release_commit})"
+        )
+        run(["python3", "scripts/ci/validate_ci_fanout.py", "--static"])
+        run(["./gradlew", "exportManualModuleInventory", "--no-daemon", "--no-configuration-cache"])
+        run(
+            [
+                "ruby",
+                "scripts/manual/release_inventory.rb",
+                release_ref,
+                release_commit,
+                str(INVENTORY.relative_to(ROOT)),
+                str(RELEASE_INVENTORY.relative_to(ROOT)),
+                str(RELEASE_COUNT),
+            ]
+        )
+        validation_env = os.environ.copy()
+        validation_env.update(
+            {
+                "MANUAL_RELEASE_REF": release_ref,
+                "MANUAL_RELEASE_COMMIT": release_commit,
+            }
+        )
+        run(
+            [
+                "ruby",
+                "scripts/manual/validate_manuals.rb",
+                str(RELEASE_INVENTORY.relative_to(ROOT)),
+                str(MANIFEST.relative_to(ROOT)),
+            ],
+            env=validation_env,
+        )
+        run(["ruby", "scripts/manual/validate_release_manuals.rb", release_ref, release_commit])
+        run(["ruby", "scripts/manual/export_manifest.rb", "--check"])
+        run(
+            [
+                "ruby",
+                "-I",
+                "scripts/manual",
+                "-e",
+                'Dir["scripts/manual/*_test.rb"].sort.each { |file| require File.expand_path(file) }',
+            ]
+        )
+        run(["ruby", "scripts/manual/validate_diagrams.rb"])
+        run(["ruby", "scripts/manual/readme_jvm25_contract.rb"])
+        run(["ruby", "scripts/manual/sync_release_diagrams.rb", "--check"])
+
+        diagram_command = ["python3", "scripts/ci/validate_diagram_contract.py"]
+        base_ref = os.environ.get("MANUAL_CONTRACT_BASE_REF", "").strip()
+        head_ref = os.environ.get("MANUAL_CONTRACT_HEAD_REF", "").strip()
+        if base_ref and head_ref and not re.fullmatch(r"0+", base_ref):
+            diagram_command.extend(["--base-ref", base_ref, "--head-ref", head_ref])
+        run(diagram_command)
+        diff_check = ["git", "diff", "--check"]
+        if base_ref and head_ref and not re.fullmatch(r"0+", base_ref):
+            diff_check.append(f"{base_ref}...{head_ref}")
+        run(diff_check)
+    except (OSError, ValueError, RuntimeError) as error:
+        print(f"Manual/release contract FAILED: {error}", file=sys.stderr)
+        return 1
+    print("Manual/release/diagram contract OK: change detection, provenance, and validation complete")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #663

문서·매뉴얼·전역 설정 변경도 모듈 변경과 동일하게 재현 가능한 CI 계약으로 검증하고, 필요한 job의 `skipped` 결과를 성공으로 오인하지 않도록 연결합니다.

## Background

Epic #697의 RELEASE-02 열차에서 기존 CI가 문서와 매뉴얼 자산을 실행 트리거에서 제외하고, manual provenance/diagram 계약을 fan-out하지 않으며, 집계기가 의도하지 않은 skip을 구분하지 못하는 공백을 해결합니다. 기준 branch는 RELEASE-01(#689) 통합 이후의 `develop`입니다.

## What This Solves

- `**.md`, `docs/**`, `scripts/manual/**` 변경이 CI에서 누락되지 않고 `manual-contract`를 실행합니다.
- workflow/Gradle/catalog 전역 변경이 `global-config` 경로를 선택하고, 영향받은 `manual-contract`가 `skipped`이면 집계가 실패합니다.
- release manifest/inventory/provenance, manual 문서, SVG/PNG 계약과 변경 SVG의 XML/geometry/arrowhead 검증을 저장소 checkout만으로 재현합니다.

## Work Done

- `.github/workflows/ci.yml`: 문서 `paths-ignore`를 제거하고 `manual-contract`/`global-config` filter와 `manual-contract` job을 `ci-status`에 연결했습니다.
- `scripts/ci/validate_ci_fanout.py`: static/runtime/self-test에 manual/global output과 의도적 skip 판정을 추가했습니다.
- `scripts/ci/validate_manual_contract.py`: Java 25 Gradle inventory, manual/release provenance, manifest/diagram checks를 하나의 계약으로 묶었습니다.
- `scripts/ci/validate_diagram_contract.py`: 변경 SVG의 XML, CSS/attribute marker, geometry, closed arrowhead를 저장소 로컬 코드로 검증하고 단위 테스트를 추가했습니다.

## Validation

- `python3 -m unittest discover -s scripts/ci -p '*_test.py'`: PASS (19 tests)
- `python3 scripts/ci/validate_ci_fanout.py --static && --self-test`: PASS
- `actionlint .github/workflows/ci.yml`: PASS
- `JAVA_HOME=...graalvm-jdk-25... python3 scripts/ci/validate_manual_contract.py`: PASS (Gradle export, 36 Ruby tests/384 assertions, release 442 checks, diagram/manual contracts)
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 없음
- Review evidence: 현재 branch diff에 대한 inline 통합 검토 및 위 fresh validation 결과

## Metadata

- Issue: #663, milestone `0.6.0`, assignee `debop`
- PR: #708, head `3acc9ea47ede38d2cb0960e1acd87abdae2563e5`, milestone `0.6.0`, assignee `debop`
- CI: [run 31811137863](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/31811137863) exact-head SUCCESS (`CI Status` 포함)

## DoD Status

Required checks: 17/18; N/A: 3; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| WF-00/WF-01 - 기준 정보 및 분류 | AGENTS hierarchy와 workflow/Kotlin 지침을 재확인하고 Type-A cross-contract train으로 분류 | PASS | 현재 scope hash와 승인된 #663 acceptance | 없음 |
| WF-02/WF-03 - 계획 승인 | RELEASE train graph와 #663 첫 PR 계획을 제시하고 사용자 `승인` 수령 | PASS | active thread 승인 | 없음 |
| WF-04 - 실행 계약 | `bluetape-workflow`, common gates, `bluetape-kotlin-patterns` 및 triggered diagram/full-feature contract를 읽음 | PASS | 현재 skill snapshot | 없음 |
| CG-01/CG-04 - 권한·언어·경계 | isolated worktree와 Korean GitHub/commit 규칙 확인 | PASS | `.worktrees/release-02-issue-663`, `ci/epic-release-02-contracts` | 없음 |
| CG-02 - 현재 증거 | Issue #663 metadata/body/comment와 live branch를 재확인 | PASS | `gh issue view 663`, `git ls-remote` | 없음 |
| CG-03 - 사용자 변경 보호 | `develop` 및 unrelated worktrees를 보존하고 feature worktree만 변경 | PASS | worktree 목록/dirty-state 점검 | 없음 |
| CG-05/CG-06 - 재사용·계약 | 기존 manual validators와 CI fan-out을 확장하고 public API 변경은 없음 | PASS / N/A | 기존 `scripts/manual/*`, API surface 미변경 | API 문서 행은 scope N/A |
| CG-07 - 대상 검증 | CI/manual/diagram 계약을 테스트 우선으로 고정하고 전체 local contract 실행 | PASS | 위 Validation 명령 | 없음 |
| CG-08 - heavy checks | DB/Testcontainers/native/backend 동작 변경 없음 | N/A | workflow/scripts만 변경, Gradle inventory만 Java 25로 실행 | backend matrix는 변경 범위 밖의 의도적 skip |
| CG-09 - lesson gate | 재사용 가능한 production/Kotlin lesson 없음; receipt scope repair는 workflow evidence로 보존 | N/A | non-production CI contract scope 및 `.bluetape` repair evidence | filler lesson을 추가하지 않음 |
| CG-10 - pre-PR convergence | current diff inline review, P0/P1 수렴, Lore commit | PASS | commit `3acc9ea47ede38d2cb0960e1acd87abdae2563e5` | 없음 |
| CG-11 - PR delivery authority | 승인된 계획이 repo `bluetape4k/bluetape4k-leader`, base `develop`, head `ci/epic-release-02-contracts`, PR 생성을 명시 | PASS | active thread와 live issue train comment | 없음 |
| CG-12 - exact head publish | remote branch를 force 없이 push하고 SHA 일치 확인 | PASS | local/remote `3acc9ea47ede38d2cb0960e1acd87abdae2563e5` | 없음 |
| CG-12A - guidance refresh | PR 직전 AGENTS/skills/common-gates/template/Issue metadata를 fresh read-back | PASS | current hashes 및 `gh issue view 663` | 없음 |
| CG-13 - PR create/read-back | Korean body와 issue metadata를 생성 후 live query로 확인 | PASS | [PR #708](https://github.com/bluetape4k/bluetape4k-leader/pull/708), head/labels/milestone/assignee/body read-back | 없음 |
| CG-14 - exact-head CI/review | hosted CI와 live review/thread를 exact head에서 확인 | PASS / N/A | [run 31811137863](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/31811137863) 전체 완료, `CI Status` SUCCESS; reviews/issues/review-comments API가 모두 `[]`; 1인 개발자 정책으로 인간 리뷰 N/A | 없음; skip은 global-config 변경에 대한 의도적 N/A이며 fan-out validator가 검증 |
| CG-15 - merge-ready DoD | CI/review green 후 current head로 merge-ready 보고 | PASS | 이 보고서에서 exact head/CI/review/thread/metadata를 재확인 | fresh merge approval 전 대기 |
| CG-16/CG-17/CG-18 - merge/sync/cleanup | fresh merge approval 후 squash merge, develop fast-forward sync, proven merged worktree/branch cleanup | PASS | 사용자 fresh approval; merge commit `4b99338a1079ccf5d792b930238cf2f56f8f1929`; local/remote `develop` 일치; `release-02-issue-663` worktree와 `ci/epic-release-02-contracts` branch 제거, unrelated worktrees 보존 | 없음 |

Final status: PR #708 exact-head CI/review read-back, fresh merge approval, squash merge, develop sync, and safe cleanup 모두 PASS

Unchecked required items: 없음
