### PR TITLE
feat(leader-core): OBS-03 audit export core contract 추가

### DIFF
--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -830,11 +830,16 @@
   stable meter identity를 재사용하면서 새 delegate snapshot source를 읽고 cumulative
   counter가 감소하지 않는지, active duplicate wrapper는 fail-fast하는지 확인한다.
   concurrent meter poll·old close·replacement acquire는 latch 기반으로 교차시켜, 모든
-  metric read가 manager 선형화 지점을 통과하고 counter가 감소하거나 `offset + old
+  metric read가 manager 선형화 지점을 통과하고 counter가 감소하지 않으며 `offset + old
   provider`를 중복 합산하지 않는지 반복 검증한다. wrapper가 소유한 delegate close 완료와
   replacement acquire crossing도 같은 barrier에서 확인해 detach 이전 provider가 replacement를
   지우지 않는지 고정한다. caller의 direct delegate close는 unsupported ownership violation으로
   문서화하고 fixture에서 허용 경로로 취급하지 않는다.
+  고정 수치 fixture에서 이전 generation offset=100, close-entry counter=40, close 중 delta=3을
+  사용해 OPEN=140, CLOSING=140, DETACHED=143, replacement 이후 `143 + newSnapshot`의
+  비감소를 exact assertion한다. final snapshot이 close-entry보다 작은 음수 delta fixture는
+  `check`/diagnostic failure로 표면화되고 0으로 clamp되지 않으며, 그 경우에도 inner
+  `finally`가 provider를 clear해 DETACHED로 복구하는지 검증한다.
   동일 registry에 대한 두 constructor를 barrier에서 동시에 시작해 store manager가 하나만
   생성·게시되고, wrapper winner 하나와 loser delegate exact-once close만 남으며, loser 이후
   replacement acquire가 stable meter identity를 재사용하는지 검증한다.
@@ -844,6 +849,8 @@
   snapshot에 보존하고 `finally`에서 `DETACHED`로 복구하는지, close 예외가 primary로 유지되고
   final snapshot/transition 예외가 suppressed되는지, 이후 replacement acquire가 성공하는지
   검증한다.
+  final snapshot 자체가 예외를 던지는 fixture도 close-entry 기반 offset/gauge를 보존하고
+  provider를 clear한 뒤 `DETACHED`로 전환하는지 확인한다.
   constructor 실패는 delegate를 정확히 한 번 close하고 primary exception을 보존하며,
   delegate close/partial-registration cleanup 예외는 primary에 suppressed로 붙이고,
   primary가 없을 때만 cleanup 예외를 던지는지 검증한다. manager-owned partial registration만
@@ -880,16 +887,19 @@
   `ManagerState(generation, activeProvider, closingProvider, detachedSnapshot, offsets, lifecycle)` 하나를
   보유하고 모든 acquire/close/provider swap과 metric callback을 동일한 lock으로
   선형화한다. callback은 lock을 획득해 state를 한 번 읽고, `OPEN`의 active provider가
-  있으면 그 안에서 snapshot을 읽은 뒤 offset을 합산하며 `CLOSING`에서는 detached state만
-  읽는다. close는 같은 lock에서 close-entry snapshot과 `closingProvider`를 보존하고
-  active provider를 `CLOSING` state로 옮긴 뒤 delegate close를 실행한다. close 성공/예외의
-  `finally`에서 같은 generation의 `finalSnapshot - closeEntrySnapshot` delta만
-  `max(0, ...)`로 정확히 한 번 offset에 반영하고 provider를 clear하여 `DETACHED`로
-  전환한다. gauge는 final snapshot을 사용하므로 close-owned cancellation/rejection도
-  보존되고 close-entry counter는 중복 집계되지 않는다. final snapshot/transition 예외는
-  close 예외가 있으면 suppressed로 붙이고, 없으면 primary로 던진다. 따라서 이전 close가
-  새 provider를 지울 수 없고, `CLOSING` 중 replacement acquire는 거부되며 manager가
-  영구 `CLOSING`에 남지 않는다.
+  있으면 그 안에서 snapshot을 읽은 뒤 offset을 합산하며 `CLOSING`에서는
+  `closingOffsets = oldOffsets + closeEntrySnapshot` detached view만 읽는다. close는 같은
+  lock에서 close-entry snapshot과 `closingProvider`를 보존하고 `closingOffsets`를 먼저
+  게시한 뒤 active provider를 `CLOSING` state로 옮겨 delegate close를 실행한다. 성공/예외의
+  `finally`에서 같은 generation의 final snapshot에 대해 각 cumulative counter의
+  `final >= close-entry` invariant를 검증하고 `final - close-entry` delta만 정확히 한 번
+  `closingOffsets`에 반영한다. 음수 delta는 `check`/diagnostic failure로 드러내며 0으로
+  clamp하지 않는다. gauge는 final snapshot을 사용하고, final snapshot 실패 시에는
+  close-entry 기반 view를 유지한 inner `finally`에서 provider를 clear하여 `DETACHED`로
+  전환한다. 따라서 close-owned cancellation/rejection은 보존되고 close-entry counter는
+  중복 집계되지 않는다. final/transition 예외는 close 예외가 있으면 suppressed로 붙이고,
+  없으면 primary로 던진다. 따라서 이전 close가 새 provider를 지울 수 없고, `CLOSING` 중
+  replacement acquire는 거부되며 manager가 영구 `CLOSING`에 남지 않는다.
   provider만 delegate를 참조하고 state 전환 후 clear되므로 registry meter가 closed delegate를
   retain하지 않는다. wrapper가 delegate ownership을 취득한 뒤 caller가 delegate를 직접
   close하는 것은 지원하지 않으며, wrapper `close()`가 유일한 ownership lifecycle이다.
@@ -920,14 +930,19 @@
   확인한다. registry shutdown callback을 요구하지 않으며 weak-key retirement가 폐기된
   Spring/test registry의 manager entry를 회수하는 수명 정책이다.
   `close()`는 generation token으로 한 번만 현재 provider를 `CLOSING`으로 옮기고
-  close-entry snapshot과 `closingProvider`를 보존한 뒤 delegate close를 실행한다.
-  성공/예외의 `finally`에서 같은 generation의 `finalSnapshot - closeEntrySnapshot` delta만
-  정확히 한 번 offset에 반영하고 provider를 clear하여 `DETACHED` claim을 해제한다.
-  cumulative counter delta는 `max(0, final - close-entry)`로 계산하고 gauge는 final
-  snapshot 값을 사용한다. 따라서 close-entry counter를 중복 집계하지 않으면서 close-owned cancellation/rejection을
-  final snapshot에 포함한다. `snapshot()`은 delegate close 후에도 final counters를 O(1)로
-  읽을 수 있어야 한다. `registry.remove`를 호출하지 않으므로 lookup/remove TOCTOU와
-  removal residue가 없고, stable meter identity는 replacement에서 재사용된다.
+  close-entry snapshot과 `closingProvider`를 보존한다. 같은 lock에서
+  `closingOffsets = oldOffsets + closeEntrySnapshot`을 먼저 게시해 CLOSING poll의
+  counter가 감소하지 않게 한 뒤 delegate close를 실행한다. 성공/예외의 `finally`에서 같은
+  generation의 final snapshot에 대해 각 cumulative counter의 `final >= close-entry`
+  invariant를 검증하고 `final - close-entry` delta만 정확히 한 번 `closingOffsets`에
+  반영한다. 음수 delta는 `check`/diagnostic failure로 드러내며 0으로 clamp하지 않는다.
+  gauge는 final snapshot 값을 사용하고, final snapshot 실패 시에는 close-entry 기반
+  `closingOffsets`/gauge를 유지한 inner `finally`에서 provider를 clear하여 `DETACHED`
+  claim을 해제한다. 따라서 close-entry counter를 중복 집계하지 않으면서 close-owned
+  cancellation/rejection을 final snapshot에 포함한다. `snapshot()`은 delegate close 후에도
+  final counters를 O(1)로 읽을 수 있어야 한다. `registry.remove`를 호출하지 않으므로
+  lookup/remove TOCTOU와 removal residue가 없고, stable meter identity는 replacement에서
+  재사용된다.
   detached state의 counter는 offset을 포함해 monotonic하게 유지하고 queue/in-flight/
   diagnostics closed gauge는 active provider 또는 detached closed snapshot을 읽는다.
   non-owning observation은 wrapper가 아니라 public `observe()` handle을 별도로 사용하며

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -918,7 +918,10 @@
   immutable temporary value로 계산하고 모든 `final >= close-entry` invariant를 먼저 검증한다.
   하나라도 음수면 어떤 양수 field도 적용하지 않고 close-entry `closingOffsets`를 유지하며
   공통 `markSourceDegraded` 경로로 `sourceDegraded`와 fixed warning
-  `leader.audit.export.meter-source-degraded`를 해당 generation에서 한 번 기록한다. 정상 final snapshot에서만
+  `leader.audit.export.meter-source-degraded`를 해당 generation에서 한 번 기록하고 snapshot
+  throw와 동일한 terminal DETACHED fallback gauge `queue=0`, `inFlight=0`,
+  `scheduledRetries=0`, `admitted=0`, `diagnosticsClosed=true`, `closed=true`를 사용한다.
+  정상 final snapshot에서만
   `final - close-entry` delta를 정확히 한 번 적용한다. gauge는 final snapshot을 사용하고,
   final snapshot 자체가 실패하면 cumulative counter만 close-entry 기반 view로 유지하며
   동일한 `markSourceDegraded` 경로로 `sourceDegraded=true`, fixed warning
@@ -973,7 +976,10 @@
   value로 계산하고 모든 `final >= close-entry` invariant를 먼저 검증한다. 하나라도 음수면
   어떤 양수 field도 적용하지 않고 close-entry 기반 `closingOffsets`를 유지하며
   공통 `markSourceDegraded` 경로로 `sourceDegraded`와 fixed warning
-  `leader.audit.export.meter-source-degraded`를 해당 generation에서 한 번 기록한다. 정상 final snapshot에서만
+  `leader.audit.export.meter-source-degraded`를 해당 generation에서 한 번 기록하고 snapshot
+  throw와 동일한 terminal DETACHED fallback gauge `queue=0`, `inFlight=0`,
+  `scheduledRetries=0`, `admitted=0`, `diagnosticsClosed=true`, `closed=true`를 사용한다.
+  정상 final snapshot에서만
   `final - close-entry` delta를 정확히 한 번 `closingOffsets`에 반영한다. gauge는 final
   snapshot 값을 사용하고, final snapshot 자체가 실패하면 cumulative counter만 close-entry
   기반 `closingOffsets`로 유지하며 동일한 `markSourceDegraded` 경로로

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -77,6 +77,12 @@
           <= LeaderAuditExportEvent.MAX_ERROR_MESSAGE_BYTES).shouldBeTrue()
       ((event.errorType?.toByteArray(Charsets.UTF_8)?.size ?: 0)
           <= LeaderAuditExportEvent.MAX_ERROR_TYPE_BYTES).shouldBeTrue()
+      listOf(event.lockName, event.nodeId, event.slotId).filterNotNull().all {
+          it.toByteArray(Charsets.UTF_8).size <= LeaderAuditExportEvent.MAX_TEXT_FIELD_BYTES
+      }.shouldBeTrue()
+      val lifecycle = lifecycleWithAttributes(emptyMap(), LeaderAuditValueSanitizer.Default)
+      (lifecycle.leaderId?.toByteArray(Charsets.UTF_8)?.size ?: 0)
+          .let { (it <= LeaderAuditExportEvent.MAX_TEXT_FIELD_BYTES).shouldBeTrue() }
       (event.attributes.size <= LeaderAuditExportEvent.MAX_ATTRIBUTES).shouldBeTrue()
       event.attributes.keys.all {
           it.toByteArray(Charsets.UTF_8).size <= LeaderAuditExportEvent.MAX_ATTRIBUTE_KEY_BYTES
@@ -87,6 +93,23 @@
       event.attributes.entries.sumOf { (key, value) ->
           key.toByteArray(Charsets.UTF_8).size + value.toByteArray(Charsets.UTF_8).size
       }.let { (it <= LeaderAuditExportEvent.MAX_ATTRIBUTES_TOTAL_BYTES).shouldBeTrue() }
+  }
+
+  @Test
+  fun `utf8 truncation and sanitized collision order are deterministic`() {
+      val truncated = LeaderAuditValueSanitizer.Truncate(maxBytes = 7)
+          .sanitize(LeaderAuditField.ERROR_MESSAGE, "가가가x")
+      truncated.shouldBeEqualTo("가가")
+      truncated.contains("\uFFFD").shouldBeFalse()
+      truncated.contains("...").shouldBeFalse()
+
+      val first = linkedMapOf("a-two" to "y-value", "a-one" to "z-value")
+      val second = linkedMapOf("a-one" to "z-value", "a-two" to "y-value")
+      val sanitizer = LeaderAuditValueSanitizer.Truncate(maxBytes = 1)
+      val firstEvent = lifecycleWithAttributes(first, sanitizer)
+      val secondEvent = lifecycleWithAttributes(second, sanitizer)
+      firstEvent.attributes.shouldBeEqualTo(secondEvent.attributes)
+      firstEvent.attributes.values.single().shouldBeEqualTo("z")
   }
 
   @Test
@@ -118,8 +141,10 @@
           maxBytes = 16,
       )
       raw.sanitize(LeaderAuditField.KIND, "ACQUIRED").shouldBeEqualTo("ACQUIRED")
-      assertFailsWith<IllegalArgumentException> {
-          raw.sanitize(LeaderAuditField.LOCK_NAME, SECRET_SENTINEL)
+      LeaderAuditField.values().filter { it != LeaderAuditField.KIND }.forEach { field ->
+          assertFailsWith<IllegalArgumentException> {
+              raw.sanitize(field, SECRET_SENTINEL)
+          }
       }
   }
   ```
@@ -176,11 +201,15 @@
   `LeaderAuditExportEvent`와 sanitizer는 `MAX_ERROR_MESSAGE_BYTES=4096`,
   `MAX_ERROR_TYPE_BYTES=128`, `MAX_TEXT_FIELD_BYTES=256`, `MAX_ATTRIBUTES=32`,
   `MAX_ATTRIBUTE_KEY_BYTES=128`, `MAX_ATTRIBUTE_VALUE_BYTES=512`,
-  `MAX_ATTRIBUTES_TOTAL_BYTES=8192`를 public constant로 고정한다. UTF-8 code point
-  경계 truncate, attribute 정렬·collision·aggregate drop 정책은 spec과 동일해야 한다.
+  `MAX_ATTRIBUTES_TOTAL_BYTES=8192`를 public constant로 고정한다. `MAX_TEXT_FIELD_BYTES`는
+  `lockName`, `nodeId`, `slotId`, `leaderId`에 적용하고 `errorType`/`errorMessage`는 전용
+  bound를 사용한다. UTF-8 code point
+  경계 truncate, `lockName/nodeId/slotId/leaderId`의 text bound, attribute 정렬·collision·
+  aggregate drop 정책은 spec과 동일해야 한다.
   `LeaderAuditValueSanitizer`는 임의 lambda가 아니라 `Default`, `Hash`, `Truncate`,
-  `Raw` 정책으로 제한한다. `Raw`는 사전에 허용된 비민감 enum field subset과 양의
-  `maxBytes`를 생성 시 검증하고, 모든 정책은 공통 byte/key limits를 적용한다. event
+  `Raw` 정책으로 제한한다. `Raw`의 `RAW_ALLOWED_FIELDS`는 `KIND` 하나로 고정하고
+  `KIND` 이외 모든 enum field allow-list와 양의 `maxBytes`를 생성 시 거부하며, 모든
+  정책은 공통 byte/key limits를 적용한다. event
   `toString()`과 encoder fixture에는 secret sentinel이 없어야 한다. 모든 map은
   defensive copy 후 `Collections.unmodifiableMap(LinkedHashMap(...))` 또는 동등한
   실제 immutable runtime map으로 노출한다. Java fixture에서 `getAttributes().put`이
@@ -643,12 +672,12 @@
 
   | Type | Exact public surface |
   |---|---|
-  | `LeaderAuditExportEvent` | sealed event boundary plus `Companion` public UTF-8 `const val` bounds `MAX_ERROR_MESSAGE_BYTES=4096`, `MAX_ERROR_TYPE_BYTES=128`, `MAX_TEXT_FIELD_BYTES=256`, `MAX_ATTRIBUTES=32`, `MAX_ATTRIBUTE_KEY_BYTES=128`, `MAX_ATTRIBUTE_VALUE_BYTES=512`, `MAX_ATTRIBUTES_TOTAL_BYTES=8192`; Java reads the exact `LeaderAuditExportEvent.Companion` fields |
+  | `LeaderAuditExportEvent` | sealed event boundary plus outer-class public static final UTF-8 constants `MAX_ERROR_MESSAGE_BYTES=4096`, `MAX_ERROR_TYPE_BYTES=128`, `MAX_TEXT_FIELD_BYTES=256`, `MAX_ATTRIBUTES=32`, `MAX_ATTRIBUTE_KEY_BYTES=128`, `MAX_ATTRIBUTE_VALUE_BYTES=512`, `MAX_ATTRIBUTES_TOTAL_BYTES=8192`; Java reads exact `LeaderAuditExportEvent.MAX_*` fields |
   | `LeaderAuditExportEvent.History` | `from(LeaderLockHistoryRecord, LeaderAuditValueSanitizer): History`; private constructor; no `token`/`LeaderLease` field |
   | `LeaderAuditExportEvent.Lifecycle` | `from(LeaderElectionEvent, Map<String,String>, LeaderAuditValueSanitizer): Lifecycle`; private constructor; no `LeaderLease` field |
   | `LeaderAuditLifecycleOutcome` | enum values `ELECTED`, `REVOKED`, `SKIPPED` only |
-  | `LeaderAuditField` | enum values `LOCK_NAME`, `KIND`, `NODE_ID`, `LEADER_ID`, `ERROR_TYPE`, `ERROR_MESSAGE`, `ATTRIBUTE_KEY`, `ATTRIBUTE_VALUE` only |
-  | `LeaderAuditValueSanitizer` | `sanitize(LeaderAuditField, String): String`; `Default`/`Hash` objects, `Truncate(maxBytes:Int)`, `Raw(allowList:Set<LeaderAuditField>, maxBytes:Int)`; no arbitrary lambda factory |
+  | `LeaderAuditField` | enum values `LOCK_NAME`, `KIND`, `NODE_ID`, `SLOT_ID`, `LEADER_ID`, `ERROR_TYPE`, `ERROR_MESSAGE`, `ATTRIBUTE_KEY`, `ATTRIBUTE_VALUE` only |
+  | `LeaderAuditValueSanitizer` | `sanitize(LeaderAuditField, String): String`; `Default`/`Hash` objects, `Truncate(maxBytes:Int)`, `Raw(allowList:Set<LeaderAuditField>, maxBytes:Int)`; `RAW_ALLOWED_FIELDS={KIND}`; no arbitrary lambda factory |
   | `LeaderAuditExporter` | `submit(LeaderAuditExportEvent): LeaderAuditSubmitResult`, `observe(LeaderAuditExportObserver): AutoCloseable`, `snapshot(): LeaderAuditExportSnapshot`, `close(): Unit` |
   | `LeaderAuditExportOptions` | `queueCapacity:Int`, `maxInFlight:Int`, `maxAttempts:Int`, `attemptTimeout:java.time.Duration`, `initialBackoff:java.time.Duration`, `maxBackoff:java.time.Duration`, `executor:Executor`, `scheduler:ScheduledExecutorService`; Java-visible 8-argument constructor, no implicit shared executor |
   | `LeaderAuditDelivery` | `deliver(LeaderAuditExportEvent): CompletableFuture<LeaderAuditDeliveryResult>` |
@@ -676,13 +705,12 @@
   `close`를 호출하고 decorator의 `snapshot()` delegation도 compile/run으로 고정한다.
   reflection으로 위 public constructor/method set과 JVM descriptor를 확인하고, event
   public field에 `token`이나 `LeaderLease`가 없는지 고정한다. `close()` idempotence와
-  `submit` return type을 JVM descriptor로 확인한다. Micrometer Java fixture는
-  `(LeaderAuditExporter, MeterRegistry)` constructor와 delegated methods, fixed 13-meter
-  ID/type/tag set, duplicate/foreign/unsupported registry failure를 compile/run으로
-  고정한다. `@JvmSynthetic internal LeaderAuditExportSnapshot.Companion.create`는
-  유일하게 허용된 synthetic surface로 allow-list하고, 그 밖의 public synthetic overload는
-  거부한다. sanitizer enum/constructor와 event factory descriptor도 Java reflection 및
-  immutable-map fixture로 확인한다.
+  `submit` return type을 JVM descriptor로 확인한다. `@JvmSynthetic internal
+  LeaderAuditExportSnapshot.Companion.create`는 유일하게 허용된 synthetic surface로
+  allow-list하고, 그 밖의 public synthetic overload는 거부한다. sanitizer enum/constructor와
+  event factory descriptor도 Java reflection 및 immutable-map fixture로 확인한다. Micrometer는
+  core 모듈을 참조할 수 없으므로 constructor/registry ABI fixture는 Task 5의
+  `leader-micrometer` Java test에서 별도로 실행한다.
 
 - [ ] **Step 2: Run contract test and verify RED**
 
@@ -721,6 +749,7 @@
 - Modify: `leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerNames.kt`
 - Create: `leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt`
 - Test: `leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt`
+- Test: `leader-micrometer/src/test/java/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterJavaContractTest.java`
 - Modify: `leader-micrometer/README.md`
 - Modify: `leader-micrometer/README.ko.md`
 
@@ -753,13 +782,27 @@
   잠기며 foreign meter를 제거하지 않는지 검증한다. 동일 registry close→replacement는
   stable meter identity를 재사용하면서 새 delegate snapshot source를 읽고 cumulative
   counter가 감소하지 않는지, active duplicate wrapper는 fail-fast하는지 확인한다.
+  concurrent meter poll·old close·replacement acquire는 latch 기반으로 교차시켜, 모든
+  metric read가 manager 선형화 지점을 통과하고 counter가 감소하거나 `offset + old
+  provider`를 중복 합산하지 않는지 반복 검증한다. wrapper가 소유한 delegate close 완료와
+  replacement acquire crossing도 같은 barrier에서 확인해 detach 이전 provider가 replacement를
+  지우지 않는지 고정한다. caller의 direct delegate close는 unsupported ownership violation으로
+  문서화하고 fixture에서 허용 경로로 취급하지 않는다.
   constructor 실패는 delegate를 정확히 한 번 close하고 primary exception을 보존하며,
   delegate close/partial-registration cleanup 예외는 primary에 suppressed로 붙이고,
   primary가 없을 때만 cleanup 예외를 던지는지 검증한다. manager-owned partial registration만
   다음 acquire에서 이어서 완성하는지 확인한다.
   manager source/offset이 closed delegate를 retain하지 않는다는 사실은 registry의
   provider-detach 기록과 새 snapshot 값으로 결정적으로 확인하며 `WeakReference`/GC에
-  의존하지 않는다.
+  의존하지 않는다. `RegistryManagerStore`의 fake reference queue를 drain하는 lifecycle
+  fixture로 폐기된 registry entry가 제거되고 manager/value가 registry를 strong-reference하지
+  않는지 결정적으로 확인한다.
+
+  `MicrometerLeaderAuditExporterJavaContractTest`는 이 모듈에서 `(LeaderAuditExporter,
+  MeterRegistry)` constructor, delegated `submit/observe/snapshot/close` descriptors,
+  fixed ID/type/tag set, duplicate/foreign/unsupported registry failure와 Java close path를
+  compile/run으로 고정한다. core의 Java fixture가 Micrometer를 참조하지 않도록 이 검증은
+  반드시 `leader-micrometer` test source set에서 실행한다.
 
 - [ ] **Step 2: Run Micrometer test and verify RED**
 
@@ -778,24 +821,42 @@
   async diagnostics observer callback이 close 직후 drop되어도 close-owned
   cancellation/rejection이 metric에서 사라지지 않는다.
   내부 registry-identity manager가 fixed ID claim과 stable meter 집합을 관리한다. manager는
-  claim token/lock, `activeProvider`, detached `lastSnapshot`, cumulative counter offset을
-  보유하며 `FunctionCounter`/`Gauge` callback은 manager state만 캡처한다. provider만
-  delegate를 참조하고 close에서 clear되므로 registry meter가 closed delegate를 retain하지
-  않는다. 첫 acquire는 fixed `name/type/tags/snapshot field` 표를 preflight하고 foreign
+  `ManagerState(generation, activeProvider, detachedSnapshot, offsets, lifecycle)` 하나를
+  보유하고 모든 acquire/close/provider swap과 metric callback을 동일한 lock으로
+  선형화한다. callback은 lock을 획득해 state를 한 번 읽고, active provider가 있으면 그
+  안에서 snapshot을 읽은 뒤 offset을 합산한다. close는 같은 lock에서 현재 snapshot을
+  offset과 detached state에 반영하고 provider를 제거한 `CLOSING` state를 먼저 게시한 뒤,
+  generation token이 일치할 때만 delegate close 완료를 `DETACHED`로 전환한다. 따라서
+  이전 close가 새 provider를 지울 수 없고, `CLOSING` 중 replacement acquire는 거부된다.
+  provider만 delegate를 참조하고 state 전환 후 clear되므로 registry meter가 closed delegate를
+  retain하지 않는다. wrapper가 delegate ownership을 취득한 뒤 caller가 delegate를 직접
+  close하는 것은 지원하지 않으며, wrapper `close()`가 유일한 ownership lifecycle이다.
+  첫 acquire는 fixed `name/type/tags/snapshot field` 표를 preflight하고 foreign
   ID 또는 설치 identity를 증명할 수 없는 registry를 fail-fast한다. 외부 registration
   crossing으로 identity가 foreign/ambiguous가 되면 fixed warning key
   `leader.audit.export.meter-ownership-conflict`를 ID별 한 번 기록하고 manager state를
   compromised로 잠근다. manager는 foreign meter를 절대로 remove하지 않으며, 수동으로
   fixed ID를 정리하거나 registry를 교체하기 전까지 새 wrapper를 허용하지 않는다.
+  public KDoc에는 generic `MeterRegistry`가 외부 `remove`/동일 ID 재등록을 원자적으로
+  관찰하지 못한다는 ownership 한계를 명시한다. caller는 wrapper 수명 동안 fixed ID를
+  직접 변경하지 않아야 하며, manager가 acquire 또는 metric read에서 crossing을 관찰한
+  경우에만 conflict warning과 detached state로 전환한다. 관찰되지 않은 외부 mutation을
+  차단하거나 metric correctness를 보장한다고 주장하지 않는다.
   전체 stable meter 등록이 성공한 뒤에만 delegate ownership을 확정하고, constructor
   실패 시 delegate를 정확히 한 번 닫고 primary exception을 보존한다. close/partial cleanup
   예외는 primary에 suppressed로 추가하며 primary가 없을 때만 cleanup 예외를 던진다.
   manager-owned
   partial registration은 state에 남아 다음 acquire에서 누락 ID만 이어서 등록하며
   foreign ID는 건드리지 않는다. active duplicate wrapper는 fail-fast한다.
-  `close()`는 delegate를 idempotently 닫고 마지막 snapshot을 offset에 반영한 뒤
-  `activeProvider`를 clear한다. `registry.remove`를 호출하지 않으므로 lookup/remove
-  TOCTOU와 removal residue가 없고, stable meter identity는 replacement에서 재사용된다.
+  registry→manager lookup은 `WeakIdentityKey<MeterRegistry>`와 `ReferenceQueue`를 사용하는
+  internal `RegistryManagerStore`로 고정한다. `acquire`/retirement마다 queue를 drain하고,
+  manager와 weak meter identity token이 registry를 강하게 역참조하지 않는지 test seam으로
+  확인한다. registry shutdown callback을 요구하지 않으며 weak-key retirement가 폐기된
+  Spring/test registry의 manager entry를 회수하는 수명 정책이다.
+  `close()`는 generation token으로 한 번만 현재 provider를 `CLOSING`에서 detach하고
+  delegate를 idempotently 닫은 뒤 `DETACHED` claim을 해제한다. `registry.remove`를 호출하지
+  않으므로 lookup/remove TOCTOU와 removal residue가 없고, stable meter identity는
+  replacement에서 재사용된다.
   detached state의 counter는 offset을 포함해 monotonic하게 유지하고 queue/in-flight/
   diagnostics closed gauge는 active provider 또는 detached closed snapshot을 읽는다.
   non-owning observation은 wrapper가 아니라 public `observe()` handle을 별도로 사용하며
@@ -828,6 +889,7 @@
   ```bash
   ./gradlew :bluetape4k-leader-micrometer:test \
     --tests 'io.bluetape4k.leader.micrometer.audit.MicrometerLeaderAuditExporterTest' \
+    --tests 'io.bluetape4k.leader.micrometer.audit.MicrometerLeaderAuditExporterJavaContractTest' \
     --tests 'io.bluetape4k.leader.micrometer.history.*'
   ```
 
@@ -835,7 +897,7 @@
   close→replacement identity reuse, cumulative counter offset monotonicity, foreign
   registration conflict warning/compromised recovery, duplicate wrapper fail-fast,
   partial manager-owned registration continuation, constructor 실패 시 delegate close와
-  primary/suppressed exception policy, 그리고 direct delegate와 wrapper의 closed admission
+  primary/suppressed exception policy, 그리고 owned delegate와 wrapper의 closed admission
   parity가 모두 PASS해야 한다.
 
 - [ ] **Step 5: Update both README locales and commit AUD-02**
@@ -1070,11 +1132,17 @@
   ```bash
   set -euo pipefail
   scan_paths=()
+  scan_tmp="$(mktemp)"
+  trap 'rm -f "$scan_tmp"' EXIT
   if [[ -d docs/manual/drafts ]]; then
+    if ! find docs/manual/drafts -maxdepth 1 -type f -name '*.md' -print0 >"$scan_tmp"; then
+      echo 'failed to enumerate docs/manual/drafts' >&2
+      exit 2
+    fi
     while IFS= read -r -d '' path; do
       [[ -f "$path" && -r "$path" ]] || { echo "unreadable scan path: $path" >&2; exit 2; }
       scan_paths+=("$path")
-    done < <(find docs/manual/drafts -maxdepth 1 -type f -name '*.md' -print0)
+    done < "$scan_tmp"
   elif [[ -e docs/manual/drafts ]]; then
     echo 'docs/manual/drafts exists but is not a directory' >&2
     exit 2
@@ -1118,6 +1186,10 @@
     ((status == 2)) || { echo "invalid regex fixture returned status=$status" >&2; exit "$status"; }
   fi
   ```
+
+  scanner fixture는 존재하지 않는 draft directory를 `find` 대상으로 주어 enumeration
+  실패가 status 2로 반환되고, `scan_paths`가 빈 배열인 채 성공하지 않는지 확인한다. 각
+  draft path의 `-f -r` 검증 실패도 동일하게 fail-closed여야 한다.
 
   gitleaks가 설치되어 있으면 추가로 repository root에서
   `gitleaks dir --no-banner --redact .`를 실행하되, 위의 명시적 파일 집합 scanner를

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -298,7 +298,11 @@
   `diagnosticsClosed=true`이고
   `diagnosticsFatalErrors`는 증가하지 않음을 고정하며, fatal/error/normal-close/idempotent
   close truth table과 Micrometer gauge parity도 함께 검증한다. `submit` source/benchmark guard는
-  lock·blocking queue·capacity wait가 없고 contention 시 즉시 drop되는지 확인한다.
+  blocking `lock()`/monitor, blocking queue, capacity wait가 없고 bounded non-blocking
+  `tryLock`은 허용되며 contention 시 즉시 drop되는지 확인한다. callback 완료 `finally`와
+  동시 observation admission을 교차시켜 `diagnosticsAdmissionLock → slot lock` 순서의
+  `running--`/slot `inFlight--`/diagnostics permit 반환이 exact-once이고 capacity가
+  전량 회복되는지도 검증한다.
   contention fixture는 32 contender, 100 iteration, barrier와 paused manual executor를
   고정하고 각 submit 호출의 반환 latch, accepted/drop 합계, `snapshot()` permit bounds를
   검증한다. wall-clock 성능 수치나 allocation threshold는 주장하지 않는다.
@@ -692,7 +696,14 @@
   않으며, snapshot object는 submit hot path에서 생성하지 않는다는 source/contract
   assertion을 추가한다. wrapper close twice에서 delegate close idempotence와
   snapshot-backed cancellation/rejection metric parity를 검증하고, wrapper close가
-  exporter close contract를 그대로 보존하는지 확인한다.
+  exporter close contract를 그대로 보존하는지 확인한다. `TrackingMeterRegistry`로
+  등록된 모든 `Meter.Id`와 function source를 기록해 wrapper `close()` 두 번 후 owned
+  meter가 모두 제거되고 registry가 closed delegate를 retain하지 않는지 검증한다. 같은
+  registry에서 close 후 새 delegate wrapper를 만들면 새 snapshot source를 읽고, active
+  duplicate wrapper는 기존 ID/source를 재사용하지 않고 fail-fast하며 부분 등록도
+  정리하는지 검증한다. close→replacement와 duplicate-registration 시나리오는
+  `WeakReference`에 의존하지 않고 registry의 등록/제거 기록과 새 snapshot 값을
+  결정적으로 확인한다.
 
 - [ ] **Step 2: Run Micrometer test and verify RED**
 
@@ -708,8 +719,13 @@
   `delegate.snapshot()`의 O(1) atomic counter이며, `FunctionCounter`/`Gauge`가 registry
   polling 시 snapshot을 읽는다. 따라서 async diagnostics observer callback이 close 직후
   drop되어도 close-owned cancellation/rejection이 metric에서 사라지지 않는다.
-  decorator close는 delegate를 idempotently 닫고 wrapper와 direct delegate 모두
-  `DROPPED_CLOSED`를 반환하도록 한다. non-owning observation은 wrapper가 아니라 public
+  constructor는 `synchronized(registry)` 안에서 고정된 name/tag 조합의 모든 `Meter.Id`를
+  먼저 preflight하고, 이미 존재하는 ID가 있으면 부분 등록을 제거한 뒤 fail-fast한다.
+  성공한 등록의 ID 목록은 wrapper가 소유한다. `close()`는 delegate를 idempotently 닫은
+  뒤 `finally`에서 소유 ID를 각각 `registry.remove(id)`로 정확히 한 번 제거하며,
+  registry 제거 예외가 caller admission/election으로 전파되지 않도록 격리한다. 따라서
+  wrapper와 direct delegate 모두 close 후 `DROPPED_CLOSED`를 반환하고 registry가 closed
+  delegate를 strong-reference하지 않는다. non-owning observation은 wrapper가 아니라 public
   `observe()` handle을 별도로 사용하며 decorator는 내부 observer handle을 등록하거나
   소유하지 않는다. delegate의 `snapshot()` descriptor와 값은 그대로 전달하며 metric
   registry 오류가 admission/election에 전파되지 않는다.
@@ -723,9 +739,11 @@
   `leader.audit.export.diagnostics.closed`로 고정한다. 각 cumulative counter는
   snapshot-backed `FunctionCounter`로 등록하고, queue/in-flight/diagnostics closed는
   snapshot-backed `Gauge`로 등록한다. `observerDrops`,
-  `observerRegistrationDrops`, `diagnosticsFatalErrors`는 snapshot과 각 counter에서 같은
-  누적값을 보이며 exporter close 후 0으로 reset하지 않는다. `diagnosticsClosed`는
-  `diagnostics.closed` gauge의 `0|1` 값과 일치한다.
+  `observerRegistrationDrops`, `diagnosticsFatalErrors`는 wrapper가 open인 동안 snapshot과
+  각 counter에서 같은 누적값을 보이며 exporter close가 delegate counter를 reset하지는
+  않는다. close 후에는 wrapper가 소유한 모든 meter가 registry에서 제거되어 stale source를
+  노출하지 않는다. `diagnosticsClosed`는 open 동안 `diagnostics.closed` gauge의 `0|1` 값과
+  일치한다.
   `outcome`, `transport`, `source` tag 값은 위 enum allow-list만 사용하고 event field는
   tag로 복사하지 않는다. 기존 `HISTORY_SINK_FAILURES` counter는 건드리지 않는다.
 
@@ -738,6 +756,10 @@
     --tests 'io.bluetape4k.leader.micrometer.audit.MicrometerLeaderAuditExporterTest' \
     --tests 'io.bluetape4k.leader.micrometer.history.*'
   ```
+
+  close idempotence, owned `Meter.Id` removal, same-registry replacement의 fresh
+  snapshot source, duplicate wrapper fail-fast/partial cleanup, 그리고 direct delegate와
+  wrapper의 closed admission parity가 모두 PASS해야 한다.
 
 - [ ] **Step 5: Update both README locales and commit AUD-02**
 

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -218,7 +218,7 @@
   fun `worker executor rejection releases every permit and recovers capacity`() { /* executor reject */ }
 
   @Test
-  fun `retry scheduler rejection releases every permit and recovers capacity`() { /* scheduler reject */ }
+  fun `retry scheduler rejection terminalizes one retry and continues the other N minus 1 items`() { /* scheduler reject */ }
 
   @Test
   fun `submit close crossing is linearized and caller executor is never shutdown`() { /* close race */ }
@@ -243,6 +243,12 @@
 
   @Test
   fun `diagnostics Error closes diagnostics without restarting the worker`() { /* fatal diagnostics */ }
+
+  @Test
+  fun `reentrant close from diagnostics callback does not self-join`() { /* reentrant close */ }
+
+  @Test
+  fun `interrupt-ignoring observer cannot block exporter close`() { /* abandon */ }
 
   @Test
   fun `exceptional and cancelled delivery futures terminalize once without throwing to submitter`() { /* exception matrix */ }
@@ -271,8 +277,12 @@
   `inFlight <= maxInFlight`, worker-exit double-check/reschedule, caller-owned
   executor/scheduler의 미종료를 함께 검증한다. diagnostics capacity
   `min(queueCapacity, 1024)`, named daemon worker termination, observer registration cap
-  16, observer handle close linearization, queued callback drop와 `observerDrops` exact
-  count도 검증한다. `submit` source/benchmark guard는
+  16, observer handle close linearization, queued callback drop와
+  `observerDrops`/`observerRegistrationDrops` exact count, `diagnosticsFatalErrors`와
+  `diagnosticsClosed` 상태도 검증한다. observer handle close 테스트는 paused diagnostics
+  worker에서 close barrier를 통과한 뒤 callback invocation reservation이 없으면 callback
+  이 시작되지 않음을 확인하고, reservation이 먼저 선형화된 crossing callback만 close
+  반환 뒤 마칠 수 있음을 별도 검증한다. `submit` source/benchmark guard는
   lock·blocking queue·capacity wait가 없고 contention 시 즉시 drop되는지 확인한다.
   contention fixture는 32 contender, 100 iteration, barrier와 paused manual executor를
   고정하고 각 submit 호출의 반환 latch, accepted/drop 합계, `snapshot()` permit bounds를
@@ -331,6 +341,9 @@
       val executorRejections: Long,
       val schedulerRejections: Long,
       val observerDrops: Long,
+      val observerRegistrationDrops: Long,
+      val diagnosticsFatalErrors: Long,
+      val diagnosticsClosed: Boolean,
       val closed: Boolean,
   ) {
       companion object {
@@ -349,11 +362,15 @@
               executorRejections: Long,
               schedulerRejections: Long,
               observerDrops: Long,
+              observerRegistrationDrops: Long,
+              diagnosticsFatalErrors: Long,
+              diagnosticsClosed: Boolean,
               closed: Boolean,
           ): LeaderAuditExportSnapshot = LeaderAuditExportSnapshot(
               queued, inFlight, scheduledRetries, admitted, accepted, droppedQueueFull,
               droppedClosed, retries, terminalFailures, cancellations, executorRejections,
-              schedulerRejections, observerDrops, closed,
+              schedulerRejections, observerDrops, observerRegistrationDrops,
+              diagnosticsFatalErrors, diagnosticsClosed, closed,
           )
       }
   }
@@ -392,36 +409,53 @@
   `Exception`만 격리하며 `Error`는 callback task를 terminalize한 뒤 전용 diagnostics
   worker의 uncaught boundary로 재전파한다. observer 또는 delivery가 `Error`를 던지면
   상태/permit을 정확히 한 번 terminalize하고 같은 원래 `Error`를 재전파한다. exporter
-  `close()`는 diagnostics closed gate를 먼저 세우고 queued diagnostics를 drop한 뒤
-  worker를 interrupt/unpark하고 join하여 worker 종료와 late callback 0을 확인한다.
-  close는 이미 실행 중인 callback을 마칠 때까지 join할 수 있으며, callback은 interrupt를
-  존중해야 한다. join이 끝난 뒤 diagnostics thread/task와 queued callback은 0이고,
-  callback이 interrupt를 무시해도 close는 callback admission을 다시 열지 않으며 해당
-  observer는 close 이후 새 callback을 받지 않는다. executor 또는 scheduler
-  rejection은 현재 worker가 보유한 queued batch 전체를 deterministic하게
-  `EXECUTOR_REJECTED` 또는 `SCHEDULER_REJECTED`로 terminalize하고 각 item의 permit을
-  정확히 한 번 반환한다. 어떤 accepted item도 고착되지 않으며, batch N개를 거부한
-  뒤 다음 `queueCapacity` submissions가 다시 모두 admission될 수 있어야 한다.
+  `close()`는 먼저 exporter admission gate를 CLOSED로 선형화하고 queued/retry/in-flight
+  work를 close-owned cancellation으로 terminalize한다. 이 단계에서 발생한
+  `CANCELLED` observation은 diagnostics gate가 아직 열려 있는 동안 admission한다. 그
+  다음 diagnostics gate를 CLOSED로 바꾸고 queued diagnostics를 drop한 뒤 worker를
+  interrupt/unpark해 late callback admission 0을 확인한다. 이미 admission된 callback은
+  daemon worker에서 abandon/완료될 수 있다. close는 callback 종료를 join하지 않으므로
+  interrupt를 무시하는 observer 때문에 무기한 hang하지 않으며, close 반환 뒤 새 callback
+  admission은 없다. diagnostics worker thread에서 재진입한 `close()`는 자기 자신을
+  interrupt/join하지 않고 CLOSED gate만 선형화한 뒤 반환한다. 이미 admission된 callback은
+  close 반환 뒤에도 현재 호출을 마칠 수 있으며, 이는 close가 callback invocation을
+  기다리지 않는다는 명시적 lifecycle 정책이다.
+  observer slot의 `active` 확인과 callback invocation reservation(`inFlight--`/`running++`)
+  은 하나의 lock 아래 원자화한다. worker는 slot lock을 잡은 채 active 상태를 확인하고
+  invocation을 예약한 뒤에만 lock을 놓고 callback을 호출한다. handle close는 같은 lock에서
+  `active=false`를 선형화한 뒤 registry에서 제거한다. close보다 먼저 reservation된
+  callback만 crossing allowance로 실행될 수 있고, close 이후에는 새 reservation이
+  불가능하므로 handle close 반환 뒤 새 callback invocation이 시작되지 않는다.
+  executor-start rejection은 현재 worker가
+  보유한 detached queued batch 전체를 deterministic하게 `EXECUTOR_REJECTED`로
+  terminalize하고 각 item의 permit을 정확히 한 번 반환한다. retry scheduler rejection은
+  해당 retry item 하나만 `SCHEDULER_REJECTED`로 terminalize하며 queue의 N-1 work는
+  계속 처리한다. 어떤 accepted item도 고착되지 않으며, batch N개를 거부한 뒤 다음
+  `queueCapacity` submissions가 다시 모두 admission될 수 있어야 한다.
   worker는 `workerRunning.compareAndSet(false, true)`로 시작한다. drain loop가 empty를
   보면 먼저 `workerRunning.set(false)`를 publish한 다음 queue를 다시 확인하고,
   non-empty면 `compareAndSet(false, true)`로 drain ownership을 재획득한다. submit도
   enqueue 직후 동일한 `tryStartWorker()` CAS를 호출하므로 flag-clear와 enqueue가
   어느 순서로 교차해도 lost wakeup이 없다. 별도 atomic
   in-flight reservation을 delivery 전에 획득하고 completion/timeout/close에서 정확히
-  반환해 `inFlight <= maxInFlight`를 유지한다. close는 gate를 닫고 queue·retry·in-flight
-  future를 취소한 뒤 scheduling critical section과 worker admission이 quiesce된 것을
-  확인하고 반환한다. network drain은 기다리지 않지만 close 반환 후 exporter가
-  executor/scheduler에 새 execute/schedule을 호출하지 않는다. injected
+  반환해 `inFlight <= maxInFlight`를 유지한다. close는 admission gate를 먼저 닫고
+  queue·retry·in-flight future를 close-owned cancellation으로 terminalize하면서
+  `CANCELLED` observation을 diagnostics gate가 열린 상태에서 admission한다. 그 뒤
+  diagnostics gate를 닫고 queue를 drop한 다음 scheduling critical section과 worker
+  admission이 quiesce된 것을 확인하고 반환한다. network drain은 기다리지 않지만 close
+  반환 후 exporter가 executor/scheduler에 새 execute/schedule을 호출하지 않는다. injected
   executor/scheduler는 exporter가 shutdown하지 않으며 ownership을 caller에게
   문서화한다.
 
-  observer registry는 최대 16개로 고정한다. `observe()` handle close는 registry에서
-  observer를 먼저 제거하고 반환하며, queued item은 callback 직전 active 상태를 다시
-  확인한다. 이미 실행 중인 callback만 현재 호출을 마친다. 17번째 registration은
-  no-op handle을 반환하고 `observerDrops`를 1 증가시킨다.
+  observer registry는 최대 16개로 고정한다. `observe()` handle close는 slot lock 아래
+  `active=false`와 registry 제거를 선형화하고 반환한다. queued item은 callback 직전
+  동일한 slot lock에서 invocation reservation을 시도하며, close 전에 reservation된
+  callback만 crossing allowance로 호출된다. 17번째 registration은 no-op handle을
+  반환하고 `observerRegistrationDrops`를 1 증가시킨다.
   diagnostics worker에서 observer `Error`가 발생하면 diagnostics gate를 CLOSED로
-  전환하고 queued callback을 drop한 뒤 원래 `Error`를 uncaught boundary로 재전파하며,
-  worker를 자동 재시작하지 않는다. 이후 `observe()`는 no-op handle을 반환한다.
+  전환하고 queued callback을 drop한 뒤 `diagnosticsFatalErrors`를 1 증가시키고
+  `diagnosticsClosed=true`로 표시한 다음 원래 `Error`를 uncaught boundary로 재전파한다.
+  worker를 자동 재시작하지 않으며 이후 `observe()`는 no-op handle을 반환한다.
 
   `queued`, `inFlight`, `scheduledRetries`, `admitted`는 각각 `AtomicInteger`로
   유지하며 snapshot은 `queue.size` 또는 work-item 순회를 사용하지 않는 O(1) 읽기로
@@ -558,7 +592,7 @@
   | `LeaderAuditExportOptions` | `queueCapacity:Int`, `maxInFlight:Int`, `maxAttempts:Int`, `attemptTimeout:java.time.Duration`, `initialBackoff:java.time.Duration`, `maxBackoff:java.time.Duration`, `executor:Executor`, `scheduler:ScheduledExecutorService`; Java-visible 8-argument constructor, no implicit shared executor |
   | `LeaderAuditDelivery` | `deliver(LeaderAuditExportEvent): CompletableFuture<LeaderAuditDeliveryResult>` |
   | `LeaderAuditExportObserver` | `onObservation(LeaderAuditExportObservation): Unit` with finite enum only |
-  | `LeaderAuditExportSnapshot` | immutable `queued`, `inFlight`, `scheduledRetries`, `admitted`, outcome counters, `observerDrops`, `closed`; no dynamic identifiers |
+  | `LeaderAuditExportSnapshot` | immutable `queued`, `inFlight`, `scheduledRetries`, `admitted`, outcome counters, `observerDrops`, `observerRegistrationDrops`, `diagnosticsFatalErrors`, `diagnosticsClosed`, `closed`; no dynamic identifiers |
   | `LeaderAuditHttpPayload` | `of(String, byte[])`, `contentType`, `body(): byte[]`; constructor/body defensively copy |
   | `LeaderAuditTrustedHttpsEndpoint` | `trusted(URI): LeaderAuditTrustedHttpsEndpoint`, `uri:URI`; caller-owned explicit trust boundary |
   | `HttpLeaderAuditExporter` | `(HttpClient, LeaderAuditTrustedHttpsEndpoint, Map<String,String>, LeaderAuditPayloadEncoder, LeaderAuditExportOptions, LeaderAuditHttpOptions)` plus `submit/observe/snapshot/close` |
@@ -625,8 +659,8 @@
 
   `SimpleMeterRegistry`에서 accepted, queue-full, closed, retry, terminal failure를
   각각 발생시키고 metric 이름과 finite tag set을 검증한다. 스냅숏의 queue depth,
-  in-flight, cancellation, executor/scheduler rejection와 observer-drop gauge/counter도
-  검증한다.
+  in-flight, cancellation, executor/scheduler rejection와 observer-drop,
+  observer-registration-drop, diagnostics-failure/closed gauge를 검증한다.
   정확한 allow-list는 `source={history,lifecycle,direct}`,
   `transport={core,http}`, `outcome={accepted,queue_full,closed,retry,failure,
   cancelled,rejected}`로 고정한다. 고유 lockName, leaderId, endpoint, error message를
@@ -647,10 +681,11 @@
 
   `MicrometerLeaderAuditExporter(delegate, registry)`는 항상 delegate를 소유하는
   `LeaderAuditExporter` decorator로 구현하고 결과별 counter와 `snapshot()` gauge를
-  delegate에 위임한다. decorator close는 observer handle을 먼저 idempotently 해제한
-  뒤 delegate를 닫아 wrapper와 direct delegate 모두 `DROPPED_CLOSED`를 반환하도록
-  한다. non-owning observation은 wrapper가 아니라 public `observe()` handle을
-  별도로 사용한다. 생성 시 delegate에 bounded
+  delegate에 위임한다. decorator close는 observer handle을 유지한 채 delegate를 먼저
+  닫아 close-owned `CANCELLED` observation을 admission한 뒤 `finally`에서 observer
+  handle을 idempotently 해제한다. 따라서 wrapper와 direct delegate 모두
+  `DROPPED_CLOSED`를 반환하도록 한다. non-owning observation은 wrapper가 아니라 public
+  `observe()` handle을 별도로 사용한다. 생성 시 delegate에 bounded
   `LeaderAuditExportObserver`를 등록해 retry, terminal failure, cancellation,
   rejection을 관찰하고 decorator close에서 observer handle을 idempotently 해제한다.
   delegate의 `snapshot()` descriptor와 값은 그대로 전달하며 metric registry 오류가
@@ -659,9 +694,13 @@
   `leader.audit.export.retries`, `leader.audit.export.failures`,
   `leader.audit.export.queue.depth`, `leader.audit.export.in.flight`,
   `leader.audit.export.cancelled`, `leader.audit.export.rejections`,
-  `leader.audit.export.observer.dropped`로 고정한다. `observerDrops`는 snapshot과
-  observer-dropped counter에서 같은 누적값을 보이며 exporter close 후 0으로 reset하지
-  않는다.
+  `leader.audit.export.observer.dropped`,
+  `leader.audit.export.observer.registration.dropped`,
+  `leader.audit.export.diagnostics.failures`,
+  `leader.audit.export.diagnostics.closed`로 고정한다. `observerDrops`,
+  `observerRegistrationDrops`, `diagnosticsFatalErrors`는 snapshot과 각 counter에서 같은
+  누적값을 보이며 exporter close 후 0으로 reset하지 않는다. `diagnosticsClosed`는
+  `diagnostics.closed` gauge의 `0|1` 값과 일치한다.
   `outcome`, `transport`, `source` tag 값은 위 enum allow-list만 사용하고 event field는
   tag로 복사하지 않는다. 기존 `HISTORY_SINK_FAILURES` counter는 건드리지 않는다.
 
@@ -895,7 +934,29 @@
   변경된 두 locale의 제목·API·metric·scope가 대응하고, draft는 0.5.0 release claim을
   과장하지 않는지 read-back한다. pinned manual의 release source validation은
   immutable commit에 대해 PASS해야 하며 draft token이 pinned 문서에 섞이지 않아야
-  한다. `rg -nP '(Authorization:\s*(Basic|Bearer)\s+(?!\$\{WEBHOOK_TOKEN\}|<REDACTED>)[A-Za-z0-9._~+/=-]{8,}|(glpat-|github_pat_|xox[baprs]-|npm_|AIza|sk-|ghp_|AKIA[0-9A-Z]{8,}))' docs/manual/drafts README.md README.ko.md leader-core/README* leader-micrometer/README*`가 0건이고, placeholder가 `${WEBHOOK_TOKEN}` 또는 `<REDACTED>`로만 존재하는지 확인한다. gitleaks가 설치되어 있으면 동일 대상에 `gitleaks dir --no-banner --redact`도 실행한다.
+  한다. 다음 결정적 scanner는 존재하는 파일만 배열에 넣고, provider prefix 앞에
+  영숫자가 없는 경우에만 secret-like literal을 매칭한다. placeholder는 negative
+  fixture로 허용하고, known secret-like positive fixture는 반드시 매칭되는지 먼저
+  확인한다.
+
+  ```bash
+  scan_paths=()
+  for path in docs/manual/drafts README.md README.ko.md leader-core/README.md \
+      leader-core/README.ko.md leader-micrometer/README.md leader-micrometer/README.ko.md; do
+    [[ -f "$path" ]] && scan_paths+=("$path")
+  done
+  ((${#scan_paths[@]} > 0))
+  rg_bin="$(command -v rg)"
+  [[ -n "$rg_bin" ]]
+  secret_pattern='Authorization:[[:space:]]*(Basic|Bearer)[[:space:]]+(?![$][{]WEBHOOK_TOKEN[}]|<REDACTED>)[A-Za-z0-9._~+/=-]{8,}|(?<![A-Za-z0-9])(glpat-|github_pat_|xox[baprs]-|npm_|AIza|sk-|ghp_|AKIA[0-9A-Z]{8,})[A-Za-z0-9._-]{8,}'
+  printf '%s' 'Authorization: Bearer sk-live-positive-fixture' | "$rg_bin" -qP "$secret_pattern"
+  ! printf '%s' 'Authorization: Bearer ${WEBHOOK_TOKEN}' 'Authorization: Bearer <REDACTED>' | "$rg_bin" -qP "$secret_pattern"
+  ! "$rg_bin" -nP "$secret_pattern" "${scan_paths[@]}"
+  ```
+
+  gitleaks가 설치되어 있으면 추가로 repository root에서
+  `gitleaks dir --no-banner --redact .`를 실행하되, 위의 명시적 파일 집합 scanner를
+  source-of-truth로 유지한다.
   diagram 변경은 없으므로
   `bluetape-diagram`은 N/A이며 evidence에 이유를 기록한다.
 

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -239,7 +239,10 @@
   fun `diagnostics capacity is bounded and close stops queued observer callbacks`() { /* diagnostics lifecycle */ }
 
   @Test
-  fun `observer handle close prevents queued callback start after return`() { /* handle */ }
+  fun `observer handle close drops inactive queued callback and recovers diagnostics capacity`() { /* handle */ }
+
+  @Test
+  fun `exporter close and dequeued observer reservation have one linearization point`() { /* close/reservation race */ }
 
   @Test
   fun `diagnostics Error closes diagnostics without restarting the worker`() { /* fatal diagnostics */ }
@@ -278,16 +281,23 @@
   executor/scheduler의 미종료를 함께 검증한다. diagnostics capacity
   `min(queueCapacity, 1024)`, named daemon worker termination, observer registration cap
   16, observer handle close linearization, queued callback drop와
-  `observerDrops`/`observerRegistrationDrops` exact count, `diagnosticsFatalErrors`와
-  `diagnosticsClosed` 상태도 검증한다. diagnostics Error 테스트는 원래 `Error`의
+  `observerDrops`/`observerRegistrationDrops` exact count, inactive dequeue/drop에서의
+  slot `inFlight`·diagnostics permit exact-once rollback과 full-capacity 재-admission,
+  `diagnosticsFatalErrors`와 `diagnosticsClosed` 상태도 검증한다. diagnostics Error 테스트는 원래 `Error`의
   uncaught capture, `diagnosticsFatalErrors=1`, `diagnosticsClosed=true`, worker 재시작
   0과 이후 observe no-op을 함께 확인한다. reentrant close 테스트는 callback 내부 close가
   자기 worker를 join하지 않고 반환하는 barrier를 사용한다. interrupt-ignoring observer
   테스트는 callback을 외부 release까지 붙잡아 둔 뒤 release 전에 exporter close가
   반환하는지 결정적으로 확인하고 teardown에서만 callback을 해제한다. observer handle close 테스트는 paused diagnostics
-  worker에서 close barrier를 통과한 뒤 callback invocation reservation이 없으면 callback
-  이 시작되지 않음을 확인하고, reservation이 먼저 선형화된 crossing callback만 close
-  반환 뒤 마칠 수 있음을 별도 검증한다. `submit` source/benchmark guard는
+  worker에서 close barrier를 통과한 뒤 inactive queued item이 callback 없이 slot/queue
+  permit을 반환하는지 확인하고, 이후 diagnostics capacity만큼 새 observation이 모두
+  admission되는지 검증한다. reservation이 먼저 선형화된 crossing callback만 close 반환
+  뒤 마칠 수 있음을 별도 검증한다. exporter close/reservation race는 gate barrier에서
+  close-first면 callback 0과 slot/diagnostics permit 0, reservation-first면 해당 callback
+  하나만 crossing으로 허용되는 양쪽 순서를 결정적으로 검증한다. normal close에서도
+  `diagnosticsClosed=true`이고
+  `diagnosticsFatalErrors`는 증가하지 않음을 고정하며, fatal/error/normal-close/idempotent
+  close truth table과 Micrometer gauge parity도 함께 검증한다. `submit` source/benchmark guard는
   lock·blocking queue·capacity wait가 없고 contention 시 즉시 drop되는지 확인한다.
   contention fixture는 32 contender, 100 iteration, barrier와 paused manual executor를
   고정하고 각 submit 호출의 반환 latch, accepted/drop 합계, `snapshot()` permit bounds를
@@ -408,7 +418,9 @@
   bounded diagnostics queue와 이름이 고정된 daemon virtual-thread worker가 observation을
   전달한다. diagnostics capacity는 `min(queueCapacity, 1024)`로 파생해 별도 public
   option 없이 항상 `1..1024`로 bounded하며, atomic permit과 `LockSupport.unpark`를
-  사용해 admission은 queue offer/CAS만 수행한다. diagnostics queue가 가득 차면
+  사용해 admission은 queue offer/CAS만 수행한다. queue poll, callback reservation, queue
+  drop은 하나의 짧은 `diagnosticsAdmissionLock`에서 선형화하고 submit-side observation
+  enqueue는 lock을 기다리지 않고 `tryLock` 실패 시 `observerDrops`를 증가시키고 drop한다. diagnostics queue가 가득 차면
   `observerDrops`를 증가시키고 callback 없이 끝낸다. callback이 오래 걸려도
   admission worker와 선거 thread는 block하지 않는다. observer callback의 일반
   `Exception`만 격리하며 `Error`는 callback task를 terminalize한 뒤 전용 diagnostics
@@ -417,7 +429,9 @@
   `close()`는 먼저 exporter admission gate를 CLOSED로 선형화하고 queued/retry/in-flight
   work를 close-owned cancellation으로 terminalize한다. 이 단계에서 발생한
   `CANCELLED` observation은 diagnostics gate가 아직 열려 있는 동안 admission한다. 그
-  다음 diagnostics gate를 CLOSED로 바꾸고 queued diagnostics를 drop한 뒤 worker를
+  다음 `diagnosticsAdmissionLock`에서 diagnostics gate를 CLOSED로 바꾸고 queued diagnostics를
+  drop하며 inactive/detached queue item의 slot `inFlight`와 diagnostics permit을 exact-once
+  rollback한 뒤 worker를
   interrupt/unpark해 late callback admission 0을 확인한다. 이미 admission된 callback은
   daemon worker에서 abandon/완료될 수 있다. close는 callback 종료를 join하지 않으므로
   interrupt를 무시하는 observer 때문에 무기한 hang하지 않으며, close 반환 뒤 새 callback
@@ -426,11 +440,12 @@
   close 반환 뒤에도 현재 호출을 마칠 수 있으며, 이는 close가 callback invocation을
   기다리지 않는다는 명시적 lifecycle 정책이다.
   observer slot의 `active` 확인과 callback invocation reservation(`inFlight--`/`running++`)
-  은 하나의 lock 아래 원자화한다. worker는 slot lock을 잡은 채 active 상태를 확인하고
-  invocation을 예약한 뒤에만 lock을 놓고 callback을 호출한다. handle close는 같은 lock에서
-  `active=false`를 선형화한 뒤 registry에서 제거한다. close보다 먼저 reservation된
-  callback만 crossing allowance로 실행될 수 있고, close 이후에는 새 reservation이
-  불가능하므로 handle close 반환 뒤 새 callback invocation이 시작되지 않는다.
+  은 `diagnosticsAdmissionLock → slot lock` 순서로 원자화한다. worker는 queue poll과
+  slot lock을 잡은 채 active 상태를 확인하고 invocation을 예약한 뒤에만 gate를 놓고
+  callback을 호출한다. handle close도 같은 lock 순서로 `active=false`를 선형화한 뒤
+  registry에서 제거한다. close보다 먼저 reservation된 callback만 crossing allowance로
+  실행될 수 있고, close 이후에는 새 reservation이 불가능하므로 handle close 반환 뒤 새
+  callback invocation이 시작되지 않는다.
   executor-start rejection은 현재 worker가
   보유한 detached queued batch 전체를 deterministic하게 `EXECUTOR_REJECTED`로
   terminalize하고 각 item의 permit을 정확히 한 번 반환한다. retry scheduler rejection은
@@ -443,26 +458,27 @@
   enqueue 직후 동일한 `tryStartWorker()` CAS를 호출하므로 flag-clear와 enqueue가
   어느 순서로 교차해도 lost wakeup이 없다. 별도 atomic
   in-flight reservation을 delivery 전에 획득하고 completion/timeout/close에서 정확히
-  반환해 `inFlight <= maxInFlight`를 유지한다. close는 admission gate를 먼저 닫고
-  queue·retry·in-flight future를 close-owned cancellation으로 terminalize하면서
-  `CANCELLED` observation을 diagnostics gate가 열린 상태에서 admission한다. 그 뒤
-  diagnostics gate를 닫고 queue를 drop한 다음 scheduling critical section과 worker
-  admission이 quiesce된 것을 확인하고 반환한다. network drain은 기다리지 않지만 close
-  반환 후 exporter가 executor/scheduler에 새 execute/schedule을 호출하지 않는다. injected
-  executor/scheduler는 exporter가 shutdown하지 않으며 ownership을 caller에게
+  반환해 `inFlight <= maxInFlight`를 유지한다. close 이후 scheduling critical section과
+  worker admission이 quiesce된 것을 확인하고 반환하며, network drain은 기다리지 않지만
+  close 반환 후 exporter가 executor/scheduler에 새 execute/schedule을 호출하지 않는다.
+  injected executor/scheduler는 exporter가 shutdown하지 않으며 ownership을 caller에게
   문서화한다.
 
-  observer registry는 최대 16개로 고정한다. `observe()` handle close는 slot lock 아래
-  `active=false`와 registry 제거를 선형화하고 반환한다. queued item은 callback 직전
-  동일한 slot lock에서 invocation reservation을 시도하며, close 전에 reservation된
-  callback만 crossing allowance로 호출된다. 17번째 registration은 no-op handle을
-  반환하고 `observerRegistrationDrops`를 1 증가시킨다.
+  observer registry는 최대 16개로 고정한다. `diagnosticsAdmissionLock`을 먼저 잡고
+  `observe()` handle close는 slot lock 아래 `active=false`와 registry 제거를 선형화하고
+  반환한다. queued item은 같은 gate lock 아래 callback 직전 invocation reservation을
+  시도하며, close 전에 reservation된 callback만 crossing allowance로 호출된다. 17번째
+  registration은 no-op handle을 반환하고 `observerRegistrationDrops`를 1 증가시킨다.
   diagnostics queue offer가 실패하면 slot의 `inFlight`와 diagnostics permit을 즉시
-  되돌리고 `observerDrops`만 증가시킨다.
+  되돌리고 `observerDrops`만 증가시킨다. inactive slot item을 dequeue하거나
+  normal/fatal close에서 queue를 drop할 때도 같은 gate lock 아래 slot `inFlight`와
+  diagnostics permit을 정확히 한 번 반환한다.
   diagnostics worker에서 observer `Error`가 발생하면 diagnostics gate를 CLOSED로
   전환하고 queued callback을 drop한 뒤 `diagnosticsFatalErrors`를 1 증가시키고
   `diagnosticsClosed=true`로 표시한 다음 원래 `Error`를 uncaught boundary로 재전파한다.
-  worker를 자동 재시작하지 않으며 이후 `observe()`는 no-op handle을 반환한다.
+  normal `close()`도 diagnostics gate를 CLOSED로 전환해 `diagnosticsClosed=true`를
+  표시하지만 fatal counter는 증가시키지 않는다. worker를 자동 재시작하지 않으며 이후
+  `observe()`는 no-op handle을 반환한다.
 
   `queued`, `inFlight`, `scheduledRetries`, `admitted`는 각각 `AtomicInteger`로
   유지하며 snapshot은 `queue.size` 또는 work-item 순회를 사용하지 않는 O(1) 읽기로
@@ -674,8 +690,9 @@
   대량 제출해도 meter 수가 증가하지 않고 해당 값이 tag에 없는지 assertion한다.
   gauge 구현은 exporter `snapshot()`의 O(1) atomic counter를 읽고 queue를 순회하지
   않으며, snapshot object는 submit hot path에서 생성하지 않는다는 source/contract
-  assertion을 추가한다. wrapper close twice에서 observer detach와 delegate close를
-  검증하고, wrapper close가 exporter close contract를 그대로 보존하는지 확인한다.
+  assertion을 추가한다. wrapper close twice에서 delegate close idempotence와
+  snapshot-backed cancellation/rejection metric parity를 검증하고, wrapper close가
+  exporter close contract를 그대로 보존하는지 확인한다.
 
 - [ ] **Step 2: Run Micrometer test and verify RED**
 
@@ -687,16 +704,15 @@
 - [ ] **Step 3: Implement decorator and constants**
 
   `MicrometerLeaderAuditExporter(delegate, registry)`는 항상 delegate를 소유하는
-  `LeaderAuditExporter` decorator로 구현하고 결과별 counter와 `snapshot()` gauge를
-  delegate에 위임한다. decorator close는 observer handle을 유지한 채 delegate를 먼저
-  닫아 close-owned `CANCELLED` observation을 admission한 뒤 `finally`에서 observer
-  handle을 idempotently 해제한다. 따라서 wrapper와 direct delegate 모두
+  `LeaderAuditExporter` decorator로 구현한다. metric의 authoritative source는
+  `delegate.snapshot()`의 O(1) atomic counter이며, `FunctionCounter`/`Gauge`가 registry
+  polling 시 snapshot을 읽는다. 따라서 async diagnostics observer callback이 close 직후
+  drop되어도 close-owned cancellation/rejection이 metric에서 사라지지 않는다.
+  decorator close는 delegate를 idempotently 닫고 wrapper와 direct delegate 모두
   `DROPPED_CLOSED`를 반환하도록 한다. non-owning observation은 wrapper가 아니라 public
-  `observe()` handle을 별도로 사용한다. 생성 시 delegate에 bounded
-  `LeaderAuditExportObserver`를 등록해 retry, terminal failure, cancellation,
-  rejection을 관찰하고 decorator close에서 observer handle을 idempotently 해제한다.
-  delegate의 `snapshot()` descriptor와 값은 그대로 전달하며 metric registry 오류가
-  admission/election에 전파되지 않는다.
+  `observe()` handle을 별도로 사용하며 decorator는 내부 observer handle을 등록하거나
+  소유하지 않는다. delegate의 `snapshot()` descriptor와 값은 그대로 전달하며 metric
+  registry 오류가 admission/election에 전파되지 않는다.
   metric names는 `leader.audit.export.accepted`, `leader.audit.export.dropped`,
   `leader.audit.export.retries`, `leader.audit.export.failures`,
   `leader.audit.export.queue.depth`, `leader.audit.export.in.flight`,
@@ -704,7 +720,9 @@
   `leader.audit.export.observer.dropped`,
   `leader.audit.export.observer.registration.dropped`,
   `leader.audit.export.diagnostics.failures`,
-  `leader.audit.export.diagnostics.closed`로 고정한다. `observerDrops`,
+  `leader.audit.export.diagnostics.closed`로 고정한다. 각 cumulative counter는
+  snapshot-backed `FunctionCounter`로 등록하고, queue/in-flight/diagnostics closed는
+  snapshot-backed `Gauge`로 등록한다. `observerDrops`,
   `observerRegistrationDrops`, `diagnosticsFatalErrors`는 snapshot과 각 counter에서 같은
   누적값을 보이며 exporter close 후 0으로 reset하지 않는다. `diagnosticsClosed`는
   `diagnostics.closed` gauge의 `0|1` 값과 일치한다.
@@ -947,18 +965,46 @@
   확인한다.
 
   ```bash
+  set -euo pipefail
   scan_paths=()
   for path in docs/manual/drafts README.md README.ko.md leader-core/README.md \
       leader-core/README.ko.md leader-micrometer/README.md leader-micrometer/README.ko.md; do
-    [[ -f "$path" ]] && scan_paths+=("$path")
+    if [[ -e "$path" ]]; then
+      [[ -f "$path" && -r "$path" ]] || { echo "unreadable scan path: $path" >&2; exit 2; }
+      scan_paths+=("$path")
+    fi
   done
   ((${#scan_paths[@]} > 0))
-  rg_bin="$(command -v rg)"
-  [[ -n "$rg_bin" ]]
+  if ! rg_bin="$(command -v rg)"; then
+    echo 'rg is required for the deterministic scanner' >&2
+    exit 127
+  fi
   secret_pattern='Authorization:[[:space:]]*(Basic|Bearer)[[:space:]]+(?![$][{]WEBHOOK_TOKEN[}]|<REDACTED>)[A-Za-z0-9._~+/=-]{8,}|(?<![A-Za-z0-9])(glpat-|github_pat_|xox[baprs]-|npm_|AIza|sk-|ghp_|AKIA[0-9A-Z]{8,})[A-Za-z0-9._-]{8,}'
-  printf '%s' 'Authorization: Bearer sk-live-positive-fixture' | "$rg_bin" -qP "$secret_pattern"
-  ! printf '%s' 'Authorization: Bearer ${WEBHOOK_TOKEN}' 'Authorization: Bearer <REDACTED>' | "$rg_bin" -qP "$secret_pattern"
-  ! "$rg_bin" -nP "$secret_pattern" "${scan_paths[@]}"
+  if ! printf '%s' 'Authorization: Bearer sk-live-positive-fixture' | "$rg_bin" -qP "$secret_pattern"; then
+    echo 'positive secret scanner fixture was not detected' >&2
+    exit 1
+  fi
+  if printf '%s' 'Authorization: Bearer ${WEBHOOK_TOKEN}' 'Authorization: Bearer <REDACTED>' | "$rg_bin" -qP "$secret_pattern"; then
+    echo 'placeholder was incorrectly detected as a secret' >&2
+    exit 1
+  else
+    status=$?
+    ((status == 1)) || exit "$status"
+  fi
+  if "$rg_bin" -nP "$secret_pattern" "${scan_paths[@]}"; then
+    echo 'secret-like literal detected' >&2
+    exit 1
+  else
+    status=$?
+    ((status == 1)) || { echo "scanner I/O failure (status=$status)" >&2; exit "$status"; }
+  fi
+  if "$rg_bin" -qP '[' <<< ''; then
+    echo 'invalid regex fixture unexpectedly passed' >&2
+    exit 1
+  else
+    status=$?
+    ((status == 2)) || { echo "invalid regex fixture returned status=$status" >&2; exit "$status"; }
+  fi
   ```
 
   gitleaks가 설치되어 있으면 추가로 repository root에서
@@ -1015,6 +1061,11 @@
 
 - [ ] **Step 3: Complete performance/stability scan**
 
+  PR3 plan gate intentionally contains only spec/plan and contract-test targets; the
+  `Create` implementation files are absent until the approved AUD-01~03 execution slices.
+  Therefore this stage records source-level implementation verification as deferred, never
+  as a PASS. Before any PR is created, the implementation files must exist and the focused
+  tests/ABI fixtures below must provide fresh evidence for every deferred row.
   Inspect the exact diff for blocking calls in `submit`/Flow callbacks, unbounded
   queue/retry, scheduler ownership leaks, virtual-thread monitor pinning, coroutine
   cancellation swallowing, duplicate late completion, response-body/secret logging,

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -840,7 +840,9 @@
   비감소를 exact assertion한다. final snapshot이 close-entry보다 작은 음수 delta fixture는
   한 cumulative field만 음수이고 다른 field는 양수인 표를 사용한다. 모든 field delta를
   immutable temporary value로 검증한 뒤 하나라도 음수면 어떤 양수 field도 적용하지 않고
-  close-entry base를 유지하는지, `sourceDegraded` 진단과 terminal gauge fallback을 기록하는지,
+  close-entry base를 유지하는지, 공통 `markSourceDegraded` 경로로
+  `sourceDegraded`와 `leader.audit.export.meter-source-degraded` fixed warning을 해당
+  generation에서 한 번 기록하는지, terminal gauge fallback을 기록하는지,
   `close()`의 예외 identity와 primary/suppressed 순서를 보존하는지, inner `finally`가 provider를
   clear해 DETACHED로 복구하는지를 함께 검증한다.
   동일 registry에 대한 두 constructor를 barrier에서 동시에 시작해 store manager가 하나만
@@ -865,8 +867,10 @@
   degraded DETACHED 뒤 동일 registry에서 stable meter claim을 재사용하는 replacement fixture는
   새 generation의 `sourceDegraded=false`, 이전 warning 재생 없음, 누적 offset·meter identity
   보존을 exact assertion한다. replacement generation에서 다시 final snapshot/invariant 실패를
-  주입하면 해당 generation에만 fixed warning이 한 번 기록되는지도 검증한다. compromised
-  registry는 generation reset 대상이 아니며 계속 거부되어야 한다.
+  주입하면 해당 generation에만 fixed warning이 한 번 기록되는지도 검증한다. 첫 generation의
+  negative delta warning count 1과 replacement generation 재실패 warning count 1이 manager
+  lifetime 누적 count 2가 되는지 확인한다. compromised registry는 generation reset 대상이
+  아니며 계속 거부되어야 한다.
   constructor 실패는 delegate를 정확히 한 번 close하고 primary exception을 보존하며,
   delegate close/partial-registration cleanup 예외는 primary에 suppressed로 붙이고,
   primary가 없을 때만 cleanup 예외를 던지는지 검증한다. manager-owned partial registration만
@@ -913,10 +917,12 @@
   `finally`에서 같은 generation의 final snapshot에 대해 모든 cumulative field의 delta를
   immutable temporary value로 계산하고 모든 `final >= close-entry` invariant를 먼저 검증한다.
   하나라도 음수면 어떤 양수 field도 적용하지 않고 close-entry `closingOffsets`를 유지하며
-  `sourceDegraded`와 diagnostic failure를 기록한다. 정상 final snapshot에서만
+  공통 `markSourceDegraded` 경로로 `sourceDegraded`와 fixed warning
+  `leader.audit.export.meter-source-degraded`를 해당 generation에서 한 번 기록한다. 정상 final snapshot에서만
   `final - close-entry` delta를 정확히 한 번 적용한다. gauge는 final snapshot을 사용하고,
   final snapshot 자체가 실패하면 cumulative counter만 close-entry 기반 view로 유지하며
-  `sourceDegraded=true`, fixed warning `leader.audit.export.meter-source-degraded`, 그리고
+  동일한 `markSourceDegraded` 경로로 `sourceDegraded=true`, fixed warning
+  `leader.audit.export.meter-source-degraded`, 그리고
   `queue=0`, `inFlight=0`, `scheduledRetries=0`, `admitted=0`, `diagnosticsClosed=true`,
   `closed=true`인 terminal fallback gauge를 합성한다. 이 비정상 경로에서는 close-entry 이후
   cancellation/rejection 정확성을 보장하지 않는다. provider 제거와 terminal DETACHED
@@ -966,11 +972,13 @@
   generation의 final snapshot에 대해 모든 cumulative field의 delta를 immutable temporary
   value로 계산하고 모든 `final >= close-entry` invariant를 먼저 검증한다. 하나라도 음수면
   어떤 양수 field도 적용하지 않고 close-entry 기반 `closingOffsets`를 유지하며
-  `sourceDegraded`와 diagnostic failure를 기록한다. 정상 final snapshot에서만
+  공통 `markSourceDegraded` 경로로 `sourceDegraded`와 fixed warning
+  `leader.audit.export.meter-source-degraded`를 해당 generation에서 한 번 기록한다. 정상 final snapshot에서만
   `final - close-entry` delta를 정확히 한 번 `closingOffsets`에 반영한다. gauge는 final
   snapshot 값을 사용하고, final snapshot 자체가 실패하면 cumulative counter만 close-entry
-  기반 `closingOffsets`로 유지하며 `sourceDegraded=true`, fixed warning
-  `leader.audit.export.meter-source-degraded`, 그리고 `queue=0`, `inFlight=0`,
+  기반 `closingOffsets`로 유지하며 동일한 `markSourceDegraded` 경로로
+  `sourceDegraded=true`, fixed warning `leader.audit.export.meter-source-degraded`, 그리고
+  `queue=0`, `inFlight=0`,
   `scheduledRetries=0`, `admitted=0`, `diagnosticsClosed=true`, `closed=true`인 terminal
   fallback gauge를 합성한다. 이 비정상 경로에서는 close-entry 이후 cancellation/rejection
   정확성을 보장하지 않는다. provider clear와 terminal `DETACHED` publication은 사용자

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -568,7 +568,13 @@
   in-flight reservation을 delivery 전에 획득하고 completion/timeout/close에서 정확히
   반환해 `inFlight <= maxInFlight`를 유지한다. close 이후 scheduling critical section과
   worker admission이 quiesce된 것을 확인하고 반환하며, network drain은 기다리지 않지만
-  close 반환 후 exporter가 executor/scheduler에 새 execute/schedule을 호출하지 않는다.
+  close 반환 후 exporter가 executor/scheduler에 새 execute/schedule handoff를 만들지
+  않는다. worker handoff는 `IDLE → CLAIMED → EXECUTING` 상태로 선형화하며,
+  `CLAIMED → EXECUTING`이 executor 호출의 선형화 지점이다. close는 `CLAIMED`를
+  `CLOSED`로 취소할 수 있고 이미 `EXECUTING`인 handoff는 caller-owned executor나
+  delivery를 기다리지 않고 close와 교차할 수 있다. 따라서 close 반환 이후 금지되는
+  것은 `CLOSED` 이후의 새 handoff이며, 이미 선형화된 `EXECUTING` 호출의 물리적
+  continuation을 close가 join하지 않는다는 의미를 고정한다.
   injected executor/scheduler는 exporter가 shutdown하지 않으며 ownership을 caller에게
   문서화한다.
 

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -71,6 +71,25 @@
   }
 
   @Test
+  fun `utf8 bounds and attribute aggregate limits are deterministic`() {
+      val event = historyWithMultibyteAndOversizedAttributes()
+      ((event.errorMessage?.toByteArray(Charsets.UTF_8)?.size ?: 0)
+          <= LeaderAuditExportEvent.MAX_ERROR_MESSAGE_BYTES).shouldBeTrue()
+      ((event.errorType?.toByteArray(Charsets.UTF_8)?.size ?: 0)
+          <= LeaderAuditExportEvent.MAX_ERROR_TYPE_BYTES).shouldBeTrue()
+      (event.attributes.size <= LeaderAuditExportEvent.MAX_ATTRIBUTES).shouldBeTrue()
+      event.attributes.keys.all {
+          it.toByteArray(Charsets.UTF_8).size <= LeaderAuditExportEvent.MAX_ATTRIBUTE_KEY_BYTES
+      }.shouldBeTrue()
+      event.attributes.values.all {
+          it.toByteArray(Charsets.UTF_8).size <= LeaderAuditExportEvent.MAX_ATTRIBUTE_VALUE_BYTES
+      }.shouldBeTrue()
+      event.attributes.entries.sumOf { (key, value) ->
+          key.toByteArray(Charsets.UTF_8).size + value.toByteArray(Charsets.UTF_8).size
+      }.let { (it <= LeaderAuditExportEvent.MAX_ATTRIBUTES_TOTAL_BYTES).shouldBeTrue() }
+  }
+
+  @Test
   fun `event and attributes are immutable snapshots without public copy mutation`() {
       val source = mutableMapOf("key" to "value")
       val event = LeaderAuditExportEvent.Lifecycle.from(
@@ -88,15 +107,15 @@
   }
 
   @Test
-  fun `hash truncate and raw modes enforce field allow list and max length`() {
+  fun `hash truncate and raw modes enforce field allow list and max bytes`() {
       LeaderAuditValueSanitizer.Hash.sanitize(LeaderAuditField.LOCK_NAME, SECRET_SENTINEL)
           .shouldNotBeEqualTo(SECRET_SENTINEL)
-      LeaderAuditValueSanitizer.Truncate(maxLength = 8)
+      LeaderAuditValueSanitizer.Truncate(maxBytes = 8)
           .sanitize(LeaderAuditField.ERROR_TYPE, SECRET_SENTINEL)
-          .length.shouldBeEqualTo(8)
+          .toByteArray(Charsets.UTF_8).size.shouldBeEqualTo(8)
       val raw = LeaderAuditValueSanitizer.Raw(
           allowList = setOf(LeaderAuditField.KIND),
-          maxLength = 16,
+          maxBytes = 16,
       )
       raw.sanitize(LeaderAuditField.KIND, "ACQUIRED").shouldBeEqualTo("ACQUIRED")
       assertFailsWith<IllegalArgumentException> {
@@ -154,9 +173,14 @@
   }
   ```
 
+  `LeaderAuditExportEvent`와 sanitizer는 `MAX_ERROR_MESSAGE_BYTES=4096`,
+  `MAX_ERROR_TYPE_BYTES=128`, `MAX_TEXT_FIELD_BYTES=256`, `MAX_ATTRIBUTES=32`,
+  `MAX_ATTRIBUTE_KEY_BYTES=128`, `MAX_ATTRIBUTE_VALUE_BYTES=512`,
+  `MAX_ATTRIBUTES_TOTAL_BYTES=8192`를 public constant로 고정한다. UTF-8 code point
+  경계 truncate, attribute 정렬·collision·aggregate drop 정책은 spec과 동일해야 한다.
   `LeaderAuditValueSanitizer`는 임의 lambda가 아니라 `Default`, `Hash`, `Truncate`,
   `Raw` 정책으로 제한한다. `Raw`는 사전에 허용된 비민감 enum field subset과 양의
-  최대 길이를 생성 시 검증하고, 모든 정책은 공통 byte/key limits를 적용한다. event
+  `maxBytes`를 생성 시 검증하고, 모든 정책은 공통 byte/key limits를 적용한다. event
   `toString()`과 encoder fixture에는 secret sentinel이 없어야 한다. 모든 map은
   defensive copy 후 `Collections.unmodifiableMap(LinkedHashMap(...))` 또는 동등한
   실제 immutable runtime map으로 노출한다. Java fixture에서 `getAttributes().put`이
@@ -619,15 +643,23 @@
 
   | Type | Exact public surface |
   |---|---|
+  | `LeaderAuditExportEvent` | sealed event boundary plus `Companion` public UTF-8 `const val` bounds `MAX_ERROR_MESSAGE_BYTES=4096`, `MAX_ERROR_TYPE_BYTES=128`, `MAX_TEXT_FIELD_BYTES=256`, `MAX_ATTRIBUTES=32`, `MAX_ATTRIBUTE_KEY_BYTES=128`, `MAX_ATTRIBUTE_VALUE_BYTES=512`, `MAX_ATTRIBUTES_TOTAL_BYTES=8192`; Java reads the exact `LeaderAuditExportEvent.Companion` fields |
+  | `LeaderAuditExportEvent.History` | `from(LeaderLockHistoryRecord, LeaderAuditValueSanitizer): History`; private constructor; no `token`/`LeaderLease` field |
+  | `LeaderAuditExportEvent.Lifecycle` | `from(LeaderElectionEvent, Map<String,String>, LeaderAuditValueSanitizer): Lifecycle`; private constructor; no `LeaderLease` field |
+  | `LeaderAuditLifecycleOutcome` | enum values `ELECTED`, `REVOKED`, `SKIPPED` only |
+  | `LeaderAuditField` | enum values `LOCK_NAME`, `KIND`, `NODE_ID`, `LEADER_ID`, `ERROR_TYPE`, `ERROR_MESSAGE`, `ATTRIBUTE_KEY`, `ATTRIBUTE_VALUE` only |
+  | `LeaderAuditValueSanitizer` | `sanitize(LeaderAuditField, String): String`; `Default`/`Hash` objects, `Truncate(maxBytes:Int)`, `Raw(allowList:Set<LeaderAuditField>, maxBytes:Int)`; no arbitrary lambda factory |
   | `LeaderAuditExporter` | `submit(LeaderAuditExportEvent): LeaderAuditSubmitResult`, `observe(LeaderAuditExportObserver): AutoCloseable`, `snapshot(): LeaderAuditExportSnapshot`, `close(): Unit` |
   | `LeaderAuditExportOptions` | `queueCapacity:Int`, `maxInFlight:Int`, `maxAttempts:Int`, `attemptTimeout:java.time.Duration`, `initialBackoff:java.time.Duration`, `maxBackoff:java.time.Duration`, `executor:Executor`, `scheduler:ScheduledExecutorService`; Java-visible 8-argument constructor, no implicit shared executor |
   | `LeaderAuditDelivery` | `deliver(LeaderAuditExportEvent): CompletableFuture<LeaderAuditDeliveryResult>` |
   | `LeaderAuditExportObserver` | `onObservation(LeaderAuditExportObservation): Unit` with finite enum only |
-  | `LeaderAuditExportSnapshot` | immutable `queued`, `inFlight`, `scheduledRetries`, `admitted`, outcome counters, `observerDrops`, `observerRegistrationDrops`, `diagnosticsFatalErrors`, `diagnosticsClosed`, `closed`; no dynamic identifiers |
+  | `LeaderAuditExportSnapshot` | immutable `queued:Int`, `inFlight:Int`, `scheduledRetries:Int`, `admitted:Int`, `accepted:Long`, `droppedQueueFull:Long`, `droppedClosed:Long`, `retries:Long`, `terminalFailures:Long`, `cancellations:Long`, `executorRejections:Long`, `schedulerRejections:Long`, `observerDrops:Long`, `observerRegistrationDrops:Long`, `diagnosticsFatalErrors:Long`, `diagnosticsClosed:Boolean`, `closed:Boolean`; no dynamic identifiers |
   | `LeaderAuditHttpPayload` | `of(String, byte[])`, `contentType`, `body(): byte[]`; constructor/body defensively copy |
+  | `LeaderAuditPayloadEncoder` | `encode(LeaderAuditExportEvent): LeaderAuditHttpPayload` single abstract method |
   | `LeaderAuditTrustedHttpsEndpoint` | `trusted(URI): LeaderAuditTrustedHttpsEndpoint`, `uri:URI`; caller-owned explicit trust boundary |
   | `HttpLeaderAuditExporter` | `(HttpClient, LeaderAuditTrustedHttpsEndpoint, Map<String,String>, LeaderAuditPayloadEncoder, LeaderAuditExportOptions, LeaderAuditHttpOptions)` plus `submit/observe/snapshot/close` |
   | `LeaderAuditHttpOptions` | 1-argument constructor `(maxPayloadBytes:Int)`, `defaults(): LeaderAuditHttpOptions`, `maxPayloadBytes:Int`; production HTTPS-only, no public scheme/loopback bypass |
+  | `MicrometerLeaderAuditExporter` | `(LeaderAuditExporter, MeterRegistry)` plus `submit/observe/snapshot/close`; fixed 13-meter registry-scoped manager; foreign/unsupported registry fails fast |
 
   Kotlin default arguments must not be the only construction path: the Java fixture
   constructs options and HTTP exporter explicitly, calls `submit`, and uses
@@ -644,7 +676,13 @@
   `close`를 호출하고 decorator의 `snapshot()` delegation도 compile/run으로 고정한다.
   reflection으로 위 public constructor/method set과 JVM descriptor를 확인하고, event
   public field에 `token`이나 `LeaderLease`가 없는지 고정한다. `close()` idempotence와
-  `submit` return type을 JVM descriptor로 확인한다.
+  `submit` return type을 JVM descriptor로 확인한다. Micrometer Java fixture는
+  `(LeaderAuditExporter, MeterRegistry)` constructor와 delegated methods, fixed 13-meter
+  ID/type/tag set, duplicate/foreign/unsupported registry failure를 compile/run으로
+  고정한다. `@JvmSynthetic internal LeaderAuditExportSnapshot.Companion.create`는
+  유일하게 허용된 synthetic surface로 allow-list하고, 그 밖의 public synthetic overload는
+  거부한다. sanitizer enum/constructor와 event factory descriptor도 Java reflection 및
+  immutable-map fixture로 확인한다.
 
 - [ ] **Step 2: Run contract test and verify RED**
 
@@ -697,25 +735,31 @@
   event fixture를 하나의 aggregate delegate로 제출해 합계가 중복·오표시되지 않고, 같은
   registry의 두 wrapper는 duplicate ID로 fail-fast하는지 검증한다. 고유 lockName, leaderId,
   endpoint, error message를 대량 제출해도 meter 수가 증가하지 않고 해당 값이 tag에 없는지
-  assertion한다.
+  assertion한다. fixed ID 표는 spec의 13개 항목과 byte-for-byte로 맞추고, `accepted` 1개,
+  `dropped` 2개(`queue_full`, `closed`), `retries`/`failures`/`cancelled`/`rejections` 각
+  1개, queue/in-flight/diagnostics gauge 3개, observer/registration diagnostics 3개를
+  합쳐 총 13개 ID임을 assertion한다. 각 ID의 meter type, exact tag set, snapshot field도
+  reflection/registry read-back으로 고정한다.
   gauge 구현은 exporter `snapshot()`의 O(1) atomic counter를 읽고 queue를 순회하지
   않으며, snapshot object는 submit hot path에서 생성하지 않는다는 source/contract
   assertion을 추가한다. wrapper close twice에서 delegate close idempotence와
   snapshot-backed cancellation/rejection metric parity를 검증하고, wrapper close가
   exporter close contract를 그대로 보존하는지 확인한다. `TrackingMeterRegistry`와
-  internal registry-identity manager test seam으로 등록 claim, exact `Meter` identity,
-  foreign-registration crossing을 기록한다. manager가 설치 callback/lookup/registrar
-  반환 identity를 모두 확인하고 foreign 또는 ambiguous ID를 소유하지 않는지 검증한다.
-  wrapper `close()` 두 번 후 exact-owned meter만 제거되고 foreign/replaced meter는
-  건드리지 않으며 첫 removal 실패 뒤에도 나머지 ID를 시도하고 fixed warning key
-  `leader.audit.export.meter-removal-failure`와 ID별 one-per-close `residueCount`를
-  남기는지 확인한다. residue claim을 유지한 상태에서 replacement constructor가 removal을
-  재시도하고 성공 후에만 새 wrapper를 허용하는 recovery 경로도 검증한다. 같은 registry에서 close 후 새 delegate wrapper를 만들면 새 snapshot
-  source를 읽고, active duplicate wrapper는 기존 ID/source를 재사용하지 않고 fail-fast하며
-  부분 등록도 정리하는지 검증한다. constructor 실패는 delegate를 정확히 한 번 close하고
-  foreign meter를 보존하는지 assertion한다. 모든 reachability 주장은 `WeakReference`/GC에
-  의존하지 않고 registry의 등록·제거·residue 기록과 새 snapshot 값으로 결정적으로
-  확인한다.
+  internal registry-identity manager test seam으로 stable `Meter.Id` 집합, exact meter
+  identity, active provider/offset 전환, foreign-registration crossing을 기록한다.
+  fixed ID별 `name/type/tags/snapshot field` 표와 총 meter 수를 고정하고, 각 metric의
+  `outcome` tag 매핑과 무태그 gauge/diagnostics를 assertion한다. 외부 foreign registration
+  crossing은 manager가 ownership conflict warning을 한 번 기록하고 compromised state로
+  잠기며 foreign meter를 제거하지 않는지 검증한다. 동일 registry close→replacement는
+  stable meter identity를 재사용하면서 새 delegate snapshot source를 읽고 cumulative
+  counter가 감소하지 않는지, active duplicate wrapper는 fail-fast하는지 확인한다.
+  constructor 실패는 delegate를 정확히 한 번 close하고 primary exception을 보존하며,
+  delegate close/partial-registration cleanup 예외는 primary에 suppressed로 붙이고,
+  primary가 없을 때만 cleanup 예외를 던지는지 검증한다. manager-owned partial registration만
+  다음 acquire에서 이어서 완성하는지 확인한다.
+  manager source/offset이 closed delegate를 retain하지 않는다는 사실은 registry의
+  provider-detach 기록과 새 snapshot 값으로 결정적으로 확인하며 `WeakReference`/GC에
+  의존하지 않는다.
 
 - [ ] **Step 2: Run Micrometer test and verify RED**
 
@@ -729,27 +773,34 @@
   `MicrometerLeaderAuditExporter(delegate, registry)`는 전체 meter 등록이 성공하면
   delegate를 소유하는 `LeaderAuditExporter` decorator로 구현한다. construction failure는
   delegate를 정확히 한 번 닫고 원래 예외를 보존한다. metric의 authoritative source는
-  `delegate.snapshot()`의 O(1) atomic counter이며, `FunctionCounter`/`Gauge`가 registry
-  polling 시 snapshot을 읽는다. 따라서 async diagnostics observer callback이 close 직후
-  drop되어도 close-owned cancellation/rejection이 metric에서 사라지지 않는다.
-  내부 registry-identity manager가 fixed ID claim과 설치 identity를 관리한다. manager는
-  claim token/lock으로 wrapper 간 중복을 막고, preflight에서 foreign ID를 확인하며,
-  registrar 반환 meter·registry lookup·등록 callback이 동일한 `Meter` identity인지 검증한다.
-  외부 registration crossing으로 identity가 foreign/ambiguous가 되면 fail-fast하고
-  unproven meter를 절대로 remove하지 않는다. 표준 registry가 설치 identity를 증명하지
-  못하면 unsupported registry로 거부한다. 모든 meter 등록이 성공한 뒤에만 delegate
-  ownership을 확정하고, constructor 실패 시 delegate를 정확히 한 번 닫고 원래 예외를
-  보존하며 partial exact-owned meter만 정리한다. 성공한 등록의 exact `Meter`/`Meter.Id`
-  목록은 wrapper가 소유한다. `close()`는 delegate를 idempotently 닫은 뒤 `finally`에서
-  현재 lookup이 exact identity인 ID만 `registry.remove(id)`를 시도하고, removal 실패나
-  foreign replacement에도 나머지 ID 제거를 계속한다. removal residue는 fixed warning key
-  `leader.audit.export.meter-removal-failure`, ID별 one-per-close warning, O(1)
-  `residueCount`로 보고하고 manager claim을 유지한다. 다음 constructor는 residue 제거를
-  먼저 재시도하며 성공 전에는 replacement를 fail-fast한다. caller admission/election에는
-  registry 오류를 전파하지 않는다. 따라서 closed delegate strong-reference 제거는
-  성공적으로 제거된 meter에 대해서만 주장한다. non-owning observation은 wrapper가 아니라 public
-  `observe()` handle을 별도로 사용하며 decorator는 내부 observer handle을 등록하거나
-  소유하지 않는다. delegate의 `snapshot()` descriptor와 값은 그대로 전달한다.
+  manager가 보유한 active provider의 `delegate.snapshot()` O(1) atomic counter와 detached
+  offset이며, `FunctionCounter`/`Gauge`가 registry polling 시 manager state를 읽는다. 따라서
+  async diagnostics observer callback이 close 직후 drop되어도 close-owned
+  cancellation/rejection이 metric에서 사라지지 않는다.
+  내부 registry-identity manager가 fixed ID claim과 stable meter 집합을 관리한다. manager는
+  claim token/lock, `activeProvider`, detached `lastSnapshot`, cumulative counter offset을
+  보유하며 `FunctionCounter`/`Gauge` callback은 manager state만 캡처한다. provider만
+  delegate를 참조하고 close에서 clear되므로 registry meter가 closed delegate를 retain하지
+  않는다. 첫 acquire는 fixed `name/type/tags/snapshot field` 표를 preflight하고 foreign
+  ID 또는 설치 identity를 증명할 수 없는 registry를 fail-fast한다. 외부 registration
+  crossing으로 identity가 foreign/ambiguous가 되면 fixed warning key
+  `leader.audit.export.meter-ownership-conflict`를 ID별 한 번 기록하고 manager state를
+  compromised로 잠근다. manager는 foreign meter를 절대로 remove하지 않으며, 수동으로
+  fixed ID를 정리하거나 registry를 교체하기 전까지 새 wrapper를 허용하지 않는다.
+  전체 stable meter 등록이 성공한 뒤에만 delegate ownership을 확정하고, constructor
+  실패 시 delegate를 정확히 한 번 닫고 primary exception을 보존한다. close/partial cleanup
+  예외는 primary에 suppressed로 추가하며 primary가 없을 때만 cleanup 예외를 던진다.
+  manager-owned
+  partial registration은 state에 남아 다음 acquire에서 누락 ID만 이어서 등록하며
+  foreign ID는 건드리지 않는다. active duplicate wrapper는 fail-fast한다.
+  `close()`는 delegate를 idempotently 닫고 마지막 snapshot을 offset에 반영한 뒤
+  `activeProvider`를 clear한다. `registry.remove`를 호출하지 않으므로 lookup/remove
+  TOCTOU와 removal residue가 없고, stable meter identity는 replacement에서 재사용된다.
+  detached state의 counter는 offset을 포함해 monotonic하게 유지하고 queue/in-flight/
+  diagnostics closed gauge는 active provider 또는 detached closed snapshot을 읽는다.
+  non-owning observation은 wrapper가 아니라 public `observe()` handle을 별도로 사용하며
+  decorator는 내부 observer handle을 등록하거나 소유하지 않는다. delegate의 `snapshot()`
+  descriptor와 값은 그대로 전달한다.
   metric names는 `leader.audit.export.accepted`, `leader.audit.export.dropped`,
   `leader.audit.export.retries`, `leader.audit.export.failures`,
   `leader.audit.export.queue.depth`, `leader.audit.export.in.flight`,
@@ -759,12 +810,13 @@
   `leader.audit.export.diagnostics.failures`,
   `leader.audit.export.diagnostics.closed`로 고정한다. 각 cumulative counter는
   snapshot-backed `FunctionCounter`로 등록하고, queue/in-flight/diagnostics closed는
-  snapshot-backed `Gauge`로 등록한다. `observerDrops`,
-  `observerRegistrationDrops`, `diagnosticsFatalErrors`는 wrapper가 open인 동안 snapshot과
-  각 counter에서 같은 누적값을 보이며 exporter close가 delegate counter를 reset하지는
-  않는다. close 후에는 wrapper가 소유한 모든 meter가 registry에서 제거되어 stale source를
-  노출하지 않는다. `diagnosticsClosed`는 open 동안 `diagnostics.closed` gauge의 `0|1` 값과
-  일치한다.
+  snapshot-backed `Gauge`로 등록한다. `droppedQueueFull`, `droppedClosed`, `cancellations`,
+  `executorRejections`, `schedulerRejections`, `observerDrops`, `observerRegistrationDrops`,
+  `diagnosticsFatalErrors`는 manager offset과 active snapshot의
+  합으로 읽히며 close 후에도 stable meter에서 monotonic 값을 유지한다. `diagnosticsClosed`는
+  active provider가 없을 때 `1`, active provider가 open일 때 `0|1` gauge의 snapshot 값과
+  일치한다. stable meter는 registry에 남지만 delegate/provider strong-reference는
+  close에서 제거된다.
   `outcome` tag만 위 enum allow-list로 사용하고 `source`/`transport` tag는 v1에서
   생성하지 않으며 event field는 tag로 복사하지 않는다. 기존 `HISTORY_SINK_FAILURES`
   counter는 건드리지 않는다.
@@ -779,11 +831,12 @@
     --tests 'io.bluetape4k.leader.micrometer.history.*'
   ```
 
-  close idempotence, exact-owned `Meter.Id` removal, foreign/replaced meter 보존, first
-  removal failure 뒤 나머지 시도와 residue report, same-registry replacement의 fresh
-  snapshot source, duplicate wrapper fail-fast/partial cleanup, constructor 실패 시
-  delegate close, 그리고 direct delegate와 wrapper의 closed admission parity가 모두
-  PASS해야 한다.
+  stable fixed `Meter.Id`/type/tag/snapshot-field set, manager source detach와
+  close→replacement identity reuse, cumulative counter offset monotonicity, foreign
+  registration conflict warning/compromised recovery, duplicate wrapper fail-fast,
+  partial manager-owned registration continuation, constructor 실패 시 delegate close와
+  primary/suppressed exception policy, 그리고 direct delegate와 wrapper의 closed admission
+  parity가 모두 PASS해야 한다.
 
 - [ ] **Step 5: Update both README locales and commit AUD-02**
 
@@ -795,7 +848,7 @@
   git add leader-micrometer/src/main leader-micrometer/src/test \
     leader-micrometer/README.md leader-micrometer/README.ko.md
   git diff --check
-  git commit -m $'OBS-03 Micrometer aggregate metric과 residue recovery를 추가한다\n\nConstraint: v1 snapshot은 aggregate counter만 제공하므로 outcome 외 source/transport 차원을 만들지 않는다.\nRejected: 계산할 수 없는 source/transport tag | mixed event를 중복·오표시함\nConfidence: high\nScope-risk: moderate\nDirective: meter removal residue는 fixed warning key와 retry 가능한 manager claim으로 추적한다.\nTested: focused and existing Micrometer history tests, README diff check\nNot-tested: HTTP delivery는 AUD-03에서 검증한다.'
+  git commit -m $'OBS-03 Micrometer aggregate metric과 stable registry source를 추가한다\n\nConstraint: v1 snapshot은 aggregate counter만 제공하므로 outcome 외 source/transport 차원을 만들지 않는다.\nRejected: 계산할 수 없는 source/transport tag와 close 시 meter 제거 | mixed event 오표시와 foreign replacement race\nConfidence: high\nScope-risk: moderate\nDirective: registry-scoped manager가 stable meter와 active provider를 소유하고 close에서 delegate source를 detach한다.\nTested: focused and existing Micrometer history tests, README diff check\nNot-tested: HTTP delivery는 AUD-03에서 검증한다.'
   ```
 
 ## Task 6: JDK HTTP/webhook delivery와 bounded retry
@@ -968,8 +1021,12 @@
   default redaction, queue drop와 close semantics를 짧은 예제로 설명한다. exporter의
   `ACCEPTED != delivered`, duplicate/reordering/process-shutdown loss와 receiver
   idempotency, `exporter.close()` 후 caller-owned scheduler/executor 종료 순서를
-  함께 고정한다. Micrometer README에는 metric catalog, queue/in-flight/rejection
-  diagnostics와 no raw/high-cardinality tag 규칙을 추가한다. top-level README
+  함께 고정한다. Micrometer README에는 metric catalog, fixed 13-meter ID set,
+  queue/in-flight/rejection diagnostics와 no raw/high-cardinality tag 규칙을 추가한다.
+  stable registry meter는 close 후 source만 detach되고 replacement에서 identity를
+  재사용한다는 점, duplicate/foreign fixed-ID 충돌 시
+  `leader.audit.export.meter-ownership-conflict` 경고와 registry 교체·수동 fixed-ID
+  정리 절차를 함께 문서화한다. top-level README
   capability matrix와 event stream 설명에는 HTTP/webhook adapter와 JSONL/OpenTelemetry
   후속 범위를 반영한다.
 
@@ -1013,7 +1070,16 @@
   ```bash
   set -euo pipefail
   scan_paths=()
-  for path in docs/manual/drafts README.md README.ko.md leader-core/README.md \
+  if [[ -d docs/manual/drafts ]]; then
+    while IFS= read -r -d '' path; do
+      [[ -f "$path" && -r "$path" ]] || { echo "unreadable scan path: $path" >&2; exit 2; }
+      scan_paths+=("$path")
+    done < <(find docs/manual/drafts -maxdepth 1 -type f -name '*.md' -print0)
+  elif [[ -e docs/manual/drafts ]]; then
+    echo 'docs/manual/drafts exists but is not a directory' >&2
+    exit 2
+  fi
+  for path in README.md README.ko.md leader-core/README.md \
       leader-core/README.ko.md leader-micrometer/README.md leader-micrometer/README.ko.md; do
     if [[ -e "$path" ]]; then
       [[ -f "$path" && -r "$path" ]] || { echo "unreadable scan path: $path" >&2; exit 2; }

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -93,6 +93,27 @@
       event.attributes.entries.sumOf { (key, value) ->
           key.toByteArray(Charsets.UTF_8).size + value.toByteArray(Charsets.UTF_8).size
       }.let { (it <= LeaderAuditExportEvent.MAX_ATTRIBUTES_TOTAL_BYTES).shouldBeTrue() }
+
+      val oversizedText = "가".repeat(200)
+      val expectedText = "가".repeat(85) // 85 * 3 = 255 UTF-8 bytes, no partial code point
+      val bounded = historyWithTextFields(
+          lockName = oversizedText,
+          nodeId = oversizedText,
+          slotId = oversizedText,
+          sanitizer = LeaderAuditValueSanitizer.Truncate(
+              maxBytes = LeaderAuditExportEvent.MAX_TEXT_FIELD_BYTES,
+          ),
+      )
+      bounded.lockName.shouldBeEqualTo(expectedText)
+      bounded.nodeId.shouldBeEqualTo(expectedText)
+      bounded.slotId.shouldBeEqualTo(expectedText)
+      val boundedLifecycle = lifecycleWithLeaderId(
+          leaderId = oversizedText,
+          sanitizer = LeaderAuditValueSanitizer.Truncate(
+              maxBytes = LeaderAuditExportEvent.MAX_TEXT_FIELD_BYTES,
+          ),
+      )
+      boundedLifecycle.leaderId.shouldBeEqualTo(expectedText)
   }
 
   @Test
@@ -146,6 +167,32 @@
               raw.sanitize(field, SECRET_SENTINEL)
           }
       }
+  }
+
+  @Test
+  fun `raw constructor rejects invalid allow lists and byte limits`() {
+      assertFailsWith<IllegalArgumentException> {
+          LeaderAuditValueSanitizer.Raw(emptySet(), maxBytes = 16)
+      }
+      assertFailsWith<IllegalArgumentException> {
+          LeaderAuditValueSanitizer.Raw(setOf(LeaderAuditField.LOCK_NAME), maxBytes = 16)
+      }
+      assertFailsWith<IllegalArgumentException> {
+          LeaderAuditValueSanitizer.Raw(
+              setOf(LeaderAuditField.KIND, LeaderAuditField.LOCK_NAME),
+              maxBytes = 16,
+          )
+      }
+      assertFailsWith<IllegalArgumentException> {
+          LeaderAuditValueSanitizer.Raw(setOf(LeaderAuditField.KIND), maxBytes = 0)
+      }
+      assertFailsWith<IllegalArgumentException> {
+          LeaderAuditValueSanitizer.Raw(setOf(LeaderAuditField.KIND), maxBytes = -1)
+      }
+      val mutableAllowList = mutableSetOf(LeaderAuditField.KIND)
+      val copied = LeaderAuditValueSanitizer.Raw(mutableAllowList, maxBytes = 16)
+      mutableAllowList.clear()
+      copied.sanitize(LeaderAuditField.KIND, "ACQUIRED").shouldBeEqualTo("ACQUIRED")
   }
   ```
 
@@ -788,6 +835,15 @@
   replacement acquire crossing도 같은 barrier에서 확인해 detach 이전 provider가 replacement를
   지우지 않는지 고정한다. caller의 direct delegate close는 unsupported ownership violation으로
   문서화하고 fixture에서 허용 경로로 취급하지 않는다.
+  동일 registry에 대한 두 constructor를 barrier에서 동시에 시작해 store manager가 하나만
+  생성·게시되고, wrapper winner 하나와 loser delegate exact-once close만 남으며, loser 이후
+  replacement acquire가 stable meter identity를 재사용하는지 검증한다.
+  compromised manager는 동일 registry에서 수동 fixed-ID 제거 뒤에도 새 wrapper를 거부하고,
+  새 `MeterRegistry` identity에서만 replacement acquire가 성공하는지 고정한다.
+  throwing delegate close fixture는 `CLOSING` 중 발생한 close-owned cancellation을 final
+  snapshot에 보존하고 `finally`에서 `DETACHED`로 복구하는지, close 예외가 primary로 유지되고
+  final snapshot/transition 예외가 suppressed되는지, 이후 replacement acquire가 성공하는지
+  검증한다.
   constructor 실패는 delegate를 정확히 한 번 close하고 primary exception을 보존하며,
   delegate close/partial-registration cleanup 예외는 primary에 suppressed로 붙이고,
   primary가 없을 때만 cleanup 예외를 던지는지 검증한다. manager-owned partial registration만
@@ -821,13 +877,19 @@
   async diagnostics observer callback이 close 직후 drop되어도 close-owned
   cancellation/rejection이 metric에서 사라지지 않는다.
   내부 registry-identity manager가 fixed ID claim과 stable meter 집합을 관리한다. manager는
-  `ManagerState(generation, activeProvider, detachedSnapshot, offsets, lifecycle)` 하나를
+  `ManagerState(generation, activeProvider, closingProvider, detachedSnapshot, offsets, lifecycle)` 하나를
   보유하고 모든 acquire/close/provider swap과 metric callback을 동일한 lock으로
-  선형화한다. callback은 lock을 획득해 state를 한 번 읽고, active provider가 있으면 그
-  안에서 snapshot을 읽은 뒤 offset을 합산한다. close는 같은 lock에서 현재 snapshot을
-  offset과 detached state에 반영하고 provider를 제거한 `CLOSING` state를 먼저 게시한 뒤,
-  generation token이 일치할 때만 delegate close 완료를 `DETACHED`로 전환한다. 따라서
-  이전 close가 새 provider를 지울 수 없고, `CLOSING` 중 replacement acquire는 거부된다.
+  선형화한다. callback은 lock을 획득해 state를 한 번 읽고, `OPEN`의 active provider가
+  있으면 그 안에서 snapshot을 읽은 뒤 offset을 합산하며 `CLOSING`에서는 detached state만
+  읽는다. close는 같은 lock에서 close-entry snapshot과 `closingProvider`를 보존하고
+  active provider를 `CLOSING` state로 옮긴 뒤 delegate close를 실행한다. close 성공/예외의
+  `finally`에서 같은 generation의 `finalSnapshot - closeEntrySnapshot` delta만
+  `max(0, ...)`로 정확히 한 번 offset에 반영하고 provider를 clear하여 `DETACHED`로
+  전환한다. gauge는 final snapshot을 사용하므로 close-owned cancellation/rejection도
+  보존되고 close-entry counter는 중복 집계되지 않는다. final snapshot/transition 예외는
+  close 예외가 있으면 suppressed로 붙이고, 없으면 primary로 던진다. 따라서 이전 close가
+  새 provider를 지울 수 없고, `CLOSING` 중 replacement acquire는 거부되며 manager가
+  영구 `CLOSING`에 남지 않는다.
   provider만 delegate를 참조하고 state 전환 후 clear되므로 registry meter가 closed delegate를
   retain하지 않는다. wrapper가 delegate ownership을 취득한 뒤 caller가 delegate를 직접
   close하는 것은 지원하지 않으며, wrapper `close()`가 유일한 ownership lifecycle이다.
@@ -835,8 +897,10 @@
   ID 또는 설치 identity를 증명할 수 없는 registry를 fail-fast한다. 외부 registration
   crossing으로 identity가 foreign/ambiguous가 되면 fixed warning key
   `leader.audit.export.meter-ownership-conflict`를 ID별 한 번 기록하고 manager state를
-  compromised로 잠근다. manager는 foreign meter를 절대로 remove하지 않으며, 수동으로
-  fixed ID를 정리하거나 registry를 교체하기 전까지 새 wrapper를 허용하지 않는다.
+  compromised로 잠근다. manager는 foreign meter를 절대로 remove하지 않으며, fixed ID를
+  수동으로 정리해도 동일 registry의 새 wrapper를 영구 거부한다. 유일한 recovery는 새
+  `MeterRegistry` identity로 replacement를 생성하는 경로이며, 이 정책을 README/manual과
+  test에 고정한다.
   public KDoc에는 generic `MeterRegistry`가 외부 `remove`/동일 ID 재등록을 원자적으로
   관찰하지 못한다는 ownership 한계를 명시한다. caller는 wrapper 수명 동안 fixed ID를
   직접 변경하지 않아야 하며, manager가 acquire 또는 metric read에서 crossing을 관찰한
@@ -849,14 +913,21 @@
   partial registration은 state에 남아 다음 acquire에서 누락 ID만 이어서 등록하며
   foreign ID는 건드리지 않는다. active duplicate wrapper는 fail-fast한다.
   registry→manager lookup은 `WeakIdentityKey<MeterRegistry>`와 `ReferenceQueue`를 사용하는
-  internal `RegistryManagerStore`로 고정한다. `acquire`/retirement마다 queue를 drain하고,
+  internal `RegistryManagerStore`로 고정한다. store 전용 단일 lock이 queue drain, identity
+  lookup, manager create/publication을 한 임계구역에서 선형화하므로 동일 registry에는
+  manager가 정확히 하나만 게시된다. `acquire`/retirement마다 queue를 drain하고,
   manager와 weak meter identity token이 registry를 강하게 역참조하지 않는지 test seam으로
   확인한다. registry shutdown callback을 요구하지 않으며 weak-key retirement가 폐기된
   Spring/test registry의 manager entry를 회수하는 수명 정책이다.
-  `close()`는 generation token으로 한 번만 현재 provider를 `CLOSING`에서 detach하고
-  delegate를 idempotently 닫은 뒤 `DETACHED` claim을 해제한다. `registry.remove`를 호출하지
-  않으므로 lookup/remove TOCTOU와 removal residue가 없고, stable meter identity는
-  replacement에서 재사용된다.
+  `close()`는 generation token으로 한 번만 현재 provider를 `CLOSING`으로 옮기고
+  close-entry snapshot과 `closingProvider`를 보존한 뒤 delegate close를 실행한다.
+  성공/예외의 `finally`에서 같은 generation의 `finalSnapshot - closeEntrySnapshot` delta만
+  정확히 한 번 offset에 반영하고 provider를 clear하여 `DETACHED` claim을 해제한다.
+  cumulative counter delta는 `max(0, final - close-entry)`로 계산하고 gauge는 final
+  snapshot 값을 사용한다. 따라서 close-entry counter를 중복 집계하지 않으면서 close-owned cancellation/rejection을
+  final snapshot에 포함한다. `snapshot()`은 delegate close 후에도 final counters를 O(1)로
+  읽을 수 있어야 한다. `registry.remove`를 호출하지 않으므로 lookup/remove TOCTOU와
+  removal residue가 없고, stable meter identity는 replacement에서 재사용된다.
   detached state의 counter는 offset을 포함해 monotonic하게 유지하고 queue/in-flight/
   diagnostics closed gauge는 active provider 또는 detached closed snapshot을 읽는다.
   non-owning observation은 wrapper가 아니라 public `observe()` handle을 별도로 사용하며
@@ -1087,8 +1158,9 @@
   queue/in-flight/rejection diagnostics와 no raw/high-cardinality tag 규칙을 추가한다.
   stable registry meter는 close 후 source만 detach되고 replacement에서 identity를
   재사용한다는 점, duplicate/foreign fixed-ID 충돌 시
-  `leader.audit.export.meter-ownership-conflict` 경고와 registry 교체·수동 fixed-ID
-  정리 절차를 함께 문서화한다. top-level README
+  `leader.audit.export.meter-ownership-conflict` 경고와 compromised registry는 수동
+  fixed-ID 제거로 재무장할 수 없고 새 `MeterRegistry` identity로만 복구한다는 절차를
+  함께 문서화한다. top-level README
   capability matrix와 event stream 설명에는 HTTP/webhook adapter와 JSONL/OpenTelemetry
   후속 범위를 반영한다.
 
@@ -1134,6 +1206,16 @@
   scan_paths=()
   scan_tmp="$(mktemp)"
   trap 'rm -f "$scan_tmp"' EXIT
+  required_drafts=(
+    docs/manual/drafts/2026-08-18-audit-export.en.md
+    docs/manual/drafts/2026-08-18-audit-export.ko.md
+  )
+  for path in "${required_drafts[@]}"; do
+    [[ -f "$path" && -r "$path" ]] || {
+      echo "required draft missing or unreadable: $path" >&2
+      exit 2
+    }
+  done
   if [[ -d docs/manual/drafts ]]; then
     if ! find docs/manual/drafts -maxdepth 1 -type f -name '*.md' -print0 >"$scan_tmp"; then
       echo 'failed to enumerate docs/manual/drafts' >&2
@@ -1187,9 +1269,11 @@
   fi
   ```
 
-  scanner fixture는 존재하지 않는 draft directory를 `find` 대상으로 주어 enumeration
-  실패가 status 2로 반환되고, `scan_paths`가 빈 배열인 채 성공하지 않는지 확인한다. 각
-  draft path의 `-f -r` 검증 실패도 동일하게 fail-closed여야 한다.
+  scanner fixture는 required EN/KO draft 파일이 없거나 읽기 불가능하면 `find` 실행 전에
+  status 2로 fail-closed하고, 기존 draft directory가 있는 fixture에서 `PATH` 앞에 controlled
+  `find` stub을 두어 enumeration failure branch도 실제로 status 2를 반환하는지 확인한다.
+  존재하지 않는 directory 자체가 native `find`에서 어떤 status를 반환하는지는 가정하지
+  않는다. 각 draft path의 `-f -r` 검증 실패와 `scan_paths` 빈 배열도 성공으로 취급하지 않는다.
 
   gitleaks가 설치되어 있으면 추가로 repository root에서
   `gitleaks dir --no-banner --redact .`를 실행하되, 위의 명시적 파일 집합 scanner를

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -6,7 +6,7 @@
 
 **Architecture:** core는 token을 제외한 immutable `LeaderAuditExportEvent`, redaction policy, non-blocking bounded admission, retryable one-shot delivery와 lifecycle을 소유한다. History sink와 `LeaderElectionEventPublisher`는 core exporter bridge를 사용하고, HTTP는 JDK `HttpClient.sendAsync`를 주입된 payload encoder와 결합한다. Micrometer는 exporter를 decorator하여 low-cardinality outcome metric만 추가한다.
 
-**Tech Stack:** Kotlin, JDK 25 `java.net.http.HttpClient`, `CompletableFuture`/`CompletionStage`, `ScheduledExecutorService`, kotlinx.coroutines Flow, Micrometer, JUnit 5, Bluetape assertions, MockK where existing patterns require it.
+**Tech Stack:** Kotlin, JDK 25 `java.net.http.HttpClient`, cancellation-capable `CompletableFuture`, `ScheduledExecutorService`, kotlinx.coroutines Flow, Micrometer, JUnit 5, Bluetape assertions, MockK where existing patterns require it.
 
 ---
 
@@ -59,11 +59,45 @@
   }
 
   @Test
-  fun `custom sanitizer can hash or truncate allow-listed values`() {
-      val sanitizer = LeaderAuditValueSanitizer { _, value -> value.take(8) }
+  fun `default policy removes sentinel from every sensitive event field and string form`() {
+      val event = LeaderAuditExportEvent.History.from(
+          record = recordWithSentinelInEveryField(),
+          sanitizer = LeaderAuditValueSanitizer.Default,
+      )
 
-      sanitizer.sanitize(LeaderAuditField.LOCK_NAME, "static-job")
-          .shouldBeEqualTo("static-j")
+      event.toString().contains(SECRET_SENTINEL).shouldBeFalse()
+      event.attributes.values.any { it.contains(SECRET_SENTINEL) }.shouldBeFalse()
+      event.errorMessage?.contains(SECRET_SENTINEL).shouldBeFalse()
+  }
+
+  @Test
+  fun `event and attributes are immutable snapshots without public copy mutation`() {
+      val source = mutableMapOf("key" to "value")
+      val event = LeaderAuditExportEvent.Lifecycle.from(
+          event = electedEvent(),
+          attributes = source,
+          sanitizer = LeaderAuditValueSanitizer.Default,
+      )
+      source["key"] = "changed"
+      event.attributes["key"].shouldBeEqualTo("value")
+      event::class.memberFunctions.none { it.name == "copy" }.shouldBeTrue()
+  }
+
+  @Test
+  fun `hash truncate and raw modes enforce field allow list and max length`() {
+      LeaderAuditValueSanitizer.Hash.sanitize(LeaderAuditField.LOCK_NAME, SECRET_SENTINEL)
+          .shouldNotBeEqualTo(SECRET_SENTINEL)
+      LeaderAuditValueSanitizer.Truncate(maxLength = 8)
+          .sanitize(LeaderAuditField.ERROR_TYPE, SECRET_SENTINEL)
+          .length.shouldBeEqualTo(8)
+      val raw = LeaderAuditValueSanitizer.Raw(
+          allowList = setOf(LeaderAuditField.KIND),
+          maxLength = 16,
+      )
+      raw.sanitize(LeaderAuditField.KIND, "ACQUIRED").shouldBeEqualTo("ACQUIRED")
+      assertFailsWith<IllegalArgumentException> {
+          raw.sanitize(LeaderAuditField.LOCK_NAME, SECRET_SENTINEL)
+      }
   }
   ```
 
@@ -80,19 +114,19 @@
 
 - [ ] **Step 3: Implement the minimum event contract**
 
-  `LeaderAuditExportEvent`는 `Serializable` sealed interface로 만들고 `History`와
+  `LeaderAuditExportEvent`는 sealed interface로 만들고 `History`와
   `Lifecycle` data class를 제공한다. token과 `LeaderLease` 객체는 field에 넣지
   않는다. `History.from(record, sanitizer)`는 기존 `sanitize(record)` 결과를
   사용하고 `Lifecycle.from(event, sanitizer)`는 `LeaderElectionEvent`의
   `lockName`, outcome, expiry만 매핑한다.
 
   ```kotlin
-  sealed interface LeaderAuditExportEvent : Serializable {
+  sealed interface LeaderAuditExportEvent {
       val occurredAt: Instant
       val lockName: String
       val attributes: Map<String, String>
 
-      data class History private constructor(
+      class History private constructor(
           override val occurredAt: Instant,
           override val lockName: String,
           val kind: LockIdentity.AnnotationKind?,
@@ -105,7 +139,7 @@
           override val attributes: Map<String, String>,
       ) : LeaderAuditExportEvent
 
-      data class Lifecycle private constructor(
+      class Lifecycle private constructor(
           override val occurredAt: Instant,
           override val lockName: String,
           val outcome: LeaderAuditLifecycleOutcome,
@@ -116,14 +150,16 @@
   }
   ```
 
-  `LeaderAuditValueSanitizer.Default`는 민감 field를 `redacted`로 바꾸고,
-  metadata/error는 기존 core byte/key limits를 재사용한다. 모든 map은 defensive
-  copy하고, public KDoc는 Korean technical register로 작성한다.
+  `LeaderAuditValueSanitizer`는 임의 lambda가 아니라 `Default`, `Hash`, `Truncate`,
+  `Raw` 정책으로 제한한다. `Raw`는 사전에 허용된 비민감 enum field subset과 양의
+  최대 길이를 생성 시 검증하고, 모든 정책은 공통 byte/key limits를 적용한다. event
+  `toString()`과 encoder fixture에는 secret sentinel이 없어야 한다. 모든 map은
+  defensive copy하고, public KDoc는 Korean technical register로 작성한다.
 
 - [ ] **Step 4: Run the focused test and verify GREEN**
 
   Run the same focused Gradle test. Expected: all event, token omission, limits,
-  and custom sanitizer cases PASS.
+  redaction-negative, and sanitizer policy cases PASS.
 
 - [ ] **Step 5: Commit AUD-01 model slice**
 
@@ -140,6 +176,7 @@
 - Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExporter.kt`
 - Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditSubmitResult.kt`
 - Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportOptions.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportSnapshot.kt`
 - Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditDelivery.kt`
 - Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt`
 - Create: `leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt`
@@ -147,7 +184,9 @@
 - [ ] **Step 1: Write failing admission and retry tests**
 
   테스트는 injected executor/scheduler와 `CompletableFuture` delivery fake를
-  사용해 wall-clock sleep 없이 다음 계약을 고정한다.
+  사용해 wall-clock sleep 없이 다음 계약을 고정한다. manual scheduler와 manual
+  executor는 task admission, cancellation, rejection, worker 종료를 관찰할 수
+  있어야 하며 fixed `delay`/sleep은 사용하지 않는다.
 
   ```kotlin
   @Test
@@ -164,10 +203,37 @@
 
   @Test
   fun `late completion after close does not schedule another attempt`() { /* race */ }
+
+  @Test
+  fun `hung delivery times out, releases slot, retries, and terminalizes once`() { /* timeout */ }
+
+  @Test
+  fun `executor and scheduler rejection terminalize accepted work and release permit`() { /* reject */ }
+
+  @Test
+  fun `submit close crossing is linearized and caller executor is never shutdown`() { /* close race */ }
+
+  @Test
+  fun `owner closes exporter before scheduler and executor and owner-first shutdown is deterministic`() { /* ownership */ }
+
+  @Test
+  fun `invalid options and saturating backoff fail fast`() { /* boundary table */ }
+
+  @Test
+  fun `observer sees exact outcomes and observer failure is isolated`() { /* observer */ }
+
+  @Test
+  fun `exceptional and cancelled delivery futures terminalize once without throwing to submitter`() { /* exception matrix */ }
+
   ```
 
   각 테스트는 `ACCEPTED`, `DROPPED_QUEUE_FULL`, `DROPPED_CLOSED`, attempt count,
   delivery completion과 close state를 `shouldBeEqualTo`/`shouldBeTrue`로 검증한다.
+  timeout 승자와 late completion의 terminalization, queued/scheduled/in-flight
+  cancel count, retry permit lifecycle, executor/scheduler rejection 이후 다음
+  submission, observer exact count, caller-owned executor/scheduler의 미종료를 함께
+  검증한다. `submit` source/benchmark guard는 lock·blocking queue·capacity wait가
+  없고 contention 시 즉시 drop되는지 확인한다.
 
 - [ ] **Step 2: Run the focused test and verify RED**
 
@@ -180,36 +246,101 @@
 
 - [ ] **Step 3: Implement non-blocking bounded dispatcher**
 
-  다음 public boundary를 구현한다.
+  다음 public boundary를 구현한다. 모든 생성자·property·method의 JVM descriptor와
+  Java creation path는 Task 4 표에 먼저 고정한다.
 
   ```kotlin
   interface LeaderAuditExporter : AutoCloseable {
       fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult
+      fun observe(observer: LeaderAuditExportObserver): AutoCloseable
+      fun snapshot(): LeaderAuditExportSnapshot
       override fun close()
   }
 
   enum class LeaderAuditSubmitResult { ACCEPTED, DROPPED_QUEUE_FULL, DROPPED_CLOSED }
 
   fun interface LeaderAuditDelivery {
-      fun deliver(event: LeaderAuditExportEvent): CompletionStage<LeaderAuditDeliveryResult>
+      fun deliver(event: LeaderAuditExportEvent): CompletableFuture<LeaderAuditDeliveryResult>
   }
 
   enum class LeaderAuditDeliveryResult { SUCCESS, RETRYABLE_FAILURE, TERMINAL_FAILURE }
+
+  enum class LeaderAuditExportObservation {
+      ACCEPTED, DROPPED_QUEUE_FULL, DROPPED_CLOSED, RETRY, TERMINAL_FAILURE,
+      CANCELLED, EXECUTOR_REJECTED, SCHEDULER_REJECTED,
+  }
+
+  fun interface LeaderAuditExportObserver {
+      fun onObservation(observation: LeaderAuditExportObservation)
+  }
+
+  data class LeaderAuditExportSnapshot(
+      val queued: Int,
+      val inFlight: Int,
+      val accepted: Long,
+      val droppedQueueFull: Long,
+      val droppedClosed: Long,
+      val retries: Long,
+      val terminalFailures: Long,
+      val cancellations: Long,
+      val executorRejections: Long,
+      val schedulerRejections: Long,
+      val closed: Boolean,
+  )
+
+  class LeaderAuditExportOptions(
+      val queueCapacity: Int,
+      val maxInFlight: Int,
+      val maxAttempts: Int,
+      val attemptTimeout: java.time.Duration,
+      val initialBackoff: java.time.Duration,
+      val maxBackoff: java.time.Duration,
+      val executor: Executor,
+      val scheduler: ScheduledExecutorService,
+  )
   ```
 
-  `BoundedLeaderAuditExporter`는 `ArrayBlockingQueue.offer`만 사용해 submit을
-  non-blocking으로 만들고, `maxInFlight`, `maxAttempts`, `initialBackoff`,
-  `maxBackoff`, `Executor`, `ScheduledExecutorService`를 options에서 받는다.
-  queue worker는 delivery completion을 한 번만 terminalize하며, close는 admission
-  flag를 먼저 바꾸고 queued item·scheduled retry·in-flight future를 취소한다.
-  injected executor/scheduler는 exporter가 shutdown하지 않으며 ownership을
-  caller에게 문서화한다.
+  `BoundedLeaderAuditExporter`는 CAS permit counter와 `ConcurrentLinkedQueue`로
+  admission을 선형화한다. `queueCapacity`는 queued, in-flight, scheduled retry를
+  합친 전체 admitted work의 hard upper bound이고 `maxInFlight <= queueCapacity`다.
+  `submit`은 lock, `put`, capacity 대기를 하지 않으며 permit CAS 실패 시 즉시
+  `DROPPED_QUEUE_FULL`을 반환한다. `maxAttempts`, 양의 유한 `attemptTimeout`,
+  `initialBackoff`, `maxBackoff`, `Executor`, `ScheduledExecutorService`는
+  `LeaderAuditExportOptions`에서 받는다. retry는 같은 permit을 유지하고 success,
+  terminal failure, close/cancel에서 정확히 한 번 반환한다.
+
+  각 attempt는 `CompletableFuture`와 timeout task 중 먼저 완료한 쪽만
+  `AtomicBoolean`으로 terminalize한다. timeout은 future를 cancel하고 retryable
+  failure로 분류하며, close가 먼저 이기면 observer/retry/failure를 만들지 않는다.
+  `observe` callback은 스냅숏 후 `runCatching`으로 격리한다. executor 또는
+  scheduler rejection은 accepted item을 고착시키지 않고 rejection terminal/drop
+  observation과 permit 반환으로 끝낸다. worker는 queue가 비면 task를 종료하고,
+  close는 gate를 닫고 queue·retry·in-flight future를 취소한 뒤 worker가 CLOSED를
+  관찰하도록 깨운다. injected executor/scheduler는 exporter가 shutdown하지 않으며
+  ownership을 caller에게 문서화한다.
+
+  `LeaderAuditExportOptions`는 Java-visible 명시적 8-argument constructor만 제공하고
+  shared executor/scheduler default를 만들지 않는다. 기본값은 `queueCapacity=1024`,
+  `maxInFlight=8`, `maxAttempts=3`, `attemptTimeout=5s`, `initialBackoff=100ms`,
+  `maxBackoff=5s`이며 hard upper bound는 각각 `65536`, `queueCapacity`, `16`,
+  `5m`, `1m`, `1m`이다. `queueCapacity`와 `maxInFlight`는 1 이상,
+  `maxInFlight <= queueCapacity`, `maxAttempts`는 1 이상, 세 Duration은 positive
+  finite, `initialBackoff <= maxBackoff`여야 하며 nanosecond/millisecond conversion
+  overflow는 fail-fast한다. backoff는 saturating multiplication으로 `maxBackoff`를
+  넘지 않는다.
+
+  delivery가 동기적으로 예외를 던지거나 exceptional future를 반환하면
+  `RETRYABLE_FAILURE` 분류 규칙에 따라 한 번만 retry/terminalize하고 `submit` 호출자에게
+  던지지 않는다. `CancellationException`은 close/timeout이 소유한 취소일 때
+  `CANCELLED`로 끝내고 재시도하지 않으며, caller delivery가 자체적으로 취소한 경우는
+  명시된 retryable cancellation 정책으로 한 번만 처리한다. `Error`는 worker 경계를
+  넘지 않도록 terminal failure로 기록하되 fatal process policy는 변경하지 않는다.
 
 - [ ] **Step 4: Run dispatcher tests and verify GREEN**
 
-  동일 focused test를 실행해 queue, retry, close, late completion 경로가 모두
-  PASS인지 확인한다. flaky wall-clock delay가 발견되면 manual scheduler seam으로
-  수정하고 테스트를 다시 실행한다.
+  동일 focused test를 실행해 queue, retry, timeout, rejection, close, late
+  completion, observer 경로가 모두 PASS인지 확인한다. flaky wall-clock delay가
+  발견되면 manual scheduler/future seam으로 수정하고 테스트를 다시 실행한다.
 
 - [ ] **Step 5: Commit core dispatcher slice**
 
@@ -227,23 +358,33 @@
 - Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/ExportingLeaderHistorySink.kt`
 - Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/ExportingSuspendLeaderHistorySink.kt`
 - Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderElectionEventExportSubscription.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/LeaderAuditPendingContextStore.kt`
 - Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/audit/ExportingLeaderHistorySinkTest.kt`
 - Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderElectionEventExportSubscriptionTest.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditPendingContextStoreTest.kt`
 
 - [ ] **Step 1: Write failing bridge tests**
 
   blocking/suspend sink는 delegate result를 보존하고 exporter의 `DROPPED_*`를
   election result로 바꾸지 않는지 검증한다. publisher bridge는 Elected/Revoked/
   Skipped를 각각 한 번 submit하고 returned `AutoCloseable` 이후에는 submit하지
-  않는지 검증한다. suspend cancellation test는 `assertFailsWith<CancellationException>`
-  으로 sink cancellation이 재전파되는지 확인한다.
+  않는지 검증한다. direct submit과 blocking/suspend/lifecycle bridge 각각에서
+  accepted/drop/retry/terminal-failure observer가 보이는지 확인하고 observer가
+  예외를 던져도 delegate/election result가 바뀌지 않는지 검증한다. suspend
+  cancellation test는 `assertFailsWith<CancellationException>`으로 sink
+  cancellation이 재전파되는지 확인한다. paused callback과 close barrier를 사용해
+  close 반환 이후 submit이 0건이고, crossing event는 gate를 먼저 획득한 쪽만
+  처리되는지 결정적으로 검증한다. virtual-thread/`VirtualFuture` wrapper도
+  blocking/suspend와 동일한 admission, result, cancellation, close semantics를
+  갖는지 검증한다.
 
 - [ ] **Step 2: Run bridge tests and verify RED**
 
   ```bash
   ./gradlew :bluetape4k-leader-core:test --tests \
     'io.bluetape4k.leader.audit.ExportingLeaderHistorySinkTest' \
-    --tests 'io.bluetape4k.leader.audit.LeaderElectionEventExportSubscriptionTest'
+    --tests 'io.bluetape4k.leader.audit.LeaderElectionEventExportSubscriptionTest' \
+    --tests 'io.bluetape4k.leader.audit.LeaderAuditPendingContextStoreTest'
   ```
 
   Expected: `FAIL` because bridge classes do not exist.
@@ -252,19 +393,32 @@
 
   `ExportingLeaderHistorySink`는 delegate를 먼저 호출한다. `recordAcquired`가
   non-null key를 반환하면 `History(ACQUIRED)`를 submit하고, completed/failed는
-  key와 종료 인자를 사용해 event를 만든다. exporter submit 결과는 무시하지 않고
-  caller가 선택적으로 관찰할 수 있는 internal counter hook에 전달하되 sink
-  return value는 변경하지 않는다.
+  key와 종료 인자를 사용해 event를 만든다. acquisition record의 kind, nodeId,
+  acquiredAt, lockedUntil, slotId, metadata는 token 자체를 export하지 않는 bounded
+  `LeaderAuditPendingContextStore`에 key fingerprint와 함께 보관한다. context는
+  terminal completed/failed에서 exactly-once 제거하고, bounded capacity/TTL eviction,
+  missing-key, duplicate completion은 deterministic policy로 처리한다. context가
+  없으면 sanitized `context_missing` attribute와 effective status만 가진 최소 event를
+  만든다. `status` nullable record는 finishedAt 기준 `effectiveStatus()` 결과를
+  사용한다. exporter submit 결과는 sink return value와 분리되며, public
+  `LeaderAuditExportObserver`를 통해 caller가 accepted/drop/retry/terminal-failure를
+  관찰할 수 있다. observer 오류는 격리하고 sink return value는 변경하지 않는다.
 
   `ExportingSuspendLeaderHistorySink`는 같은 mapping을 suspend 함수에 적용하고
   sink 호출 전후의 `CancellationException`/`InterruptedException` 경계를 보존한다.
   `LeaderElectionEventExportSubscription`은 기존 `onEvent(scope, listener)`를
-  사용하고 scope cancellation과 explicit close를 모두 idempotent하게 처리한다.
+  사용하되 atomic gate와 lock으로 callback admission/close를 선형화한다. close가
+  gate를 닫고 이미 admitted callback이 끝난 뒤 job을 cancel하므로 scope
+  cancellation과 explicit close를 모두 idempotent하게 처리하고 close 반환 이후
+  새 submit을 만들지 않는다. 기존 `LeaderElectionEventPublisher`/`Listening*`
+  wrapper에만 연결하며 backend elector 자체의 recorder 경로를 자동 변경하지 않는다.
 
 - [ ] **Step 4: Run bridge tests and verify GREEN**
 
   동일 Gradle test를 실행하고, `runTest`에서 subscription cancellation·late event가
-  추가 submit을 만들지 않는지 확인한다.
+  추가 submit을 만들지 않는지, observer exact count와 close linearization이
+  결정적인지 확인한다. context store overflow/TTL/missing-key/duplicate completion과
+  blocking/suspend/virtual-thread wrapper parity도 함께 확인한다.
 
 - [ ] **Step 5: Commit bridge slice**
 
@@ -280,14 +434,36 @@
 **Files:**
 
 - Create: `leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportBoundaryContractTest.kt`
+- Create: `leader-core/src/test/java/io/bluetape4k/leader/audit/LeaderAuditExportJavaContractTest.java`
 - Modify: audit public types의 KDoc files from Tasks 1–3
 
 - [ ] **Step 1: Write failing public boundary checks**
 
-  reflection으로 `LeaderAuditExporter`, `LeaderAuditExportEvent`, options와 result
-  enum의 public constructor/method set을 확인하고, event public field에 `token`이나
-  `LeaderLease`가 없는지 고정한다. `close()` idempotence와 `submit` return type을
-  JVM descriptor로 확인한다.
+  다음 exact public surface를 표와 reflection fixture로 먼저 고정한다.
+
+  | Type | Exact public surface |
+  |---|---|
+  | `LeaderAuditExporter` | `submit(LeaderAuditExportEvent): LeaderAuditSubmitResult`, `observe(LeaderAuditExportObserver): AutoCloseable`, `close(): Unit` |
+  | `LeaderAuditExportOptions` | `queueCapacity:Int`, `maxInFlight:Int`, `maxAttempts:Int`, `attemptTimeout:java.time.Duration`, `initialBackoff:java.time.Duration`, `maxBackoff:java.time.Duration`, `executor:Executor`, `scheduler:ScheduledExecutorService`; Java-visible 8-argument constructor, no implicit shared executor |
+  | `LeaderAuditDelivery` | `deliver(LeaderAuditExportEvent): CompletableFuture<LeaderAuditDeliveryResult>` |
+  | `LeaderAuditExportObserver` | `onObservation(LeaderAuditExportObservation): Unit` with finite enum only |
+  | `LeaderAuditExportSnapshot` | immutable counters/depths and `closed:Boolean`; no dynamic identifiers |
+  | `LeaderAuditHttpPayload` | `of(String, byte[])`, `contentType`, `body(): byte[]`; constructor/body defensively copy |
+  | `HttpLeaderAuditExporter` | `(HttpClient, URI, Map<String,String>, LeaderAuditPayloadEncoder, LeaderAuditExportOptions, LeaderAuditHttpOptions)` plus `submit/observe/close` |
+  | `LeaderAuditHttpOptions` | 3-argument constructor, `defaults(): LeaderAuditHttpOptions`, `maxPayloadBytes:Int`, `allowedSchemes:Set<String>`, `allowInsecureLoopback:Boolean`; immutable defensive copies |
+
+  Kotlin default arguments must not be the only construction path: the Java fixture
+  constructs options and HTTP exporter explicitly, calls `submit`, and uses
+  try-with-resources `close`. Duration units, caller ownership, `ACCEPTED != delivered`,
+  and redirect/header trust rules are part of the exact KDoc/ABI contract. Event types
+  are not `Serializable`; v1 wire/Java serialization compatibility is intentionally
+  out of scope. The fixture also records nullable event properties (`nodeId`, `slotId`,
+  `leaderId`, `leaseExpiry`, `errorType`, `errorMessage`) and rejects accidental platform
+  types or synthetic overloads.
+
+  reflection으로 위 public constructor/method set과 JVM descriptor를 확인하고, event
+  public field에 `token`이나 `LeaderLease`가 없는지 고정한다. `close()` idempotence와
+  `submit` return type을 JVM descriptor로 확인한다.
 
 - [ ] **Step 2: Run contract test and verify RED**
 
@@ -298,15 +474,17 @@
 
 - [ ] **Step 3: Align KDoc and ABI without widening the API**
 
-  public KDoc에는 caller-owned executor/scheduler, queue drop semantics, redaction
-  default, close ownership, JSONL/OpenTelemetry exclusion을 명시한다. 생성자에는
-  `@JvmOverloads`를 추가하지 않고, Kotlin default constructor가 필요한 경우
-  reflection fixture에 exact descriptor를 기록한다.
+  public KDoc에는 caller-owned executor/scheduler의 종료 순서(`exporter.close()` 후
+  scheduler/executor shutdown), queue drop semantics, `ACCEPTED != delivered`,
+  best-effort 중복/순서/프로세스 종료 손실, redaction default, close ownership,
+  JSONL/OpenTelemetry exclusion, URI/header trust boundary를 명시한다. 생성자에는
+  `@JvmOverloads`를 추가하지 않고 Java 8-argument construction path를 유지한다.
 
 - [ ] **Step 4: Run contract test and verify GREEN**
 
-  같은 명령과 `git diff --check`를 실행한다. ABI fixture는 새 public API의 이름,
-  descriptor, token 부재, close/submit semantics를 모두 PASS해야 한다.
+  같은 명령과 `git diff --check`를 실행하고 Kotlin/Java fixture를 함께 컴파일한다.
+  ABI fixture는 새 public API의 이름, descriptor, token 부재, close/submit semantics,
+  Java try-with-resources construction을 모두 PASS해야 한다.
 
 - [ ] **Step 5: Commit core contract evidence**
 
@@ -329,8 +507,12 @@
 - [ ] **Step 1: Write failing metric tests**
 
   `SimpleMeterRegistry`에서 accepted, queue-full, closed, retry, terminal failure를
-  각각 발생시키고 metric 이름과 finite tag set을 검증한다. `lockName`, `leaderId`,
-  endpoint, error message가 meter tag에 없는지도 assertion한다.
+  각각 발생시키고 metric 이름과 finite tag set을 검증한다. 스냅숏의 queue depth,
+  in-flight, cancellation, executor/scheduler rejection gauge/counter도 검증한다.
+  정확한 allow-list는 `source={history,lifecycle,direct}`,
+  `transport={core,http}`, `outcome={accepted,queue_full,closed,retry,failure,
+  cancelled,rejected}`로 고정한다. 고유 lockName, leaderId, endpoint, error message를
+  대량 제출해도 meter 수가 증가하지 않고 해당 값이 tag에 없는지 assertion한다.
 
 - [ ] **Step 2: Run Micrometer test and verify RED**
 
@@ -342,10 +524,16 @@
 - [ ] **Step 3: Implement decorator and constants**
 
   `MicrometerLeaderAuditExporter(delegate, registry)`는 `LeaderAuditExporter`를
-  그대로 반환하고 결과별 counter를 increment한다. metric names는
-  `leader.audit.export.accepted`, `leader.audit.export.dropped`,
-  `leader.audit.export.retries`, `leader.audit.export.failures`로 고정한다.
-  `outcome`, `transport` tag 값은 enum/string allow-list만 사용하고 event field는
+  그대로 반환하고 결과별 counter와 `snapshot()` gauge를 increment/update한다.
+  생성 시 delegate에 bounded `LeaderAuditExportObserver`를 등록해 retry, terminal
+  failure, cancellation, rejection을 관찰하고 decorator close에서 observer handle을
+  idempotently 해제한다. delegate가 observer callback을 격리하므로 metric registry
+  오류가 admission/election에 전파되지 않는다.
+  metric names는 `leader.audit.export.accepted`, `leader.audit.export.dropped`,
+  `leader.audit.export.retries`, `leader.audit.export.failures`,
+  `leader.audit.export.queue.depth`, `leader.audit.export.in.flight`,
+  `leader.audit.export.cancelled`, `leader.audit.export.rejections`로 고정한다.
+  `outcome`, `transport`, `source` tag 값은 위 enum allow-list만 사용하고 event field는
   tag로 복사하지 않는다. 기존 `HISTORY_SINK_FAILURES` counter는 건드리지 않는다.
 
 - [ ] **Step 4: Run Micrometer tests and verify GREEN**
@@ -376,6 +564,7 @@
 **Files:**
 
 - Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/LeaderAuditPayloadEncoder.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/LeaderAuditHttpOptions.kt`
 - Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditDelivery.kt`
 - Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditExporter.kt`
 - Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditDeliveryTest.kt`
@@ -383,13 +572,20 @@
 
 - [ ] **Step 1: Write failing HTTP contract tests**
 
-  JDK `HttpServer`를 loopback에 순차적으로 띄워 다음 응답을 검증한다.
+  classifier/retry/close는 stub `HttpClient`, manual future, manual scheduler로
+  deterministic하게 검증하고, JDK `HttpServer` loopback은 request integration smoke로
+  분리한다. fixed sleep 없이 모든 future/server/executor를 drain하고 반복 실행한다.
 
   - `202`/`204`를 success로 분류한다.
   - `429`, `503`, I/O disconnect는 최대 attempt까지 retry한다.
   - `400`, `401`, `403`, `404`는 retry하지 않는다.
-  - encoder가 만든 body와 allow-listed headers만 request에 전달한다.
-  - response body와 endpoint credential이 log에 남지 않는다.
+  - encoder가 만든 body는 `maxPayloadBytes`를 넘지 않고 immutable 스냅숏으로
+    전달되며 allow-listed headers만 request에 전달한다.
+  - oversized/chunked response는 `BodyHandlers.discarding()`으로 보존하지 않는다.
+  - HTTPS 기본값, unsafe URI/user-info/query/fragment, redirect, CRLF/forbidden header를
+    거부한다. loopback HTTP는 명시적 test-only allow-list에서만 허용한다.
+  - encoder throw, exceptional/cancelled future, response body와 endpoint credential이
+    log에 남지 않는 negative matrix를 검증한다.
   - exporter close가 in-flight future와 scheduled retry를 취소하고 late completion이
     새 retry를 만들지 않는다.
 
@@ -408,25 +604,58 @@
       fun encode(event: LeaderAuditExportEvent): LeaderAuditHttpPayload
   }
 
-  data class LeaderAuditHttpPayload(
+  class LeaderAuditHttpPayload private constructor(
       val contentType: String,
-      val body: ByteArray,
-  )
+      private val bytes: ByteArray,
+  ) {
+      fun body(): ByteArray = bytes.copyOf()
+
+      companion object {
+          @JvmStatic
+          fun of(contentType: String, body: ByteArray): LeaderAuditHttpPayload =
+              LeaderAuditHttpPayload(contentType, body.copyOf())
+      }
+  }
+
+  class LeaderAuditHttpOptions(
+      val maxPayloadBytes: Int,
+      val allowedSchemes: Set<String>,
+      val allowInsecureLoopback: Boolean,
+  ) {
+      companion object {
+          @JvmStatic
+          fun defaults(): LeaderAuditHttpOptions =
+              LeaderAuditHttpOptions(64 * 1024, setOf("https"), false)
+      }
+  }
   ```
 
-  `HttpLeaderAuditDelivery`는 `HttpRequest.newBuilder(uri).POST(...)`와
-  `HttpClient.sendAsync`를 사용한다. 2xx는 `SUCCESS`, 408/429/5xx와 I/O exception은
-  `RETRYABLE_FAILURE`, 나머지 4xx는 `TERMINAL_FAILURE`로 매핑한다. 요청 header는
-  constructor allow-list를 통해 복사하고 secret 값을 logger에 전달하지 않는다.
+  `LeaderAuditHttpOptions`는 `maxPayloadBytes` 기본 64 KiB, hard upper bound 1 MiB,
+  `allowedSchemes`의 기본 HTTPS, test-only loopback HTTP 허용 여부를 검증한다.
+  `HttpLeaderAuditDelivery`는
+  `HttpRequest.newBuilder(uri).timeout(options.attemptTimeout).POST(...)`와
+  `HttpClient.sendAsync(..., BodyHandlers.discarding())`를 사용한다. injected client의
+  `followRedirects()`가 `Redirect.NEVER`가 아니면 생성에 실패한다. 2xx는 `SUCCESS`,
+  408/429/5xx와 I/O/timeout exception은 `RETRYABLE_FAILURE`, 나머지 4xx는
+  `TERMINAL_FAILURE`로 매핑한다. 요청 header는 immutable constructor allow-list로
+  복사하고 CR/LF 및 `Host`, `Content-Length`, `Connection`, `Transfer-Encoding`을
+  거부하며 secret 값을 logger/metric에 전달하지 않는다. encoder 예외는 delivery
+  future의 terminal failure로 격리한다.
   `HttpLeaderAuditExporter`는 Task 2 dispatcher에 delivery를 주입하고, URI·encoder·
-  options·executor ownership을 KDoc로 명시한다. JSON serialization을 추가하지
-  않으며 JSONL/OpenTelemetry implementation도 만들지 않는다.
+  options·executor ownership 및 `exporter.close()` 후 외부 scheduler/executor를
+  종료하는 순서를 KDoc로 명시한다. JSON serialization을 추가하지 않으며
+  JSONL/OpenTelemetry implementation도 만들지 않는다.
+
+  최소 runnable caller 예제는 dependency-free text encoder, `Content-Type`와
+  allow-listed `Authorization` header, receiver의 duplicate/idempotency 및
+  `ACCEPTED != delivered` 주의를 함께 보여준다.
 
 - [ ] **Step 4: Run HTTP tests and verify GREEN**
 
-  focused HTTP suite를 실행하고 Testcontainers 없이 loopback server lifecycle이
-  매 테스트 종료 시 닫히는지 확인한다. 실패 시 response classification 또는
-  cancellation race를 먼저 수정하고 재실행한다.
+  focused HTTP suite와 deterministic fake suite를 실행하고 Testcontainers 없이
+  loopback server lifecycle이 매 테스트 종료 시 닫히는지 확인한다. 실패 시 response
+  classification, timeout, URI/header trust, payload immutability 또는 cancellation
+  race를 먼저 수정하고 재실행한다.
 
 - [ ] **Step 5: Commit AUD-03 transport slice**
 
@@ -447,16 +676,34 @@
 - Modify: `leader-micrometer/README.ko.md`
 - Modify: `README.md`
 - Modify: `README.ko.md`
-- Modify: `docs/manual/en/modules/bluetape4k-leader-micrometer.md`
-- Modify: `docs/manual/ko/modules/bluetape4k-leader-micrometer.md`
+- Create: `docs/manual/drafts/2026-08-18-audit-export.en.md`
+- Create: `docs/manual/drafts/2026-08-18-audit-export.ko.md`
 
 - [ ] **Step 1: Add matching Korean/English capability guidance**
 
   core README에는 `LeaderAuditExportEvent`, `LeaderAuditExporter`, bridge lifecycle,
-  default redaction, queue drop와 close semantics를 짧은 예제로 설명한다.
-  Micrometer README/manual에는 metric catalog와 no raw/high-cardinality tag 규칙을
-  추가한다. top-level README capability matrix와 event stream 설명에는 HTTP/webhook
-  adapter와 JSONL/OpenTelemetry 후속 범위를 반영한다.
+  default redaction, queue drop와 close semantics를 짧은 예제로 설명한다. exporter의
+  `ACCEPTED != delivered`, duplicate/reordering/process-shutdown loss와 receiver
+  idempotency, `exporter.close()` 후 caller-owned scheduler/executor 종료 순서를
+  함께 고정한다. Micrometer README에는 metric catalog, queue/in-flight/rejection
+  diagnostics와 no raw/high-cardinality tag 규칙을 추가한다. top-level README
+  capability matrix와 event stream 설명에는 HTTP/webhook adapter와 JSONL/OpenTelemetry
+  후속 범위를 반영한다.
+
+  운영 lifecycle 표는 `construct resources → create exporter → submit/observe →
+  exporter.close() → scheduler.shutdown()/executor.shutdown()` 순서를 제시하고,
+  owner가 먼저 외부 executor를 종료한 경우 rejection이 bounded terminal/drop으로
+  끝나며 caller 예외가 되지 않는다는 진단 절차를 포함한다. `ACCEPTED`는 delivered가
+  아니며 receiver idempotency, duplicate/reordering, crash/close loss를 명시한다.
+
+  release-pinned `docs/manual/manifest.yaml`는 현재 `0.5.0`/immutable
+  `releaseCommit`을 가리키므로 이번 train에서 해당 release manual을 수정하지 않는다.
+  대신 draft EN/KO manual에 core 조립 순서
+  (`sink → ExportingSink → SafeRecorder → backend`), `Listening*` lifecycle wrapper,
+  HTTP encoder/headers/receiver 예제, migration/limitations를 기록하고
+  “0.6.0 release manifest 전환 전에는 released claim이 아님”을 명시한다. 0.6
+  release-authorized 후속 작업에서 draft를 pinned manual로 승격하고 manifest/
+  release inventory를 함께 갱신한다.
 
 - [ ] **Step 2: Validate docs and locale parity**
 
@@ -464,19 +711,24 @@
   git diff --check
   ./gradlew exportManualModuleInventory
   ruby scripts/manual/validate_manuals.rb build/manual/module-inventory.json
+  ruby scripts/manual/validate_release_manuals.rb "$(ruby -e 'require "yaml"; m=YAML.load_file("docs/manual/manifest.yaml"); puts m["releaseRef"]' )" "$(ruby -e 'require "yaml"; m=YAML.load_file("docs/manual/manifest.yaml"); puts m["releaseCommit"]' )"
+  ruby scripts/manual/export_manifest.rb --check
+  ruby -I scripts/manual -e 'Dir["scripts/manual/*_test.rb"].sort.each { |file| require File.expand_path(file) }'
   ```
 
-  변경된 두 locale의 제목·API·metric·scope가 대응하고, release-pinned manual의
-  현재 source claim을 과장하지 않는지 read-back한다. diagram 변경은 없으므로
-  `bluetape-diagram`은 N/A이며 evidence에 이유를 기록한다.
+  변경된 두 locale의 제목·API·metric·scope가 대응하고, draft는 0.5.0 release claim을
+  과장하지 않는지 read-back한다. pinned manual의 release source validation은
+  immutable commit에 대해 PASS해야 하며 draft token이 pinned 문서에 섞이지 않아야
+  한다. diagram 변경은 없으므로 `bluetape-diagram`은 N/A이며 evidence에 이유를
+  기록한다.
 
 - [ ] **Step 3: Commit documentation slice**
 
   ```bash
   git add README.md README.ko.md leader-core/README.md leader-core/README.ko.md \
     leader-micrometer/README.md leader-micrometer/README.ko.md \
-    docs/manual/en/modules/bluetape4k-leader-micrometer.md \
-    docs/manual/ko/modules/bluetape4k-leader-micrometer.md
+    docs/manual/drafts/2026-08-18-audit-export.en.md \
+    docs/manual/drafts/2026-08-18-audit-export.ko.md
   git commit -m $'OBS-03 audit exporter 사용 계약을 README와 manual에 반영한다\n\nConstraint: README는 concise entry point이고 manual은 release-facing source of truth다.\nRejected: 한 locale만 수정 | public API와 redaction guidance가 불일치함\nConfidence: high\nScope-risk: moderate\nDirective: JSONL/OpenTelemetry 후속 범위를 문서에서 명확히 유지한다.\nTested: locale parity, manual validator, diff check\nNot-tested: CI workflow는 변경하지 않는다.'
   ```
 
@@ -485,7 +737,11 @@
 **Files:**
 
 - Inspect all AUD-01~03 changed files and tests
-- Create only if required: `docs/review/2026-08-18-issue-535-audit-export-review.md`
+- Create: `docs/review/2026-08-18-issue-535-audit-export-review.md`
+
+  Review artifact must contain Korean summary, exact plan/spec HEAD, six lens identity
+  and verdict table, each finding's file/line and repair, focused validation outputs,
+  release-pinned manual evidence, rollback SHA table, and final `P0/P1/P2/P3` totals.
 
 - [ ] **Step 1: Run targeted module validation**
 
@@ -517,8 +773,13 @@
   Inspect the exact diff for blocking calls in `submit`/Flow callbacks, unbounded
   queue/retry, scheduler ownership leaks, virtual-thread monitor pinning, coroutine
   cancellation swallowing, duplicate late completion, response-body/secret logging,
-  and per-lock Micrometer tags. Record the command, files, and either PASS or a
-  repaired finding in the tracked review artifact.
+  URI/header trust, payload aliasing, executor/scheduler rejection, and per-lock
+  Micrometer tags. Record every six independent lens command, exact head, files,
+  P0/P1/P2/P3 result, repair or PASS evidence, CI/manual evidence, and final DoD in
+  the required tracked review artifact. A benchmark framework is not added; the
+  performance claim is limited to source-verified CAS/non-blocking admission plus a
+  deterministic contention test with a documented threshold of no blocking wait and
+  bounded allocation per accepted item.
 
 - [ ] **Step 4: Run final acceptance matrix**
 
@@ -528,9 +789,12 @@
   | blocking/suspend/event bridge parity | bridge tests + cancellation test |
   | queue/drop/failure isolation | bounded exporter tests + fake delivery |
   | HTTP status/retry/backoff/close | loopback HTTP tests |
-  | Micrometer finite cardinality | `MicrometerLeaderAuditExporterTest` |
+  | HTTP timeout/URI/header/payload/response bounds | deterministic fake HTTP tests + loopback smoke |
+  | Micrometer finite cardinality/diagnostics | `MicrometerLeaderAuditExporterTest` |
   | no dependency/module registration | `git diff`, `./gradlew projects` |
-  | docs locale parity | README/manual validator and read-back |
+  | docs locale parity/release pin | README/draft manual validators and release read-back |
+  | public Java/Kotlin ABI | reflection + Java compile fixture |
+  | backend bridge context/virtual-thread parity | bridge/context/virtual-thread tests |
 
   Every row must have fresh output before Step 8 is checked.
 
@@ -572,24 +836,47 @@
 | Spec requirement | Plan tasks |
 |---|---|
 | safe event/token omission/redaction | 1, 4, 8 |
-| bounded admission/close/retry | 2, 8 |
-| history and lifecycle bridges | 3, 8 |
-| Micrometer accepted/drop/retry/failure | 5, 8 |
-| HTTP status classification and webhook delivery | 6, 8 |
-| README/manual locale parity | 5, 7 |
+| immutable event/context/status mapping | 1, 3, 4, 8 |
+| bounded CAS admission/close/retry/timeout/rejection | 2, 8 |
+| history/lifecycle/virtual-thread bridges | 3, 8 |
+| Micrometer accepted/drop/retry/failure/diagnostics | 5, 8 |
+| HTTP status/timeout/trust/byte bounds and webhook delivery | 6, 8 |
+| README/draft manual locale parity and release pin | 5, 7, 8 |
 | no new dependency/module and ABI compatibility | 4, 8, 9 |
 | JSONL/OpenTelemetry excluded | 6, 7, 9 |
 | stacked PR exact base/head and fresh CI/review | 9 |
 
 ## Rollback and rerun points
 
-- Task 1–4 failure: revert the latest Lore commit on AUD-01; existing history/event
-  APIs remain unchanged because all new types are opt-in.
-- Task 5 failure: drop AUD-02 branch/commits and retain the green AUD-01 head; core
-  exporter behavior is independent of Micrometer.
-- Task 6 failure: drop AUD-03 transport commits and retain AUD-02; no HTTP request is
-  created by existing elector code without explicit opt-in.
+- Before any rollback, require a clean target worktree, record exact branch/PR head,
+  and verify the target commit is not merged. Never use `reset --hard` or delete a
+  branch as a first step. Use `git revert <known-good-parent>..<bad-head>` on the
+  isolated slice, then rerun dependent acceptance and `git diff --check`.
+- AUD-01 known-good SHA is the last green core event/dispatcher/bridge/ABI commit
+  recorded in the PR body; retain that SHA in the review artifact before AUD-02 starts.
+  AUD-01 failure reverts only its latest Lore commit and reruns core tests/ABI/context
+  fixtures; existing history/event APIs remain unchanged because all new types are opt-in.
+- AUD-02 known-good SHA is the green AUD-01 head plus the Micrometer decorator/docs
+  commit. Its failure retains the recorded AUD-01 SHA, reverts only AUD-02 commits,
+  and reruns core acceptance plus Micrometer baseline tests.
+- AUD-03 known-good SHA is the green AUD-02 head plus the HTTP transport commit. Its
+  failure retains the recorded AUD-02 SHA, reverts only AUD-03 commits, and reruns
+  core/Micrometer acceptance; no HTTP request is created by existing elector code
+  without explicit opt-in.
 - Task 7 validator or locale mismatch: repair docs only and rerun manual/read-back
   checks; do not rerun code tests unless a code claim changed.
 - Any P1 from performance/stability review: stop PR delivery, repair the affected
   task, rerun its focused test and all dependent validation rows.
+
+## Writer gate evidence
+
+- `SPW-01` 범위: Korean spec/plan이며 API·commands·URLs·numeric limits는 원문 token을
+  보존한다.
+- `SPW-02` 사실 보존: six-lens findings, release pin `0.5.0`/`721a9a...`, JSONL/
+  OpenTelemetry follow-up 경계를 변경하지 않았다.
+- `SPW-03` 자연스러움: `korean-naturalness-checklist.md` 기준으로 문장 주어·술어,
+  기술 register, `스냅숏`/`스케줄러` 용어를 점검한다.
+- `SPW-04` 범위 보존: draft manual은 release-pinned manual과 분리하고, 이번 train에
+  새 manual claim을 승격하지 않는다.
+- `SPW-05` read-back: `git diff --check`, placeholder scan, 문서 token/locale
+  parity와 exact spec/plan read-back 결과를 review artifact에 기록한다.

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -236,6 +236,15 @@
   fun `blocking observer never delays submit and diagnostic drop is counted`() { /* async observer */ }
 
   @Test
+  fun `diagnostics capacity is bounded and close stops queued observer callbacks`() { /* diagnostics lifecycle */ }
+
+  @Test
+  fun `observer handle close prevents queued callback start after return`() { /* handle */ }
+
+  @Test
+  fun `diagnostics Error closes diagnostics without restarting the worker`() { /* fatal diagnostics */ }
+
+  @Test
   fun `exceptional and cancelled delivery futures terminalize once without throwing to submitter`() { /* exception matrix */ }
 
   @Test
@@ -247,6 +256,11 @@
   @Test
   fun `worker exit and concurrent submit reschedule without lost wakeup`() { /* worker barrier */ }
 
+  @Test
+  fun `fixed contention has no submit wait and bounded admission outcomes`() {
+      // 32 contenders × 100 iterations, barrier before each batch, manual executor paused.
+  }
+
   ```
 
   각 테스트는 `ACCEPTED`, `DROPPED_QUEUE_FULL`, `DROPPED_CLOSED`, attempt count,
@@ -255,8 +269,14 @@
   queued/scheduled/in-flight cancel count, retry permit lifecycle, executor rejection과
   scheduler rejection 각각의 capacity recovery, observer exact count와 async dispatch,
   `inFlight <= maxInFlight`, worker-exit double-check/reschedule, caller-owned
-  executor/scheduler의 미종료를 함께 검증한다. `submit` source/benchmark guard는
+  executor/scheduler의 미종료를 함께 검증한다. diagnostics capacity
+  `min(queueCapacity, 1024)`, named daemon worker termination, observer registration cap
+  16, observer handle close linearization, queued callback drop와 `observerDrops` exact
+  count도 검증한다. `submit` source/benchmark guard는
   lock·blocking queue·capacity wait가 없고 contention 시 즉시 drop되는지 확인한다.
+  contention fixture는 32 contender, 100 iteration, barrier와 paused manual executor를
+  고정하고 각 submit 호출의 반환 latch, accepted/drop 합계, `snapshot()` permit bounds를
+  검증한다. wall-clock 성능 수치나 allocation threshold는 주장하지 않는다.
 
 - [ ] **Step 2: Run the focused test and verify RED**
 
@@ -363,17 +383,30 @@
   `AtomicBoolean`으로 terminalize한다. timeout은 future를 cancel하고 retryable
   failure로 분류하며, close가 먼저 이기면 observer/retry/failure를 만들지 않는다.
   `observe` callback은 submit thread에서 직접 실행하지 않는다. exporter가 소유하는
-  bounded diagnostics queue와 전용 diagnostics worker가 observation을 전달하며,
-  admission은 queue offer/CAS만 수행한다. diagnostics queue가 가득 차면
+  bounded diagnostics queue와 이름이 고정된 daemon virtual-thread worker가 observation을
+  전달한다. diagnostics capacity는 `min(queueCapacity, 1024)`로 파생해 별도 public
+  option 없이 항상 `1..1024`로 bounded하며, atomic permit과 `LockSupport.unpark`를
+  사용해 admission은 queue offer/CAS만 수행한다. diagnostics queue가 가득 차면
   `observerDrops`를 증가시키고 callback 없이 끝낸다. callback이 오래 걸려도
   admission worker와 선거 thread는 block하지 않는다. observer callback의 일반
   `Exception`만 격리하며 `Error`는 callback task를 terminalize한 뒤 전용 diagnostics
   worker의 uncaught boundary로 재전파한다. observer 또는 delivery가 `Error`를 던지면
-  상태/permit을 정확히 한 번 terminalize하고 같은 원래 `Error`를 재전파한다. executor 또는 scheduler rejection은 accepted item을
-  고착시키지 않고 rejection terminal/drop observation과 permit 반환으로 끝낸다.
-  worker는 `workerRunning.compareAndSet(false, true)`로 시작하고, empty 관찰 후
-  running flag를 clear하기 직전에 queue를 다시 확인한다. clear 이후 submit과 교차하면
-  submit이 double-check/reschedule을 수행하므로 lost wakeup이 없다. 별도 atomic
+  상태/permit을 정확히 한 번 terminalize하고 같은 원래 `Error`를 재전파한다. exporter
+  `close()`는 diagnostics closed gate를 먼저 세우고 queued diagnostics를 drop한 뒤
+  worker를 interrupt/unpark하고 join하여 worker 종료와 late callback 0을 확인한다.
+  close는 이미 실행 중인 callback을 마칠 때까지 join할 수 있으며, callback은 interrupt를
+  존중해야 한다. join이 끝난 뒤 diagnostics thread/task와 queued callback은 0이고,
+  callback이 interrupt를 무시해도 close는 callback admission을 다시 열지 않으며 해당
+  observer는 close 이후 새 callback을 받지 않는다. executor 또는 scheduler
+  rejection은 현재 worker가 보유한 queued batch 전체를 deterministic하게
+  `EXECUTOR_REJECTED` 또는 `SCHEDULER_REJECTED`로 terminalize하고 각 item의 permit을
+  정확히 한 번 반환한다. 어떤 accepted item도 고착되지 않으며, batch N개를 거부한
+  뒤 다음 `queueCapacity` submissions가 다시 모두 admission될 수 있어야 한다.
+  worker는 `workerRunning.compareAndSet(false, true)`로 시작한다. drain loop가 empty를
+  보면 먼저 `workerRunning.set(false)`를 publish한 다음 queue를 다시 확인하고,
+  non-empty면 `compareAndSet(false, true)`로 drain ownership을 재획득한다. submit도
+  enqueue 직후 동일한 `tryStartWorker()` CAS를 호출하므로 flag-clear와 enqueue가
+  어느 순서로 교차해도 lost wakeup이 없다. 별도 atomic
   in-flight reservation을 delivery 전에 획득하고 completion/timeout/close에서 정확히
   반환해 `inFlight <= maxInFlight`를 유지한다. close는 gate를 닫고 queue·retry·in-flight
   future를 취소한 뒤 scheduling critical section과 worker admission이 quiesce된 것을
@@ -381,6 +414,14 @@
   executor/scheduler에 새 execute/schedule을 호출하지 않는다. injected
   executor/scheduler는 exporter가 shutdown하지 않으며 ownership을 caller에게
   문서화한다.
+
+  observer registry는 최대 16개로 고정한다. `observe()` handle close는 registry에서
+  observer를 먼저 제거하고 반환하며, queued item은 callback 직전 active 상태를 다시
+  확인한다. 이미 실행 중인 callback만 현재 호출을 마친다. 17번째 registration은
+  no-op handle을 반환하고 `observerDrops`를 1 증가시킨다.
+  diagnostics worker에서 observer `Error`가 발생하면 diagnostics gate를 CLOSED로
+  전환하고 queued callback을 drop한 뒤 원래 `Error`를 uncaught boundary로 재전파하며,
+  worker를 자동 재시작하지 않는다. 이후 `observe()`는 no-op handle을 반환한다.
 
   `queued`, `inFlight`, `scheduledRetries`, `admitted`는 각각 `AtomicInteger`로
   유지하며 snapshot은 `queue.size` 또는 work-item 순회를 사용하지 않는 O(1) 읽기로
@@ -519,19 +560,22 @@
   | `LeaderAuditExportObserver` | `onObservation(LeaderAuditExportObservation): Unit` with finite enum only |
   | `LeaderAuditExportSnapshot` | immutable `queued`, `inFlight`, `scheduledRetries`, `admitted`, outcome counters, `observerDrops`, `closed`; no dynamic identifiers |
   | `LeaderAuditHttpPayload` | `of(String, byte[])`, `contentType`, `body(): byte[]`; constructor/body defensively copy |
-  | `HttpLeaderAuditExporter` | `(HttpClient, URI, Map<String,String>, LeaderAuditPayloadEncoder, LeaderAuditExportOptions, LeaderAuditHttpOptions)` plus `submit/observe/snapshot/close` |
+  | `LeaderAuditTrustedHttpsEndpoint` | `trusted(URI): LeaderAuditTrustedHttpsEndpoint`, `uri:URI`; caller-owned explicit trust boundary |
+  | `HttpLeaderAuditExporter` | `(HttpClient, LeaderAuditTrustedHttpsEndpoint, Map<String,String>, LeaderAuditPayloadEncoder, LeaderAuditExportOptions, LeaderAuditHttpOptions)` plus `submit/observe/snapshot/close` |
   | `LeaderAuditHttpOptions` | 1-argument constructor `(maxPayloadBytes:Int)`, `defaults(): LeaderAuditHttpOptions`, `maxPayloadBytes:Int`; production HTTPS-only, no public scheme/loopback bypass |
 
   Kotlin default arguments must not be the only construction path: the Java fixture
   constructs options and HTTP exporter explicitly, calls `submit`, and uses
   try-with-resources `close`. Duration units, caller ownership, `ACCEPTED != delivered`,
-  and redirect/header trust rules are part of the exact KDoc/ABI contract. Event types
+  explicit trusted endpoint construction, and redirect/header trust rules are part of the exact
+  KDoc/ABI contract. Event types
   are not `Serializable`; v1 wire/Java serialization compatibility is intentionally
   out of scope. The fixture also records nullable event properties (`nodeId`, `slotId`,
   `leaderId`, `leaseExpiry`, `errorType`, `errorMessage`) and rejects accidental platform
   types or synthetic overloads.
 
-  Java fixture는 core exporter와 HTTP exporter에서 `submit`, `observe`, `snapshot`,
+  Java fixture는 `LeaderAuditTrustedHttpsEndpoint.trusted(URI)`를 먼저 구성하고 core
+  exporter와 HTTP exporter에서 `submit`, `observe`, `snapshot`,
   `close`를 호출하고 decorator의 `snapshot()` delegation도 compile/run으로 고정한다.
   reflection으로 위 public constructor/method set과 JVM descriptor를 확인하고, event
   public field에 `token`이나 `LeaderLease`가 없는지 고정한다. `close()` idempotence와
@@ -581,15 +625,16 @@
 
   `SimpleMeterRegistry`에서 accepted, queue-full, closed, retry, terminal failure를
   각각 발생시키고 metric 이름과 finite tag set을 검증한다. 스냅숏의 queue depth,
-  in-flight, cancellation, executor/scheduler rejection gauge/counter도 검증한다.
+  in-flight, cancellation, executor/scheduler rejection와 observer-drop gauge/counter도
+  검증한다.
   정확한 allow-list는 `source={history,lifecycle,direct}`,
   `transport={core,http}`, `outcome={accepted,queue_full,closed,retry,failure,
   cancelled,rejected}`로 고정한다. 고유 lockName, leaderId, endpoint, error message를
   대량 제출해도 meter 수가 증가하지 않고 해당 값이 tag에 없는지 assertion한다.
   gauge 구현은 exporter `snapshot()`의 O(1) atomic counter를 읽고 queue를 순회하지
   않으며, snapshot object는 submit hot path에서 생성하지 않는다는 source/contract
-  assertion을 추가한다. `ownsDelegate=true/false` 각각에서 wrapper close twice,
-  observer detach, delegate close 여부와 snapshot delegation을 검증한다.
+  assertion을 추가한다. wrapper close twice에서 observer detach와 delegate close를
+  검증하고, wrapper close가 exporter close contract를 그대로 보존하는지 확인한다.
 
 - [ ] **Step 2: Run Micrometer test and verify RED**
 
@@ -600,10 +645,12 @@
 
 - [ ] **Step 3: Implement decorator and constants**
 
-  `MicrometerLeaderAuditExporter(delegate, registry, ownsDelegate)`는
-  `LeaderAuditExporter`를 그대로 구현하고 결과별 counter와 `snapshot()` gauge를
-  delegate에 위임한다. `ownsDelegate=true`일 때만 decorator close가 delegate를
-  닫고, `false`일 때는 observer handle만 해제한다. 생성 시 delegate에 bounded
+  `MicrometerLeaderAuditExporter(delegate, registry)`는 항상 delegate를 소유하는
+  `LeaderAuditExporter` decorator로 구현하고 결과별 counter와 `snapshot()` gauge를
+  delegate에 위임한다. decorator close는 observer handle을 먼저 idempotently 해제한
+  뒤 delegate를 닫아 wrapper와 direct delegate 모두 `DROPPED_CLOSED`를 반환하도록
+  한다. non-owning observation은 wrapper가 아니라 public `observe()` handle을
+  별도로 사용한다. 생성 시 delegate에 bounded
   `LeaderAuditExportObserver`를 등록해 retry, terminal failure, cancellation,
   rejection을 관찰하고 decorator close에서 observer handle을 idempotently 해제한다.
   delegate의 `snapshot()` descriptor와 값은 그대로 전달하며 metric registry 오류가
@@ -611,7 +658,10 @@
   metric names는 `leader.audit.export.accepted`, `leader.audit.export.dropped`,
   `leader.audit.export.retries`, `leader.audit.export.failures`,
   `leader.audit.export.queue.depth`, `leader.audit.export.in.flight`,
-  `leader.audit.export.cancelled`, `leader.audit.export.rejections`로 고정한다.
+  `leader.audit.export.cancelled`, `leader.audit.export.rejections`,
+  `leader.audit.export.observer.dropped`로 고정한다. `observerDrops`는 snapshot과
+  observer-dropped counter에서 같은 누적값을 보이며 exporter close 후 0으로 reset하지
+  않는다.
   `outcome`, `transport`, `source` tag 값은 위 enum allow-list만 사용하고 event field는
   tag로 복사하지 않는다. 기존 `HISTORY_SINK_FAILURES` counter는 건드리지 않는다.
 
@@ -644,6 +694,7 @@
 
 - Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/LeaderAuditPayloadEncoder.kt`
 - Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/LeaderAuditHttpOptions.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/LeaderAuditTrustedHttpsEndpoint.kt`
 - Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditDelivery.kt`
 - Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditExporter.kt`
 - Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditDeliveryTest.kt`
@@ -664,9 +715,14 @@
   - oversized/chunked response는 `BodyHandlers.discarding()`으로 0 byte만 보존한다.
     이 계약은 메모리 retention bound이며 네트워크 ingress truncation을 약속하지
     않는다는 문서·negative test를 포함한다.
-  - production HTTPS-only, unsafe URI/user-info/query/fragment, loopback/link-local/
-    RFC1918 literal host, redirect, CRLF/unknown/forbidden header를 거부한다.
-    loopback HTTP는 public option이 아닌 `internal` test-only factory에서만 허용한다.
+  - production은 `LeaderAuditTrustedHttpsEndpoint.trusted(uri)`로 명시적으로 감싼
+    HTTPS-only target만 받고, unsafe URI/user-info/query/fragment/control character와
+    redirect/CRLF/unknown/forbidden header를 거부한다. private/link-local/ULA/CGNAT와
+    DNS rebinding 차단은 caller-owned trust boundary의 비목표임을 문서화하고, loopback
+    HTTP는 public option이 아닌 `internal` test-only factory에서만 허용한다.
+  - raw `URI`를 직접 받는 public constructor가 없고, unsafe URI는 trusted wrapper 생성에서
+    거부되며, private/ULA/CGNAT endpoint를 사용하려면 caller가 explicit trusted boundary를
+    선택해야 한다는 ABI/negative fixture를 고정한다.
   - encoder throw, exceptional/cancelled future, response body와 endpoint credential이
     log에 남지 않는 negative matrix를 검증한다.
   - exporter close가 in-flight future와 scheduled retry를 취소하고 late completion이
@@ -717,22 +773,34 @@
               LeaderAuditHttpOptions(64 * 1024)
       }
   }
+
+  class LeaderAuditTrustedHttpsEndpoint private constructor(
+      val uri: URI,
+  ) {
+      companion object {
+          @JvmStatic
+          fun trusted(uri: URI): LeaderAuditTrustedHttpsEndpoint {
+              require(uri.scheme.equals("https", ignoreCase = true))
+              require(uri.userInfo == null && uri.query == null && uri.fragment == null)
+              require(uri.host.isNotBlank())
+              require(uri.toString().none { it.code < 0x20 || it.code == 0x7f })
+              return LeaderAuditTrustedHttpsEndpoint(uri)
+          }
+      }
+  }
   ```
 
   `HARD_MAX_PAYLOAD_BYTES`는 1 MiB 상수로 고정하고 `of`는 caller ByteArray를 복사하기
   전에 그 상한을 검사한다. adapter는 다시 configured `maxPayloadBytes`를 검사해
   lower bound도 request 생성 전에 거부한다. `LeaderAuditHttpOptions`는
   `maxPayloadBytes` 기본 64 KiB, hard upper bound 1 MiB를
-  검증한다. production `HttpLeaderAuditExporter`는 HTTPS URI만 허용하며 public
-  options에 scheme allow-list나 insecure-loopback flag를 노출하지 않는다. loopback
-  HTTP는 `internal` test-only delivery factory에서만 허용하고 public Java/Kotlin ABI에
-  포함하지 않는다. production target은 user-info/query/fragment/control character와
-  loopback·link-local·RFC1918 literal address를 거부한다. private endpoint 예외는
-  이번 public API에 포함하지 않으며 후속 보안 검토 issue에서 별도 trusted boundary로
-  정의한다. production resolver는 URI host의 모든 `InetAddress` 결과에 대해
-  `isLoopbackAddress`, `isLinkLocalAddress`, `isSiteLocalAddress`, `isAnyLocalAddress`
-  를 검사하고 하나라도 해당하면 fail-fast한다. resolver는 `internal` seam으로 주입해
-  negative test가 DNS/network에 의존하지 않게 한다.
+  검증한다. production `HttpLeaderAuditExporter`는 위 `LeaderAuditTrustedHttpsEndpoint`
+  로 명시적으로 감싼 HTTPS target만 받는다. 이 타입은 caller가 allow-list와 DNS/SSRF
+  trust를 확인했다는 ownership boundary이며 library는 hostname을 IP에 pin하거나
+  DNS rebinding을 방지한다고 주장하지 않는다. 따라서 private/link-local/ULA/CGNAT와
+  DNS rebinding은 v1 비목표이고, 운영 문서는 static trusted endpoint 또는 별도 egress
+  proxy를 사용하도록 안내한다. loopback HTTP는 `internal` test-only delivery factory에서만
+  허용하고 public Java/Kotlin ABI에 포함하지 않는다.
   `HttpLeaderAuditDelivery`는
   `HttpRequest.newBuilder(uri).timeout(options.attemptTimeout).POST(...)`와
   `HttpClient.sendAsync(..., BodyHandlers.discarding())`를 사용한다. injected client의
@@ -745,7 +813,7 @@
   `Proxy-Authorization`, `X-Api-Key`, `Forwarded`와 모든 unknown header를 거부한다.
   encoder 예외는 delivery
   future의 terminal failure로 격리한다.
-  `HttpLeaderAuditExporter`는 Task 2 dispatcher에 delivery를 주입하고, URI·encoder·
+  `HttpLeaderAuditExporter`는 Task 2 dispatcher에 delivery를 주입하고, trusted endpoint·encoder·
   options·executor ownership 및 `exporter.close()` 후 외부 scheduler/executor를
   종료하는 순서를 KDoc로 명시한다. `snapshot()`은 delegate snapshot을 그대로
   반환한다. JSON serialization을 추가하지 않으며
@@ -805,7 +873,8 @@
   `releaseCommit`을 가리키므로 이번 train에서 해당 release manual을 수정하지 않는다.
   대신 draft EN/KO manual에 core 조립 순서
   (`sink → ExportingSink → SafeRecorder → backend`), `Listening*` lifecycle wrapper,
-  HTTP encoder/headers/receiver 예제, migration/limitations를 기록하고
+  `LeaderAuditTrustedHttpsEndpoint` construction, HTTP encoder/headers/receiver 예제,
+  caller-owned DNS/SSRF trust boundary와 migration/limitations를 기록하고
   “0.6.0 release manifest 전환 전에는 released claim이 아님”을 명시한다. 0.6
   release-authorized 후속 작업에서 draft를 pinned manual로 승격하고 manifest/
   release inventory를 함께 갱신한다. HTTP 예제의 `Authorization` 값은
@@ -826,9 +895,7 @@
   변경된 두 locale의 제목·API·metric·scope가 대응하고, draft는 0.5.0 release claim을
   과장하지 않는지 read-back한다. pinned manual의 release source validation은
   immutable commit에 대해 PASS해야 하며 draft token이 pinned 문서에 섞이지 않아야
-  한다. `rg -n 'Authorization: Bearer (sk-|ghp_|AKIA|eyJ)' docs/manual/drafts
-  README.md README.ko.md leader-core/README* leader-micrometer/README*`가 0건이고,
-  placeholder가 `${WEBHOOK_TOKEN}` 또는 `<REDACTED>`로만 존재하는지 확인한다.
+  한다. `rg -nP '(Authorization:\s*(Basic|Bearer)\s+(?!\$\{WEBHOOK_TOKEN\}|<REDACTED>)[A-Za-z0-9._~+/=-]{8,}|(glpat-|github_pat_|xox[baprs]-|npm_|AIza|sk-|ghp_|AKIA[0-9A-Z]{8,}))' docs/manual/drafts README.md README.ko.md leader-core/README* leader-micrometer/README*`가 0건이고, placeholder가 `${WEBHOOK_TOKEN}` 또는 `<REDACTED>`로만 존재하는지 확인한다. gitleaks가 설치되어 있으면 동일 대상에 `gitleaks dir --no-banner --redact`도 실행한다.
   diagram 변경은 없으므로
   `bluetape-diagram`은 N/A이며 evidence에 이유를 기록한다.
 
@@ -887,9 +954,9 @@
   Micrometer tags. Record every six independent lens command, exact head, files,
   P0/P1/P2/P3 result, repair or PASS evidence, CI/manual evidence, and final DoD in
   the required tracked review artifact. A benchmark framework is not added; the
-  performance claim is limited to source-verified CAS/non-blocking admission plus a
-  deterministic contention test with a documented threshold of no blocking wait and
-  bounded allocation per accepted item.
+  performance claim is limited to source-verified CAS/non-blocking admission plus the
+  fixed 32×100 contention fixture's submit-return latch and permit-bound evidence. No
+  allocation or wall-clock throughput threshold is claimed.
 
 - [ ] **Step 4: Run final acceptance matrix**
 
@@ -899,7 +966,7 @@
   | blocking/suspend/event bridge parity | bridge tests + cancellation test |
   | queue/drop/failure isolation | bounded exporter tests + fake delivery |
   | HTTP status/retry/backoff/close | loopback HTTP tests |
-  | HTTP timeout/URI/header/payload/response bounds | deterministic fake HTTP tests + loopback smoke |
+  | HTTP timeout/trusted-endpoint/header/payload/response bounds | deterministic fake HTTP tests + loopback smoke; DNS/SSRF non-goal documented |
   | Micrometer finite cardinality/diagnostics | `MicrometerLeaderAuditExporterTest` |
   | no dependency/module registration | `git diff`, `./gradlew projects` |
   | docs locale parity/release pin | README/draft manual validators and release read-back |

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -1,0 +1,595 @@
+# OBS-03 Audit Export Adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `test-driven-development` and the matching Kotlin pattern skill to implement this plan task-by-task. Steps use checkbox syntax for tracking.
+
+**Goal:** `leader-core`와 `leader-micrometer`에 election/history event를 안전하게 bounded asynchronous exporter로 전달하고, JDK HTTP/webhook transport와 관찰 metric을 제공한다.
+
+**Architecture:** core는 token을 제외한 immutable `LeaderAuditExportEvent`, redaction policy, non-blocking bounded admission, retryable one-shot delivery와 lifecycle을 소유한다. History sink와 `LeaderElectionEventPublisher`는 core exporter bridge를 사용하고, HTTP는 JDK `HttpClient.sendAsync`를 주입된 payload encoder와 결합한다. Micrometer는 exporter를 decorator하여 low-cardinality outcome metric만 추가한다.
+
+**Tech Stack:** Kotlin, JDK 25 `java.net.http.HttpClient`, `CompletableFuture`/`CompletionStage`, `ScheduledExecutorService`, kotlinx.coroutines Flow, Micrometer, JUnit 5, Bluetape assertions, MockK where existing patterns require it.
+
+---
+
+## 실행 경계와 공통 규칙
+
+- 작업 worktree: `.worktrees/issue-535-audit-core`
+- AUD-01 branch: `feat/epic-obs-03-audit-export-core`, base `origin/develop`
+- AUD-02 branch: `feat/epic-obs-03-audit-export-micrometer`, base AUD-01 exact head
+- AUD-03 branch: `feat/epic-obs-03-audit-export`, base AUD-02 exact head
+- 각 task는 RED → 실패 확인 → 최소 구현 → GREEN → `git diff --check` → Lore commit 순서로 실행한다.
+- 새 exception test는 `io.bluetape4k.assertions.assertFailsWith`만 사용한다. JUnit `assertThrows`, `kotlin.test.assertFailsWith`, `shouldThrow`는 사용하지 않는다.
+- exporter callback은 election 결과를 변경하지 않는다. coroutine cancellation은 broad `Exception`보다 먼저 재전파한다.
+- 외부 dependency, 새 module, BOM/CI/Nightly registration은 추가하지 않는다.
+
+## Task 1: 안전한 core audit event와 redaction policy
+
+**Files:**
+
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditLifecycleOutcome.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditValueSanitizer.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt`
+
+- [ ] **Step 1: Write the failing event/redaction tests**
+
+  다음 테스트를 작성한다.
+
+  ```kotlin
+  @Test
+  fun `history event never exposes token and bounds error metadata`() {
+      val event = LeaderAuditExportEvent.History.from(
+          record = recordWithTokenAndOversizedMetadata(),
+          sanitizer = LeaderAuditValueSanitizer.Default,
+      )
+
+      event::class.memberProperties.none { it.name == "token" }.shouldBeTrue()
+      val errorBytes = event.errorMessage?.toByteArray(Charsets.UTF_8)?.size ?: 0
+      (errorBytes <= LeaderAuditExportEvent.MAX_ERROR_MESSAGE_BYTES).shouldBeTrue()
+      (event.attributes.size <= LeaderAuditExportEvent.MAX_ATTRIBUTES).shouldBeTrue()
+  }
+
+  @Test
+  fun `default sanitizer redacts lock node and leader identity`() {
+      val sanitizer = LeaderAuditValueSanitizer.Default
+
+      sanitizer.sanitize(LeaderAuditField.LOCK_NAME, "tenant-42-job")
+          .shouldBeEqualTo("redacted")
+      sanitizer.sanitize(LeaderAuditField.LEADER_ID, "node-1")
+          .shouldBeEqualTo("redacted")
+  }
+
+  @Test
+  fun `custom sanitizer can hash or truncate allow-listed values`() {
+      val sanitizer = LeaderAuditValueSanitizer { _, value -> value.take(8) }
+
+      sanitizer.sanitize(LeaderAuditField.LOCK_NAME, "static-job")
+          .shouldBeEqualTo("static-j")
+  }
+  ```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+  Run:
+
+  ```bash
+  ./gradlew :bluetape4k-leader-core:test --tests \
+    'io.bluetape4k.leader.audit.LeaderAuditExportEventTest'
+  ```
+
+  Expected: `FAIL` because the audit package and event types do not exist.
+
+- [ ] **Step 3: Implement the minimum event contract**
+
+  `LeaderAuditExportEvent`는 `Serializable` sealed interface로 만들고 `History`와
+  `Lifecycle` data class를 제공한다. token과 `LeaderLease` 객체는 field에 넣지
+  않는다. `History.from(record, sanitizer)`는 기존 `sanitize(record)` 결과를
+  사용하고 `Lifecycle.from(event, sanitizer)`는 `LeaderElectionEvent`의
+  `lockName`, outcome, expiry만 매핑한다.
+
+  ```kotlin
+  sealed interface LeaderAuditExportEvent : Serializable {
+      val occurredAt: Instant
+      val lockName: String
+      val attributes: Map<String, String>
+
+      data class History private constructor(
+          override val occurredAt: Instant,
+          override val lockName: String,
+          val kind: LockIdentity.AnnotationKind?,
+          val status: LeaderHistoryStatus,
+          val nodeId: String?,
+          val slotId: String?,
+          val durationMs: Long?,
+          val errorType: String?,
+          val errorMessage: String?,
+          override val attributes: Map<String, String>,
+      ) : LeaderAuditExportEvent
+
+      data class Lifecycle private constructor(
+          override val occurredAt: Instant,
+          override val lockName: String,
+          val outcome: LeaderAuditLifecycleOutcome,
+          val leaderId: String?,
+          val leaseExpiry: Instant?,
+          override val attributes: Map<String, String>,
+      ) : LeaderAuditExportEvent
+  }
+  ```
+
+  `LeaderAuditValueSanitizer.Default`는 민감 field를 `redacted`로 바꾸고,
+  metadata/error는 기존 core byte/key limits를 재사용한다. 모든 map은 defensive
+  copy하고, public KDoc는 Korean technical register로 작성한다.
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+  Run the same focused Gradle test. Expected: all event, token omission, limits,
+  and custom sanitizer cases PASS.
+
+- [ ] **Step 5: Commit AUD-01 model slice**
+
+  ```bash
+  git add leader-core/src/main/kotlin/io/bluetape4k/leader/audit \
+    leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
+  git commit -m $'OBS-03 안전한 audit export event 계약을 추가한다\n\nConstraint: token과 high-cardinality 값은 core event 경계에서 제거한다.\nRejected: 기존 LeaderLockHistoryRecord를 외부 payload로 직접 노출 | token/redaction 경계가 불명확함\nConfidence: high\nScope-risk: moderate\nDirective: exporter는 sanitized event만 수신해야 한다.\nTested: focused LeaderAuditExportEventTest\nNot-tested: dispatcher와 transport는 후속 task에서 검증한다.'
+  ```
+
+## Task 2: bounded exporter SPI, admission, retry lifecycle
+
+**Files:**
+
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExporter.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditSubmitResult.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportOptions.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditDelivery.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt`
+- Create: `leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt`
+
+- [ ] **Step 1: Write failing admission and retry tests**
+
+  테스트는 injected executor/scheduler와 `CompletableFuture` delivery fake를
+  사용해 wall-clock sleep 없이 다음 계약을 고정한다.
+
+  ```kotlin
+  @Test
+  fun `queue full returns dropped without calling delivery`() { /* capacity=1 */ }
+
+  @Test
+  fun `closed exporter rejects new work and cancels pending retry`() { /* close */ }
+
+  @Test
+  fun `retryable failure stops at max attempts and never throws to submitter`() { /* 503 */ }
+
+  @Test
+  fun `non retryable failure is terminal without retry`() { /* 400 */ }
+
+  @Test
+  fun `late completion after close does not schedule another attempt`() { /* race */ }
+  ```
+
+  각 테스트는 `ACCEPTED`, `DROPPED_QUEUE_FULL`, `DROPPED_CLOSED`, attempt count,
+  delivery completion과 close state를 `shouldBeEqualTo`/`shouldBeTrue`로 검증한다.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+  ```bash
+  ./gradlew :bluetape4k-leader-core:test --tests \
+    'io.bluetape4k.leader.audit.BoundedLeaderAuditExporterTest'
+  ```
+
+  Expected: `FAIL` because the exporter SPI and dispatcher are not present.
+
+- [ ] **Step 3: Implement non-blocking bounded dispatcher**
+
+  다음 public boundary를 구현한다.
+
+  ```kotlin
+  interface LeaderAuditExporter : AutoCloseable {
+      fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult
+      override fun close()
+  }
+
+  enum class LeaderAuditSubmitResult { ACCEPTED, DROPPED_QUEUE_FULL, DROPPED_CLOSED }
+
+  fun interface LeaderAuditDelivery {
+      fun deliver(event: LeaderAuditExportEvent): CompletionStage<LeaderAuditDeliveryResult>
+  }
+
+  enum class LeaderAuditDeliveryResult { SUCCESS, RETRYABLE_FAILURE, TERMINAL_FAILURE }
+  ```
+
+  `BoundedLeaderAuditExporter`는 `ArrayBlockingQueue.offer`만 사용해 submit을
+  non-blocking으로 만들고, `maxInFlight`, `maxAttempts`, `initialBackoff`,
+  `maxBackoff`, `Executor`, `ScheduledExecutorService`를 options에서 받는다.
+  queue worker는 delivery completion을 한 번만 terminalize하며, close는 admission
+  flag를 먼저 바꾸고 queued item·scheduled retry·in-flight future를 취소한다.
+  injected executor/scheduler는 exporter가 shutdown하지 않으며 ownership을
+  caller에게 문서화한다.
+
+- [ ] **Step 4: Run dispatcher tests and verify GREEN**
+
+  동일 focused test를 실행해 queue, retry, close, late completion 경로가 모두
+  PASS인지 확인한다. flaky wall-clock delay가 발견되면 manual scheduler seam으로
+  수정하고 테스트를 다시 실행한다.
+
+- [ ] **Step 5: Commit core dispatcher slice**
+
+  ```bash
+  git add leader-core/src/main/kotlin/io/bluetape4k/leader/audit \
+    leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
+  git diff --check
+  git commit -m $'OBS-03 bounded audit exporter lifecycle을 구현한다\n\nConstraint: election hot path는 queue admission만 수행하고 delivery latency를 기다리지 않는다.\nRejected: 무한 queue와 무제한 retry | 종료 불능과 장애 전파 위험\nConfidence: high\nScope-risk: broad\nDirective: close와 late completion의 상태 전이를 유지한다.\nTested: focused bounded exporter tests\nNot-tested: history bridge와 HTTP delivery는 후속 task에서 검증한다.'
+  ```
+
+## Task 3: history sink와 lifecycle publisher bridge
+
+**Files:**
+
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/ExportingLeaderHistorySink.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/ExportingSuspendLeaderHistorySink.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderElectionEventExportSubscription.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/audit/ExportingLeaderHistorySinkTest.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderElectionEventExportSubscriptionTest.kt`
+
+- [ ] **Step 1: Write failing bridge tests**
+
+  blocking/suspend sink는 delegate result를 보존하고 exporter의 `DROPPED_*`를
+  election result로 바꾸지 않는지 검증한다. publisher bridge는 Elected/Revoked/
+  Skipped를 각각 한 번 submit하고 returned `AutoCloseable` 이후에는 submit하지
+  않는지 검증한다. suspend cancellation test는 `assertFailsWith<CancellationException>`
+  으로 sink cancellation이 재전파되는지 확인한다.
+
+- [ ] **Step 2: Run bridge tests and verify RED**
+
+  ```bash
+  ./gradlew :bluetape4k-leader-core:test --tests \
+    'io.bluetape4k.leader.audit.ExportingLeaderHistorySinkTest' \
+    --tests 'io.bluetape4k.leader.audit.LeaderElectionEventExportSubscriptionTest'
+  ```
+
+  Expected: `FAIL` because bridge classes do not exist.
+
+- [ ] **Step 3: Implement delegate-first, export-best-effort bridges**
+
+  `ExportingLeaderHistorySink`는 delegate를 먼저 호출한다. `recordAcquired`가
+  non-null key를 반환하면 `History(ACQUIRED)`를 submit하고, completed/failed는
+  key와 종료 인자를 사용해 event를 만든다. exporter submit 결과는 무시하지 않고
+  caller가 선택적으로 관찰할 수 있는 internal counter hook에 전달하되 sink
+  return value는 변경하지 않는다.
+
+  `ExportingSuspendLeaderHistorySink`는 같은 mapping을 suspend 함수에 적용하고
+  sink 호출 전후의 `CancellationException`/`InterruptedException` 경계를 보존한다.
+  `LeaderElectionEventExportSubscription`은 기존 `onEvent(scope, listener)`를
+  사용하고 scope cancellation과 explicit close를 모두 idempotent하게 처리한다.
+
+- [ ] **Step 4: Run bridge tests and verify GREEN**
+
+  동일 Gradle test를 실행하고, `runTest`에서 subscription cancellation·late event가
+  추가 submit을 만들지 않는지 확인한다.
+
+- [ ] **Step 5: Commit bridge slice**
+
+  ```bash
+  git add leader-core/src/main/kotlin/io/bluetape4k/leader/audit \
+    leader-core/src/test/kotlin/io/bluetape4k/leader/audit
+  git diff --check
+  git commit -m $'OBS-03 history와 lifecycle event를 exporter에 연결한다\n\nConstraint: 기존 sink와 publisher의 결과·취소 계약을 보존한다.\nRejected: elector 내부에 HTTP/export side effect를 직접 삽입 | backend hot path와 framework contract 결합\nConfidence: high\nScope-risk: broad\nDirective: bridge는 exporter drop을 election outcome으로 변환하지 않는다.\nTested: blocking/suspend bridge and publisher subscription tests\nNot-tested: Micrometer와 HTTP transport는 후속 slice에서 검증한다.'
+  ```
+
+## Task 4: core public ABI와 contract evidence
+
+**Files:**
+
+- Create: `leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportBoundaryContractTest.kt`
+- Modify: audit public types의 KDoc files from Tasks 1–3
+
+- [ ] **Step 1: Write failing public boundary checks**
+
+  reflection으로 `LeaderAuditExporter`, `LeaderAuditExportEvent`, options와 result
+  enum의 public constructor/method set을 확인하고, event public field에 `token`이나
+  `LeaderLease`가 없는지 고정한다. `close()` idempotence와 `submit` return type을
+  JVM descriptor로 확인한다.
+
+- [ ] **Step 2: Run contract test and verify RED**
+
+  ```bash
+  ./gradlew :bluetape4k-leader-core:test --tests \
+    'io.bluetape4k.leader.audit.LeaderAuditExportBoundaryContractTest'
+  ```
+
+- [ ] **Step 3: Align KDoc and ABI without widening the API**
+
+  public KDoc에는 caller-owned executor/scheduler, queue drop semantics, redaction
+  default, close ownership, JSONL/OpenTelemetry exclusion을 명시한다. 생성자에는
+  `@JvmOverloads`를 추가하지 않고, Kotlin default constructor가 필요한 경우
+  reflection fixture에 exact descriptor를 기록한다.
+
+- [ ] **Step 4: Run contract test and verify GREEN**
+
+  같은 명령과 `git diff --check`를 실행한다. ABI fixture는 새 public API의 이름,
+  descriptor, token 부재, close/submit semantics를 모두 PASS해야 한다.
+
+- [ ] **Step 5: Commit core contract evidence**
+
+  ```bash
+  git add leader-core/src/main/kotlin/io/bluetape4k/leader/audit \
+    leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportBoundaryContractTest.kt
+  git commit -m $'OBS-03 core exporter public ABI와 KDoc를 고정한다\n\nConstraint: 기존 core public contract와 binary compatibility를 유지한다.\nRejected: 편의용 overload와 raw record exposure | JVM descriptor와 redaction 경계 확대\nConfidence: high\nScope-risk: moderate\nDirective: 후속 transport는 이 stable event boundary를 사용한다.\nTested: ABI boundary contract test and diff check\nNot-tested: Micrometer/HTTP integration은 후속 slice에서 검증한다.'
+  ```
+
+## Task 5: Micrometer exporter decorator와 low-cardinality metrics
+
+**Files:**
+
+- Modify: `leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerNames.kt`
+- Create: `leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt`
+- Test: `leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt`
+- Modify: `leader-micrometer/README.md`
+- Modify: `leader-micrometer/README.ko.md`
+
+- [ ] **Step 1: Write failing metric tests**
+
+  `SimpleMeterRegistry`에서 accepted, queue-full, closed, retry, terminal failure를
+  각각 발생시키고 metric 이름과 finite tag set을 검증한다. `lockName`, `leaderId`,
+  endpoint, error message가 meter tag에 없는지도 assertion한다.
+
+- [ ] **Step 2: Run Micrometer test and verify RED**
+
+  ```bash
+  ./gradlew :bluetape4k-leader-micrometer:test --tests \
+    'io.bluetape4k.leader.micrometer.audit.MicrometerLeaderAuditExporterTest'
+  ```
+
+- [ ] **Step 3: Implement decorator and constants**
+
+  `MicrometerLeaderAuditExporter(delegate, registry)`는 `LeaderAuditExporter`를
+  그대로 반환하고 결과별 counter를 increment한다. metric names는
+  `leader.audit.export.accepted`, `leader.audit.export.dropped`,
+  `leader.audit.export.retries`, `leader.audit.export.failures`로 고정한다.
+  `outcome`, `transport` tag 값은 enum/string allow-list만 사용하고 event field는
+  tag로 복사하지 않는다. 기존 `HISTORY_SINK_FAILURES` counter는 건드리지 않는다.
+
+- [ ] **Step 4: Run Micrometer tests and verify GREEN**
+
+  focused test 후 기존 history/micrometer suite를 실행한다.
+
+  ```bash
+  ./gradlew :bluetape4k-leader-micrometer:test \
+    --tests 'io.bluetape4k.leader.micrometer.audit.MicrometerLeaderAuditExporterTest' \
+    --tests 'io.bluetape4k.leader.micrometer.history.*'
+  ```
+
+- [ ] **Step 5: Update both README locales and commit AUD-02**
+
+  두 README에 exporter opt-in, drop/failure metric, default redaction, no JSONL/
+  OpenTelemetry statement를 같은 구조로 추가한다. Korean prose는 기술 register로
+  작성하고 API·metric·commands는 그대로 보존한다.
+
+  ```bash
+  git add leader-micrometer/src/main leader-micrometer/src/test \
+    leader-micrometer/README.md leader-micrometer/README.ko.md
+  git diff --check
+  git commit -m $'OBS-03 Micrometer audit exporter metric을 추가한다\n\nConstraint: metric cardinality는 finite outcome/transport tag로 제한한다.\nRejected: lock별 metric tag | dynamic lock name으로 cardinality가 증가함\nConfidence: high\nScope-risk: moderate\nDirective: 기존 history sink metric semantics를 변경하지 않는다.\nTested: focused and existing Micrometer history tests, README diff check\nNot-tested: HTTP delivery는 AUD-03에서 검증한다.'
+  ```
+
+## Task 6: JDK HTTP/webhook delivery와 bounded retry
+
+**Files:**
+
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/LeaderAuditPayloadEncoder.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditDelivery.kt`
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditExporter.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditDeliveryTest.kt`
+- Test: `leader-core/src/test/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditExporterTest.kt`
+
+- [ ] **Step 1: Write failing HTTP contract tests**
+
+  JDK `HttpServer`를 loopback에 순차적으로 띄워 다음 응답을 검증한다.
+
+  - `202`/`204`를 success로 분류한다.
+  - `429`, `503`, I/O disconnect는 최대 attempt까지 retry한다.
+  - `400`, `401`, `403`, `404`는 retry하지 않는다.
+  - encoder가 만든 body와 allow-listed headers만 request에 전달한다.
+  - response body와 endpoint credential이 log에 남지 않는다.
+  - exporter close가 in-flight future와 scheduled retry를 취소하고 late completion이
+    새 retry를 만들지 않는다.
+
+- [ ] **Step 2: Run HTTP tests and verify RED**
+
+  ```bash
+  ./gradlew :bluetape4k-leader-core:test --tests \
+    'io.bluetape4k.leader.audit.http.HttpLeaderAuditDeliveryTest' \
+    --tests 'io.bluetape4k.leader.audit.http.HttpLeaderAuditExporterTest'
+  ```
+
+- [ ] **Step 3: Implement encoder, delivery, and exporter composition**
+
+  ```kotlin
+  fun interface LeaderAuditPayloadEncoder {
+      fun encode(event: LeaderAuditExportEvent): LeaderAuditHttpPayload
+  }
+
+  data class LeaderAuditHttpPayload(
+      val contentType: String,
+      val body: ByteArray,
+  )
+  ```
+
+  `HttpLeaderAuditDelivery`는 `HttpRequest.newBuilder(uri).POST(...)`와
+  `HttpClient.sendAsync`를 사용한다. 2xx는 `SUCCESS`, 408/429/5xx와 I/O exception은
+  `RETRYABLE_FAILURE`, 나머지 4xx는 `TERMINAL_FAILURE`로 매핑한다. 요청 header는
+  constructor allow-list를 통해 복사하고 secret 값을 logger에 전달하지 않는다.
+  `HttpLeaderAuditExporter`는 Task 2 dispatcher에 delivery를 주입하고, URI·encoder·
+  options·executor ownership을 KDoc로 명시한다. JSON serialization을 추가하지
+  않으며 JSONL/OpenTelemetry implementation도 만들지 않는다.
+
+- [ ] **Step 4: Run HTTP tests and verify GREEN**
+
+  focused HTTP suite를 실행하고 Testcontainers 없이 loopback server lifecycle이
+  매 테스트 종료 시 닫히는지 확인한다. 실패 시 response classification 또는
+  cancellation race를 먼저 수정하고 재실행한다.
+
+- [ ] **Step 5: Commit AUD-03 transport slice**
+
+  ```bash
+  git add leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http \
+    leader-core/src/test/kotlin/io/bluetape4k/leader/audit/http
+  git diff --check
+  git commit -m $'OBS-03 JDK HTTP webhook delivery를 추가한다\n\nConstraint: 새 HTTP/serialization dependency 없이 sendAsync와 bounded retry만 사용한다.\nRejected: JSONL/OpenTelemetry를 같은 PR에 포함 | transport scope와 후속 issue 경계가 흐려짐\nConfidence: high\nScope-risk: broad\nDirective: 2xx/429/5xx/4xx와 close cancellation 분류를 유지한다.\nTested: loopback HTTP delivery and retry tests\nNot-tested: full repository validation은 final verification에서 수행한다.'
+  ```
+
+## Task 7: core README와 manual parity
+
+**Files:**
+
+- Modify: `leader-core/README.md`
+- Modify: `leader-core/README.ko.md`
+- Modify: `leader-micrometer/README.md`
+- Modify: `leader-micrometer/README.ko.md`
+- Modify: `README.md`
+- Modify: `README.ko.md`
+- Modify: `docs/manual/en/modules/bluetape4k-leader-micrometer.md`
+- Modify: `docs/manual/ko/modules/bluetape4k-leader-micrometer.md`
+
+- [ ] **Step 1: Add matching Korean/English capability guidance**
+
+  core README에는 `LeaderAuditExportEvent`, `LeaderAuditExporter`, bridge lifecycle,
+  default redaction, queue drop와 close semantics를 짧은 예제로 설명한다.
+  Micrometer README/manual에는 metric catalog와 no raw/high-cardinality tag 규칙을
+  추가한다. top-level README capability matrix와 event stream 설명에는 HTTP/webhook
+  adapter와 JSONL/OpenTelemetry 후속 범위를 반영한다.
+
+- [ ] **Step 2: Validate docs and locale parity**
+
+  ```bash
+  git diff --check
+  ./gradlew exportManualModuleInventory
+  ruby scripts/manual/validate_manuals.rb build/manual/module-inventory.json
+  ```
+
+  변경된 두 locale의 제목·API·metric·scope가 대응하고, release-pinned manual의
+  현재 source claim을 과장하지 않는지 read-back한다. diagram 변경은 없으므로
+  `bluetape-diagram`은 N/A이며 evidence에 이유를 기록한다.
+
+- [ ] **Step 3: Commit documentation slice**
+
+  ```bash
+  git add README.md README.ko.md leader-core/README.md leader-core/README.ko.md \
+    leader-micrometer/README.md leader-micrometer/README.ko.md \
+    docs/manual/en/modules/bluetape4k-leader-micrometer.md \
+    docs/manual/ko/modules/bluetape4k-leader-micrometer.md
+  git commit -m $'OBS-03 audit exporter 사용 계약을 README와 manual에 반영한다\n\nConstraint: README는 concise entry point이고 manual은 release-facing source of truth다.\nRejected: 한 locale만 수정 | public API와 redaction guidance가 불일치함\nConfidence: high\nScope-risk: moderate\nDirective: JSONL/OpenTelemetry 후속 범위를 문서에서 명확히 유지한다.\nTested: locale parity, manual validator, diff check\nNot-tested: CI workflow는 변경하지 않는다.'
+  ```
+
+## Task 8: 통합 검증과 performance/stability scan
+
+**Files:**
+
+- Inspect all AUD-01~03 changed files and tests
+- Create only if required: `docs/review/2026-08-18-issue-535-audit-export-review.md`
+
+- [ ] **Step 1: Run targeted module validation**
+
+  ```bash
+  ./gradlew :bluetape4k-leader-core:test \
+    :bluetape4k-leader-micrometer:test
+  ./gradlew detekt
+  git diff --check
+  ```
+
+  Expected: all affected tests, detekt, and diff check PASS; no new dependency or
+  module registration appears in `git diff`.
+
+- [ ] **Step 2: Run proportional integration checks**
+
+  ```bash
+  ./gradlew :bluetape4k-leader-core:build \
+    :bluetape4k-leader-micrometer:build
+  ./gradlew projects
+  ```
+
+  Verify compile/test fixtures, public ABI, and Kover inputs remain present. No
+  Testcontainers backend matrix is triggered because this change does not touch
+  backend modules or external databases; local loopback HTTP lifecycle tests are
+  the scoped transport proof.
+
+- [ ] **Step 3: Complete performance/stability scan**
+
+  Inspect the exact diff for blocking calls in `submit`/Flow callbacks, unbounded
+  queue/retry, scheduler ownership leaks, virtual-thread monitor pinning, coroutine
+  cancellation swallowing, duplicate late completion, response-body/secret logging,
+  and per-lock Micrometer tags. Record the command, files, and either PASS or a
+  repaired finding in the tracked review artifact.
+
+- [ ] **Step 4: Run final acceptance matrix**
+
+  | Acceptance | Evidence |
+  |---|---|
+  | token/raw sensitive value absent | `LeaderAuditExportEventTest` + boundary fixture |
+  | blocking/suspend/event bridge parity | bridge tests + cancellation test |
+  | queue/drop/failure isolation | bounded exporter tests + fake delivery |
+  | HTTP status/retry/backoff/close | loopback HTTP tests |
+  | Micrometer finite cardinality | `MicrometerLeaderAuditExporterTest` |
+  | no dependency/module registration | `git diff`, `./gradlew projects` |
+  | docs locale parity | README/manual validator and read-back |
+
+  Every row must have fresh output before Step 8 is checked.
+
+## Task 9: stacked PR delivery preparation
+
+- [ ] **Step 1: Verify branch ancestry and clean slices**
+
+  ```bash
+  git log --graph --oneline --decorate --all --max-count=30
+  git status --short --branch
+  git diff origin/develop...HEAD --stat
+  ```
+
+  AUD-01 contains only core event/dispatcher/bridge/contract commits; AUD-02 adds
+  only Micrometer and its docs; AUD-03 adds only HTTP/webhook and final docs. Any
+  cross-slice file drift is repaired before PR creation.
+
+- [ ] **Step 2: Build PR bodies from fresh evidence**
+
+  Each PR uses Korean public prose, assignee `debop`, milestone `0.6.0`, Issue #535
+  link and mirrored labels. The final section is exactly `## DoD Status` and includes
+  reconciled `Required checks: X/Y; N/A: N; Blocked: N`, evidence table, final status,
+  and unchecked items. Base/head SHA and predecessor PR are recorded explicitly.
+
+- [ ] **Step 3: Run Type-A pre-PR review**
+
+  Execute six independent perspectives plus main-session integration against each
+  exact stacked diff. P0/P1 blocks PR creation; P2/P3 is fixed or filed with rationale.
+  Apply the Korean writer gate to the integrated review artifact.
+
+- [ ] **Step 4: Stop at merge-ready**
+
+  Re-read exact PR head, CI, review threads, mergeability, linked Issue #535 and
+  final `## DoD Status`. Report merge-ready only after required checks pass; do not
+  merge until fresh approval for that exact head.
+
+## Traceability matrix
+
+| Spec requirement | Plan tasks |
+|---|---|
+| safe event/token omission/redaction | 1, 4, 8 |
+| bounded admission/close/retry | 2, 8 |
+| history and lifecycle bridges | 3, 8 |
+| Micrometer accepted/drop/retry/failure | 5, 8 |
+| HTTP status classification and webhook delivery | 6, 8 |
+| README/manual locale parity | 5, 7 |
+| no new dependency/module and ABI compatibility | 4, 8, 9 |
+| JSONL/OpenTelemetry excluded | 6, 7, 9 |
+| stacked PR exact base/head and fresh CI/review | 9 |
+
+## Rollback and rerun points
+
+- Task 1–4 failure: revert the latest Lore commit on AUD-01; existing history/event
+  APIs remain unchanged because all new types are opt-in.
+- Task 5 failure: drop AUD-02 branch/commits and retain the green AUD-01 head; core
+  exporter behavior is independent of Micrometer.
+- Task 6 failure: drop AUD-03 transport commits and retain AUD-02; no HTTP request is
+  created by existing elector code without explicit opt-in.
+- Task 7 validator or locale mismatch: repair docs only and rerun manual/read-back
+  checks; do not rerun code tests unless a code claim changed.
+- Any P1 from performance/stability review: stop PR delivery, repair the affected
+  task, rerun its focused test and all dependent validation rows.

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -849,8 +849,10 @@
   snapshot에 보존하고 `finally`에서 `DETACHED`로 복구하는지, close 예외가 primary로 유지되고
   final snapshot/transition 예외가 suppressed되는지, 이후 replacement acquire가 성공하는지
   검증한다.
-  final snapshot 자체가 예외를 던지는 fixture도 close-entry 기반 offset/gauge를 보존하고
-  provider를 clear한 뒤 `DETACHED`로 전환하는지 확인한다.
+  final snapshot 자체가 예외를 던지는 fixture도 close-entry 기반 offset을 보존하고
+  provider를 clear한 뒤 `DETACHED`로 전환하는지 확인한다. 이 fallback에서는 cumulative
+  counter offset만 보존하고 `queue=0`, `inFlight=0`, `scheduledRetries=0`, `admitted=0`,
+  `diagnosticsClosed=true`, `closed=true`인 terminal gauge truth table을 exact assertion한다.
   constructor 실패는 delegate를 정확히 한 번 close하고 primary exception을 보존하며,
   delegate close/partial-registration cleanup 예외는 primary에 suppressed로 붙이고,
   primary가 없을 때만 cleanup 예외를 던지는지 검증한다. manager-owned partial registration만
@@ -894,9 +896,11 @@
   `finally`에서 같은 generation의 final snapshot에 대해 각 cumulative counter의
   `final >= close-entry` invariant를 검증하고 `final - close-entry` delta만 정확히 한 번
   `closingOffsets`에 반영한다. 음수 delta는 `check`/diagnostic failure로 드러내며 0으로
-  clamp하지 않는다. gauge는 final snapshot을 사용하고, final snapshot 실패 시에는
-  close-entry 기반 view를 유지한 inner `finally`에서 provider를 clear하여 `DETACHED`로
-  전환한다. 따라서 close-owned cancellation/rejection은 보존되고 close-entry counter는
+  clamp하지 않는다. gauge는 final snapshot을 사용하고, final snapshot 실패 시에는 cumulative
+  counter만 close-entry 기반 view로 유지하며 `queue=0`, `inFlight=0`,
+  `scheduledRetries=0`, `admitted=0`, `diagnosticsClosed=true`, `closed=true`인 terminal
+  fallback gauge를 합성한 뒤 inner `finally`에서 provider를 clear하여 `DETACHED`로 전환한다.
+  따라서 close-owned cancellation/rejection은 보존되고 close-entry counter는
   중복 집계되지 않는다. final/transition 예외는 close 예외가 있으면 suppressed로 붙이고,
   없으면 primary로 던진다. 따라서 이전 close가 새 provider를 지울 수 없고, `CLOSING` 중
   replacement acquire는 거부되며 manager가 영구 `CLOSING`에 남지 않는다.
@@ -936,9 +940,11 @@
   generation의 final snapshot에 대해 각 cumulative counter의 `final >= close-entry`
   invariant를 검증하고 `final - close-entry` delta만 정확히 한 번 `closingOffsets`에
   반영한다. 음수 delta는 `check`/diagnostic failure로 드러내며 0으로 clamp하지 않는다.
-  gauge는 final snapshot 값을 사용하고, final snapshot 실패 시에는 close-entry 기반
-  `closingOffsets`/gauge를 유지한 inner `finally`에서 provider를 clear하여 `DETACHED`
-  claim을 해제한다. 따라서 close-entry counter를 중복 집계하지 않으면서 close-owned
+  gauge는 final snapshot 값을 사용하고, final snapshot 실패 시에는 cumulative counter만
+  close-entry 기반 `closingOffsets`로 유지하며 `queue=0`, `inFlight=0`,
+  `scheduledRetries=0`, `admitted=0`, `diagnosticsClosed=true`, `closed=true`인 terminal
+  fallback gauge를 합성한 inner `finally`에서 provider를 clear하여 `DETACHED` claim을
+  해제한다. 따라서 close-entry counter를 중복 집계하지 않으면서 close-owned
   cancellation/rejection을 final snapshot에 포함한다. `snapshot()`은 delegate close 후에도
   final counters를 O(1)로 읽을 수 있어야 한다. `registry.remove`를 호출하지 않으므로
   lookup/remove TOCTOU와 removal residue가 없고, stable meter identity는 replacement에서

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -449,7 +449,11 @@
   callback을 호출한다. handle close도 같은 lock 순서로 `active=false`를 선형화한 뒤
   registry에서 제거한다. close보다 먼저 reservation된 callback만 crossing allowance로
   실행될 수 있고, close 이후에는 새 reservation이 불가능하므로 handle close 반환 뒤 새
-  callback invocation이 시작되지 않는다.
+  callback invocation이 시작되지 않는다. callback의 `finally` cleanup도 같은
+  `diagnosticsAdmissionLock → slot lock` 순서 또는 동등한 원자 경로에서
+  `running--`, slot `inFlight--`, diagnostics permit 반환을 정확히 한 번 수행한다.
+  callback 완료와 동시 admission이 교차해도 permit 누수·double release·capacity 고착이
+  발생하지 않는다.
   executor-start rejection은 현재 worker가
   보유한 detached queued batch 전체를 deterministic하게 `EXECUTOR_REJECTED`로
   terminalize하고 각 item의 permit을 정확히 한 번 반환한다. retry scheduler rejection은

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -692,10 +692,12 @@
   각각 발생시키고 metric 이름과 finite tag set을 검증한다. 스냅숏의 queue depth,
   in-flight, cancellation, executor/scheduler rejection와 observer-drop,
   observer-registration-drop, diagnostics-failure/closed gauge를 검증한다.
-  정확한 allow-list는 `source={history,lifecycle,direct}`,
-  `transport={core,http}`, `outcome={accepted,queue_full,closed,retry,failure,
-  cancelled,rejected}`로 고정한다. 고유 lockName, leaderId, endpoint, error message를
-  대량 제출해도 meter 수가 증가하지 않고 해당 값이 tag에 없는지 assertion한다.
+  정확한 v1 allow-list는 `outcome={accepted,queue_full,closed,retry,failure,cancelled,
+  rejected}`만 사용하며 `source`/`transport` tag는 생성하지 않는다. mixed source/transport
+  event fixture를 하나의 aggregate delegate로 제출해 합계가 중복·오표시되지 않고, 같은
+  registry의 두 wrapper는 duplicate ID로 fail-fast하는지 검증한다. 고유 lockName, leaderId,
+  endpoint, error message를 대량 제출해도 meter 수가 증가하지 않고 해당 값이 tag에 없는지
+  assertion한다.
   gauge 구현은 exporter `snapshot()`의 O(1) atomic counter를 읽고 queue를 순회하지
   않으며, snapshot object는 submit hot path에서 생성하지 않는다는 source/contract
   assertion을 추가한다. wrapper close twice에서 delegate close idempotence와
@@ -705,8 +707,10 @@
   foreign-registration crossing을 기록한다. manager가 설치 callback/lookup/registrar
   반환 identity를 모두 확인하고 foreign 또는 ambiguous ID를 소유하지 않는지 검증한다.
   wrapper `close()` 두 번 후 exact-owned meter만 제거되고 foreign/replaced meter는
-  건드리지 않으며 첫 removal 실패 뒤에도 나머지 ID를 시도하고 residue warning/counter를
-  남기는지 확인한다. 같은 registry에서 close 후 새 delegate wrapper를 만들면 새 snapshot
+  건드리지 않으며 첫 removal 실패 뒤에도 나머지 ID를 시도하고 fixed warning key
+  `leader.audit.export.meter-removal-failure`와 ID별 one-per-close `residueCount`를
+  남기는지 확인한다. residue claim을 유지한 상태에서 replacement constructor가 removal을
+  재시도하고 성공 후에만 새 wrapper를 허용하는 recovery 경로도 검증한다. 같은 registry에서 close 후 새 delegate wrapper를 만들면 새 snapshot
   source를 읽고, active duplicate wrapper는 기존 ID/source를 재사용하지 않고 fail-fast하며
   부분 등록도 정리하는지 검증한다. constructor 실패는 delegate를 정확히 한 번 close하고
   foreign meter를 보존하는지 assertion한다. 모든 reachability 주장은 `WeakReference`/GC에
@@ -722,8 +726,9 @@
 
 - [ ] **Step 3: Implement decorator and constants**
 
-  `MicrometerLeaderAuditExporter(delegate, registry)`는 항상 delegate를 소유하는
-  `LeaderAuditExporter` decorator로 구현한다. metric의 authoritative source는
+  `MicrometerLeaderAuditExporter(delegate, registry)`는 전체 meter 등록이 성공하면
+  delegate를 소유하는 `LeaderAuditExporter` decorator로 구현한다. construction failure는
+  delegate를 정확히 한 번 닫고 원래 예외를 보존한다. metric의 authoritative source는
   `delegate.snapshot()`의 O(1) atomic counter이며, `FunctionCounter`/`Gauge`가 registry
   polling 시 snapshot을 읽는다. 따라서 async diagnostics observer callback이 close 직후
   drop되어도 close-owned cancellation/rejection이 metric에서 사라지지 않는다.
@@ -737,10 +742,12 @@
   보존하며 partial exact-owned meter만 정리한다. 성공한 등록의 exact `Meter`/`Meter.Id`
   목록은 wrapper가 소유한다. `close()`는 delegate를 idempotently 닫은 뒤 `finally`에서
   현재 lookup이 exact identity인 ID만 `registry.remove(id)`를 시도하고, removal 실패나
-  foreign replacement에도 나머지 ID 제거를 계속한다. removal residue는 fixed-ID
-  lifecycle warning/counter로 보고하고 caller admission/election에는 registry 오류를
-  전파하지 않는다. 따라서 closed delegate strong-reference 제거는 성공적으로 제거된
-  meter에 대해서만 주장한다. non-owning observation은 wrapper가 아니라 public
+  foreign replacement에도 나머지 ID 제거를 계속한다. removal residue는 fixed warning key
+  `leader.audit.export.meter-removal-failure`, ID별 one-per-close warning, O(1)
+  `residueCount`로 보고하고 manager claim을 유지한다. 다음 constructor는 residue 제거를
+  먼저 재시도하며 성공 전에는 replacement를 fail-fast한다. caller admission/election에는
+  registry 오류를 전파하지 않는다. 따라서 closed delegate strong-reference 제거는
+  성공적으로 제거된 meter에 대해서만 주장한다. non-owning observation은 wrapper가 아니라 public
   `observe()` handle을 별도로 사용하며 decorator는 내부 observer handle을 등록하거나
   소유하지 않는다. delegate의 `snapshot()` descriptor와 값은 그대로 전달한다.
   metric names는 `leader.audit.export.accepted`, `leader.audit.export.dropped`,
@@ -758,8 +765,9 @@
   않는다. close 후에는 wrapper가 소유한 모든 meter가 registry에서 제거되어 stale source를
   노출하지 않는다. `diagnosticsClosed`는 open 동안 `diagnostics.closed` gauge의 `0|1` 값과
   일치한다.
-  `outcome`, `transport`, `source` tag 값은 위 enum allow-list만 사용하고 event field는
-  tag로 복사하지 않는다. 기존 `HISTORY_SINK_FAILURES` counter는 건드리지 않는다.
+  `outcome` tag만 위 enum allow-list로 사용하고 `source`/`transport` tag는 v1에서
+  생성하지 않으며 event field는 tag로 복사하지 않는다. 기존 `HISTORY_SINK_FAILURES`
+  counter는 건드리지 않는다.
 
 - [ ] **Step 4: Run Micrometer tests and verify GREEN**
 
@@ -787,7 +795,7 @@
   git add leader-micrometer/src/main leader-micrometer/src/test \
     leader-micrometer/README.md leader-micrometer/README.ko.md
   git diff --check
-  git commit -m $'OBS-03 Micrometer audit exporter metric을 추가한다\n\nConstraint: metric cardinality는 finite outcome/transport tag로 제한한다.\nRejected: lock별 metric tag | dynamic lock name으로 cardinality가 증가함\nConfidence: high\nScope-risk: moderate\nDirective: 기존 history sink metric semantics를 변경하지 않는다.\nTested: focused and existing Micrometer history tests, README diff check\nNot-tested: HTTP delivery는 AUD-03에서 검증한다.'
+  git commit -m $'OBS-03 Micrometer aggregate metric과 residue recovery를 추가한다\n\nConstraint: v1 snapshot은 aggregate counter만 제공하므로 outcome 외 source/transport 차원을 만들지 않는다.\nRejected: 계산할 수 없는 source/transport tag | mixed event를 중복·오표시함\nConfidence: high\nScope-risk: moderate\nDirective: meter removal residue는 fixed warning key와 retry 가능한 manager claim으로 추적한다.\nTested: focused and existing Micrometer history tests, README diff check\nNot-tested: HTTP delivery는 AUD-03에서 검증한다.'
   ```
 
 ## Task 6: JDK HTTP/webhook delivery와 bounded retry

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -279,7 +279,12 @@
   `min(queueCapacity, 1024)`, named daemon worker termination, observer registration cap
   16, observer handle close linearization, queued callback drop와
   `observerDrops`/`observerRegistrationDrops` exact count, `diagnosticsFatalErrors`와
-  `diagnosticsClosed` 상태도 검증한다. observer handle close 테스트는 paused diagnostics
+  `diagnosticsClosed` 상태도 검증한다. diagnostics Error 테스트는 원래 `Error`의
+  uncaught capture, `diagnosticsFatalErrors=1`, `diagnosticsClosed=true`, worker 재시작
+  0과 이후 observe no-op을 함께 확인한다. reentrant close 테스트는 callback 내부 close가
+  자기 worker를 join하지 않고 반환하는 barrier를 사용한다. interrupt-ignoring observer
+  테스트는 callback을 외부 release까지 붙잡아 둔 뒤 release 전에 exporter close가
+  반환하는지 결정적으로 확인하고 teardown에서만 callback을 해제한다. observer handle close 테스트는 paused diagnostics
   worker에서 close barrier를 통과한 뒤 callback invocation reservation이 없으면 callback
   이 시작되지 않음을 확인하고, reservation이 먼저 선형화된 crossing callback만 close
   반환 뒤 마칠 수 있음을 별도 검증한다. `submit` source/benchmark guard는
@@ -452,6 +457,8 @@
   동일한 slot lock에서 invocation reservation을 시도하며, close 전에 reservation된
   callback만 crossing allowance로 호출된다. 17번째 registration은 no-op handle을
   반환하고 `observerRegistrationDrops`를 1 증가시킨다.
+  diagnostics queue offer가 실패하면 slot의 `inFlight`와 diagnostics permit을 즉시
+  되돌리고 `observerDrops`만 증가시킨다.
   diagnostics worker에서 observer `Error`가 발생하면 diagnostics gate를 CLOSED로
   전환하고 queued callback을 drop한 뒤 `diagnosticsFatalErrors`를 1 증가시키고
   `diagnosticsClosed=true`로 표시한 다음 원래 `Error`를 uncaught boundary로 재전파한다.

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -838,21 +838,30 @@
   고정 수치 fixture에서 이전 generation offset=100, close-entry counter=40, close 중 delta=3을
   사용해 OPEN=140, CLOSING=140, DETACHED=143, replacement 이후 `143 + newSnapshot`의
   비감소를 exact assertion한다. final snapshot이 close-entry보다 작은 음수 delta fixture는
-  `check`/diagnostic failure로 표면화되고 0으로 clamp되지 않으며, 그 경우에도 inner
-  `finally`가 provider를 clear해 DETACHED로 복구하는지 검증한다.
+  한 cumulative field만 음수이고 다른 field는 양수인 표를 사용한다. 모든 field delta를
+  immutable temporary value로 검증한 뒤 하나라도 음수면 어떤 양수 field도 적용하지 않고
+  close-entry base를 유지하는지, `sourceDegraded` 진단과 terminal gauge fallback을 기록하는지,
+  `close()`의 예외 identity와 primary/suppressed 순서를 보존하는지, inner `finally`가 provider를
+  clear해 DETACHED로 복구하는지를 함께 검증한다.
   동일 registry에 대한 두 constructor를 barrier에서 동시에 시작해 store manager가 하나만
   생성·게시되고, wrapper winner 하나와 loser delegate exact-once close만 남으며, loser 이후
   replacement acquire가 stable meter identity를 재사용하는지 검증한다.
   compromised manager는 동일 registry에서 수동 fixed-ID 제거 뒤에도 새 wrapper를 거부하고,
   새 `MeterRegistry` identity에서만 replacement acquire가 성공하는지 고정한다.
-  throwing delegate close fixture는 `CLOSING` 중 발생한 close-owned cancellation을 final
-  snapshot에 보존하고 `finally`에서 `DETACHED`로 복구하는지, close 예외가 primary로 유지되고
-  final snapshot/transition 예외가 suppressed되는지, 이후 replacement acquire가 성공하는지
-  검증한다.
-  final snapshot 자체가 예외를 던지는 fixture도 close-entry 기반 offset을 보존하고
-  provider를 clear한 뒤 `DETACHED`로 전환하는지 확인한다. 이 fallback에서는 cumulative
-  counter offset만 보존하고 `queue=0`, `inFlight=0`, `scheduledRetries=0`, `admitted=0`,
-  `diagnosticsClosed=true`, `closed=true`인 terminal gauge truth table을 exact assertion한다.
+  throwing delegate close fixture는 정상 final snapshot 경로에서 `CLOSING` 중 발생한
+  close-owned cancellation/rejection을 final snapshot에 보존하고 `finally`에서 `DETACHED`로
+  복구하는지 검증한다. close 성공/실패, final snapshot/invariant 실패, transition/diagnostic
+  실패를 각각 주입해 `delegate.close` → final snapshot/invariant → transition/diagnostic
+  순서에서 첫 예외 identity가 primary이고 이후 예외가 발생 순서대로 suppressed되는지,
+  예외가 있어도 provider null/DETACHED와 이후 replacement acquire 성공을 함께 확인한다.
+  final snapshot 자체가 예외를 던지는 fixture는 close-entry 이후 cancellation/rejection을
+  한 번 발생시킨 뒤 final snapshot을 실패시켜, 그 후속 delta를 metric에 추정해 더하지
+  않는지 결정적으로 확인한다. `sourceDegraded=true` 내부 상태와
+  `leader.audit.export.meter-source-degraded` fixed warning을 기록하고 close-entry 기반
+  counter offset만 보존하는지 확인한다. close-entry 이후 cancellation/rejection은 이
+  비정상 경로에서 보장하지 않으며, `queue=0`, `inFlight=0`, `scheduledRetries=0`,
+  `admitted=0`, `diagnosticsClosed=true`, `closed=true`인 terminal gauge truth table과
+  final snapshot 예외의 primary/suppressed 전파를 exact assertion한다.
   constructor 실패는 delegate를 정확히 한 번 close하고 primary exception을 보존하며,
   delegate close/partial-registration cleanup 예외는 primary에 suppressed로 붙이고,
   primary가 없을 때만 cleanup 예외를 던지는지 검증한다. manager-owned partial registration만
@@ -882,28 +891,35 @@
   delegate를 소유하는 `LeaderAuditExporter` decorator로 구현한다. construction failure는
   delegate를 정확히 한 번 닫고 원래 예외를 보존한다. metric의 authoritative source는
   manager가 보유한 active provider의 `delegate.snapshot()` O(1) atomic counter와 detached
-  offset이며, `FunctionCounter`/`Gauge`가 registry polling 시 manager state를 읽는다. 따라서
-  async diagnostics observer callback이 close 직후 drop되어도 close-owned
-  cancellation/rejection이 metric에서 사라지지 않는다.
+  offset이며, `FunctionCounter`/`Gauge`가 registry polling 시 manager state를 읽는다. 정상적인
+  final snapshot 경로에서는 async diagnostics observer callback이 close 직후 drop되어도
+  close-owned cancellation/rejection이 metric에서 사라지지 않는다. final snapshot 자체가
+  실패하는 비정상 delegate는 `sourceDegraded` 예외 경로로 분류하며 close-entry 이후
+  cancellation/rejection 정확성은 보장하지 않는다.
   내부 registry-identity manager가 fixed ID claim과 stable meter 집합을 관리한다. manager는
-  `ManagerState(generation, activeProvider, closingProvider, detachedSnapshot, offsets, lifecycle)` 하나를
+  `ManagerState(generation, activeProvider, closingProvider, detachedSnapshot, offsets, lifecycle,
+  sourceDegraded)` 하나를
   보유하고 모든 acquire/close/provider swap과 metric callback을 동일한 lock으로
   선형화한다. callback은 lock을 획득해 state를 한 번 읽고, `OPEN`의 active provider가
   있으면 그 안에서 snapshot을 읽은 뒤 offset을 합산하며 `CLOSING`에서는
   `closingOffsets = oldOffsets + closeEntrySnapshot` detached view만 읽는다. close는 같은
   lock에서 close-entry snapshot과 `closingProvider`를 보존하고 `closingOffsets`를 먼저
   게시한 뒤 active provider를 `CLOSING` state로 옮겨 delegate close를 실행한다. 성공/예외의
-  `finally`에서 같은 generation의 final snapshot에 대해 각 cumulative counter의
-  `final >= close-entry` invariant를 검증하고 `final - close-entry` delta만 정확히 한 번
-  `closingOffsets`에 반영한다. 음수 delta는 `check`/diagnostic failure로 드러내며 0으로
-  clamp하지 않는다. gauge는 final snapshot을 사용하고, final snapshot 실패 시에는 cumulative
-  counter만 close-entry 기반 view로 유지하며 `queue=0`, `inFlight=0`,
-  `scheduledRetries=0`, `admitted=0`, `diagnosticsClosed=true`, `closed=true`인 terminal
-  fallback gauge를 합성한 뒤 inner `finally`에서 provider를 clear하여 `DETACHED`로 전환한다.
-  따라서 close-owned cancellation/rejection은 보존되고 close-entry counter는
-  중복 집계되지 않는다. final/transition 예외는 close 예외가 있으면 suppressed로 붙이고,
-  없으면 primary로 던진다. 따라서 이전 close가 새 provider를 지울 수 없고, `CLOSING` 중
-  replacement acquire는 거부되며 manager가 영구 `CLOSING`에 남지 않는다.
+  `finally`에서 같은 generation의 final snapshot에 대해 모든 cumulative field의 delta를
+  immutable temporary value로 계산하고 모든 `final >= close-entry` invariant를 먼저 검증한다.
+  하나라도 음수면 어떤 양수 field도 적용하지 않고 close-entry `closingOffsets`를 유지하며
+  `sourceDegraded`와 diagnostic failure를 기록한다. 정상 final snapshot에서만
+  `final - close-entry` delta를 정확히 한 번 적용한다. gauge는 final snapshot을 사용하고,
+  final snapshot 자체가 실패하면 cumulative counter만 close-entry 기반 view로 유지하며
+  `sourceDegraded=true`, fixed warning `leader.audit.export.meter-source-degraded`, 그리고
+  `queue=0`, `inFlight=0`, `scheduledRetries=0`, `admitted=0`, `diagnosticsClosed=true`,
+  `closed=true`인 terminal fallback gauge를 합성한다. 이 비정상 경로에서는 close-entry 이후
+  cancellation/rejection 정확성을 보장하지 않는다. provider 제거와 terminal DETACHED
+  publication은 사용자 callback 없이 non-throwing inner `finally`에서 예외 aggregation보다
+  먼저 완료한다. 예외는 `delegate.close` → final snapshot/invariant → transition/diagnostic
+  발생 순서로 첫 예외를 primary로 유지하고 이후 예외를 발생 순서대로 suppressed로 붙인다.
+  따라서 이전 close가 새 provider를 지울 수 없고, `CLOSING` 중 replacement acquire는 거부되며
+  manager가 영구 `CLOSING`에 남지 않는다.
   provider만 delegate를 참조하고 state 전환 후 clear되므로 registry meter가 closed delegate를
   retain하지 않는다. wrapper가 delegate ownership을 취득한 뒤 caller가 delegate를 직접
   close하는 것은 지원하지 않으며, wrapper `close()`가 유일한 ownership lifecycle이다.
@@ -937,18 +953,23 @@
   close-entry snapshot과 `closingProvider`를 보존한다. 같은 lock에서
   `closingOffsets = oldOffsets + closeEntrySnapshot`을 먼저 게시해 CLOSING poll의
   counter가 감소하지 않게 한 뒤 delegate close를 실행한다. 성공/예외의 `finally`에서 같은
-  generation의 final snapshot에 대해 각 cumulative counter의 `final >= close-entry`
-  invariant를 검증하고 `final - close-entry` delta만 정확히 한 번 `closingOffsets`에
-  반영한다. 음수 delta는 `check`/diagnostic failure로 드러내며 0으로 clamp하지 않는다.
-  gauge는 final snapshot 값을 사용하고, final snapshot 실패 시에는 cumulative counter만
-  close-entry 기반 `closingOffsets`로 유지하며 `queue=0`, `inFlight=0`,
+  generation의 final snapshot에 대해 모든 cumulative field의 delta를 immutable temporary
+  value로 계산하고 모든 `final >= close-entry` invariant를 먼저 검증한다. 하나라도 음수면
+  어떤 양수 field도 적용하지 않고 close-entry 기반 `closingOffsets`를 유지하며
+  `sourceDegraded`와 diagnostic failure를 기록한다. 정상 final snapshot에서만
+  `final - close-entry` delta를 정확히 한 번 `closingOffsets`에 반영한다. gauge는 final
+  snapshot 값을 사용하고, final snapshot 자체가 실패하면 cumulative counter만 close-entry
+  기반 `closingOffsets`로 유지하며 `sourceDegraded=true`, fixed warning
+  `leader.audit.export.meter-source-degraded`, 그리고 `queue=0`, `inFlight=0`,
   `scheduledRetries=0`, `admitted=0`, `diagnosticsClosed=true`, `closed=true`인 terminal
-  fallback gauge를 합성한 inner `finally`에서 provider를 clear하여 `DETACHED` claim을
-  해제한다. 따라서 close-entry counter를 중복 집계하지 않으면서 close-owned
-  cancellation/rejection을 final snapshot에 포함한다. `snapshot()`은 delegate close 후에도
-  final counters를 O(1)로 읽을 수 있어야 한다. `registry.remove`를 호출하지 않으므로
-  lookup/remove TOCTOU와 removal residue가 없고, stable meter identity는 replacement에서
-  재사용된다.
+  fallback gauge를 합성한다. 이 비정상 경로에서는 close-entry 이후 cancellation/rejection
+  정확성을 보장하지 않는다. provider clear와 terminal `DETACHED` publication은 사용자
+  callback 없이 non-throwing inner `finally`에서 예외 aggregation보다 먼저 완료한다.
+  예외는 `delegate.close` → final snapshot/invariant → transition/diagnostic 발생 순서로
+  첫 예외를 primary로 유지하고 이후 예외를 발생 순서대로 suppressed로 붙인다.
+  `snapshot()`은 delegate close 후에도 마지막으로 신뢰한 counter를 O(1)로 읽을 수 있다.
+  `registry.remove`를 호출하지 않으므로 lookup/remove TOCTOU와 removal residue가 없고,
+  stable meter identity는 replacement에서 재사용된다.
   detached state의 counter는 offset을 포함해 monotonic하게 유지하고 queue/in-flight/
   diagnostics closed gauge는 active provider 또는 detached closed snapshot을 읽는다.
   non-owning observation은 wrapper가 아니라 public `observe()` handle을 별도로 사용하며

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -700,14 +700,18 @@
   않으며, snapshot object는 submit hot path에서 생성하지 않는다는 source/contract
   assertion을 추가한다. wrapper close twice에서 delegate close idempotence와
   snapshot-backed cancellation/rejection metric parity를 검증하고, wrapper close가
-  exporter close contract를 그대로 보존하는지 확인한다. `TrackingMeterRegistry`로
-  등록된 모든 `Meter.Id`와 function source를 기록해 wrapper `close()` 두 번 후 owned
-  meter가 모두 제거되고 registry가 closed delegate를 retain하지 않는지 검증한다. 같은
-  registry에서 close 후 새 delegate wrapper를 만들면 새 snapshot source를 읽고, active
-  duplicate wrapper는 기존 ID/source를 재사용하지 않고 fail-fast하며 부분 등록도
-  정리하는지 검증한다. close→replacement와 duplicate-registration 시나리오는
-  `WeakReference`에 의존하지 않고 registry의 등록/제거 기록과 새 snapshot 값을
-  결정적으로 확인한다.
+  exporter close contract를 그대로 보존하는지 확인한다. `TrackingMeterRegistry`와
+  internal registry-identity manager test seam으로 등록 claim, exact `Meter` identity,
+  foreign-registration crossing을 기록한다. manager가 설치 callback/lookup/registrar
+  반환 identity를 모두 확인하고 foreign 또는 ambiguous ID를 소유하지 않는지 검증한다.
+  wrapper `close()` 두 번 후 exact-owned meter만 제거되고 foreign/replaced meter는
+  건드리지 않으며 첫 removal 실패 뒤에도 나머지 ID를 시도하고 residue warning/counter를
+  남기는지 확인한다. 같은 registry에서 close 후 새 delegate wrapper를 만들면 새 snapshot
+  source를 읽고, active duplicate wrapper는 기존 ID/source를 재사용하지 않고 fail-fast하며
+  부분 등록도 정리하는지 검증한다. constructor 실패는 delegate를 정확히 한 번 close하고
+  foreign meter를 보존하는지 assertion한다. 모든 reachability 주장은 `WeakReference`/GC에
+  의존하지 않고 registry의 등록·제거·residue 기록과 새 snapshot 값으로 결정적으로
+  확인한다.
 
 - [ ] **Step 2: Run Micrometer test and verify RED**
 
@@ -723,16 +727,22 @@
   `delegate.snapshot()`의 O(1) atomic counter이며, `FunctionCounter`/`Gauge`가 registry
   polling 시 snapshot을 읽는다. 따라서 async diagnostics observer callback이 close 직후
   drop되어도 close-owned cancellation/rejection이 metric에서 사라지지 않는다.
-  constructor는 `synchronized(registry)` 안에서 고정된 name/tag 조합의 모든 `Meter.Id`를
-  먼저 preflight하고, 이미 존재하는 ID가 있으면 부분 등록을 제거한 뒤 fail-fast한다.
-  성공한 등록의 ID 목록은 wrapper가 소유한다. `close()`는 delegate를 idempotently 닫은
-  뒤 `finally`에서 소유 ID를 각각 `registry.remove(id)`로 정확히 한 번 제거하며,
-  registry 제거 예외가 caller admission/election으로 전파되지 않도록 격리한다. 따라서
-  wrapper와 direct delegate 모두 close 후 `DROPPED_CLOSED`를 반환하고 registry가 closed
-  delegate를 strong-reference하지 않는다. non-owning observation은 wrapper가 아니라 public
+  내부 registry-identity manager가 fixed ID claim과 설치 identity를 관리한다. manager는
+  claim token/lock으로 wrapper 간 중복을 막고, preflight에서 foreign ID를 확인하며,
+  registrar 반환 meter·registry lookup·등록 callback이 동일한 `Meter` identity인지 검증한다.
+  외부 registration crossing으로 identity가 foreign/ambiguous가 되면 fail-fast하고
+  unproven meter를 절대로 remove하지 않는다. 표준 registry가 설치 identity를 증명하지
+  못하면 unsupported registry로 거부한다. 모든 meter 등록이 성공한 뒤에만 delegate
+  ownership을 확정하고, constructor 실패 시 delegate를 정확히 한 번 닫고 원래 예외를
+  보존하며 partial exact-owned meter만 정리한다. 성공한 등록의 exact `Meter`/`Meter.Id`
+  목록은 wrapper가 소유한다. `close()`는 delegate를 idempotently 닫은 뒤 `finally`에서
+  현재 lookup이 exact identity인 ID만 `registry.remove(id)`를 시도하고, removal 실패나
+  foreign replacement에도 나머지 ID 제거를 계속한다. removal residue는 fixed-ID
+  lifecycle warning/counter로 보고하고 caller admission/election에는 registry 오류를
+  전파하지 않는다. 따라서 closed delegate strong-reference 제거는 성공적으로 제거된
+  meter에 대해서만 주장한다. non-owning observation은 wrapper가 아니라 public
   `observe()` handle을 별도로 사용하며 decorator는 내부 observer handle을 등록하거나
-  소유하지 않는다. delegate의 `snapshot()` descriptor와 값은 그대로 전달하며 metric
-  registry 오류가 admission/election에 전파되지 않는다.
+  소유하지 않는다. delegate의 `snapshot()` descriptor와 값은 그대로 전달한다.
   metric names는 `leader.audit.export.accepted`, `leader.audit.export.dropped`,
   `leader.audit.export.retries`, `leader.audit.export.failures`,
   `leader.audit.export.queue.depth`, `leader.audit.export.in.flight`,
@@ -761,9 +771,11 @@
     --tests 'io.bluetape4k.leader.micrometer.history.*'
   ```
 
-  close idempotence, owned `Meter.Id` removal, same-registry replacement의 fresh
-  snapshot source, duplicate wrapper fail-fast/partial cleanup, 그리고 direct delegate와
-  wrapper의 closed admission parity가 모두 PASS해야 한다.
+  close idempotence, exact-owned `Meter.Id` removal, foreign/replaced meter 보존, first
+  removal failure 뒤 나머지 시도와 residue report, same-registry replacement의 fresh
+  snapshot source, duplicate wrapper fail-fast/partial cleanup, constructor 실패 시
+  delegate close, 그리고 direct delegate와 wrapper의 closed admission parity가 모두
+  PASS해야 한다.
 
 - [ ] **Step 5: Update both README locales and commit AUD-02**
 

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -115,7 +115,7 @@
 - [ ] **Step 3: Implement the minimum event contract**
 
   `LeaderAuditExportEvent`는 sealed interface로 만들고 `History`와
-  `Lifecycle` data class를 제공한다. token과 `LeaderLease` 객체는 field에 넣지
+  `Lifecycle` 일반 불변 클래스를 제공한다. token과 `LeaderLease` 객체는 field에 넣지
   않는다. `History.from(record, sanitizer)`는 기존 `sanitize(record)` 결과를
   사용하고 `Lifecycle.from(event, sanitizer)`는 `LeaderElectionEvent`의
   `lockName`, outcome, expiry만 매핑한다.
@@ -208,7 +208,10 @@
   fun `hung delivery times out, releases slot, retries, and terminalizes once`() { /* timeout */ }
 
   @Test
-  fun `executor and scheduler rejection terminalize accepted work and release permit`() { /* reject */ }
+  fun `worker executor rejection releases every permit and recovers capacity`() { /* executor reject */ }
+
+  @Test
+  fun `retry scheduler rejection releases every permit and recovers capacity`() { /* scheduler reject */ }
 
   @Test
   fun `submit close crossing is linearized and caller executor is never shutdown`() { /* close race */ }
@@ -223,17 +226,30 @@
   fun `observer sees exact outcomes and observer failure is isolated`() { /* observer */ }
 
   @Test
+  fun `blocking observer never delays submit and diagnostic drop is counted`() { /* async observer */ }
+
+  @Test
   fun `exceptional and cancelled delivery futures terminalize once without throwing to submitter`() { /* exception matrix */ }
+
+  @Test
+  fun `max in flight never exceeds configured cap under concurrent submissions`() { /* cap */ }
+
+  @Test
+  fun `observer and delivery Error rethrow after permit cleanup at uncaught boundary`() { /* fatal */ }
+
+  @Test
+  fun `worker exit and concurrent submit reschedule without lost wakeup`() { /* worker barrier */ }
 
   ```
 
   각 테스트는 `ACCEPTED`, `DROPPED_QUEUE_FULL`, `DROPPED_CLOSED`, attempt count,
   delivery completion과 close state를 `shouldBeEqualTo`/`shouldBeTrue`로 검증한다.
-  timeout 승자와 late completion의 terminalization, queued/scheduled/in-flight
-  cancel count, retry permit lifecycle, executor/scheduler rejection 이후 다음
-  submission, observer exact count, caller-owned executor/scheduler의 미종료를 함께
-  검증한다. `submit` source/benchmark guard는 lock·blocking queue·capacity wait가
-  없고 contention 시 즉시 drop되는지 확인한다.
+  timeout/self-cancel/close cancellation matrix와 late completion의 terminalization,
+  queued/scheduled/in-flight cancel count, retry permit lifecycle, executor rejection과
+  scheduler rejection 각각의 capacity recovery, observer exact count와 async dispatch,
+  `inFlight <= maxInFlight`, worker-exit double-check/reschedule, caller-owned
+  executor/scheduler의 미종료를 함께 검증한다. `submit` source/benchmark guard는
+  lock·blocking queue·capacity wait가 없고 contention 시 즉시 drop되는지 확인한다.
 
 - [ ] **Step 2: Run the focused test and verify RED**
 
@@ -274,9 +290,11 @@
       fun onObservation(observation: LeaderAuditExportObservation)
   }
 
-  data class LeaderAuditExportSnapshot(
+  class LeaderAuditExportSnapshot private constructor(
       val queued: Int,
       val inFlight: Int,
+      val scheduledRetries: Int,
+      val admitted: Int,
       val accepted: Long,
       val droppedQueueFull: Long,
       val droppedClosed: Long,
@@ -285,8 +303,33 @@
       val cancellations: Long,
       val executorRejections: Long,
       val schedulerRejections: Long,
+      val observerDrops: Long,
       val closed: Boolean,
-  )
+  ) {
+      companion object {
+          @JvmSynthetic
+          internal fun create(
+              queued: Int,
+              inFlight: Int,
+              scheduledRetries: Int,
+              admitted: Int,
+              accepted: Long,
+              droppedQueueFull: Long,
+              droppedClosed: Long,
+              retries: Long,
+              terminalFailures: Long,
+              cancellations: Long,
+              executorRejections: Long,
+              schedulerRejections: Long,
+              observerDrops: Long,
+              closed: Boolean,
+          ): LeaderAuditExportSnapshot = LeaderAuditExportSnapshot(
+              queued, inFlight, scheduledRetries, admitted, accepted, droppedQueueFull,
+              droppedClosed, retries, terminalFailures, cancellations, executorRejections,
+              schedulerRejections, observerDrops, closed,
+          )
+      }
+  }
 
   class LeaderAuditExportOptions(
       val queueCapacity: Int,
@@ -312,12 +355,32 @@
   각 attempt는 `CompletableFuture`와 timeout task 중 먼저 완료한 쪽만
   `AtomicBoolean`으로 terminalize한다. timeout은 future를 cancel하고 retryable
   failure로 분류하며, close가 먼저 이기면 observer/retry/failure를 만들지 않는다.
-  `observe` callback은 스냅숏 후 `runCatching`으로 격리한다. executor 또는
-  scheduler rejection은 accepted item을 고착시키지 않고 rejection terminal/drop
-  observation과 permit 반환으로 끝낸다. worker는 queue가 비면 task를 종료하고,
-  close는 gate를 닫고 queue·retry·in-flight future를 취소한 뒤 worker가 CLOSED를
-  관찰하도록 깨운다. injected executor/scheduler는 exporter가 shutdown하지 않으며
-  ownership을 caller에게 문서화한다.
+  `observe` callback은 submit thread에서 직접 실행하지 않는다. exporter가 소유하는
+  bounded diagnostics queue와 전용 diagnostics worker가 observation을 전달하며,
+  admission은 queue offer/CAS만 수행한다. diagnostics queue가 가득 차면
+  `observerDrops`를 증가시키고 callback 없이 끝낸다. callback이 오래 걸려도
+  admission worker와 선거 thread는 block하지 않는다. observer callback의 일반
+  `Exception`만 격리하며 `Error`는 callback task를 terminalize한 뒤 전용 diagnostics
+  worker의 uncaught boundary로 재전파한다. observer 또는 delivery가 `Error`를 던지면
+  상태/permit을 정확히 한 번 terminalize하고 같은 원래 `Error`를 재전파한다. executor 또는 scheduler rejection은 accepted item을
+  고착시키지 않고 rejection terminal/drop observation과 permit 반환으로 끝낸다.
+  worker는 `workerRunning.compareAndSet(false, true)`로 시작하고, empty 관찰 후
+  running flag를 clear하기 직전에 queue를 다시 확인한다. clear 이후 submit과 교차하면
+  submit이 double-check/reschedule을 수행하므로 lost wakeup이 없다. 별도 atomic
+  in-flight reservation을 delivery 전에 획득하고 completion/timeout/close에서 정확히
+  반환해 `inFlight <= maxInFlight`를 유지한다. close는 gate를 닫고 queue·retry·in-flight
+  future를 취소한 뒤 scheduling critical section과 worker admission이 quiesce된 것을
+  확인하고 반환한다. network drain은 기다리지 않지만 close 반환 후 exporter가
+  executor/scheduler에 새 execute/schedule을 호출하지 않는다. injected
+  executor/scheduler는 exporter가 shutdown하지 않으며 ownership을 caller에게
+  문서화한다.
+
+  `queued`, `inFlight`, `scheduledRetries`, `admitted`는 각각 `AtomicInteger`로
+  유지하며 snapshot은 `queue.size` 또는 work-item 순회를 사용하지 않는 O(1) 읽기로
+  생성한다. outcome/rejection/observer-drop 누적값도 atomic counter로 유지한다.
+  snapshot은 명시적으로 호출될 때만 할당하고 `submit`/delivery hot path에서는 생성하지
+  않는다. quiescent 상태에서 `queued + inFlight + scheduledRetries == admitted`와
+  `0 <= admitted <= queueCapacity`, `0 <= inFlight <= maxInFlight`를 검증한다.
 
   `LeaderAuditExportOptions`는 Java-visible 명시적 8-argument constructor만 제공하고
   shared executor/scheduler default를 만들지 않는다. 기본값은 `queueCapacity=1024`,
@@ -329,12 +392,12 @@
   overflow는 fail-fast한다. backoff는 saturating multiplication으로 `maxBackoff`를
   넘지 않는다.
 
-  delivery가 동기적으로 예외를 던지거나 exceptional future를 반환하면
+  delivery가 동기적으로 `Exception`을 던지거나 exceptional future를 반환하면
   `RETRYABLE_FAILURE` 분류 규칙에 따라 한 번만 retry/terminalize하고 `submit` 호출자에게
-  던지지 않는다. `CancellationException`은 close/timeout이 소유한 취소일 때
-  `CANCELLED`로 끝내고 재시도하지 않으며, caller delivery가 자체적으로 취소한 경우는
-  명시된 retryable cancellation 정책으로 한 번만 처리한다. `Error`는 worker 경계를
-  넘지 않도록 terminal failure로 기록하되 fatal process policy는 변경하지 않는다.
+  던지지 않는다. `CancellationException`은 원인을 `CLOSE`, `TIMEOUT`, `CALLER`로
+  구분한다. `CLOSE`는 `CANCELLED`만, `TIMEOUT`은 timeout의 `RETRY` 또는 마지막
+  attempt의 `TERMINAL_FAILURE`만, `CALLER`는 `CANCELLED`만 기록하고 모두 재시도하지
+  않는다. `Error`는 permit/attempt 정리 후 executor uncaught boundary로 재전파한다.
 
 - [ ] **Step 4: Run dispatcher tests and verify GREEN**
 
@@ -443,14 +506,14 @@
 
   | Type | Exact public surface |
   |---|---|
-  | `LeaderAuditExporter` | `submit(LeaderAuditExportEvent): LeaderAuditSubmitResult`, `observe(LeaderAuditExportObserver): AutoCloseable`, `close(): Unit` |
+  | `LeaderAuditExporter` | `submit(LeaderAuditExportEvent): LeaderAuditSubmitResult`, `observe(LeaderAuditExportObserver): AutoCloseable`, `snapshot(): LeaderAuditExportSnapshot`, `close(): Unit` |
   | `LeaderAuditExportOptions` | `queueCapacity:Int`, `maxInFlight:Int`, `maxAttempts:Int`, `attemptTimeout:java.time.Duration`, `initialBackoff:java.time.Duration`, `maxBackoff:java.time.Duration`, `executor:Executor`, `scheduler:ScheduledExecutorService`; Java-visible 8-argument constructor, no implicit shared executor |
   | `LeaderAuditDelivery` | `deliver(LeaderAuditExportEvent): CompletableFuture<LeaderAuditDeliveryResult>` |
   | `LeaderAuditExportObserver` | `onObservation(LeaderAuditExportObservation): Unit` with finite enum only |
-  | `LeaderAuditExportSnapshot` | immutable counters/depths and `closed:Boolean`; no dynamic identifiers |
+  | `LeaderAuditExportSnapshot` | immutable `queued`, `inFlight`, `scheduledRetries`, `admitted`, outcome counters, `observerDrops`, `closed`; no dynamic identifiers |
   | `LeaderAuditHttpPayload` | `of(String, byte[])`, `contentType`, `body(): byte[]`; constructor/body defensively copy |
-  | `HttpLeaderAuditExporter` | `(HttpClient, URI, Map<String,String>, LeaderAuditPayloadEncoder, LeaderAuditExportOptions, LeaderAuditHttpOptions)` plus `submit/observe/close` |
-  | `LeaderAuditHttpOptions` | 3-argument constructor, `defaults(): LeaderAuditHttpOptions`, `maxPayloadBytes:Int`, `allowedSchemes:Set<String>`, `allowInsecureLoopback:Boolean`; immutable defensive copies |
+  | `HttpLeaderAuditExporter` | `(HttpClient, URI, Map<String,String>, LeaderAuditPayloadEncoder, LeaderAuditExportOptions, LeaderAuditHttpOptions)` plus `submit/observe/snapshot/close` |
+  | `LeaderAuditHttpOptions` | 1-argument constructor `(maxPayloadBytes:Int)`, `defaults(): LeaderAuditHttpOptions`, `maxPayloadBytes:Int`; production HTTPS-only, no public scheme/loopback bypass |
 
   Kotlin default arguments must not be the only construction path: the Java fixture
   constructs options and HTTP exporter explicitly, calls `submit`, and uses
@@ -461,6 +524,8 @@
   `leaderId`, `leaseExpiry`, `errorType`, `errorMessage`) and rejects accidental platform
   types or synthetic overloads.
 
+  Java fixture는 core exporter와 HTTP exporter에서 `submit`, `observe`, `snapshot`,
+  `close`를 호출하고 decorator의 `snapshot()` delegation도 compile/run으로 고정한다.
   reflection으로 위 public constructor/method set과 JVM descriptor를 확인하고, event
   public field에 `token`이나 `LeaderLease`가 없는지 고정한다. `close()` idempotence와
   `submit` return type을 JVM descriptor로 확인한다.
@@ -490,7 +555,8 @@
 
   ```bash
   git add leader-core/src/main/kotlin/io/bluetape4k/leader/audit \
-    leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportBoundaryContractTest.kt
+    leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportBoundaryContractTest.kt \
+    leader-core/src/test/java/io/bluetape4k/leader/audit/LeaderAuditExportJavaContractTest.java
   git commit -m $'OBS-03 core exporter public ABI와 KDoc를 고정한다\n\nConstraint: 기존 core public contract와 binary compatibility를 유지한다.\nRejected: 편의용 overload와 raw record exposure | JVM descriptor와 redaction 경계 확대\nConfidence: high\nScope-risk: moderate\nDirective: 후속 transport는 이 stable event boundary를 사용한다.\nTested: ABI boundary contract test and diff check\nNot-tested: Micrometer/HTTP integration은 후속 slice에서 검증한다.'
   ```
 
@@ -513,6 +579,10 @@
   `transport={core,http}`, `outcome={accepted,queue_full,closed,retry,failure,
   cancelled,rejected}`로 고정한다. 고유 lockName, leaderId, endpoint, error message를
   대량 제출해도 meter 수가 증가하지 않고 해당 값이 tag에 없는지 assertion한다.
+  gauge 구현은 exporter `snapshot()`의 O(1) atomic counter를 읽고 queue를 순회하지
+  않으며, snapshot object는 submit hot path에서 생성하지 않는다는 source/contract
+  assertion을 추가한다. `ownsDelegate=true/false` 각각에서 wrapper close twice,
+  observer detach, delegate close 여부와 snapshot delegation을 검증한다.
 
 - [ ] **Step 2: Run Micrometer test and verify RED**
 
@@ -523,12 +593,14 @@
 
 - [ ] **Step 3: Implement decorator and constants**
 
-  `MicrometerLeaderAuditExporter(delegate, registry)`는 `LeaderAuditExporter`를
-  그대로 반환하고 결과별 counter와 `snapshot()` gauge를 increment/update한다.
-  생성 시 delegate에 bounded `LeaderAuditExportObserver`를 등록해 retry, terminal
-  failure, cancellation, rejection을 관찰하고 decorator close에서 observer handle을
-  idempotently 해제한다. delegate가 observer callback을 격리하므로 metric registry
-  오류가 admission/election에 전파되지 않는다.
+  `MicrometerLeaderAuditExporter(delegate, registry, ownsDelegate)`는
+  `LeaderAuditExporter`를 그대로 구현하고 결과별 counter와 `snapshot()` gauge를
+  delegate에 위임한다. `ownsDelegate=true`일 때만 decorator close가 delegate를
+  닫고, `false`일 때는 observer handle만 해제한다. 생성 시 delegate에 bounded
+  `LeaderAuditExportObserver`를 등록해 retry, terminal failure, cancellation,
+  rejection을 관찰하고 decorator close에서 observer handle을 idempotently 해제한다.
+  delegate의 `snapshot()` descriptor와 값은 그대로 전달하며 metric registry 오류가
+  admission/election에 전파되지 않는다.
   metric names는 `leader.audit.export.accepted`, `leader.audit.export.dropped`,
   `leader.audit.export.retries`, `leader.audit.export.failures`,
   `leader.audit.export.queue.depth`, `leader.audit.export.in.flight`,
@@ -580,10 +652,14 @@
   - `429`, `503`, I/O disconnect는 최대 attempt까지 retry한다.
   - `400`, `401`, `403`, `404`는 retry하지 않는다.
   - encoder가 만든 body는 `maxPayloadBytes`를 넘지 않고 immutable 스냅숏으로
-    전달되며 allow-listed headers만 request에 전달한다.
-  - oversized/chunked response는 `BodyHandlers.discarding()`으로 보존하지 않는다.
-  - HTTPS 기본값, unsafe URI/user-info/query/fragment, redirect, CRLF/forbidden header를
-    거부한다. loopback HTTP는 명시적 test-only allow-list에서만 허용한다.
+    전달되며, hard 1 MiB 초과는 copy 전에 거부하고 allow-listed headers만 request에
+    전달한다.
+  - oversized/chunked response는 `BodyHandlers.discarding()`으로 0 byte만 보존한다.
+    이 계약은 메모리 retention bound이며 네트워크 ingress truncation을 약속하지
+    않는다는 문서·negative test를 포함한다.
+  - production HTTPS-only, unsafe URI/user-info/query/fragment, loopback/link-local/
+    RFC1918 literal host, redirect, CRLF/unknown/forbidden header를 거부한다.
+    loopback HTTP는 public option이 아닌 `internal` test-only factory에서만 허용한다.
   - encoder throw, exceptional/cancelled future, response body와 endpoint credential이
     log에 남지 않는 negative matrix를 검증한다.
   - exporter close가 in-flight future와 scheduled retry를 취소하고 late completion이
@@ -611,27 +687,45 @@
       fun body(): ByteArray = bytes.copyOf()
 
       companion object {
+          private const val HARD_MAX_PAYLOAD_BYTES = 1024 * 1024
+
           @JvmStatic
-          fun of(contentType: String, body: ByteArray): LeaderAuditHttpPayload =
-              LeaderAuditHttpPayload(contentType, body.copyOf())
+          fun of(contentType: String, body: ByteArray): LeaderAuditHttpPayload {
+              require(contentType.isNotBlank() && contentType.none { it.code < 0x20 || it.code == 0x7f })
+              require(body.size <= HARD_MAX_PAYLOAD_BYTES)
+              return LeaderAuditHttpPayload(contentType, body.copyOf())
+          }
       }
   }
 
   class LeaderAuditHttpOptions(
       val maxPayloadBytes: Int,
-      val allowedSchemes: Set<String>,
-      val allowInsecureLoopback: Boolean,
   ) {
+      init {
+          require(maxPayloadBytes in 1..(1024 * 1024))
+      }
       companion object {
           @JvmStatic
           fun defaults(): LeaderAuditHttpOptions =
-              LeaderAuditHttpOptions(64 * 1024, setOf("https"), false)
+              LeaderAuditHttpOptions(64 * 1024)
       }
   }
   ```
 
-  `LeaderAuditHttpOptions`는 `maxPayloadBytes` 기본 64 KiB, hard upper bound 1 MiB,
-  `allowedSchemes`의 기본 HTTPS, test-only loopback HTTP 허용 여부를 검증한다.
+  `HARD_MAX_PAYLOAD_BYTES`는 1 MiB 상수로 고정하고 `of`는 caller ByteArray를 복사하기
+  전에 그 상한을 검사한다. adapter는 다시 configured `maxPayloadBytes`를 검사해
+  lower bound도 request 생성 전에 거부한다. `LeaderAuditHttpOptions`는
+  `maxPayloadBytes` 기본 64 KiB, hard upper bound 1 MiB를
+  검증한다. production `HttpLeaderAuditExporter`는 HTTPS URI만 허용하며 public
+  options에 scheme allow-list나 insecure-loopback flag를 노출하지 않는다. loopback
+  HTTP는 `internal` test-only delivery factory에서만 허용하고 public Java/Kotlin ABI에
+  포함하지 않는다. production target은 user-info/query/fragment/control character와
+  loopback·link-local·RFC1918 literal address를 거부한다. private endpoint 예외는
+  이번 public API에 포함하지 않으며 후속 보안 검토 issue에서 별도 trusted boundary로
+  정의한다. production resolver는 URI host의 모든 `InetAddress` 결과에 대해
+  `isLoopbackAddress`, `isLinkLocalAddress`, `isSiteLocalAddress`, `isAnyLocalAddress`
+  를 검사하고 하나라도 해당하면 fail-fast한다. resolver는 `internal` seam으로 주입해
+  negative test가 DNS/network에 의존하지 않게 한다.
   `HttpLeaderAuditDelivery`는
   `HttpRequest.newBuilder(uri).timeout(options.attemptTimeout).POST(...)`와
   `HttpClient.sendAsync(..., BodyHandlers.discarding())`를 사용한다. injected client의
@@ -639,11 +733,15 @@
   408/429/5xx와 I/O/timeout exception은 `RETRYABLE_FAILURE`, 나머지 4xx는
   `TERMINAL_FAILURE`로 매핑한다. 요청 header는 immutable constructor allow-list로
   복사하고 CR/LF 및 `Host`, `Content-Length`, `Connection`, `Transfer-Encoding`을
-  거부하며 secret 값을 logger/metric에 전달하지 않는다. encoder 예외는 delivery
+  거부하며 secret 값을 logger/metric에 전달하지 않는다. 허용 header 이름은
+  `Content-Type`, `Authorization` 두 개로 고정하고 그 밖의 `Cookie`,
+  `Proxy-Authorization`, `X-Api-Key`, `Forwarded`와 모든 unknown header를 거부한다.
+  encoder 예외는 delivery
   future의 terminal failure로 격리한다.
   `HttpLeaderAuditExporter`는 Task 2 dispatcher에 delivery를 주입하고, URI·encoder·
   options·executor ownership 및 `exporter.close()` 후 외부 scheduler/executor를
-  종료하는 순서를 KDoc로 명시한다. JSON serialization을 추가하지 않으며
+  종료하는 순서를 KDoc로 명시한다. `snapshot()`은 delegate snapshot을 그대로
+  반환한다. JSON serialization을 추가하지 않으며
   JSONL/OpenTelemetry implementation도 만들지 않는다.
 
   최소 runnable caller 예제는 dependency-free text encoder, `Content-Type`와
@@ -703,7 +801,9 @@
   HTTP encoder/headers/receiver 예제, migration/limitations를 기록하고
   “0.6.0 release manifest 전환 전에는 released claim이 아님”을 명시한다. 0.6
   release-authorized 후속 작업에서 draft를 pinned manual로 승격하고 manifest/
-  release inventory를 함께 갱신한다.
+  release inventory를 함께 갱신한다. HTTP 예제의 `Authorization` 값은
+  `${WEBHOOK_TOKEN}` 또는 `<REDACTED>` placeholder만 사용하고 실제 secret-like
+  literal은 금지한다.
 
 - [ ] **Step 2: Validate docs and locale parity**
 
@@ -719,8 +819,11 @@
   변경된 두 locale의 제목·API·metric·scope가 대응하고, draft는 0.5.0 release claim을
   과장하지 않는지 read-back한다. pinned manual의 release source validation은
   immutable commit에 대해 PASS해야 하며 draft token이 pinned 문서에 섞이지 않아야
-  한다. diagram 변경은 없으므로 `bluetape-diagram`은 N/A이며 evidence에 이유를
-  기록한다.
+  한다. `rg -n 'Authorization: Bearer (sk-|ghp_|AKIA|eyJ)' docs/manual/drafts
+  README.md README.ko.md leader-core/README* leader-micrometer/README*`가 0건이고,
+  placeholder가 `${WEBHOOK_TOKEN}` 또는 `<REDACTED>`로만 존재하는지 확인한다.
+  diagram 변경은 없으므로
+  `bluetape-diagram`은 N/A이며 evidence에 이유를 기록한다.
 
 - [ ] **Step 3: Commit documentation slice**
 

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -80,6 +80,10 @@
       )
       source["key"] = "changed"
       event.attributes["key"].shouldBeEqualTo("value")
+      assertFailsWith<UnsupportedOperationException> {
+          @Suppress("UNCHECKED_CAST")
+          (event.attributes as MutableMap<String, String>)["key"] = "mutated"
+      }
       event::class.memberFunctions.none { it.name == "copy" }.shouldBeTrue()
   }
 
@@ -154,7 +158,10 @@
   `Raw` 정책으로 제한한다. `Raw`는 사전에 허용된 비민감 enum field subset과 양의
   최대 길이를 생성 시 검증하고, 모든 정책은 공통 byte/key limits를 적용한다. event
   `toString()`과 encoder fixture에는 secret sentinel이 없어야 한다. 모든 map은
-  defensive copy하고, public KDoc는 Korean technical register로 작성한다.
+  defensive copy 후 `Collections.unmodifiableMap(LinkedHashMap(...))` 또는 동등한
+  실제 immutable runtime map으로 노출한다. Java fixture에서 `getAttributes().put`이
+  `UnsupportedOperationException`을 내고 원본 map mutation도 event에 반영되지 않는지
+  고정한다. public KDoc는 Korean technical register로 작성한다.
 
 - [ ] **Step 4: Run the focused test and verify GREEN**
 

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -862,6 +862,11 @@
   비정상 경로에서 보장하지 않으며, `queue=0`, `inFlight=0`, `scheduledRetries=0`,
   `admitted=0`, `diagnosticsClosed=true`, `closed=true`인 terminal gauge truth table과
   final snapshot 예외의 primary/suppressed 전파를 exact assertion한다.
+  degraded DETACHED 뒤 동일 registry에서 stable meter claim을 재사용하는 replacement fixture는
+  새 generation의 `sourceDegraded=false`, 이전 warning 재생 없음, 누적 offset·meter identity
+  보존을 exact assertion한다. replacement generation에서 다시 final snapshot/invariant 실패를
+  주입하면 해당 generation에만 fixed warning이 한 번 기록되는지도 검증한다. compromised
+  registry는 generation reset 대상이 아니며 계속 거부되어야 한다.
   constructor 실패는 delegate를 정확히 한 번 close하고 primary exception을 보존하며,
   delegate close/partial-registration cleanup 예외는 primary에 suppressed로 붙이고,
   primary가 없을 때만 cleanup 예외를 던지는지 검증한다. manager-owned partial registration만
@@ -920,6 +925,11 @@
   발생 순서로 첫 예외를 primary로 유지하고 이후 예외를 발생 순서대로 suppressed로 붙인다.
   따라서 이전 close가 새 provider를 지울 수 없고, `CLOSING` 중 replacement acquire는 거부되며
   manager가 영구 `CLOSING`에 남지 않는다.
+  `sourceDegraded`는 generation-scoped로 관리한다. final snapshot 실패 후 DETACHED가 된
+  동일 registry replacement가 성공하면 새 generation은 `sourceDegraded=false`로 시작하고
+  이전 fixed warning을 재생하지 않으며 누적 offset과 stable meter identity를 이어받는다.
+  새 generation의 실패는 그 generation에 한해 warning을 한 번 기록하고, compromised
+  registry는 이 reset 경로보다 우선하여 계속 거부한다.
   provider만 delegate를 참조하고 state 전환 후 clear되므로 registry meter가 closed delegate를
   retain하지 않는다. wrapper가 delegate ownership을 취득한 뒤 caller가 delegate를 직접
   close하는 것은 지원하지 않으며, wrapper `close()`가 유일한 ownership lifecycle이다.
@@ -970,6 +980,9 @@
   `snapshot()`은 delegate close 후에도 마지막으로 신뢰한 counter를 O(1)로 읽을 수 있다.
   `registry.remove`를 호출하지 않으므로 lookup/remove TOCTOU와 removal residue가 없고,
   stable meter identity는 replacement에서 재사용된다.
+  replacement acquire는 generation-scoped `sourceDegraded`를 false로 reset하되 cumulative
+  offset은 보존한다. 동일 registry에서 degraded generation의 warning을 재생하지 않고,
+  replacement generation이 다시 degraded가 될 때만 fixed warning을 한 번 기록한다.
   detached state의 counter는 offset을 포함해 monotonic하게 유지하고 queue/in-flight/
   diagnostics closed gauge는 active provider 또는 detached closed snapshot을 읽는다.
   non-owning observation은 wrapper가 아니라 public `observe()` handle을 별도로 사용하며

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -121,11 +121,17 @@ leader identity, attribute, error message를 우회해 복원할 수 없다. eve
 v1 bound 상수는 `MAX_ERROR_MESSAGE_BYTES=4096`, `MAX_ERROR_TYPE_BYTES=128`,
 `MAX_TEXT_FIELD_BYTES=256`, `MAX_ATTRIBUTES=32`, `MAX_ATTRIBUTE_KEY_BYTES=128`,
 `MAX_ATTRIBUTE_VALUE_BYTES=512`, `MAX_ATTRIBUTES_TOTAL_BYTES=8192`로 고정한다.
+`MAX_TEXT_FIELD_BYTES`는 `lockName`, `nodeId`, `slotId`, `leaderId`에 적용하고,
+`errorType`과 `errorMessage`는 각각 전용 bound를 사용한다. `LeaderAuditField` enum은
+`LOCK_NAME`, `KIND`, `NODE_ID`, `SLOT_ID`, `LEADER_ID`, `ERROR_TYPE`, `ERROR_MESSAGE`,
+`ATTRIBUTE_KEY`, `ATTRIBUTE_VALUE`만 제공한다. `RAW_ALLOWED_FIELDS`는 `KIND` 하나로
+고정하며 `Raw` 생성자는 이 집합 밖의 allow-list를 모두 거부한다.
 모든 byte bound는 UTF-8 기준이며 over-limit 문자열은 code point를 자르지 않는 최대
 prefix로 truncate하고 ellipsis를 추가하지 않는다. attribute는 sanitized key의 UTF-8
-byte 순으로 정렬한 뒤 key/value 개별 bound와 aggregate bound를 순서대로 적용하며,
-한도를 넘는 후속 entry는 drop한다. sanitize 후 key collision은 정렬상 먼저 온 entry만
-유지한다. `Raw(maxBytes)`는 양수 byte 값과 비민감 field allow-list를 생성 시 검증하고,
+byte와 원본 key의 UTF-8 byte를 순서대로 정렬한 뒤 key/value 개별 bound와 aggregate
+bound를 적용하며, 한도를 넘는 후속 entry는 drop한다. sanitize 후 key collision은 이
+secondary key 순서에서 먼저 온 entry만 유지하므로 입력 Map의 insertion order에 영향을
+받지 않는다. `Raw(maxBytes)`는 양수 byte 값과 비민감 field allow-list를 생성 시 검증하고,
 허용되지 않은 field는 `IllegalArgumentException`으로 거부한다.
 
 ### Exporter와 admission
@@ -320,22 +326,40 @@ detached offset이며 `FunctionCounter`/`Gauge`가 registry polling 시 manager 
 따라서 async diagnostics observer callback이 close 직후 drop되어도 close-owned
 cancellation/rejection이 metric에서 사라지지 않는다.
 decorator는 registry identity별 내부 manager가 고정된 `Meter.Id` 집합을 한 번만 등록하고
-stable meter를 소유한다. manager는 자체 lock/claim token과 `activeProvider` indirection을
-사용하며 `FunctionCounter`/`Gauge` callback은 manager state만 캡처하고 delegate를 직접
-참조하지 않는다. 첫 acquire에서 foreign ID가 이미 존재하거나 등록 identity를 증명할 수
-없으면 constructor는 fail-fast한다. 외부 registration crossing으로 manager-owned identity가
-바뀌거나 ambiguous가 되면 `leader.audit.export.meter-ownership-conflict` fixed warning을
-한 번 기록하고 state를 compromised로 잠근다. manager는 foreign meter를 절대로 제거하지
-않으며, compromised registry는 수동으로 fixed ID를 정리하거나 registry를 교체하기 전까지
-새 wrapper를 허용하지 않는다.
+stable meter를 소유한다. manager는 자체 lock/claim token과 immutable manager state를
+사용한다. state는 `activeProvider`, detached snapshot, cumulative offset, lifecycle와
+`compromised` flag를 함께 보유하며, `FunctionCounter`/`Gauge` callback도 같은 lock으로
+state와 provider snapshot을 한 번에 읽는다. close와 acquire는 offset 반영·provider 전환을
+하나의 선형화 지점에서 수행하므로 poll이 `offset + 이전 provider`를 섞어 읽지 않는다.
+첫 acquire에서 foreign ID가 이미 존재하거나 등록 identity를 증명할 수 없으면 constructor는
+fail-fast한다. 외부 registration crossing으로 manager-owned identity가 바뀌거나 ambiguous가
+되면 `leader.audit.export.meter-ownership-conflict` fixed warning을 한 번 기록하고 state를
+compromised로 잠근다. manager는 foreign meter를 절대로 제거하지 않으며, compromised
+registry는 수동으로 fixed ID를 정리하거나 registry를 교체하기 전까지 새 wrapper를
+허용하지 않는다.
+
+manager 저장소는 registry를 강하게 보유하지 않는 weak identity key와 `ReferenceQueue`를
+사용한다. 매 acquire/retirement 때 queue를 drain해 stale manager를 결정적으로 제거하고,
+manager와 weak meter identity token은 registry를 역참조하지 않는다. 따라서 Spring/test
+context가 폐기되면 registry identity와 manager가 함께 회수될 수 있으며, stable meter가
+registry에 남는 동안에는 manager state만 callback source로 유지한다. 외부 registry mutation은
+manager lock으로 막을 수 없으므로 supported ownership 경계 밖이다. 각 acquire와 metric read에서
+identity mismatch를 감지하면 conflict state로 전환하고 detached 값만 읽으며 foreign meter를
+삭제하거나 ownership을 추정하지 않는다.
+public KDoc는 generic `MeterRegistry`가 외부 `remove`/동일 ID 재등록을 원자적으로
+감시할 수 없다는 한계를 명시한다. caller는 wrapper 수명 동안 fixed ID를 직접 변경하지
+않아야 하며, 이 ownership 경계를 어긴 뒤의 외부 metric 값은 보장하지 않는다. manager가
+acquire 또는 metric read에서 crossing을 관찰한 경우에만 conflict warning과 detached 상태로
+전환하며, 관찰하지 못한 외부 mutation을 막는다고 주장하지 않는다.
 
 전체 stable meter 등록이 성공한 뒤에만 wrapper가 delegate ownership을 확정한다.
 constructor 실패 시에는 delegate를 정확히 한 번 닫고 원래 primary 실패를 보존하며,
 delegate close/partial-registration cleanup 예외는 primary의 suppressed exception으로
 붙인다. primary 실패가 없을 때만 cleanup 예외를 primary로 던진다. 부분 등록은
 manager-owned stable meter와 claim state로 남겨 다음 acquire가 누락 ID만 이어서 등록할
-수 있으며 foreign ID는 건드리지 않는다. `close()`는 delegate를 idempotently 닫고 마지막
-snapshot을 manager offset에 반영한 뒤 `activeProvider`를 clear한다. `registry.remove`를
+수 있으며 foreign ID는 건드리지 않는다. `close()`는 generation token으로 한 번만 현재
+provider를 `CLOSING`에서 detach하고 delegate를 idempotently 닫은 뒤 `DETACHED` claim을
+해제한다. 마지막 snapshot은 manager offset에 반영된다. `registry.remove`를
 호출하지 않으므로 lookup/remove 사이 foreign replacement race와 removal residue가 없다.
 stable meter는 registry에 남지만 closed delegate를 strong-reference하지 않고 마지막
 snapshot/closed 상태를 읽는다. 같은 registry의 새 wrapper는 stable meter identity를

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -127,10 +127,14 @@ public `LeaderAuditExporter`는 다음 경계를 갖는다.
 - 결과는 `ACCEPTED`, `DROPPED_QUEUE_FULL`, `DROPPED_CLOSED`로 구분한다.
 - `submit`은 delivery 오류를 throw하지 않는다. caller가 결과를 관찰할 수 있지만
   leader election의 반환값·예외에는 영향을 주지 않는다.
-- `close()`는 신규 admission을 차단하고 queued/retry 작업을 취소한다. close는
-  네트워크 drain은 기다리지 않지만 diagnostics worker와 이미 실행 중인 observer
-  callback의 종료를 join한 뒤 반환하며 idempotent다. callback이 interrupt를 무시해도
-  close 이후 새 callback admission은 허용하지 않는다.
+- `close()`는 먼저 exporter admission gate를 닫고 queued/retry/in-flight work를
+  close-owned cancellation으로 terminalize한다. 이때 발생한 `CANCELLED` observation은
+  diagnostics gate가 아직 열려 있을 때 admission한 뒤 diagnostics gate를 닫고 queued
+  diagnostics를 drop하며 worker를 interrupt/unpark한다. 네트워크 drain은 기다리지 않는다.
+  이미 admission된 observer callback은 완료 또는 abandon될 수 있지만 close는 callback
+  종료를 join하지 않으므로 interrupt를 무시하는 callback 때문에 무기한 hang하지 않는다.
+  close 이후 새 callback admission은 허용하지 않으며, close 전에 invocation reservation된
+  callback만 crossing allowance로 close 반환 뒤 현재 호출을 마칠 수 있다.
 - `observe(observer)`는 accepted/drop/retry/terminal-failure/cancel/rejection의 유한한 lifecycle
   outcome을 exporter가 소유하는 diagnostics queue와 이름이 고정된 daemon virtual-thread
   worker를 통해 caller thread 밖에서 best-effort로 전달한다. queue capacity는
@@ -138,13 +142,17 @@ public `LeaderAuditExporter`는 다음 경계를 갖는다.
   non-blocking offer만 수행하므로 observer callback과 diagnostics worker가 block되어도
   admission thread를 block하지 않는다. queue가 가득 차면 callback 없이 `observerDrops`만
   증가한다. exporter `close()`는 diagnostics gate를 닫고 queued callback을 drop한 뒤
-  worker를 interrupt/unpark하고 join하여 종료와 late callback 0을 확인한다. observer가
+  worker를 interrupt/unpark하고 diagnostics queue를 drain하여 더 이상의 callback admission
+  0을 확인한다. close는 이미 admission된 callback의 완료를 기다리지 않으므로
+  interrupt를 무시하는 observer 때문에 무기한 hang하지 않는다. 이미 admission된 callback은
+  close 반환 뒤에도 현재 호출을 마칠 수 있지만 새 callback은 시작하지 않는다. observer가
   `Exception`을 던져도 admission, permit, election 결과에는 영향을 주지 않으며 observer
   `Error`는 callback state를 terminalize한 뒤 worker uncaught boundary로 재전파한다.
   event 값·lock 이름·endpoint·error message는 observer payload에 포함하지 않는다.
 - `snapshot()`은 queued, in-flight, scheduled-retry, total admitted 수와
   accepted/drop/retry/terminal failure, cancellation, executor/scheduler rejection,
-  observer drop을 누적한 bounded diagnostics를 반환한다. 스냅숏 값은 lock 이름·endpoint·
+  observer drop, registration drop, diagnostics fatal error와 diagnostics closed 상태도
+  누적/표시한 bounded diagnostics를 반환한다. 스냅숏 값은 lock 이름·endpoint·
   error message를 포함하지 않는다. point-in-time 값은 concurrent update 중 fuzzy할 수
   있고, quiescent 시 `queued + inFlight + scheduledRetries == admitted <= capacity`를
   만족해야 한다.
@@ -160,13 +168,20 @@ observer enum은 `ACCEPTED`,
 `TERMINAL_FAILURE`만 만들고 `CANCELLED`를 중복 생성하지 않는다. close-owned cancel은
 `CANCELLED`만 만들며 retry/failure를 만들지 않는다.
 
-observer registration은 최대 16개로 제한한다. `observe()`가 반환하는 handle의
-`close()`는 registry에서 observer를 선형적으로 제거하고 반환 이후 해당 observer에
-대한 callback 시작을 허용하지 않는다. 이미 실행 중인 callback은 현재 호출만 마친다.
-17번째 registration은 no-op handle을 반환하고 `observerDrops`를 1 증가시킨다.
+observer registration은 최대 16개로 제한한다. 각 slot은 `active`와
+`inFlight`/invocation reservation을 하나의 lock 아래 관리한다. observation admission은
+slot lock을 잡고 `active=true`일 때만 queue permit과 `inFlight++`를 수행한다. worker는
+callback 직전 같은 slot lock에서 `active=true`를 확인하고 invocation을 reservation한 뒤
+lock을 놓고 호출한다. handle `close()`는 같은 lock에서 `active=false`를 선형화한 뒤
+registry에서 제거한다. close 전에 reservation된 callback만 crossing allowance로 남기므로
+close 반환 뒤 새 callback invocation은 시작하지 않지만 이미 reservation된 callback은
+현재 호출을 마칠 수 있다. 17번째 registration은 no-op handle을 반환하고
+`observerRegistrationDrops`를 1 증가시킨다. diagnostics queue 포화는 별도의
+`observerDrops`에만 합산한다.
 diagnostics worker에서 observer `Error`가 발생하면 diagnostics gate를 CLOSED로
-전환하고 queued callback을 drop한 뒤 원래 `Error`를 uncaught boundary로 재전파하며,
-worker를 자동 재시작하지 않는다. 이후 `observe()`는 no-op handle을 반환한다.
+전환하고 queued callback을 drop한 뒤 `diagnosticsFatalErrors`를 증가시키고
+`diagnosticsClosed=true`로 표시한 다음 원래 `Error`를 uncaught boundary로 재전파한다.
+worker를 자동 재시작하지 않으며 이후 `observe()`는 no-op handle을 반환한다.
 
 취소 원인별 관찰 순서는 다음 표로 고정한다.
 
@@ -184,9 +199,12 @@ executor 주입점으로 구성한다. queue admission은 CAS permit과 non-bloc
 permit을 유지하고 terminal success/failure/drop/close에서 정확히 한 번 반환한다.
 기본값과 hard upper bound는 모두 유한하며, 0/음수·`initialBackoff > maxBackoff`·기간
 overflow를 fail-fast로 거부한다. executor/scheduler는 caller 소유이고 exporter가
-shutdown하지 않는다. worker/retry schedule rejection은 accepted item을 고착시키지
-않고 terminal/drop outcome과 permit 반환으로 끝내며, close는 worker가 다음 admission을
-만들지 않고 실행 중 drain이 종료될 때까지 상태를 CLOSED로 유지한다.
+shutdown하지 않는다. worker-start executor rejection은 그 시점에 worker가 분리한
+queued batch만 `EXECUTOR_REJECTED`로 terminalize하고, retry scheduler rejection은
+거부된 retry item 하나만 `SCHEDULER_REJECTED`로 terminalize한다. 나머지 queued work는
+계속 처리하며 어떤 accepted item도 고착시키지 않고 terminal/drop outcome과 permit
+반환으로 끝낸다. close는 worker가 다음 admission을 만들지 않고 실행 중 drain이
+종료될 때까지 상태를 CLOSED로 유지한다.
 
 기본 dispatcher 값은 `queueCapacity=1024`, `maxInFlight=8`, `maxAttempts=3`,
 `attemptTimeout=5s`, `initialBackoff=100ms`, `maxBackoff=5s`이며 hard upper bound는
@@ -262,9 +280,10 @@ crash 또는 close는 drain하지 않은 work를 잃을 수 있다. receiver는 
 
 `MicrometerLeaderAuditExporter`는 core exporter를 소유하는 decorator하고
 `(delegate, registry)` exact constructor로 다음 metric을 제공한다. decorator `close()`는
-observer handle을 해제한 뒤 delegate를 닫아 wrapper와 direct delegate 모두 close 후
-`DROPPED_CLOSED`가 되게 한다. non-owning observation은 wrapper가 아니라 public
-`observe()` handle을 별도로 사용한다.
+observer handle을 유지한 채 delegate를 먼저 닫아 delegate close에서 발생한 `CANCELLED`
+관찰을 admission한 뒤, `finally`에서 observer handle을 해제한다. 따라서 wrapper와 direct
+delegate 모두 close 후 `DROPPED_CLOSED`가 되며 close observation도 metric에 반영된다.
+non-owning observation은 wrapper가 아니라 public `observe()` handle을 별도로 사용한다.
 
 - accepted submissions
 - queue-full drops
@@ -274,6 +293,11 @@ observer handle을 해제한 뒤 delegate를 닫아 wrapper와 direct delegate �
 - queue depth, in-flight delivery, cancellation/rejection diagnostics
 - diagnostics queue saturation as `leader.audit.export.observer.dropped`; this cumulative
   counter mirrors `snapshot().observerDrops` and is not reset by `close()`.
+- observer registration cap rejections as `leader.audit.export.observer.registration.dropped`,
+  mirroring `snapshot().observerRegistrationDrops`.
+- diagnostics fatal errors as `leader.audit.export.diagnostics.failures` and the CLOSED state
+  as `leader.audit.export.diagnostics.closed` (`0|1` gauge), mirroring the corresponding
+  snapshot fields.
 
 metric tag는 `source`, `outcome`, `transport`처럼 유한한 값만 사용한다. raw
 lock name, leader ID, endpoint, error message는 metric tag가 되지 않는다.

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -130,18 +130,39 @@ public `LeaderAuditExporter`는 다음 경계를 갖는다.
 - `close()`는 신규 admission을 차단하고 queued/retry 작업을 취소한다. close는
   네트워크 drain을 기다리지 않으며 idempotent다.
 - `observe(observer)`는 accepted/drop/retry/terminal-failure/cancel/rejection의 유한한 lifecycle
-  outcome만 전달한다. observer가 예외를 던져도 admission, permit, election 결과에는
-  영향을 주지 않으며, event 값·lock 이름·endpoint·error message는 observer payload에
-  포함하지 않는다.
-- `snapshot()`은 queue depth, in-flight 수, accepted/drop/retry/terminal failure,
-  cancellation 및 executor/scheduler rejection을 누적한 bounded diagnostics를
-  반환한다. 스냅숏 값은 lock 이름·endpoint·error message를 포함하지 않는다.
+  outcome을 exporter가 소유하는 bounded diagnostics queue와 전용 diagnostics worker를
+  통해 caller thread 밖에서 best-effort로 전달한다. `submit`은 diagnostics queue에
+  non-blocking offer만 수행하므로 observer callback과 diagnostics worker가 block되어도
+  admission thread를 block하지 않는다. diagnostics queue가 가득 차면 callback 없이
+  `observerDrops`만 증가한다. observer가 `Exception`을 던져도 admission, permit, election
+  결과에는 영향을 주지 않는다. observer `Error`는 callback task를 terminalize한 뒤
+  diagnostics worker의 uncaught boundary로 원래 인스턴스를 재전파한다. event 값·lock 이름·
+  endpoint·error message는 observer payload에 포함하지 않는다.
+- `snapshot()`은 queued, in-flight, scheduled-retry, total admitted 수와
+  accepted/drop/retry/terminal failure, cancellation, executor/scheduler rejection,
+  observer drop을 누적한 bounded diagnostics를 반환한다. 스냅숏 값은 lock 이름·endpoint·
+  error message를 포함하지 않는다. point-in-time 값은 concurrent update 중 fuzzy할 수
+  있고, quiescent 시 `queued + inFlight + scheduledRetries == admitted <= capacity`를
+  만족해야 한다.
 
 이 관찰 경계는 public `LeaderAuditExportObserver`와 immutable
-`LeaderAuditExportSnapshot`으로 고정한다. observer enum은 `ACCEPTED`,
+`LeaderAuditExportSnapshot`으로 고정한다. snapshot은 explicit 호출 시 O(1) atomic
+counter를 읽어 생성하며 submit hot path에서 snapshot 객체를 할당하지 않는다.
+Micrometer gauge도 registry poll 시 snapshot을 읽고 admission 중 queue를 순회하지 않는다.
+observer enum은 `ACCEPTED`,
 `DROPPED_QUEUE_FULL`, `DROPPED_CLOSED`, `RETRY`, `TERMINAL_FAILURE`, `CANCELLED`,
 `EXECUTOR_REJECTED`, `SCHEDULER_REJECTED`만 허용하며, snapshot에는 dynamic identifier가
-없다.
+없다. timeout이 소유한 future cancel은 `RETRY` 또는 마지막 attempt의
+`TERMINAL_FAILURE`만 만들고 `CANCELLED`를 중복 생성하지 않는다. close-owned cancel은
+`CANCELLED`만 만들며 retry/failure를 만들지 않는다.
+
+취소 원인별 관찰 순서는 다음 표로 고정한다.
+
+| 취소 주체 | future 결과 | 재시도 | 관찰 outcome | permit |
+|---|---|---|---|---|
+| timeout winner | `CancellationException(TIMEOUT)` | 남은 attempt가 있으면 `RETRY`, 마지막이면 `TERMINAL_FAILURE` | 위 outcome을 각 1회 | terminal에서 1회 반환 |
+| exporter close winner | `CancellationException(CLOSE)` | 없음 | `CANCELLED` 1회 | close에서 1회 반환 |
+| caller-owned delivery cancel | `CancellationException(CALLER)` | 없음 | `CANCELLED` 1회 | completion에서 1회 반환 |
 
 dispatcher 옵션은 전체 admitted work(queued, in-flight, scheduled retry)를 제한하는
 queue capacity, 최대 동시 delivery, 최대 attempt 수, 양의 유한 `attemptTimeout`,
@@ -179,15 +200,25 @@ dispatcher는 transport-neutral one-shot delivery 함수와 분리한다. HTTP a
   observer를 만들지 않는다.
 - HTTP adapter의 기본 response body handler는 `BodyHandlers.discarding()`이며 response
   body 보존 상한은 0 byte다. 따라서 oversized/chunked body를 메모리에 축적하지 않는다.
-  log에는 endpoint credential이나 body를 남기지 않는다.
-- target URI는 기본적으로 HTTPS만 허용하고, user-info/query/fragment와 control
-  character를 거부한다. HTTP loopback은 명시적 test-only allow-list에서만 허용한다.
+  이는 메모리 retention bound일 뿐 네트워크 ingress truncation 계약은 아니다. log에는
+  endpoint credential이나 body를 남기지 않는다.
+- target URI는 production에서 HTTPS만 허용하고, user-info/query/fragment와 control
+  character를 거부한다. loopback·link-local·RFC1918 private address는 거부하며,
+  HTTP loopback은 public option이 아니라 `internal` test-only allow-list에서만 허용한다.
+  resolver가 반환한 모든 주소에 대해 loopback/link-local/site-local/any-local을
+  검사하며, 따라서 public API에는 임의 scheme allow-list나 insecure-loopback flag가
+  없다. resolver는 `internal` test seam으로 주입해 이 검사를 DNS/network 없이
+  deterministic하게 검증한다.
   injected `HttpClient`는 `Redirect.NEVER`여야 하며, header map은 immutable
   allow-list로 복사하고 CR/LF·`Host`·`Content-Length`·`Connection` 등 forbidden header를
   거부한다. Authorization 같은 credential header는 전송할 수 있지만 로그·metric·event에는
   절대 복사하지 않는다.
 - HTTP adapter는 core에 JSON library를 추가하지 않는다. JSON payload가 필요한
   사용자는 encoder를 제공하며, JSONL/OpenTelemetry는 후속 adapter가 담당한다.
+- public `LeaderAuditHttpOptions(maxPayloadBytes)`는 1 MiB hard upper bound와
+  기본 64 KiB를 검증하고 scheme allow-list나 insecure-loopback flag를 노출하지 않는다.
+  `LeaderAuditHttpPayload.of`는 caller `ByteArray`를 복사하기 전에 1 MiB hard limit을
+  검사하며, adapter는 configured lower limit도 request 생성 전에 검사한다.
 
 ### 기존 계약 연결
 
@@ -214,7 +245,8 @@ crash 또는 close는 drain하지 않은 work를 잃을 수 있다. receiver는 
 
 ### Micrometer 관찰
 
-`MicrometerLeaderAuditExporter`는 core exporter를 decorator하고 다음 metric을
+`MicrometerLeaderAuditExporter`는 core exporter를 decorator하고
+`(delegate, registry, ownsDelegate:Boolean)` exact constructor로 다음 metric을
 제공한다.
 
 - accepted submissions

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -110,9 +110,13 @@ issue의 framework-neutral core contract와 작은 train 범위를 넘어가므�
 event에는 backend token, `LeaderHistoryKey.token`, raw `LeaderLease` 객체를 넣지
 않는다. `lockName`, `nodeId`, `leaderId`, attribute key/value와 error message는
 event를 만들기 전에 core redaction policy를 적용한다. 기본 policy는 민감하거나
-무제한 cardinality가 될 수 있는 값을 `redacted`로 바꾸며, 명시적 opt-in에서만
-`HASH` 또는 길이 제한 `TRUNCATE`를 허용한다. `RAW`는 기본값이 아니며 allow-list와
-최대 길이 검증을 통과해야 한다.
+무제한 cardinality가 될 수 있는 값을 `redacted`로 바꾼다. 정책은 임의 함수를
+주입하는 형태가 아니라 `REDACT`, `HASH`, `TRUNCATE`, `RAW` 모드와 검증된 field
+allow-list로 표현한다. `HASH`와 `TRUNCATE`는 명시적 opt-in에서만 허용하고,
+`RAW`는 사전에 정해진 비민감 enum field에 대해서만 allow-list와 최대 길이 검증을
+통과할 때 사용할 수 있다. 따라서 임의 sanitizer 구현이 token, credential, lock 이름,
+leader identity, attribute, error message를 우회해 복원할 수 없다. event의
+`toString()`과 payload encoder 입력도 이 sanitized 값만 포함한다.
 
 ### Exporter와 admission
 
@@ -125,11 +129,30 @@ public `LeaderAuditExporter`는 다음 경계를 갖는다.
   leader election의 반환값·예외에는 영향을 주지 않는다.
 - `close()`는 신규 admission을 차단하고 queued/retry 작업을 취소한다. close는
   네트워크 drain을 기다리지 않으며 idempotent다.
+- `observe(observer)`는 accepted/drop/retry/terminal-failure/cancel/rejection의 유한한 lifecycle
+  outcome만 전달한다. observer가 예외를 던져도 admission, permit, election 결과에는
+  영향을 주지 않으며, event 값·lock 이름·endpoint·error message는 observer payload에
+  포함하지 않는다.
+- `snapshot()`은 queue depth, in-flight 수, accepted/drop/retry/terminal failure,
+  cancellation 및 executor/scheduler rejection을 누적한 bounded diagnostics를
+  반환한다. 스냅숏 값은 lock 이름·endpoint·error message를 포함하지 않는다.
 
-dispatcher 옵션은 queue capacity, 최대 동시 delivery, 최대 attempt 수, initial
-   backoff, 최대 backoff, retryable status/exception 분류, clock/scheduler와
-   executor 주입점으로 구성한다. 기본값은 유한한 queue와 retry 횟수이며 무한
-   retry·무한 queue를 허용하지 않는다.
+dispatcher 옵션은 전체 admitted work(queued, in-flight, scheduled retry)를 제한하는
+queue capacity, 최대 동시 delivery, 최대 attempt 수, 양의 유한 `attemptTimeout`,
+initial backoff, 최대 backoff, retryable status/exception 분류, clock/scheduler와
+executor 주입점으로 구성한다. queue admission은 CAS permit과 non-blocking queue로
+선형화하며, `submit`은 lock이나 capacity 대기를 수행하지 않는다. retry는 같은
+permit을 유지하고 terminal success/failure/drop/close에서 정확히 한 번 반환한다.
+기본값과 hard upper bound는 모두 유한하며, 0/음수·`initialBackoff > maxBackoff`·기간
+overflow를 fail-fast로 거부한다. executor/scheduler는 caller 소유이고 exporter가
+shutdown하지 않는다. worker/retry schedule rejection은 accepted item을 고착시키지
+않고 terminal/drop outcome과 permit 반환으로 끝내며, close는 worker가 다음 admission을
+만들지 않고 실행 중 drain이 종료될 때까지 상태를 CLOSED로 유지한다.
+
+기본 dispatcher 값은 `queueCapacity=1024`, `maxInFlight=8`, `maxAttempts=3`,
+`attemptTimeout=5s`, `initialBackoff=100ms`, `maxBackoff=5s`이며 hard upper bound는
+각각 `65536`, `queueCapacity`, `16`, `5m`, `1m`, `1m`이다. HTTP payload는 기본
+64 KiB, hard upper bound 1 MiB이고 response body는 0 byte로 discard한다.
 
 ### Delivery와 HTTP/webhook
 
@@ -138,12 +161,25 @@ dispatcher는 transport-neutral one-shot delivery 함수와 분리한다. HTTP a
 사용한다.
 
 - encoder는 이미 redacted event를 `ByteArray`로 변환하고 content type을 제공한다.
+  payload에는 양의 유한 `maxPayloadBytes` 상한을 적용하며 초과 payload는 request를
+  만들기 전에 terminal failure로 끝낸다.
 - request는 `POST`로 만들며 2xx만 성공으로 처리한다.
 - 408, 429, 5xx와 I/O 실패만 bounded retry 대상이다. 다른 4xx는 즉시 terminal
   failure다.
-- `sendAsync` completion은 dispatcher가 재시도·성공·실패로 분류한다.
-- response body는 제한된 크기까지만 읽고 log에는 endpoint credential이나 body를
-  남기지 않는다.
+- `sendAsync` completion은 dispatcher가 재시도·성공·실패로 분류한다. dispatcher의
+  `attemptTimeout`과 HTTP request timeout은 모두 양의 유한 값이며, timeout은 retryable
+  failure로 한 번만 terminalize한다. timeout 승자는 underlying future를 cancel하고,
+  completion 승자는 timeout task를 cancel한다. close가 먼저 이기면 retry/failure
+  observer를 만들지 않는다.
+- HTTP adapter의 기본 response body handler는 `BodyHandlers.discarding()`이며 response
+  body 보존 상한은 0 byte다. 따라서 oversized/chunked body를 메모리에 축적하지 않는다.
+  log에는 endpoint credential이나 body를 남기지 않는다.
+- target URI는 기본적으로 HTTPS만 허용하고, user-info/query/fragment와 control
+  character를 거부한다. HTTP loopback은 명시적 test-only allow-list에서만 허용한다.
+  injected `HttpClient`는 `Redirect.NEVER`여야 하며, header map은 immutable
+  allow-list로 복사하고 CR/LF·`Host`·`Content-Length`·`Connection` 등 forbidden header를
+  거부한다. Authorization 같은 credential header는 전송할 수 있지만 로그·metric·event에는
+  절대 복사하지 않는다.
 - HTTP adapter는 core에 JSON library를 추가하지 않는다. JSON payload가 필요한
   사용자는 encoder를 제공하며, JSONL/OpenTelemetry는 후속 adapter가 담당한다.
 
@@ -151,15 +187,24 @@ dispatcher는 transport-neutral one-shot delivery 함수와 분리한다. HTTP a
 
 - `ExportingLeaderHistorySink`는 기존 sink를 먼저 호출하고, 반환된 key/record로
   sanitized `History` event를 submit한다. exporter 결과가 `DROPPED_*`여도 기존
-  sink 결과를 변경하지 않는다.
+  sink 결과를 변경하지 않는다. non-blocking 보장은 exporter admission과 delivery
+  대기를 제외하는 의미이며, 기존 history sink/recorder의 동기 latency는 유지한다.
 - suspend variant는 같은 admission API를 사용하고 suspend sink 호출의
   `CancellationException` 전파를 유지한다. export submission 자체는 blocking하지
   않는다.
 - `LeaderElectionEventPublisher` bridge는 `events`를 구독해 `Lifecycle` event를
-  submit하고, 구독 close handle을 반환한다. callback 또는 exporter failure는
-  publisher contract 밖으로 전파하지 않는다.
+  submit하고, 구독 close handle을 반환한다. callback admission과 close는 atomic gate로
+  선형화하며 close가 gate를 닫은 뒤 이미 admitted callback이 끝날 때까지 기다린다.
+  따라서 close가 반환된 뒤에는 새 submit이 없고, close와 crossing한 event는 gate를
+  먼저 획득한 쪽의 결과만 갖는다. callback 또는 exporter failure는 publisher contract
+  밖으로 전파하지 않는다.
 - exporter lifecycle은 caller가 소유한다. Spring/Ktor가 자동으로 bean·scope를
   만들거나 닫는 동작은 후속 integration issue에서 정의한다.
+
+export delivery는 best-effort다. `ACCEPTED`는 queue admission만 뜻하며 delivered를
+보장하지 않는다. `maxInFlight > 1`이면 retry 중복·reordering이 가능하고, process
+crash 또는 close는 drain하지 않은 work를 잃을 수 있다. receiver는 event identity를
+사용해 idempotency를 제공해야 한다.
 
 ### Micrometer 관찰
 
@@ -171,6 +216,7 @@ dispatcher는 transport-neutral one-shot delivery 함수와 분리한다. HTTP a
 - closed drops
 - retry attempts
 - terminal delivery failures
+- queue depth, in-flight delivery, cancellation/rejection diagnostics
 
 metric tag는 `source`, `outcome`, `transport`처럼 유한한 값만 사용한다. raw
 lock name, leader ID, endpoint, error message는 metric tag가 되지 않는다.
@@ -188,7 +234,9 @@ lock name, leader ID, endpoint, error message는 metric tag가 되지 않는다.
 5. coroutine scope가 취소되면 bridge subscription은 닫히지만, history recorder가
    sink에서 받은 `CancellationException`을 삼키지 않는다.
 6. in-flight HTTP future와 scheduled retry는 close에서 취소하고, late completion은
-   counter를 두 번 올리거나 새 retry를 예약하지 않는다.
+   counter를 두 번 올리거나 새 retry를 예약하지 않는다. generic delivery도
+   cancellation-capable `CompletableFuture`를 반환하므로 close/timeout이 취소를
+   전파할 수 있다.
 7. exporter callback/encoder가 예외를 내도 기존 election result와 history sink
    result는 보존한다.
 
@@ -226,6 +274,10 @@ lock name, leader ID, endpoint, error message는 metric tag가 되지 않는다.
 - [ ] queue 포화·delivery 실패·retry 소진이 election outcome을 변경하지 않는다.
 - [ ] retryable/non-retryable HTTP 분류, 최대 attempt, backoff, close/cancel이
       deterministic test로 검증된다.
+- [ ] timeout, executor/scheduler rejection, submit-close crossing과 worker 종료가
+      deterministic test로 검증된다.
+- [ ] URI/header trust boundary와 payload/response byte bound가 negative test로
+      검증된다.
 - [ ] Micrometer metric은 accepted/drop/retry/failure를 관찰하고 raw/high-cardinality
       값을 tag로 만들지 않는다.
 - [ ] 새 dependency와 Spring/Ktor auto-config 없이 `leader-core` 및
@@ -243,4 +295,3 @@ lock name, leader ID, endpoint, error message는 metric tag가 되지 않는다.
 - export failure가 election을 중단하지 않는 fake delivery 증거가 있다.
 - PR CI와 독립 7-tier review에서 P0/P1이 0이다.
 - merge는 현재 exact head에 대한 fresh approval 전에는 실행하지 않는다.
-

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -379,8 +379,10 @@ metric이 감소하지 않는다. close가 성공하거나 예외를 던지는 �
 1. 같은 generation의 final snapshot을 읽고 모든 cumulative field의 delta를 immutable
    temporary value로 계산한다.
 2. 모든 field가 `final >= close-entry`인지 먼저 검증한다. 하나라도 음수면 어떤 field도
-   `closingOffsets`에 적용하지 않고 close-entry base를 유지하며 `sourceDegraded=true`와
-   진단을 기록한다. 양수 field만 부분 적용하는 것은 금지한다.
+   `closingOffsets`에 적용하지 않고 close-entry base를 유지하며 공통
+   `markSourceDegraded` 경로로 `sourceDegraded=true`와
+   `leader.audit.export.meter-source-degraded` fixed warning을 해당 generation에서 한 번
+   기록한다. 양수 field만 부분 적용하는 것은 금지한다.
 3. provider 제거와 terminal `DETACHED` publication을 non-throwing inner `finally`에서
    먼저 완료한다. 이 cleanup은 사용자 callback을 호출하지 않으며, 이후에만 예외를
    집계한다. 따라서 transition/diagnostic 예외가 cleanup을 건너뛰게 할 수 없다.
@@ -389,7 +391,8 @@ metric이 감소하지 않는다. close가 성공하거나 예외를 던지는 �
 경로에서는 close 중 발생한 cancellation/rejection이 final delta에 포함된다. 반대로 final
 snapshot 자체가 실패하면 cumulative counter는 close-entry 기반 `closingOffsets`만 보존하고
 `sourceDegraded=true`를 설정한다. 이 비정상 경로에서는 close-entry 이후 cancellation/rejection
-정확성을 보장하지 않으며 `leader.audit.export.meter-source-degraded` fixed warning을 한 번
+정확성을 보장하지 않으며 동일한 `markSourceDegraded` 경로로
+`leader.audit.export.meter-source-degraded` fixed warning을 해당 generation에서 한 번
 기록한다. terminal DETACHED fallback gauge는 `queue=0`, `inFlight=0`,
 `scheduledRetries=0`, `admitted=0`, `diagnosticsClosed=true`, `closed=true`로 합성한다.
 `snapshot()`은 마지막으로 신뢰한 close-entry counters를 O(1)로 읽으며, degraded 상태는
@@ -411,7 +414,8 @@ snapshot 실패로 DETACHED가 된 뒤 stable meter claim이 유효한 동일 re
 warning을 재생하지 않으며, 누적 offset과 stable meter identity만 이어받는다. 새 generation
 에서도 final snapshot/invariant 실패가 발생하면 그 generation에 한해 warning을 한 번
 기록한다. compromised registry identity는 이 reset 경로보다 우선하여 계속 거부된다.
-이 generation reset, warning 횟수, offset 보존은 결정적 replacement fixture로 고정한다.
+첫 generation의 negative delta와 replacement generation의 재실패는 각각 warning count 1을
+기록하고 manager lifetime 누적 count 2가 되는지 결정적 replacement fixture로 고정한다.
 wrapper와 owned delegate admission 모두 close 후 `DROPPED_CLOSED`가 된다.
 non-owning observation은 wrapper가 아니라 public `observe()` handle을 별도로 사용하며
 decorator는 내부 observer handle을 소유하지 않는다. stable meter는 close 후에도 manager의

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -118,6 +118,16 @@ allow-list로 표현한다. `HASH`와 `TRUNCATE`는 명시적 opt-in에서만 �
 leader identity, attribute, error message를 우회해 복원할 수 없다. event의
 `toString()`과 payload encoder 입력도 이 sanitized 값만 포함한다.
 
+v1 bound 상수는 `MAX_ERROR_MESSAGE_BYTES=4096`, `MAX_ERROR_TYPE_BYTES=128`,
+`MAX_TEXT_FIELD_BYTES=256`, `MAX_ATTRIBUTES=32`, `MAX_ATTRIBUTE_KEY_BYTES=128`,
+`MAX_ATTRIBUTE_VALUE_BYTES=512`, `MAX_ATTRIBUTES_TOTAL_BYTES=8192`로 고정한다.
+모든 byte bound는 UTF-8 기준이며 over-limit 문자열은 code point를 자르지 않는 최대
+prefix로 truncate하고 ellipsis를 추가하지 않는다. attribute는 sanitized key의 UTF-8
+byte 순으로 정렬한 뒤 key/value 개별 bound와 aggregate bound를 순서대로 적용하며,
+한도를 넘는 후속 entry는 drop한다. sanitize 후 key collision은 정렬상 먼저 온 entry만
+유지한다. `Raw(maxBytes)`는 양수 byte 값과 비민감 field allow-list를 생성 시 검증하고,
+허용되지 않은 field는 `IllegalArgumentException`으로 거부한다.
+
 ### Exporter와 admission
 
 public `LeaderAuditExporter`는 다음 경계를 갖는다.
@@ -305,34 +315,37 @@ crash 또는 close는 drain하지 않은 work를 잃을 수 있다. receiver는 
 
 `MicrometerLeaderAuditExporter`는 core exporter를 소유하는 decorator하고
 `(delegate, registry)` exact constructor로 다음 metric을 제공한다. metric의 authoritative
-source는 `delegate.snapshot()`의 O(1) atomic counter이며 `FunctionCounter`/`Gauge`가
-registry polling 시 snapshot을 읽는다. 따라서 async diagnostics observer callback이 close
-직후 drop되어도 close-owned cancellation/rejection이 metric에서 사라지지 않는다.
-decorator는 registry identity별 내부 ownership manager가 claim하고 설치 identity를 검증한
-`Meter`만 소유한다. manager는 자체 lock과 claim token으로 wrapper 간 중복을 막고, 외부
-registry monitor에 의존하지 않는다. 고정 name/tag ID가 preflight에서 이미 존재하거나,
-등록 후 registrar가 반환한 meter·registry lookup·등록 callback의 identity가 일치하지
-않거나 foreign/ambiguous registration crossing이 관찰되면 constructor는 fail-fast한다.
-이 경우 foreign meter를 제거하지 않으며, 부분 등록 중 exact-owned meter만 정리한다.
-표준 Micrometer API가 설치 identity를 증명하지 못하는 registry는 지원하지 않는 것으로
-간주하고 ownership을 추정하지 않는다. 성공한 전체 등록이 끝난 뒤에만 wrapper가
-delegate ownership을 확정하며, constructor 실패 시에는 delegate를 정확히 한 번 닫고
-원래 실패를 보존한다.
+source는 manager가 보유한 active provider의 `delegate.snapshot()` O(1) atomic counter와
+detached offset이며 `FunctionCounter`/`Gauge`가 registry polling 시 manager state를 읽는다.
+따라서 async diagnostics observer callback이 close 직후 drop되어도 close-owned
+cancellation/rejection이 metric에서 사라지지 않는다.
+decorator는 registry identity별 내부 manager가 고정된 `Meter.Id` 집합을 한 번만 등록하고
+stable meter를 소유한다. manager는 자체 lock/claim token과 `activeProvider` indirection을
+사용하며 `FunctionCounter`/`Gauge` callback은 manager state만 캡처하고 delegate를 직접
+참조하지 않는다. 첫 acquire에서 foreign ID가 이미 존재하거나 등록 identity를 증명할 수
+없으면 constructor는 fail-fast한다. 외부 registration crossing으로 manager-owned identity가
+바뀌거나 ambiguous가 되면 `leader.audit.export.meter-ownership-conflict` fixed warning을
+한 번 기록하고 state를 compromised로 잠근다. manager는 foreign meter를 절대로 제거하지
+않으며, compromised registry는 수동으로 fixed ID를 정리하거나 registry를 교체하기 전까지
+새 wrapper를 허용하지 않는다.
 
-`close()`는 delegate를 idempotently 닫은 뒤 `finally`에서 소유 meter마다 현재 registry
-lookup이 저장된 meter와 identity-equal인 경우에만 `registry.remove(id)`를 시도한다.
-lookup이 foreign/replaced meter이거나 removal이 실패해도 그 ID를 제거했다고 가장하지
-않으며, 나머지 ID 제거를 계속한다. residue는 registry identity state가 exact meter claim을
-유지한 채 `leader.audit.export.meter-removal-failure` fixed warning key와 O(1)
-`residueCount`로 보고한다. 같은 `close()` 호출에서는 ID별 warning을 한 번만 내고
-idempotent close는 반복하지 않는다. 다음 wrapper constructor는 residue removal을 먼저
-재시도하며, 성공한 ID만 claim을 해제한다. 따라서 closed delegate의 strong-reference 제거는
-성공적으로 제거된 meter에 대해서만 보장되고, 복구 전에는 replacement가 stale source를
-재사용하지 못한다. wrapper와 direct delegate 모두 close 후 `DROPPED_CLOSED`가 된다.
+전체 stable meter 등록이 성공한 뒤에만 wrapper가 delegate ownership을 확정한다.
+constructor 실패 시에는 delegate를 정확히 한 번 닫고 원래 primary 실패를 보존하며,
+delegate close/partial-registration cleanup 예외는 primary의 suppressed exception으로
+붙인다. primary 실패가 없을 때만 cleanup 예외를 primary로 던진다. 부분 등록은
+manager-owned stable meter와 claim state로 남겨 다음 acquire가 누락 ID만 이어서 등록할
+수 있으며 foreign ID는 건드리지 않는다. `close()`는 delegate를 idempotently 닫고 마지막
+snapshot을 manager offset에 반영한 뒤 `activeProvider`를 clear한다. `registry.remove`를
+호출하지 않으므로 lookup/remove 사이 foreign replacement race와 removal residue가 없다.
+stable meter는 registry에 남지만 closed delegate를 strong-reference하지 않고 마지막
+snapshot/closed 상태를 읽는다. 같은 registry의 새 wrapper는 stable meter identity를
+재사용하면서 새 provider를 연결한다. outcome counter는 manager offset을 누적해
+replacement에서도 감소하지 않으며 queue/in-flight/closed gauge는 현재 provider 또는
+detached closed state를 반영한다. wrapper와 direct delegate 모두 close 후
+`DROPPED_CLOSED`가 된다.
 non-owning observation은 wrapper가 아니라 public `observe()` handle을 별도로 사용하며
-decorator는 내부 observer handle을 소유하지 않는다. snapshot counter 값은 reset하지
-않지만 close 후 성공적으로 제거된 meter는 registry에 존재하지 않는다. 같은 registry에
-새 delegate wrapper를 만들면 manager claim이 해제된 ID에 새 snapshot source를 등록한다.
+decorator는 내부 observer handle을 소유하지 않는다. stable meter는 close 후에도 manager의
+detached snapshot/offset을 읽고 새 wrapper가 acquire되면 새 provider로 전환한다.
 
 - accepted submissions
 - queue-full drops
@@ -341,13 +354,30 @@ decorator는 내부 observer handle을 소유하지 않는다. snapshot counter 
 - terminal delivery failures
 - queue depth, in-flight delivery, cancellation/rejection diagnostics
 - diagnostics admission saturation as `leader.audit.export.observer.dropped`; this cumulative
-  counter mirrors `snapshot().observerDrops` while the wrapper is open and is unregistered
-  with the other meters on `close()`.
+  counter mirrors manager offset plus the active snapshot and remains readable after close
+  without retaining the closed delegate.
 - observer registration cap rejections as `leader.audit.export.observer.registration.dropped`,
-  mirroring `snapshot().observerRegistrationDrops` while open.
+  mirroring manager offset plus the active snapshot without a delegate reference after close.
 - diagnostics fatal errors as `leader.audit.export.diagnostics.failures` and the CLOSED state
   as `leader.audit.export.diagnostics.closed` (`0|1` gauge), mirroring the corresponding
   snapshot fields.
+
+v1 fixed meter ID 표는 다음과 같으며 총 13개 ID를 등록한다.
+
+| 이름 | 타입 | 정확한 tag | snapshot source |
+|---|---|---|---|
+| `leader.audit.export.accepted` | `FunctionCounter` | `outcome=accepted` | `accepted` |
+| `leader.audit.export.dropped` | `FunctionCounter` | `outcome=queue_full`, `outcome=closed` | `droppedQueueFull`, `droppedClosed` |
+| `leader.audit.export.retries` | `FunctionCounter` | `outcome=retry` | `retries` |
+| `leader.audit.export.failures` | `FunctionCounter` | `outcome=failure` | `terminalFailures` |
+| `leader.audit.export.queue.depth` | `Gauge` | 없음 | `queued` |
+| `leader.audit.export.in.flight` | `Gauge` | 없음 | `inFlight` |
+| `leader.audit.export.cancelled` | `FunctionCounter` | `outcome=cancelled` | `cancellations` |
+| `leader.audit.export.rejections` | `FunctionCounter` | `outcome=rejected` | `executorRejections + schedulerRejections` |
+| `leader.audit.export.observer.dropped` | `FunctionCounter` | 없음 | `observerDrops` |
+| `leader.audit.export.observer.registration.dropped` | `FunctionCounter` | 없음 | `observerRegistrationDrops` |
+| `leader.audit.export.diagnostics.failures` | `FunctionCounter` | 없음 | `diagnosticsFatalErrors` |
+| `leader.audit.export.diagnostics.closed` | `Gauge` | 없음 | `diagnosticsClosed` |
 
 v1 aggregate metric은 snapshot에 차원별 값이 없고 decorator constructor에도 source/
 transport context가 없으므로 `outcome={accepted,queue_full,closed,retry,failure,cancelled,

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -331,10 +331,12 @@ decorator는 registry identity별 내부 manager가 고정된 `Meter.Id` 집합�
 stable meter를 소유한다. manager는 자체 lock/claim token과 immutable manager state를
 사용한다. state는 `activeProvider`, `closingProvider`, detached snapshot, cumulative offset, lifecycle와
 `compromised` flag를 함께 보유하며, `FunctionCounter`/`Gauge` callback도 같은 lock으로
-state와 provider snapshot을 한 번에 읽는다. `CLOSING` state는 metric callback에는 detached
-snapshot만 노출하고 final snapshot을 읽기 위한 `closingProvider`만 임시로 보유한다. close와
-acquire는 offset 반영·provider 전환을 하나의 선형화 지점에서 수행하므로 poll이
-`offset + 이전 provider`를 섞어 읽지 않는다.
+state와 provider snapshot을 한 번에 읽는다. `CLOSING` state는 cumulative field에
+`closingOffsets = oldOffsets + closeEntrySnapshot`을 반영하고 gauge에는 close-entry 값을
+사용하는 detached view만 metric callback에 노출하며,
+final snapshot을 읽기 위한 `closingProvider`만 임시로 보유한다. close와 acquire는 offset
+반영·provider 전환을 하나의 선형화 지점에서 수행하므로 poll이 `offset + 이전 provider`를
+섞어 읽지 않는다.
 첫 acquire에서 foreign ID가 이미 존재하거나 등록 identity를 증명할 수 없으면 constructor는
 fail-fast한다. 외부 registration crossing으로 manager-owned identity가 바뀌거나 ambiguous가
 되면 `leader.audit.export.meter-ownership-conflict` fixed warning을 한 번 기록하고 state를
@@ -366,17 +368,19 @@ delegate close/partial-registration cleanup 예외는 primary의 suppressed exce
 manager-owned stable meter와 claim state로 남겨 다음 acquire가 누락 ID만 이어서 등록할
 수 있으며 foreign ID는 건드리지 않는다. `close()`는 generation token으로 한 번만 현재
 provider를 `CLOSING`으로 바꾸고 `closingProvider`와 close-entry snapshot을 보존한 뒤
-delegate close를 실행한다. close가 성공하거나 예외를 던지는 모든 경로의 `finally`에서
-lock을 재획득해 같은 generation의 `closingProvider` final snapshot을 읽고
-`final - close-entry` delta만 정확히 한 번 cumulative offset에 반영한 뒤 provider를
-clear하여 `DETACHED` claim을 해제한다. 각 cumulative counter delta는
-`max(0, final - close-entry)`로 계산하고 gauge는 final snapshot 값을 사용한다. 따라서
-close-entry counter를 다시 더해 중복 집계하지 않으며 close 중 발생한
-cancellation/rejection도 final delta에 포함된다.
-final snapshot/transition 예외는 close 예외가 있으면 suppressed로 붙이고, 없으면
-primary로 던진다. 따라서 manager가 영구 `CLOSING`에 남지 않으며, replacement는
-`DETACHED` 이후에만 허용된다. `snapshot()`은 delegate close 후에도 final counters를 읽을
-수 있는 O(1) 계약을 유지한다. `registry.remove`를
+`closingOffsets = oldOffsets + closeEntrySnapshot`을 먼저 게시하고 delegate close를
+실행한다. 따라서 close-entry가 이전 generation offset에 편입되어 CLOSING poll에서도
+metric이 감소하지 않는다. close가 성공하거나 예외를 던지는 모든 경로의 `finally`에서
+lock을 재획득해 같은 generation의 `closingProvider` final snapshot을 읽고 각 cumulative
+counter에 대해 `final >= close-entry` invariant를 검증한 뒤 `final - close-entry` delta만
+정확히 한 번 `closingOffsets`에 반영한다. 음수 delta는 `check`/진단 실패로 드러내며 0으로
+숨기지 않는다. gauge는 final snapshot 값을 사용하고, final snapshot이 실패해도 close-entry
+기반 `closingOffsets`와 gauge를 유지한 채 inner `finally`에서 provider를 clear하여
+`DETACHED`로 전환한다. 따라서 close-entry counter를 다시 더해 중복 집계하지 않으며 close
+중 발생한 cancellation/rejection도 final delta에 포함된다. close/final snapshot/transition
+예외는 close 예외가 있으면 suppressed로 붙이고, 없으면 primary로 던진다. 따라서 manager가
+영구 `CLOSING`에 남지 않으며, replacement는 `DETACHED` 이후에만 허용된다. `snapshot()`은
+delegate close 후에도 final counters를 읽을 수 있는 O(1) 계약을 유지한다. `registry.remove`를
 호출하지 않으므로 lookup/remove 사이 foreign replacement race와 removal residue가 없다.
 stable meter는 registry에 남지만 closed delegate를 strong-reference하지 않고 마지막
 snapshot/closed 상태를 읽는다. 같은 registry의 새 wrapper는 stable meter identity를

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -405,8 +405,14 @@ stable meter는 registry에 남지만 closed delegate를 strong-reference하지 
 snapshot/closed 상태를 읽는다. 같은 registry의 새 wrapper는 stable meter identity를
 재사용하면서 새 provider를 연결한다. outcome counter는 manager offset을 누적해
 replacement에서도 감소하지 않으며 queue/in-flight/closed gauge는 현재 provider 또는
-detached closed state를 반영한다. wrapper와 owned delegate admission 모두 close 후
-`DROPPED_CLOSED`가 된다.
+detached closed state를 반영한다. `sourceDegraded`는 generation-scoped 상태다. final
+snapshot 실패로 DETACHED가 된 뒤 stable meter claim이 유효한 동일 registry replacement를
+성공적으로 acquire하면 새 generation은 `sourceDegraded=false`로 시작하고 이전 fixed
+warning을 재생하지 않으며, 누적 offset과 stable meter identity만 이어받는다. 새 generation
+에서도 final snapshot/invariant 실패가 발생하면 그 generation에 한해 warning을 한 번
+기록한다. compromised registry identity는 이 reset 경로보다 우선하여 계속 거부된다.
+이 generation reset, warning 횟수, offset 보존은 결정적 replacement fixture로 고정한다.
+wrapper와 owned delegate admission 모두 close 후 `DROPPED_CLOSED`가 된다.
 non-owning observation은 wrapper가 아니라 public `observe()` handle을 별도로 사용하며
 decorator는 내부 observer handle을 소유하지 않는다. stable meter는 close 후에도 manager의
 detached snapshot/offset을 읽고 새 wrapper가 acquire되면 새 provider로 전환한다.

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -137,6 +137,12 @@ public `LeaderAuditExporter`는 다음 경계를 갖는다.
   cancellation 및 executor/scheduler rejection을 누적한 bounded diagnostics를
   반환한다. 스냅숏 값은 lock 이름·endpoint·error message를 포함하지 않는다.
 
+이 관찰 경계는 public `LeaderAuditExportObserver`와 immutable
+`LeaderAuditExportSnapshot`으로 고정한다. observer enum은 `ACCEPTED`,
+`DROPPED_QUEUE_FULL`, `DROPPED_CLOSED`, `RETRY`, `TERMINAL_FAILURE`, `CANCELLED`,
+`EXECUTOR_REJECTED`, `SCHEDULER_REJECTED`만 허용하며, snapshot에는 dynamic identifier가
+없다.
+
 dispatcher 옵션은 전체 admitted work(queued, in-flight, scheduled retry)를 제한하는
 queue capacity, 최대 동시 delivery, 최대 attempt 수, 양의 유한 `attemptTimeout`,
 initial backoff, 최대 backoff, retryable status/exception 분류, clock/scheduler와

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -374,9 +374,11 @@ metric이 감소하지 않는다. close가 성공하거나 예외를 던지는 �
 lock을 재획득해 같은 generation의 `closingProvider` final snapshot을 읽고 각 cumulative
 counter에 대해 `final >= close-entry` invariant를 검증한 뒤 `final - close-entry` delta만
 정확히 한 번 `closingOffsets`에 반영한다. 음수 delta는 `check`/진단 실패로 드러내며 0으로
-숨기지 않는다. gauge는 final snapshot 값을 사용하고, final snapshot이 실패해도 close-entry
-기반 `closingOffsets`와 gauge를 유지한 채 inner `finally`에서 provider를 clear하여
-`DETACHED`로 전환한다. 따라서 close-entry counter를 다시 더해 중복 집계하지 않으며 close
+숨기지 않는다. gauge는 final snapshot 값을 사용하고, final snapshot이 실패하면 cumulative
+counter는 close-entry 기반 `closingOffsets`를 유지하되 terminal DETACHED fallback gauge
+`queue=0`, `inFlight=0`, `scheduledRetries=0`, `admitted=0`, `diagnosticsClosed=true`,
+`closed=true`를 합성한 뒤 inner `finally`에서 provider를 clear하여 `DETACHED`로 전환한다.
+따라서 close-entry counter를 다시 더해 중복 집계하지 않으며 close
 중 발생한 cancellation/rejection도 final delta에 포함된다. close/final snapshot/transition
 예외는 close 예외가 있으면 suppressed로 붙이고, 없으면 primary로 던진다. 따라서 manager가
 영구 `CLOSING`에 남지 않으며, replacement는 `DETACHED` 이후에만 허용된다. `snapshot()`은

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -177,7 +177,8 @@ registry에서 제거한다. close 전에 reservation된 callback만 crossing al
 close 반환 뒤 새 callback invocation은 시작하지 않지만 이미 reservation된 callback은
 현재 호출을 마칠 수 있다. 17번째 registration은 no-op handle을 반환하고
 `observerRegistrationDrops`를 1 증가시킨다. diagnostics queue 포화는 별도의
-`observerDrops`에만 합산한다.
+`observerDrops`에만 합산하며, queue offer가 실패하면 해당 slot의 `inFlight`와 queue
+permit을 즉시 되돌린다.
 diagnostics worker에서 observer `Error`가 발생하면 diagnostics gate를 CLOSED로
 전환하고 queued callback을 drop한 뒤 `diagnosticsFatalErrors`를 증가시키고
 `diagnosticsClosed=true`로 표시한 다음 원래 `Error`를 uncaught boundary로 재전파한다.

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -1,0 +1,246 @@
+# Issue #535 OBS-03 audit export adapter 설계
+
+## 상태와 범위
+
+- Issue: #535
+- Epic: #699 관측성 진단 및 관리 표면 확장
+- Train: OBS-03
+- 선행: OBS-01/#533, OBS-02/#559 및 잔여 P2/#726
+- 후행: OBS-04/#532
+- 기준: `origin/develop` `99245f51456eb8fd79f7eeb6f4233577aa39f8ad`
+
+이 문서는 승인된 OBS-03 설계를 고정한다. v1은 `leader-core`의 framework-neutral
+export contract, sanitization/redaction, bounded asynchronous delivery와
+`leader-micrometer`의 failure/backpressure metrics, JDK `HttpClient` 기반
+HTTP/webhook transport를 포함한다.
+
+JSONL sink와 OpenTelemetry adapter는 후속 이슈로 분리한다. Spring Boot와 Ktor
+auto-configuration, durable outbox, transport별 운영 설정도 이번 train의 범위에
+넣지 않는다.
+
+## 현재 근거
+
+현재 구현과 baseline은 다음 계약을 제공한다.
+
+- `LeaderHistorySink`와 `SuspendLeaderHistorySink`는 acquired/completed/failed
+  history 저장과 retention 삭제를 정의한다.
+- `LeaderLockHistoryRecord`는 token을 보유하지만 `toString()`에서 token을 가리고,
+  `SafeLeaderHistoryRecorder` 계층은 error message와 metadata를 길이·문자 제한에
+  맞게 정제한다.
+- `LeaderElectionEventPublisher`는 `Elected`, `Revoked`, `Skipped`를 `Flow`로
+  노출하며 callback 예외를 선거 실행으로 전파하지 않는다.
+- `SafeLeaderHistoryRecorder`와 `SuspendSafeLeaderHistoryRecorder`는 일반 sink
+  예외를 best-effort로 격리하고 `CancellationException`과 `InterruptedException`은
+  전파한다.
+- `leader-micrometer`에는 history sink failure와 acquire-missing counter 및
+  `LeaderMetricTagRule` 기반 redaction/cardinality 규칙이 이미 있다.
+- 변경 전 `./gradlew :bluetape4k-leader-core:test
+  :bluetape4k-leader-micrometer:test`가 `BUILD SUCCESSFUL`이었다.
+
+따라서 새 exporter는 기존 history 저장 계약을 대체하지 않고 decorator/bridge로
+재사용해야 하며, core가 Micrometer나 Spring/Ktor에 의존해서는 안 된다.
+
+## 문제
+
+외부 audit sink로 lifecycle/history event를 전달하는 공통 adapter가 없다. 선거
+hot path에서 HTTP 호출을 직접 실행하면 네트워크 지연과 retry가 lock 획득·해제와
+결합된다. 반대로 단순히 예외를 삼키면 queue 포화, retry 소진, exporter 종료를
+관찰할 수 없다. token, raw lock name, leader identity, 예외 메시지를 외부로
+그대로 내보내는 것도 보안·cardinality 경계를 위반한다.
+
+## 목표
+
+1. token을 포함하지 않는 immutable `LeaderAuditExportEvent`와 exporter SPI를
+   `leader-core`에 추가한다.
+2. history sink와 election event publisher를 exporter에 연결하는 blocking/suspend
+   bridge를 제공한다.
+3. bounded queue, 즉시 admission 결과, bounded retry/backoff, close/cancel 계약을
+   core에서 정의한다.
+4. export 실패·retry 소진·queue 포화가 leader election 결과나 caller 예외를
+   변경하지 않도록 한다.
+5. JDK `java.net.http.HttpClient`의 `sendAsync`를 사용하는 HTTP/webhook delivery를
+   제공한다. payload encoding은 주입 가능한 함수로 두어 core에 JSON dependency를
+   추가하지 않는다.
+6. `leader-micrometer`에서 accepted, dropped, retry, delivery failure를 low-cardinality
+   metric으로 관찰한다.
+7. redaction, metadata/error size, retry/cancellation, backpressure와 lifecycle을
+   deterministic test로 고정한다.
+
+## 비목표
+
+- JSONL file sink
+- OpenTelemetry log/event exporter
+- exactly-once 또는 durable outbox/transactional delivery
+- 분산 순서 보장과 cross-process queue
+- Spring Boot/Ktor auto-configuration 및 운영 endpoint
+- 새 외부 serialization/HTTP dependency 추가
+- 기존 `LeaderHistorySink` 저장 semantics 변경
+
+## 설계 선택지
+
+### 선택 A — bounded asynchronous, transport-neutral exporter (채택)
+
+core가 bounded admission과 delivery lifecycle을 소유하고, history/event bridge는
+non-blocking `submit`만 호출한다. HTTP adapter는 one-shot delivery를 제공하고
+dispatcher가 retry/backoff와 close를 관리한다. 외부 dependency 없이 election hot
+path를 보호하며, JSONL/OpenTelemetry를 후속 transport로 추가할 수 있다.
+
+### 선택 B — 동기 adapter와 호출자별 retry
+
+구현은 작지만 sink 또는 HTTP latency가 election thread에 남는다. queue 포화와
+caller cancellation을 transport마다 다시 정의해야 하므로 채택하지 않는다.
+
+### 선택 C — HTTP 전용 별도 모듈
+
+transport 격리는 분명하지만 새 모듈·BOM·CI·dependency surface가 생긴다. 이번
+issue의 framework-neutral core contract와 작은 train 범위를 넘어가므로 채택하지
+않는다.
+
+## 제안 계약
+
+### 안전한 export event
+
+`LeaderAuditExportEvent`는 sealed interface로 두고 다음 두 변형을 제공한다.
+
+- `History`: `occurredAt`, `lockName`, `kind`, `status`, `nodeId`, `slotId`,
+  `durationMs`, `errorType`, `errorMessage`, bounded `attributes`
+- `Lifecycle`: `occurredAt`, `lockName`, `outcome(ELECTED|REVOKED|SKIPPED)`,
+  optional `leaderId`, `leaseExpiry`, bounded `attributes`
+
+event에는 backend token, `LeaderHistoryKey.token`, raw `LeaderLease` 객체를 넣지
+않는다. `lockName`, `nodeId`, `leaderId`, attribute key/value와 error message는
+event를 만들기 전에 core redaction policy를 적용한다. 기본 policy는 민감하거나
+무제한 cardinality가 될 수 있는 값을 `redacted`로 바꾸며, 명시적 opt-in에서만
+`HASH` 또는 길이 제한 `TRUNCATE`를 허용한다. `RAW`는 기본값이 아니며 allow-list와
+최대 길이 검증을 통과해야 한다.
+
+### Exporter와 admission
+
+public `LeaderAuditExporter`는 다음 경계를 갖는다.
+
+- `submit(event): LeaderAuditSubmitResult`는 queue에 넣는 순간만 동기적으로
+  수행한다.
+- 결과는 `ACCEPTED`, `DROPPED_QUEUE_FULL`, `DROPPED_CLOSED`로 구분한다.
+- `submit`은 delivery 오류를 throw하지 않는다. caller가 결과를 관찰할 수 있지만
+  leader election의 반환값·예외에는 영향을 주지 않는다.
+- `close()`는 신규 admission을 차단하고 queued/retry 작업을 취소한다. close는
+  네트워크 drain을 기다리지 않으며 idempotent다.
+
+dispatcher 옵션은 queue capacity, 최대 동시 delivery, 최대 attempt 수, initial
+   backoff, 최대 backoff, retryable status/exception 분류, clock/scheduler와
+   executor 주입점으로 구성한다. 기본값은 유한한 queue와 retry 횟수이며 무한
+   retry·무한 queue를 허용하지 않는다.
+
+### Delivery와 HTTP/webhook
+
+dispatcher는 transport-neutral one-shot delivery 함수와 분리한다. HTTP adapter는
+주입받은 `HttpClient`, target `URI`, headers, `LeaderAuditPayloadEncoder`를
+사용한다.
+
+- encoder는 이미 redacted event를 `ByteArray`로 변환하고 content type을 제공한다.
+- request는 `POST`로 만들며 2xx만 성공으로 처리한다.
+- 408, 429, 5xx와 I/O 실패만 bounded retry 대상이다. 다른 4xx는 즉시 terminal
+  failure다.
+- `sendAsync` completion은 dispatcher가 재시도·성공·실패로 분류한다.
+- response body는 제한된 크기까지만 읽고 log에는 endpoint credential이나 body를
+  남기지 않는다.
+- HTTP adapter는 core에 JSON library를 추가하지 않는다. JSON payload가 필요한
+  사용자는 encoder를 제공하며, JSONL/OpenTelemetry는 후속 adapter가 담당한다.
+
+### 기존 계약 연결
+
+- `ExportingLeaderHistorySink`는 기존 sink를 먼저 호출하고, 반환된 key/record로
+  sanitized `History` event를 submit한다. exporter 결과가 `DROPPED_*`여도 기존
+  sink 결과를 변경하지 않는다.
+- suspend variant는 같은 admission API를 사용하고 suspend sink 호출의
+  `CancellationException` 전파를 유지한다. export submission 자체는 blocking하지
+  않는다.
+- `LeaderElectionEventPublisher` bridge는 `events`를 구독해 `Lifecycle` event를
+  submit하고, 구독 close handle을 반환한다. callback 또는 exporter failure는
+  publisher contract 밖으로 전파하지 않는다.
+- exporter lifecycle은 caller가 소유한다. Spring/Ktor가 자동으로 bean·scope를
+  만들거나 닫는 동작은 후속 integration issue에서 정의한다.
+
+### Micrometer 관찰
+
+`MicrometerLeaderAuditExporter`는 core exporter를 decorator하고 다음 metric을
+제공한다.
+
+- accepted submissions
+- queue-full drops
+- closed drops
+- retry attempts
+- terminal delivery failures
+
+metric tag는 `source`, `outcome`, `transport`처럼 유한한 값만 사용한다. raw
+lock name, leader ID, endpoint, error message는 metric tag가 되지 않는다.
+기존 `HISTORY_SINK_FAILURES` semantics는 유지하며 새 exporter metric과 합산하지
+않는다.
+
+## 실패·취소·수명주기 계약
+
+1. queue가 가득 차면 `DROPPED_QUEUE_FULL`을 반환하고 election은 계속 진행한다.
+2. exporter가 닫힌 뒤 submit하면 `DROPPED_CLOSED`를 반환하고 worker/retry가 새
+   작업을 만들지 않는다.
+3. delivery가 retryable 실패를 반복하면 최대 attempt 후 terminal failure로
+   끝내며 caller에게 예외를 던지지 않는다.
+4. non-retryable 4xx는 즉시 terminal failure로 처리한다.
+5. coroutine scope가 취소되면 bridge subscription은 닫히지만, history recorder가
+   sink에서 받은 `CancellationException`을 삼키지 않는다.
+6. in-flight HTTP future와 scheduled retry는 close에서 취소하고, late completion은
+   counter를 두 번 올리거나 새 retry를 예약하지 않는다.
+7. exporter callback/encoder가 예외를 내도 기존 election result와 history sink
+   result는 보존한다.
+
+## 호환성과 migration
+
+- 기존 public interface와 backend sink 구현은 source/binary 호환을 유지한다.
+- exporter는 opt-in 객체이며 기존 recorder/listener 동작은 기본적으로 변하지
+  않는다.
+- 새 public type에는 Korean KDoc와 JVM ABI fixture를 추가한다.
+- serialization format은 v1에서 고정하지 않는다. payload encoder가 wire format을
+  소유하므로 JSONL/OpenTelemetry 후속 adapter가 현재 event contract를 재사용할 수
+  있다.
+- 새 module/dependency/BOM 등록은 발생하지 않는다. `leader-core`와
+  `leader-micrometer`만 변경한다.
+
+## Stacked PR 경계
+
+1. `AUD-01` — `feat/epic-obs-03-audit-export-core` / `develop` 기반
+   - safe event model, redaction, exporter SPI, bounded dispatcher, history/event
+     bridge와 core contract tests
+2. `AUD-02` — `feat/epic-obs-03-audit-export-micrometer` / AUD-01 기반
+   - Micrometer decorator, low-cardinality counters와 metrics tests
+3. `AUD-03` — `feat/epic-obs-03-audit-export` / AUD-02 기반
+   - JDK HTTP/webhook delivery, retry/backoff/cancellation tests와 KDoc/README 계약
+
+각 PR은 부모 head를 정확히 고정하고 독립적으로 compile/test 가능한 범위를
+가져야 한다. JSONL과 OpenTelemetry는 이 train에 포함하지 않으며 별도 issue로
+추적한다.
+
+## 수용 기준
+
+- [ ] core event가 token과 raw sensitive value를 export하지 않는다.
+- [ ] blocking/suspend history 및 lifecycle publisher가 같은 exporter admission
+      contract를 사용한다.
+- [ ] queue 포화·delivery 실패·retry 소진이 election outcome을 변경하지 않는다.
+- [ ] retryable/non-retryable HTTP 분류, 최대 attempt, backoff, close/cancel이
+      deterministic test로 검증된다.
+- [ ] Micrometer metric은 accepted/drop/retry/failure를 관찰하고 raw/high-cardinality
+      값을 tag로 만들지 않는다.
+- [ ] 새 dependency와 Spring/Ktor auto-config 없이 `leader-core` 및
+      `leader-micrometer` 테스트가 통과한다.
+- [ ] 기존 public ABI와 history sink semantics가 유지된다.
+- [ ] JSONL/OpenTelemetry가 v1 산출물과 문서에 포함되지 않는다.
+
+## DoD
+
+- 승인된 spec과 implementation plan이 각각 review gate를 통과한다.
+- AUD-01~03 stacked PR의 exact head/base, Korean metadata, `## DoD Status`가
+  일치한다.
+- 대상 Gradle test, `git diff --check`, ABI/contract fixture와 redaction/
+  cancellation/backpressure 검증이 fresh PASS다.
+- export failure가 election을 중단하지 않는 fake delivery 증거가 있다.
+- PR CI와 독립 7-tier review에서 P0/P1이 0이다.
+- merge는 현재 exact head에 대한 fresh approval 전에는 실행하지 않는다.
+

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -382,7 +382,9 @@ metric이 감소하지 않는다. close가 성공하거나 예외를 던지는 �
    `closingOffsets`에 적용하지 않고 close-entry base를 유지하며 공통
    `markSourceDegraded` 경로로 `sourceDegraded=true`와
    `leader.audit.export.meter-source-degraded` fixed warning을 해당 generation에서 한 번
-   기록한다. 양수 field만 부분 적용하는 것은 금지한다.
+   기록하고 snapshot throw와 동일한 terminal DETACHED fallback gauge
+   `queue=0`, `inFlight=0`, `scheduledRetries=0`, `admitted=0`, `diagnosticsClosed=true`,
+   `closed=true`를 사용한다. 양수 field만 부분 적용하는 것은 금지한다.
 3. provider 제거와 terminal `DETACHED` publication을 non-throwing inner `finally`에서
    먼저 완료한다. 이 cleanup은 사용자 callback을 호출하지 않으며, 이후에만 예외를
    집계한다. 따라서 transition/diagnostic 예외가 cleanup을 건너뛰게 할 수 없다.

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -141,9 +141,12 @@ public `LeaderAuditExporter`는 다음 경계를 갖는다.
   `min(queueCapacity, 1024)`로 파생하고 atomic permit으로 제한한다. `submit`은 queue에
   non-blocking offer만 수행하므로 observer callback과 diagnostics worker가 block되어도
   admission thread를 block하지 않는다. queue가 가득 차면 callback 없이 `observerDrops`만
-  증가한다. exporter `close()`는 diagnostics gate를 닫고 queued callback을 drop한 뒤
-  worker를 interrupt/unpark하고 diagnostics queue를 drain하여 더 이상의 callback admission
-  0을 확인한다. close는 이미 admission된 callback의 완료를 기다리지 않으므로
+  증가한다. queue poll, callback reservation, queue drop은 하나의 짧은
+  `diagnosticsAdmissionLock`에서 선형화하고, submit-side observation enqueue는 lock을
+  기다리지 않고 `tryLock` 실패 시 `observerDrops`를 증가시키고 drop한다. exporter `close()`는 같은 lock을 잡아
+  diagnostics gate를 닫고 queued callback을 drop한 뒤 worker를 interrupt/unpark하고
+  diagnostics queue를 drain하여 더 이상의 callback admission 0을 확인한다. close는 이미
+  admission된 callback의 완료를 기다리지 않으므로
   interrupt를 무시하는 observer 때문에 무기한 hang하지 않는다. 이미 admission된 callback은
   close 반환 뒤에도 현재 호출을 마칠 수 있지만 새 callback은 시작하지 않는다. observer가
   `Exception`을 던져도 admission, permit, election 결과에는 영향을 주지 않으며 observer
@@ -152,7 +155,9 @@ public `LeaderAuditExporter`는 다음 경계를 갖는다.
 - `snapshot()`은 queued, in-flight, scheduled-retry, total admitted 수와
   accepted/drop/retry/terminal failure, cancellation, executor/scheduler rejection,
   observer drop, registration drop, diagnostics fatal error와 diagnostics closed 상태도
-  누적/표시한 bounded diagnostics를 반환한다. 스냅숏 값은 lock 이름·endpoint·
+  누적/표시한 bounded diagnostics를 반환한다. `diagnosticsClosed`는 정상 `close()`와
+  observer `Error` 모두에서 diagnostics gate가 닫혔음을 뜻하고,
+  `diagnosticsFatalErrors`만 fatal 원인을 구분한다. 스냅숏 값은 lock 이름·endpoint·
   error message를 포함하지 않는다. point-in-time 값은 concurrent update 중 fuzzy할 수
   있고, quiescent 시 `queued + inFlight + scheduledRetries == admitted <= capacity`를
   만족해야 한다.
@@ -168,21 +173,35 @@ observer enum은 `ACCEPTED`,
 `TERMINAL_FAILURE`만 만들고 `CANCELLED`를 중복 생성하지 않는다. close-owned cancel은
 `CANCELLED`만 만들며 retry/failure를 만들지 않는다.
 
-observer registration은 최대 16개로 제한한다. 각 slot은 `active`와
-`inFlight`/invocation reservation을 하나의 lock 아래 관리한다. observation admission은
-slot lock을 잡고 `active=true`일 때만 queue permit과 `inFlight++`를 수행한다. worker는
-callback 직전 같은 slot lock에서 `active=true`를 확인하고 invocation을 reservation한 뒤
-lock을 놓고 호출한다. handle `close()`는 같은 lock에서 `active=false`를 선형화한 뒤
-registry에서 제거한다. close 전에 reservation된 callback만 crossing allowance로 남기므로
-close 반환 뒤 새 callback invocation은 시작하지 않지만 이미 reservation된 callback은
-현재 호출을 마칠 수 있다. 17번째 registration은 no-op handle을 반환하고
+observer registration은 최대 16개로 제한한다. `diagnosticsAdmissionLock`을 먼저 잡고
+각 slot의 `active`와 `inFlight`/invocation reservation을 slot lock에서 관리한다.
+observation admission은 gate가 열려 있고 slot `active=true`일 때만 queue permit과
+`inFlight++`를 수행한다. worker는 queue poll과 callback 직전 reservation을 같은 gate
+lock 아래 수행한다. handle `close()`도 gate lock을 먼저 잡아 slot `active=false`를
+선형화한 뒤 registry에서 제거한다. close 전에 reservation된 callback만 crossing
+allowance로 남기므로 close 반환 뒤 새 callback invocation은 시작하지 않지만 이미
+reservation된 callback은 현재 호출을 마칠 수 있다. 17번째 registration은 no-op handle을 반환하고
 `observerRegistrationDrops`를 1 증가시킨다. diagnostics queue 포화는 별도의
 `observerDrops`에만 합산하며, queue offer가 실패하면 해당 slot의 `inFlight`와 queue
-permit을 즉시 되돌린다.
+permit을 즉시 되돌린다. inactive slot item을 dequeue하거나 normal/fatal close에서
+queue를 drop할 때도 slot `inFlight`와 diagnostics permit을 같은 gate lock 아래
+정확히 한 번 반환한다.
 diagnostics worker에서 observer `Error`가 발생하면 diagnostics gate를 CLOSED로
 전환하고 queued callback을 drop한 뒤 `diagnosticsFatalErrors`를 증가시키고
 `diagnosticsClosed=true`로 표시한 다음 원래 `Error`를 uncaught boundary로 재전파한다.
-worker를 자동 재시작하지 않으며 이후 `observe()`는 no-op handle을 반환한다.
+normal `close()`도 diagnostics gate를 CLOSED로 전환해 `diagnosticsClosed=true`를
+표시하지만 fatal counter는 증가시키지 않는다. open 상태에서는 false이며 idempotent
+close 이후에도 true를 유지한다. worker를 자동 재시작하지 않으며 이후 `observe()`는
+no-op handle을 반환한다.
+
+diagnostics state truth table:
+
+| 상태 | `diagnosticsClosed` | `diagnosticsFatalErrors` |
+|---|---:|---:|
+| open | `false` | `0` 이상 누적값 |
+| 정상 close | `true` | close 전 값 유지 |
+| observer `Error` | `true` | 이전 값 + 1 |
+| idempotent close | 이전 값 유지 | 이전 값 유지 |
 
 취소 원인별 관찰 순서는 다음 표로 고정한다.
 
@@ -280,11 +299,13 @@ crash 또는 close는 drain하지 않은 work를 잃을 수 있다. receiver는 
 ### Micrometer 관찰
 
 `MicrometerLeaderAuditExporter`는 core exporter를 소유하는 decorator하고
-`(delegate, registry)` exact constructor로 다음 metric을 제공한다. decorator `close()`는
-observer handle을 유지한 채 delegate를 먼저 닫아 delegate close에서 발생한 `CANCELLED`
-관찰을 admission한 뒤, `finally`에서 observer handle을 해제한다. 따라서 wrapper와 direct
-delegate 모두 close 후 `DROPPED_CLOSED`가 되며 close observation도 metric에 반영된다.
-non-owning observation은 wrapper가 아니라 public `observe()` handle을 별도로 사용한다.
+`(delegate, registry)` exact constructor로 다음 metric을 제공한다. metric의 authoritative
+source는 `delegate.snapshot()`의 O(1) atomic counter이며 `FunctionCounter`/`Gauge`가
+registry polling 시 snapshot을 읽는다. 따라서 async diagnostics observer callback이 close
+직후 drop되어도 close-owned cancellation/rejection이 metric에서 사라지지 않는다.
+decorator `close()`는 delegate를 idempotently 닫아 wrapper와 direct delegate 모두 close 후
+`DROPPED_CLOSED`가 되게 한다. non-owning observation은 wrapper가 아니라 public
+`observe()` handle을 별도로 사용하며 decorator는 내부 observer handle을 소유하지 않는다.
 
 - accepted submissions
 - queue-full drops
@@ -292,7 +313,7 @@ non-owning observation은 wrapper가 아니라 public `observe()` handle을 별�
 - retry attempts
 - terminal delivery failures
 - queue depth, in-flight delivery, cancellation/rejection diagnostics
-- diagnostics queue saturation as `leader.audit.export.observer.dropped`; this cumulative
+- diagnostics admission saturation as `leader.audit.export.observer.dropped`; this cumulative
   counter mirrors `snapshot().observerDrops` and is not reset by `close()`.
 - observer registration cap rejections as `leader.audit.export.observer.registration.dropped`,
   mirroring `snapshot().observerRegistrationDrops`.

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -128,16 +128,20 @@ public `LeaderAuditExporter`는 다음 경계를 갖는다.
 - `submit`은 delivery 오류를 throw하지 않는다. caller가 결과를 관찰할 수 있지만
   leader election의 반환값·예외에는 영향을 주지 않는다.
 - `close()`는 신규 admission을 차단하고 queued/retry 작업을 취소한다. close는
-  네트워크 drain을 기다리지 않으며 idempotent다.
+  네트워크 drain은 기다리지 않지만 diagnostics worker와 이미 실행 중인 observer
+  callback의 종료를 join한 뒤 반환하며 idempotent다. callback이 interrupt를 무시해도
+  close 이후 새 callback admission은 허용하지 않는다.
 - `observe(observer)`는 accepted/drop/retry/terminal-failure/cancel/rejection의 유한한 lifecycle
-  outcome을 exporter가 소유하는 bounded diagnostics queue와 전용 diagnostics worker를
-  통해 caller thread 밖에서 best-effort로 전달한다. `submit`은 diagnostics queue에
+  outcome을 exporter가 소유하는 diagnostics queue와 이름이 고정된 daemon virtual-thread
+  worker를 통해 caller thread 밖에서 best-effort로 전달한다. queue capacity는
+  `min(queueCapacity, 1024)`로 파생하고 atomic permit으로 제한한다. `submit`은 queue에
   non-blocking offer만 수행하므로 observer callback과 diagnostics worker가 block되어도
-  admission thread를 block하지 않는다. diagnostics queue가 가득 차면 callback 없이
-  `observerDrops`만 증가한다. observer가 `Exception`을 던져도 admission, permit, election
-  결과에는 영향을 주지 않는다. observer `Error`는 callback task를 terminalize한 뒤
-  diagnostics worker의 uncaught boundary로 원래 인스턴스를 재전파한다. event 값·lock 이름·
-  endpoint·error message는 observer payload에 포함하지 않는다.
+  admission thread를 block하지 않는다. queue가 가득 차면 callback 없이 `observerDrops`만
+  증가한다. exporter `close()`는 diagnostics gate를 닫고 queued callback을 drop한 뒤
+  worker를 interrupt/unpark하고 join하여 종료와 late callback 0을 확인한다. observer가
+  `Exception`을 던져도 admission, permit, election 결과에는 영향을 주지 않으며 observer
+  `Error`는 callback state를 terminalize한 뒤 worker uncaught boundary로 재전파한다.
+  event 값·lock 이름·endpoint·error message는 observer payload에 포함하지 않는다.
 - `snapshot()`은 queued, in-flight, scheduled-retry, total admitted 수와
   accepted/drop/retry/terminal failure, cancellation, executor/scheduler rejection,
   observer drop을 누적한 bounded diagnostics를 반환한다. 스냅숏 값은 lock 이름·endpoint·
@@ -155,6 +159,14 @@ observer enum은 `ACCEPTED`,
 없다. timeout이 소유한 future cancel은 `RETRY` 또는 마지막 attempt의
 `TERMINAL_FAILURE`만 만들고 `CANCELLED`를 중복 생성하지 않는다. close-owned cancel은
 `CANCELLED`만 만들며 retry/failure를 만들지 않는다.
+
+observer registration은 최대 16개로 제한한다. `observe()`가 반환하는 handle의
+`close()`는 registry에서 observer를 선형적으로 제거하고 반환 이후 해당 observer에
+대한 callback 시작을 허용하지 않는다. 이미 실행 중인 callback은 현재 호출만 마친다.
+17번째 registration은 no-op handle을 반환하고 `observerDrops`를 1 증가시킨다.
+diagnostics worker에서 observer `Error`가 발생하면 diagnostics gate를 CLOSED로
+전환하고 queued callback을 drop한 뒤 원래 `Error`를 uncaught boundary로 재전파하며,
+worker를 자동 재시작하지 않는다. 이후 `observe()`는 no-op handle을 반환한다.
 
 취소 원인별 관찰 순서는 다음 표로 고정한다.
 
@@ -184,8 +196,10 @@ shutdown하지 않는다. worker/retry schedule rejection은 accepted item을 �
 ### Delivery와 HTTP/webhook
 
 dispatcher는 transport-neutral one-shot delivery 함수와 분리한다. HTTP adapter는
-주입받은 `HttpClient`, target `URI`, headers, `LeaderAuditPayloadEncoder`를
-사용한다.
+주입받은 `HttpClient`, `LeaderAuditTrustedHttpsEndpoint`, headers,
+`LeaderAuditPayloadEncoder`를 사용한다. `LeaderAuditTrustedHttpsEndpoint.trusted(URI)`
+는 HTTPS·URI syntax만 검사하는 명시적 caller trust wrapper이며, private-network와
+DNS/SSRF 정책의 ownership을 caller에게 남긴다.
 
 - encoder는 이미 redacted event를 `ByteArray`로 변환하고 content type을 제공한다.
   payload에는 양의 유한 `maxPayloadBytes` 상한을 적용하며 초과 payload는 request를
@@ -202,13 +216,14 @@ dispatcher는 transport-neutral one-shot delivery 함수와 분리한다. HTTP a
   body 보존 상한은 0 byte다. 따라서 oversized/chunked body를 메모리에 축적하지 않는다.
   이는 메모리 retention bound일 뿐 네트워크 ingress truncation 계약은 아니다. log에는
   endpoint credential이나 body를 남기지 않는다.
-- target URI는 production에서 HTTPS만 허용하고, user-info/query/fragment와 control
-  character를 거부한다. loopback·link-local·RFC1918 private address는 거부하며,
-  HTTP loopback은 public option이 아니라 `internal` test-only allow-list에서만 허용한다.
-  resolver가 반환한 모든 주소에 대해 loopback/link-local/site-local/any-local을
-  검사하며, 따라서 public API에는 임의 scheme allow-list나 insecure-loopback flag가
-  없다. resolver는 `internal` test seam으로 주입해 이 검사를 DNS/network 없이
-  deterministic하게 검증한다.
+- production target은 `LeaderAuditTrustedHttpsEndpoint.trusted(uri)`로 명시적으로
+  감싼 HTTPS-only endpoint만 받고 user-info/query/fragment와 control character를
+  거부한다. 이 타입은 caller가 endpoint allow-list와 DNS/SSRF trust를 확인했다는
+  explicit ownership boundary이며 library는 hostname을 IP에 pin하거나 DNS rebinding을
+  막는다고 주장하지 않는다. private/link-local/ULA/CGNAT와 DNS rebinding은 v1 비목표이고
+  운영 문서는 static trusted endpoint 또는 별도 egress proxy를 사용하도록 한다. HTTP
+  loopback은 public option이 아니라 `internal` test-only allow-list에서만 허용하며,
+  public API에는 임의 scheme allow-list나 insecure-loopback flag가 없다.
   injected `HttpClient`는 `Redirect.NEVER`여야 하며, header map은 immutable
   allow-list로 복사하고 CR/LF·`Host`·`Content-Length`·`Connection` 등 forbidden header를
   거부한다. Authorization 같은 credential header는 전송할 수 있지만 로그·metric·event에는
@@ -245,9 +260,11 @@ crash 또는 close는 drain하지 않은 work를 잃을 수 있다. receiver는 
 
 ### Micrometer 관찰
 
-`MicrometerLeaderAuditExporter`는 core exporter를 decorator하고
-`(delegate, registry, ownsDelegate:Boolean)` exact constructor로 다음 metric을
-제공한다.
+`MicrometerLeaderAuditExporter`는 core exporter를 소유하는 decorator하고
+`(delegate, registry)` exact constructor로 다음 metric을 제공한다. decorator `close()`는
+observer handle을 해제한 뒤 delegate를 닫아 wrapper와 direct delegate 모두 close 후
+`DROPPED_CLOSED`가 되게 한다. non-owning observation은 wrapper가 아니라 public
+`observe()` handle을 별도로 사용한다.
 
 - accepted submissions
 - queue-full drops
@@ -255,6 +272,8 @@ crash 또는 close는 drain하지 않은 work를 잃을 수 있다. receiver는 
 - retry attempts
 - terminal delivery failures
 - queue depth, in-flight delivery, cancellation/rejection diagnostics
+- diagnostics queue saturation as `leader.audit.export.observer.dropped`; this cumulative
+  counter mirrors `snapshot().observerDrops` and is not reset by `close()`.
 
 metric tag는 `source`, `outcome`, `transport`처럼 유한한 값만 사용한다. raw
 lock name, leader ID, endpoint, error message는 metric tag가 되지 않는다.

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -322,15 +322,18 @@ crash 또는 close는 drain하지 않은 work를 잃을 수 있다. receiver는 
 ### Micrometer 관찰
 
 `MicrometerLeaderAuditExporter`는 core exporter를 소유하는 decorator하고
-`(delegate, registry)` exact constructor로 다음 metric을 제공한다. metric의 authoritative
-source는 manager가 보유한 active provider의 `delegate.snapshot()` O(1) atomic counter와
-detached offset이며 `FunctionCounter`/`Gauge`가 registry polling 시 manager state를 읽는다.
-따라서 async diagnostics observer callback이 close 직후 drop되어도 close-owned
-cancellation/rejection이 metric에서 사라지지 않는다.
+`(delegate, registry)` exact constructor로 다음 metric을 제공한다. 정상적인 final snapshot
+경로에서 metric의 authoritative source는 manager가 보유한 active provider의
+`delegate.snapshot()` O(1) atomic counter와 detached offset이며 `FunctionCounter`/`Gauge`가
+registry polling 시 manager state를 읽는다. 따라서 async diagnostics observer callback이
+close 직후 drop되어도 정상 경로의 close-owned cancellation/rejection이 metric에서 사라지지
+않는다. 단, final snapshot 자체가 실패하는 비정상 delegate는 `sourceDegraded` 예외 경로로
+분류한다. 이 경로는 close-entry counter만 보존하고 close-entry 이후 cancellation/rejection
+정확성을 보장하지 않으며, terminal gauge fallback과 고정 warning으로 저하 상태를 드러낸다.
 decorator는 registry identity별 내부 manager가 고정된 `Meter.Id` 집합을 한 번만 등록하고
 stable meter를 소유한다. manager는 자체 lock/claim token과 immutable manager state를
 사용한다. state는 `activeProvider`, `closingProvider`, detached snapshot, cumulative offset, lifecycle와
-`compromised` flag를 함께 보유하며, `FunctionCounter`/`Gauge` callback도 같은 lock으로
+`compromised`, `sourceDegraded` flag를 함께 보유하며, `FunctionCounter`/`Gauge` callback도 같은 lock으로
 state와 provider snapshot을 한 번에 읽는다. `CLOSING` state는 cumulative field에
 `closingOffsets = oldOffsets + closeEntrySnapshot`을 반영하고 gauge에는 close-entry 값을
 사용하는 detached view만 metric callback에 노출하며,
@@ -370,20 +373,34 @@ manager-owned stable meter와 claim state로 남겨 다음 acquire가 누락 ID�
 provider를 `CLOSING`으로 바꾸고 `closingProvider`와 close-entry snapshot을 보존한 뒤
 `closingOffsets = oldOffsets + closeEntrySnapshot`을 먼저 게시하고 delegate close를
 실행한다. 따라서 close-entry가 이전 generation offset에 편입되어 CLOSING poll에서도
-metric이 감소하지 않는다. close가 성공하거나 예외를 던지는 모든 경로의 `finally`에서
-lock을 재획득해 같은 generation의 `closingProvider` final snapshot을 읽고 각 cumulative
-counter에 대해 `final >= close-entry` invariant를 검증한 뒤 `final - close-entry` delta만
-정확히 한 번 `closingOffsets`에 반영한다. 음수 delta는 `check`/진단 실패로 드러내며 0으로
-숨기지 않는다. gauge는 final snapshot 값을 사용하고, final snapshot이 실패하면 cumulative
-counter는 close-entry 기반 `closingOffsets`를 유지하되 terminal DETACHED fallback gauge
-`queue=0`, `inFlight=0`, `scheduledRetries=0`, `admitted=0`, `diagnosticsClosed=true`,
-`closed=true`를 합성한 뒤 inner `finally`에서 provider를 clear하여 `DETACHED`로 전환한다.
-따라서 close-entry counter를 다시 더해 중복 집계하지 않으며 close
-중 발생한 cancellation/rejection도 final delta에 포함된다. close/final snapshot/transition
-예외는 close 예외가 있으면 suppressed로 붙이고, 없으면 primary로 던진다. 따라서 manager가
-영구 `CLOSING`에 남지 않으며, replacement는 `DETACHED` 이후에만 허용된다. `snapshot()`은
-delegate close 후에도 final counters를 읽을 수 있는 O(1) 계약을 유지한다. `registry.remove`를
-호출하지 않으므로 lookup/remove 사이 foreign replacement race와 removal residue가 없다.
+metric이 감소하지 않는다. close가 성공하거나 예외를 던지는 모든 경로에서 finalization은
+다음 순서를 따른다.
+
+1. 같은 generation의 final snapshot을 읽고 모든 cumulative field의 delta를 immutable
+   temporary value로 계산한다.
+2. 모든 field가 `final >= close-entry`인지 먼저 검증한다. 하나라도 음수면 어떤 field도
+   `closingOffsets`에 적용하지 않고 close-entry base를 유지하며 `sourceDegraded=true`와
+   진단을 기록한다. 양수 field만 부분 적용하는 것은 금지한다.
+3. provider 제거와 terminal `DETACHED` publication을 non-throwing inner `finally`에서
+   먼저 완료한다. 이 cleanup은 사용자 callback을 호출하지 않으며, 이후에만 예외를
+   집계한다. 따라서 transition/diagnostic 예외가 cleanup을 건너뛰게 할 수 없다.
+
+정상 final snapshot에서만 검증된 `final - close-entry` delta를 정확히 한 번 반영한다. 이
+경로에서는 close 중 발생한 cancellation/rejection이 final delta에 포함된다. 반대로 final
+snapshot 자체가 실패하면 cumulative counter는 close-entry 기반 `closingOffsets`만 보존하고
+`sourceDegraded=true`를 설정한다. 이 비정상 경로에서는 close-entry 이후 cancellation/rejection
+정확성을 보장하지 않으며 `leader.audit.export.meter-source-degraded` fixed warning을 한 번
+기록한다. terminal DETACHED fallback gauge는 `queue=0`, `inFlight=0`,
+`scheduledRetries=0`, `admitted=0`, `diagnosticsClosed=true`, `closed=true`로 합성한다.
+`snapshot()`은 마지막으로 신뢰한 close-entry counters를 O(1)로 읽으며, degraded 상태는
+fixed warning과 close 예외로 관찰한다. close-entry counter를 다시 더해 중복 집계하지 않는다.
+
+예외 aggregation 순서는 `delegate.close` → final snapshot/invariant → transition/diagnostic
+발생 순서다. 첫 예외를 primary로 유지하고 이후 예외를 발생 순서대로 suppressed로 붙인다.
+cleanup과 `DETACHED` publication은 이 aggregation보다 먼저 끝나므로 close가 예외를 던져도
+manager가 영구 `CLOSING`에 남지 않으며 replacement는 `DETACHED` 이후에만 허용된다.
+`registry.remove`를 호출하지 않으므로 lookup/remove 사이 foreign replacement race와 removal
+residue가 없다.
 stable meter는 registry에 남지만 closed delegate를 strong-reference하지 않고 마지막
 snapshot/closed 상태를 읽는다. 같은 registry의 새 wrapper는 stable meter identity를
 재사용하면서 새 provider를 연결한다. outcome counter는 manager offset을 누적해

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -322,9 +322,13 @@ delegate ownership을 확정하며, constructor 실패 시에는 delegate를 정
 `close()`는 delegate를 idempotently 닫은 뒤 `finally`에서 소유 meter마다 현재 registry
 lookup이 저장된 meter와 identity-equal인 경우에만 `registry.remove(id)`를 시도한다.
 lookup이 foreign/replaced meter이거나 removal이 실패해도 그 ID를 제거했다고 가장하지
-않으며, 나머지 ID 제거를 계속하고 fixed-ID residue를 internal lifecycle warning/counter로
-보고한다. 따라서 closed delegate의 strong-reference 제거는 성공적으로 제거된 meter에
-대해서만 보장된다. wrapper와 direct delegate 모두 close 후 `DROPPED_CLOSED`가 된다.
+않으며, 나머지 ID 제거를 계속한다. residue는 registry identity state가 exact meter claim을
+유지한 채 `leader.audit.export.meter-removal-failure` fixed warning key와 O(1)
+`residueCount`로 보고한다. 같은 `close()` 호출에서는 ID별 warning을 한 번만 내고
+idempotent close는 반복하지 않는다. 다음 wrapper constructor는 residue removal을 먼저
+재시도하며, 성공한 ID만 claim을 해제한다. 따라서 closed delegate의 strong-reference 제거는
+성공적으로 제거된 meter에 대해서만 보장되고, 복구 전에는 replacement가 stale source를
+재사용하지 못한다. wrapper와 direct delegate 모두 close 후 `DROPPED_CLOSED`가 된다.
 non-owning observation은 wrapper가 아니라 public `observe()` handle을 별도로 사용하며
 decorator는 내부 observer handle을 소유하지 않는다. snapshot counter 값은 reset하지
 않지만 close 후 성공적으로 제거된 meter는 registry에 존재하지 않는다. 같은 registry에
@@ -345,8 +349,12 @@ decorator는 내부 observer handle을 소유하지 않는다. snapshot counter 
   as `leader.audit.export.diagnostics.closed` (`0|1` gauge), mirroring the corresponding
   snapshot fields.
 
-metric tag는 `source`, `outcome`, `transport`처럼 유한한 값만 사용한다. raw
-lock name, leader ID, endpoint, error message는 metric tag가 되지 않는다.
+v1 aggregate metric은 snapshot에 차원별 값이 없고 decorator constructor에도 source/
+transport context가 없으므로 `outcome={accepted,queue_full,closed,retry,failure,cancelled,
+rejected}`만 유한 tag로 사용한다. `source`와 `transport` tag는 v1에서 생략하며, mixed
+source/transport를 허위로 복제·라벨링하지 않는다. per-dimension metric은 후속 이슈에서
+명시적 context 또는 bounded snapshot을 추가할 때만 도입한다. raw lock name, leader ID,
+endpoint, error message는 metric tag가 되지 않는다.
 기존 `HISTORY_SINK_FAILURES` semantics는 유지하며 새 exporter metric과 합산하지
 않는다.
 

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -308,16 +308,27 @@ crash 또는 close는 drain하지 않은 work를 잃을 수 있다. receiver는 
 source는 `delegate.snapshot()`의 O(1) atomic counter이며 `FunctionCounter`/`Gauge`가
 registry polling 시 snapshot을 읽는다. 따라서 async diagnostics observer callback이 close
 직후 drop되어도 close-owned cancellation/rejection이 metric에서 사라지지 않는다.
-decorator는 등록한 모든 `Meter.Id`를 소유한다. constructor는 registry lock 아래 고정된
-name/tag ID를 선점하고 이미 같은 ID가 있으면 부분 등록을 정리한 뒤 fail-fast하여 duplicate
-wrapper가 기존 delegate source를 재사용하지 못하게 한다. `close()`는 delegate를
-idempotently 닫은 뒤 `finally`에서 소유 meter를 `registry.remove(id)`로 제거한다. 따라서
-wrapper와 direct delegate 모두 close 후 `DROPPED_CLOSED`가 되고 registry가 closed
-delegate를 strong-reference하지 않는다. non-owning observation은 wrapper가 아니라
-public `observe()` handle을 별도로 사용하며 decorator는 내부 observer handle을 소유하지
-않는다. snapshot counter 값은 reset하지 않지만 close 후에는 해당 meter가 registry에
-존재하지 않는다. 같은 registry에 새 delegate wrapper를 만들면 새 snapshot source로
-새 meter가 등록된다.
+decorator는 registry identity별 내부 ownership manager가 claim하고 설치 identity를 검증한
+`Meter`만 소유한다. manager는 자체 lock과 claim token으로 wrapper 간 중복을 막고, 외부
+registry monitor에 의존하지 않는다. 고정 name/tag ID가 preflight에서 이미 존재하거나,
+등록 후 registrar가 반환한 meter·registry lookup·등록 callback의 identity가 일치하지
+않거나 foreign/ambiguous registration crossing이 관찰되면 constructor는 fail-fast한다.
+이 경우 foreign meter를 제거하지 않으며, 부분 등록 중 exact-owned meter만 정리한다.
+표준 Micrometer API가 설치 identity를 증명하지 못하는 registry는 지원하지 않는 것으로
+간주하고 ownership을 추정하지 않는다. 성공한 전체 등록이 끝난 뒤에만 wrapper가
+delegate ownership을 확정하며, constructor 실패 시에는 delegate를 정확히 한 번 닫고
+원래 실패를 보존한다.
+
+`close()`는 delegate를 idempotently 닫은 뒤 `finally`에서 소유 meter마다 현재 registry
+lookup이 저장된 meter와 identity-equal인 경우에만 `registry.remove(id)`를 시도한다.
+lookup이 foreign/replaced meter이거나 removal이 실패해도 그 ID를 제거했다고 가장하지
+않으며, 나머지 ID 제거를 계속하고 fixed-ID residue를 internal lifecycle warning/counter로
+보고한다. 따라서 closed delegate의 strong-reference 제거는 성공적으로 제거된 meter에
+대해서만 보장된다. wrapper와 direct delegate 모두 close 후 `DROPPED_CLOSED`가 된다.
+non-owning observation은 wrapper가 아니라 public `observe()` handle을 별도로 사용하며
+decorator는 내부 observer handle을 소유하지 않는다. snapshot counter 값은 reset하지
+않지만 close 후 성공적으로 제거된 meter는 registry에 존재하지 않는다. 같은 registry에
+새 delegate wrapper를 만들면 manager claim이 해제된 ID에 새 snapshot source를 등록한다.
 
 - accepted submissions
 - queue-full drops

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -142,13 +142,18 @@ public `LeaderAuditExporter`는 다음 경계를 갖는다.
   non-blocking offer만 수행하므로 observer callback과 diagnostics worker가 block되어도
   admission thread를 block하지 않는다. queue가 가득 차면 callback 없이 `observerDrops`만
   증가한다. queue poll, callback reservation, queue drop은 하나의 짧은
-  `diagnosticsAdmissionLock`에서 선형화하고, submit-side observation enqueue는 lock을
-  기다리지 않고 `tryLock` 실패 시 `observerDrops`를 증가시키고 drop한다. exporter `close()`는 같은 lock을 잡아
+  `diagnosticsAdmissionLock`에서 선형화하고, submit-side observation enqueue는 blocking
+  `lock()`/monitor/queue wait를 사용하지 않으며 bounded non-blocking `tryLock` 실패 시
+  `observerDrops`를 증가시키고 drop한다. exporter `close()`는 같은 lock을 잡아
   diagnostics gate를 닫고 queued callback을 drop한 뒤 worker를 interrupt/unpark하고
   diagnostics queue를 drain하여 더 이상의 callback admission 0을 확인한다. close는 이미
   admission된 callback의 완료를 기다리지 않으므로
   interrupt를 무시하는 observer 때문에 무기한 hang하지 않는다. 이미 admission된 callback은
-  close 반환 뒤에도 현재 호출을 마칠 수 있지만 새 callback은 시작하지 않는다. observer가
+  close 반환 뒤에도 현재 호출을 마칠 수 있지만 새 callback은 시작하지 않는다. callback
+  완료 `finally`도 `diagnosticsAdmissionLock → slot lock` 순서 또는 동등한 원자 경로에서
+  `running--`, slot `inFlight--`, diagnostics permit 반환을 exact-once 수행한다. 따라서
+  callback 완료와 동시 observation admission이 교차해도 capacity leak이나 double-release가
+  없다. observer가
   `Exception`을 던져도 admission, permit, election 결과에는 영향을 주지 않으며 observer
   `Error`는 callback state를 terminalize한 뒤 worker uncaught boundary로 재전파한다.
   event 값·lock 이름·endpoint·error message는 observer payload에 포함하지 않는다.
@@ -303,9 +308,16 @@ crash 또는 close는 drain하지 않은 work를 잃을 수 있다. receiver는 
 source는 `delegate.snapshot()`의 O(1) atomic counter이며 `FunctionCounter`/`Gauge`가
 registry polling 시 snapshot을 읽는다. 따라서 async diagnostics observer callback이 close
 직후 drop되어도 close-owned cancellation/rejection이 metric에서 사라지지 않는다.
-decorator `close()`는 delegate를 idempotently 닫아 wrapper와 direct delegate 모두 close 후
-`DROPPED_CLOSED`가 되게 한다. non-owning observation은 wrapper가 아니라 public
-`observe()` handle을 별도로 사용하며 decorator는 내부 observer handle을 소유하지 않는다.
+decorator는 등록한 모든 `Meter.Id`를 소유한다. constructor는 registry lock 아래 고정된
+name/tag ID를 선점하고 이미 같은 ID가 있으면 부분 등록을 정리한 뒤 fail-fast하여 duplicate
+wrapper가 기존 delegate source를 재사용하지 못하게 한다. `close()`는 delegate를
+idempotently 닫은 뒤 `finally`에서 소유 meter를 `registry.remove(id)`로 제거한다. 따라서
+wrapper와 direct delegate 모두 close 후 `DROPPED_CLOSED`가 되고 registry가 closed
+delegate를 strong-reference하지 않는다. non-owning observation은 wrapper가 아니라
+public `observe()` handle을 별도로 사용하며 decorator는 내부 observer handle을 소유하지
+않는다. snapshot counter 값은 reset하지 않지만 close 후에는 해당 meter가 registry에
+존재하지 않는다. 같은 registry에 새 delegate wrapper를 만들면 새 snapshot source로
+새 meter가 등록된다.
 
 - accepted submissions
 - queue-full drops
@@ -314,9 +326,10 @@ decorator `close()`는 delegate를 idempotently 닫아 wrapper와 direct delegat
 - terminal delivery failures
 - queue depth, in-flight delivery, cancellation/rejection diagnostics
 - diagnostics admission saturation as `leader.audit.export.observer.dropped`; this cumulative
-  counter mirrors `snapshot().observerDrops` and is not reset by `close()`.
+  counter mirrors `snapshot().observerDrops` while the wrapper is open and is unregistered
+  with the other meters on `close()`.
 - observer registration cap rejections as `leader.audit.export.observer.registration.dropped`,
-  mirroring `snapshot().observerRegistrationDrops`.
+  mirroring `snapshot().observerRegistrationDrops` while open.
 - diagnostics fatal errors as `leader.audit.export.diagnostics.failures` and the CLOSED state
   as `leader.audit.export.diagnostics.closed` (`0|1` gauge), mirroring the corresponding
   snapshot fields.

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -125,7 +125,9 @@ v1 bound 상수는 `MAX_ERROR_MESSAGE_BYTES=4096`, `MAX_ERROR_TYPE_BYTES=128`,
 `errorType`과 `errorMessage`는 각각 전용 bound를 사용한다. `LeaderAuditField` enum은
 `LOCK_NAME`, `KIND`, `NODE_ID`, `SLOT_ID`, `LEADER_ID`, `ERROR_TYPE`, `ERROR_MESSAGE`,
 `ATTRIBUTE_KEY`, `ATTRIBUTE_VALUE`만 제공한다. `RAW_ALLOWED_FIELDS`는 `KIND` 하나로
-고정하며 `Raw` 생성자는 이 집합 밖의 allow-list를 모두 거부한다.
+고정하며 `Raw` 생성자는 빈 allow-list, 이 집합 밖의 allow-list, `maxBytes <= 0`을 모두
+`IllegalArgumentException`으로 거부한다. 생성 시 allow-list를 방어적으로 복사하므로
+생성 뒤 원본 컬렉션 변경도 정책을 바꾸지 않는다.
 모든 byte bound는 UTF-8 기준이며 over-limit 문자열은 code point를 자르지 않는 최대
 prefix로 truncate하고 ellipsis를 추가하지 않는다. attribute는 sanitized key의 UTF-8
 byte와 원본 key의 UTF-8 byte를 순서대로 정렬한 뒤 key/value 개별 bound와 aggregate
@@ -327,19 +329,24 @@ detached offset이며 `FunctionCounter`/`Gauge`가 registry polling 시 manager 
 cancellation/rejection이 metric에서 사라지지 않는다.
 decorator는 registry identity별 내부 manager가 고정된 `Meter.Id` 집합을 한 번만 등록하고
 stable meter를 소유한다. manager는 자체 lock/claim token과 immutable manager state를
-사용한다. state는 `activeProvider`, detached snapshot, cumulative offset, lifecycle와
+사용한다. state는 `activeProvider`, `closingProvider`, detached snapshot, cumulative offset, lifecycle와
 `compromised` flag를 함께 보유하며, `FunctionCounter`/`Gauge` callback도 같은 lock으로
-state와 provider snapshot을 한 번에 읽는다. close와 acquire는 offset 반영·provider 전환을
-하나의 선형화 지점에서 수행하므로 poll이 `offset + 이전 provider`를 섞어 읽지 않는다.
+state와 provider snapshot을 한 번에 읽는다. `CLOSING` state는 metric callback에는 detached
+snapshot만 노출하고 final snapshot을 읽기 위한 `closingProvider`만 임시로 보유한다. close와
+acquire는 offset 반영·provider 전환을 하나의 선형화 지점에서 수행하므로 poll이
+`offset + 이전 provider`를 섞어 읽지 않는다.
 첫 acquire에서 foreign ID가 이미 존재하거나 등록 identity를 증명할 수 없으면 constructor는
 fail-fast한다. 외부 registration crossing으로 manager-owned identity가 바뀌거나 ambiguous가
 되면 `leader.audit.export.meter-ownership-conflict` fixed warning을 한 번 기록하고 state를
 compromised로 잠근다. manager는 foreign meter를 절대로 제거하지 않으며, compromised
-registry는 수동으로 fixed ID를 정리하거나 registry를 교체하기 전까지 새 wrapper를
-허용하지 않는다.
+registry identity에서 영구적으로 새 wrapper를 거부한다. 고장 난 registry에서 수동으로
+fixed ID를 제거해도 manager를 재무장하지 않으며, 유일한 복구 경로는 새 `MeterRegistry`
+identity로 wrapper를 생성하는 것이다. 이 경계는 operator 문서와 recovery test에 고정한다.
 
 manager 저장소는 registry를 강하게 보유하지 않는 weak identity key와 `ReferenceQueue`를
-사용한다. 매 acquire/retirement 때 queue를 drain해 stale manager를 결정적으로 제거하고,
+사용한다. store 전용 단일 lock이 queue drain, identity lookup, manager create/publication을
+한 임계구역에서 선형화하므로 동일 registry에는 manager가 정확히 하나만 게시된다. 매
+acquire/retirement 때 queue를 drain해 stale manager를 결정적으로 제거하고,
 manager와 weak meter identity token은 registry를 역참조하지 않는다. 따라서 Spring/test
 context가 폐기되면 registry identity와 manager가 함께 회수될 수 있으며, stable meter가
 registry에 남는 동안에는 manager state만 callback source로 유지한다. 외부 registry mutation은
@@ -358,8 +365,18 @@ delegate close/partial-registration cleanup 예외는 primary의 suppressed exce
 붙인다. primary 실패가 없을 때만 cleanup 예외를 primary로 던진다. 부분 등록은
 manager-owned stable meter와 claim state로 남겨 다음 acquire가 누락 ID만 이어서 등록할
 수 있으며 foreign ID는 건드리지 않는다. `close()`는 generation token으로 한 번만 현재
-provider를 `CLOSING`에서 detach하고 delegate를 idempotently 닫은 뒤 `DETACHED` claim을
-해제한다. 마지막 snapshot은 manager offset에 반영된다. `registry.remove`를
+provider를 `CLOSING`으로 바꾸고 `closingProvider`와 close-entry snapshot을 보존한 뒤
+delegate close를 실행한다. close가 성공하거나 예외를 던지는 모든 경로의 `finally`에서
+lock을 재획득해 같은 generation의 `closingProvider` final snapshot을 읽고
+`final - close-entry` delta만 정확히 한 번 cumulative offset에 반영한 뒤 provider를
+clear하여 `DETACHED` claim을 해제한다. 각 cumulative counter delta는
+`max(0, final - close-entry)`로 계산하고 gauge는 final snapshot 값을 사용한다. 따라서
+close-entry counter를 다시 더해 중복 집계하지 않으며 close 중 발생한
+cancellation/rejection도 final delta에 포함된다.
+final snapshot/transition 예외는 close 예외가 있으면 suppressed로 붙이고, 없으면
+primary로 던진다. 따라서 manager가 영구 `CLOSING`에 남지 않으며, replacement는
+`DETACHED` 이후에만 허용된다. `snapshot()`은 delegate close 후에도 final counters를 읽을
+수 있는 O(1) 계약을 유지한다. `registry.remove`를
 호출하지 않으므로 lookup/remove 사이 foreign replacement race와 removal residue가 없다.
 stable meter는 registry에 남지만 closed delegate를 strong-reference하지 않고 마지막
 snapshot/closed 상태를 읽는다. 같은 registry의 새 wrapper는 stable meter identity를

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -365,7 +365,7 @@ stable meter는 registry에 남지만 closed delegate를 strong-reference하지 
 snapshot/closed 상태를 읽는다. 같은 registry의 새 wrapper는 stable meter identity를
 재사용하면서 새 provider를 연결한다. outcome counter는 manager offset을 누적해
 replacement에서도 감소하지 않으며 queue/in-flight/closed gauge는 현재 provider 또는
-detached closed state를 반영한다. wrapper와 direct delegate 모두 close 후
+detached closed state를 반영한다. wrapper와 owned delegate admission 모두 close 후
 `DROPPED_CLOSED`가 된다.
 non-owning observation은 wrapper가 아니라 public `observe()` handle을 별도로 사용하며
 decorator는 내부 observer handle을 소유하지 않는다. stable meter는 close 후에도 manager의

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/ExportingLeaderHistorySink.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/ExportingLeaderHistorySink.kt
@@ -1,0 +1,147 @@
+@file:Suppress("TooGenericExceptionCaught")
+
+package io.bluetape4k.leader.audit
+
+import io.bluetape4k.leader.history.LeaderHistoryKey
+import io.bluetape4k.leader.history.LeaderHistorySink
+import io.bluetape4k.leader.history.LeaderHistoryStatus
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
+import io.bluetape4k.leader.audit.internal.LeaderAuditPendingContextStore
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import kotlinx.coroutines.CancellationException
+import java.time.Instant
+
+/**
+ * 기존 blocking history sink 결과를 유지하면서 sanitized audit event를 exporter에 전달합니다.
+ *
+ * delegate 호출이 먼저 실행되고 exporter의 `ACCEPTED` 또는 `DROPPED_*` 결과는 history
+ * 저장 결과로 변환되지 않습니다. exporter는 best-effort 부가 경로이며, caller가 executor와
+ * scheduler를 소유하는 경우 이 wrapper를 닫기 전에 exporter를 먼저 닫아야 합니다.
+ */
+class ExportingLeaderHistorySink private constructor(
+    private val delegate: LeaderHistorySink,
+    private val exporter: LeaderAuditExporter,
+    private val sanitizer: LeaderAuditValueSanitizer,
+    private val contexts: LeaderAuditPendingContextStore,
+) : LeaderHistorySink {
+
+    /** 기본 redaction 정책을 사용하는 wrapper입니다. */
+    constructor(delegate: LeaderHistorySink, exporter: LeaderAuditExporter) : this(
+        delegate,
+        exporter,
+        LeaderAuditValueSanitizer.Default,
+        LeaderAuditPendingContextStore(),
+    )
+
+    /** 지정한 redaction 정책을 사용하는 wrapper입니다. */
+    constructor(
+        delegate: LeaderHistorySink,
+        exporter: LeaderAuditExporter,
+        sanitizer: LeaderAuditValueSanitizer,
+    ) : this(delegate, exporter, sanitizer, LeaderAuditPendingContextStore())
+
+    override fun recordAcquired(record: LeaderLockHistoryRecord): LeaderHistoryKey? {
+        val key = delegate.recordAcquired(record)
+        if (key != null) {
+            contexts.put(key, record)
+            submitSafely(LeaderAuditExportEvent.History.from(record, sanitizer))
+        }
+        return key
+    }
+
+    override fun recordCompleted(key: LeaderHistoryKey, finishedAt: Instant, durationMs: Long) {
+        delegate.recordCompleted(key, finishedAt, durationMs)
+        val context = contexts.remove(key)
+        submitSafely(
+            historyEvent(
+                key = key,
+                context = context,
+                finishedAt = finishedAt,
+                durationMs = durationMs,
+                status = LeaderHistoryStatus.COMPLETED,
+            ),
+        )
+    }
+
+    override fun recordFailed(
+        key: LeaderHistoryKey,
+        finishedAt: Instant,
+        durationMs: Long,
+        errorType: String?,
+        errorMessage: String?,
+    ) {
+        delegate.recordFailed(key, finishedAt, durationMs, errorType, errorMessage)
+        val context = contexts.remove(key)
+        submitSafely(
+            historyEvent(
+                key = key,
+                context = context,
+                finishedAt = finishedAt,
+                durationMs = durationMs,
+                status = LeaderHistoryStatus.FAILED,
+                errorType = errorType,
+                errorMessage = errorMessage,
+            ),
+        )
+    }
+
+    override fun deleteOlderThan(cutoff: Instant, limit: Int): Int = delegate.deleteOlderThan(cutoff, limit)
+
+    private fun historyEvent(
+        key: LeaderHistoryKey,
+        context: LeaderAuditPendingContextStore.PendingContext?,
+        finishedAt: Instant,
+        durationMs: Long,
+        status: LeaderHistoryStatus,
+        errorType: String? = null,
+        errorMessage: String? = null,
+    ): LeaderAuditExportEvent.History {
+        val source = context ?: LeaderAuditPendingContextStore.PendingContext(
+            lockName = key.lockName,
+            kind = io.bluetape4k.leader.LockIdentity.AnnotationKind.SINGLE,
+            acquiredAt = finishedAt,
+            lockedUntil = finishedAt,
+            nodeId = null,
+            slotId = key.slotId,
+            metadata = mapOf(CONTEXT_ATTRIBUTE to CONTEXT_MISSING),
+        )
+        return LeaderAuditExportEvent.History.from(
+            LeaderLockHistoryRecord(
+                lockName = source.lockName,
+                token = TOKEN_PLACEHOLDER,
+                kind = source.kind,
+                acquiredAt = source.acquiredAt,
+                lockedUntil = source.lockedUntil,
+                nodeId = source.nodeId,
+                finishedAt = finishedAt,
+                durationMs = durationMs,
+                status = status,
+                errorType = errorType,
+                errorMessage = errorMessage,
+                slotId = source.slotId,
+                metadata = source.metadata,
+            ),
+            sanitizer,
+        )
+    }
+
+    private fun submitSafely(event: LeaderAuditExportEvent) {
+        try {
+            exporter.submit(event)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "Audit export submission failed and was ignored" }
+        }
+    }
+
+    private companion object : KLogging() {
+        const val TOKEN_PLACEHOLDER: String = "audit-context"
+        const val CONTEXT_ATTRIBUTE: String = "audit_context"
+        const val CONTEXT_MISSING: String = "missing"
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/ExportingSuspendLeaderHistorySink.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/ExportingSuspendLeaderHistorySink.kt
@@ -40,9 +40,10 @@ class ExportingSuspendLeaderHistorySink private constructor(
     ) : this(delegate, exporter, sanitizer, LeaderAuditPendingContextStore())
 
     override suspend fun recordAcquired(record: LeaderLockHistoryRecord): LeaderHistoryKey? {
+        currentCoroutineContext().ensureActive()
         val key = delegate.recordAcquired(record)
+        currentCoroutineContext().ensureActive()
         if (key != null) {
-            currentCoroutineContext().ensureActive()
             contexts.put(key, record)
             submitSafely(LeaderAuditExportEvent.History.from(record, sanitizer))
         }
@@ -50,6 +51,7 @@ class ExportingSuspendLeaderHistorySink private constructor(
     }
 
     override suspend fun recordCompleted(key: LeaderHistoryKey, finishedAt: Instant, durationMs: Long) {
+        currentCoroutineContext().ensureActive()
         delegate.recordCompleted(key, finishedAt, durationMs)
         currentCoroutineContext().ensureActive()
         submitSafely(
@@ -70,6 +72,7 @@ class ExportingSuspendLeaderHistorySink private constructor(
         errorType: String?,
         errorMessage: String?,
     ) {
+        currentCoroutineContext().ensureActive()
         delegate.recordFailed(key, finishedAt, durationMs, errorType, errorMessage)
         currentCoroutineContext().ensureActive()
         submitSafely(
@@ -85,8 +88,12 @@ class ExportingSuspendLeaderHistorySink private constructor(
         )
     }
 
-    override suspend fun deleteOlderThan(cutoff: Instant, limit: Int): Int =
-        delegate.deleteOlderThan(cutoff, limit)
+    override suspend fun deleteOlderThan(cutoff: Instant, limit: Int): Int {
+        currentCoroutineContext().ensureActive()
+        val deleted = delegate.deleteOlderThan(cutoff, limit)
+        currentCoroutineContext().ensureActive()
+        return deleted
+    }
 
     private fun historyEvent(
         key: LeaderHistoryKey,

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/ExportingSuspendLeaderHistorySink.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/ExportingSuspendLeaderHistorySink.kt
@@ -1,0 +1,147 @@
+@file:Suppress("TooGenericExceptionCaught")
+
+package io.bluetape4k.leader.audit
+
+import io.bluetape4k.leader.history.LeaderHistoryKey
+import io.bluetape4k.leader.history.LeaderHistoryStatus
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
+import io.bluetape4k.leader.history.SuspendLeaderHistorySink
+import io.bluetape4k.leader.audit.internal.LeaderAuditPendingContextStore
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import java.time.Instant
+
+/**
+ * suspend history sink의 delegate 결과와 cancellation을 보존하면서 audit event를 전달합니다.
+ */
+class ExportingSuspendLeaderHistorySink private constructor(
+    private val delegate: SuspendLeaderHistorySink,
+    private val exporter: LeaderAuditExporter,
+    private val sanitizer: LeaderAuditValueSanitizer,
+    private val contexts: LeaderAuditPendingContextStore,
+) : SuspendLeaderHistorySink {
+
+    /** 기본 redaction 정책을 사용하는 wrapper입니다. */
+    constructor(delegate: SuspendLeaderHistorySink, exporter: LeaderAuditExporter) : this(
+        delegate,
+        exporter,
+        LeaderAuditValueSanitizer.Default,
+        LeaderAuditPendingContextStore(),
+    )
+
+    /** 지정한 redaction 정책을 사용하는 wrapper입니다. */
+    constructor(
+        delegate: SuspendLeaderHistorySink,
+        exporter: LeaderAuditExporter,
+        sanitizer: LeaderAuditValueSanitizer,
+    ) : this(delegate, exporter, sanitizer, LeaderAuditPendingContextStore())
+
+    override suspend fun recordAcquired(record: LeaderLockHistoryRecord): LeaderHistoryKey? {
+        val key = delegate.recordAcquired(record)
+        if (key != null) {
+            currentCoroutineContext().ensureActive()
+            contexts.put(key, record)
+            submitSafely(LeaderAuditExportEvent.History.from(record, sanitizer))
+        }
+        return key
+    }
+
+    override suspend fun recordCompleted(key: LeaderHistoryKey, finishedAt: Instant, durationMs: Long) {
+        delegate.recordCompleted(key, finishedAt, durationMs)
+        currentCoroutineContext().ensureActive()
+        submitSafely(
+            historyEvent(
+                key,
+                contexts.remove(key),
+                finishedAt,
+                durationMs,
+                LeaderHistoryStatus.COMPLETED,
+            ),
+        )
+    }
+
+    override suspend fun recordFailed(
+        key: LeaderHistoryKey,
+        finishedAt: Instant,
+        durationMs: Long,
+        errorType: String?,
+        errorMessage: String?,
+    ) {
+        delegate.recordFailed(key, finishedAt, durationMs, errorType, errorMessage)
+        currentCoroutineContext().ensureActive()
+        submitSafely(
+            historyEvent(
+                key,
+                contexts.remove(key),
+                finishedAt,
+                durationMs,
+                LeaderHistoryStatus.FAILED,
+                errorType,
+                errorMessage,
+            ),
+        )
+    }
+
+    override suspend fun deleteOlderThan(cutoff: Instant, limit: Int): Int =
+        delegate.deleteOlderThan(cutoff, limit)
+
+    private fun historyEvent(
+        key: LeaderHistoryKey,
+        context: LeaderAuditPendingContextStore.PendingContext?,
+        finishedAt: Instant,
+        durationMs: Long,
+        status: LeaderHistoryStatus,
+        errorType: String? = null,
+        errorMessage: String? = null,
+    ): LeaderAuditExportEvent.History {
+        val source = context ?: LeaderAuditPendingContextStore.PendingContext(
+            lockName = key.lockName,
+            kind = io.bluetape4k.leader.LockIdentity.AnnotationKind.SINGLE,
+            acquiredAt = finishedAt,
+            lockedUntil = finishedAt,
+            nodeId = null,
+            slotId = key.slotId,
+            metadata = mapOf(CONTEXT_ATTRIBUTE to CONTEXT_MISSING),
+        )
+        return LeaderAuditExportEvent.History.from(
+            LeaderLockHistoryRecord(
+                lockName = source.lockName,
+                token = TOKEN_PLACEHOLDER,
+                kind = source.kind,
+                acquiredAt = source.acquiredAt,
+                lockedUntil = source.lockedUntil,
+                nodeId = source.nodeId,
+                finishedAt = finishedAt,
+                durationMs = durationMs,
+                status = status,
+                errorType = errorType,
+                errorMessage = errorMessage,
+                slotId = source.slotId,
+                metadata = source.metadata,
+            ),
+            sanitizer,
+        )
+    }
+
+    private fun submitSafely(event: LeaderAuditExportEvent) {
+        try {
+            exporter.submit(event)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "Audit export submission failed and was ignored" }
+        }
+    }
+
+    private companion object : KLogging() {
+        const val TOKEN_PLACEHOLDER: String = "audit-context"
+        const val CONTEXT_ATTRIBUTE: String = "audit_context"
+        const val CONTEXT_MISSING: String = "missing"
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditDelivery.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditDelivery.kt
@@ -1,0 +1,24 @@
+package io.bluetape4k.leader.audit
+
+import java.util.concurrent.CompletableFuture
+
+/**
+ * 하나의 sanitized event delivery를 시작하는 callback입니다.
+ *
+ * 반환 future는 exporter가 timeout/close 시 취소할 수 있으므로 caller는 해당 ownership을
+ * 보존해야 합니다. callback이 동기적으로 예외를 던지는 경우 exporter가 retry/terminalize합니다.
+ */
+fun interface LeaderAuditDelivery {
+
+    /** delivery를 시작하고 cancellation-capable future를 반환합니다. */
+    fun deliver(event: LeaderAuditExportEvent): CompletableFuture<LeaderAuditDeliveryResult>
+}
+
+/**
+ * 하나의 delivery attempt 결과입니다.
+ */
+enum class LeaderAuditDeliveryResult {
+    SUCCESS,
+    RETRYABLE_FAILURE,
+    TERMINAL_FAILURE,
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
@@ -58,25 +58,39 @@ sealed interface LeaderAuditExportEvent {
      * 생성자는 외부에서 직접 호출할 수 없으며 `from` factory가 token을 버리고
      * sanitizer를 적용하는 유일한 진입점입니다.
      */
-    class History private constructor(
-        override val occurredAt: Instant,
-        override val lockName: String,
+    class History private constructor(snapshot: Snapshot) : LeaderAuditExportEvent {
+
+        /** factory가 검증·정제한 값만 보관하는 opaque construction payload입니다. */
+        private class Snapshot(
+            val occurredAt: Instant,
+            val lockName: String,
+            val kind: LockIdentity.AnnotationKind,
+            val status: LeaderHistoryStatus,
+            val nodeId: String?,
+            val slotId: String?,
+            val durationMs: Long?,
+            val errorType: String?,
+            val errorMessage: String?,
+            val attributes: Map<String, String>,
+        )
+
+        override val occurredAt: Instant = snapshot.occurredAt
+        override val lockName: String = snapshot.lockName
         /** single/group election 분류입니다. */
-        val kind: LockIdentity.AnnotationKind,
+        val kind: LockIdentity.AnnotationKind = snapshot.kind
         /** history lifecycle 상태입니다. */
-        val status: LeaderHistoryStatus,
+        val status: LeaderHistoryStatus = snapshot.status
         /** sanitizer가 적용된 node identity입니다. */
-        val nodeId: String?,
+        val nodeId: String? = snapshot.nodeId
         /** sanitizer가 적용된 group slot identity입니다. */
-        val slotId: String?,
+        val slotId: String? = snapshot.slotId
         /** 사용자 작업 실행 시간입니다. */
-        val durationMs: Long?,
+        val durationMs: Long? = snapshot.durationMs
         /** sanitizer가 적용된 예외 type입니다. */
-        val errorType: String?,
+        val errorType: String? = snapshot.errorType
         /** sanitizer가 적용된 예외 message입니다. */
-        val errorMessage: String?,
-        override val attributes: Map<String, String>,
-    ) : LeaderAuditExportEvent {
+        val errorMessage: String? = snapshot.errorMessage
+        override val attributes: Map<String, String> = snapshot.attributes
 
         companion object {
             /**
@@ -93,24 +107,31 @@ sealed interface LeaderAuditExportEvent {
                 val exportNow = Instant.now()
                 val occurredAt = record.finishedAt ?: record.acquiredAt
                 return History(
-                    occurredAt = occurredAt,
-                    lockName = bounded(sanitizer, LeaderAuditField.LOCK_NAME, record.lockName, MAX_TEXT_FIELD_BYTES),
-                    kind = record.kind,
-                    status = record.effectiveStatus(exportNow),
-                    nodeId = record.nodeId?.let {
-                        bounded(sanitizer, LeaderAuditField.NODE_ID, it, MAX_TEXT_FIELD_BYTES)
-                    },
-                    slotId = record.slotId?.let {
-                        bounded(sanitizer, LeaderAuditField.SLOT_ID, it, MAX_TEXT_FIELD_BYTES)
-                    },
-                    durationMs = record.durationMs,
-                    errorType = record.errorType?.let {
-                        bounded(sanitizer, LeaderAuditField.ERROR_TYPE, it, MAX_ERROR_TYPE_BYTES)
-                    },
-                    errorMessage = record.errorMessage?.let {
-                        bounded(sanitizer, LeaderAuditField.ERROR_MESSAGE, it, MAX_ERROR_MESSAGE_BYTES)
-                    },
-                    attributes = sanitizeAttributes(record.metadata, sanitizer),
+                    Snapshot(
+                        occurredAt = occurredAt,
+                        lockName = bounded(
+                            sanitizer,
+                            LeaderAuditField.LOCK_NAME,
+                            record.lockName,
+                            MAX_TEXT_FIELD_BYTES,
+                        ),
+                        kind = record.kind,
+                        status = record.effectiveStatus(exportNow),
+                        nodeId = record.nodeId?.let {
+                            bounded(sanitizer, LeaderAuditField.NODE_ID, it, MAX_TEXT_FIELD_BYTES)
+                        },
+                        slotId = record.slotId?.let {
+                            bounded(sanitizer, LeaderAuditField.SLOT_ID, it, MAX_TEXT_FIELD_BYTES)
+                        },
+                        durationMs = record.durationMs,
+                        errorType = record.errorType?.let {
+                            bounded(sanitizer, LeaderAuditField.ERROR_TYPE, it, MAX_ERROR_TYPE_BYTES)
+                        },
+                        errorMessage = record.errorMessage?.let {
+                            bounded(sanitizer, LeaderAuditField.ERROR_MESSAGE, it, MAX_ERROR_MESSAGE_BYTES)
+                        },
+                        attributes = sanitizeAttributes(record.metadata, sanitizer),
+                    ),
                 )
             }
         }
@@ -124,17 +145,27 @@ sealed interface LeaderAuditExportEvent {
     /**
      * `LeaderElectionEvent`에서 생성한 bounded lifecycle event입니다.
      */
-    class Lifecycle private constructor(
-        override val occurredAt: Instant,
-        override val lockName: String,
+    class Lifecycle private constructor(snapshot: Snapshot) : LeaderAuditExportEvent {
+
+        /** factory가 검증·정제한 값만 보관하는 opaque construction payload입니다. */
+        private class Snapshot(
+            val occurredAt: Instant,
+            val lockName: String,
+            val outcome: LeaderAuditLifecycleOutcome,
+            val leaderId: String?,
+            val leaseExpiry: Instant?,
+            val attributes: Map<String, String>,
+        )
+
+        override val occurredAt: Instant = snapshot.occurredAt
+        override val lockName: String = snapshot.lockName
         /** lifecycle 결과입니다. */
-        val outcome: LeaderAuditLifecycleOutcome,
+        val outcome: LeaderAuditLifecycleOutcome = snapshot.outcome
         /** sanitizer가 적용된 leader identity입니다. */
-        val leaderId: String?,
+        val leaderId: String? = snapshot.leaderId
         /** leader lease 만료 시각입니다. */
-        val leaseExpiry: Instant?,
-        override val attributes: Map<String, String>,
-    ) : LeaderAuditExportEvent {
+        val leaseExpiry: Instant? = snapshot.leaseExpiry
+        override val attributes: Map<String, String> = snapshot.attributes
 
         companion object {
             /**
@@ -152,18 +183,25 @@ sealed interface LeaderAuditExportEvent {
             ): Lifecycle {
                 val elected = event as? LeaderElectionEvent.Elected
                 return Lifecycle(
-                    occurredAt = Instant.now(),
-                    lockName = bounded(sanitizer, LeaderAuditField.LOCK_NAME, event.lockName, MAX_TEXT_FIELD_BYTES),
-                    outcome = when (event) {
-                        is LeaderElectionEvent.Elected -> LeaderAuditLifecycleOutcome.ELECTED
-                        is LeaderElectionEvent.Revoked -> LeaderAuditLifecycleOutcome.REVOKED
-                        is LeaderElectionEvent.Skipped -> LeaderAuditLifecycleOutcome.SKIPPED
-                    },
-                    leaderId = elected?.leaderId?.let {
-                        bounded(sanitizer, LeaderAuditField.LEADER_ID, it, MAX_TEXT_FIELD_BYTES)
-                    },
-                    leaseExpiry = elected?.leaseExpiry,
-                    attributes = sanitizeAttributes(attributes, sanitizer),
+                    Snapshot(
+                        occurredAt = Instant.now(),
+                        lockName = bounded(
+                            sanitizer,
+                            LeaderAuditField.LOCK_NAME,
+                            event.lockName,
+                            MAX_TEXT_FIELD_BYTES,
+                        ),
+                        outcome = when (event) {
+                            is LeaderElectionEvent.Elected -> LeaderAuditLifecycleOutcome.ELECTED
+                            is LeaderElectionEvent.Revoked -> LeaderAuditLifecycleOutcome.REVOKED
+                            is LeaderElectionEvent.Skipped -> LeaderAuditLifecycleOutcome.SKIPPED
+                        },
+                        leaderId = elected?.leaderId?.let {
+                            bounded(sanitizer, LeaderAuditField.LEADER_ID, it, MAX_TEXT_FIELD_BYTES)
+                        },
+                        leaseExpiry = elected?.leaseExpiry,
+                        attributes = sanitizeAttributes(attributes, sanitizer),
+                    ),
                 )
             }
         }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
@@ -88,7 +88,7 @@ sealed interface LeaderAuditExportEvent {
              */
             fun from(
                 record: LeaderLockHistoryRecord,
-                sanitizer: LeaderAuditValueSanitizer = LeaderAuditValueSanitizer.Default,
+                sanitizer: LeaderAuditValueSanitizer,
             ): History {
                 val occurredAt = record.finishedAt ?: record.acquiredAt
                 return History(
@@ -146,8 +146,8 @@ sealed interface LeaderAuditExportEvent {
              */
             fun from(
                 event: LeaderElectionEvent,
-                attributes: Map<String, String> = emptyMap(),
-                sanitizer: LeaderAuditValueSanitizer = LeaderAuditValueSanitizer.Default,
+                attributes: Map<String, String>,
+                sanitizer: LeaderAuditValueSanitizer,
             ): Lifecycle {
                 val elected = event as? LeaderElectionEvent.Elected
                 return Lifecycle(

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
@@ -90,12 +90,13 @@ sealed interface LeaderAuditExportEvent {
                 record: LeaderLockHistoryRecord,
                 sanitizer: LeaderAuditValueSanitizer,
             ): History {
+                val exportNow = Instant.now()
                 val occurredAt = record.finishedAt ?: record.acquiredAt
                 return History(
                     occurredAt = occurredAt,
                     lockName = bounded(sanitizer, LeaderAuditField.LOCK_NAME, record.lockName, MAX_TEXT_FIELD_BYTES),
                     kind = record.kind,
-                    status = record.effectiveStatus(occurredAt),
+                    status = record.effectiveStatus(exportNow),
                     nodeId = record.nodeId?.let {
                         bounded(sanitizer, LeaderAuditField.NODE_ID, it, MAX_TEXT_FIELD_BYTES)
                     },
@@ -178,9 +179,17 @@ private fun bounded(
     field: LeaderAuditField,
     value: String,
     maxBytes: Int,
-): String = value
-    .let { sanitizer.sanitize(field, it) }
-    .truncateUtf8(maxBytes)
+): String {
+    val sanitized = if (sanitizer is LeaderAuditValueSanitizer.Raw &&
+        field !in LeaderAuditValueSanitizer.RAW_ALLOWED_FIELDS
+    ) {
+        // Raw는 KIND만 직접 허용하므로 event의 민감한 문자열은 안전한 기본 redaction으로 처리합니다.
+        LeaderAuditValueSanitizer.Default.sanitize(field, value)
+    } else {
+        sanitizer.sanitize(field, value)
+    }
+    return sanitized.truncateUtf8(maxBytes)
+}
 
 private fun sanitizeAttributes(
     source: Map<String, String>,

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
@@ -1,0 +1,233 @@
+package io.bluetape4k.leader.audit
+
+import io.bluetape4k.leader.LeaderElectionEvent
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.history.LeaderHistoryStatus
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
+import io.bluetape4k.leader.history.effectiveStatus
+import io.bluetape4k.support.truncateUtf8
+import java.time.Instant
+import java.util.Collections
+import java.util.LinkedHashMap
+
+/**
+ * 외부 exporter가 받을 수 있는 token-free, bounded audit event입니다.
+ *
+ * `LeaderLockHistoryRecord`의 token과 `LeaderLease` 객체는 이 경계를 통과하지
+ * 않습니다. 모든 문자열과 attribute는 factory에서 sanitizer와 byte 상한을
+ * 적용한 뒤 immutable snapshot으로 보관합니다.
+ */
+sealed interface LeaderAuditExportEvent {
+
+    /** event가 발생한 wall-clock 시각입니다. */
+    val occurredAt: Instant
+
+    /** sanitizer가 적용된 lock 이름입니다. */
+    val lockName: String
+
+    /** sanitizer와 aggregate 상한이 적용된 immutable attributes입니다. */
+    val attributes: Map<String, String>
+
+    /** history event와 lifecycle event의 공통 bounded 상수입니다. */
+    companion object {
+        /** error message의 최대 UTF-8 byte 수입니다. */
+        const val MAX_ERROR_MESSAGE_BYTES: Int = 4096
+
+        /** error type의 최대 UTF-8 byte 수입니다. */
+        const val MAX_ERROR_TYPE_BYTES: Int = 128
+
+        /** lock/node/slot/leader text의 최대 UTF-8 byte 수입니다. */
+        const val MAX_TEXT_FIELD_BYTES: Int = 256
+
+        /** attributes의 최대 항목 수입니다. */
+        const val MAX_ATTRIBUTES: Int = 32
+
+        /** attribute key의 최대 UTF-8 byte 수입니다. */
+        const val MAX_ATTRIBUTE_KEY_BYTES: Int = 128
+
+        /** attribute value의 최대 UTF-8 byte 수입니다. */
+        const val MAX_ATTRIBUTE_VALUE_BYTES: Int = 512
+
+        /** attributes key/value 합계의 최대 UTF-8 byte 수입니다. */
+        const val MAX_ATTRIBUTES_TOTAL_BYTES: Int = 8192
+    }
+
+    /**
+     * history recorder에서 생성한 bounded event입니다.
+     *
+     * 생성자는 외부에서 직접 호출할 수 없으며 `from` factory가 token을 버리고
+     * sanitizer를 적용하는 유일한 진입점입니다.
+     */
+    class History private constructor(
+        override val occurredAt: Instant,
+        override val lockName: String,
+        /** single/group election 분류입니다. */
+        val kind: LockIdentity.AnnotationKind,
+        /** history lifecycle 상태입니다. */
+        val status: LeaderHistoryStatus,
+        /** sanitizer가 적용된 node identity입니다. */
+        val nodeId: String?,
+        /** sanitizer가 적용된 group slot identity입니다. */
+        val slotId: String?,
+        /** 사용자 작업 실행 시간입니다. */
+        val durationMs: Long?,
+        /** sanitizer가 적용된 예외 type입니다. */
+        val errorType: String?,
+        /** sanitizer가 적용된 예외 message입니다. */
+        val errorMessage: String?,
+        override val attributes: Map<String, String>,
+    ) : LeaderAuditExportEvent {
+
+        companion object {
+            /**
+             * history record를 token-free export event로 변환합니다.
+             *
+             * @param record 내부 history record입니다.
+             * @param sanitizer 문자열 redaction 정책입니다.
+             * @return immutable bounded history event입니다.
+             */
+            fun from(
+                record: LeaderLockHistoryRecord,
+                sanitizer: LeaderAuditValueSanitizer = LeaderAuditValueSanitizer.Default,
+            ): History {
+                val occurredAt = record.finishedAt ?: record.acquiredAt
+                return History(
+                    occurredAt = occurredAt,
+                    lockName = bounded(sanitizer, LeaderAuditField.LOCK_NAME, record.lockName, MAX_TEXT_FIELD_BYTES),
+                    kind = record.kind,
+                    status = record.effectiveStatus(occurredAt),
+                    nodeId = record.nodeId?.let {
+                        bounded(sanitizer, LeaderAuditField.NODE_ID, it, MAX_TEXT_FIELD_BYTES)
+                    },
+                    slotId = record.slotId?.let {
+                        bounded(sanitizer, LeaderAuditField.SLOT_ID, it, MAX_TEXT_FIELD_BYTES)
+                    },
+                    durationMs = record.durationMs,
+                    errorType = record.errorType?.let {
+                        bounded(sanitizer, LeaderAuditField.ERROR_TYPE, it, MAX_ERROR_TYPE_BYTES)
+                    },
+                    errorMessage = record.errorMessage?.let {
+                        bounded(sanitizer, LeaderAuditField.ERROR_MESSAGE, it, MAX_ERROR_MESSAGE_BYTES)
+                    },
+                    attributes = sanitizeAttributes(record.metadata, sanitizer),
+                )
+            }
+        }
+
+        override fun toString(): String =
+            "History(occurredAt=$occurredAt, lockName=$lockName, kind=$kind, status=$status, " +
+                "nodeId=$nodeId, slotId=$slotId, durationMs=$durationMs, errorType=$errorType, " +
+                "errorMessage=$errorMessage, attributes=$attributes)"
+    }
+
+    /**
+     * `LeaderElectionEvent`에서 생성한 bounded lifecycle event입니다.
+     */
+    class Lifecycle private constructor(
+        override val occurredAt: Instant,
+        override val lockName: String,
+        /** lifecycle 결과입니다. */
+        val outcome: LeaderAuditLifecycleOutcome,
+        /** sanitizer가 적용된 leader identity입니다. */
+        val leaderId: String?,
+        /** leader lease 만료 시각입니다. */
+        val leaseExpiry: Instant?,
+        override val attributes: Map<String, String>,
+    ) : LeaderAuditExportEvent {
+
+        companion object {
+            /**
+             * election event를 token-free export event로 변환합니다.
+             *
+             * @param event 내부 lifecycle event입니다.
+             * @param attributes 호출자가 제공한 context입니다.
+             * @param sanitizer 문자열 redaction 정책입니다.
+             * @return immutable bounded lifecycle event입니다.
+             */
+            fun from(
+                event: LeaderElectionEvent,
+                attributes: Map<String, String> = emptyMap(),
+                sanitizer: LeaderAuditValueSanitizer = LeaderAuditValueSanitizer.Default,
+            ): Lifecycle {
+                val elected = event as? LeaderElectionEvent.Elected
+                return Lifecycle(
+                    occurredAt = Instant.now(),
+                    lockName = bounded(sanitizer, LeaderAuditField.LOCK_NAME, event.lockName, MAX_TEXT_FIELD_BYTES),
+                    outcome = when (event) {
+                        is LeaderElectionEvent.Elected -> LeaderAuditLifecycleOutcome.ELECTED
+                        is LeaderElectionEvent.Revoked -> LeaderAuditLifecycleOutcome.REVOKED
+                        is LeaderElectionEvent.Skipped -> LeaderAuditLifecycleOutcome.SKIPPED
+                    },
+                    leaderId = elected?.leaderId?.let {
+                        bounded(sanitizer, LeaderAuditField.LEADER_ID, it, MAX_TEXT_FIELD_BYTES)
+                    },
+                    leaseExpiry = elected?.leaseExpiry,
+                    attributes = sanitizeAttributes(attributes, sanitizer),
+                )
+            }
+        }
+
+        override fun toString(): String =
+            "Lifecycle(occurredAt=$occurredAt, lockName=$lockName, outcome=$outcome, " +
+                "leaderId=$leaderId, leaseExpiry=$leaseExpiry, attributes=$attributes)"
+    }
+}
+
+private fun bounded(
+    sanitizer: LeaderAuditValueSanitizer,
+    field: LeaderAuditField,
+    value: String,
+    maxBytes: Int,
+): String = value
+    .let { sanitizer.sanitize(field, it) }
+    .truncateUtf8(maxBytes)
+
+private fun sanitizeAttributes(
+    source: Map<String, String>,
+    sanitizer: LeaderAuditValueSanitizer,
+): Map<String, String> {
+    val candidates = source.entries
+        .map { entry ->
+            val sanitizedKey = bounded(
+                sanitizer,
+                LeaderAuditField.ATTRIBUTE_KEY,
+                entry.key,
+                LeaderAuditExportEvent.MAX_ATTRIBUTE_KEY_BYTES,
+            )
+            val sanitizedValue = bounded(
+                sanitizer,
+                LeaderAuditField.ATTRIBUTE_VALUE,
+                entry.value,
+                LeaderAuditExportEvent.MAX_ATTRIBUTE_VALUE_BYTES,
+            )
+            Triple(entry.key, sanitizedKey, sanitizedValue)
+        }
+        .sortedWith { left, right ->
+            compareUtf8(left.second, right.second).takeUnless { it == 0 }
+                ?: compareUtf8(left.first, right.first)
+        }
+
+    val result = LinkedHashMap<String, String>()
+    var totalBytes = 0
+    candidates.forEach { (_, sanitizedKey, sanitizedValue) ->
+        if (result.size >= LeaderAuditExportEvent.MAX_ATTRIBUTES || result.containsKey(sanitizedKey)) return@forEach
+        val entryBytes = sanitizedKey.utf8Size() + sanitizedValue.utf8Size()
+        if (totalBytes + entryBytes > LeaderAuditExportEvent.MAX_ATTRIBUTES_TOTAL_BYTES) return@forEach
+        result[sanitizedKey] = sanitizedValue
+        totalBytes += entryBytes
+    }
+    return Collections.unmodifiableMap(LinkedHashMap(result))
+}
+
+private fun String.utf8Size(): Int = toByteArray(Charsets.UTF_8).size
+
+private fun compareUtf8(left: String, right: String): Int {
+    val leftBytes = left.toByteArray(Charsets.UTF_8)
+    val rightBytes = right.toByteArray(Charsets.UTF_8)
+    val commonLength = minOf(leftBytes.size, rightBytes.size)
+    for (index in 0 until commonLength) {
+        val comparison = (leftBytes[index].toInt() and 0xff) - (rightBytes[index].toInt() and 0xff)
+        if (comparison != 0) return comparison
+    }
+    return leftBytes.size - rightBytes.size
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportOptions.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportOptions.kt
@@ -40,15 +40,15 @@ class LeaderAuditExportOptions(
     }
 
     companion object {
-        internal const val MAX_QUEUE_CAPACITY: Int = 65_536
-        internal const val MAX_ATTEMPTS: Int = 16
+        private const val MAX_QUEUE_CAPACITY: Int = 65_536
+        private const val MAX_ATTEMPTS: Int = 16
     }
 }
 
-internal val MAX_ATTEMPT_TIMEOUT_NANOS: Duration = Duration.ofMinutes(5)
-internal val MAX_BACKOFF_NANOS: Duration = Duration.ofMinutes(1)
+private val MAX_ATTEMPT_TIMEOUT_NANOS: Duration = Duration.ofMinutes(5)
+private val MAX_BACKOFF_NANOS: Duration = Duration.ofMinutes(1)
 
-internal fun Duration.toAuditPositiveNanos(name: String, maximum: Duration): Long {
+private fun Duration.toAuditPositiveNanos(name: String, maximum: Duration): Long {
     require(!isZero && !isNegative) { "$name must be positive: $this" }
     val nanos = try {
         toNanos()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportOptions.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportOptions.kt
@@ -1,0 +1,67 @@
+package io.bluetape4k.leader.audit
+
+import java.time.Duration
+import java.util.concurrent.Executor
+import java.util.concurrent.ScheduledExecutorService
+
+/**
+ * bounded exporter의 queue, retry, timeout과 caller-owned 실행기를 정의합니다.
+ *
+ * executor와 scheduler는 exporter가 소유하거나 종료하지 않습니다. exporter를 먼저
+ * `close`한 뒤 caller가 실행기를 종료해야 합니다.
+ */
+class LeaderAuditExportOptions(
+    val queueCapacity: Int,
+    val maxInFlight: Int,
+    val maxAttempts: Int,
+    val attemptTimeout: Duration,
+    val initialBackoff: Duration,
+    val maxBackoff: Duration,
+    val executor: Executor,
+    val scheduler: ScheduledExecutorService,
+) {
+
+    /** 검증된 nanosecond timeout입니다. */
+    internal val attemptTimeoutNanos: Long = attemptTimeout.toPositiveNanos("attemptTimeout", MAX_ATTEMPT_TIMEOUT)
+
+    /** 검증된 nanosecond initial backoff입니다. */
+    internal val initialBackoffNanos: Long = initialBackoff.toPositiveNanos("initialBackoff", MAX_BACKOFF)
+
+    /** 검증된 nanosecond maximum backoff입니다. */
+    internal val maxBackoffNanos: Long = maxBackoff.toPositiveNanos("maxBackoff", MAX_BACKOFF)
+
+    init {
+        require(queueCapacity in 1..MAX_QUEUE_CAPACITY) {
+            "queueCapacity must be in 1..$MAX_QUEUE_CAPACITY: $queueCapacity"
+        }
+        require(maxInFlight in 1..queueCapacity) {
+            "maxInFlight must be in 1..queueCapacity: $maxInFlight"
+        }
+        require(maxAttempts in 1..MAX_ATTEMPTS) {
+            "maxAttempts must be in 1..$MAX_ATTEMPTS: $maxAttempts"
+        }
+        require(initialBackoffNanos <= maxBackoffNanos) {
+            "initialBackoff must be <= maxBackoff"
+        }
+    }
+
+    companion object {
+        internal const val MAX_QUEUE_CAPACITY: Int = 65_536
+        internal const val MAX_ATTEMPTS: Int = 16
+        private val MAX_ATTEMPT_TIMEOUT: Duration = Duration.ofMinutes(5)
+        private val MAX_BACKOFF: Duration = Duration.ofMinutes(1)
+    }
+}
+
+private fun Duration.toPositiveNanos(name: String, maximum: Duration): Long {
+    require(!isZero && !isNegative) { "$name must be positive: $this" }
+    val nanos = try {
+        toNanos()
+    } catch (e: ArithmeticException) {
+        throw IllegalArgumentException("$name does not fit in nanoseconds: $this", e)
+    }
+    require(nanos > 0) { "$name must be positive: $this" }
+    val maximumNanos = maximum.toNanos()
+    require(nanos <= maximumNanos) { "$name must be <= $maximum: $this" }
+    return nanos
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportOptions.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportOptions.kt
@@ -21,16 +21,10 @@ class LeaderAuditExportOptions(
     val scheduler: ScheduledExecutorService,
 ) {
 
-    private val validatedAttemptTimeoutNanos: Long =
-        attemptTimeout.toAuditPositiveNanos("attemptTimeout", MAX_ATTEMPT_TIMEOUT_NANOS)
-
-    private val validatedInitialBackoffNanos: Long =
-        initialBackoff.toAuditPositiveNanos("initialBackoff", MAX_BACKOFF_NANOS)
-
-    private val validatedMaxBackoffNanos: Long =
-        maxBackoff.toAuditPositiveNanos("maxBackoff", MAX_BACKOFF_NANOS)
-
     init {
+        attemptTimeout.toAuditPositiveNanos("attemptTimeout", MAX_ATTEMPT_TIMEOUT_NANOS)
+        val initialBackoffNanos = initialBackoff.toAuditPositiveNanos("initialBackoff", MAX_BACKOFF_NANOS)
+        val maxBackoffNanos = maxBackoff.toAuditPositiveNanos("maxBackoff", MAX_BACKOFF_NANOS)
         require(queueCapacity in 1..MAX_QUEUE_CAPACITY) {
             "queueCapacity must be in 1..$MAX_QUEUE_CAPACITY: $queueCapacity"
         }
@@ -40,7 +34,7 @@ class LeaderAuditExportOptions(
         require(maxAttempts in 1..MAX_ATTEMPTS) {
             "maxAttempts must be in 1..$MAX_ATTEMPTS: $maxAttempts"
         }
-        require(validatedInitialBackoffNanos <= validatedMaxBackoffNanos) {
+        require(initialBackoffNanos <= maxBackoffNanos) {
             "initialBackoff must be <= maxBackoff"
         }
     }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportOptions.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportOptions.kt
@@ -21,14 +21,14 @@ class LeaderAuditExportOptions(
     val scheduler: ScheduledExecutorService,
 ) {
 
-    /** 검증된 nanosecond timeout입니다. */
-    internal val attemptTimeoutNanos: Long = attemptTimeout.toPositiveNanos("attemptTimeout", MAX_ATTEMPT_TIMEOUT)
+    private val validatedAttemptTimeoutNanos: Long =
+        attemptTimeout.toAuditPositiveNanos("attemptTimeout", MAX_ATTEMPT_TIMEOUT_NANOS)
 
-    /** 검증된 nanosecond initial backoff입니다. */
-    internal val initialBackoffNanos: Long = initialBackoff.toPositiveNanos("initialBackoff", MAX_BACKOFF)
+    private val validatedInitialBackoffNanos: Long =
+        initialBackoff.toAuditPositiveNanos("initialBackoff", MAX_BACKOFF_NANOS)
 
-    /** 검증된 nanosecond maximum backoff입니다. */
-    internal val maxBackoffNanos: Long = maxBackoff.toPositiveNanos("maxBackoff", MAX_BACKOFF)
+    private val validatedMaxBackoffNanos: Long =
+        maxBackoff.toAuditPositiveNanos("maxBackoff", MAX_BACKOFF_NANOS)
 
     init {
         require(queueCapacity in 1..MAX_QUEUE_CAPACITY) {
@@ -40,7 +40,7 @@ class LeaderAuditExportOptions(
         require(maxAttempts in 1..MAX_ATTEMPTS) {
             "maxAttempts must be in 1..$MAX_ATTEMPTS: $maxAttempts"
         }
-        require(initialBackoffNanos <= maxBackoffNanos) {
+        require(validatedInitialBackoffNanos <= validatedMaxBackoffNanos) {
             "initialBackoff must be <= maxBackoff"
         }
     }
@@ -48,12 +48,13 @@ class LeaderAuditExportOptions(
     companion object {
         internal const val MAX_QUEUE_CAPACITY: Int = 65_536
         internal const val MAX_ATTEMPTS: Int = 16
-        private val MAX_ATTEMPT_TIMEOUT: Duration = Duration.ofMinutes(5)
-        private val MAX_BACKOFF: Duration = Duration.ofMinutes(1)
     }
 }
 
-private fun Duration.toPositiveNanos(name: String, maximum: Duration): Long {
+internal val MAX_ATTEMPT_TIMEOUT_NANOS: Duration = Duration.ofMinutes(5)
+internal val MAX_BACKOFF_NANOS: Duration = Duration.ofMinutes(1)
+
+internal fun Duration.toAuditPositiveNanos(name: String, maximum: Duration): Long {
     require(!isZero && !isNegative) { "$name must be positive: $this" }
     val nanos = try {
         toNanos()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportSnapshot.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportSnapshot.kt
@@ -5,25 +5,45 @@ package io.bluetape4k.leader.audit
  *
  * snapshot은 동적 lock name, node id, endpoint, error message를 포함하지 않습니다.
  */
-class LeaderAuditExportSnapshot private constructor(
-    val queued: Int,
-    val inFlight: Int,
-    val scheduledRetries: Int,
-    val admitted: Int,
-    val accepted: Long,
-    val droppedQueueFull: Long,
-    val droppedClosed: Long,
-    val retries: Long,
-    val terminalFailures: Long,
-    val cancellations: Long,
-    val executorRejections: Long,
-    val schedulerRejections: Long,
-    val observerDrops: Long,
-    val observerRegistrationDrops: Long,
-    val diagnosticsFatalErrors: Long,
-    val diagnosticsClosed: Boolean,
-    val closed: Boolean,
-) {
+class LeaderAuditExportSnapshot private constructor(payload: Payload) {
+
+    val queued: Int = payload.queued
+    val inFlight: Int = payload.inFlight
+    val scheduledRetries: Int = payload.scheduledRetries
+    val admitted: Int = payload.admitted
+    val accepted: Long = payload.accepted
+    val droppedQueueFull: Long = payload.droppedQueueFull
+    val droppedClosed: Long = payload.droppedClosed
+    val retries: Long = payload.retries
+    val terminalFailures: Long = payload.terminalFailures
+    val cancellations: Long = payload.cancellations
+    val executorRejections: Long = payload.executorRejections
+    val schedulerRejections: Long = payload.schedulerRejections
+    val observerDrops: Long = payload.observerDrops
+    val observerRegistrationDrops: Long = payload.observerRegistrationDrops
+    val diagnosticsFatalErrors: Long = payload.diagnosticsFatalErrors
+    val diagnosticsClosed: Boolean = payload.diagnosticsClosed
+    val closed: Boolean = payload.closed
+
+    private class Payload(
+        val queued: Int,
+        val inFlight: Int,
+        val scheduledRetries: Int,
+        val admitted: Int,
+        val accepted: Long,
+        val droppedQueueFull: Long,
+        val droppedClosed: Long,
+        val retries: Long,
+        val terminalFailures: Long,
+        val cancellations: Long,
+        val executorRejections: Long,
+        val schedulerRejections: Long,
+        val observerDrops: Long,
+        val observerRegistrationDrops: Long,
+        val diagnosticsFatalErrors: Long,
+        val diagnosticsClosed: Boolean,
+        val closed: Boolean,
+    )
 
     companion object {
         /** 내부 counter state를 immutable public snapshot으로 만듭니다. */
@@ -47,6 +67,7 @@ class LeaderAuditExportSnapshot private constructor(
             diagnosticsClosed: Boolean,
             closed: Boolean,
         ): LeaderAuditExportSnapshot = LeaderAuditExportSnapshot(
+            Payload(
             queued = queued,
             inFlight = inFlight,
             scheduledRetries = scheduledRetries,
@@ -64,6 +85,7 @@ class LeaderAuditExportSnapshot private constructor(
             diagnosticsFatalErrors = diagnosticsFatalErrors,
             diagnosticsClosed = diagnosticsClosed,
             closed = closed,
+            ),
         )
     }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportSnapshot.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportSnapshot.kt
@@ -1,0 +1,69 @@
+package io.bluetape4k.leader.audit
+
+/**
+ * exporter의 bounded queue, in-flight와 누적 lifecycle counter snapshot입니다.
+ *
+ * snapshot은 동적 lock name, node id, endpoint, error message를 포함하지 않습니다.
+ */
+class LeaderAuditExportSnapshot private constructor(
+    val queued: Int,
+    val inFlight: Int,
+    val scheduledRetries: Int,
+    val admitted: Int,
+    val accepted: Long,
+    val droppedQueueFull: Long,
+    val droppedClosed: Long,
+    val retries: Long,
+    val terminalFailures: Long,
+    val cancellations: Long,
+    val executorRejections: Long,
+    val schedulerRejections: Long,
+    val observerDrops: Long,
+    val observerRegistrationDrops: Long,
+    val diagnosticsFatalErrors: Long,
+    val diagnosticsClosed: Boolean,
+    val closed: Boolean,
+) {
+
+    companion object {
+        /** 내부 counter state를 immutable public snapshot으로 만듭니다. */
+        @JvmSynthetic
+        internal fun create(
+            queued: Int,
+            inFlight: Int,
+            scheduledRetries: Int,
+            admitted: Int,
+            accepted: Long,
+            droppedQueueFull: Long,
+            droppedClosed: Long,
+            retries: Long,
+            terminalFailures: Long,
+            cancellations: Long,
+            executorRejections: Long,
+            schedulerRejections: Long,
+            observerDrops: Long,
+            observerRegistrationDrops: Long,
+            diagnosticsFatalErrors: Long,
+            diagnosticsClosed: Boolean,
+            closed: Boolean,
+        ): LeaderAuditExportSnapshot = LeaderAuditExportSnapshot(
+            queued = queued,
+            inFlight = inFlight,
+            scheduledRetries = scheduledRetries,
+            admitted = admitted,
+            accepted = accepted,
+            droppedQueueFull = droppedQueueFull,
+            droppedClosed = droppedClosed,
+            retries = retries,
+            terminalFailures = terminalFailures,
+            cancellations = cancellations,
+            executorRejections = executorRejections,
+            schedulerRejections = schedulerRejections,
+            observerDrops = observerDrops,
+            observerRegistrationDrops = observerRegistrationDrops,
+            diagnosticsFatalErrors = diagnosticsFatalErrors,
+            diagnosticsClosed = diagnosticsClosed,
+            closed = closed,
+        )
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExporter.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExporter.kt
@@ -1,0 +1,59 @@
+package io.bluetape4k.leader.audit
+
+/**
+ * sanitized audit event를 bounded delivery pipeline에 제출하는 public exporter 계약입니다.
+ *
+ * `submit`은 delivery 완료를 기다리지 않으며, `ACCEPTED`는 admission만 의미합니다.
+ * queue가 가득 찼거나 exporter가 닫힌 경우에는 예외 대신 명시적인 drop 결과를 반환합니다.
+ */
+interface LeaderAuditExporter : AutoCloseable {
+
+    /** event를 bounded pipeline에 non-blocking admission합니다. */
+    fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult
+
+    /** 유한 lifecycle observation을 비동기로 받을 observer를 등록합니다. */
+    fun observe(observer: LeaderAuditExportObserver): AutoCloseable
+
+    /** 현재 exporter counter와 lifecycle의 O(1) snapshot을 반환합니다. */
+    fun snapshot(): LeaderAuditExportSnapshot
+
+    /** exporter를 idempotently 닫고 queued/retry/in-flight work를 취소합니다. */
+    override fun close()
+}
+
+/**
+ * exporter admission 결과입니다.
+ */
+enum class LeaderAuditSubmitResult {
+    /** work가 pipeline permit을 획득했습니다. delivery 성공을 의미하지 않습니다. */
+    ACCEPTED,
+
+    /** bounded admission capacity가 소진되었습니다. */
+    DROPPED_QUEUE_FULL,
+
+    /** exporter가 닫힌 뒤 제출되었습니다. */
+    DROPPED_CLOSED,
+}
+
+/**
+ * exporter lifecycle을 외부에 전달하는 유한 observation 종류입니다.
+ */
+enum class LeaderAuditExportObservation {
+    ACCEPTED,
+    DROPPED_QUEUE_FULL,
+    DROPPED_CLOSED,
+    RETRY,
+    TERMINAL_FAILURE,
+    CANCELLED,
+    EXECUTOR_REJECTED,
+    SCHEDULER_REJECTED,
+}
+
+/**
+ * delivery/admission lifecycle을 비동기로 받는 callback입니다.
+ */
+fun interface LeaderAuditExportObserver {
+
+    /** observer callback입니다. 일반 `Exception`은 exporter가 격리합니다. */
+    fun onObservation(observation: LeaderAuditExportObservation)
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditLifecycleOutcome.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditLifecycleOutcome.kt
@@ -1,0 +1,17 @@
+package io.bluetape4k.leader.audit
+
+/**
+ * leader election lifecycle event의 외부 관찰 결과입니다.
+ *
+ * 이 값은 선출, 회수, contention에 따른 skip을 low-cardinality 상태로 표현합니다.
+ */
+enum class LeaderAuditLifecycleOutcome {
+    /** leadership을 획득했습니다. */
+    ELECTED,
+
+    /** 기존 leadership이 회수되었습니다. */
+    REVOKED,
+
+    /** contention으로 leadership 획득을 건너뛰었습니다. */
+    SKIPPED,
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditValueSanitizer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditValueSanitizer.kt
@@ -28,7 +28,7 @@ sealed interface LeaderAuditValueSanitizer {
      */
     data object Default : LeaderAuditValueSanitizer {
         override fun sanitize(field: LeaderAuditField, value: String): String =
-            if (field == LeaderAuditField.KIND) value else REDACTED
+            if (field == LeaderAuditField.KIND) value else AUDIT_REDACTED
     }
 
     /**
@@ -81,17 +81,9 @@ sealed interface LeaderAuditValueSanitizer {
             return value.truncateUtf8(maxBytes)
         }
 
-        /**
-         * Java/Kotlin 호출자가 원본 set mutation으로 정책을 변경하지 못하도록 복사본을 반환합니다.
-         */
-        val allowList: Set<LeaderAuditField>
-            get() = copiedAllowList
     }
 
     companion object {
-        /** 기본 redaction 결과입니다. */
-        const val REDACTED: String = "redacted"
-
         /** v1에서 raw export를 허용하는 field의 고정 목록입니다. */
         val RAW_ALLOWED_FIELDS: Set<LeaderAuditField> =
             Collections.unmodifiableSet(setOf(LeaderAuditField.KIND))
@@ -124,3 +116,4 @@ private fun sha256Hex(value: String): String {
 private const val NIBBLE_SHIFT = 4
 private const val NIBBLE_MASK = 0x0f
 private const val HEX_DIGITS = "0123456789abcdef"
+private const val AUDIT_REDACTED = "redacted"

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditValueSanitizer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditValueSanitizer.kt
@@ -1,0 +1,126 @@
+package io.bluetape4k.leader.audit
+
+import io.bluetape4k.support.truncateUtf8
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.Collections
+
+/**
+ * audit event의 문자열 field를 안전한 외부 표현으로 변환하는 정책입니다.
+ *
+ * 임의 lambda를 공개하지 않고 제한된 정책만 제공하여 token, credential, raw
+ * high-cardinality 값을 실수로 export하는 경계를 고정합니다.
+ */
+sealed interface LeaderAuditValueSanitizer {
+
+    /**
+     * field의 값을 정책에 따라 변환합니다.
+     *
+     * @param field 변환 대상 field입니다.
+     * @param value 원본 문자열입니다.
+     * @return 정책이 허용하는 외부 표현입니다.
+     */
+    fun sanitize(field: LeaderAuditField, value: String): String
+
+    /**
+     * 기본 redaction 정책입니다. `KIND`만 low-cardinality 값으로 유지하고 나머지는
+     * 고정된 문자열로 치환합니다.
+     */
+    data object Default : LeaderAuditValueSanitizer {
+        override fun sanitize(field: LeaderAuditField, value: String): String =
+            if (field == LeaderAuditField.KIND) value else REDACTED
+    }
+
+    /**
+     * SHA-256 hex digest로 값을 변환하는 명시적 opt-in 정책입니다.
+     */
+    data object Hash : LeaderAuditValueSanitizer {
+        override fun sanitize(field: LeaderAuditField, value: String): String =
+            sha256Hex(value)
+    }
+
+    /**
+     * 원본의 UTF-8 byte 길이를 제한하는 명시적 opt-in 정책입니다.
+     *
+     * code point 경계에서만 자르므로 잘못된 UTF-8 surrogate를 만들지 않습니다.
+     */
+    data class Truncate(val maxBytes: Int) : LeaderAuditValueSanitizer {
+        init {
+            require(maxBytes > 0) { "maxBytes must be positive: $maxBytes" }
+        }
+
+        override fun sanitize(field: LeaderAuditField, value: String): String =
+            value.truncateUtf8(maxBytes)
+    }
+
+    /**
+     * 명시적으로 허용한 field에만 원본을 유지하는 정책입니다.
+     *
+     * 현재 v1에서는 low-cardinality `KIND`만 raw export를 허용합니다. 허용 목록과
+     * byte 상한은 생성 시 defensive copy되며, 다른 field를 요청하면 실패합니다.
+     */
+    class Raw(
+        allowList: Set<LeaderAuditField>,
+        val maxBytes: Int,
+    ) : LeaderAuditValueSanitizer {
+        private val copiedAllowList: Set<LeaderAuditField>
+
+        init {
+            require(allowList.isNotEmpty()) { "allowList must not be empty" }
+            require(allowList.all { it in RAW_ALLOWED_FIELDS }) {
+                "Raw export is only allowed for $RAW_ALLOWED_FIELDS: $allowList"
+            }
+            require(maxBytes > 0) { "maxBytes must be positive: $maxBytes" }
+            copiedAllowList = Collections.unmodifiableSet(allowList.toSet())
+        }
+
+        override fun sanitize(field: LeaderAuditField, value: String): String {
+            require(field in copiedAllowList) {
+                "Raw export is not allowed for field=$field; allowList=$copiedAllowList"
+            }
+            return value.truncateUtf8(maxBytes)
+        }
+
+        /**
+         * Java/Kotlin 호출자가 원본 set mutation으로 정책을 변경하지 못하도록 복사본을 반환합니다.
+         */
+        val allowList: Set<LeaderAuditField>
+            get() = copiedAllowList
+    }
+
+    companion object {
+        /** 기본 redaction 결과입니다. */
+        const val REDACTED: String = "redacted"
+
+        /** v1에서 raw export를 허용하는 field의 고정 목록입니다. */
+        val RAW_ALLOWED_FIELDS: Set<LeaderAuditField> =
+            Collections.unmodifiableSet(setOf(LeaderAuditField.KIND))
+    }
+}
+
+/** audit event 문자열 field의 종류입니다. */
+enum class LeaderAuditField {
+    LOCK_NAME,
+    KIND,
+    NODE_ID,
+    SLOT_ID,
+    LEADER_ID,
+    ERROR_TYPE,
+    ERROR_MESSAGE,
+    ATTRIBUTE_KEY,
+    ATTRIBUTE_VALUE,
+}
+
+private fun sha256Hex(value: String): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(value.toByteArray(StandardCharsets.UTF_8))
+    return buildString(digest.size * 2) {
+        digest.forEach { byte ->
+            append(HEX_DIGITS[(byte.toInt() ushr NIBBLE_SHIFT) and NIBBLE_MASK])
+            append(HEX_DIGITS[byte.toInt() and NIBBLE_MASK])
+        }
+    }
+}
+
+private const val NIBBLE_SHIFT = 4
+private const val NIBBLE_MASK = 0x0f
+private const val HEX_DIGITS = "0123456789abcdef"

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderElectionEventExportSubscription.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderElectionEventExportSubscription.kt
@@ -1,0 +1,69 @@
+package io.bluetape4k.leader.audit
+
+import io.bluetape4k.leader.LeaderElectionEvent
+import io.bluetape4k.leader.LeaderElectionEventPublisher
+import kotlinx.coroutines.CoroutineScope
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
+import java.util.function.Consumer
+
+/**
+ * `LeaderElectionEventPublisher` lifecycle event를 exporter에 연결하는 closeable subscription입니다.
+ *
+ * callback admission과 `close()`는 하나의 lock으로 선형화합니다. close가 반환된 뒤에는
+ * 새 lifecycle submit이 시작되지 않으며, close 직전에 lock을 획득한 callback 하나는
+ * crossing allowance로 완료할 수 있습니다. exporter의 drop 결과는 publisher event의
+ * 의미나 upstream scope를 변경하지 않습니다.
+ */
+class LeaderElectionEventExportSubscription private constructor(
+    private val exporter: LeaderAuditExporter,
+    private val sanitizer: LeaderAuditValueSanitizer,
+    private val attributes: Map<String, String>,
+) : AutoCloseable {
+
+    private val gate = ReentrantLock()
+    private val closed = AtomicBoolean(false)
+    private var upstream: AutoCloseable? = null
+
+    /** publisher를 구독하고 subscription handle을 반환합니다. */
+    constructor(
+        publisher: LeaderElectionEventPublisher,
+        scope: CoroutineScope,
+        exporter: LeaderAuditExporter,
+    ) : this(publisher, scope, exporter, emptyMap(), LeaderAuditValueSanitizer.Default)
+
+    /** 지정한 attributes와 redaction 정책으로 publisher를 구독합니다. */
+    constructor(
+        publisher: LeaderElectionEventPublisher,
+        scope: CoroutineScope,
+        exporter: LeaderAuditExporter,
+        attributes: Map<String, String>,
+        sanitizer: LeaderAuditValueSanitizer,
+    ) : this(exporter, sanitizer, attributes.toMap()) {
+        upstream = publisher.onEvent(
+            scope,
+            Consumer { event -> submitIfOpen(event) },
+        )
+    }
+
+    override fun close() {
+        gate.lock()
+        try {
+            if (!closed.compareAndSet(false, true)) return
+            upstream?.close()
+            upstream = null
+        } finally {
+            gate.unlock()
+        }
+    }
+
+    private fun submitIfOpen(event: LeaderElectionEvent) {
+        gate.lock()
+        try {
+            if (closed.get()) return
+            exporter.submit(LeaderAuditExportEvent.Lifecycle.from(event, attributes, sanitizer))
+        } finally {
+            gate.unlock()
+        }
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
@@ -19,6 +19,8 @@ import io.bluetape4k.leader.audit.LeaderAuditExportOptions
 import io.bluetape4k.leader.audit.LeaderAuditExportSnapshot
 import io.bluetape4k.leader.audit.LeaderAuditExporter
 import io.bluetape4k.leader.audit.LeaderAuditSubmitResult
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
 import java.time.Duration
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
@@ -75,6 +77,9 @@ internal class BoundedLeaderAuditExporter(
     private val observerDrops = AtomicLong()
     private val observerRegistrationDrops = AtomicLong()
     private val diagnosticsFatalErrors = AtomicLong()
+    private val schedulingLock = ReentrantLock()
+    private val schedulingComplete = schedulingLock.newCondition()
+    private var schedulingCalls: Int = 0
 
     override fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult {
         if (!admissionLock.tryLock()) {
@@ -163,6 +168,7 @@ internal class BoundedLeaderAuditExporter(
             admissionLock.unlock()
         }
 
+        awaitSchedulingQuiescence()
         active.toList().forEach(::cancelWork)
 
         diagnosticsLock.lock()
@@ -185,8 +191,12 @@ internal class BoundedLeaderAuditExporter(
     }
 
     private fun tryStartWorker() {
-        if (closed.get() && worker.isEmpty()) return
+        if (closed.get()) return
         if (!workerRunning.compareAndSet(false, true)) return
+        if (!beginScheduling()) {
+            workerRunning.set(false)
+            return
+        }
         try {
             options.executor.execute(::runWorker)
         } catch (e: RejectedExecutionException) {
@@ -196,10 +206,13 @@ internal class BoundedLeaderAuditExporter(
             workerRunning.set(false)
             terminalizeQueued(LeaderAuditExportObservation.EXECUTOR_REJECTED)
             throw e
+        } finally {
+            endScheduling()
         }
     }
 
     private fun runWorker() {
+        var waitingForInFlight = false
         try {
             while (true) {
                 val item = worker.poll() ?: break
@@ -212,13 +225,16 @@ internal class BoundedLeaderAuditExporter(
                 if (!reserveInFlight()) {
                     worker.offer(item)
                     queued.incrementAndGet()
+                    waitingForInFlight = true
                     break
                 }
                 startAttempt(item)
             }
         } finally {
             workerRunning.set(false)
-            if (worker.isNotEmpty() && !closed.get()) tryStartWorker()
+            if (shouldRestartWorker(waitingForInFlight)) {
+                tryStartWorker()
+            }
         }
     }
 
@@ -240,6 +256,11 @@ internal class BoundedLeaderAuditExporter(
         val attempt = Attempt(item.attempts + 1)
         item.attempts = attempt.number
         item.currentAttempt = attempt
+        if (!beginScheduling()) {
+            releaseAttempt(item, attempt)
+            finishWork(item, LeaderAuditExportObservation.CANCELLED)
+            return
+        }
         try {
             attempt.timeout = options.scheduler.schedule(
                 { timeout(item, attempt) },
@@ -248,9 +269,10 @@ internal class BoundedLeaderAuditExporter(
             )
         } catch (e: RejectedExecutionException) {
             releaseAttempt(item, attempt)
-            schedulerRejections.incrementAndGet()
             finishWork(item, LeaderAuditExportObservation.SCHEDULER_REJECTED)
             return
+        } finally {
+            endScheduling()
         }
 
         val future = try {
@@ -345,6 +367,13 @@ internal class BoundedLeaderAuditExporter(
         item.retryClaimed.set(false)
         scheduledRetries.incrementAndGet()
         val delay = saturatingBackoff(options.initialBackoffNanos, item.attempts)
+        if (!beginScheduling()) {
+            if (item.retryClaimed.compareAndSet(false, true)) {
+                scheduledRetries.decrementAndGet()
+                finishWork(item, LeaderAuditExportObservation.CANCELLED)
+            }
+            return
+        }
         try {
             item.retry = options.scheduler.schedule(
                 {
@@ -365,9 +394,10 @@ internal class BoundedLeaderAuditExporter(
         } catch (e: RejectedExecutionException) {
             if (item.retryClaimed.compareAndSet(false, true)) {
                 scheduledRetries.decrementAndGet()
-                schedulerRejections.incrementAndGet()
                 finishWork(item, LeaderAuditExportObservation.SCHEDULER_REJECTED)
             }
+        } finally {
+            endScheduling()
         }
     }
 
@@ -483,7 +513,7 @@ internal class BoundedLeaderAuditExporter(
             }
             diagnosticsQueued.decrementAndGet()
             val reserved = diagnosticsLock.withLockIfAvailable {
-                if (work.slot.active.get()) {
+                if (!diagnosticsClosed.get() && work.slot.active.get()) {
                     work.slot.running.incrementAndGet()
                     true
                 } else {
@@ -495,6 +525,9 @@ internal class BoundedLeaderAuditExporter(
                 work.slot.observer.onObservation(work.observation)
             } catch (e: Exception) {
                 // observer failures are isolated from admission and delivery.
+                BoundedLeaderAuditExporterLogger.log.warn {
+                    "Leader audit observer failed and was isolated"
+                }
             } catch (e: Error) {
                 diagnosticsFatalErrors.incrementAndGet()
                 diagnosticsLock.lock()
@@ -562,7 +595,47 @@ internal class BoundedLeaderAuditExporter(
         const val MAX_DIAGNOSTICS_CAPACITY: Int = 1024
         const val MAX_OBSERVERS: Int = 16
     }
+
+    private fun beginScheduling(): Boolean {
+        schedulingLock.lock()
+        return try {
+            if (closed.get()) {
+                false
+            } else {
+                schedulingCalls++
+                true
+            }
+        } finally {
+            schedulingLock.unlock()
+        }
+    }
+
+    private fun endScheduling() {
+        schedulingLock.lock()
+        try {
+            schedulingCalls--
+            if (schedulingCalls == 0) schedulingComplete.signalAll()
+        } finally {
+            schedulingLock.unlock()
+        }
+    }
+
+    private fun awaitSchedulingQuiescence() {
+        schedulingLock.lock()
+        try {
+            while (schedulingCalls > 0) schedulingComplete.awaitUninterruptibly()
+        } finally {
+            schedulingLock.unlock()
+        }
+    }
+
+    private fun shouldRestartWorker(waitingForInFlight: Boolean): Boolean {
+        if (worker.isEmpty() || closed.get()) return false
+        return !waitingForInFlight || inFlight.get() < options.maxInFlight
+    }
 }
+
+private object BoundedLeaderAuditExporterLogger : KLogging()
 
 private inline fun <T> ReentrantLock.withLockIfAvailable(block: () -> T): T {
     lock()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
@@ -66,6 +66,7 @@ internal class BoundedLeaderAuditExporter(
     )
 
     private val admissionLock = ReentrantLock()
+    private val workerDispatchLock = ReentrantLock()
     private val diagnosticsLock = ReentrantLock()
     private val closed = AtomicBoolean(false)
     private val diagnosticsClosed = AtomicBoolean(false)
@@ -178,8 +179,13 @@ internal class BoundedLeaderAuditExporter(
             admissionLock.lock()
         }
         try {
-            if (closed.getAndSet(true)) return
-            drainQueued(LeaderAuditExportObservation.CANCELLED)
+            workerDispatchLock.lock()
+            try {
+                if (closed.getAndSet(true)) return
+                drainQueued(LeaderAuditExportObservation.CANCELLED)
+            } finally {
+                workerDispatchLock.unlock()
+            }
         } finally {
             admissionLock.unlock()
         }
@@ -223,6 +229,16 @@ internal class BoundedLeaderAuditExporter(
         Thread.ofVirtual()
             .name("bluetape4k-leader-audit-worker-dispatch")
             .start {
+                workerDispatchLock.lock()
+                val handoffAllowed = try {
+                    !closed.get()
+                } finally {
+                    workerDispatchLock.unlock()
+                }
+                if (!handoffAllowed) {
+                    workerRunning.set(false)
+                    return@start
+                }
                 try {
                     options.executor.execute(::runWorker)
                 } catch (e: RejectedExecutionException) {
@@ -485,15 +501,10 @@ internal class BoundedLeaderAuditExporter(
             item.retry = null
         }
         val attempt = item.currentAttempt
-        if (attempt != null) {
-            val future = attempt.future
-            if (!attempt.deliveryStarted.get() || future != null) {
-                if (attempt.done.compareAndSet(false, true)) {
-                    attempt.timeout?.cancel(false)
-                    future?.cancel(true)
-                    releaseAttempt(item, attempt)
-                }
-            }
+        if (attempt != null && attempt.done.compareAndSet(false, true)) {
+            attempt.timeout?.cancel(false)
+            attempt.future?.cancel(true)
+            releaseAttempt(item, attempt)
         }
         finishWork(item, LeaderAuditExportObservation.CANCELLED)
     }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
@@ -19,9 +19,6 @@ import io.bluetape4k.leader.audit.LeaderAuditExportOptions
 import io.bluetape4k.leader.audit.LeaderAuditExportSnapshot
 import io.bluetape4k.leader.audit.LeaderAuditExporter
 import io.bluetape4k.leader.audit.LeaderAuditSubmitResult
-import io.bluetape4k.leader.audit.MAX_ATTEMPT_TIMEOUT_NANOS
-import io.bluetape4k.leader.audit.MAX_BACKOFF_NANOS
-import io.bluetape4k.leader.audit.toAuditPositiveNanos
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
 import java.time.Duration
@@ -52,25 +49,25 @@ internal class BoundedLeaderAuditExporter(
     private val options: LeaderAuditExportOptions,
 ) : LeaderAuditExporter {
 
-    private val attemptTimeoutNanos = options.attemptTimeout.toAuditPositiveNanos(
+    private val attemptTimeoutNanos = options.attemptTimeout.toBoundedPositiveNanos(
         "attemptTimeout",
-        MAX_ATTEMPT_TIMEOUT_NANOS,
+        MAX_ATTEMPT_TIMEOUT,
     )
-    private val initialBackoffNanos = options.initialBackoff.toAuditPositiveNanos(
+    private val initialBackoffNanos = options.initialBackoff.toBoundedPositiveNanos(
         "initialBackoff",
-        MAX_BACKOFF_NANOS,
+        MAX_BACKOFF,
     )
-    private val maxBackoffNanos = options.maxBackoff.toAuditPositiveNanos(
+    private val maxBackoffNanos = options.maxBackoff.toBoundedPositiveNanos(
         "maxBackoff",
-        MAX_BACKOFF_NANOS,
+        MAX_BACKOFF,
     )
 
     private val admissionLock = ReentrantLock()
-    private val workerDispatchLock = ReentrantLock()
     private val diagnosticsLock = ReentrantLock()
     private val closed = AtomicBoolean(false)
     private val diagnosticsClosed = AtomicBoolean(false)
     private val workerRunning = AtomicBoolean(false)
+    private val workerHandoffState = AtomicReference(WorkerHandoffState.IDLE)
     private val worker = ConcurrentLinkedQueue<WorkItem>()
     private val active = ConcurrentHashMap.newKeySet<WorkItem>()
     private val diagnostics = ConcurrentLinkedQueue<ObservationWork>()
@@ -179,13 +176,8 @@ internal class BoundedLeaderAuditExporter(
             admissionLock.lock()
         }
         try {
-            workerDispatchLock.lock()
-            try {
-                if (closed.getAndSet(true)) return
-                drainQueued(LeaderAuditExportObservation.CANCELLED)
-            } finally {
-                workerDispatchLock.unlock()
-            }
+            if (!claimCloseHandoff()) return
+            drainQueued(LeaderAuditExportObservation.CANCELLED)
         } finally {
             admissionLock.unlock()
         }
@@ -229,17 +221,14 @@ internal class BoundedLeaderAuditExporter(
         Thread.ofVirtual()
             .name("bluetape4k-leader-audit-worker-dispatch")
             .start {
-                workerDispatchLock.lock()
-                val handoffAllowed = try {
-                    !closed.get()
-                } finally {
-                    workerDispatchLock.unlock()
-                }
-                if (!handoffAllowed) {
+                if (!workerHandoffState.compareAndSet(WorkerHandoffState.IDLE, WorkerHandoffState.CLAIMED)) {
                     workerRunning.set(false)
                     return@start
                 }
                 try {
+                    // This CAS is the execute handoff linearization point. close() wins
+                    // with IDLE -> CLOSED, or observes CLAIMED and allows this crossing
+                    // without waiting for the caller-owned executor or delivery.
                     options.executor.execute(::runWorker)
                 } catch (e: RejectedExecutionException) {
                     workerRunning.set(false)
@@ -248,8 +237,32 @@ internal class BoundedLeaderAuditExporter(
                     workerRunning.set(false)
                     terminalizeQueued(LeaderAuditExportObservation.EXECUTOR_REJECTED)
                     throw e
+                } finally {
+                    if (!closed.get()) {
+                        workerHandoffState.compareAndSet(WorkerHandoffState.CLAIMED, WorkerHandoffState.IDLE)
+                    }
                 }
             }
+    }
+
+    private fun claimCloseHandoff(): Boolean {
+        while (true) {
+            when (workerHandoffState.get()) {
+                WorkerHandoffState.IDLE -> {
+                    if (workerHandoffState.compareAndSet(WorkerHandoffState.IDLE, WorkerHandoffState.CLOSED)) {
+                        closed.set(true)
+                        return true
+                    }
+                }
+
+                WorkerHandoffState.CLAIMED -> {
+                    if (closed.compareAndSet(false, true)) return true
+                    return false
+                }
+
+                WorkerHandoffState.CLOSED -> return false
+            }
+        }
     }
 
     private fun runWorker() {
@@ -323,7 +336,7 @@ internal class BoundedLeaderAuditExporter(
         val future = try {
             delivery.deliver(item.event)
         } catch (e: Throwable) {
-            attempt.done.set(true)
+            if (!attempt.done.compareAndSet(false, true)) return
             attempt.timeout?.cancel(false)
             releaseAttempt(item, attempt)
             if (e is Error) {
@@ -661,6 +674,12 @@ internal class BoundedLeaderAuditExporter(
         @Volatile var timeout: ScheduledFuture<*>? = null
     }
 
+    private enum class WorkerHandoffState {
+        IDLE,
+        CLAIMED,
+        CLOSED,
+    }
+
     private class ObserverSlot(val observer: LeaderAuditExportObserver) {
         val active = AtomicBoolean(true)
         val running = AtomicInteger()
@@ -678,6 +697,8 @@ internal class BoundedLeaderAuditExporter(
     private companion object {
         const val MAX_DIAGNOSTICS_CAPACITY: Int = 1024
         const val MAX_OBSERVERS: Int = 16
+        val MAX_ATTEMPT_TIMEOUT: Duration = Duration.ofMinutes(5)
+        val MAX_BACKOFF: Duration = Duration.ofMinutes(1)
     }
 
     private fun beginScheduling(): Boolean {
@@ -720,6 +741,19 @@ internal class BoundedLeaderAuditExporter(
 }
 
 private object BoundedLeaderAuditExporterLogger : KLogging()
+
+private fun Duration.toBoundedPositiveNanos(name: String, maximum: Duration): Long {
+    require(!isZero && !isNegative) { "$name must be positive: $this" }
+    val nanos = try {
+        toNanos()
+    } catch (e: ArithmeticException) {
+        throw IllegalArgumentException("$name does not fit in nanoseconds: $this", e)
+    }
+    require(nanos > 0) { "$name must be positive: $this" }
+    val maximumNanos = maximum.toNanos()
+    require(nanos <= maximumNanos) { "$name must be <= $maximum: $this" }
+    return nanos
+}
 
 private inline fun <T> ReentrantLock.withLockIfAvailable(block: () -> T): T {
     lock()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
@@ -223,10 +223,6 @@ internal class BoundedLeaderAuditExporter(
         Thread.ofVirtual()
             .name("bluetape4k-leader-audit-worker-dispatch")
             .start {
-                if (!beginScheduling()) {
-                    workerRunning.set(false)
-                    return@start
-                }
                 try {
                     options.executor.execute(::runWorker)
                 } catch (e: RejectedExecutionException) {
@@ -236,8 +232,6 @@ internal class BoundedLeaderAuditExporter(
                     workerRunning.set(false)
                     terminalizeQueued(LeaderAuditExportObservation.EXECUTOR_REJECTED)
                     throw e
-                } finally {
-                    endScheduling()
                 }
             }
     }
@@ -324,7 +318,13 @@ internal class BoundedLeaderAuditExporter(
             return
         }
         attempt.future = future
-        if (attempt.done.get()) {
+        if (attempt.done.get() || closed.get()) {
+            if (attempt.done.compareAndSet(false, true)) {
+                attempt.timeout?.cancel(false)
+                future.cancel(true)
+                releaseAttempt(item, attempt)
+                finishWork(item, LeaderAuditExportObservation.CANCELLED)
+            }
             future.cancel(true)
             return
         }
@@ -367,6 +367,7 @@ internal class BoundedLeaderAuditExporter(
         admissionLock.lock()
         return try {
             if (!closed.get() && !attempt.done.get()) {
+                attempt.deliveryStarted.set(true)
                 true
             } else {
                 if (attempt.done.compareAndSet(false, true)) {
@@ -484,10 +485,15 @@ internal class BoundedLeaderAuditExporter(
             item.retry = null
         }
         val attempt = item.currentAttempt
-        if (attempt != null && attempt.done.compareAndSet(false, true)) {
-            attempt.timeout?.cancel(false)
-            attempt.future?.cancel(true)
-            releaseAttempt(item, attempt)
+        if (attempt != null) {
+            val future = attempt.future
+            if (!attempt.deliveryStarted.get() || future != null) {
+                if (attempt.done.compareAndSet(false, true)) {
+                    attempt.timeout?.cancel(false)
+                    future?.cancel(true)
+                    releaseAttempt(item, attempt)
+                }
+            }
         }
         finishWork(item, LeaderAuditExportObservation.CANCELLED)
     }
@@ -639,6 +645,7 @@ internal class BoundedLeaderAuditExporter(
 
     private class Attempt(val number: Int) {
         val done = AtomicBoolean(false)
+        val deliveryStarted = AtomicBoolean(false)
         @Volatile var future: CompletableFuture<LeaderAuditDeliveryResult>? = null
         @Volatile var timeout: ScheduledFuture<*>? = null
     }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
@@ -1,5 +1,6 @@
 @file:Suppress(
     "LoopWithTooManyJumpStatements",
+    "LargeClass",
     "MagicNumber",
     "ReturnCount",
     "SwallowedException",
@@ -67,6 +68,7 @@ internal class BoundedLeaderAuditExporter(
     private val closed = AtomicBoolean(false)
     private val diagnosticsClosed = AtomicBoolean(false)
     private val workerRunning = AtomicBoolean(false)
+    private val workerRestartRequested = AtomicBoolean(false)
     private val workerHandoffState = AtomicReference(WorkerHandoffState.IDLE)
     private val worker = ConcurrentLinkedQueue<WorkItem>()
     private val active = ConcurrentHashMap.newKeySet<WorkItem>()
@@ -223,12 +225,18 @@ internal class BoundedLeaderAuditExporter(
             .start {
                 if (!workerHandoffState.compareAndSet(WorkerHandoffState.IDLE, WorkerHandoffState.CLAIMED)) {
                     workerRunning.set(false)
+                    if (!closed.get()) workerRestartRequested.set(true)
+                    return@start
+                }
+                if (!workerHandoffState.compareAndSet(WorkerHandoffState.CLAIMED, WorkerHandoffState.EXECUTING)) {
+                    workerRunning.set(false)
                     return@start
                 }
                 try {
-                    // This CAS is the execute handoff linearization point. close() wins
-                    // with IDLE -> CLOSED, or observes CLAIMED and allows this crossing
-                    // without waiting for the caller-owned executor or delivery.
+                    // CLAIMED -> EXECUTING is the execute handoff linearization point.
+                    // close() can cancel a claimed-but-not-started dispatch, while an
+                    // executing handoff is allowed to cross close without waiting for the
+                    // caller-owned executor or delivery.
                     options.executor.execute(::runWorker)
                 } catch (e: RejectedExecutionException) {
                     workerRunning.set(false)
@@ -238,8 +246,10 @@ internal class BoundedLeaderAuditExporter(
                     terminalizeQueued(LeaderAuditExportObservation.EXECUTOR_REJECTED)
                     throw e
                 } finally {
-                    if (!closed.get()) {
-                        workerHandoffState.compareAndSet(WorkerHandoffState.CLAIMED, WorkerHandoffState.IDLE)
+                    if (!closed.get() &&
+                        workerHandoffState.compareAndSet(WorkerHandoffState.EXECUTING, WorkerHandoffState.IDLE)
+                    ) {
+                        if (workerRestartRequested.getAndSet(false)) tryStartWorker()
                     }
                 }
             }
@@ -256,6 +266,13 @@ internal class BoundedLeaderAuditExporter(
                 }
 
                 WorkerHandoffState.CLAIMED -> {
+                    if (workerHandoffState.compareAndSet(WorkerHandoffState.CLAIMED, WorkerHandoffState.CLOSED)) {
+                        closed.set(true)
+                        return true
+                    }
+                }
+
+                WorkerHandoffState.EXECUTING -> {
                     if (closed.compareAndSet(false, true)) return true
                     return false
                 }
@@ -677,6 +694,7 @@ internal class BoundedLeaderAuditExporter(
     private enum class WorkerHandoffState {
         IDLE,
         CLAIMED,
+        EXECUTING,
         CLOSED,
     }
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
@@ -19,6 +19,9 @@ import io.bluetape4k.leader.audit.LeaderAuditExportOptions
 import io.bluetape4k.leader.audit.LeaderAuditExportSnapshot
 import io.bluetape4k.leader.audit.LeaderAuditExporter
 import io.bluetape4k.leader.audit.LeaderAuditSubmitResult
+import io.bluetape4k.leader.audit.MAX_ATTEMPT_TIMEOUT_NANOS
+import io.bluetape4k.leader.audit.MAX_BACKOFF_NANOS
+import io.bluetape4k.leader.audit.toAuditPositiveNanos
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
 import java.time.Duration
@@ -48,6 +51,19 @@ internal class BoundedLeaderAuditExporter(
     private val delivery: LeaderAuditDelivery,
     private val options: LeaderAuditExportOptions,
 ) : LeaderAuditExporter {
+
+    private val attemptTimeoutNanos = options.attemptTimeout.toAuditPositiveNanos(
+        "attemptTimeout",
+        MAX_ATTEMPT_TIMEOUT_NANOS,
+    )
+    private val initialBackoffNanos = options.initialBackoff.toAuditPositiveNanos(
+        "initialBackoff",
+        MAX_BACKOFF_NANOS,
+    )
+    private val maxBackoffNanos = options.maxBackoff.toAuditPositiveNanos(
+        "maxBackoff",
+        MAX_BACKOFF_NANOS,
+    )
 
     private val admissionLock = ReentrantLock()
     private val diagnosticsLock = ReentrantLock()
@@ -169,7 +185,15 @@ internal class BoundedLeaderAuditExporter(
         }
 
         awaitSchedulingQuiescence()
-        active.toList().forEach(::cancelWork)
+        // Serialize cancellation with the short attempt-start gate. This prevents a
+        // timeout/close crossing from admitting a delivery after the exporter has
+        // already published CLOSED.
+        admissionLock.lock()
+        try {
+            active.toList().forEach(::cancelWork)
+        } finally {
+            admissionLock.unlock()
+        }
 
         diagnosticsLock.lock()
         try {
@@ -193,22 +217,29 @@ internal class BoundedLeaderAuditExporter(
     private fun tryStartWorker() {
         if (closed.get()) return
         if (!workerRunning.compareAndSet(false, true)) return
-        if (!beginScheduling()) {
-            workerRunning.set(false)
-            return
-        }
-        try {
-            options.executor.execute(::runWorker)
-        } catch (e: RejectedExecutionException) {
-            workerRunning.set(false)
-            terminalizeQueued(LeaderAuditExportObservation.EXECUTOR_REJECTED)
-        } catch (e: Error) {
-            workerRunning.set(false)
-            terminalizeQueued(LeaderAuditExportObservation.EXECUTOR_REJECTED)
-            throw e
-        } finally {
-            endScheduling()
-        }
+        // An Executor is allowed to run inline. Invoke it from a dedicated virtual
+        // thread so submit() remains an admission-only, non-blocking boundary even
+        // with DirectExecutor/CallerRunsPolicy implementations.
+        Thread.ofVirtual()
+            .name("bluetape4k-leader-audit-worker-dispatch")
+            .start {
+                if (!beginScheduling()) {
+                    workerRunning.set(false)
+                    return@start
+                }
+                try {
+                    options.executor.execute(::runWorker)
+                } catch (e: RejectedExecutionException) {
+                    workerRunning.set(false)
+                    terminalizeQueued(LeaderAuditExportObservation.EXECUTOR_REJECTED)
+                } catch (e: Error) {
+                    workerRunning.set(false)
+                    terminalizeQueued(LeaderAuditExportObservation.EXECUTOR_REJECTED)
+                    throw e
+                } finally {
+                    endScheduling()
+                }
+            }
     }
 
     private fun runWorker() {
@@ -264,7 +295,7 @@ internal class BoundedLeaderAuditExporter(
         try {
             attempt.timeout = options.scheduler.schedule(
                 { timeout(item, attempt) },
-                options.attemptTimeoutNanos,
+                attemptTimeoutNanos,
                 TimeUnit.NANOSECONDS,
             )
         } catch (e: RejectedExecutionException) {
@@ -274,6 +305,10 @@ internal class BoundedLeaderAuditExporter(
         } finally {
             endScheduling()
         }
+
+        // Close and timeout may win while the attempt timeout is being installed.
+        // Re-check under the admission gate before invoking user delivery code.
+        if (!prepareAttemptDelivery(item, attempt)) return
 
         val future = try {
             delivery.deliver(item.event)
@@ -319,12 +354,30 @@ internal class BoundedLeaderAuditExporter(
         when {
             failure is Error -> {
                 finishWork(item, LeaderAuditExportObservation.TERMINAL_FAILURE)
-                throw failure
+                rethrowOnUncaughtBoundary(failure)
             }
             failure != null -> completeFailure(item, attempt, failure)
             result == LeaderAuditDeliveryResult.SUCCESS -> finishWork(item, null)
             result == LeaderAuditDeliveryResult.RETRYABLE_FAILURE -> retryOrFail(item)
             else -> finishWork(item, LeaderAuditExportObservation.TERMINAL_FAILURE)
+        }
+    }
+
+    private fun prepareAttemptDelivery(item: WorkItem, attempt: Attempt): Boolean {
+        admissionLock.lock()
+        return try {
+            if (!closed.get() && !attempt.done.get()) {
+                true
+            } else {
+                if (attempt.done.compareAndSet(false, true)) {
+                    attempt.timeout?.cancel(false)
+                    releaseAttempt(item, attempt)
+                    finishWork(item, LeaderAuditExportObservation.CANCELLED)
+                }
+                false
+            }
+        } finally {
+            admissionLock.unlock()
         }
     }
 
@@ -366,7 +419,7 @@ internal class BoundedLeaderAuditExporter(
         }
         item.retryClaimed.set(false)
         scheduledRetries.incrementAndGet()
-        val delay = saturatingBackoff(options.initialBackoffNanos, item.attempts)
+        val delay = saturatingBackoff(initialBackoffNanos, item.attempts)
         if (!beginScheduling()) {
             if (item.retryClaimed.compareAndSet(false, true)) {
                 scheduledRetries.decrementAndGet()
@@ -379,14 +432,21 @@ internal class BoundedLeaderAuditExporter(
                 {
                     if (!item.retryClaimed.compareAndSet(false, true)) return@schedule
                     scheduledRetries.decrementAndGet()
-                    item.retry = null
-                    if (closed.get()) {
-                        finishWork(item, LeaderAuditExportObservation.CANCELLED)
-                    } else {
-                        worker.offer(item)
-                        queued.incrementAndGet()
-                        tryStartWorker()
+                    var restart = false
+                    admissionLock.lock()
+                    try {
+                        item.retry = null
+                        if (closed.get() || item.terminalized.get()) {
+                            finishWork(item, LeaderAuditExportObservation.CANCELLED)
+                        } else {
+                            worker.offer(item)
+                            queued.incrementAndGet()
+                            restart = true
+                        }
+                    } finally {
+                        admissionLock.unlock()
                     }
+                    if (restart) tryStartWorker()
                 },
                 delay,
                 TimeUnit.NANOSECONDS,
@@ -404,10 +464,16 @@ internal class BoundedLeaderAuditExporter(
     private fun saturatingBackoff(initial: Long, attempt: Int): Long {
         var value = initial
         repeat((attempt - 1).coerceAtMost(62)) {
-            if (value >= options.maxBackoffNanos / 2) return options.maxBackoffNanos
+            if (value >= maxBackoffNanos / 2) return maxBackoffNanos
             value *= 2
         }
-        return min(value, options.maxBackoffNanos)
+        return min(value, maxBackoffNanos)
+    }
+
+    private fun rethrowOnUncaughtBoundary(error: Error) {
+        Thread.ofVirtual()
+            .name("bluetape4k-leader-audit-fatal")
+            .start { throw error }
     }
 
     private fun cancelWork(item: WorkItem) {

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
@@ -1,0 +1,574 @@
+@file:Suppress(
+    "LoopWithTooManyJumpStatements",
+    "MagicNumber",
+    "ReturnCount",
+    "SwallowedException",
+    "TooGenericExceptionCaught",
+    "TooManyFunctions",
+    "UnusedParameter",
+)
+
+package io.bluetape4k.leader.audit.internal
+
+import io.bluetape4k.leader.audit.LeaderAuditDelivery
+import io.bluetape4k.leader.audit.LeaderAuditDeliveryResult
+import io.bluetape4k.leader.audit.LeaderAuditExportEvent
+import io.bluetape4k.leader.audit.LeaderAuditExportObservation
+import io.bluetape4k.leader.audit.LeaderAuditExportObserver
+import io.bluetape4k.leader.audit.LeaderAuditExportOptions
+import io.bluetape4k.leader.audit.LeaderAuditExportSnapshot
+import io.bluetape4k.leader.audit.LeaderAuditExporter
+import io.bluetape4k.leader.audit.LeaderAuditSubmitResult
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executor
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.locks.LockSupport
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.math.min
+
+/**
+ * caller-owned executor/scheduler 위에서 bounded admission과 retry를 수행하는 core exporter입니다.
+ *
+ * 이 구현은 queue, in-flight, scheduled retry를 하나의 `admitted` permit으로 묶습니다.
+ * `submit`은 capacity를 기다리지 않고 즉시 결과를 반환하며, 외부 실행기를 종료하지 않습니다.
+ */
+internal class BoundedLeaderAuditExporter(
+    private val delivery: LeaderAuditDelivery,
+    private val options: LeaderAuditExportOptions,
+) : LeaderAuditExporter {
+
+    private val admissionLock = ReentrantLock()
+    private val diagnosticsLock = ReentrantLock()
+    private val closed = AtomicBoolean(false)
+    private val diagnosticsClosed = AtomicBoolean(false)
+    private val workerRunning = AtomicBoolean(false)
+    private val worker = ConcurrentLinkedQueue<WorkItem>()
+    private val active = ConcurrentHashMap.newKeySet<WorkItem>()
+    private val diagnostics = ConcurrentLinkedQueue<ObservationWork>()
+    private val observerSlots = LinkedHashSet<ObserverSlot>()
+    private val diagnosticsWorker = AtomicReference<Thread?>(null)
+    private val diagnosticsQueued = AtomicInteger()
+    private val diagnosticsCapacity = min(options.queueCapacity, MAX_DIAGNOSTICS_CAPACITY)
+
+    private val queued = AtomicInteger()
+    private val inFlight = AtomicInteger()
+    private val scheduledRetries = AtomicInteger()
+    private val admitted = AtomicInteger()
+    private val accepted = AtomicLong()
+    private val droppedQueueFull = AtomicLong()
+    private val droppedClosed = AtomicLong()
+    private val retries = AtomicLong()
+    private val terminalFailures = AtomicLong()
+    private val cancellations = AtomicLong()
+    private val executorRejections = AtomicLong()
+    private val schedulerRejections = AtomicLong()
+    private val observerDrops = AtomicLong()
+    private val observerRegistrationDrops = AtomicLong()
+    private val diagnosticsFatalErrors = AtomicLong()
+
+    override fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult {
+        if (!admissionLock.tryLock()) {
+            droppedQueueFull.incrementAndGet()
+            publish(LeaderAuditExportObservation.DROPPED_QUEUE_FULL)
+            return LeaderAuditSubmitResult.DROPPED_QUEUE_FULL
+        }
+
+        val item = try {
+            if (closed.get()) {
+                droppedClosed.incrementAndGet()
+                publish(LeaderAuditExportObservation.DROPPED_CLOSED)
+                return LeaderAuditSubmitResult.DROPPED_CLOSED
+            }
+            if (!reservePermit()) {
+                droppedQueueFull.incrementAndGet()
+                publish(LeaderAuditExportObservation.DROPPED_QUEUE_FULL)
+                return LeaderAuditSubmitResult.DROPPED_QUEUE_FULL
+            }
+            WorkItem(event).also {
+                active.add(it)
+                queued.incrementAndGet()
+                worker.offer(it)
+                accepted.incrementAndGet()
+                publish(LeaderAuditExportObservation.ACCEPTED)
+            }
+        } finally {
+            admissionLock.unlock()
+        }
+
+        tryStartWorker()
+        return if (item.terminalized.get()) {
+            // A concurrent close may have won immediately after admission. The admission itself
+            // remains ACCEPTED; terminal cancellation is observable separately.
+            LeaderAuditSubmitResult.ACCEPTED
+        } else {
+            LeaderAuditSubmitResult.ACCEPTED
+        }
+    }
+
+    override fun observe(observer: LeaderAuditExportObserver): AutoCloseable {
+        diagnosticsLock.lock()
+        try {
+            if (diagnosticsClosed.get() || observerSlots.size >= MAX_OBSERVERS) {
+                observerRegistrationDrops.incrementAndGet()
+                return NoopCloseable
+            }
+            val slot = ObserverSlot(observer)
+            observerSlots += slot
+            return AutoCloseable { closeObserver(slot) }
+        } finally {
+            diagnosticsLock.unlock()
+        }
+    }
+
+    override fun snapshot(): LeaderAuditExportSnapshot = LeaderAuditExportSnapshot.create(
+        queued = queued.get(),
+        inFlight = inFlight.get(),
+        scheduledRetries = scheduledRetries.get(),
+        admitted = admitted.get(),
+        accepted = accepted.get(),
+        droppedQueueFull = droppedQueueFull.get(),
+        droppedClosed = droppedClosed.get(),
+        retries = retries.get(),
+        terminalFailures = terminalFailures.get(),
+        cancellations = cancellations.get(),
+        executorRejections = executorRejections.get(),
+        schedulerRejections = schedulerRejections.get(),
+        observerDrops = observerDrops.get(),
+        observerRegistrationDrops = observerRegistrationDrops.get(),
+        diagnosticsFatalErrors = diagnosticsFatalErrors.get(),
+        diagnosticsClosed = diagnosticsClosed.get(),
+        closed = closed.get(),
+    )
+
+    override fun close() {
+        if (!admissionLock.tryLock()) {
+            // close is allowed to wait for the short admission critical section; submit never
+            // waits, preserving the hot-path non-blocking contract.
+            admissionLock.lock()
+        }
+        try {
+            if (closed.getAndSet(true)) return
+            drainQueued(LeaderAuditExportObservation.CANCELLED)
+        } finally {
+            admissionLock.unlock()
+        }
+
+        active.toList().forEach(::cancelWork)
+
+        diagnosticsLock.lock()
+        try {
+            diagnosticsClosed.set(true)
+            drainDiagnostics()
+        } finally {
+            diagnosticsLock.unlock()
+        }
+        diagnosticsWorker.get()?.let(LockSupport::unpark)
+        tryStartWorker()
+    }
+
+    private fun reservePermit(): Boolean {
+        while (true) {
+            val current = admitted.get()
+            if (current >= options.queueCapacity) return false
+            if (admitted.compareAndSet(current, current + 1)) return true
+        }
+    }
+
+    private fun tryStartWorker() {
+        if (closed.get() && worker.isEmpty()) return
+        if (!workerRunning.compareAndSet(false, true)) return
+        try {
+            options.executor.execute(::runWorker)
+        } catch (e: RejectedExecutionException) {
+            workerRunning.set(false)
+            terminalizeQueued(LeaderAuditExportObservation.EXECUTOR_REJECTED)
+        } catch (e: Error) {
+            workerRunning.set(false)
+            terminalizeQueued(LeaderAuditExportObservation.EXECUTOR_REJECTED)
+            throw e
+        }
+    }
+
+    private fun runWorker() {
+        try {
+            while (true) {
+                val item = worker.poll() ?: break
+                queued.decrementAndGet()
+                if (item.terminalized.get()) continue
+                if (closed.get()) {
+                    finishWork(item, LeaderAuditExportObservation.CANCELLED)
+                    continue
+                }
+                if (!reserveInFlight()) {
+                    worker.offer(item)
+                    queued.incrementAndGet()
+                    break
+                }
+                startAttempt(item)
+            }
+        } finally {
+            workerRunning.set(false)
+            if (worker.isNotEmpty() && !closed.get()) tryStartWorker()
+        }
+    }
+
+    private fun reserveInFlight(): Boolean {
+        while (true) {
+            val current = inFlight.get()
+            if (current >= options.maxInFlight) return false
+            if (inFlight.compareAndSet(current, current + 1)) return true
+        }
+    }
+
+    private fun startAttempt(item: WorkItem) {
+        if (closed.get()) {
+            releaseInFlight()
+            finishWork(item, LeaderAuditExportObservation.CANCELLED)
+            return
+        }
+
+        val attempt = Attempt(item.attempts + 1)
+        item.attempts = attempt.number
+        item.currentAttempt = attempt
+        try {
+            attempt.timeout = options.scheduler.schedule(
+                { timeout(item, attempt) },
+                options.attemptTimeoutNanos,
+                TimeUnit.NANOSECONDS,
+            )
+        } catch (e: RejectedExecutionException) {
+            releaseAttempt(item, attempt)
+            schedulerRejections.incrementAndGet()
+            finishWork(item, LeaderAuditExportObservation.SCHEDULER_REJECTED)
+            return
+        }
+
+        val future = try {
+            delivery.deliver(item.event)
+        } catch (e: Throwable) {
+            attempt.done.set(true)
+            attempt.timeout?.cancel(false)
+            releaseAttempt(item, attempt)
+            if (e is Error) {
+                finishWork(item, LeaderAuditExportObservation.TERMINAL_FAILURE)
+                throw e
+            }
+            completeFailure(item, attempt, e)
+            return
+        }
+        attempt.future = future
+        if (attempt.done.get()) {
+            future.cancel(true)
+            return
+        }
+        future.whenComplete { result, failure ->
+            complete(item, attempt, result, failure)
+        }
+    }
+
+    private fun complete(
+        item: WorkItem,
+        attempt: Attempt,
+        result: LeaderAuditDeliveryResult?,
+        failure: Throwable?,
+    ) {
+        if (!attempt.done.compareAndSet(false, true)) return
+        attempt.timeout?.cancel(false)
+        if (failure is java.util.concurrent.CancellationException) {
+            releaseAttempt(item, attempt)
+            finishWork(item, LeaderAuditExportObservation.CANCELLED)
+            return
+        }
+        releaseAttempt(item, attempt)
+        if (closed.get()) {
+            finishWork(item, LeaderAuditExportObservation.CANCELLED)
+            return
+        }
+        when {
+            failure is Error -> {
+                finishWork(item, LeaderAuditExportObservation.TERMINAL_FAILURE)
+                throw failure
+            }
+            failure != null -> completeFailure(item, attempt, failure)
+            result == LeaderAuditDeliveryResult.SUCCESS -> finishWork(item, null)
+            result == LeaderAuditDeliveryResult.RETRYABLE_FAILURE -> retryOrFail(item)
+            else -> finishWork(item, LeaderAuditExportObservation.TERMINAL_FAILURE)
+        }
+    }
+
+    private fun completeFailure(item: WorkItem, attempt: Attempt, failure: Throwable) {
+        if (failure is java.util.concurrent.CancellationException) {
+            finishWork(item, LeaderAuditExportObservation.CANCELLED)
+        } else {
+            retryOrFail(item)
+        }
+    }
+
+    private fun timeout(item: WorkItem, attempt: Attempt) {
+        if (!attempt.done.compareAndSet(false, true)) return
+        attempt.future?.cancel(true)
+        releaseAttempt(item, attempt)
+        if (closed.get()) {
+            finishWork(item, LeaderAuditExportObservation.CANCELLED)
+        } else {
+            retryOrFail(item)
+        }
+    }
+
+    private fun retryOrFail(item: WorkItem) {
+        if (closed.get()) {
+            finishWork(item, LeaderAuditExportObservation.CANCELLED)
+        } else if (item.attempts >= options.maxAttempts) {
+            finishWork(item, LeaderAuditExportObservation.TERMINAL_FAILURE)
+        } else {
+            retries.incrementAndGet()
+            publish(LeaderAuditExportObservation.RETRY)
+            scheduleRetry(item)
+        }
+    }
+
+    private fun scheduleRetry(item: WorkItem) {
+        if (closed.get()) {
+            finishWork(item, LeaderAuditExportObservation.CANCELLED)
+            return
+        }
+        item.retryClaimed.set(false)
+        scheduledRetries.incrementAndGet()
+        val delay = saturatingBackoff(options.initialBackoffNanos, item.attempts)
+        try {
+            item.retry = options.scheduler.schedule(
+                {
+                    if (!item.retryClaimed.compareAndSet(false, true)) return@schedule
+                    scheduledRetries.decrementAndGet()
+                    item.retry = null
+                    if (closed.get()) {
+                        finishWork(item, LeaderAuditExportObservation.CANCELLED)
+                    } else {
+                        worker.offer(item)
+                        queued.incrementAndGet()
+                        tryStartWorker()
+                    }
+                },
+                delay,
+                TimeUnit.NANOSECONDS,
+            )
+        } catch (e: RejectedExecutionException) {
+            if (item.retryClaimed.compareAndSet(false, true)) {
+                scheduledRetries.decrementAndGet()
+                schedulerRejections.incrementAndGet()
+                finishWork(item, LeaderAuditExportObservation.SCHEDULER_REJECTED)
+            }
+        }
+    }
+
+    private fun saturatingBackoff(initial: Long, attempt: Int): Long {
+        var value = initial
+        repeat((attempt - 1).coerceAtMost(62)) {
+            if (value >= options.maxBackoffNanos / 2) return options.maxBackoffNanos
+            value *= 2
+        }
+        return min(value, options.maxBackoffNanos)
+    }
+
+    private fun cancelWork(item: WorkItem) {
+        val retry = item.retry
+        if (retry != null && item.retryClaimed.compareAndSet(false, true)) {
+            retry.cancel(false)
+            scheduledRetries.decrementAndGet()
+            item.retry = null
+        }
+        val attempt = item.currentAttempt
+        if (attempt != null && attempt.done.compareAndSet(false, true)) {
+            attempt.timeout?.cancel(false)
+            attempt.future?.cancel(true)
+            releaseAttempt(item, attempt)
+        }
+        finishWork(item, LeaderAuditExportObservation.CANCELLED)
+    }
+
+    private fun releaseAttempt(item: WorkItem, attempt: Attempt) {
+        if (item.currentAttempt === attempt) item.currentAttempt = null
+        releaseInFlight()
+    }
+
+    private fun releaseInFlight() {
+        inFlight.decrementAndGet()
+        tryStartWorker()
+    }
+
+    private fun finishWork(item: WorkItem, observation: LeaderAuditExportObservation?) {
+        if (!item.terminalized.compareAndSet(false, true)) return
+        active.remove(item)
+        admitted.decrementAndGet()
+        if (observation != null) {
+            when (observation) {
+                LeaderAuditExportObservation.TERMINAL_FAILURE -> terminalFailures.incrementAndGet()
+                LeaderAuditExportObservation.CANCELLED -> cancellations.incrementAndGet()
+                LeaderAuditExportObservation.EXECUTOR_REJECTED -> executorRejections.incrementAndGet()
+                LeaderAuditExportObservation.SCHEDULER_REJECTED -> schedulerRejections.incrementAndGet()
+                else -> Unit
+            }
+            publish(observation)
+        }
+    }
+
+    private fun drainQueued(observation: LeaderAuditExportObservation) {
+        while (true) {
+            val item = worker.poll() ?: break
+            queued.decrementAndGet()
+            finishWork(item, observation)
+        }
+    }
+
+    private fun terminalizeQueued(observation: LeaderAuditExportObservation) {
+        drainQueued(observation)
+    }
+
+    private fun publish(observation: LeaderAuditExportObservation) {
+        if (diagnosticsClosed.get()) return
+        if (!diagnosticsLock.tryLock()) {
+            observerDrops.incrementAndGet()
+            return
+        }
+        try {
+            if (diagnosticsClosed.get()) return
+            observerSlots.toList().forEach { slot ->
+                if (!slot.active.get()) return@forEach
+                while (true) {
+                    val current = diagnosticsQueued.get()
+                    if (current >= diagnosticsCapacity) {
+                        observerDrops.incrementAndGet()
+                        break
+                    }
+                    if (diagnosticsQueued.compareAndSet(current, current + 1)) {
+                        diagnostics.offer(ObservationWork(slot, observation))
+                        ensureDiagnosticsWorker()
+                        break
+                    }
+                }
+            }
+        } finally {
+            diagnosticsLock.unlock()
+        }
+    }
+
+    private fun ensureDiagnosticsWorker() {
+        val existing = diagnosticsWorker.get()
+        if (existing != null && existing.isAlive) {
+            LockSupport.unpark(existing)
+            return
+        }
+        val thread = Thread.ofVirtual()
+            .name("bluetape4k-leader-audit-observer")
+            .unstarted(::runDiagnostics)
+        if (diagnosticsWorker.compareAndSet(existing, thread)) thread.start() else thread.interrupt()
+    }
+
+    private fun runDiagnostics() {
+        while (!diagnosticsClosed.get() || diagnostics.isNotEmpty()) {
+            val work = diagnostics.poll()
+            if (work == null) {
+                LockSupport.park()
+                continue
+            }
+            diagnosticsQueued.decrementAndGet()
+            val reserved = diagnosticsLock.withLockIfAvailable {
+                if (work.slot.active.get()) {
+                    work.slot.running.incrementAndGet()
+                    true
+                } else {
+                    false
+                }
+            }
+            if (!reserved) continue
+            try {
+                work.slot.observer.onObservation(work.observation)
+            } catch (e: Exception) {
+                // observer failures are isolated from admission and delivery.
+            } catch (e: Error) {
+                diagnosticsFatalErrors.incrementAndGet()
+                diagnosticsLock.lock()
+                try {
+                    diagnosticsClosed.set(true)
+                    drainDiagnostics()
+                } finally {
+                    diagnosticsLock.unlock()
+                }
+                throw e
+            } finally {
+                work.slot.running.decrementAndGet()
+            }
+        }
+    }
+
+    private fun closeObserver(slot: ObserverSlot) {
+        diagnosticsLock.lock()
+        try {
+            if (!slot.active.getAndSet(false)) return
+            observerSlots.remove(slot)
+            diagnostics.removeIf { work ->
+                if (work.slot !== slot) return@removeIf false
+                diagnosticsQueued.decrementAndGet()
+                true
+            }
+        } finally {
+            diagnosticsLock.unlock()
+        }
+    }
+
+    private fun drainDiagnostics() {
+        while (diagnostics.poll() != null) diagnosticsQueued.decrementAndGet()
+    }
+
+    private class WorkItem(val event: LeaderAuditExportEvent) {
+        var attempts: Int = 0
+        @Volatile var currentAttempt: Attempt? = null
+        @Volatile var retry: ScheduledFuture<*>? = null
+        val retryClaimed = AtomicBoolean(true)
+        val terminalized = AtomicBoolean(false)
+    }
+
+    private class Attempt(val number: Int) {
+        val done = AtomicBoolean(false)
+        @Volatile var future: CompletableFuture<LeaderAuditDeliveryResult>? = null
+        @Volatile var timeout: ScheduledFuture<*>? = null
+    }
+
+    private class ObserverSlot(val observer: LeaderAuditExportObserver) {
+        val active = AtomicBoolean(true)
+        val running = AtomicInteger()
+    }
+
+    private data class ObservationWork(
+        val slot: ObserverSlot,
+        val observation: LeaderAuditExportObservation,
+    )
+
+    private object NoopCloseable : AutoCloseable {
+        override fun close() = Unit
+    }
+
+    private companion object {
+        const val MAX_DIAGNOSTICS_CAPACITY: Int = 1024
+        const val MAX_OBSERVERS: Int = 16
+    }
+}
+
+private inline fun <T> ReentrantLock.withLockIfAvailable(block: () -> T): T {
+    lock()
+    return try {
+        block()
+    } finally {
+        unlock()
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/LeaderAuditPendingContextStore.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/LeaderAuditPendingContextStore.kt
@@ -1,0 +1,137 @@
+package io.bluetape4k.leader.audit.internal
+
+import io.bluetape4k.leader.history.LeaderHistoryKey
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
+import java.security.MessageDigest
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.util.LinkedHashMap
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+ * acquisition과 terminal history 사이의 bounded context를 보관합니다.
+ *
+ * backend token은 digest 계산에만 사용하고 entry에 저장하지 않습니다. 따라서 sink가
+ * 오래 살아 있어도 pending map이 token credential을 보유하지 않습니다. capacity와 TTL은
+ * 모두 유한하며, eviction은 export를 막지 않는 best-effort 정책입니다.
+ */
+internal class LeaderAuditPendingContextStore(
+    private val maxEntries: Int = DEFAULT_MAX_ENTRIES,
+    private val ttl: Duration = DEFAULT_TTL,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+
+    private val lock = ReentrantLock()
+    private val entries = LinkedHashMap<String, Entry>(maxEntries)
+
+    init {
+        require(maxEntries in 1..MAX_ENTRIES) {
+            "maxEntries must be in 1..$MAX_ENTRIES: $maxEntries"
+        }
+        require(!ttl.isZero && !ttl.isNegative) { "ttl must be positive: $ttl" }
+    }
+
+    /** acquisition context를 저장하고 오래된 entry를 제거합니다. */
+    fun put(key: LeaderHistoryKey, record: LeaderLockHistoryRecord) {
+        val fingerprint = fingerprint(key)
+        val context = PendingContext(
+            lockName = record.lockName,
+            kind = record.kind,
+            acquiredAt = record.acquiredAt,
+            lockedUntil = record.lockedUntil,
+            nodeId = record.nodeId,
+            slotId = record.slotId,
+            metadata = record.metadata.toMap(),
+        )
+        lock.lock()
+        try {
+            evictExpired(Instant.now(clock))
+            entries[fingerprint] = Entry(context, Instant.now(clock))
+            while (entries.size > maxEntries) {
+                entries.entries.iterator().let { iterator ->
+                    if (iterator.hasNext()) {
+                        iterator.next()
+                        iterator.remove()
+                    }
+                }
+            }
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    /** terminal history context를 exactly-once로 꺼내 제거합니다. */
+    fun remove(key: LeaderHistoryKey): PendingContext? {
+        val fingerprint = fingerprint(key)
+        lock.lock()
+        return try {
+            evictExpired(Instant.now(clock))
+            entries.remove(fingerprint)?.context
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    /** 테스트와 운영 진단을 위한 현재 entry 수입니다. */
+    fun size(): Int {
+        lock.lock()
+        return try {
+            evictExpired(Instant.now(clock))
+            entries.size
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    private fun evictExpired(now: Instant) {
+        val cutoff = now.minus(ttl)
+        entries.entries.removeIf { it.value.createdAt.isBefore(cutoff) }
+    }
+
+    private fun fingerprint(key: LeaderHistoryKey): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        digest.updateField(key.id?.toString())
+        digest.updateField(key.historyId)
+        digest.updateField(key.lockName)
+        digest.updateField(key.token)
+        digest.updateField(key.slotId)
+        return digest.digest().joinToString(HEX_SEPARATOR) { byte ->
+            "%02x".format(byte.toInt() and BYTE_MASK)
+        }
+    }
+
+    private fun MessageDigest.updateField(value: String?) {
+        val bytes = value?.toByteArray(Charsets.UTF_8)
+        val length = bytes?.size ?: NULL_LENGTH
+        update(length.toString().toByteArray(Charsets.UTF_8))
+        update(FIELD_SEPARATOR)
+        if (bytes != null) update(bytes)
+        update(FIELD_SEPARATOR)
+    }
+
+    internal data class PendingContext(
+        val lockName: String,
+        val kind: io.bluetape4k.leader.LockIdentity.AnnotationKind,
+        val acquiredAt: Instant,
+        val lockedUntil: Instant,
+        val nodeId: String?,
+        val slotId: String?,
+        val metadata: Map<String, String>,
+    )
+
+    private data class Entry(
+        val context: PendingContext,
+        val createdAt: Instant,
+    )
+
+    private companion object {
+        const val DEFAULT_MAX_ENTRIES: Int = 4096
+        const val MAX_ENTRIES: Int = 65_536
+        val DEFAULT_TTL: Duration = Duration.ofMinutes(15)
+        const val NULL_LENGTH: Int = -1
+        const val BYTE_MASK: Int = 0xff
+        const val HEX_SEPARATOR: String = ""
+        val FIELD_SEPARATOR: ByteArray = byteArrayOf(0)
+    }
+}

--- a/leader-core/src/test/java/io/bluetape4k/leader/audit/LeaderAuditExportJavaContractFixture.java
+++ b/leader-core/src/test/java/io/bluetape4k/leader/audit/LeaderAuditExportJavaContractFixture.java
@@ -1,0 +1,71 @@
+package io.bluetape4k.leader.audit;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+/** Java compile/run fixture for the stable audit exporter boundary. */
+public final class LeaderAuditExportJavaContractFixture {
+
+    private LeaderAuditExportJavaContractFixture() {
+    }
+
+    public static boolean exercise() {
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            Executor executor = Runnable::run;
+            LeaderAuditExportOptions options = new LeaderAuditExportOptions(
+                8,
+                2,
+                3,
+                Duration.ofSeconds(5),
+                Duration.ofMillis(1),
+                Duration.ofSeconds(1),
+                executor,
+                scheduler
+            );
+            if (options.getQueueCapacity() != 8 || options.getMaxInFlight() != 2) {
+                return false;
+            }
+
+            LeaderAuditDelivery delivery = event ->
+                CompletableFuture.completedFuture(LeaderAuditDeliveryResult.SUCCESS);
+            LeaderAuditExportObserver observer = observation -> {
+            };
+            LeaderAuditExporter exporter = new LeaderAuditExporter() {
+                @Override
+                public LeaderAuditSubmitResult submit(LeaderAuditExportEvent event) {
+                    return LeaderAuditSubmitResult.DROPPED_CLOSED;
+                }
+
+                @Override
+                public AutoCloseable observe(LeaderAuditExportObserver value) {
+                    return () -> {
+                    };
+                }
+
+                @Override
+                public LeaderAuditExportSnapshot snapshot() {
+                    return null;
+                }
+
+                @Override
+                public void close() {
+                }
+            };
+
+            try (LeaderAuditExporter ignored = exporter) {
+                exporter.observe(observer).close();
+                exporter.submit(null);
+                delivery.deliver(null);
+            }
+            return true;
+        } catch (Exception e) {
+            return false;
+        } finally {
+            scheduler.shutdownNow();
+        }
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
@@ -67,14 +67,17 @@ class BoundedLeaderAuditExporterTest {
 
     @Test
     fun `successful delivery releases admission permit`() {
+        val delivered = CountDownLatch(1)
         val exporter = exporter(
             delivery = LeaderAuditDelivery {
+                delivered.countDown()
                 CompletableFuture.completedFuture(LeaderAuditDeliveryResult.SUCCESS)
             },
             executor = Executor { it.run() },
         )
 
         exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        delivered.await(5, TimeUnit.SECONDS).shouldBeTrue()
         val snapshot = exporter.snapshot()
         snapshot.admitted.shouldBeEqualTo(0)
         snapshot.inFlight.shouldBeEqualTo(0)
@@ -125,14 +128,19 @@ class BoundedLeaderAuditExporterTest {
     @Test
     fun `close cancels an in flight future exactly once`() {
         val future = CompletableFuture<LeaderAuditDeliveryResult>()
+        val deliveryStarted = CountDownLatch(1)
         val cancelled = CountDownLatch(1)
         future.whenComplete { _, failure -> if (failure is CancellationException) cancelled.countDown() }
         val exporter = exporter(
-            delivery = LeaderAuditDelivery { future },
+            delivery = LeaderAuditDelivery {
+                deliveryStarted.countDown()
+                future
+            },
             executor = Executor { it.run() },
         )
 
         exporter.submit(event())
+        deliveryStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
         exporter.close()
         cancelled.await(5, TimeUnit.SECONDS).shouldBeTrue()
         exporter.snapshot().cancellations.shouldBeEqualTo(1)
@@ -166,7 +174,9 @@ class BoundedLeaderAuditExporterTest {
 
     @Test
     fun `in flight saturation waits for release without recursive worker spin`() {
-        val started = CountDownLatch(2)
+        val firstStarted = CountDownLatch(1)
+        val secondStarted = CountDownLatch(1)
+        val calls = AtomicInteger()
         val futures = ConcurrentLinkedQueue<CompletableFuture<LeaderAuditDeliveryResult>>()
         val exporter = exporter(
             queueCapacity = 3,
@@ -174,16 +184,17 @@ class BoundedLeaderAuditExporterTest {
             delivery = LeaderAuditDelivery {
                 CompletableFuture<LeaderAuditDeliveryResult>().also {
                     futures += it
-                    started.countDown()
+                    if (calls.incrementAndGet() == 1) firstStarted.countDown() else secondStarted.countDown()
                 }
             },
             executor = Executor { it.run() },
         )
 
         exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        firstStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
         exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
         futures.remove().complete(LeaderAuditDeliveryResult.SUCCESS)
-        started.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        secondStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
         exporter.snapshot().inFlight.shouldBeEqualTo(1)
         futures.remove().complete(LeaderAuditDeliveryResult.SUCCESS)
         exporter.close()
@@ -193,21 +204,83 @@ class BoundedLeaderAuditExporterTest {
     @Test
     fun `executor rejection releases all permits and later submissions recover`() {
         val rejectFirst = AtomicBoolean(true)
+        val rejected = CountDownLatch(1)
+        val recovered = CountDownLatch(1)
         val executor = Executor { command ->
             if (rejectFirst.getAndSet(false)) throw RejectedExecutionException("first")
             command.run()
         }
         val exporter = exporter(
             queueCapacity = 2,
+            delivery = LeaderAuditDelivery {
+                recovered.countDown()
+                CompletableFuture.completedFuture(LeaderAuditDeliveryResult.SUCCESS)
+            },
             executor = executor,
+            onObservation = { if (it == LeaderAuditExportObservation.EXECUTOR_REJECTED) rejected.countDown() },
         )
 
         exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        rejected.await(5, TimeUnit.SECONDS).shouldBeTrue()
         exporter.snapshot().admitted.shouldBeEqualTo(0)
         exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        recovered.await(5, TimeUnit.SECONDS).shouldBeTrue()
         exporter.snapshot().admitted.shouldBeEqualTo(0)
         exporter.snapshot().executorRejections.shouldBeEqualTo(1)
         exporter.close()
+    }
+
+    @Test
+    fun `direct executor cannot make submit wait for blocking delivery`() {
+        val deliveryStarted = CountDownLatch(1)
+        val releaseDelivery = CountDownLatch(1)
+        val submitReturned = CountDownLatch(1)
+        val exporter = exporter(
+            delivery = LeaderAuditDelivery {
+                deliveryStarted.countDown()
+                releaseDelivery.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                CompletableFuture.completedFuture(LeaderAuditDeliveryResult.SUCCESS)
+            },
+            executor = Executor { it.run() },
+        )
+
+        Thread.ofVirtual().start {
+            exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+            submitReturned.countDown()
+        }
+        submitReturned.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        deliveryStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        releaseDelivery.countDown()
+        exporter.close()
+    }
+
+    @Test
+    fun `exceptional delivery Error reaches uncaught boundary after cleanup`() {
+        val uncaught = CountDownLatch(1)
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { _, error ->
+            if (error is AssertionError) uncaught.countDown()
+        }
+        try {
+            val future = CompletableFuture<LeaderAuditDeliveryResult>()
+            val deliveryStarted = CountDownLatch(1)
+            val exporter = exporter(
+                delivery = LeaderAuditDelivery {
+                    deliveryStarted.countDown()
+                    future
+                },
+                executor = Executor { it.run() },
+                maxAttempts = 1,
+            )
+            exporter.submit(event())
+            deliveryStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            future.completeExceptionally(AssertionError("delivery-error"))
+            uncaught.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            exporter.snapshot().admitted.shouldBeEqualTo(0)
+            exporter.close()
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(previous)
+        }
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.audit
 
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.leader.audit.internal.BoundedLeaderAuditExporter
 import io.bluetape4k.leader.history.LeaderHistoryStatus
@@ -133,6 +134,122 @@ class BoundedLeaderAuditExporterTest {
         cancelled.await(5, TimeUnit.SECONDS).shouldBeTrue()
         exporter.snapshot().cancellations.shouldBeEqualTo(1)
         exporter.snapshot().admitted.shouldBeEqualTo(0)
+    }
+
+    @Test
+    fun `hung delivery times out and retries up to the configured attempt limit`() {
+        val attempts = AtomicInteger()
+        val terminal = CountDownLatch(1)
+        val exporter = exporter(
+            delivery = LeaderAuditDelivery {
+                attempts.incrementAndGet()
+                CompletableFuture()
+            },
+            maxAttempts = 2,
+            attemptTimeout = Duration.ofMillis(10),
+            initialBackoff = Duration.ofNanos(1),
+            onObservation = { if (it == LeaderAuditExportObservation.TERMINAL_FAILURE) terminal.countDown() },
+            executor = Executor { it.run() },
+        )
+
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        terminal.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        attempts.get().shouldBeEqualTo(2)
+        exporter.snapshot().retries.shouldBeEqualTo(1)
+        exporter.snapshot().inFlight.shouldBeEqualTo(0)
+        exporter.snapshot().admitted.shouldBeEqualTo(0)
+        exporter.close()
+    }
+
+    @Test
+    fun `invalid options fail fast at every bounded boundary`() {
+        val executor = Executor { }
+        val scheduler = scheduler()
+
+        assertFailsWith<IllegalArgumentException> {
+            LeaderAuditExportOptions(
+                queueCapacity = 0,
+                maxInFlight = 1,
+                maxAttempts = 1,
+                attemptTimeout = Duration.ofSeconds(1),
+                initialBackoff = Duration.ofMillis(1),
+                maxBackoff = Duration.ofSeconds(1),
+                executor = executor,
+                scheduler = scheduler,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LeaderAuditExportOptions(
+                queueCapacity = 1,
+                maxInFlight = 2,
+                maxAttempts = 1,
+                attemptTimeout = Duration.ofSeconds(1),
+                initialBackoff = Duration.ofMillis(1),
+                maxBackoff = Duration.ofSeconds(1),
+                executor = executor,
+                scheduler = scheduler,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LeaderAuditExportOptions(
+                queueCapacity = 1,
+                maxInFlight = 1,
+                maxAttempts = 17,
+                attemptTimeout = Duration.ofSeconds(1),
+                initialBackoff = Duration.ofMillis(1),
+                maxBackoff = Duration.ofSeconds(1),
+                executor = executor,
+                scheduler = scheduler,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LeaderAuditExportOptions(
+                queueCapacity = 1,
+                maxInFlight = 1,
+                maxAttempts = 1,
+                attemptTimeout = Duration.ZERO,
+                initialBackoff = Duration.ofMillis(1),
+                maxBackoff = Duration.ofSeconds(1),
+                executor = executor,
+                scheduler = scheduler,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LeaderAuditExportOptions(
+                queueCapacity = 1,
+                maxInFlight = 1,
+                maxAttempts = 1,
+                attemptTimeout = Duration.ofSeconds(1),
+                initialBackoff = Duration.ZERO,
+                maxBackoff = Duration.ofSeconds(1),
+                executor = executor,
+                scheduler = scheduler,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LeaderAuditExportOptions(
+                queueCapacity = 1,
+                maxInFlight = 1,
+                maxAttempts = 1,
+                attemptTimeout = Duration.ofSeconds(1),
+                initialBackoff = Duration.ofSeconds(2),
+                maxBackoff = Duration.ofSeconds(1),
+                executor = executor,
+                scheduler = scheduler,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LeaderAuditExportOptions(
+                queueCapacity = 1,
+                maxInFlight = 1,
+                maxAttempts = 1,
+                attemptTimeout = Duration.ofMinutes(6),
+                initialBackoff = Duration.ofMillis(1),
+                maxBackoff = Duration.ofSeconds(1),
+                executor = executor,
+                scheduler = scheduler,
+            )
+        }
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
@@ -1,0 +1,210 @@
+package io.bluetape4k.leader.audit
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.audit.internal.BoundedLeaderAuditExporter
+import io.bluetape4k.leader.history.LeaderHistoryStatus
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.CancellationException
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class BoundedLeaderAuditExporterTest {
+
+    private val schedulers = mutableListOf<ScheduledExecutorService>()
+
+    @AfterEach
+    fun tearDown() {
+        schedulers.forEach { it.shutdownNow() }
+    }
+
+    @Test
+    fun `queue full returns dropped without calling delivery`() {
+        val executor = Executor { }
+        val scheduler = scheduler()
+        val calls = AtomicInteger()
+        val exporter = exporter(
+            delivery = LeaderAuditDelivery {
+                calls.incrementAndGet()
+                CompletableFuture.completedFuture(LeaderAuditDeliveryResult.SUCCESS)
+            },
+            queueCapacity = 1,
+            executor = executor,
+            scheduler = scheduler,
+        )
+
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.DROPPED_QUEUE_FULL)
+        calls.get().shouldBeEqualTo(0)
+        exporter.snapshot().droppedQueueFull.shouldBeEqualTo(1)
+        exporter.close()
+    }
+
+    @Test
+    fun `closed exporter rejects new work and snapshot is closed`() {
+        val exporter = exporter(executor = Executor { })
+
+        exporter.close()
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.DROPPED_CLOSED)
+        val snapshot = exporter.snapshot()
+        snapshot.closed.shouldBeTrue()
+        snapshot.droppedClosed.shouldBeEqualTo(1)
+    }
+
+    @Test
+    fun `successful delivery releases admission permit`() {
+        val exporter = exporter(
+            delivery = LeaderAuditDelivery {
+                CompletableFuture.completedFuture(LeaderAuditDeliveryResult.SUCCESS)
+            },
+            executor = Executor { it.run() },
+        )
+
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        val snapshot = exporter.snapshot()
+        snapshot.admitted.shouldBeEqualTo(0)
+        snapshot.inFlight.shouldBeEqualTo(0)
+        snapshot.accepted.shouldBeEqualTo(1)
+        exporter.close()
+    }
+
+    @Test
+    fun `retryable failure is bounded by max attempts`() {
+        val attempts = AtomicInteger()
+        val terminal = CountDownLatch(1)
+        val exporter = exporter(
+            delivery = LeaderAuditDelivery {
+                attempts.incrementAndGet()
+                CompletableFuture.completedFuture(LeaderAuditDeliveryResult.RETRYABLE_FAILURE)
+            },
+            maxAttempts = 2,
+            initialBackoff = Duration.ofNanos(1),
+            executor = Executor { it.run() },
+            onObservation = { if (it == LeaderAuditExportObservation.TERMINAL_FAILURE) terminal.countDown() },
+        )
+
+        exporter.submit(event())
+        terminal.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        attempts.get().shouldBeEqualTo(2)
+        exporter.snapshot().terminalFailures.shouldBeEqualTo(1)
+        exporter.snapshot().admitted.shouldBeEqualTo(0)
+        exporter.close()
+    }
+
+    @Test
+    fun `synchronous delivery failure terminalizes without leaking in flight`() {
+        val terminal = CountDownLatch(1)
+        val exporter = exporter(
+            delivery = LeaderAuditDelivery { throw IllegalStateException("delivery-failed") },
+            maxAttempts = 1,
+            executor = Executor { it.run() },
+            onObservation = { if (it == LeaderAuditExportObservation.TERMINAL_FAILURE) terminal.countDown() },
+        )
+
+        exporter.submit(event())
+        terminal.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        exporter.snapshot().inFlight.shouldBeEqualTo(0)
+        exporter.snapshot().admitted.shouldBeEqualTo(0)
+        exporter.close()
+    }
+
+    @Test
+    fun `close cancels an in flight future exactly once`() {
+        val future = CompletableFuture<LeaderAuditDeliveryResult>()
+        val cancelled = CountDownLatch(1)
+        future.whenComplete { _, failure -> if (failure is CancellationException) cancelled.countDown() }
+        val exporter = exporter(
+            delivery = LeaderAuditDelivery { future },
+            executor = Executor { it.run() },
+        )
+
+        exporter.submit(event())
+        exporter.close()
+        cancelled.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        exporter.snapshot().cancellations.shouldBeEqualTo(1)
+        exporter.snapshot().admitted.shouldBeEqualTo(0)
+    }
+
+    @Test
+    fun `observer receives accepted and failure observations without changing submit result`() {
+        val observations = mutableListOf<LeaderAuditExportObservation>()
+        val observed = CountDownLatch(1)
+        val exporter = exporter(
+            delivery = LeaderAuditDelivery {
+                CompletableFuture.completedFuture(LeaderAuditDeliveryResult.TERMINAL_FAILURE)
+            },
+            executor = Executor { it.run() },
+            onObservation = {
+                synchronized(observations) { observations += it }
+                if (it == LeaderAuditExportObservation.TERMINAL_FAILURE) observed.countDown()
+            },
+        )
+
+        exporter.observe(LeaderAuditExportObserver { observedObservation ->
+            synchronized(observations) { observations += observedObservation }
+        })
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        observed.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        synchronized(observations) {
+            observations.contains(LeaderAuditExportObservation.ACCEPTED).shouldBeTrue()
+            observations.contains(LeaderAuditExportObservation.TERMINAL_FAILURE).shouldBeTrue()
+        }
+        exporter.close()
+    }
+
+    private fun exporter(
+        delivery: LeaderAuditDelivery = LeaderAuditDelivery {
+            CompletableFuture.completedFuture(LeaderAuditDeliveryResult.SUCCESS)
+        },
+        queueCapacity: Int = 8,
+        maxInFlight: Int = minOf(queueCapacity, 2),
+        maxAttempts: Int = 3,
+        attemptTimeout: Duration = Duration.ofSeconds(1),
+        initialBackoff: Duration = Duration.ofMillis(1),
+        maxBackoff: Duration = Duration.ofSeconds(1),
+        executor: Executor = Executor { it.run() },
+        scheduler: ScheduledExecutorService = scheduler(),
+        onObservation: (LeaderAuditExportObservation) -> Unit = {},
+    ): BoundedLeaderAuditExporter {
+        val exporter = BoundedLeaderAuditExporter(
+            delivery = delivery,
+            options = LeaderAuditExportOptions(
+                queueCapacity = queueCapacity,
+                maxInFlight = maxInFlight,
+                maxAttempts = maxAttempts,
+                attemptTimeout = attemptTimeout,
+                initialBackoff = initialBackoff,
+                maxBackoff = maxBackoff,
+                executor = executor,
+                scheduler = scheduler,
+            ),
+        )
+        exporter.observe(LeaderAuditExportObserver(onObservation))
+        return exporter
+    }
+
+    private fun scheduler(): ScheduledExecutorService =
+        Executors.newSingleThreadScheduledExecutor().also(schedulers::add)
+
+    private fun event(): LeaderAuditExportEvent.History = LeaderAuditExportEvent.History.from(
+        record = LeaderLockHistoryRecord(
+            lockName = "lock",
+            token = "token",
+            kind = LockIdentity.AnnotationKind.SINGLE,
+            acquiredAt = Instant.parse("2026-08-18T00:00:00Z"),
+            lockedUntil = Instant.parse("2026-08-18T00:01:00Z"),
+            status = LeaderHistoryStatus.ACQUIRED,
+        ),
+        sanitizer = LeaderAuditValueSanitizer.Default,
+    )
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
@@ -250,8 +250,13 @@ class BoundedLeaderAuditExporterTest {
         }
         submitReturned.await(5, TimeUnit.SECONDS).shouldBeTrue()
         deliveryStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        val closeReturned = CountDownLatch(1)
+        Thread.ofVirtual().start {
+            exporter.close()
+            closeReturned.countDown()
+        }
+        closeReturned.await(1, TimeUnit.SECONDS).shouldBeTrue()
         releaseDelivery.countDown()
-        exporter.close()
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
@@ -242,6 +242,50 @@ class BoundedLeaderAuditExporterTest {
     }
 
     @Test
+    fun `worker handoff retries after inline executor exits with queued work`() {
+        val firstFuture = CompletableFuture<LeaderAuditDeliveryResult>()
+        val firstStarted = CountDownLatch(1)
+        val allowFirstReturn = CountDownLatch(1)
+        val workerExited = CountDownLatch(1)
+        val releaseExecutor = CountDownLatch(1)
+        val secondStarted = CountDownLatch(1)
+        val calls = AtomicInteger()
+        val executor = Executor { command ->
+            command.run()
+            workerExited.countDown()
+            releaseExecutor.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        }
+        val exporter = exporter(
+            queueCapacity = 2,
+            maxInFlight = 1,
+            delivery = LeaderAuditDelivery {
+                if (calls.incrementAndGet() == 1) {
+                    firstStarted.countDown()
+                    allowFirstReturn.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                    firstFuture
+                } else {
+                    secondStarted.countDown()
+                    CompletableFuture.completedFuture(LeaderAuditDeliveryResult.SUCCESS)
+                }
+            },
+            executor = executor,
+        )
+
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        firstStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        allowFirstReturn.countDown()
+        workerExited.await(5, TimeUnit.SECONDS).shouldBeTrue()
+
+        firstFuture.complete(LeaderAuditDeliveryResult.SUCCESS).shouldBeTrue()
+        releaseExecutor.countDown()
+        secondStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        awaitAdmissionReleased(exporter)
+        exporter.snapshot().admitted.shouldBeEqualTo(0)
+        exporter.close()
+    }
+
+    @Test
     fun `executor rejection releases all permits and later submissions recover`() {
         val rejectFirst = AtomicBoolean(true)
         val rejected = CountDownLatch(1)

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
@@ -16,8 +16,11 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import java.util.concurrent.CancellationException
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 class BoundedLeaderAuditExporterTest {
@@ -157,6 +160,69 @@ class BoundedLeaderAuditExporterTest {
         attempts.get().shouldBeEqualTo(2)
         exporter.snapshot().retries.shouldBeEqualTo(1)
         exporter.snapshot().inFlight.shouldBeEqualTo(0)
+        exporter.snapshot().admitted.shouldBeEqualTo(0)
+        exporter.close()
+    }
+
+    @Test
+    fun `in flight saturation waits for release without recursive worker spin`() {
+        val started = CountDownLatch(2)
+        val futures = ConcurrentLinkedQueue<CompletableFuture<LeaderAuditDeliveryResult>>()
+        val exporter = exporter(
+            queueCapacity = 3,
+            maxInFlight = 1,
+            delivery = LeaderAuditDelivery {
+                CompletableFuture<LeaderAuditDeliveryResult>().also {
+                    futures += it
+                    started.countDown()
+                }
+            },
+            executor = Executor { it.run() },
+        )
+
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        futures.remove().complete(LeaderAuditDeliveryResult.SUCCESS)
+        started.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        exporter.snapshot().inFlight.shouldBeEqualTo(1)
+        futures.remove().complete(LeaderAuditDeliveryResult.SUCCESS)
+        exporter.close()
+        exporter.snapshot().admitted.shouldBeEqualTo(0)
+    }
+
+    @Test
+    fun `executor rejection releases all permits and later submissions recover`() {
+        val rejectFirst = AtomicBoolean(true)
+        val executor = Executor { command ->
+            if (rejectFirst.getAndSet(false)) throw RejectedExecutionException("first")
+            command.run()
+        }
+        val exporter = exporter(
+            queueCapacity = 2,
+            executor = executor,
+        )
+
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        exporter.snapshot().admitted.shouldBeEqualTo(0)
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        exporter.snapshot().admitted.shouldBeEqualTo(0)
+        exporter.snapshot().executorRejections.shouldBeEqualTo(1)
+        exporter.close()
+    }
+
+    @Test
+    fun `scheduler rejection is counted once and terminalizes the attempt`() {
+        val rejected = CountDownLatch(1)
+        val scheduler = scheduler().also { it.shutdownNow() }
+        val exporter = exporter(
+            scheduler = scheduler,
+            executor = Executor { it.run() },
+            onObservation = { if (it == LeaderAuditExportObservation.SCHEDULER_REJECTED) rejected.countDown() },
+        )
+
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        rejected.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        exporter.snapshot().schedulerRejections.shouldBeEqualTo(1)
         exporter.snapshot().admitted.shouldBeEqualTo(0)
         exporter.close()
     }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
@@ -78,6 +78,7 @@ class BoundedLeaderAuditExporterTest {
 
         exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
         delivered.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        awaitAdmissionReleased(exporter)
         val snapshot = exporter.snapshot()
         snapshot.admitted.shouldBeEqualTo(0)
         snapshot.inFlight.shouldBeEqualTo(0)
@@ -123,6 +124,45 @@ class BoundedLeaderAuditExporterTest {
         exporter.snapshot().inFlight.shouldBeEqualTo(0)
         exporter.snapshot().admitted.shouldBeEqualTo(0)
         exporter.close()
+    }
+
+    @Test
+    fun `close winning before synchronous delivery failure releases permit exactly once`() {
+        val deliveryStarted = CountDownLatch(1)
+        val releaseDelivery = CountDownLatch(1)
+        val deliveryFailed = CountDownLatch(1)
+        val exporter = exporter(
+            delivery = LeaderAuditDelivery {
+                deliveryStarted.countDown()
+                releaseDelivery.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                deliveryFailed.countDown()
+                throw IllegalStateException("late-delivery-failure")
+            },
+            maxAttempts = 1,
+            executor = Executor { it.run() },
+        )
+
+        val submitReturned = CountDownLatch(1)
+        Thread.ofVirtual().start {
+            exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+            submitReturned.countDown()
+        }
+        submitReturned.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        deliveryStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+
+        val closeReturned = CountDownLatch(1)
+        Thread.ofVirtual().start {
+            exporter.close()
+            closeReturned.countDown()
+        }
+        closeReturned.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        releaseDelivery.countDown()
+        deliveryFailed.await(5, TimeUnit.SECONDS).shouldBeTrue()
+
+        val snapshot = exporter.snapshot()
+        snapshot.cancellations.shouldBeEqualTo(1)
+        snapshot.inFlight.shouldBeEqualTo(0)
+        snapshot.admitted.shouldBeEqualTo(0)
     }
 
     @Test
@@ -206,6 +246,7 @@ class BoundedLeaderAuditExporterTest {
         val rejectFirst = AtomicBoolean(true)
         val rejected = CountDownLatch(1)
         val recovered = CountDownLatch(1)
+        val deliveryFuture = CompletableFuture<LeaderAuditDeliveryResult>()
         val executor = Executor { command ->
             if (rejectFirst.getAndSet(false)) throw RejectedExecutionException("first")
             command.run()
@@ -214,7 +255,7 @@ class BoundedLeaderAuditExporterTest {
             queueCapacity = 2,
             delivery = LeaderAuditDelivery {
                 recovered.countDown()
-                CompletableFuture.completedFuture(LeaderAuditDeliveryResult.SUCCESS)
+                deliveryFuture
             },
             executor = executor,
             onObservation = { if (it == LeaderAuditExportObservation.EXECUTOR_REJECTED) rejected.countDown() },
@@ -225,6 +266,7 @@ class BoundedLeaderAuditExporterTest {
         exporter.snapshot().admitted.shouldBeEqualTo(0)
         exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
         recovered.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        deliveryFuture.complete(LeaderAuditDeliveryResult.SUCCESS).shouldBeTrue()
         exporter.snapshot().admitted.shouldBeEqualTo(0)
         exporter.snapshot().executorRejections.shouldBeEqualTo(1)
         exporter.close()
@@ -468,4 +510,11 @@ class BoundedLeaderAuditExporterTest {
         ),
         sanitizer = LeaderAuditValueSanitizer.Default,
     )
+
+    private fun awaitAdmissionReleased(exporter: BoundedLeaderAuditExporter) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (exporter.snapshot().admitted != 0 && System.nanoTime() < deadline) {
+            Thread.onSpinWait()
+        }
+    }
 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/ExportingLeaderHistorySinkTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/ExportingLeaderHistorySinkTest.kt
@@ -9,6 +9,9 @@ import io.bluetape4k.leader.history.LeaderHistorySink
 import io.bluetape4k.leader.history.LeaderLockHistoryRecord
 import io.bluetape4k.leader.history.LeaderHistoryStatus
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -79,8 +82,72 @@ class ExportingLeaderHistorySinkTest {
             exporter = exporter,
         )
 
-        assertFailsWith<CancellationException> { sink.recordAcquired(record()) }
+        assertFailsWith<CancellationException> {
+            withContext(Job()) {
+                sink.recordAcquired(record())
+            }
+        }
         exporter.events.size shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `suspend delegate cancellation after null result is rethrown`() = runTest {
+        val sink = ExportingSuspendLeaderHistorySink(
+            delegate = object : io.bluetape4k.leader.history.SuspendLeaderHistorySink {
+                override suspend fun recordAcquired(record: LeaderLockHistoryRecord): LeaderHistoryKey? {
+                    currentCoroutineContext()[Job]?.cancel()
+                    return null
+                }
+
+                override suspend fun recordCompleted(key: LeaderHistoryKey, finishedAt: Instant, durationMs: Long) = Unit
+
+                override suspend fun recordFailed(
+                    key: LeaderHistoryKey,
+                    finishedAt: Instant,
+                    durationMs: Long,
+                    errorType: String?,
+                    errorMessage: String?,
+                ) = Unit
+            },
+            exporter = RecordingExporter(),
+        )
+
+        assertFailsWith<CancellationException> {
+            withContext(Job()) {
+                sink.recordAcquired(record())
+            }
+        }
+    }
+
+    @Test
+    fun `suspend deleteOlderThan rechecks cancellation after delegate`() = runTest {
+        val sink = ExportingSuspendLeaderHistorySink(
+            delegate = object : io.bluetape4k.leader.history.SuspendLeaderHistorySink {
+                override suspend fun recordAcquired(record: LeaderLockHistoryRecord): LeaderHistoryKey? = null
+
+                override suspend fun recordCompleted(key: LeaderHistoryKey, finishedAt: Instant, durationMs: Long) = Unit
+
+                override suspend fun recordFailed(
+                    key: LeaderHistoryKey,
+                    finishedAt: Instant,
+                    durationMs: Long,
+                    errorType: String?,
+                    errorMessage: String?,
+                ) = Unit
+
+                override suspend fun deleteOlderThan(cutoff: Instant, limit: Int): Int {
+                    currentCoroutineContext()[Job]?.cancel()
+                    return 1
+                }
+            },
+            exporter = RecordingExporter(),
+        )
+
+        assertFailsWith<CancellationException> {
+            withContext(Job()) {
+                sink.deleteOlderThan(FINISHED_AT, 1)
+            }
+        }
     }
 
     private class RecordingSink(private val key: LeaderHistoryKey) : LeaderHistorySink {

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/ExportingLeaderHistorySinkTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/ExportingLeaderHistorySinkTest.kt
@@ -1,0 +1,161 @@
+package io.bluetape4k.leader.audit
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.history.LeaderHistoryKey
+import io.bluetape4k.leader.history.LeaderHistorySink
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
+import io.bluetape4k.leader.history.LeaderHistoryStatus
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+class ExportingLeaderHistorySinkTest {
+
+    @Test
+    fun `delegate result is preserved and history lifecycle is exported`() {
+        val exporter = RecordingExporter()
+        val key = LeaderHistoryKey(historyId = "history-1", lockName = "job", token = "secret")
+        val delegate = RecordingSink(key)
+        val sink = ExportingLeaderHistorySink(delegate, exporter)
+
+        sink.recordAcquired(record()) shouldBeEqualTo key
+        sink.recordCompleted(key, FINISHED_AT, 42)
+
+        delegate.acquired shouldBeEqualTo 1
+        delegate.completed shouldBeEqualTo 1
+        exporter.events.size shouldBeEqualTo 2
+        (exporter.events[0] as LeaderAuditExportEvent.History).status shouldBeEqualTo LeaderHistoryStatus.ACQUIRED
+        (exporter.events[1] as LeaderAuditExportEvent.History).status shouldBeEqualTo LeaderHistoryStatus.COMPLETED
+        exporter.events.joinToString().contains("secret").not().shouldBeTrue()
+    }
+
+    @Test
+    fun `exporter drop does not change delegate result and missing context is bounded`() {
+        val exporter = RecordingExporter(LeaderAuditSubmitResult.DROPPED_QUEUE_FULL)
+        val key = LeaderHistoryKey(lockName = "job", token = "secret")
+        val sink = ExportingLeaderHistorySink(
+            RecordingSink(key),
+            exporter,
+            LeaderAuditValueSanitizer.Truncate(maxBytes = 64),
+        )
+
+        sink.recordAcquired(record()) shouldBeEqualTo key
+        sink.recordFailed(
+            LeaderHistoryKey(lockName = "unknown", token = "unknown"),
+            FINISHED_AT,
+            7,
+            "java.lang.IllegalStateException",
+            "failed",
+        )
+
+        exporter.events.size shouldBeEqualTo 2
+        (exporter.events.last() as LeaderAuditExportEvent.History)
+            .attributes["audit_context"] shouldBeEqualTo "missing"
+    }
+
+    @Test
+    fun `suspend delegate cancellation is rethrown before export`() = runTest {
+        val exporter = RecordingExporter()
+        val sink = ExportingSuspendLeaderHistorySink(
+            delegate = object : io.bluetape4k.leader.history.SuspendLeaderHistorySink {
+                override suspend fun recordAcquired(record: LeaderLockHistoryRecord): LeaderHistoryKey? =
+                    throw CancellationException("cancelled")
+
+                override suspend fun recordCompleted(key: LeaderHistoryKey, finishedAt: Instant, durationMs: Long) = Unit
+
+                override suspend fun recordFailed(
+                    key: LeaderHistoryKey,
+                    finishedAt: Instant,
+                    durationMs: Long,
+                    errorType: String?,
+                    errorMessage: String?,
+                ) = Unit
+            },
+            exporter = exporter,
+        )
+
+        assertFailsWith<CancellationException> { sink.recordAcquired(record()) }
+        exporter.events.size shouldBeEqualTo 0
+    }
+
+    private class RecordingSink(private val key: LeaderHistoryKey) : LeaderHistorySink {
+        var acquired = 0
+        var completed = 0
+
+        override fun recordAcquired(record: LeaderLockHistoryRecord): LeaderHistoryKey? {
+            acquired++
+            return key
+        }
+
+        override fun recordCompleted(key: LeaderHistoryKey, finishedAt: Instant, durationMs: Long) {
+            completed++
+        }
+
+        override fun recordFailed(
+            key: LeaderHistoryKey,
+            finishedAt: Instant,
+            durationMs: Long,
+            errorType: String?,
+            errorMessage: String?,
+        ) = Unit
+    }
+
+    private class RecordingExporter(
+        private val result: LeaderAuditSubmitResult = LeaderAuditSubmitResult.ACCEPTED,
+    ) : LeaderAuditExporter {
+        val events = mutableListOf<LeaderAuditExportEvent>()
+        private val closed = AtomicInteger()
+
+        override fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult {
+            events += event
+            return result
+        }
+
+        override fun observe(observer: LeaderAuditExportObserver): AutoCloseable = AutoCloseable { }
+
+        override fun snapshot(): LeaderAuditExportSnapshot = LeaderAuditExportSnapshot.create(
+            queued = 0,
+            inFlight = 0,
+            scheduledRetries = 0,
+            admitted = 0,
+            accepted = events.size.toLong(),
+            droppedQueueFull = 0,
+            droppedClosed = 0,
+            retries = 0,
+            terminalFailures = 0,
+            cancellations = 0,
+            executorRejections = 0,
+            schedulerRejections = 0,
+            observerDrops = 0,
+            observerRegistrationDrops = 0,
+            diagnosticsFatalErrors = 0,
+            diagnosticsClosed = closed.get() > 0,
+            closed = closed.get() > 0,
+        )
+
+        override fun close() {
+            closed.incrementAndGet()
+        }
+    }
+
+    private fun record(): LeaderLockHistoryRecord = LeaderLockHistoryRecord(
+        lockName = "job",
+        token = "secret",
+        kind = LockIdentity.AnnotationKind.SINGLE,
+        acquiredAt = ACQUIRED_AT,
+        lockedUntil = LOCKED_UNTIL,
+        nodeId = "node-1",
+        status = LeaderHistoryStatus.ACQUIRED,
+    )
+
+    private companion object {
+        val ACQUIRED_AT: Instant = Instant.parse("2026-08-19T00:00:00Z")
+        val LOCKED_UNTIL: Instant = Instant.parse("2026-08-19T00:01:00Z")
+        val FINISHED_AT: Instant = Instant.parse("2026-08-19T00:00:42Z")
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportBoundaryContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportBoundaryContractTest.kt
@@ -1,0 +1,86 @@
+package io.bluetape4k.leader.audit
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.leader.audit.LeaderAuditExportJavaContractFixture
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Modifier
+import java.time.Instant
+
+class LeaderAuditExportBoundaryContractTest {
+
+    @Test
+    fun `public event constants and factories keep the bounded ABI`() {
+        val eventType = LeaderAuditExportEvent::class.java
+        eventType.getField("MAX_ERROR_MESSAGE_BYTES").getInt(null) shouldBeEqualTo 4096
+        eventType.getField("MAX_ERROR_TYPE_BYTES").getInt(null) shouldBeEqualTo 128
+        eventType.getField("MAX_TEXT_FIELD_BYTES").getInt(null) shouldBeEqualTo 256
+        eventType.getField("MAX_ATTRIBUTES").getInt(null) shouldBeEqualTo 32
+        eventType.getField("MAX_ATTRIBUTE_KEY_BYTES").getInt(null) shouldBeEqualTo 128
+        eventType.getField("MAX_ATTRIBUTE_VALUE_BYTES").getInt(null) shouldBeEqualTo 512
+        eventType.getField("MAX_ATTRIBUTES_TOTAL_BYTES").getInt(null) shouldBeEqualTo 8192
+
+        LeaderAuditExportEvent.History.Companion::class.java.getMethod(
+            "from",
+            LeaderLockHistoryRecord::class.java,
+            LeaderAuditValueSanitizer::class.java,
+        )
+        LeaderAuditExportEvent.Lifecycle.Companion::class.java.methods
+            .single { it.name == "from" }
+
+        val rawParameterTypes = LeaderAuditExportEvent.History::class.java.declaredConstructors
+            .flatMap { it.parameterTypes.asList() }
+        listOf(String::class.java, Map::class.java, Instant::class.java)
+            .none { it in rawParameterTypes }
+            .shouldBeTrue()
+    }
+
+    @Test
+    fun `exporter options snapshot and observer surfaces have exact descriptors`() {
+        val optionsConstructor = LeaderAuditExportOptions::class.java.declaredConstructors.single()
+        optionsConstructor.parameterTypes.size shouldBeEqualTo 8
+        optionsConstructor.parameterTypes[0] shouldBeEqualTo Int::class.javaPrimitiveType
+        optionsConstructor.parameterTypes[3] shouldBeEqualTo java.time.Duration::class.java
+
+        val exporterMethods = LeaderAuditExporter::class.java.declaredMethods
+            .map { it.name }
+            .toSet()
+        exporterMethods shouldBeEqualTo setOf("submit", "observe", "snapshot", "close")
+
+        val snapshotConstructors = LeaderAuditExportSnapshot::class.java.declaredConstructors
+        val publicSnapshotConstructors = snapshotConstructors.filter { Modifier.isPublic(it.modifiers) }
+        publicSnapshotConstructors.size shouldBeEqualTo 1
+        publicSnapshotConstructors.single().parameterTypes.size shouldBeEqualTo 2
+        publicSnapshotConstructors.single().isSynthetic.shouldBeTrue()
+
+        val publicSnapshotMethods = LeaderAuditExportSnapshot::class.java.declaredMethods
+            .filter { Modifier.isPublic(it.modifiers) }
+            .map { it.name }
+            .toSet()
+        publicSnapshotMethods shouldBeEqualTo setOf(
+            "getQueued",
+            "getInFlight",
+            "getScheduledRetries",
+            "getAdmitted",
+            "getAccepted",
+            "getDroppedQueueFull",
+            "getDroppedClosed",
+            "getRetries",
+            "getTerminalFailures",
+            "getCancellations",
+            "getExecutorRejections",
+            "getSchedulerRejections",
+            "getObserverDrops",
+            "getObserverRegistrationDrops",
+            "getDiagnosticsFatalErrors",
+            "getDiagnosticsClosed",
+            "getClosed",
+        )
+    }
+
+    @Test
+    fun `java fixture constructs options and closes exporter`() {
+        LeaderAuditExportJavaContractFixture.exercise().shouldBeTrue()
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
@@ -55,6 +55,23 @@ class LeaderAuditExportEventTest {
     }
 
     @Test
+    fun `history status uses export time for unfinished expired records`() {
+        val expiredRecord = LeaderLockHistoryRecord(
+            lockName = "expired-lock",
+            token = secretSentinel,
+            kind = LockIdentity.AnnotationKind.SINGLE,
+            acquiredAt = occurredAt,
+            lockedUntil = Instant.now().minusSeconds(1),
+            nodeId = null,
+        )
+
+        LeaderAuditExportEvent.History.from(
+            record = expiredRecord,
+            sanitizer = LeaderAuditValueSanitizer.Default,
+        ).status.shouldBeEqualTo(LeaderHistoryStatus.EXPIRED)
+    }
+
+    @Test
     fun `utf8 bounds and attribute aggregate limits are deterministic`() {
         val event = historyWithMultibyteAndOversizedAttributes()
 
@@ -154,6 +171,30 @@ class LeaderAuditExportEventTest {
                 raw.sanitize(field, secretSentinel)
             }
         }
+    }
+
+    @Test
+    fun `raw policy remains safe when used by event factories`() {
+        val raw = LeaderAuditValueSanitizer.Raw(
+            allowList = setOf(LeaderAuditField.KIND),
+            maxBytes = 16,
+        )
+
+        val history = LeaderAuditExportEvent.History.from(
+            record = recordWithSentinelInEveryField(),
+            sanitizer = raw,
+        )
+        val lifecycle = LeaderAuditExportEvent.Lifecycle.from(
+            event = LeaderElectionEvent.Elected("lock", leaderId = secretSentinel),
+            attributes = mapOf(secretSentinel to secretSentinel),
+            sanitizer = raw,
+        )
+
+        history.lockName.shouldBeEqualTo("redacted")
+        history.nodeId.shouldBeEqualTo("redacted")
+        lifecycle.lockName.shouldBeEqualTo("redacted")
+        lifecycle.leaderId.shouldBeEqualTo("redacted")
+        lifecycle.toString().contains(secretSentinel).shouldBeFalse()
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
@@ -1,0 +1,291 @@
+package io.bluetape4k.leader.audit
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.leader.LeaderElectionEvent
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.history.LeaderHistoryStatus
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.reflect.full.memberFunctions
+import kotlin.reflect.full.memberProperties
+
+class LeaderAuditExportEventTest {
+
+    private val occurredAt = Instant.parse("2026-08-18T00:00:00Z")
+    private val leaseExpiry = occurredAt.plusSeconds(60)
+    private val secretSentinel = "SECRET-TOKEN-DO-NOT-EXPORT"
+
+    @Test
+    fun `history event never exposes token and bounds error metadata`() {
+        val event = LeaderAuditExportEvent.History.from(
+            record = recordWithTokenAndOversizedMetadata(),
+            sanitizer = LeaderAuditValueSanitizer.Default,
+        )
+
+        event::class.memberProperties.none { it.name == "token" }.shouldBeTrue()
+        val errorBytes = event.errorMessage?.toByteArray(Charsets.UTF_8)?.size ?: 0
+        (errorBytes <= LeaderAuditExportEvent.MAX_ERROR_MESSAGE_BYTES).shouldBeTrue()
+        (event.attributes.size <= LeaderAuditExportEvent.MAX_ATTRIBUTES).shouldBeTrue()
+    }
+
+    @Test
+    fun `default sanitizer redacts lock node and leader identity`() {
+        val sanitizer = LeaderAuditValueSanitizer.Default
+
+        sanitizer.sanitize(LeaderAuditField.LOCK_NAME, "tenant-42-job")
+            .shouldBeEqualTo("redacted")
+        sanitizer.sanitize(LeaderAuditField.LEADER_ID, "node-1")
+            .shouldBeEqualTo("redacted")
+    }
+
+    @Test
+    fun `default policy removes sentinel from every sensitive event field and string form`() {
+        val event = LeaderAuditExportEvent.History.from(
+            record = recordWithSentinelInEveryField(),
+            sanitizer = LeaderAuditValueSanitizer.Default,
+        )
+
+        event.toString().contains(secretSentinel).shouldBeFalse()
+        event.attributes.values.any { it.contains(secretSentinel) }.shouldBeFalse()
+        event.errorMessage?.contains(secretSentinel).shouldBeFalse()
+    }
+
+    @Test
+    fun `utf8 bounds and attribute aggregate limits are deterministic`() {
+        val event = historyWithMultibyteAndOversizedAttributes()
+
+        ((event.errorMessage?.toByteArray(Charsets.UTF_8)?.size ?: 0)
+            <= LeaderAuditExportEvent.MAX_ERROR_MESSAGE_BYTES).shouldBeTrue()
+        ((event.errorType?.toByteArray(Charsets.UTF_8)?.size ?: 0)
+            <= LeaderAuditExportEvent.MAX_ERROR_TYPE_BYTES).shouldBeTrue()
+        listOf(event.lockName, event.nodeId, event.slotId).filterNotNull().all {
+            it.toByteArray(Charsets.UTF_8).size <= LeaderAuditExportEvent.MAX_TEXT_FIELD_BYTES
+        }.shouldBeTrue()
+        val lifecycle = lifecycleWithAttributes(emptyMap(), LeaderAuditValueSanitizer.Default)
+        (lifecycle.leaderId?.toByteArray(Charsets.UTF_8)?.size ?: 0)
+            .let { (it <= LeaderAuditExportEvent.MAX_TEXT_FIELD_BYTES).shouldBeTrue() }
+        (event.attributes.size <= LeaderAuditExportEvent.MAX_ATTRIBUTES).shouldBeTrue()
+        event.attributes.keys.all {
+            it.toByteArray(Charsets.UTF_8).size <= LeaderAuditExportEvent.MAX_ATTRIBUTE_KEY_BYTES
+        }.shouldBeTrue()
+        event.attributes.values.all {
+            it.toByteArray(Charsets.UTF_8).size <= LeaderAuditExportEvent.MAX_ATTRIBUTE_VALUE_BYTES
+        }.shouldBeTrue()
+        event.attributes.entries.sumOf { (key, value) ->
+            key.toByteArray(Charsets.UTF_8).size + value.toByteArray(Charsets.UTF_8).size
+        }.let { (it <= LeaderAuditExportEvent.MAX_ATTRIBUTES_TOTAL_BYTES).shouldBeTrue() }
+
+        val oversizedText = "가".repeat(200)
+        val expectedText = "가".repeat(85)
+        val bounded = historyWithTextFields(
+            lockName = oversizedText,
+            nodeId = oversizedText,
+            slotId = oversizedText,
+            sanitizer = LeaderAuditValueSanitizer.Truncate(
+                maxBytes = LeaderAuditExportEvent.MAX_TEXT_FIELD_BYTES,
+            ),
+        )
+        bounded.lockName.shouldBeEqualTo(expectedText)
+        bounded.nodeId.shouldBeEqualTo(expectedText)
+        bounded.slotId.shouldBeEqualTo(expectedText)
+
+        val boundedLifecycle = lifecycleWithLeaderId(
+            leaderId = oversizedText,
+            sanitizer = LeaderAuditValueSanitizer.Truncate(
+                maxBytes = LeaderAuditExportEvent.MAX_TEXT_FIELD_BYTES,
+            ),
+        )
+        boundedLifecycle.leaderId.shouldBeEqualTo(expectedText)
+    }
+
+    @Test
+    fun `utf8 truncation and sanitized collision order are deterministic`() {
+        val truncated = LeaderAuditValueSanitizer.Truncate(maxBytes = 7)
+            .sanitize(LeaderAuditField.ERROR_MESSAGE, "가가가x")
+        truncated.shouldBeEqualTo("가가")
+        truncated.contains("\uFFFD").shouldBeFalse()
+        truncated.contains("...").shouldBeFalse()
+
+        val first = linkedMapOf("a-two" to "y-value", "a-one" to "z-value")
+        val second = linkedMapOf("a-one" to "z-value", "a-two" to "y-value")
+        val sanitizer = LeaderAuditValueSanitizer.Truncate(maxBytes = 1)
+        val firstEvent = lifecycleWithAttributes(first, sanitizer)
+        val secondEvent = lifecycleWithAttributes(second, sanitizer)
+        firstEvent.attributes.shouldBeEqualTo(secondEvent.attributes)
+        firstEvent.attributes.values.single().shouldBeEqualTo("z")
+    }
+
+    @Test
+    fun `event and attributes are immutable snapshots without public copy mutation`() {
+        val source = mutableMapOf("key" to "value")
+        val event = LeaderAuditExportEvent.Lifecycle.from(
+            event = LeaderElectionEvent.Elected("lock", leaderId = "leader"),
+            attributes = source,
+            sanitizer = LeaderAuditValueSanitizer.Default,
+        )
+
+        source["key"] = "changed"
+        event.attributes["redacted"].shouldBeEqualTo("redacted")
+        assertFailsWith<UnsupportedOperationException> {
+            @Suppress("UNCHECKED_CAST")
+            (event.attributes as MutableMap<String, String>)["key"] = "mutated"
+        }
+        event::class.memberFunctions.none { it.name == "copy" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `hash truncate and raw modes enforce field allow list and max bytes`() {
+        (LeaderAuditValueSanitizer.Hash.sanitize(LeaderAuditField.LOCK_NAME, secretSentinel) != secretSentinel)
+            .shouldBeTrue()
+        LeaderAuditValueSanitizer.Truncate(maxBytes = 8)
+            .sanitize(LeaderAuditField.ERROR_TYPE, secretSentinel)
+            .toByteArray(Charsets.UTF_8).size.shouldBeEqualTo(8)
+        val raw = LeaderAuditValueSanitizer.Raw(
+            allowList = setOf(LeaderAuditField.KIND),
+            maxBytes = 16,
+        )
+        raw.sanitize(LeaderAuditField.KIND, "ACQUIRED").shouldBeEqualTo("ACQUIRED")
+        LeaderAuditField.values().filter { it != LeaderAuditField.KIND }.forEach { field ->
+            assertFailsWith<IllegalArgumentException> {
+                raw.sanitize(field, secretSentinel)
+            }
+        }
+    }
+
+    @Test
+    fun `raw constructor rejects invalid allow lists and byte limits`() {
+        assertFailsWith<IllegalArgumentException> {
+            LeaderAuditValueSanitizer.Raw(emptySet(), maxBytes = 16)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LeaderAuditValueSanitizer.Raw(setOf(LeaderAuditField.LOCK_NAME), maxBytes = 16)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LeaderAuditValueSanitizer.Raw(
+                setOf(LeaderAuditField.KIND, LeaderAuditField.LOCK_NAME),
+                maxBytes = 16,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LeaderAuditValueSanitizer.Raw(setOf(LeaderAuditField.KIND), maxBytes = 0)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LeaderAuditValueSanitizer.Raw(setOf(LeaderAuditField.KIND), maxBytes = -1)
+        }
+        val mutableAllowList = mutableSetOf(LeaderAuditField.KIND)
+        val copied = LeaderAuditValueSanitizer.Raw(mutableAllowList, maxBytes = 16)
+        mutableAllowList.clear()
+        copied.sanitize(LeaderAuditField.KIND, "ACQUIRED").shouldBeEqualTo("ACQUIRED")
+    }
+
+    private fun recordWithTokenAndOversizedMetadata(): LeaderLockHistoryRecord =
+        LeaderLockHistoryRecord(
+            lockName = "tenant-42-job",
+            token = secretSentinel,
+            kind = LockIdentity.AnnotationKind.GROUP,
+            acquiredAt = occurredAt,
+            lockedUntil = leaseExpiry,
+            nodeId = "node-1",
+            finishedAt = occurredAt.plusSeconds(1),
+            durationMs = 42,
+            status = LeaderHistoryStatus.COMPLETED,
+            errorType = "x".repeat(256),
+            errorMessage = "가".repeat(5000),
+            slotId = "slot-1",
+            metadata = (1..64).associate { "key-$it" to "value-$it" },
+        )
+
+    private fun recordWithSentinelInEveryField(): LeaderLockHistoryRecord =
+        LeaderLockHistoryRecord(
+            lockName = secretSentinel,
+            token = secretSentinel,
+            kind = LockIdentity.AnnotationKind.SINGLE,
+            acquiredAt = occurredAt,
+            lockedUntil = leaseExpiry,
+            nodeId = secretSentinel,
+            finishedAt = occurredAt.plusSeconds(1),
+            durationMs = 1,
+            status = LeaderHistoryStatus.FAILED,
+            errorType = secretSentinel,
+            errorMessage = secretSentinel,
+            slotId = secretSentinel,
+            metadata = mapOf(secretSentinel to secretSentinel),
+        )
+
+    private fun historyWithMultibyteAndOversizedAttributes(): LeaderAuditExportEvent.History =
+        LeaderAuditExportEvent.History.from(
+            record = record(
+                errorType = "가".repeat(200),
+                errorMessage = "가".repeat(2000),
+                metadata = (1..64).associate { "키-$it" to "값-$it".repeat(200) },
+            ),
+            sanitizer = LeaderAuditValueSanitizer.Truncate(maxBytes = 8192),
+        )
+
+    private fun historyWithTextFields(
+        lockName: String,
+        nodeId: String,
+        slotId: String,
+        sanitizer: LeaderAuditValueSanitizer,
+    ): LeaderAuditExportEvent.History =
+        LeaderAuditExportEvent.History.from(
+            record = record(
+                lockName = lockName,
+                nodeId = nodeId,
+                slotId = slotId,
+            ),
+            sanitizer = sanitizer,
+        )
+
+    private fun record(
+        lockName: String = secretSentinel,
+        nodeId: String? = secretSentinel,
+        slotId: String? = secretSentinel,
+        errorType: String? = secretSentinel,
+        errorMessage: String? = secretSentinel,
+        metadata: Map<String, String> = mapOf(secretSentinel to secretSentinel),
+    ): LeaderLockHistoryRecord =
+        LeaderLockHistoryRecord(
+            lockName = lockName,
+            token = secretSentinel,
+            kind = LockIdentity.AnnotationKind.SINGLE,
+            acquiredAt = occurredAt,
+            lockedUntil = leaseExpiry,
+            nodeId = nodeId,
+            finishedAt = occurredAt.plusSeconds(1),
+            durationMs = 1,
+            status = LeaderHistoryStatus.FAILED,
+            errorType = errorType,
+            errorMessage = errorMessage,
+            slotId = slotId,
+            metadata = metadata,
+        )
+
+    private fun lifecycleWithAttributes(
+        attributes: Map<String, String>,
+        sanitizer: LeaderAuditValueSanitizer,
+    ): LeaderAuditExportEvent.Lifecycle =
+        LeaderAuditExportEvent.Lifecycle.from(
+            event = LeaderElectionEvent.Elected(
+                lockName = "lock",
+                leaderId = "leader",
+                leaseExpiry = leaseExpiry,
+            ),
+            attributes = attributes,
+            sanitizer = sanitizer,
+        )
+
+    private fun lifecycleWithLeaderId(
+        leaderId: String,
+        sanitizer: LeaderAuditValueSanitizer,
+    ): LeaderAuditExportEvent.Lifecycle =
+        LeaderAuditExportEvent.Lifecycle.from(
+            event = LeaderElectionEvent.Elected("lock", leaderId = leaderId),
+            attributes = emptyMap(),
+            sanitizer = sanitizer,
+        )
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
@@ -9,6 +9,7 @@ import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.leader.history.LeaderHistoryStatus
 import io.bluetape4k.leader.history.LeaderLockHistoryRecord
 import org.junit.jupiter.api.Test
+import java.lang.reflect.Modifier
 import java.time.Instant
 import kotlin.reflect.full.memberFunctions
 import kotlin.reflect.full.memberProperties
@@ -152,6 +153,28 @@ class LeaderAuditExportEventTest {
             (event.attributes as MutableMap<String, String>)["key"] = "mutated"
         }
         event::class.memberFunctions.none { it.name == "copy" }.shouldBeTrue()
+    }
+
+    @Test
+    fun `event construction bytecode does not expose raw field parameters`() {
+        val rawTypes = setOf(
+            String::class.java,
+            Instant::class.java,
+            Map::class.java,
+            Long::class.java,
+            LockIdentity.AnnotationKind::class.java,
+            LeaderHistoryStatus::class.java,
+            LeaderAuditLifecycleOutcome::class.java,
+        )
+        listOf(
+            LeaderAuditExportEvent.History::class.java,
+            LeaderAuditExportEvent.Lifecycle::class.java,
+        ).forEach { eventType ->
+            eventType.declaredConstructors
+                .filter { Modifier.isPublic(it.modifiers) && it.isSynthetic }
+                .all { constructor -> constructor.parameterTypes.none(rawTypes::contains) }
+                .shouldBeTrue()
+        }
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditPendingContextStoreTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditPendingContextStoreTest.kt
@@ -1,0 +1,48 @@
+package io.bluetape4k.leader.audit
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.audit.internal.LeaderAuditPendingContextStore
+import io.bluetape4k.leader.history.LeaderHistoryKey
+import io.bluetape4k.leader.history.LeaderHistoryStatus
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class LeaderAuditPendingContextStoreTest {
+
+    @Test
+    fun `store removes by token fingerprint without retaining token in context`() {
+        val store = LeaderAuditPendingContextStore(maxEntries = 1)
+        val key = LeaderHistoryKey(lockName = "job", token = "credential")
+        store.put(key, record())
+
+        store.size() shouldBeEqualTo 1
+        val context = store.remove(key)
+        context?.lockName shouldBeEqualTo "job"
+        context.toString().contains("credential").not().shouldBeTrue()
+        store.size() shouldBeEqualTo 0
+    }
+
+    @Test
+    fun `bounded capacity evicts oldest acquisition context`() {
+        val store = LeaderAuditPendingContextStore(maxEntries = 1)
+        val first = LeaderHistoryKey(lockName = "first", token = "one")
+        val second = LeaderHistoryKey(lockName = "second", token = "two")
+        store.put(first, record("first"))
+        store.put(second, record("second"))
+
+        store.remove(first).shouldBeEqualTo(null)
+        store.remove(second)?.lockName shouldBeEqualTo "second"
+    }
+
+    private fun record(lockName: String = "job"): LeaderLockHistoryRecord = LeaderLockHistoryRecord(
+        lockName = lockName,
+        token = "credential",
+        kind = LockIdentity.AnnotationKind.SINGLE,
+        acquiredAt = Instant.parse("2026-08-19T00:00:00Z"),
+        lockedUntil = Instant.parse("2026-08-19T00:01:00Z"),
+        status = LeaderHistoryStatus.ACQUIRED,
+    )
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderElectionEventExportSubscriptionTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderElectionEventExportSubscriptionTest.kt
@@ -1,0 +1,70 @@
+package io.bluetape4k.leader.audit
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.leader.LeaderElectionEvent
+import io.bluetape4k.leader.LeaderElectionEventPublisher
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class LeaderElectionEventExportSubscriptionTest {
+
+    @Test
+    fun `subscription exports lifecycle events and stops after close`() = runTest {
+        val publisher = FakePublisher()
+        val exporter = RecordingExporter()
+        val subscription = LeaderElectionEventExportSubscription(publisher, this, exporter)
+
+        runCurrent()
+        publisher.subject.emit(LeaderElectionEvent.Elected("job", leaderId = "node-1"))
+        runCurrent()
+        subscription.close()
+        publisher.subject.emit(LeaderElectionEvent.Revoked("job"))
+        runCurrent()
+
+        exporter.events.size shouldBeEqualTo 1
+        (exporter.events.single() as LeaderAuditExportEvent.Lifecycle).outcome
+            .shouldBeEqualTo(LeaderAuditLifecycleOutcome.ELECTED)
+        subscription.close()
+    }
+
+    private class FakePublisher : LeaderElectionEventPublisher {
+        val subject = MutableSharedFlow<LeaderElectionEvent>(extraBufferCapacity = 8)
+        override val events: kotlinx.coroutines.flow.Flow<LeaderElectionEvent>
+            get() = subject
+    }
+
+    private class RecordingExporter : LeaderAuditExporter {
+        val events = mutableListOf<LeaderAuditExportEvent>()
+
+        override fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult {
+            events += event
+            return LeaderAuditSubmitResult.ACCEPTED
+        }
+
+        override fun observe(observer: LeaderAuditExportObserver): AutoCloseable = AutoCloseable { }
+
+        override fun snapshot(): LeaderAuditExportSnapshot = LeaderAuditExportSnapshot.create(
+            queued = 0,
+            inFlight = 0,
+            scheduledRetries = 0,
+            admitted = 0,
+            accepted = events.size.toLong(),
+            droppedQueueFull = 0,
+            droppedClosed = 0,
+            retries = 0,
+            terminalFailures = 0,
+            cancellations = 0,
+            executorRejections = 0,
+            schedulerRejections = 0,
+            observerDrops = 0,
+            observerRegistrationDrops = 0,
+            diagnosticsFatalErrors = 0,
+            diagnosticsClosed = false,
+            closed = false,
+        )
+
+        override fun close() = Unit
+    }
+}


### PR DESCRIPTION
## 요약

Issue #535의 OBS-03 audit export train에서 core contract와 bounded exporter 구현을 추가합니다. 이 PR은 Micrometer decorator가 쌓이는 parent slice입니다.

## Stacked PR train

- Epic: #535
- 현재 slice: OBS-03 / AUD-01 core contract
- base: `develop`
- child: AUD-02 Micrometer decorator는 이 branch를 base로 쌓습니다.
- 후속: AUD-03 HTTP/JSONL/OpenTelemetry는 별도 issue와 child train으로 분리합니다.

## 변경 범위

- sanitized audit event/snapshot/observer public SPI
- bounded queue와 retry/backoff, cancellation, executor/scheduler rejection, close 선형화
- history sink와 lifecycle event bridge
- low-cardinality diagnostics snapshot 및 observer failure 격리
- Kotlin/Java ABI 및 cancellation contract fixture

## 검증

- leader-core 전체 테스트 — 801/801 PASS
- leader-core detekt — PASS
- focused audit contract — 24/24 PASS
- `git diff --check` — PASS
- fresh inline 7-tier review — P0/P1 0, 잔여 P2는 #732/#733으로 분리
- hosted CI — run 32176335834 attempt 2, 47/47 PASS (최초 attempt의 Maven Central 429는 실패 job 재실행으로 해소)

## DoD Status

Required checks: 6/6; N/A: 0; Blocked: 0

| Check | Status | Evidence |
| --- | --- | --- |
| public audit SPI and ABI | PASS | core source plus Kotlin/Java contract fixture |
| bounded delivery, retry, cancellation | PASS | focused audit contract 24/24 |
| history/lifecycle bridge | PASS | core test suite 801/801 |
| close/rejection/permit lifecycle | PASS | deterministic boundary tests |
| Kotlin patterns and static analysis | PASS | detekt PASS |
| exact head/worktree review | PASS | head 7bba9f3ae36aa1ab4869add821672859317d20e7, diff-check PASS |

최종 상태: DONE — merged at `d3b1f74acb67f1d2712e7051b79f9d226ea5ce09`

미완료:

- P2 follow-up #732, #733


