### PR TITLE
fix(exposed): 그룹 취소 이력을 terminal 상태로 마감한다

### DIFF
--- a/docs/lessons/2026-08-16-group-cancellation-history.md
+++ b/docs/lessons/2026-08-16-group-cancellation-history.md
@@ -1,0 +1,55 @@
+# 배운 교훈 - 그룹 선출 취소와 terminal history
+
+## 맥락
+
+Issue #692의 Exposed JDBC/R2DBC 그룹 선출기는 슬롯을 획득한 뒤 audit history를
+`ACQUIRED`로 기록합니다. 이후 action이 취소되면 취소 예외는 호출자에게
+재전파하고, 슬롯과 로컬 캐시는 반드시 정리해야 합니다. 이미 만들어진 history도
+실행 중인 작업으로 오인되지 않도록 terminal 상태로 닫아야 합니다.
+
+## 원인
+
+두 그룹 선출 경로는 일반 예외일 때만 실패 상태 변수를 설정했습니다.
+`CancellationException` 경로는 예외를 곧바로 재전파했기 때문에 cleanup 자체는
+실행됐지만, `finally`의 history 분기에는 성공도 실패도 전달되지 않았습니다. 그
+결과 unlock과 cache decrement가 끝난 뒤에도 audit row는 `ACQUIRED`이고
+`finishedAt`과 `durationMs`는 비어 있었습니다.
+
+## 결정
+
+취소 예외를 일반 오류로 변환하거나 삼키지 않습니다. 대신 catch 지점에서 기존
+실패 상태 변수에 취소 사실을 남긴 뒤 같은 예외를 재전파합니다. cleanup은 기존
+순서대로 history를 `FAILED`로 마감하고, 이어서 슬롯을 해제하고 캐시를 줄입니다.
+
+R2DBC는 이 전체 정리를 `NonCancellable` context에서 수행합니다. 따라서 action의
+Job이 취소된 상태에서도 history와 unlock이 중단되지 않습니다. setup 단계에서
+history ID를 만들기 전에 취소된 경우에는 `recordFailed(null, ...)`이 아무 작업도
+하지 않는 기존 null-safe 계약을 유지합니다.
+
+이 결정은 Exposed 그룹의 blocking/suspend action 경로에 한정합니다. single
+elector와 `CompletableFuture` cancellation은 별도 계약이므로, 같은 상태 전이를
+근거 없이 확장하지 않습니다.
+
+## 결과
+
+그룹 action 취소는 호출자에게 계속 전달됩니다. 동시에 JDBC/R2DBC history는
+`FAILED`, non-null `finishedAt`, 0 이상 `durationMs`를 가지며, active slot은 0으로
+복구되어 같은 lock을 다시 획득할 수 있습니다. 공개 API와 정상 contention의
+skip/null 계약은 변경하지 않았습니다.
+
+## 검증
+
+- RED: JDBC/R2DBC H2에서 취소 후 history가 `ACQUIRED`로 남아 각각 실패
+- GREEN: JDBC/R2DBC H2, PostgreSQL, MySQL targeted 테스트 각각 3개 통과
+- JDBC 모듈 테스트 290개와 Detekt 통과
+- R2DBC 모듈 테스트 312개와 Detekt 통과
+- setup cancellation에서 history row 0개, active slot 0을 확인
+- `git diff --check` 통과
+
+## 향후 지침
+
+취소를 재전파한다는 이유로 audit 종료 처리를 건너뛰지 마세요. 자원 획득 뒤 생성된
+history ID가 있다면 취소된 context와 분리된 cleanup에서 terminal 상태와 종료
+시각을 먼저 기록하고 자원을 반환해야 합니다. 회귀 테스트는 예외 전파만 보지 말고
+history 상태, 종료 메타데이터, unlock/cache 정리, 후속 재획득을 함께 검증해야
+합니다.

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElector.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElector.kt
@@ -203,6 +203,7 @@ class ExposedJdbcLeaderGroupElector private constructor(
                 actionSucceeded = true
                 return result
             } catch (e: CancellationException) {
+                capturedError = e
                 throw e
             } catch (e: Throwable) {
                 capturedError = e

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElectionTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElectionTest.kt
@@ -18,6 +18,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldBeLessOrEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
@@ -26,6 +27,7 @@ import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import io.bluetape4k.assertions.assertFailsWith
+import kotlinx.coroutines.CancellationException
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import kotlin.time.Duration
@@ -300,6 +302,36 @@ class ExposedJdbcLeaderGroupElectionTest: AbstractExposedJdbcLeaderTest() {
         rows.size shouldBeEqualTo 1
         rows[0][LeaderLockHistoryTable.status] shouldBeEqualTo LeaderHistoryStatus.COMPLETED.name
         rows[0][LeaderLockHistoryTable.slot].shouldNotBeNull()
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runIfLeader - action 취소 후 FAILED 이력을 기록하고 슬롯을 반환한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val options = ExposedJdbcLeaderGroupElectionOptions(
+            leaderGroupOptions = LeaderGroupElectionOptions(maxLeaders = 3),
+        )
+        val recorder = SafeLeaderHistoryRecorder(ExposedLeaderHistorySink(db))
+        val election = ExposedJdbcLeaderGroupElector(db, options, recorder)
+        val cancellation = CancellationException("cancel group action")
+
+        val thrown = assertFailsWith<CancellationException> {
+            election.runIfLeader(lockName) { throw cancellation }
+        }
+
+        thrown shouldBeEqualTo cancellation
+        val history = transaction(db) {
+            LeaderLockHistoryTable.selectAll()
+                .where { LeaderLockHistoryTable.lockName eq lockName }
+                .single()
+        }
+        history[LeaderLockHistoryTable.status] shouldBeEqualTo LeaderHistoryStatus.FAILED.name
+        history[LeaderLockHistoryTable.finishedAt].shouldNotBeNull()
+        history[LeaderLockHistoryTable.durationMs].shouldNotBeNull() shouldBeGreaterOrEqualTo 0L
+        election.activeCount(lockName) shouldBeEqualTo 0
+        election.runIfLeader(lockName) { "group-recovered-after-cancel" } shouldBeEqualTo "group-recovered-after-cancel"
     }
 
     @ParameterizedTest

--- a/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElector.kt
+++ b/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElector.kt
@@ -324,6 +324,7 @@ class ExposedR2DbcSuspendLeaderGroupElector private constructor(
                 actionSucceeded = true
                 return result
             } catch (e: CancellationException) {
+                actionFailed = true
                 throw e
             } catch (e: Throwable) {
                 actionFailed = true

--- a/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElectorTest.kt
+++ b/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElectorTest.kt
@@ -6,6 +6,8 @@ import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.exposed.r2dbc.lock.ExposedR2dbcGroupLock
 import io.bluetape4k.leader.exposed.r2dbc.lock.ExposedR2dbcSchemaInitializer
 import io.bluetape4k.leader.exposed.retry.RetryStrategy
+import io.bluetape4k.leader.exposed.tables.LeaderLockHistoryTable
+import io.bluetape4k.leader.history.LeaderHistoryStatus
 import io.bluetape4k.leader.exposed.ExposedLeaderConstants.GROUP_LOCK_TABLE_NAME
 import io.bluetape4k.leader.exposed.ExposedLeaderConstants.LOCK_HISTORY_TABLE_NAME
 import io.bluetape4k.logging.coroutines.KLoggingChannel
@@ -16,9 +18,11 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeout
 import org.jetbrains.exposed.v1.core.statements.StatementContext
 import org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction
+import org.jetbrains.exposed.v1.r2dbc.selectAll
 import org.jetbrains.exposed.v1.r2dbc.statements.GlobalSuspendStatementInterceptor
 import org.jetbrains.exposed.v1.r2dbc.transactions.suspendTransaction
 import io.bluetape4k.assertions.shouldBeEqualTo
@@ -29,6 +33,7 @@ import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeTrue
+import org.jetbrains.exposed.v1.core.eq
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import kotlin.time.Duration
@@ -169,12 +174,26 @@ class ExposedR2DbcSuspendLeaderGroupElectorTest: AbstractExposedR2dbcLeaderTest(
         val db = setupDb(testDB)
         cleanTables(db)
         val lockName = randomName()
-        val election = makeGroupElection(testDB)
+        val options = ExposedR2dbcLeaderGroupElectionOptions(
+            leaderGroupOptions = LeaderGroupElectionOptions(maxLeaders = maxLeaders),
+            recordHistory = true,
+        )
+        val election = ExposedR2DbcSuspendLeaderGroupElector(db, options)
+        val cancellation = CancellationException("cancel group action")
 
-        assertFailsWith<CancellationException> {
-            election.runIfLeader(lockName) { throw CancellationException("cancel group action") }
+        val thrown = assertFailsWith<CancellationException> {
+            election.runIfLeader(lockName) { throw cancellation }
         }
 
+        thrown.message shouldBeEqualTo cancellation.message
+        val history = suspendTransaction(db) {
+            LeaderLockHistoryTable.selectAll()
+                .where { LeaderLockHistoryTable.lockName eq lockName }
+                .first()
+        }
+        history[LeaderLockHistoryTable.status] shouldBeEqualTo LeaderHistoryStatus.FAILED.name
+        history[LeaderLockHistoryTable.finishedAt].shouldNotBeNull()
+        history[LeaderLockHistoryTable.durationMs].shouldNotBeNull() shouldBeGreaterOrEqualTo 0L
         election.activeCount(lockName) shouldBeEqualTo 0
         election.runIfLeader(lockName) { "group-recovered-after-cancel" } shouldBeEqualTo "group-recovered-after-cancel"
     }
@@ -228,6 +247,12 @@ class ExposedR2DbcSuspendLeaderGroupElectorTest: AbstractExposedR2dbcLeaderTest(
         }
 
         election.activeCount(lockName) shouldBeEqualTo 0
+        val historyCount = suspendTransaction(db) {
+            LeaderLockHistoryTable.selectAll()
+                .where { LeaderLockHistoryTable.lockName eq lockName }
+                .count()
+        }
+        historyCount shouldBeEqualTo 0L
         election.runIfLeader(lockName) { "recovered-after-setup-cancel" } shouldBeEqualTo "recovered-after-setup-cancel"
     }
 


### PR DESCRIPTION
## 요약

Exposed JDBC/R2DBC 그룹 action이 취소될 때 이미 생성된 history를 `FAILED` terminal 상태로 마감합니다. 취소 예외 재전파, unlock, cache decrement, 후속 재획득 계약은 그대로 유지합니다.

Closes #692

## 원인

두 그룹 선출기는 일반 예외에서만 실패 상태 변수를 설정했습니다. `CancellationException`은 즉시 재전파되어 cleanup은 실행됐지만 history 종료 분기가 선택되지 않았고, row가 `ACQUIRED`와 null 종료 메타데이터로 남았습니다.

## 변경

- JDBC 동기 그룹 경로에서 cancellation을 기존 `capturedError`에 기록합니다.
- R2DBC suspend 그룹 경로에서 cancellation을 기존 `actionFailed`에 기록합니다.
- JDBC/R2DBC 회귀 테스트가 취소 전파, `FAILED`, `finishedAt`, `durationMs`, active slot 0, 후속 재획득을 함께 검증합니다.
- R2DBC setup cancellation은 history row 0개와 null-safe cleanup을 검증합니다.
- 재사용 가능한 규칙을 `docs/lessons/2026-08-16-group-cancellation-history.md`에 기록했습니다.

## Stacked PR Train

- Epic: #695
- 이전 stack: PR #713 merge 완료
- 현재 stack: PR #714 rebase merge 완료 (`452a9f4fdfc29d8691eaa3c20cb843aff586c7a1`)
- 다음 stack: Issue #681을 갱신된 `develop`에서 시작

## 검증

- RED: JDBC/R2DBC H2에서 `ACQUIRED != FAILED`로 각각 실패
- GREEN targeted: JDBC 3/3, R2DBC 3/3 — H2, PostgreSQL, MySQL
- merge 전 JDBC module: 290 tests, failures/errors/skipped 0, Detekt PASS
- merge 전 R2DBC module: 312 tests, failures/errors/skipped 0, Detekt PASS
- hosted CI run `31920243608`: SUCCESS 20, path-filter SKIPPED 27, 실패 0
- 변경 대상 JDBC/R2DBC H2·PostgreSQL·MySQL 6개 job과 `CI Status` PASS
- merge 후 `develop`: JDBC 290/290, R2DBC 312/312, 양 모듈 Detekt PASS
- `git diff --check` PASS, rebase merge tree diff 0
- 7-tier inline review: findings 0
- human/live review: N/A — 1인 개발자 지침
- workflow completion-check: complete, failed checks 0
- GNO lesson read-back: `gno://bluetape4k-docs/bluetape4k-leader/docs/lessons/2026-08-16-group-cancellation-history.md`

## 위험과 경계

- 공개 API와 정상 contention의 skip/null 계약은 변경하지 않습니다.
- single elector와 `CompletableFuture` cancellation은 기존 별도 계약을 유지합니다.
- cancellation 경로에서 기존 history update 1회를 활성화하며 정상 경로의 비용은 변하지 않습니다.

## DoD Status

- [x] Issue #692 수용 기준 구현
- [x] RED/GREEN 및 세 dialect targeted 검증
- [x] 관련 모듈 전체 테스트와 Detekt
- [x] lesson 작성, GNO update/embed/read-back
- [x] 7-tier inline review findings 0
- [x] hosted CI required checks 통과
- [x] exact head `e19d4ea7d14e6a59e8544ea24a0cc42a76ef199e` fresh merge 승인
- [x] rebase merge, local sync, post-merge 검증, safe cleanup
