### PR TITLE
test: 동시성·수명주기 테스트 timing flake 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,8 @@ jobs:
           python3 scripts/ci/validate_leader_contract_matrix.py --self-test
           python3 scripts/ci/validate_test_assertion_contract.py
           python3 scripts/ci/validate_test_assertion_contract_test.py
+          python3 scripts/ci/validate_timing_contract.py
+          python3 scripts/ci/validate_timing_contract_test.py
           python3 scripts/compatibility/check_binary_api_test.py
 
   # ── 2-B. 매뉴얼/릴리스 provenance 계약 검증 ─────────────────────────────

--- a/docs/lessons/2026-08-16-issue-673-timing-stability.md
+++ b/docs/lessons/2026-08-16-issue-673-timing-stability.md
@@ -1,0 +1,41 @@
+# Issue #673 timing 안정화 교훈
+
+## 결정
+
+동시성 테스트의 준비 상태는 고정된 `delay`나 무제한 polling으로 추정하지
+않고, 관찰 가능한 상태를 bounded Awaitility assertion으로 기다린다. timeout
+메시지는 lock name, backend, 현재 count를 보존해야 한다.
+
+- Redisson group 슬롯 준비: `while`/`delay`를 `atMost(5.seconds)`와
+  `untilAsserted`로 교체했다.
+- `LeaderLeaseAutoExtender` 첫 stress case: 5초 고정 `delay`를 delegate 호출
+  count의 bounded assertion으로 교체하고 watchdog을 `finally`에서 닫는다.
+- async extend case: `Thread.sleep`과 600ms latch deadline 대신
+  `CompletableFuture` gate를 사용한다. 세 delegate가 gate에서 동시에 시작된
+  뒤 release되므로 serial scheduler는 2초 bounded assertion에서 진단된다.
+- Local suspend skip case: 300ms wall-clock `delay`를 `CompletableDeferred`
+  release gate로 교체해 wait-time contract만 검증한다.
+
+## 검증 계약
+
+`scripts/ci/validate_timing_contract.py`는 TEST-02의 세 대상 파일에서 무제한
+polling, 고정 delay, `Thread.sleep`, 모호한 600ms latch deadline을 차단한다.
+validator 자체는 `validate_timing_contract_test.py`로 clean/violation fixture를
+검증하고 `ci-contract` job에서 실행한다.
+
+관련 모듈의 targeted Gradle test와 반복 실행 결과는 PR 본문 및 `## DoD Status`
+에 exact command와 함께 기록한다. CI job timeout은 기존 `ci-contract` 5분과
+각 모듈 test job의 repository 설정을 유지하며, 새 테스트는 그 제한 안에서
+bounded await가 실패하도록 한다.
+
+이번 fresh 반복 검증에서는 core 대상 11개 테스트를 3회, Redisson group 대상
+16개 테스트를 3회 실행해 모두 `BUILD SUCCESSFUL`이었고 flake failure는 각각
+`0/3`이었다. core/Redisson `detekt`, 기존 CI contract와 timing validator,
+`git diff --check`도 통과했다.
+
+## 재발 방지
+
+새 concurrency/lifecycle test는 준비 신호(`Channel`, `CompletableDeferred`,
+`AtomicInteger`)를 먼저 노출하고, Awaitility timeout과 진단 가능한 assertion을
+추가한다. 실제 backend watchdog을 검증하는 테스트는 `runSuspendIO`를 유지하고
+`runTest`의 virtual time으로 scheduler thread를 가리지 않는다.

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtenderStressTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtenderStressTest.kt
@@ -1,15 +1,20 @@
 package io.bluetape4k.leader
 
-import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.internal.ExtendDelegate
-import kotlinx.coroutines.delay
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.awaitility.kotlin.withAlias
+import org.awaitility.kotlin.withPollInterval
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.time.Instant
-import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
@@ -54,12 +59,18 @@ class LeaderLeaseAutoExtenderStressTest {
             LeaderLeaseAutoExtender.start(true, 3.seconds, it)
         }
 
-        delay(5.seconds)
-
-        watchdogs.forEach { it.close() }
-
-        val allCalled = delegates.all { it.extendCalls.get() >= 1 }
-        allCalled.shouldBeTrue()
+        try {
+            await
+                .withAlias("LeaderLeaseAutoExtender delegates called: n=$n")
+                .atMost(5.seconds)
+                .withPollInterval(50.milliseconds)
+                .untilAsserted {
+                    val missingDelegates = delegates.count { it.extendCalls.get() < 1 }
+                    missingDelegates shouldBeEqualTo 0
+                }
+        } finally {
+            watchdogs.forEach { it.close() }
+        }
     }
 
     @Test
@@ -68,7 +79,8 @@ class LeaderLeaseAutoExtenderStressTest {
         LeaderLeaseAutoExtender.shutdown()
         LeaderLeaseAutoExtender.restart()
 
-        val extendStartedLatch = CountDownLatch(3)
+        val extendStartedCount = AtomicInteger(0)
+        val releaseSlowExtends = CompletableFuture<Unit>()
 
         val delegates = List(3) {
             object : ExtendDelegate {
@@ -76,9 +88,16 @@ class LeaderLeaseAutoExtenderStressTest {
                 override val lastExtendDeadline: AtomicReference<Instant> get() = _lastExtendDeadline
 
                 override fun extend(lockAtMostFor: Duration): ExtendOutcome {
-                    extendStartedLatch.countDown()
-                    // Simulate a slow backend — blocks for 500ms per extend call
-                    Thread.sleep(500)
+                    extendStartedCount.incrementAndGet()
+                    try {
+                        // A controllable gate models a slow backend without wall-clock sleep.
+                        releaseSlowExtends.get(5, TimeUnit.SECONDS)
+                    } catch (e: TimeoutException) {
+                        throw IllegalStateException(
+                            "slow delegate gate timed out: started=${extendStartedCount.get()}/3",
+                            e,
+                        )
+                    }
                     return ExtendOutcome.Extended(Instant.now().plusMillis(lockAtMostFor.inWholeMilliseconds))
                 }
 
@@ -91,12 +110,18 @@ class LeaderLeaseAutoExtenderStressTest {
             LeaderLeaseAutoExtender.start(true, 300.milliseconds, it)
         }
 
-        // If async: all 3 start within one cadence window (~600ms). If serial: would take ~1500ms.
-        val allConcurrent = extendStartedLatch.await(600, TimeUnit.MILLISECONDS)
-
-        watchdogs.forEach { it.close() }
-
-        // Virtual-thread dispatch allows all 3 slow extends to start concurrently.
-        allConcurrent.shouldBeTrue()
+        try {
+            // Async dispatch must start all delegates while the first three calls are gated.
+            await
+                .withAlias("LeaderLeaseAutoExtender async delegates: started=${extendStartedCount.get()}/3")
+                .atMost(2.seconds)
+                .withPollInterval(25.milliseconds)
+                .untilAsserted {
+                    extendStartedCount.get() shouldBeEqualTo 3
+                }
+        } finally {
+            releaseSlowExtends.complete(Unit)
+            watchdogs.forEach { it.close() }
+        }
     }
 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElectorTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElectorTest.kt
@@ -8,19 +8,19 @@ import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeNull
 import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import java.util.concurrent.atomic.AtomicInteger
-import kotlin.random.Random
-import kotlin.time.Duration.Companion.milliseconds
 
 class LocalSuspendLeaderElectorTest {
 
@@ -145,22 +145,26 @@ class LocalSuspendLeaderElectorTest {
             LeaderElectionOptions(waitTime = 50.milliseconds)
         )
         val holderReady = Channel<Unit>(1)
-        val holderDone = Channel<Unit>(1)
+        val holderRelease = CompletableDeferred<Unit>()
         val lockName2 = randomLockName()
 
-        // 홀더: 락 획득 후 300ms 유지
+        // 홀더: short-wait 검증이 끝날 때까지 controllable gate에서 유지
         val holder = async {
             skipElection.runIfLeader(lockName2) {
                 holderReady.send(Unit)
-                delay(300.milliseconds)
+                holderRelease.await()
                 "holder"
             }
         }
 
         holderReady.receive() // 홀더가 락 획득할 때까지 대기
-        // 스키퍼: 짧은 waitTime(50ms) 으로 시도 → null 반환
-        val skipped = skipElection.runIfLeader(lockName2) { "should-skip" }
-        skipped.shouldBeNull()
+        try {
+            // 스키퍼: 짧은 waitTime(50ms) 으로 시도 → null 반환
+            val skipped = skipElection.runIfLeader(lockName2) { "should-skip" }
+            skipped.shouldBeNull()
+        } finally {
+            holderRelease.complete(Unit)
+        }
 
         holder.await()
     }

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElectorTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElectorTest.kt
@@ -154,17 +154,23 @@ class RedissonSuspendLeaderGroupElectorTest: AbstractRedissonLeaderTest() {
                 }
             }
 
-            // 모든 슬롯이 점유될 때까지 대기
-            while (startedCount.get() < maxLeaders) {
-                delay(5.milliseconds)
+            try {
+                // 모든 슬롯이 점유될 때까지 bounded await. timeout 시 assertion이 현재 count를 보존한다.
+                await
+                    .withAlias("Redisson group slots lock=$lockName")
+                    .atMost(5.seconds)
+                    .withPollInterval(50.milliseconds)
+                    .untilAsserted {
+                        startedCount.get() shouldBeEqualTo maxLeaders
+                    }
+
+                election.state(lockName).isFull.shouldBeTrue()
+                election.activeCount(lockName) shouldBeEqualTo maxLeaders
+                election.availableSlots(lockName) shouldBeEqualTo 0
+            } finally {
+                holdSignal.complete(Unit)
+                jobs.awaitAll()
             }
-
-            election.state(lockName).isFull.shouldBeTrue()
-            election.activeCount(lockName) shouldBeEqualTo maxLeaders
-            election.availableSlots(lockName) shouldBeEqualTo 0
-
-            holdSignal.complete(Unit)
-            jobs.awaitAll()
         }
 
         // 완료 후 초기 상태 복귀

--- a/scripts/ci/validate_timing_contract.py
+++ b/scripts/ci/validate_timing_contract.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""TEST-02 대상 Kotlin 테스트의 무제한·wall-clock timing 의존성을 검출한다."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+TARGET_PATTERNS: dict[str, tuple[tuple[re.Pattern[str], str], ...]] = {
+    "leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElectorTest.kt": (
+        (re.compile(r"(?m)^\s*while\s*\("), "무제한 polling"),
+    ),
+    "leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtenderStressTest.kt": (
+        (re.compile(r"\bdelay\(5\.seconds\)"), "고정 delay"),
+        (re.compile(r"\bThread\.sleep\s*\("), "Thread.sleep"),
+        (
+            re.compile(r"\.await\(\s*600\s*,\s*TimeUnit\.MILLISECONDS\s*\)"),
+            "latch deadline",
+        ),
+    ),
+    "leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElectorTest.kt": (
+        (re.compile(r"\bdelay\(300\.milliseconds\)"), "wall-clock delay"),
+    ),
+}
+
+
+def _line_number(source: str, offset: int) -> int:
+    return source.count("\n", 0, offset) + 1
+
+
+def validate_source(root: Path, relative_path: str) -> list[str]:
+    path = root / relative_path
+    if path.is_symlink() or not path.is_file():
+        return []
+
+    source = path.read_text(encoding="utf-8")
+    violations: list[str] = []
+    for pattern, description in TARGET_PATTERNS[relative_path]:
+        for match in pattern.finditer(source):
+            violations.append(
+                f"{path}:{_line_number(source, match.start())}: {description}는 "
+                "bounded helper 또는 controllable fixture로 대체하십시오"
+            )
+    return violations
+
+
+def validate_sources(root: Path) -> list[str]:
+    """Validate the three TEST-02 timing-sensitive sources under ``root``."""
+
+    resolved_root = root.resolve()
+    return [
+        violation
+        for relative_path in TARGET_PATTERNS
+        for violation in validate_source(resolved_root, relative_path)
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[2])
+    args = parser.parse_args()
+    violations = validate_sources(args.root)
+    if violations:
+        for violation in violations:
+            print(f"::error::{violation}")
+        return 1
+    print("Kotlin timing contract OK: bounded polling and controllable fixtures")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/validate_timing_contract_test.py
+++ b/scripts/ci/validate_timing_contract_test.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Timing contract validator의 회귀 테스트."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from validate_timing_contract import validate_sources
+
+
+TARGETS = {
+    "leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonSuspendLeaderGroupElectorTest.kt":
+        "await.atMost(5.seconds) untilAsserted { startedCount.get() == maxLeaders }",
+    "leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtenderStressTest.kt":
+        "await.atMost(5.seconds) untilAsserted { delegates.all { it.extendCalls.get() >= 1 } }",
+    "leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines/LocalSuspendLeaderElectorTest.kt":
+        "holderRelease.await()",
+}
+
+
+class TestTimingContractValidator(unittest.TestCase):
+    def _write_target(self, root: Path, relative_path: str, source: str) -> None:
+        target = root / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(source, encoding="utf-8")
+
+    def test_accepts_bounded_and_controllable_timing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for relative_path, source in TARGETS.items():
+                self._write_target(root, relative_path, source)
+
+            self.assertEqual(validate_sources(root), [])
+
+    def test_rejects_known_unbounded_or_wall_clock_patterns(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._write_target(
+                root,
+                next(path for path in TARGETS if path.startswith("leader-redis-redisson")),
+                "while (startedCount.get() < maxLeaders) { delay(5.milliseconds) }",
+            )
+            self._write_target(
+                root,
+                next(path for path in TARGETS if path.startswith("leader-core/src/test/kotlin/io/bluetape4k/leader/Leader")),
+                "delay(5.seconds)\nThread.sleep(500)\nextendStartedLatch.await(600, TimeUnit.MILLISECONDS)",
+            )
+            self._write_target(
+                root,
+                next(path for path in TARGETS if path.startswith("leader-core/src/test/kotlin/io/bluetape4k/leader/coroutines")),
+                "delay(300.milliseconds)",
+            )
+
+            violations = validate_sources(root)
+
+            self.assertEqual(len(violations), 5)
+            self.assertTrue(any("무제한 polling" in item for item in violations))
+            self.assertTrue(any("고정 delay" in item for item in violations))
+            self.assertTrue(any("Thread.sleep" in item for item in violations))
+            self.assertTrue(any("latch deadline" in item for item in violations))
+            self.assertTrue(any("wall-clock delay" in item for item in violations))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #673

TEST-02에서 동시성·수명주기 테스트의 무제한 polling과 wall-clock timing 의존성을 제거하고, timeout 원인을 현재 상태와 함께 관찰할 수 있도록 고정했습니다.

## Background

Epic #696의 stacked PR train `TEST-02`입니다. 선행 TEST-01 #674 / PR #710은 이미 `develop`에 merge되었습니다. 이번 변경은 production leader contract를 바꾸지 않고 테스트 신뢰성과 CI 진단성을 개선합니다.

## What This Solves

- Redisson group 슬롯 준비를 무제한 `while`/`delay` 대신 5초 bounded Awaitility assertion으로 검증합니다.
- auto-extender stress 테스트의 고정 5초 `delay`, `Thread.sleep(500)`, 600ms latch deadline을 호출 count assertion과 controllable `CompletableFuture` gate로 대체합니다.
- Local suspend skip 테스트의 300ms wall-clock `delay`를 `CompletableDeferred` release gate로 대체합니다.
- timing contract validator와 CI `ci-contract` hook을 추가해 동일한 회귀 패턴을 정적으로 차단합니다.

## Work Done

- `leader-core` 두 테스트와 `leader-redis-redisson` group 테스트의 준비 신호·timeout·resource cleanup을 정리했습니다.
- `scripts/ci/validate_timing_contract.py` 및 self-test를 추가했습니다.
- 반복 실행 결과와 CI timeout 기준을 `docs/lessons/2026-08-16-issue-673-timing-stability.md`에 기록했습니다.

## Validation

- core targeted tests: 11 passing
- Redisson group targeted tests: 16 passing
- fresh rerun: core 3회 `0/3` failure, Redisson 3회 `0/3` failure
- core/Redisson detekt: PASS
- CI fan-out/leader matrix/assertion/timing/compatibility validators 및 self-test: PASS
- `git diff --check`: PASS
- inline 7-tier review: P0/P1 0, P2/P3 없음
- [CI run 31893677121](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/31893677121): 47/47 jobs PASS, `CI Status` PASS
- [post-merge CI run 31894478867](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/31894478867): merge commit 기준 47/47 jobs PASS, `CI Status` PASS

## Stacked PR Train

| 순서 | 이슈 | PR | 기준 |
|---|---:|---:|---|
| TEST-01 | #674 | #710 merged | develop |
| TEST-02 | #673 | 현재 PR | develop (TEST-01 선행 완료) |

## Metadata

- Issue: #673, milestone `0.6.0`, assignee `debop`
- PR branch: `test/epic-test-02-timing`
- base: `develop`
- exact local head: `b5e57b156b8cc72e8e39dd766e8b5548c5a4ef9c`
- hosted CI run: `31893677121`
- merge commit: `05c1104308a00e38995bed8338533d40e5e13f10`
- local/origin `develop`: `05c1104308a00e38995bed8338533d40e5e13f10`
- human review: 1인 개발자 지시에 따라 N/A

## DoD Status

Required checks: 19/19; N/A: 1 (human review); Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01~CG-10 - Pre-PR proof | 계획·격리 worktree·구현·검증·inline review·lesson·Lore commit 완료 | PASS | commit `b5e57b156b8cc72e8e39dd766e8b5548c5a4ef9c` | none |
| CG-11 - PR delivery authority | repo/base/head 확인 | PASS | `bluetape4k/bluetape4k-leader`, `develop`, `test/epic-test-02-timing` | none |
| CG-12 - Exact head publication | force 없이 branch push | PASS | exact head `b5e57b156b8cc72e8e39dd766e8b5548c5a4ef9c` | none |
| CG-12A - Guidance refresh | issue·epic·workflow·Kotlin pattern·metadata 재확인 | PASS | #673/#696 live read-back 및 receipt run `20260815T152508Z-346ed2f3` | none |
| CG-13 - PR creation/read-back | Korean body·assignee·milestone·labels·exact head 확인 | PASS | PR #711 live read-back, assignee `debop`, milestone `0.6.0`, labels `bug/test/maintenance`, head `b5e57b156b8cc72e8e39dd766e8b5548c5a4ef9c` | none |
| CG-14 - Exact-head CI/review | hosted required CI와 review/thread 확인 | PASS | run `31893677121` 47/47 PASS, reviews/threads 0 | human review N/A |
| CG-15 - Merge-ready report | CI·issue/PR evidence 재집계 | PASS | exact head `b5e57b156b8cc72e8e39dd766e8b5548c5a4ef9c`, `CLEAN`, `MERGEABLE` | none |
| CG-16 - Fresh merge approval | exact PR/head 별도 승인 재확인 | PASS | 사용자 승인 후 exact head `b5e57b156b8cc72e8e39dd766e8b5548c5a4ef9c` live 재검증 | none |
| CG-17 - Merge | approved merge strategy로 merge 및 live read-back | PASS | PR #711 MERGED, merge commit `05c1104308a00e38995bed8338533d40e5e13f10` | none |
| CG-18 - Local sync/cleanup | `develop` fast-forward 및 대상 worktree/local branch 안전 정리 | PASS | local/origin `develop`=`05c1104308a00e38995bed8338533d40e5e13f10`; 관련 없는 worktree 보존 | remote branch는 별도 삭제 권한이 없어 보존 |

Final status: DONE

Unchecked required items: none