### PR TITLE
test(r2dbc): active-count cache 퇴거와 재생성 계약을 고정한다

### DIFF
--- a/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElectorTest.kt
+++ b/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElectorTest.kt
@@ -22,6 +22,7 @@ import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
 import org.jetbrains.exposed.v1.r2dbc.statements.GlobalSuspendStatementInterceptor
 import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldBeInRange
 import io.bluetape4k.assertions.shouldBeNull
@@ -58,6 +59,13 @@ class ExposedR2DbcSuspendLeaderGroupElectorTest: AbstractExposedR2dbcLeaderTest(
                 retryStrategy = RetryStrategy.Jitter(),
             ),
         )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun ExposedR2DbcSuspendLeaderGroupElector.hasCachedActiveCount(lockName: String): Boolean {
+        val cacheField = javaClass.getDeclaredField("cachedActiveCounts")
+        cacheField.isAccessible = true
+        return (cacheField.get(this) as Map<String, *>).containsKey(lockName)
     }
 
     @ParameterizedTest
@@ -282,6 +290,56 @@ class ExposedR2DbcSuspendLeaderGroupElectorTest: AbstractExposedR2dbcLeaderTest(
         release.complete(Unit)
         holdJob.await()
     }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `동시 슬롯 해제 후 0이 된 active count cache를 같은 lockName으로 재생성한다`(testDB: TestR2dbcDB) =
+        runSuspendIO {
+            val db = setupDb(testDB)
+            cleanTables(db)
+            val lockName = randomName()
+            val maxLeaders = 2
+            val options = ExposedR2dbcLeaderGroupElectionOptions(
+                leaderGroupOptions = LeaderGroupElectionOptions(
+                    maxLeaders = maxLeaders,
+                    waitTime = 5.seconds,
+                    leaseTime = 30.seconds,
+                ),
+            )
+            val election = ExposedR2DbcSuspendLeaderGroupElector(db, options)
+            val acquiredCount = AtomicInteger(0)
+            val allAcquired = CompletableDeferred<Unit>()
+            val release = CompletableDeferred<Unit>()
+
+            // SuspendedJobTester는 실행 중인 두 슬롯의 cache 상태를 관찰할 수 없어 명시적 barrier를 사용한다.
+            val jobs = (1..maxLeaders).map {
+                async {
+                    election.runIfLeader(lockName) {
+                        if (acquiredCount.incrementAndGet() == maxLeaders) {
+                            allAcquired.complete(Unit)
+                        }
+                        release.await()
+                    }
+                }
+            }
+
+            withTimeout(10.seconds) { allAcquired.await() }
+            election.activeCount(lockName) shouldBeEqualTo maxLeaders
+            election.hasCachedActiveCount(lockName).shouldBeTrue()
+
+            release.complete(Unit)
+            withTimeout(10.seconds) { jobs.awaitAll() }
+            election.activeCount(lockName) shouldBeEqualTo 0
+            election.hasCachedActiveCount(lockName).shouldBeFalse()
+
+            election.runIfLeader(lockName) {
+                election.activeCount(lockName) shouldBeEqualTo 1
+                election.hasCachedActiveCount(lockName).shouldBeTrue()
+                "recreated"
+            } shouldBeEqualTo "recreated"
+            election.activeCount(lockName) shouldBeEqualTo 0
+            election.hasCachedActiveCount(lockName).shouldBeFalse()
+        }
 
     @ParameterizedTest
     @MethodSource("enableDialects")


### PR DESCRIPTION
## Summary

Closes #675

선행 병합으로 제거된 R2DBC 그룹 active-count cache의 production `!!`가 다시 도입되지 않도록, 동시 점유·zero-count 퇴거·동일 `lockName` 재생성 계약을 회귀 테스트로 고정합니다.

## Background

- 부모 Epic: #695
- Stacked PR train: R2DBC-01/04
- Base: `develop`
- Head: `test/issue-675-r2dbc-active-count-cache`
- 다음 PR #691은 이 branch를 base로 사용합니다.

## What This Solves

- 동시 acquire/release 후 cache entry가 0 값으로 잔류하는 회귀를 검출합니다.
- 퇴거된 동일 `lockName`이 다음 선출에서 정상적으로 다시 생성되는지 검증합니다.
- production 구현의 불필요한 `!!`가 없는 상태를 정적 검사로 확인합니다.

## Work Done

- 같은 elector에서 두 슬롯을 동시에 점유하고 `activeCount == 2`와 cache key 존재를 검증했습니다.
- 두 슬롯 해제 후 `activeCount == 0`과 cache key 제거를 검증했습니다.
- 동일 `lockName` 재선출 중 cache key 재생성과 종료 후 재퇴거를 검증했습니다.
- 실행 중 내부 cache 상태를 구분해야 하므로 test-only reflection helper를 사용했습니다. production API와 동작은 변경하지 않았습니다.

## Validation

- `./gradlew :bluetape4k-leader-exposed-r2dbc:test --tests 'io.bluetape4k.leader.exposed.r2dbc.ExposedR2DbcSuspendLeaderGroupElectorTest.동시 슬롯*' --no-build-cache --no-daemon --console=plain`: PASS (H2/PostgreSQL/MySQL 3 tests)
- `./gradlew :bluetape4k-leader-exposed-r2dbc:cleanTest :bluetape4k-leader-exposed-r2dbc:test :bluetape4k-leader-exposed-r2dbc:detekt --no-build-cache --no-daemon --console=plain`: PASS (309 tests, Detekt)
- `git diff --check`: PASS
- production `ExposedR2DbcSuspendLeaderGroupElector.kt`의 `!!` 검사: PASS (0건)

## Review Notes

- P0/P1: 0
- P2/P3: 0
- Review evidence: 1인 개발자 지침에 따라 human review는 N/A이며, final diff inline review를 완료했습니다.
- Lesson: 기존 Kotlin null-safety·concurrency lifecycle 규칙을 재사용했으며 새 lesson이 필요한 failure/recovery/design/operation 규칙은 없습니다.

## Metadata

- Issue: #675, milestone `0.6.0`, assignee `debop`
- Epic: #695, train `R2DBC-01/04`
- PR: head `5124ef186cb35debfb89430555c5580a7ff534ec`, milestone `0.6.0`, assignee `debop`
- CI: run `31908873092` SUCCESS (18 PASS, 경로 조건 SKIPPED 29, 실패 0)

## DoD Status

Required checks: 18/18; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| WF-00~WF-04A | 지침·분류·계획 승인·격리 worktree 실행 | PASS | Type E, Issue #675, `test/issue-675-r2dbc-active-count-cache` | 없음 |
| E-01~E-06 | test-only 계약 보강과 pre-PR 검증 | PASS | 변경 1파일, production 동작 변경 없음 | 없음 |
| KT-TEST-01~05 | coroutine barrier와 세 dialect 회귀 검증 | PASS | targeted 3 tests, module 309 tests | 없음 |
| RED | production 동작 변경 전 실패 테스트 | N/A | production 수정은 선행 병합으로 완료됐고 이번 PR은 누락된 회귀 증거만 추가 | 없음 |
| CG-09 | lesson gate 평가 | PASS | 기존 규칙 재사용, 신규 lesson 대상 없음 | 없음 |
| CG-10~CG-12 | review·commit·exact-head publish | PASS | P0/P1=0, `5124ef186cb35debfb89430555c5580a7ff534ec` | 없음 |
| CG-12A | 현재 `AGENTS.md`, leaf skill, common gates, PR template, Issue #675 재확인 | PASS | hash 및 live metadata drift 없음 | 없음 |
| CG-13 | PR 생성과 metadata read-back | PASS | PR 생성 후 live read-back | metadata 불일치 시 즉시 수정 |
| CG-14 | exact-head CI와 live review 확인 | PASS | run `31908873092`: 18 PASS, 29 경로 조건 SKIPPED, review/thread 0/0 | 없음 |
| CG-15 | merge-ready DoD 보고 | PASS | exact head `5124ef186cb35debfb89430555c5580a7ff534ec`, CI 및 review evidence read-back | 없음 |
| CG-16~CG-18 | fresh merge 승인·merge·동기화·정리 | PASS | squash merge `6952998fae2d956e64c7c9a6de4ad059005f2e49`; stacked train 완료 후 local=origin/develop | 없음 |

Final status: DONE (exact-head CI·merge·stacked train closeout 완료)

Unchecked required items: 없음