### PR TITLE
fix(r2dbc): 오래된 상태 조회가 최신 DB 장애를 숨기지 못하게 한다

### DIFF
--- a/docs/lessons/2026-08-16-r2dbc-availability-epoch.md
+++ b/docs/lessons/2026-08-16-r2dbc-availability-epoch.md
@@ -1,0 +1,50 @@
+# 배운 교훈 - R2DBC DB-time availability의 인과 순서
+
+## 맥락
+
+Issue #691의 Exposed R2DBC 그룹 선출기는 DB time 조회가 실패하면 해당
+`lockName`의 `activeCount`, `availableSlots`, `state`를 fail-closed로 유지해야
+합니다. 그러나 실패 뒤에 완료된 조회라도 실제 시작 시점이 더 이르면, 최신 장애를
+복구 증거로 사용할 수 없습니다.
+
+## 원인
+
+기존 구현은 `unavailableLockNames`를 Boolean marker처럼 추가하거나
+제거했습니다. 먼저 시작한 `activeCountSuspend`가 대기하는 동안 다른 선출 시도가
+DB time 조회에 실패해 marker를 추가해도, 오래된 조회가 나중에 성공하면 marker를
+무조건 제거했습니다. 성공과 실패의 발생 순서를 저장하지 않아 완료 순서가 상태를
+결정한 것이 원인입니다.
+
+## 결정
+
+전역 `availabilityEpoch`와 `lockName`별 최신 실패 epoch를 함께 저장합니다. DB
+작업은 시작 전에 epoch 스냅숏을 남기고, 성공 시점에는 같은 키의 `compute`에서 최신
+실패 epoch와 비교합니다. 작업 시작 뒤에 기록된 실패가 있으면 marker를 유지하고
+`maxLeaders`를 반환합니다. 장애보다 늦게 시작한 DB 작업이 성공한 경우에만 marker를
+제거합니다.
+
+`markUnavailable`과 `markAvailable`은 모두 같은 키의 `compute`를 사용합니다.
+이렇게 해야 epoch 증가와 marker 저장 사이에 성공 경로가 끼어드는 경우도 같은
+인과 규칙으로 직렬화됩니다.
+
+## 결과
+
+오래된 성공은 최신 DB-time 장애를 숨기지 못합니다. 장애 구간에는
+`activeCount=maxLeaders`, `availableSlots=0`을 유지하고, 이후 새로 시작한 DB
+조회가 성공하면 정상 캐시 값과 슬롯 수를 다시 노출합니다. 공개 API와
+skip-on-contention 계약은 변경하지 않았습니다.
+
+## 검증
+
+- RED: H2, PostgreSQL, MySQL에서 오래된 조회 성공이 marker를 제거해 3개 테스트 실패
+- GREEN: 같은 세 dialect의 순서 고정 회귀 테스트 3개 통과
+- 그룹 선출기 테스트 57개 통과
+- `bluetape4k-leader-exposed-r2dbc` 모듈 테스트 312개와 Detekt 통과
+- `git diff --check` 통과
+
+## 향후 지침
+
+비동기 상태 갱신에서 Boolean availability marker를 무조건 지우지 마세요. 성공이
+장애를 해제하려면 작업 시작 시점이 최신 실패보다 뒤라는 인과 증거가 필요합니다.
+테스트는 단순 동시 실행 횟수보다 SQL 경계의 선후 관계를 barrier로 고정하고,
+fail-closed 유지와 후속 정상 복구를 함께 검증해야 합니다.

--- a/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElector.kt
+++ b/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElector.kt
@@ -100,7 +100,24 @@ class ExposedR2DbcSuspendLeaderGroupElector private constructor(
     )
 
     private val cachedActiveCounts = ConcurrentHashMap<String, CachedActiveCount>()
-    private val unavailableLockNames = ConcurrentHashMap.newKeySet<String>()
+    private val availabilityEpoch = AtomicLong()
+    private val unavailableLockEpochs = ConcurrentHashMap<String, Long>()
+
+    private fun availabilitySnapshot(): Long = availabilityEpoch.get()
+
+    private fun markUnavailable(lockName: String) {
+        unavailableLockEpochs.compute(lockName) { _, current ->
+            maxOf(current ?: 0L, availabilityEpoch.incrementAndGet())
+        }
+    }
+
+    private fun markAvailable(lockName: String, startedAtEpoch: Long): Boolean {
+        var available = true
+        unavailableLockEpochs.compute(lockName) { _, failureEpoch ->
+            failureEpoch?.takeIf { it > startedAtEpoch }?.also { available = false }
+        }
+        return available
+    }
 
     /**
      * Local acquisitions and releases are serialized through the map entry.  The generation lets a
@@ -162,10 +179,13 @@ class ExposedR2DbcSuspendLeaderGroupElector private constructor(
     /**
      * `activeCount` 호출은 Exposed database backend leader election 계약의 일부 동작을 수행합니다.
      *
+     * DB time 조회 실패 후에는 해당 `lockName`에서 더 최신인 DB 성공이 확인될 때까지 `maxLeaders`를 반환합니다.
+     * 따라서 `availableSlots`와 `state`도 장애 구간에 사용 가능한 슬롯을 노출하지 않습니다.
+     *
      * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
      */
     override fun activeCount(lockName: String): Int =
-        if (lockName in unavailableLockNames) maxLeaders else cachedActiveCounts[lockName]?.value?.get() ?: 0
+        if (unavailableLockEpochs.containsKey(lockName)) maxLeaders else cachedActiveCounts[lockName]?.value?.get() ?: 0
 
     /**
      * `availableSlots` 호출은 Exposed database backend leader election 계약의 일부 동작을 수행합니다.
@@ -185,12 +205,16 @@ class ExposedR2DbcSuspendLeaderGroupElector private constructor(
     /**
      * `activeCountSuspend` 호출은 Exposed database backend leader election 계약의 일부 동작을 수행합니다.
      *
+     * DB time 모드의 오류는 JDBC `activeCount`와 동일하게 `maxLeaders`로 fail-closed 처리합니다.
+     * 조회 시작 이후 다른 작업에서 발생한 최신 DB 오류는 오래된 조회 성공으로 해제하지 않습니다.
+     *
      * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
      */
     @Suppress("ReturnCount")
     suspend fun activeCountSuspend(lockName: String): Int {
         validateExposedR2dbcLockName(lockName)
         val snapshot = cacheSnapshot(lockName)
+        val startedAtAvailabilityEpoch = availabilitySnapshot()
         val refreshedCount = try {
             suspendTransaction(db) {
                 val now = currentTime(options.leaderGroupOptions.useDbTime)
@@ -207,14 +231,14 @@ class ExposedR2DbcSuspendLeaderGroupElector private constructor(
             throw e
         } catch (e: Exception) {
             if (options.leaderGroupOptions.useDbTime) {
-                unavailableLockNames.add(lockName)
+                markUnavailable(lockName)
                 log.warn(e) { "activeCount DB 조회 오류 (fail-closed: $maxLeaders 반환): lockName=$lockName" }
                 return maxLeaders
             }
             log.warn(e) { "activeCount DB 조회 오류 (기존 캐시 유지): lockName=$lockName" }
             return cachedActiveCounts[lockName]?.value?.get() ?: 0
         }
-        unavailableLockNames.remove(lockName)
+        if (!markAvailable(lockName, startedAtAvailabilityEpoch)) return maxLeaders
         return applyActiveCountRefresh(lockName, snapshot, refreshedCount)
     }
 
@@ -235,6 +259,7 @@ class ExposedR2DbcSuspendLeaderGroupElector private constructor(
 
         for (i in 0 until maxLeaders) {
             val slot = (start + i) % maxLeaders
+            val startedAtAvailabilityEpoch = availabilitySnapshot()
             val lock = ExposedR2dbcGroupLock(
                 db,
                 lockName,
@@ -244,9 +269,9 @@ class ExposedR2DbcSuspendLeaderGroupElector private constructor(
                 options.leaderGroupOptions.useDbTime,
                 onAvailabilityChanged = { available ->
                     if (available) {
-                        unavailableLockNames.remove(lockName)
+                        markAvailable(lockName, startedAtAvailabilityEpoch)
                     } else {
-                        unavailableLockNames.add(lockName)
+                        markUnavailable(lockName)
                     }
                 },
             )

--- a/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElectorTest.kt
+++ b/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElectorTest.kt
@@ -34,6 +34,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 class ExposedR2DbcSuspendLeaderGroupElectorTest: AbstractExposedR2dbcLeaderTest() {
@@ -375,6 +376,53 @@ class ExposedR2DbcSuspendLeaderGroupElectorTest: AbstractExposedR2dbcLeaderTest(
 
     @ParameterizedTest
     @MethodSource("enableDialects")
+    fun `activeCountSuspend - 오래된 성공이 이후 DB 오류 marker를 지우지 않는다`(testDB: TestR2dbcDB) = runSuspendIO {
+        val db = setupDb(testDB)
+        cleanTables(db)
+        val maxLeaders = 2
+        val lockName = randomName()
+        val election = ExposedR2DbcSuspendLeaderGroupElector(
+            db,
+            ExposedR2dbcLeaderGroupElectionOptions(
+                leaderGroupOptions = LeaderGroupElectionOptions(
+                    maxLeaders = maxLeaders,
+                    waitTime = 100.milliseconds,
+                    leaseTime = 30.seconds,
+                    useDbTime = true,
+                ),
+                retryStrategy = RetryStrategy.Fixed(fixedMs = 10L),
+            ),
+        )
+        val interceptor = BlockActiveCountThenFailDbTime()
+        R2dbcTransaction.globalInterceptors += interceptor
+
+        val staleRefresh = async { election.activeCountSuspend(lockName) }
+        try {
+            // SQL 경계의 선후 관계를 검증해야 하므로 일반 coroutine stress helper 대신 interceptor barrier를 사용한다.
+            withTimeout(5.seconds) { interceptor.refreshBlocked.await() }
+            interceptor.failNextDbTimeRead()
+
+            election.runIfLeader(lockName) { "must-not-run" }.shouldBeNull()
+            election.activeCount(lockName) shouldBeEqualTo maxLeaders
+            election.availableSlots(lockName) shouldBeEqualTo 0
+
+            interceptor.releaseRefresh.complete(Unit)
+            staleRefresh.await() shouldBeEqualTo maxLeaders
+            election.activeCount(lockName) shouldBeEqualTo maxLeaders
+            election.availableSlots(lockName) shouldBeEqualTo 0
+
+            election.activeCountSuspend(lockName) shouldBeEqualTo 0
+            election.activeCount(lockName) shouldBeEqualTo 0
+            election.availableSlots(lockName) shouldBeEqualTo maxLeaders
+        } finally {
+            interceptor.releaseRefresh.complete(Unit)
+            staleRefresh.cancelAndJoin()
+            R2dbcTransaction.globalInterceptors.remove(interceptor)
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
     fun `복구 후 정상 경합 결과가 fail-closed 상태를 해제한다`(testDB: TestR2dbcDB) = runSuspendIO {
         val db = setupDb(testDB)
         cleanTables(db)
@@ -553,6 +601,35 @@ class ExposedR2DbcSuspendLeaderGroupElectorTest: AbstractExposedR2dbcLeaderTest(
             if (!cancelled && context.sql(transaction).contains(LOCK_HISTORY_TABLE_NAME, ignoreCase = true)) {
                 cancelled = true
                 throw CancellationException("cancel during group history setup")
+            }
+        }
+    }
+
+    private class BlockActiveCountThenFailDbTime : GlobalSuspendStatementInterceptor {
+        val refreshBlocked = CompletableDeferred<Unit>()
+        val releaseRefresh = CompletableDeferred<Unit>()
+        private val shouldBlockRefresh = AtomicBoolean(true)
+        private val shouldFailDbTime = AtomicBoolean(false)
+
+        fun failNextDbTimeRead() {
+            shouldFailDbTime.set(true)
+        }
+
+        override suspend fun beforeExecution(transaction: R2dbcTransaction, context: StatementContext) {
+            val sql = context.sql(transaction)
+            if (
+                sql.contains(GROUP_LOCK_TABLE_NAME, ignoreCase = true) &&
+                sql.contains("COUNT", ignoreCase = true) &&
+                shouldBlockRefresh.compareAndSet(true, false)
+            ) {
+                refreshBlocked.complete(Unit)
+                releaseRefresh.await()
+            }
+            if (
+                sql.contains("CURRENT_TIMESTAMP", ignoreCase = true) &&
+                shouldFailDbTime.compareAndSet(true, false)
+            ) {
+                error("synthetic DB-time failure")
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes #691

먼저 시작한 R2DBC 상태 조회가 나중에 관측된 DB-time 장애를 지우지 못하도록,
availability 복구에 작업 시작 epoch와 lock별 최신 실패 epoch를 적용합니다.

## Background

- 부모 Epic: #695
- Stacked PR train: R2DBC-02/04
- 선행 PR: #712 (R2DBC-01, merged)
- Base: `develop`
- Head: `fix/issue-691-r2dbc-availability-epoch`
- 다음 PR #692는 이 branch를 base로 사용하고, 이 PR이 merge되면 `develop`으로 rebase/retarget합니다.

기존 Boolean marker는 `activeCountSuspend()`의 시작 순서와 DB 오류의 발생 순서를
구분하지 못했습니다. 그 결과 오래된 조회가 늦게 성공하면 최신 장애 marker를
무조건 제거해 상태 조회가 fail-open처럼 보일 수 있었습니다.

## What This Solves

- 오래된 DB 조회 성공이 최신 DB-time 장애 marker를 제거하는 경합을 막습니다.
- 장애 동안 `activeCount=maxLeaders`, `availableSlots=0`의 fail-closed 상태를 유지합니다.
- 장애 뒤에 새로 시작한 DB 작업이 성공했을 때만 정상 상태로 복구합니다.

## Work Done

- `availabilityEpoch`와 `lockName`별 최신 실패 epoch를 도입했습니다.
- 성공·실패 상태 변경을 같은 키의 `ConcurrentHashMap.compute`로 직렬화했습니다.
- H2, PostgreSQL, MySQL에서 SQL barrier로 stale refresh → DB-time failure → stale success → fresh recovery 순서를 고정했습니다.
- 공개 상태 조회 KDoc과 `docs/lessons/2026-08-16-r2dbc-availability-epoch.md`에 JDBC/R2DBC fail-closed 계약과 재발 방지 규칙을 기록했습니다.

## Validation

- RED: 수정 전 세 dialect 회귀 테스트 3개 FAIL (`expected: 2`, `actual: 0`)
- `./gradlew :bluetape4k-leader-exposed-r2dbc:test --tests '*오래된 성공이 이후 DB 오류 marker를 지우지 않는다*' --no-build-cache --no-daemon --console=plain`: PASS (3 tests, `BUILD SUCCESSFUL in 12s`)
- `./gradlew :bluetape4k-leader-exposed-r2dbc:cleanTest :bluetape4k-leader-exposed-r2dbc:test :bluetape4k-leader-exposed-r2dbc:detekt --no-build-cache --no-daemon --console=plain`: PASS (312 tests, failures/errors/skipped 0, Detekt)
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 0
- Review evidence: correctness, concurrency, coroutine cancellation, Kotlin safety, DB portability, test determinism, API/docs·performance를 포함한 7-tier inline review 완료
- Human review: 1인 개발자 지침에 따라 N/A
- Lesson: `docs/lessons/2026-08-16-r2dbc-availability-epoch.md`; `bluetape4k-docs`가 `.worktrees`를 제외하므로 merge·local sync 뒤 index 검증 예정

## Metadata

- Issue: #691, milestone `0.6.0`, assignee `debop`
- PR: #713, source head `124148315c973946ddb29b0845f5a86f532dc3cc`, merge commit `5ee9430dcd668c07eba9ccaf71beacbadcfff5c5`, milestone `0.6.0`, assignee `debop`
- CI: https://github.com/bluetape4k/bluetape4k-leader/actions/runs/31911720603 (exact head, 19 PASS, 28 intended SKIPPED)

## DoD Status

Required checks: 19/19; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01~CG-05 | 지침·GNO/live evidence·격리 worktree·Kotlin 패턴 확인 | PASS | Type C, Epic #695, Issue #691, isolated branch | 없음 |
| C-01~C-04 / CG-07 | 원인 진단, 결정론적 RED, epoch 기반 최소 수정 | PASS | RED 3 failures → GREEN 3 tests | 없음 |
| C-05 / CG-08 | targeted·모듈·Detekt를 직렬 실행 | PASS | 3 tests; 312 tests; Detekt | 없음 |
| C-06 / CG-06·CG-09 | KDoc과 재사용 가능한 lesson 기록 | PASS | lesson commit; GNO index는 merge 후 기본 checkout에서 실행 | CG-18에서 index/read-back |
| CG-10 | 7-tier inline review와 converged commit | PASS | P0/P1/P2/P3=0; `124148315c973946ddb29b0845f5a86f532dc3cc` | 없음 |
| CG-11~CG-12 | PR authority와 exact-head publish | PASS | repo `bluetape4k-leader`, base `develop`, local=remote head | 없음 |
| CG-12A | 현재 AGENTS hierarchy, leaf skills, common gates, PR template, Issue #691 재확인 | PASS | hashes와 live metadata drift 없음 | 없음 |
| CG-13 | PR 생성과 metadata read-back | PASS | PR #713; base/head·assignee·milestone·labels 일치; 최종 heading `## DoD Status` | 없음 |
| CG-14 | exact-head CI와 live review 확인 | PASS | run `31911720603`: 19 PASS, 28 intended SKIPPED, 실패/비종료 0; reviews/threads 0 | 없음 |
| CG-15 | merge-ready DoD 보고 | PASS | exact head `124148315c973946ddb29b0845f5a86f532dc3cc`, CI run `31911720603`, Epic #695 train read-back | 없음 |
| CG-16~CG-18 | fresh merge 승인·rebase merge·동기화·정리·lesson index | PASS | 승인 후 merge `5ee9430dcd668c07eba9ccaf71beacbadcfff5c5`; local=origin/develop; 312 tests+Detekt; GNO 109 embeddings/errors 0; target worktree/branch 제거 | 없음 |
| Human review | 외부 인간 reviewer 승인 | N/A | 1인 개발자 지침 | inline review를 증거로 사용 |

Final status: DONE (merge·develop 동기화·검증·lesson index·안전 정리 완료)

Unchecked required items: none
