### PR TITLE
test(leader-core): OBS-02 accepted callback 수명주기 증거 보강

### DIFF
--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObserversTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObserversTest.kt
@@ -167,28 +167,34 @@ class LeaderLeaseExtensionObserversTest {
     }
 
     @Test
-    fun `accepted callback can finish after its registration closes`() {
-        val releaseCallback = CountDownLatch(1)
-        val deliveredAfterClose = CountDownLatch(1)
-        val closed = AtomicReference(false)
-        val observer = LeaderLeaseExtensionObserver {
-            releaseCallback.await(5, TimeUnit.SECONDS)
-            if (closed.get()) {
-                deliveredAfterClose.countDown()
+    fun `accepted callback runs after close while post-close publish is ignored`() {
+        withManualDispatcher { submitted ->
+            val closed = AtomicBoolean(false)
+            val callbacks = AtomicInteger(0)
+            val acceptedAfterClose = AtomicBoolean(false)
+            val observer = LeaderLeaseExtensionObserver {
+                callbacks.incrementAndGet()
+                acceptedAfterClose.set(closed.get())
             }
-        }
-        val registration = LeaderLeaseExtensionObservers.addObserver(observer)
+            val registration = LeaderLeaseExtensionObservers.addObserver(observer)
 
-        try {
-            LeaderLeaseExtensionObservers.publish(testEvent())
-            closed.set(true)
-            registration.close()
-            releaseCallback.countDown()
+            try {
+                LeaderLeaseExtensionObservers.publish(testEvent())
+                submitted.size shouldBeEqualTo 1
 
-            deliveredAfterClose.await(5, TimeUnit.SECONDS).shouldBeTrue()
-        } finally {
-            releaseCallback.countDown()
-            registration.close()
+                closed.set(true)
+                registration.close()
+                submitted.single().run()
+
+                acceptedAfterClose.get().shouldBeTrue()
+                callbacks.get() shouldBeEqualTo 1
+
+                LeaderLeaseExtensionObservers.publish(testEvent())
+                submitted.size shouldBeEqualTo 1
+                callbacks.get() shouldBeEqualTo 1
+            } finally {
+                registration.close()
+            }
         }
     }
 


### PR DESCRIPTION
## 요약

Issue #726의 OBS-02-P2.1 slice입니다. lease-extension observer가 이미 admission한 callback은 registration close 이후에도 실행할 수 있고, close 이후 새 publish는 전달하지 않는다는 lifecycle 계약을 deterministic dispatcher로 검증합니다.

## 변경 범위

- 기존 leaderLeaseExtensionDispatcher manual seam 재사용
- accepted task를 queue에 admission한 뒤 registration close 및 callback 실행 검증
- close 이후 새 publish가 task를 추가하지 않고 callback exactly-once인지 검증
- production source, public API, runtime semantics, dependency는 변경하지 않음

## Stacked PR train

- Epic: #699
- parent contract: #559
- 선행 PR: #725 (merged, base fbcb72fd5079cddef9be045581ac110d5efcd770)
- 후속 issue: #726
- 현재 slice: OBS-02-P2.1
- 후속 slice: PR #728 (https://github.com/bluetape4k/bluetape4k-leader/pull/728), OBS-02-P2.2, 현재 PR head 위에 stack

## 검증

- targeted core test — 15/15 PASS
- full core test — 763/763 PASS
- ./gradlew :bluetape4k-leader-core:detekt — PASS
- git diff --check — PASS
- hosted CI run 32122720496 (https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32122720496) — PASS
- fresh exact-head inline review — PASS; exact head 6f2c29db8aec086b2b1f939c01cbcbe5bb1f102a와 test-only diff를 재확인

## DoD Status

Required checks: 4/4; N/A: 0; Blocked: 0

| Check | Status | Evidence |
| --- | --- | --- |
| deterministic accepted callback-after-close | PASS | manual dispatcher admission 후 close 뒤 queued task exactly-once 실행 |
| post-close publish 차단 | PASS | close 이후 dispatcher 제출 0건 및 callback count 1 유지 |
| core 회귀·diff·Kotlin 규칙 | PASS | targeted 15/15, core 763/763, detekt, diff-check |
| fresh exact-head review/read-back | PASS | head 6f2c29db8aec086b2b1f939c01cbcbe5bb1f102a, test-only 변경과 metadata 재확인 |

최종 상태: DONE — PR #727 merged into develop, merge SHA e069c603a47f2f33a1b430d819ff48db03a260c4; 후속 PR #728도 merge 완료

미완료:

- 없음


