### PR TITLE
feat(leader-micrometer): OBS-03 audit export Micrometer metrics 추가

### DIFF
--- a/leader-micrometer/README.ko.md
+++ b/leader-micrometer/README.ko.md
@@ -8,13 +8,14 @@ bluetape4k leader election을 위한 Micrometer 계측 모듈입니다.
 
 ## 개요
 
-`leader-micrometer`는 다섯 가지 계측 경로를 제공합니다.
+`leader-micrometer`는 여섯 가지 계측 경로를 제공합니다.
 
 - `leader-spring-boot`의 어노테이션 AOP를 위한 `MicrometerLeaderAopMetricsRecorder`
 - Micrometer Observation tracing bridge를 위한 `MicrometerObservationLeaderAopMetricsRecorder`, `MicrometerObservationLeaderElectionListener`
 - elector를 직접 호출할 때 사용하는 `InstrumentedLeaderElector`, `InstrumentedLeaderGroupElector`, `InstrumentedSuspendLeaderElector` 데코레이터
 - `LeaderElectionListenerRegistry` 생명주기 callback을 counter로 기록하는 `MicrometerLeaderElectionListener`
 - history sink 상태 counter를 위한 `MicrometerSafeLeaderHistoryRecorder`, `MicrometerSuspendSafeLeaderHistoryRecorder`
+- bounded audit export counter와 gauge를 위한 `MicrometerLeaderAuditExporter`
 
 이 모듈은 `leader-core`, Micrometer core, Micrometer Observation에 의존합니다. Prometheus, Datadog, OTLP 같은 metric export 형식은 애플리케이션이 선택한 Micrometer registry가 결정합니다. Observation export는 애플리케이션이 추가한 Micrometer tracing bridge와 exporter가 결정합니다.
 

--- a/leader-micrometer/README.ko.md
+++ b/leader-micrometer/README.ko.md
@@ -278,6 +278,8 @@ meter ID입니다. Counter 값은 detached generation offset과 active delegate
 snapshot을 합산해 replacement 후에도 감소하지 않습니다. close 중 delegate
 snapshot이 감소하거나 실패하면 마지막으로 신뢰한 offset을 유지하고 source를
 degraded로 표시한 뒤 delegate reference를 분리하고 원래 예외를 전달합니다.
+degraded 경로는 `leader.audit.export.meter-source-degraded` fixed warning을 사용하며
+snapshot payload나 exception message를 로그에 남기지 않습니다.
 open generation에서 metric polling 중 `delegate.snapshot()`을 읽지 못하면
 decorator는 마지막으로 신뢰한 cumulative·gauge 값을 유지하고
 `diagnosticsClosed=0`을 보존하며 해당 generation에서 fixed warning을 최대 한 번만

--- a/leader-micrometer/README.ko.md
+++ b/leader-micrometer/README.ko.md
@@ -277,6 +277,10 @@ meter ID입니다. Counter 값은 detached generation offset과 active delegate
 snapshot을 합산해 replacement 후에도 감소하지 않습니다. close 중 delegate
 snapshot이 감소하거나 실패하면 마지막으로 신뢰한 offset을 유지하고 source를
 degraded로 표시한 뒤 delegate reference를 분리하고 원래 예외를 전달합니다.
+open generation에서 metric polling 중 `delegate.snapshot()`을 읽지 못하면
+decorator는 마지막으로 신뢰한 cumulative·gauge 값을 유지하고
+`diagnosticsClosed=0`을 보존하며 해당 generation에서 fixed warning을 최대 한 번만
+기록합니다.
 
 이번 slice는 Micrometer 메트릭만 제공합니다. JSONL 출력과 OpenTelemetry
 SDK/bridge/exporter는 별도 후속 범위이며 애플리케이션이 해당 의존성과 transport를

--- a/leader-micrometer/README.ko.md
+++ b/leader-micrometer/README.ko.md
@@ -282,6 +282,13 @@ open generation에서 metric polling 중 `delegate.snapshot()`을 읽지 못하�
 decorator는 마지막으로 신뢰한 cumulative·gauge 값을 유지하고
 `diagnosticsClosed=0`을 보존하며 해당 generation에서 fixed warning을 최대 한 번만
 기록합니다.
+각 metric read는 decorator가 소유한 13개 meter의 identity도 다시 확인합니다. 다른
+컴포넌트가 고정 ID를 제거하거나 교체하면 manager는 마지막으로 신뢰한 detached 값을
+고정하고 `leader.audit.export.meter-ownership-conflict` warning을 한 번만 기록하며
+foreign meter를 읽거나 제거하지 않습니다. compromised manager는 재사용하지 않으므로
+충돌 등록을 제거한 뒤 새 `MeterRegistry`를 사용해야 복구할 수 있습니다. registry가
+달라도 동일 delegate를 두 decorator가 감쌀 수 없으며, 실패한 wrapper는 active owner를
+닫지 않습니다.
 
 이번 slice는 Micrometer 메트릭만 제공합니다. JSONL 출력과 OpenTelemetry
 SDK/bridge/exporter는 별도 후속 범위이며 애플리케이션이 해당 의존성과 transport를

--- a/leader-micrometer/README.ko.md
+++ b/leader-micrometer/README.ko.md
@@ -236,6 +236,52 @@ election.runIfLeader("daily-report") {
 | `leader.history.sink.failures` | Counter | `sink` | cancellation/interruption 경로를 제외한 history sink 호출 실패 |
 | `leader.history.acquire.missing` | Counter | `sink` | 사용할 수 없거나 중복된 acquire record 때문에 `recordAcquired`가 `null`을 반환 |
 
+## Audit Export 메트릭
+
+bounded audit delivery 결과를 Micrometer로 export하려면 core
+`LeaderAuditExporter`를 감쌉니다.
+
+```kotlin
+val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+exporter.submit(event)
+// ACCEPTED는 admission만 의미하며 delivery 성공을 의미하지 않습니다.
+exporter.close() // delegate를 정확히 한 번 소유하고 닫습니다.
+```
+
+decorator는 고정 aggregate metric catalog 하나만 제공합니다. lock name,
+leader ID, endpoint, error message, `source`, `transport`를 tag로 복사하지
+않습니다. 유일한 tag는 아래의 제한된 `outcome` 값입니다. registry는 close 후
+replacement generation에서도 meter identity를 유지하므로 `MeterRegistry.remove`
+를 호출하거나 다른 컴포넌트에서 고정 ID를 등록하지 마세요. 동일 registry에서
+active wrapper를 중복 생성하거나 foreign fixed-ID가 발견되면 즉시 실패합니다.
+non-owning observation이 필요하면 같은 delegate를 두 번 wrapping하지 말고
+`delegate.observe(...)`로 observer를 등록하세요.
+
+| Meter | 타입 | Tag / outcome | Snapshot source |
+|---|---|---|---|
+| `leader.audit.export.accepted` | FunctionCounter | `outcome=accepted` | `accepted` |
+| `leader.audit.export.dropped` | FunctionCounter | `outcome=queue_full` 또는 `closed` | `droppedQueueFull`, `droppedClosed` |
+| `leader.audit.export.retries` | FunctionCounter | `outcome=retry` | `retries` |
+| `leader.audit.export.failures` | FunctionCounter | `outcome=failure` | `terminalFailures` |
+| `leader.audit.export.queue.depth` | Gauge | 없음 | `queued` |
+| `leader.audit.export.in.flight` | Gauge | 없음 | `inFlight` |
+| `leader.audit.export.cancelled` | FunctionCounter | `outcome=cancelled` | `cancellations` |
+| `leader.audit.export.rejections` | FunctionCounter | `outcome=rejected` | executor + scheduler rejection 합계 |
+| `leader.audit.export.observer.dropped` | FunctionCounter | 없음 | `observerDrops` |
+| `leader.audit.export.observer.registration.dropped` | FunctionCounter | 없음 | `observerRegistrationDrops` |
+| `leader.audit.export.diagnostics.failures` | FunctionCounter | 없음 | `diagnosticsFatalErrors` |
+| `leader.audit.export.diagnostics.closed` | Gauge | 없음 | `diagnosticsClosed` |
+
+dropped meter는 두 개의 outcome-tagged ID를 가지므로 고정 catalog는 총 13개
+meter ID입니다. Counter 값은 detached generation offset과 active delegate
+snapshot을 합산해 replacement 후에도 감소하지 않습니다. close 중 delegate
+snapshot이 감소하거나 실패하면 마지막으로 신뢰한 offset을 유지하고 source를
+degraded로 표시한 뒤 delegate reference를 분리하고 원래 예외를 전달합니다.
+
+이번 slice는 Micrometer 메트릭만 제공합니다. JSONL 출력과 OpenTelemetry
+SDK/bridge/exporter는 별도 후속 범위이며 애플리케이션이 해당 의존성과 transport를
+명시적으로 추가해야 합니다.
+
 Micrometer naming convention이 export backend에 맞춰 이름을 바꿉니다. Prometheus에서는 `leader_aop_attempts_total`, `leader_aop_execution_duration_seconds`, `shedlock_leader_acquired_total` 같은 이름으로 노출됩니다.
 
 ## Prometheus Export

--- a/leader-micrometer/README.ko.md
+++ b/leader-micrometer/README.ko.md
@@ -276,8 +276,10 @@ non-owning observation이 필요하면 같은 delegate를 두 번 wrapping하지
 dropped meter는 두 개의 outcome-tagged ID를 가지므로 고정 catalog는 총 13개
 meter ID입니다. Counter 값은 detached generation offset과 active delegate
 snapshot을 합산해 replacement 후에도 감소하지 않습니다. close 중 delegate
-snapshot이 감소하거나 실패하면 마지막으로 신뢰한 offset을 유지하고 source를
-degraded로 표시한 뒤 delegate reference를 분리하고 원래 예외를 전달합니다.
+close 중 snapshot이 예외를 던지면 마지막으로 신뢰한 offset을 유지하고 source를
+degraded로 표시한 뒤 delegate reference를 분리하고 원래 예외를 전달합니다. snapshot이
+더 낮은 cumulative 값을 반환하는 경우에는 trusted baseline을 유지하고 degraded warning만
+기록한 뒤 정상 반환하며, 예외를 새로 만들지 않습니다.
 degraded 경로는 `leader.audit.export.meter-source-degraded` fixed warning을 사용하며
 snapshot payload나 exception message를 로그에 남기지 않습니다.
 open generation에서 metric polling 중 `delegate.snapshot()`을 읽지 못하면

--- a/leader-micrometer/README.md
+++ b/leader-micrometer/README.md
@@ -8,13 +8,14 @@ Micrometer instrumentation for bluetape4k leader election.
 
 ## Overview
 
-`leader-micrometer` provides five instrumentation paths:
+`leader-micrometer` provides six instrumentation paths:
 
 - `MicrometerLeaderAopMetricsRecorder` for Spring AOP annotations from `leader-spring-boot`
 - `MicrometerObservationLeaderAopMetricsRecorder` and `MicrometerObservationLeaderElectionListener` for Micrometer Observation tracing bridges
 - `InstrumentedLeaderElector`, `InstrumentedLeaderGroupElector`, and `InstrumentedSuspendLeaderElector` decorators for direct elector calls
 - `MicrometerLeaderElectionListener` for lifecycle callback counters from `LeaderElectionListenerRegistry`
 - `MicrometerSafeLeaderHistoryRecorder` and `MicrometerSuspendSafeLeaderHistoryRecorder` for history sink health counters
+- `MicrometerLeaderAuditExporter` for bounded audit export counters and gauges
 
 The module depends only on `leader-core`, Micrometer core, and Micrometer Observation. Metric export format is chosen by the application's Micrometer registry, such as Prometheus, Datadog, OTLP, or a composite registry. Observation export is chosen by the application-provided Micrometer tracing bridge and exporter.
 

--- a/leader-micrometer/README.md
+++ b/leader-micrometer/README.md
@@ -282,6 +282,13 @@ the original exception.
 During an open generation, if a metric poll cannot read `delegate.snapshot()`, the
 decorator keeps the last trusted cumulative and gauge values, leaves
 `diagnosticsClosed=0`, and emits the fixed warning at most once for that generation.
+Every metric read also rechecks the identity of the 13 meters it owns. If another
+component removes or replaces one of those IDs, the manager freezes the last
+trusted detached values and emits the fixed `leader.audit.export.meter-ownership-conflict`
+warning once; it never reads or removes the foreign meter. A compromised manager
+is not reused, so recovery requires a fresh `MeterRegistry` after the conflicting
+registration is removed. The same delegate cannot be wrapped by two decorators,
+even when the registries differ; the failed wrapper leaves the active owner open.
 
 This slice provides Micrometer metrics only. JSONL output and an OpenTelemetry
 SDK/bridge/exporter are separate follow-up scope; applications must add those

--- a/leader-micrometer/README.md
+++ b/leader-micrometer/README.md
@@ -236,6 +236,53 @@ election.runIfLeader("daily-report") {
 | `leader.history.sink.failures` | Counter | `sink` | History sink call failures, excluding cancellation and interruption paths |
 | `leader.history.acquire.missing` | Counter | `sink` | `recordAcquired` returned `null` for unavailable or duplicate acquisition records |
 
+## Audit Export Metrics
+
+Wrap a core `LeaderAuditExporter` when bounded audit delivery outcomes should be
+exported to Micrometer:
+
+```kotlin
+val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+exporter.submit(event)
+// ACCEPTED means admission only; it does not mean that delivery succeeded.
+exporter.close() // owns and closes delegate exactly once
+```
+
+The decorator publishes one fixed, aggregate metric catalog. It never copies lock
+names, leader IDs, endpoints, error messages, `source`, or `transport` into tags.
+The only tag is `outcome`, with the bounded values shown below. A registry keeps
+the meter identity across close-and-replacement generations; do not call
+`MeterRegistry.remove` or register the fixed IDs from another component. A
+duplicate active wrapper or a foreign fixed-ID registration fails fast. For a
+non-owning observation, register an observer with `delegate.observe(...)` rather
+than wrapping the same delegate twice.
+
+| Meter | Type | Tags / outcome | Snapshot source |
+|---|---|---|---|
+| `leader.audit.export.accepted` | FunctionCounter | `outcome=accepted` | `accepted` |
+| `leader.audit.export.dropped` | FunctionCounter | `outcome=queue_full` or `closed` | `droppedQueueFull`, `droppedClosed` |
+| `leader.audit.export.retries` | FunctionCounter | `outcome=retry` | `retries` |
+| `leader.audit.export.failures` | FunctionCounter | `outcome=failure` | `terminalFailures` |
+| `leader.audit.export.queue.depth` | Gauge | none | `queued` |
+| `leader.audit.export.in.flight` | Gauge | none | `inFlight` |
+| `leader.audit.export.cancelled` | FunctionCounter | `outcome=cancelled` | `cancellations` |
+| `leader.audit.export.rejections` | FunctionCounter | `outcome=rejected` | executor + scheduler rejections |
+| `leader.audit.export.observer.dropped` | FunctionCounter | none | `observerDrops` |
+| `leader.audit.export.observer.registration.dropped` | FunctionCounter | none | `observerRegistrationDrops` |
+| `leader.audit.export.diagnostics.failures` | FunctionCounter | none | `diagnosticsFatalErrors` |
+| `leader.audit.export.diagnostics.closed` | Gauge | none | `diagnosticsClosed` |
+
+The dropped meter has two outcome-tagged IDs, so the fixed catalog contains 13
+meter IDs. Counter values remain monotonic across replacement by combining the
+detached generation offset with the active delegate snapshot. If a delegate
+snapshot regresses or fails during close, the decorator keeps the last trusted
+offset, marks the source degraded, and detaches the delegate before propagating
+the original exception.
+
+This slice provides Micrometer metrics only. JSONL output and an OpenTelemetry
+SDK/bridge/exporter are separate follow-up scope; applications must add those
+dependencies and transports explicitly.
+
 Micrometer naming conventions convert names for the export backend. Prometheus exposes examples such as `leader_aop_attempts_total`, `leader_aop_execution_duration_seconds`, and `shedlock_leader_acquired_total`.
 
 ## Prometheus Export

--- a/leader-micrometer/README.md
+++ b/leader-micrometer/README.md
@@ -279,6 +279,8 @@ detached generation offset with the active delegate snapshot. If a delegate
 snapshot regresses or fails during close, the decorator keeps the last trusted
 offset, marks the source degraded, and detaches the delegate before propagating
 the original exception.
+The degraded path uses the fixed `leader.audit.export.meter-source-degraded` warning
+and never logs snapshot payloads or exception messages.
 During an open generation, if a metric poll cannot read `delegate.snapshot()`, the
 decorator keeps the last trusted cumulative and gauge values, leaves
 `diagnosticsClosed=0`, and emits the fixed warning at most once for that generation.

--- a/leader-micrometer/README.md
+++ b/leader-micrometer/README.md
@@ -275,10 +275,11 @@ than wrapping the same delegate twice.
 
 The dropped meter has two outcome-tagged IDs, so the fixed catalog contains 13
 meter IDs. Counter values remain monotonic across replacement by combining the
-detached generation offset with the active delegate snapshot. If a delegate
-snapshot regresses or fails during close, the decorator keeps the last trusted
-offset, marks the source degraded, and detaches the delegate before propagating
-the original exception.
+detached generation offset with the active delegate snapshot. If a close-time
+snapshot throws, the decorator keeps the last trusted offset, marks the source
+degraded, detaches the delegate, and propagates the original exception. If a
+snapshot returns a lower cumulative value, it keeps the trusted baseline and
+returns normally with the degraded warning; no exception is fabricated.
 The degraded path uses the fixed `leader.audit.export.meter-source-degraded` warning
 and never logs snapshot payloads or exception messages.
 During an open generation, if a metric poll cannot read `delegate.snapshot()`, the

--- a/leader-micrometer/README.md
+++ b/leader-micrometer/README.md
@@ -278,6 +278,9 @@ detached generation offset with the active delegate snapshot. If a delegate
 snapshot regresses or fails during close, the decorator keeps the last trusted
 offset, marks the source degraded, and detaches the delegate before propagating
 the original exception.
+During an open generation, if a metric poll cannot read `delegate.snapshot()`, the
+decorator keeps the last trusted cumulative and gauge values, leaves
+`diagnosticsClosed=0`, and emits the fixed warning at most once for that generation.
 
 This slice provides Micrometer metrics only. JSONL output and an OpenTelemetry
 SDK/bridge/exporter are separate follow-up scope; applications must add those

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerNames.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerNames.kt
@@ -84,6 +84,48 @@ const val OBSERVATION_TAG_EXECUTION_ELAPSED_MS: String = "execution.elapsed.ms"
  */
 internal object MicrometerNames {
 
+    // --- Audit exporter meters ---
+
+    /** bounded audit admission 성공 누적 counter입니다. */
+    const val AUDIT_EXPORT_ACCEPTED = "leader.audit.export.accepted"
+
+    /** bounded audit admission drop 누적 counter입니다. */
+    const val AUDIT_EXPORT_DROPPED = "leader.audit.export.dropped"
+
+    /** bounded audit retry 누적 counter입니다. */
+    const val AUDIT_EXPORT_RETRIES = "leader.audit.export.retries"
+
+    /** bounded audit terminal failure 누적 counter입니다. */
+    const val AUDIT_EXPORT_FAILURES = "leader.audit.export.failures"
+
+    /** bounded audit queue depth gauge입니다. */
+    const val AUDIT_EXPORT_QUEUE_DEPTH = "leader.audit.export.queue.depth"
+
+    /** bounded audit in-flight gauge입니다. */
+    const val AUDIT_EXPORT_IN_FLIGHT = "leader.audit.export.in.flight"
+
+    /** bounded audit cancellation 누적 counter입니다. */
+    const val AUDIT_EXPORT_CANCELLED = "leader.audit.export.cancelled"
+
+    /** bounded audit executor/scheduler rejection counter입니다. */
+    const val AUDIT_EXPORT_REJECTIONS = "leader.audit.export.rejections"
+
+    /** diagnostics observer drop 누적 counter입니다. */
+    const val AUDIT_EXPORT_OBSERVER_DROPPED = "leader.audit.export.observer.dropped"
+
+    /** diagnostics observer registration drop 누적 counter입니다. */
+    const val AUDIT_EXPORT_OBSERVER_REGISTRATION_DROPPED =
+        "leader.audit.export.observer.registration.dropped"
+
+    /** diagnostics worker fatal error 누적 counter입니다. */
+    const val AUDIT_EXPORT_DIAGNOSTICS_FAILURES = "leader.audit.export.diagnostics.failures"
+
+    /** diagnostics worker closed 상태 gauge입니다. */
+    const val AUDIT_EXPORT_DIAGNOSTICS_CLOSED = "leader.audit.export.diagnostics.closed"
+
+    /** audit metric의 bounded outcome tag key입니다. */
+    const val AUDIT_EXPORT_TAG_OUTCOME = "outcome"
+
     // --- Meter names ---
 
     /**

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
@@ -55,18 +55,26 @@ class MicrometerLeaderAuditExporter(
     private val closeFailure = AtomicReference<Throwable?>(null)
 
     init {
-        registration = try {
-            val ownershipToken = Any()
+        registration = acquireRegistration(registry, delegate)
+    }
+
+    private fun acquireRegistration(registry: MeterRegistry, delegate: LeaderAuditExporter): Registration {
+        val ownershipToken = Any()
+        try {
             DelegateOwnershipStore.claim(delegate, ownershipToken)
-            try {
-                RegistryManagerStore.acquire(registry, delegate, ownershipToken)
-            } catch (failure: Throwable) {
-                DelegateOwnershipStore.release(delegate, ownershipToken)
-                throw failure
-            }
         } catch (failure: Throwable) {
             if (failure !is DelegateAlreadyOwnedException) {
                 closeAfterConstructionFailure(delegate, failure)
+            }
+            throw failure
+        }
+        return try {
+            RegistryManagerStore.acquire(registry, delegate, ownershipToken)
+        } catch (failure: Throwable) {
+            try {
+                closeAfterConstructionFailure(delegate, failure)
+            } finally {
+                DelegateOwnershipStore.release(delegate, ownershipToken)
             }
             throw failure
         }
@@ -260,7 +268,7 @@ class MicrometerLeaderAuditExporter(
         private var ownershipWarningIssued = false
 
         fun isUnused(): Boolean = synchronized(lock) {
-            activeDelegate == null && meters.isEmpty()
+            activeDelegate == null && meters.isEmpty() && !compromised
         }
 
         fun acquire(registry: MeterRegistry, delegate: LeaderAuditExporter, ownershipToken: Any): Registration =
@@ -303,12 +311,12 @@ class MicrometerLeaderAuditExporter(
             } catch (failure: Throwable) {
                 primary = failure
             }
-            closeEntryFailure?.let { primary = appendFailure(primary, it) }
             try {
                 finalSnapshot = delegate.snapshot()
             } catch (failure: Throwable) {
                 primary = appendFailure(primary, failure)
             }
+            closeEntryFailure?.let { primary = appendFailure(primary, it) }
 
             synchronized(lock) {
                 try {
@@ -469,8 +477,12 @@ class MicrometerLeaderAuditExporter(
             if (!compromised) {
                 compromised = true
                 detachedSnapshot = DetachedSnapshot(
-                    cumulative = offsets + lastTrustedCumulative,
-                    gauges = lastTrustedGauge,
+                    cumulative = if (state == ManagerState.DETACHED) offsets else offsets + lastTrustedCumulative,
+                    gauges = if (state == ManagerState.DETACHED) {
+                        detachedSnapshot.gaugeValues()
+                    } else {
+                        lastTrustedGauge
+                    },
                 ).asTerminal()
             }
             if (!ownershipWarningIssued) {

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
@@ -24,9 +24,11 @@ import io.micrometer.core.instrument.MeterRegistry
 import java.lang.ref.ReferenceQueue
 import java.lang.ref.WeakReference
 import java.util.HashMap
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.locks.ReentrantLock
-import kotlin.concurrent.withLock
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * core audit exporter를 Micrometer의 고정 low-cardinality meter 집합으로 장식합니다.
@@ -42,12 +44,22 @@ class MicrometerLeaderAuditExporter(
 ) : LeaderAuditExporter {
 
     private val registration: Registration
-    private val closed = AtomicBoolean(false)
-    private val lifecycleLock = ReentrantLock()
+    private val lifecycleState = AtomicReference(LifecycleState.OPEN)
+    private val admittedCalls = AtomicInteger(0)
+    private val submissionsDrained = AtomicReference<CountDownLatch?>(null)
+    private val closeCompleted = CountDownLatch(1)
+    private val closeFailure = AtomicReference<Throwable?>(null)
 
     init {
         registration = try {
-            RegistryManagerStore.acquire(registry, delegate)
+            val ownershipToken = Any()
+            DelegateOwnershipStore.claim(delegate, ownershipToken)
+            try {
+                RegistryManagerStore.acquire(registry, delegate, ownershipToken)
+            } catch (failure: Throwable) {
+                DelegateOwnershipStore.release(delegate, ownershipToken)
+                throw failure
+            }
         } catch (failure: Throwable) {
             if (failure !is DelegateAlreadyOwnedException) {
                 closeAfterConstructionFailure(delegate, failure)
@@ -56,18 +68,80 @@ class MicrometerLeaderAuditExporter(
         }
     }
 
-    override fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult = lifecycleLock.withLock {
-        if (closed.get()) LeaderAuditSubmitResult.DROPPED_CLOSED else registration.delegate.submit(event)
+    override fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult {
+        if (!admitLifecycleCall()) return LeaderAuditSubmitResult.DROPPED_CLOSED
+        return try {
+            registration.delegate.submit(event)
+        } finally {
+            releaseLifecycleCall()
+        }
     }
 
-    override fun observe(observer: LeaderAuditExportObserver): AutoCloseable = lifecycleLock.withLock {
-        if (closed.get()) AutoCloseable { } else registration.delegate.observe(observer)
+    override fun observe(observer: LeaderAuditExportObserver): AutoCloseable {
+        if (!admitLifecycleCall()) return AutoCloseable { }
+        return try {
+            registration.delegate.observe(observer)
+        } finally {
+            releaseLifecycleCall()
+        }
     }
 
     override fun snapshot(): LeaderAuditExportSnapshot = registration.delegate.snapshot()
 
-    override fun close() = lifecycleLock.withLock {
-        if (closed.compareAndSet(false, true)) registration.close()
+    override fun close() {
+        if (lifecycleState.compareAndSet(LifecycleState.OPEN, LifecycleState.CLOSING)) {
+            awaitAdmittedCalls()
+            try {
+                registration.close()
+            } catch (failure: Throwable) {
+                closeFailure.set(failure)
+                throw failure
+            } finally {
+                lifecycleState.set(LifecycleState.CLOSED)
+                closeCompleted.countDown()
+            }
+        } else {
+            awaitCloseCompletion()
+            closeFailure.get()?.let { throw it }
+        }
+    }
+
+    private fun admitLifecycleCall(): Boolean {
+        var admitted = lifecycleState.get() == LifecycleState.OPEN
+        if (admitted) {
+            admittedCalls.incrementAndGet()
+            admitted = lifecycleState.get() == LifecycleState.OPEN
+            if (!admitted) releaseLifecycleCall()
+        }
+        return admitted
+    }
+
+    private fun releaseLifecycleCall() {
+        if (admittedCalls.decrementAndGet() == 0) submissionsDrained.get()?.countDown()
+    }
+
+    private fun awaitAdmittedCalls() {
+        val drain = CountDownLatch(1)
+        submissionsDrained.set(drain)
+        if (admittedCalls.get() == 0) drain.countDown()
+        awaitUninterruptibly(drain)
+    }
+
+    private fun awaitCloseCompletion() {
+        awaitUninterruptibly(closeCompleted)
+    }
+
+    private fun awaitUninterruptibly(latch: CountDownLatch) {
+        var interrupted = false
+        while (true) {
+            try {
+                latch.await()
+                break
+            } catch (_: InterruptedException) {
+                interrupted = true
+            }
+        }
+        if (interrupted) Thread.currentThread().interrupt()
     }
 
     private fun closeAfterConstructionFailure(delegate: LeaderAuditExporter, failure: Throwable) {
@@ -81,12 +155,40 @@ class MicrometerLeaderAuditExporter(
     private class Registration(
         val manager: RegistryManager,
         val delegate: LeaderAuditExporter,
+        private val ownershipToken: Any,
     ) : AutoCloseable {
         private val closed = AtomicBoolean(false)
 
         override fun close() {
             if (closed.compareAndSet(false, true)) {
-                manager.close(delegate)
+                try {
+                    manager.close(delegate)
+                } finally {
+                    DelegateOwnershipStore.release(delegate, ownershipToken)
+                }
+            }
+        }
+    }
+
+    private object DelegateOwnershipStore {
+        private val lock = Any()
+        private val referenceQueue = ReferenceQueue<LeaderAuditExporter>()
+        private val owners = HashMap<WeakIdentityKey<LeaderAuditExporter>, Any>()
+
+        fun claim(delegate: LeaderAuditExporter, token: Any) = synchronized(lock) {
+            drainCollectedDelegates()
+            if (owners.keys.any { it.get() === delegate }) throw DelegateAlreadyOwnedException()
+            owners[WeakIdentityKey(delegate, referenceQueue)] = token
+        }
+
+        fun release(delegate: LeaderAuditExporter, token: Any) = synchronized(lock) {
+            owners.entries.removeIf { (key, owner) -> key.get() === delegate && owner === token }
+        }
+
+        private fun drainCollectedDelegates() {
+            while (true) {
+                val collected = referenceQueue.poll() as WeakIdentityKey<LeaderAuditExporter>? ?: return
+                owners.remove(collected)
             }
         }
     }
@@ -94,9 +196,9 @@ class MicrometerLeaderAuditExporter(
     private object RegistryManagerStore {
         private val lock = Any()
         private val referenceQueue = ReferenceQueue<MeterRegistry>()
-        private val managers = HashMap<WeakIdentityKey, RegistryManager>()
+        private val managers = HashMap<WeakIdentityKey<MeterRegistry>, RegistryManager>()
 
-        fun acquire(registry: MeterRegistry, delegate: LeaderAuditExporter): Registration =
+        fun acquire(registry: MeterRegistry, delegate: LeaderAuditExporter, ownershipToken: Any): Registration =
             synchronized(lock) {
                 drainCollectedRegistries()
                 val entry = managers.entries.firstOrNull { it.key.get() === registry }
@@ -104,7 +206,7 @@ class MicrometerLeaderAuditExporter(
                     managers[WeakIdentityKey(registry, referenceQueue)] = it
                 }
                 try {
-                    manager.acquire(registry, delegate)
+                    manager.acquire(registry, delegate, ownershipToken)
                 } catch (failure: Throwable) {
                     if (manager.isUnused()) {
                         managers.entries.removeIf { it.value === manager }
@@ -115,27 +217,33 @@ class MicrometerLeaderAuditExporter(
 
         private fun drainCollectedRegistries() {
             while (true) {
-                val collected = referenceQueue.poll() as WeakIdentityKey? ?: return
+                val collected = referenceQueue.poll() as WeakIdentityKey<MeterRegistry>? ?: return
                 managers.remove(collected)
             }
         }
     }
 
-    private class WeakIdentityKey(
-        referent: MeterRegistry,
-        queue: ReferenceQueue<MeterRegistry>,
-    ) : WeakReference<MeterRegistry>(referent, queue) {
+    private class WeakIdentityKey<T : Any>(
+        referent: T,
+        queue: ReferenceQueue<T>,
+    ) : WeakReference<T>(referent, queue) {
         private val identityHash = System.identityHashCode(referent)
 
         override fun hashCode(): Int = identityHash
 
-        override fun equals(other: Any?): Boolean =
-            this === other || (other is WeakIdentityKey && get() != null && get() === other.get())
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            val otherKey = other as? WeakIdentityKey<*> ?: return false
+            val referent = get() ?: return false
+            return referent === otherKey.get()
+        }
     }
 
     private class RegistryManager {
         private val lock = Any()
         private val meters = HashMap<MetricDescriptor, Meter>()
+        private var registryReference: WeakReference<MeterRegistry>? = null
+        private var metersReady = false
         private var activeDelegate: LeaderAuditExporter? = null
         private var offsets = CumulativeValues.ZERO
         private var detachedSnapshot = TerminalSnapshot
@@ -145,12 +253,13 @@ class MicrometerLeaderAuditExporter(
         private var sourceDegraded = false
         private var lastTrustedCumulative = CumulativeValues.ZERO
         private var lastTrustedGauge = GaugeValues(0, 0, false)
+        private var ownershipWarningIssued = false
 
         fun isUnused(): Boolean = synchronized(lock) {
-            activeDelegate == null && meters.isEmpty() && !compromised
+            activeDelegate == null && meters.isEmpty()
         }
 
-        fun acquire(registry: MeterRegistry, delegate: LeaderAuditExporter): Registration =
+        fun acquire(registry: MeterRegistry, delegate: LeaderAuditExporter, ownershipToken: Any): Registration =
             synchronized(lock) {
                 check(!compromised) {
                     OWNERSHIP_CONFLICT_MESSAGE
@@ -159,13 +268,15 @@ class MicrometerLeaderAuditExporter(
                     if (active === delegate) throw DelegateAlreadyOwnedException()
                     error("A MicrometerLeaderAuditExporter is already active for this MeterRegistry")
                 }
+                registryReference = registryReference ?: WeakReference(registry)
                 ensureMeters(registry)
+                metersReady = true
                 activeDelegate = delegate
                 state = ManagerState.OPEN
                 sourceDegraded = false
                 lastTrustedCumulative = CumulativeValues.ZERO
                 lastTrustedGauge = GaugeValues(0, 0, false)
-                Registration(this, delegate)
+                Registration(this, delegate, ownershipToken)
             }
 
         fun close(delegate: LeaderAuditExporter) {
@@ -199,18 +310,34 @@ class MicrometerLeaderAuditExporter(
                 try {
                     val closeEntry = closingSnapshot
                     val final = finalSnapshot
-                    if (final != null && closeEntry != null && final.isNotLessThan(closeEntry)) {
+                    val trustedCumulative = closeEntry
+                        ?.cumulativeValues()
+                        ?.takeIf { it.isNotLessThan(lastTrustedCumulative) }
+                        ?: lastTrustedCumulative
+                    val trustedGauge = closeEntry?.gaugeValues() ?: lastTrustedGauge
+                    if (closeEntry == null || !closeEntry.cumulativeValues().isNotLessThan(lastTrustedCumulative)) {
+                        markSourceDegraded()
+                    }
+                    if (final != null && final.cumulativeValues().isNotLessThan(trustedCumulative)) {
                         offsets = offsets + final.cumulativeValues()
                         detachedSnapshot = final.asDetached()
                     } else {
                         markSourceDegraded()
-                        offsets = offsets + (closeEntry?.cumulativeValues() ?: CumulativeValues.ZERO)
-                        detachedSnapshot = (closeEntry?.asDetached() ?: TerminalSnapshot).asTerminal()
+                        offsets = offsets + trustedCumulative
+                        detachedSnapshot = DetachedSnapshot(trustedCumulative, trustedGauge).asTerminal()
                     }
                 } catch (failure: Throwable) {
                     primary = appendFailure(primary, failure)
                     markSourceDegraded()
-                    detachedSnapshot = (closingSnapshot?.asDetached() ?: TerminalSnapshot).asTerminal()
+                    val fallback = closingSnapshot
+                        ?.cumulativeValues()
+                        ?.takeIf { it.isNotLessThan(lastTrustedCumulative) }
+                        ?: lastTrustedCumulative
+                    offsets = offsets + fallback
+                    detachedSnapshot = DetachedSnapshot(
+                        fallback,
+                        closingSnapshot?.gaugeValues() ?: lastTrustedGauge,
+                    ).asTerminal()
                 } finally {
                     activeDelegate = null
                     closingSnapshot = null
@@ -221,34 +348,52 @@ class MicrometerLeaderAuditExporter(
         }
 
         fun counter(descriptor: MetricDescriptor): Double = synchronized(lock) {
+            verifyMeterOwnership()
             currentCumulative().value(descriptor.field).toDouble()
         }
 
         fun gauge(field: SnapshotField): Double = synchronized(lock) {
+            verifyMeterOwnership()
             currentGauge().value(field)
         }
 
         private fun ensureMeters(registry: MeterRegistry) {
-            METRIC_DESCRIPTORS.forEach { descriptor ->
-                val existing = meters[descriptor]
-                if (existing != null) {
-                    val registered = findMeter(registry, descriptor)
-                    check(registered === existing) {
-                        compromised = true
-                        OWNERSHIP_CONFLICT_MESSAGE
+            val createdDescriptors = mutableListOf<MetricDescriptor>()
+            try {
+                METRIC_DESCRIPTORS.forEach { descriptor ->
+                    val existing = meters[descriptor]
+                    if (existing != null) {
+                        if (findMeter(registry, descriptor) !== existing) failOwnership()
+                        return@forEach
                     }
-                    return@forEach
+                    if (findMeter(registry, descriptor) != null) failOwnership()
+                    val created = registerMeter(registry, descriptor)
+                    if (findMeter(registry, descriptor) !== created) failOwnership()
+                    meters[descriptor] = created
+                    createdDescriptors += descriptor
                 }
-                check(findMeter(registry, descriptor) == null) {
-                    compromised = true
-                    OWNERSHIP_CONFLICT_MESSAGE
+            } catch (failure: Throwable) {
+                createdDescriptors.forEach { descriptor ->
+                    meters.remove(descriptor)?.let { meter -> registry.remove(meter) }
                 }
-                val created = registerMeter(registry, descriptor)
-                check(findMeter(registry, descriptor) === created) {
-                    compromised = true
-                    OWNERSHIP_CONFLICT_MESSAGE
+                throw failure
+            }
+        }
+
+        private fun failOwnership(): Nothing {
+            markOwnershipCompromised()
+            throw IllegalStateException(OWNERSHIP_CONFLICT_MESSAGE)
+        }
+
+        private fun verifyMeterOwnership() {
+            if (!metersReady || compromised) return
+            val registry = registryReference?.get() ?: return
+            if (METRIC_DESCRIPTORS.any { descriptor ->
+                    val expected = meters[descriptor] ?: return@any true
+                    findMeter(registry, descriptor) !== expected
                 }
-                meters[descriptor] = created
+            ) {
+                markOwnershipCompromised()
             }
         }
 
@@ -277,6 +422,7 @@ class MicrometerLeaderAuditExporter(
         }
 
         private fun currentCumulative(): CumulativeValues {
+            if (compromised) return detachedSnapshot.cumulativeValues()
             val active = activeDelegate
             return when (state) {
                 ManagerState.OPEN -> offsets +
@@ -288,6 +434,7 @@ class MicrometerLeaderAuditExporter(
         }
 
         private fun currentGauge(): GaugeValues {
+            if (compromised) return detachedSnapshot.gaugeValues()
             val active = activeDelegate
             return when (state) {
                 ManagerState.OPEN -> active?.let(::readSnapshot)?.gaugeValues() ?: lastTrustedGauge
@@ -298,9 +445,16 @@ class MicrometerLeaderAuditExporter(
 
         private fun readSnapshot(delegate: LeaderAuditExporter): LeaderAuditExportSnapshot? = try {
             delegate.snapshot().also { snapshot ->
-                lastTrustedCumulative = snapshot.cumulativeValues()
+                val cumulative = snapshot.cumulativeValues()
+                if (!cumulative.isNotLessThan(lastTrustedCumulative)) {
+                    markSourceDegraded()
+                    return null
+                }
+                lastTrustedCumulative = cumulative
                 lastTrustedGauge = snapshot.gaugeValues()
             }
+        } catch (failure: CancellationException) {
+            throw failure
         } catch (_: Exception) {
             markSourceDegraded()
             null
@@ -312,12 +466,32 @@ class MicrometerLeaderAuditExporter(
                 log.warn { SOURCE_DEGRADED_MESSAGE }
             }
         }
+
+        private fun markOwnershipCompromised() {
+            if (!compromised) {
+                compromised = true
+                detachedSnapshot = DetachedSnapshot(
+                    cumulative = offsets + lastTrustedCumulative,
+                    gauges = lastTrustedGauge,
+                ).asTerminal()
+            }
+            if (!ownershipWarningIssued) {
+                ownershipWarningIssued = true
+                log.warn { OWNERSHIP_CONFLICT_WARNING }
+            }
+        }
     }
 
     private enum class ManagerState {
         OPEN,
         CLOSING,
         DETACHED,
+    }
+
+    private enum class LifecycleState {
+        OPEN,
+        CLOSING,
+        CLOSED,
     }
 
     private class DelegateAlreadyOwnedException : IllegalStateException(
@@ -423,6 +597,7 @@ class MicrometerLeaderAuditExporter(
     private companion object : KLogging() {
         const val OWNERSHIP_CONFLICT_MESSAGE =
             "MeterRegistry already contains a foreign or compromised leader audit meter"
+        const val OWNERSHIP_CONFLICT_WARNING = "leader.audit.export.meter-ownership-conflict"
         const val SOURCE_DEGRADED_MESSAGE = "leader.audit.export.meter-source-degraded"
 
         val TerminalSnapshot = DetachedSnapshot(

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
@@ -23,7 +23,6 @@ import io.micrometer.core.instrument.Meter
 import io.micrometer.core.instrument.MeterRegistry
 import java.lang.ref.ReferenceQueue
 import java.lang.ref.WeakReference
-import java.util.ArrayList
 import java.util.HashMap
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -41,6 +40,7 @@ class MicrometerLeaderAuditExporter(
 ) : LeaderAuditExporter {
 
     private val registration: Registration
+    private val closed = AtomicBoolean(false)
 
     init {
         registration = try {
@@ -52,7 +52,7 @@ class MicrometerLeaderAuditExporter(
     }
 
     override fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult =
-        registration.delegate.submit(event)
+        if (closed.get()) LeaderAuditSubmitResult.DROPPED_CLOSED else registration.delegate.submit(event)
 
     override fun observe(observer: LeaderAuditExportObserver): AutoCloseable =
         registration.delegate.observe(observer)
@@ -60,7 +60,7 @@ class MicrometerLeaderAuditExporter(
     override fun snapshot(): LeaderAuditExportSnapshot = registration.delegate.snapshot()
 
     override fun close() {
-        registration.close()
+        if (closed.compareAndSet(false, true)) registration.close()
     }
 
     private fun closeAfterConstructionFailure(delegate: LeaderAuditExporter, failure: Throwable) {
@@ -123,7 +123,7 @@ class MicrometerLeaderAuditExporter(
         override fun hashCode(): Int = identityHash
 
         override fun equals(other: Any?): Boolean =
-            other is WeakIdentityKey && get() != null && get() === other.get()
+            this === other || (other is WeakIdentityKey && get() != null && get() === other.get())
     }
 
     private class RegistryManager {
@@ -334,7 +334,8 @@ class MicrometerLeaderAuditExporter(
         val retries: Long,
         val failures: Long,
         val cancellations: Long,
-        val rejections: Long,
+        val executorRejections: Long,
+        val schedulerRejections: Long,
         val observerDrops: Long,
         val observerRegistrationDrops: Long,
         val diagnosticsFailures: Long,
@@ -346,7 +347,8 @@ class MicrometerLeaderAuditExporter(
             retries + other.retries,
             failures + other.failures,
             cancellations + other.cancellations,
-            rejections + other.rejections,
+            executorRejections + other.executorRejections,
+            schedulerRejections + other.schedulerRejections,
             observerDrops + other.observerDrops,
             observerRegistrationDrops + other.observerRegistrationDrops,
             diagnosticsFailures + other.diagnosticsFailures,
@@ -359,7 +361,7 @@ class MicrometerLeaderAuditExporter(
             SnapshotField.RETRIES -> retries
             SnapshotField.FAILURES -> failures
             SnapshotField.CANCELLATIONS -> cancellations
-            SnapshotField.REJECTIONS -> rejections
+            SnapshotField.REJECTIONS -> executorRejections + schedulerRejections
             SnapshotField.OBSERVER_DROPS -> observerDrops
             SnapshotField.OBSERVER_REGISTRATION_DROPS -> observerRegistrationDrops
             SnapshotField.DIAGNOSTICS_FAILURES -> diagnosticsFailures
@@ -367,7 +369,7 @@ class MicrometerLeaderAuditExporter(
         }
 
         companion object {
-            val ZERO = CumulativeValues(0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            val ZERO = CumulativeValues(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
         }
     }
 
@@ -488,7 +490,8 @@ private fun LeaderAuditExportSnapshot.cumulativeValues(): MicrometerLeaderAuditE
         retries = retries,
         failures = terminalFailures,
         cancellations = cancellations,
-        rejections = executorRejections + schedulerRejections,
+            executorRejections = executorRejections,
+            schedulerRejections = schedulerRejections,
         observerDrops = observerDrops,
         observerRegistrationDrops = observerRegistrationDrops,
         diagnosticsFailures = diagnosticsFatalErrors,
@@ -519,7 +522,8 @@ private fun MicrometerLeaderAuditExporter.CumulativeValues.isNotLessThan(
     retries >= other.retries,
     failures >= other.failures,
     cancellations >= other.cancellations,
-    rejections >= other.rejections,
+    executorRejections >= other.executorRejections,
+    schedulerRejections >= other.schedulerRejections,
     observerDrops >= other.observerDrops,
     observerRegistrationDrops >= other.observerRegistrationDrops,
     diagnosticsFailures >= other.diagnosticsFailures,

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
@@ -320,36 +320,42 @@ class MicrometerLeaderAuditExporter(
 
             synchronized(lock) {
                 try {
-                    val closeEntry = closingSnapshot
-                    val final = finalSnapshot
-                    val trustedCumulative = closeEntry
-                        ?.cumulativeValues()
-                        ?.takeIf { it.isNotLessThan(lastTrustedCumulative) }
-                        ?: lastTrustedCumulative
-                    val trustedGauge = closeEntry?.gaugeValues() ?: lastTrustedGauge
-                    if (closeEntry == null || !closeEntry.cumulativeValues().isNotLessThan(lastTrustedCumulative)) {
-                        markSourceDegraded()
-                    }
-                    if (final != null && final.cumulativeValues().isNotLessThan(trustedCumulative)) {
-                        offsets = offsets + final.cumulativeValues()
-                        detachedSnapshot = final.asDetached()
-                    } else {
-                        markSourceDegraded()
-                        offsets = offsets + trustedCumulative
-                        detachedSnapshot = DetachedSnapshot(trustedCumulative, trustedGauge).asTerminal()
+                    if (!compromised) {
+                        val closeEntry = closingSnapshot
+                        val final = finalSnapshot
+                        val trustedCumulative = closeEntry
+                            ?.cumulativeValues()
+                            ?.takeIf { it.isNotLessThan(lastTrustedCumulative) }
+                            ?: lastTrustedCumulative
+                        val trustedGauge = closeEntry?.gaugeValues() ?: lastTrustedGauge
+                        if (closeEntry == null ||
+                            !closeEntry.cumulativeValues().isNotLessThan(lastTrustedCumulative)
+                        ) {
+                            markSourceDegraded()
+                        }
+                        if (final != null && final.cumulativeValues().isNotLessThan(trustedCumulative)) {
+                            offsets = offsets + final.cumulativeValues()
+                            detachedSnapshot = final.asDetached()
+                        } else {
+                            markSourceDegraded()
+                            offsets = offsets + trustedCumulative
+                            detachedSnapshot = DetachedSnapshot(trustedCumulative, trustedGauge).asTerminal()
+                        }
                     }
                 } catch (failure: Throwable) {
-                    primary = appendFailure(primary, failure)
-                    markSourceDegraded()
-                    val fallback = closingSnapshot
-                        ?.cumulativeValues()
-                        ?.takeIf { it.isNotLessThan(lastTrustedCumulative) }
-                        ?: lastTrustedCumulative
-                    offsets = offsets + fallback
-                    detachedSnapshot = DetachedSnapshot(
-                        fallback,
-                        closingSnapshot?.gaugeValues() ?: lastTrustedGauge,
-                    ).asTerminal()
+                    if (!compromised) {
+                        primary = appendFailure(primary, failure)
+                        markSourceDegraded()
+                        val fallback = closingSnapshot
+                            ?.cumulativeValues()
+                            ?.takeIf { it.isNotLessThan(lastTrustedCumulative) }
+                            ?: lastTrustedCumulative
+                        offsets = offsets + fallback
+                        detachedSnapshot = DetachedSnapshot(
+                            fallback,
+                            closingSnapshot?.gaugeValues() ?: lastTrustedGauge,
+                        ).asTerminal()
+                    }
                 } finally {
                     activeDelegate = null
                     closingSnapshot = null
@@ -476,13 +482,24 @@ class MicrometerLeaderAuditExporter(
         private fun markOwnershipCompromised() {
             if (!compromised) {
                 compromised = true
+                val trustedCumulative = when (state) {
+                    ManagerState.OPEN -> offsets + lastTrustedCumulative
+                    ManagerState.CLOSING -> offsets + (
+                        closingSnapshot
+                            ?.cumulativeValues()
+                            ?.takeIf { it.isNotLessThan(lastTrustedCumulative) }
+                            ?: lastTrustedCumulative
+                        )
+                    ManagerState.DETACHED -> offsets
+                }
+                val trustedGauge = when (state) {
+                    ManagerState.OPEN -> lastTrustedGauge
+                    ManagerState.CLOSING -> closingSnapshot?.gaugeValues() ?: lastTrustedGauge
+                    ManagerState.DETACHED -> detachedSnapshot.gaugeValues()
+                }
                 detachedSnapshot = DetachedSnapshot(
-                    cumulative = if (state == ManagerState.DETACHED) offsets else offsets + lastTrustedCumulative,
-                    gauges = if (state == ManagerState.DETACHED) {
-                        detachedSnapshot.gaugeValues()
-                    } else {
-                        lastTrustedGauge
-                    },
+                    cumulative = trustedCumulative,
+                    gauges = trustedGauge,
                 ).asTerminal()
             }
             if (!ownershipWarningIssued) {

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
@@ -25,6 +25,8 @@ import java.lang.ref.ReferenceQueue
 import java.lang.ref.WeakReference
 import java.util.HashMap
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 /**
  * core audit exporter를 Micrometer의 고정 low-cardinality meter 집합으로 장식합니다.
@@ -41,25 +43,30 @@ class MicrometerLeaderAuditExporter(
 
     private val registration: Registration
     private val closed = AtomicBoolean(false)
+    private val lifecycleLock = ReentrantLock()
 
     init {
         registration = try {
             RegistryManagerStore.acquire(registry, delegate)
         } catch (failure: Throwable) {
-            closeAfterConstructionFailure(delegate, failure)
+            if (failure !is DelegateAlreadyOwnedException) {
+                closeAfterConstructionFailure(delegate, failure)
+            }
             throw failure
         }
     }
 
-    override fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult =
+    override fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult = lifecycleLock.withLock {
         if (closed.get()) LeaderAuditSubmitResult.DROPPED_CLOSED else registration.delegate.submit(event)
+    }
 
-    override fun observe(observer: LeaderAuditExportObserver): AutoCloseable =
-        registration.delegate.observe(observer)
+    override fun observe(observer: LeaderAuditExportObserver): AutoCloseable = lifecycleLock.withLock {
+        if (closed.get()) AutoCloseable { } else registration.delegate.observe(observer)
+    }
 
     override fun snapshot(): LeaderAuditExportSnapshot = registration.delegate.snapshot()
 
-    override fun close() {
+    override fun close() = lifecycleLock.withLock {
         if (closed.compareAndSet(false, true)) registration.close()
     }
 
@@ -148,8 +155,9 @@ class MicrometerLeaderAuditExporter(
                 check(!compromised) {
                     OWNERSHIP_CONFLICT_MESSAGE
                 }
-                check(activeDelegate == null) {
-                    "A MicrometerLeaderAuditExporter is already active for this MeterRegistry"
+                activeDelegate?.let { active ->
+                    if (active === delegate) throw DelegateAlreadyOwnedException()
+                    error("A MicrometerLeaderAuditExporter is already active for this MeterRegistry")
                 }
                 ensureMeters(registry)
                 activeDelegate = delegate
@@ -273,7 +281,8 @@ class MicrometerLeaderAuditExporter(
             return when (state) {
                 ManagerState.OPEN -> offsets +
                     (active?.let(::readSnapshot)?.cumulativeValues() ?: lastTrustedCumulative)
-                ManagerState.CLOSING -> offsets + (closingSnapshot?.cumulativeValues() ?: CumulativeValues.ZERO)
+                ManagerState.CLOSING -> offsets +
+                    (closingSnapshot?.cumulativeValues() ?: lastTrustedCumulative)
                 ManagerState.DETACHED -> offsets
             }
         }
@@ -282,7 +291,7 @@ class MicrometerLeaderAuditExporter(
             val active = activeDelegate
             return when (state) {
                 ManagerState.OPEN -> active?.let(::readSnapshot)?.gaugeValues() ?: lastTrustedGauge
-                ManagerState.CLOSING -> closingSnapshot?.gaugeValues() ?: TerminalSnapshot.gaugeValues()
+                ManagerState.CLOSING -> closingSnapshot?.gaugeValues() ?: lastTrustedGauge
                 ManagerState.DETACHED -> detachedSnapshot.gaugeValues()
             }
         }
@@ -292,19 +301,15 @@ class MicrometerLeaderAuditExporter(
                 lastTrustedCumulative = snapshot.cumulativeValues()
                 lastTrustedGauge = snapshot.gaugeValues()
             }
-        } catch (failure: Throwable) {
-            markSourceDegraded(failure)
+        } catch (_: Exception) {
+            markSourceDegraded()
             null
         }
 
-        private fun markSourceDegraded(failure: Throwable? = null) {
+        private fun markSourceDegraded() {
             if (!sourceDegraded) {
                 sourceDegraded = true
-                if (failure == null) {
-                    log.warn { SOURCE_DEGRADED_MESSAGE }
-                } else {
-                    log.warn(failure) { SOURCE_DEGRADED_MESSAGE }
-                }
+                log.warn { SOURCE_DEGRADED_MESSAGE }
             }
         }
     }
@@ -314,6 +319,10 @@ class MicrometerLeaderAuditExporter(
         CLOSING,
         DETACHED,
     }
+
+    private class DelegateAlreadyOwnedException : IllegalStateException(
+        "The delegate is already owned by an active MicrometerLeaderAuditExporter",
+    )
 
     private enum class MetricKind {
         COUNTER,

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
@@ -1,0 +1,532 @@
+@file:Suppress(
+    "LargeClass",
+    "LongMethod",
+    "MagicNumber",
+    "CyclomaticComplexMethod",
+    "TooManyFunctions",
+    "TooGenericExceptionCaught",
+)
+
+package io.bluetape4k.leader.micrometer.audit
+
+import io.bluetape4k.leader.audit.LeaderAuditExportEvent
+import io.bluetape4k.leader.audit.LeaderAuditExportObserver
+import io.bluetape4k.leader.audit.LeaderAuditExportSnapshot
+import io.bluetape4k.leader.audit.LeaderAuditExporter
+import io.bluetape4k.leader.audit.LeaderAuditSubmitResult
+import io.bluetape4k.leader.micrometer.MicrometerNames
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import io.micrometer.core.instrument.FunctionCounter
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.Meter
+import io.micrometer.core.instrument.MeterRegistry
+import java.lang.ref.ReferenceQueue
+import java.lang.ref.WeakReference
+import java.util.ArrayList
+import java.util.HashMap
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * core audit exporter를 Micrometer의 고정 low-cardinality meter 집합으로 장식합니다.
+ *
+ * decorator는 생성에 성공하면 delegate를 소유하고 `close()`에서 한 번만 닫습니다.
+ * meter는 registry에 남아 stable identity를 유지하지만 close 이후에는 delegate를
+ * 참조하지 않습니다. v1 metric은 aggregate snapshot만 알 수 있으므로 `outcome` 외
+ * `source`/`transport` 차원은 생성하지 않습니다.
+ */
+class MicrometerLeaderAuditExporter(
+    delegate: LeaderAuditExporter,
+    registry: MeterRegistry,
+) : LeaderAuditExporter {
+
+    private val registration: Registration
+
+    init {
+        registration = try {
+            RegistryManagerStore.acquire(registry, delegate)
+        } catch (failure: Throwable) {
+            closeAfterConstructionFailure(delegate, failure)
+            throw failure
+        }
+    }
+
+    override fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult =
+        registration.delegate.submit(event)
+
+    override fun observe(observer: LeaderAuditExportObserver): AutoCloseable =
+        registration.delegate.observe(observer)
+
+    override fun snapshot(): LeaderAuditExportSnapshot = registration.delegate.snapshot()
+
+    override fun close() {
+        registration.close()
+    }
+
+    private fun closeAfterConstructionFailure(delegate: LeaderAuditExporter, failure: Throwable) {
+        try {
+            delegate.close()
+        } catch (cleanup: Throwable) {
+            if (cleanup !== failure) failure.addSuppressed(cleanup)
+        }
+    }
+
+    private class Registration(
+        val manager: RegistryManager,
+        val delegate: LeaderAuditExporter,
+    ) : AutoCloseable {
+        private val closed = AtomicBoolean(false)
+
+        override fun close() {
+            if (closed.compareAndSet(false, true)) {
+                manager.close(delegate)
+            }
+        }
+    }
+
+    private object RegistryManagerStore {
+        private val lock = Any()
+        private val referenceQueue = ReferenceQueue<MeterRegistry>()
+        private val managers = HashMap<WeakIdentityKey, RegistryManager>()
+
+        fun acquire(registry: MeterRegistry, delegate: LeaderAuditExporter): Registration =
+            synchronized(lock) {
+                drainCollectedRegistries()
+                val entry = managers.entries.firstOrNull { it.key.get() === registry }
+                val manager = entry?.value ?: RegistryManager().also {
+                    managers[WeakIdentityKey(registry, referenceQueue)] = it
+                }
+                try {
+                    manager.acquire(registry, delegate)
+                } catch (failure: Throwable) {
+                    if (manager.isUnused()) {
+                        managers.entries.removeIf { it.value === manager }
+                    }
+                    throw failure
+                }
+            }
+
+        private fun drainCollectedRegistries() {
+            while (true) {
+                val collected = referenceQueue.poll() as WeakIdentityKey? ?: return
+                managers.remove(collected)
+            }
+        }
+    }
+
+    private class WeakIdentityKey(
+        referent: MeterRegistry,
+        queue: ReferenceQueue<MeterRegistry>,
+    ) : WeakReference<MeterRegistry>(referent, queue) {
+        private val identityHash = System.identityHashCode(referent)
+
+        override fun hashCode(): Int = identityHash
+
+        override fun equals(other: Any?): Boolean =
+            other is WeakIdentityKey && get() != null && get() === other.get()
+    }
+
+    private class RegistryManager {
+        private val lock = Any()
+        private val meters = HashMap<MetricDescriptor, Meter>()
+        private var activeDelegate: LeaderAuditExporter? = null
+        private var offsets = CumulativeValues.ZERO
+        private var detachedSnapshot = TerminalSnapshot
+        private var closingSnapshot: LeaderAuditExportSnapshot? = null
+        private var state = ManagerState.DETACHED
+        private var compromised = false
+        private var sourceDegraded = false
+
+        fun isUnused(): Boolean = synchronized(lock) {
+            activeDelegate == null && meters.isEmpty() && !compromised
+        }
+
+        fun acquire(registry: MeterRegistry, delegate: LeaderAuditExporter): Registration =
+            synchronized(lock) {
+                check(!compromised) {
+                    OWNERSHIP_CONFLICT_MESSAGE
+                }
+                check(activeDelegate == null) {
+                    "A MicrometerLeaderAuditExporter is already active for this MeterRegistry"
+                }
+                ensureMeters(registry)
+                activeDelegate = delegate
+                state = ManagerState.OPEN
+                sourceDegraded = false
+                Registration(this, delegate)
+            }
+
+        fun close(delegate: LeaderAuditExporter) {
+            var primary: Throwable? = null
+            var finalSnapshot: LeaderAuditExportSnapshot? = null
+            var closeEntryFailure: Throwable? = null
+            synchronized(lock) {
+                if (activeDelegate !== delegate || state != ManagerState.OPEN) return
+                try {
+                    closingSnapshot = delegate.snapshot()
+                } catch (failure: Throwable) {
+                    closeEntryFailure = failure
+                    closingSnapshot = null
+                }
+                state = ManagerState.CLOSING
+            }
+
+            try {
+                delegate.close()
+            } catch (failure: Throwable) {
+                primary = failure
+            }
+            closeEntryFailure?.let { primary = appendFailure(primary, it) }
+            try {
+                finalSnapshot = delegate.snapshot()
+            } catch (failure: Throwable) {
+                primary = appendFailure(primary, failure)
+            }
+
+            synchronized(lock) {
+                try {
+                    val closeEntry = closingSnapshot
+                    val final = finalSnapshot
+                    if (final != null && closeEntry != null && final.isNotLessThan(closeEntry)) {
+                        offsets = offsets + final.cumulativeValues()
+                        detachedSnapshot = final.asDetached()
+                    } else {
+                        sourceDegraded = true
+                        offsets = offsets + (closeEntry?.cumulativeValues() ?: CumulativeValues.ZERO)
+                        detachedSnapshot = (closeEntry?.asDetached() ?: TerminalSnapshot).asTerminal()
+                        log.warn { SOURCE_DEGRADED_MESSAGE }
+                    }
+                } catch (failure: Throwable) {
+                    primary = appendFailure(primary, failure)
+                    sourceDegraded = true
+                    detachedSnapshot = (closingSnapshot?.asDetached() ?: TerminalSnapshot).asTerminal()
+                } finally {
+                    activeDelegate = null
+                    closingSnapshot = null
+                    state = ManagerState.DETACHED
+                }
+            }
+            if (primary != null) throw primary
+        }
+
+        fun counter(descriptor: MetricDescriptor): Double = synchronized(lock) {
+            currentCumulative().value(descriptor.field).toDouble()
+        }
+
+        fun gauge(field: SnapshotField): Double = synchronized(lock) {
+            currentGauge().value(field)
+        }
+
+        private fun ensureMeters(registry: MeterRegistry) {
+            METRIC_DESCRIPTORS.forEach { descriptor ->
+                val existing = meters[descriptor]
+                if (existing != null) {
+                    val registered = findMeter(registry, descriptor)
+                    check(registered === existing) {
+                        compromised = true
+                        OWNERSHIP_CONFLICT_MESSAGE
+                    }
+                    return@forEach
+                }
+                check(findMeter(registry, descriptor) == null) {
+                    compromised = true
+                    OWNERSHIP_CONFLICT_MESSAGE
+                }
+                val created = registerMeter(registry, descriptor)
+                check(findMeter(registry, descriptor) === created) {
+                    compromised = true
+                    OWNERSHIP_CONFLICT_MESSAGE
+                }
+                meters[descriptor] = created
+            }
+        }
+
+        private fun registerMeter(
+            registry: MeterRegistry,
+            descriptor: MetricDescriptor,
+        ): Meter = when (descriptor.kind) {
+            MetricKind.COUNTER -> FunctionCounter.builder(descriptor.name, this) {
+                counter(descriptor)
+            }.apply {
+                descriptor.outcome?.let { tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, it) }
+            }.register(registry)
+            MetricKind.GAUGE -> Gauge.builder(descriptor.name, this) {
+                gauge(descriptor.field)
+            }.apply {
+                descriptor.outcome?.let { tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, it) }
+            }.register(registry)
+        }
+
+        private fun findMeter(registry: MeterRegistry, descriptor: MetricDescriptor): Meter? {
+            var search = registry.find(descriptor.name)
+            descriptor.outcome?.let {
+                search = search.tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, it)
+            }
+            return search.meter()
+        }
+
+        private fun currentCumulative(): CumulativeValues {
+            val active = activeDelegate
+            return when (state) {
+                ManagerState.OPEN -> offsets +
+                    (active?.let(::readSnapshot)?.cumulativeValues() ?: CumulativeValues.ZERO)
+                ManagerState.CLOSING -> offsets + (closingSnapshot?.cumulativeValues() ?: CumulativeValues.ZERO)
+                ManagerState.DETACHED -> offsets
+            }
+        }
+
+        private fun currentGauge(): GaugeValues {
+            val active = activeDelegate
+            return when (state) {
+                ManagerState.OPEN -> active?.let(::readSnapshot)?.gaugeValues() ?: TerminalSnapshot.gaugeValues()
+                ManagerState.CLOSING -> closingSnapshot?.gaugeValues() ?: TerminalSnapshot.gaugeValues()
+                ManagerState.DETACHED -> detachedSnapshot.gaugeValues()
+            }
+        }
+
+        private fun readSnapshot(delegate: LeaderAuditExporter): LeaderAuditExportSnapshot? = try {
+            delegate.snapshot()
+        } catch (failure: Throwable) {
+            sourceDegraded = true
+            log.warn(failure) { SOURCE_DEGRADED_MESSAGE }
+            null
+        }
+    }
+
+    private enum class ManagerState {
+        OPEN,
+        CLOSING,
+        DETACHED,
+    }
+
+    private enum class MetricKind {
+        COUNTER,
+        GAUGE,
+    }
+
+    internal enum class SnapshotField {
+        ACCEPTED,
+        DROPPED_QUEUE_FULL,
+        DROPPED_CLOSED,
+        RETRIES,
+        FAILURES,
+        CANCELLATIONS,
+        REJECTIONS,
+        OBSERVER_DROPS,
+        OBSERVER_REGISTRATION_DROPS,
+        DIAGNOSTICS_FAILURES,
+        QUEUED,
+        IN_FLIGHT,
+        DIAGNOSTICS_CLOSED,
+    }
+
+    private data class MetricDescriptor(
+        val name: String,
+        val field: SnapshotField,
+        val kind: MetricKind,
+        val outcome: String? = null,
+    )
+
+    internal data class CumulativeValues(
+        val accepted: Long,
+        val droppedQueueFull: Long,
+        val droppedClosed: Long,
+        val retries: Long,
+        val failures: Long,
+        val cancellations: Long,
+        val rejections: Long,
+        val observerDrops: Long,
+        val observerRegistrationDrops: Long,
+        val diagnosticsFailures: Long,
+    ) {
+        operator fun plus(other: CumulativeValues): CumulativeValues = CumulativeValues(
+            accepted + other.accepted,
+            droppedQueueFull + other.droppedQueueFull,
+            droppedClosed + other.droppedClosed,
+            retries + other.retries,
+            failures + other.failures,
+            cancellations + other.cancellations,
+            rejections + other.rejections,
+            observerDrops + other.observerDrops,
+            observerRegistrationDrops + other.observerRegistrationDrops,
+            diagnosticsFailures + other.diagnosticsFailures,
+        )
+
+        internal fun value(field: SnapshotField): Long = when (field) {
+            SnapshotField.ACCEPTED -> accepted
+            SnapshotField.DROPPED_QUEUE_FULL -> droppedQueueFull
+            SnapshotField.DROPPED_CLOSED -> droppedClosed
+            SnapshotField.RETRIES -> retries
+            SnapshotField.FAILURES -> failures
+            SnapshotField.CANCELLATIONS -> cancellations
+            SnapshotField.REJECTIONS -> rejections
+            SnapshotField.OBSERVER_DROPS -> observerDrops
+            SnapshotField.OBSERVER_REGISTRATION_DROPS -> observerRegistrationDrops
+            SnapshotField.DIAGNOSTICS_FAILURES -> diagnosticsFailures
+            else -> 0
+        }
+
+        companion object {
+            val ZERO = CumulativeValues(0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        }
+    }
+
+    internal data class GaugeValues(
+        val queued: Int,
+        val inFlight: Int,
+        val diagnosticsClosed: Boolean,
+    ) {
+        internal fun value(field: SnapshotField): Double = when (field) {
+            SnapshotField.QUEUED -> queued.toDouble()
+            SnapshotField.IN_FLIGHT -> inFlight.toDouble()
+            SnapshotField.DIAGNOSTICS_CLOSED -> if (diagnosticsClosed) 1.0 else 0.0
+            else -> 0.0
+        }
+    }
+
+    internal data class DetachedSnapshot(
+        val cumulative: CumulativeValues,
+        val gauges: GaugeValues,
+    ) {
+        fun cumulativeValues(): CumulativeValues = cumulative
+        fun gaugeValues(): GaugeValues = gauges
+        fun asTerminal(): DetachedSnapshot = copy(gauges = GaugeValues(0, 0, true))
+    }
+
+    private companion object : KLogging() {
+        const val OWNERSHIP_CONFLICT_MESSAGE =
+            "MeterRegistry already contains a foreign or compromised leader audit meter"
+        const val SOURCE_DEGRADED_MESSAGE = "leader.audit.export.meter-source-degraded"
+
+        val TerminalSnapshot = DetachedSnapshot(
+            cumulative = CumulativeValues.ZERO,
+            gauges = GaugeValues(0, 0, true),
+        )
+
+        val METRIC_DESCRIPTORS = listOf(
+            MetricDescriptor(
+                MicrometerNames.AUDIT_EXPORT_ACCEPTED,
+                SnapshotField.ACCEPTED,
+                MetricKind.COUNTER,
+                "accepted",
+            ),
+            MetricDescriptor(
+                MicrometerNames.AUDIT_EXPORT_DROPPED,
+                SnapshotField.DROPPED_QUEUE_FULL,
+                MetricKind.COUNTER,
+                "queue_full",
+            ),
+            MetricDescriptor(
+                MicrometerNames.AUDIT_EXPORT_DROPPED,
+                SnapshotField.DROPPED_CLOSED,
+                MetricKind.COUNTER,
+                "closed",
+            ),
+            MetricDescriptor(
+                MicrometerNames.AUDIT_EXPORT_RETRIES,
+                SnapshotField.RETRIES,
+                MetricKind.COUNTER,
+                "retry",
+            ),
+            MetricDescriptor(
+                MicrometerNames.AUDIT_EXPORT_FAILURES,
+                SnapshotField.FAILURES,
+                MetricKind.COUNTER,
+                "failure",
+            ),
+            MetricDescriptor(
+                MicrometerNames.AUDIT_EXPORT_QUEUE_DEPTH,
+                SnapshotField.QUEUED,
+                MetricKind.GAUGE,
+            ),
+            MetricDescriptor(
+                MicrometerNames.AUDIT_EXPORT_IN_FLIGHT,
+                SnapshotField.IN_FLIGHT,
+                MetricKind.GAUGE,
+            ),
+            MetricDescriptor(
+                MicrometerNames.AUDIT_EXPORT_CANCELLED,
+                SnapshotField.CANCELLATIONS,
+                MetricKind.COUNTER,
+                "cancelled",
+            ),
+            MetricDescriptor(
+                MicrometerNames.AUDIT_EXPORT_REJECTIONS,
+                SnapshotField.REJECTIONS,
+                MetricKind.COUNTER,
+                "rejected",
+            ),
+            MetricDescriptor(
+                MicrometerNames.AUDIT_EXPORT_OBSERVER_DROPPED,
+                SnapshotField.OBSERVER_DROPS,
+                MetricKind.COUNTER,
+            ),
+            MetricDescriptor(
+                MicrometerNames.AUDIT_EXPORT_OBSERVER_REGISTRATION_DROPPED,
+                SnapshotField.OBSERVER_REGISTRATION_DROPS,
+                MetricKind.COUNTER,
+            ),
+            MetricDescriptor(
+                MicrometerNames.AUDIT_EXPORT_DIAGNOSTICS_FAILURES,
+                SnapshotField.DIAGNOSTICS_FAILURES,
+                MetricKind.COUNTER,
+            ),
+            MetricDescriptor(
+                MicrometerNames.AUDIT_EXPORT_DIAGNOSTICS_CLOSED,
+                SnapshotField.DIAGNOSTICS_CLOSED,
+                MetricKind.GAUGE,
+            ),
+        )
+    }
+}
+
+private fun LeaderAuditExportSnapshot.cumulativeValues(): MicrometerLeaderAuditExporter.CumulativeValues =
+    MicrometerLeaderAuditExporter.CumulativeValues(
+        accepted = accepted,
+        droppedQueueFull = droppedQueueFull,
+        droppedClosed = droppedClosed,
+        retries = retries,
+        failures = terminalFailures,
+        cancellations = cancellations,
+        rejections = executorRejections + schedulerRejections,
+        observerDrops = observerDrops,
+        observerRegistrationDrops = observerRegistrationDrops,
+        diagnosticsFailures = diagnosticsFatalErrors,
+    )
+
+private fun appendFailure(primary: Throwable?, next: Throwable): Throwable {
+    if (primary == null) return next
+    if (primary !== next) primary.addSuppressed(next)
+    return primary
+}
+
+private fun LeaderAuditExportSnapshot.gaugeValues(): MicrometerLeaderAuditExporter.GaugeValues =
+    MicrometerLeaderAuditExporter.GaugeValues(
+        queued = queued,
+        inFlight = inFlight,
+        diagnosticsClosed = diagnosticsClosed,
+    )
+
+private fun LeaderAuditExportSnapshot.isNotLessThan(other: LeaderAuditExportSnapshot): Boolean =
+    cumulativeValues().isNotLessThan(other.cumulativeValues())
+
+private fun MicrometerLeaderAuditExporter.CumulativeValues.isNotLessThan(
+    other: MicrometerLeaderAuditExporter.CumulativeValues,
+): Boolean = listOf(
+    accepted >= other.accepted,
+    droppedQueueFull >= other.droppedQueueFull,
+    droppedClosed >= other.droppedClosed,
+    retries >= other.retries,
+    failures >= other.failures,
+    cancellations >= other.cancellations,
+    rejections >= other.rejections,
+    observerDrops >= other.observerDrops,
+    observerRegistrationDrops >= other.observerRegistrationDrops,
+    diagnosticsFailures >= other.diagnosticsFailures,
+).all { it }
+
+private fun LeaderAuditExportSnapshot.asDetached(): MicrometerLeaderAuditExporter.DetachedSnapshot =
+    MicrometerLeaderAuditExporter.DetachedSnapshot(
+        cumulative = cumulativeValues(),
+        gauges = gaugeValues().copy(diagnosticsClosed = true),
+    )

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
@@ -358,25 +358,16 @@ class MicrometerLeaderAuditExporter(
         }
 
         private fun ensureMeters(registry: MeterRegistry) {
-            val createdDescriptors = mutableListOf<MetricDescriptor>()
-            try {
-                METRIC_DESCRIPTORS.forEach { descriptor ->
-                    val existing = meters[descriptor]
-                    if (existing != null) {
-                        if (findMeter(registry, descriptor) !== existing) failOwnership()
-                        return@forEach
-                    }
-                    if (findMeter(registry, descriptor) != null) failOwnership()
-                    val created = registerMeter(registry, descriptor)
-                    if (findMeter(registry, descriptor) !== created) failOwnership()
-                    meters[descriptor] = created
-                    createdDescriptors += descriptor
+            METRIC_DESCRIPTORS.forEach { descriptor ->
+                val existing = meters[descriptor]
+                if (existing != null) {
+                    if (findMeter(registry, descriptor) !== existing) failOwnership()
+                    return@forEach
                 }
-            } catch (failure: Throwable) {
-                createdDescriptors.forEach { descriptor ->
-                    meters.remove(descriptor)?.let { meter -> registry.remove(meter) }
-                }
-                throw failure
+                if (findMeter(registry, descriptor) != null) failOwnership()
+                val created = registerMeter(registry, descriptor)
+                if (findMeter(registry, descriptor) !== created) failOwnership()
+                meters[descriptor] = created
             }
         }
 

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
@@ -37,6 +37,10 @@ import java.util.concurrent.atomic.AtomicReference
  * meter는 registry에 남아 stable identity를 유지하지만 close 이후에는 delegate를
  * 참조하지 않습니다. v1 metric은 aggregate snapshot만 알 수 있으므로 `outcome` 외
  * `source`/`transport` 차원은 생성하지 않습니다.
+ * wrapper 수명 동안 caller는 fixed meter ID를 직접 제거하거나 재등록하지 않아야 합니다.
+ * manager는 acquire 또는 metric read에서 관찰한 identity crossing만 compromised로 잠그며,
+ * foreign meter를 제거하지 않습니다. compromised registry의 복구에는 새
+ * `MeterRegistry` identity가 필요합니다.
  */
 class MicrometerLeaderAuditExporter(
     delegate: LeaderAuditExporter,

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
@@ -423,7 +423,10 @@ class MicrometerLeaderAuditExporter(
                 ManagerState.OPEN -> offsets +
                     (active?.let(::readSnapshot)?.cumulativeValues() ?: lastTrustedCumulative)
                 ManagerState.CLOSING -> offsets +
-                    (closingSnapshot?.cumulativeValues() ?: lastTrustedCumulative)
+                    (closingSnapshot
+                        ?.cumulativeValues()
+                        ?.takeIf { it.isNotLessThan(lastTrustedCumulative) }
+                        ?: lastTrustedCumulative)
                 ManagerState.DETACHED -> offsets
             }
         }

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
@@ -136,6 +136,8 @@ class MicrometerLeaderAuditExporter(
         private var state = ManagerState.DETACHED
         private var compromised = false
         private var sourceDegraded = false
+        private var lastTrustedCumulative = CumulativeValues.ZERO
+        private var lastTrustedGauge = GaugeValues(0, 0, false)
 
         fun isUnused(): Boolean = synchronized(lock) {
             activeDelegate == null && meters.isEmpty() && !compromised
@@ -153,6 +155,8 @@ class MicrometerLeaderAuditExporter(
                 activeDelegate = delegate
                 state = ManagerState.OPEN
                 sourceDegraded = false
+                lastTrustedCumulative = CumulativeValues.ZERO
+                lastTrustedGauge = GaugeValues(0, 0, false)
                 Registration(this, delegate)
             }
 
@@ -191,14 +195,13 @@ class MicrometerLeaderAuditExporter(
                         offsets = offsets + final.cumulativeValues()
                         detachedSnapshot = final.asDetached()
                     } else {
-                        sourceDegraded = true
+                        markSourceDegraded()
                         offsets = offsets + (closeEntry?.cumulativeValues() ?: CumulativeValues.ZERO)
                         detachedSnapshot = (closeEntry?.asDetached() ?: TerminalSnapshot).asTerminal()
-                        log.warn { SOURCE_DEGRADED_MESSAGE }
                     }
                 } catch (failure: Throwable) {
                     primary = appendFailure(primary, failure)
-                    sourceDegraded = true
+                    markSourceDegraded()
                     detachedSnapshot = (closingSnapshot?.asDetached() ?: TerminalSnapshot).asTerminal()
                 } finally {
                     activeDelegate = null
@@ -269,7 +272,7 @@ class MicrometerLeaderAuditExporter(
             val active = activeDelegate
             return when (state) {
                 ManagerState.OPEN -> offsets +
-                    (active?.let(::readSnapshot)?.cumulativeValues() ?: CumulativeValues.ZERO)
+                    (active?.let(::readSnapshot)?.cumulativeValues() ?: lastTrustedCumulative)
                 ManagerState.CLOSING -> offsets + (closingSnapshot?.cumulativeValues() ?: CumulativeValues.ZERO)
                 ManagerState.DETACHED -> offsets
             }
@@ -278,18 +281,31 @@ class MicrometerLeaderAuditExporter(
         private fun currentGauge(): GaugeValues {
             val active = activeDelegate
             return when (state) {
-                ManagerState.OPEN -> active?.let(::readSnapshot)?.gaugeValues() ?: TerminalSnapshot.gaugeValues()
+                ManagerState.OPEN -> active?.let(::readSnapshot)?.gaugeValues() ?: lastTrustedGauge
                 ManagerState.CLOSING -> closingSnapshot?.gaugeValues() ?: TerminalSnapshot.gaugeValues()
                 ManagerState.DETACHED -> detachedSnapshot.gaugeValues()
             }
         }
 
         private fun readSnapshot(delegate: LeaderAuditExporter): LeaderAuditExportSnapshot? = try {
-            delegate.snapshot()
+            delegate.snapshot().also { snapshot ->
+                lastTrustedCumulative = snapshot.cumulativeValues()
+                lastTrustedGauge = snapshot.gaugeValues()
+            }
         } catch (failure: Throwable) {
-            sourceDegraded = true
-            log.warn(failure) { SOURCE_DEGRADED_MESSAGE }
+            markSourceDegraded(failure)
             null
+        }
+
+        private fun markSourceDegraded(failure: Throwable? = null) {
+            if (!sourceDegraded) {
+                sourceDegraded = true
+                if (failure == null) {
+                    log.warn { SOURCE_DEGRADED_MESSAGE }
+                } else {
+                    log.warn(failure) { SOURCE_DEGRADED_MESSAGE }
+                }
+            }
         }
     }
 

--- a/leader-micrometer/src/test/java/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterJavaContractTest.java
+++ b/leader-micrometer/src/test/java/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterJavaContractTest.java
@@ -1,0 +1,62 @@
+package io.bluetape4k.leader.micrometer.audit;
+
+import io.bluetape4k.leader.audit.LeaderAuditExportEvent;
+import io.bluetape4k.leader.audit.LeaderAuditExportObserver;
+import io.bluetape4k.leader.audit.LeaderAuditExportSnapshot;
+import io.bluetape4k.leader.audit.LeaderAuditExporter;
+import io.bluetape4k.leader.audit.LeaderAuditSubmitResult;
+import io.bluetape4k.leader.audit.LeaderAuditValueSanitizer;
+import io.bluetape4k.leader.LeaderElectionEvent;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+import java.util.Collections;
+
+/** Java compile/run fixture for the Micrometer audit decorator ABI. */
+public final class MicrometerLeaderAuditExporterJavaContractTest {
+
+    private MicrometerLeaderAuditExporterJavaContractTest() {
+    }
+
+    public static boolean exercise() throws Exception {
+        MeterRegistry registry = new SimpleMeterRegistry();
+        LeaderAuditExporter delegate = new LeaderAuditExporter() {
+            @Override
+            public LeaderAuditSubmitResult submit(LeaderAuditExportEvent event) {
+                return LeaderAuditSubmitResult.ACCEPTED;
+            }
+
+            @Override
+            public AutoCloseable observe(LeaderAuditExportObserver observer) {
+                return () -> {
+                };
+            }
+
+            @Override
+            public LeaderAuditExportSnapshot snapshot() {
+                return null;
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+
+        try (MicrometerLeaderAuditExporter exporter =
+                 new MicrometerLeaderAuditExporter(delegate, registry)) {
+            exporter.submit(LeaderAuditExportEvent.Lifecycle.Companion.from(
+                new LeaderElectionEvent.Elected("java-contract"),
+                Collections.emptyMap(),
+                LeaderAuditValueSanitizer.Default.INSTANCE
+            ));
+            try (AutoCloseable ignored = exporter.observe(observation -> {
+            })) {
+                // Java try-with-resources exercises the AutoCloseable observer handle.
+            }
+            exporter.snapshot();
+            return true;
+        } catch (RuntimeException failure) {
+            return false;
+        }
+    }
+}

--- a/leader-micrometer/src/test/java/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterJavaContractTest.java
+++ b/leader-micrometer/src/test/java/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterJavaContractTest.java
@@ -11,6 +11,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 import java.util.Collections;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 /** Java compile/run fixture for the Micrometer audit decorator ABI. */
 public final class MicrometerLeaderAuditExporterJavaContractTest {
@@ -34,7 +36,11 @@ public final class MicrometerLeaderAuditExporterJavaContractTest {
 
             @Override
             public LeaderAuditExportSnapshot snapshot() {
-                return null;
+                try {
+                    return MicrometerLeaderAuditExporterJavaContractTest.snapshot();
+                } catch (ReflectiveOperationException failure) {
+                    throw new IllegalStateException(failure);
+                }
             }
 
             @Override
@@ -53,10 +59,43 @@ public final class MicrometerLeaderAuditExporterJavaContractTest {
             })) {
                 // Java try-with-resources exercises the AutoCloseable observer handle.
             }
-            exporter.snapshot();
-            return true;
+            LeaderAuditExportSnapshot snapshot = exporter.snapshot();
+            return snapshot != null && snapshot.getQueued() == 0 && !snapshot.getClosed();
         } catch (RuntimeException failure) {
             return false;
         }
+    }
+
+    private static LeaderAuditExportSnapshot snapshot() throws ReflectiveOperationException {
+        Field companionField = LeaderAuditExportSnapshot.class.getDeclaredField("Companion");
+        companionField.setAccessible(true);
+        Object companion = companionField.get(null);
+        Method create = companion.getClass().getDeclaredMethod(
+            "create$io_github_bluetape4k_leader_bluetape4k_leader_core",
+            int.class,
+            int.class,
+            int.class,
+            int.class,
+            long.class,
+            long.class,
+            long.class,
+            long.class,
+            long.class,
+            long.class,
+            long.class,
+            long.class,
+            long.class,
+            long.class,
+            long.class,
+            boolean.class,
+            boolean.class
+        );
+        create.setAccessible(true);
+        return (LeaderAuditExportSnapshot) create.invoke(
+            companion,
+            0, 0, 0, 0,
+            0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L, 0L,
+            false, false
+        );
     }
 }

--- a/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
+++ b/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
@@ -264,6 +264,34 @@ class MicrometerLeaderAuditExporterTest {
     }
 
     @Test
+    fun `closing metric poll keeps the trusted baseline before close completes`() {
+        val registry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(snapshot(accepted = 100))
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+        val accepted = registry.find(MicrometerNames.AUDIT_EXPORT_ACCEPTED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "accepted")
+            .functionCounter()
+            .shouldNotBeNull()
+        accepted.count() shouldBeEqualTo 100.0
+
+        delegate.setSnapshot(snapshot(accepted = 40))
+        val closeEntered = CountDownLatch(1)
+        val closeRelease = CountDownLatch(1)
+        delegate.blockClose(closeEntered, closeRelease)
+        val closeFinished = CountDownLatch(1)
+        Thread {
+            exporter.close()
+            closeFinished.countDown()
+        }.start()
+        closeEntered.await(1, TimeUnit.SECONDS).shouldBeTrue()
+
+        accepted.count() shouldBeEqualTo 100.0
+
+        closeRelease.countDown()
+        closeFinished.await(1, TimeUnit.SECONDS).shouldBeTrue()
+    }
+
+    @Test
     fun `source snapshot fields map to their fixed meter types`() {
         val registry = SimpleMeterRegistry()
         val delegate = SnapshotExporter(

--- a/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
+++ b/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
@@ -205,7 +205,7 @@ class MicrometerLeaderAuditExporterTest {
     @Test
     fun `foreign fixed meter registration fails before ownership transfer`() {
         val registry = SimpleMeterRegistry()
-        registry.counter(
+        val foreign = registry.counter(
             MicrometerNames.AUDIT_EXPORT_ACCEPTED,
             MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME,
             "accepted",
@@ -215,6 +215,51 @@ class MicrometerLeaderAuditExporterTest {
         assertFailsWith<IllegalStateException> {
             MicrometerLeaderAuditExporter(delegate, registry)
         }
+        delegate.closeCount shouldBeEqualTo 1
+
+        registry.remove(foreign)
+        val retryDelegate = SnapshotExporter(snapshot())
+        assertFailsWith<IllegalStateException> {
+            MicrometerLeaderAuditExporter(retryDelegate, registry)
+        }
+        retryDelegate.closeCount shouldBeEqualTo 1
+
+        val freshRegistry = SimpleMeterRegistry()
+        val recovered = MicrometerLeaderAuditExporter(SnapshotExporter(snapshot()), freshRegistry)
+        recovered.close()
+    }
+
+    @Test
+    fun `failed construction keeps delegate ownership through cleanup`() {
+        val failingRegistry = SimpleMeterRegistry()
+        failingRegistry.counter(
+            MicrometerNames.AUDIT_EXPORT_ACCEPTED,
+            MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME,
+            "accepted",
+        )
+        val secondRegistry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(snapshot())
+        val closeEntered = CountDownLatch(1)
+        val closeRelease = CountDownLatch(1)
+        delegate.blockClose(closeEntered, closeRelease)
+        val failure = AtomicReference<Throwable?>(null)
+        val construction = Thread {
+            try {
+                MicrometerLeaderAuditExporter(delegate, failingRegistry)
+            } catch (caught: Throwable) {
+                failure.set(caught)
+            }
+        }
+        construction.start()
+        closeEntered.await(1, TimeUnit.SECONDS).shouldBeTrue()
+
+        assertFailsWith<IllegalStateException> {
+            MicrometerLeaderAuditExporter(delegate, secondRegistry)
+        }
+
+        closeRelease.countDown()
+        construction.join(1_000)
+        failure.get().shouldNotBeNull()
         delegate.closeCount shouldBeEqualTo 1
     }
 
@@ -380,6 +425,28 @@ class MicrometerLeaderAuditExporterTest {
 
         owned.count() shouldBeEqualTo 7.0
         exporter.close()
+    }
+
+    @Test
+    fun `foreign meter replacement after close does not double count trusted values`() {
+        val registry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(snapshot(accepted = 100))
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+        val owned = registry.find(MicrometerNames.AUDIT_EXPORT_ACCEPTED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "accepted")
+            .meter()
+            .shouldNotBeNull()
+        (owned as FunctionCounter).count() shouldBeEqualTo 100.0
+
+        exporter.close()
+        registry.remove(owned)
+        registry.counter(
+            MicrometerNames.AUDIT_EXPORT_ACCEPTED,
+            MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME,
+            "accepted",
+        )
+
+        owned.count() shouldBeEqualTo 100.0
     }
 
     @Test

--- a/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
+++ b/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.time.Instant
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -120,7 +121,7 @@ class MicrometerLeaderAuditExporterTest {
         submitThread.start()
         entered.await(1, TimeUnit.SECONDS).shouldBeTrue()
         closeThread.start()
-        closeFinished.await(100, TimeUnit.MILLISECONDS).shouldBeFalse()
+        delegate.closeCount shouldBeEqualTo 0
 
         release.countDown()
         submitFinished.await(1, TimeUnit.SECONDS).shouldBeTrue()
@@ -129,6 +130,30 @@ class MicrometerLeaderAuditExporterTest {
         closeThread.join(1_000)
         delegate.closeCount shouldBeEqualTo 1
         exporter.submit(event()) shouldBeEqualTo LeaderAuditSubmitResult.DROPPED_CLOSED
+    }
+
+    @Test
+    fun `submit drops immediately while close is closing the delegate`() {
+        val registry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(snapshot())
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+        val closeEntered = CountDownLatch(1)
+        val closeRelease = CountDownLatch(1)
+        delegate.blockClose(closeEntered, closeRelease)
+        val closeFinished = CountDownLatch(1)
+
+        val closeThread = Thread {
+            exporter.close()
+            closeFinished.countDown()
+        }
+        closeThread.start()
+        closeEntered.await(1, TimeUnit.SECONDS).shouldBeTrue()
+
+        exporter.submit(event()) shouldBeEqualTo LeaderAuditSubmitResult.DROPPED_CLOSED
+
+        closeRelease.countDown()
+        closeFinished.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        closeThread.join(1_000)
     }
 
     @Test
@@ -154,6 +179,22 @@ class MicrometerLeaderAuditExporterTest {
 
         assertFailsWith<IllegalStateException> {
             MicrometerLeaderAuditExporter(delegate, registry)
+        }
+        delegate.closeCount shouldBeEqualTo 0
+
+        winner.close()
+        delegate.closeCount shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `wrapping the same delegate across registries does not close the active owner`() {
+        val firstRegistry = SimpleMeterRegistry()
+        val secondRegistry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(snapshot())
+        val winner = MicrometerLeaderAuditExporter(delegate, firstRegistry)
+
+        assertFailsWith<IllegalStateException> {
+            MicrometerLeaderAuditExporter(delegate, secondRegistry)
         }
         delegate.closeCount shouldBeEqualTo 0
 
@@ -195,6 +236,30 @@ class MicrometerLeaderAuditExporterTest {
             .meter()
         meterAfter shouldBeEqualTo meterBefore
         (meterAfter as FunctionCounter).count() shouldBeEqualTo 103.0
+        replacement.close()
+    }
+
+    @Test
+    fun `close entry regression keeps the last trusted cumulative baseline`() {
+        val registry = SimpleMeterRegistry()
+        val oldDelegate = SnapshotExporter(snapshot(accepted = 100))
+        val old = MicrometerLeaderAuditExporter(oldDelegate, registry)
+        val accepted = registry.find(MicrometerNames.AUDIT_EXPORT_ACCEPTED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "accepted")
+            .functionCounter()
+            .shouldNotBeNull()
+        accepted.count() shouldBeEqualTo 100.0
+
+        oldDelegate.setSnapshot(snapshot(accepted = 40))
+        old.close()
+
+        val replacementDelegate = SnapshotExporter(snapshot(accepted = 1))
+        val replacement = MicrometerLeaderAuditExporter(replacementDelegate, registry)
+        registry.find(MicrometerNames.AUDIT_EXPORT_ACCEPTED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "accepted")
+            .functionCounter()
+            .shouldNotBeNull()
+            .count() shouldBeEqualTo 101.0
         replacement.close()
     }
 
@@ -268,6 +333,28 @@ class MicrometerLeaderAuditExporterTest {
     }
 
     @Test
+    fun `foreign meter replacement is detected during metric reads`() {
+        val registry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(snapshot(accepted = 7))
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+        val owned = registry.find(MicrometerNames.AUDIT_EXPORT_ACCEPTED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "accepted")
+            .meter()
+            .shouldNotBeNull()
+        (owned as FunctionCounter).count() shouldBeEqualTo 7.0
+
+        registry.remove(owned)
+        registry.counter(
+            MicrometerNames.AUDIT_EXPORT_ACCEPTED,
+            MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME,
+            "accepted",
+        )
+
+        owned.count() shouldBeEqualTo 7.0
+        exporter.close()
+    }
+
+    @Test
     fun `fatal snapshot error is rethrown from metric polling`() {
         val registry = SimpleMeterRegistry()
         val delegate = SnapshotExporter(snapshot(accepted = 7))
@@ -279,6 +366,23 @@ class MicrometerLeaderAuditExporterTest {
 
         delegate.failSnapshotsWith(AssertionError("secret-token"))
         assertFailsWith<AssertionError> { accepted.count() }
+
+        delegate.failSnapshotsWith(null)
+        exporter.close()
+    }
+
+    @Test
+    fun `snapshot cancellation is rethrown from metric polling`() {
+        val registry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(snapshot(accepted = 7))
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+        val accepted = registry.find(MicrometerNames.AUDIT_EXPORT_ACCEPTED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "accepted")
+            .functionCounter()
+            .shouldNotBeNull()
+
+        delegate.failSnapshotsWith(CancellationException("cancelled"))
+        assertFailsWith<CancellationException> { accepted.count() }
 
         delegate.failSnapshotsWith(null)
         exporter.close()
@@ -357,6 +461,8 @@ class MicrometerLeaderAuditExporterTest {
         private val snapshotFailure = AtomicReference<Throwable?>(null)
         private var submitEntered: CountDownLatch? = null
         private var submitRelease: CountDownLatch? = null
+        private var closeEntered: CountDownLatch? = null
+        private var closeRelease: CountDownLatch? = null
         private var closed = false
         var closeCount: Int = 0
             private set
@@ -379,12 +485,23 @@ class MicrometerLeaderAuditExporterTest {
             snapshotFailure.set(failure)
         }
 
+        fun setSnapshot(snapshot: LeaderAuditExportSnapshot) {
+            current.set(snapshot)
+        }
+
         fun blockSubmissions(entered: CountDownLatch, release: CountDownLatch) {
             submitEntered = entered
             submitRelease = release
         }
 
+        fun blockClose(entered: CountDownLatch, release: CountDownLatch) {
+            closeEntered = entered
+            closeRelease = release
+        }
+
         override fun close() {
+            closeEntered?.countDown()
+            closeRelease?.await(5, TimeUnit.SECONDS)
             closeCount++
             closed = true
         }

--- a/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
+++ b/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
@@ -464,6 +464,7 @@ class MicrometerLeaderAuditExporterTest {
         (owned as FunctionCounter).count() shouldBeEqualTo 100.0
         val closeEntered = CountDownLatch(1)
         val closeRelease = CountDownLatch(1)
+        delegate.setSnapshot(snapshot(accepted = 110))
         delegate.blockClose(closeEntered, closeRelease)
         val closeFinished = CountDownLatch(1)
         Thread {
@@ -478,12 +479,12 @@ class MicrometerLeaderAuditExporterTest {
             MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME,
             "accepted",
         )
-        owned.count() shouldBeEqualTo 100.0
+        owned.count() shouldBeEqualTo 110.0
 
         delegate.setSnapshot(snapshot(accepted = 200))
         closeRelease.countDown()
         closeFinished.await(1, TimeUnit.SECONDS).shouldBeTrue()
-        owned.count() shouldBeEqualTo 100.0
+        owned.count() shouldBeEqualTo 110.0
     }
 
     @Test

--- a/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
+++ b/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
@@ -1,0 +1,301 @@
+package io.bluetape4k.leader.micrometer.audit
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.leader.audit.LeaderAuditExportEvent
+import io.bluetape4k.leader.audit.LeaderAuditExportObserver
+import io.bluetape4k.leader.audit.LeaderAuditExportSnapshot
+import io.bluetape4k.leader.audit.LeaderAuditExporter
+import io.bluetape4k.leader.audit.LeaderAuditSubmitResult
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.micrometer.MicrometerNames
+import io.bluetape4k.leader.micrometer.audit.MicrometerLeaderAuditExporterJavaContractTest
+import io.micrometer.core.instrument.FunctionCounter
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.Meter
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicReference
+
+class MicrometerLeaderAuditExporterTest {
+
+    @Test
+    fun `fixed audit meter catalog exposes only bounded outcome tags`() {
+        val registry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(
+            snapshot(accepted = 2, droppedQueueFull = 3, droppedClosed = 4, diagnosticsClosed = true),
+        )
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+
+        val expectedNames = setOf(
+            MicrometerNames.AUDIT_EXPORT_ACCEPTED,
+            MicrometerNames.AUDIT_EXPORT_DROPPED,
+            MicrometerNames.AUDIT_EXPORT_RETRIES,
+            MicrometerNames.AUDIT_EXPORT_FAILURES,
+            MicrometerNames.AUDIT_EXPORT_QUEUE_DEPTH,
+            MicrometerNames.AUDIT_EXPORT_IN_FLIGHT,
+            MicrometerNames.AUDIT_EXPORT_CANCELLED,
+            MicrometerNames.AUDIT_EXPORT_REJECTIONS,
+            MicrometerNames.AUDIT_EXPORT_OBSERVER_DROPPED,
+            MicrometerNames.AUDIT_EXPORT_OBSERVER_REGISTRATION_DROPPED,
+            MicrometerNames.AUDIT_EXPORT_DIAGNOSTICS_FAILURES,
+            MicrometerNames.AUDIT_EXPORT_DIAGNOSTICS_CLOSED,
+        )
+        val auditMeters = registry.meters.filter { it.id.name in expectedNames }
+        auditMeters.map { it.id.name }.toSet() shouldBeEqualTo expectedNames
+        auditMeters.size shouldBeEqualTo 13
+
+        val outcomeValues = auditMeters.flatMap { meter ->
+            meter.id.tags.filter { it.key == MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME }
+                .map { it.value }
+        }.toSet()
+        outcomeValues shouldBeEqualTo setOf("accepted", "queue_full", "closed", "retry", "failure", "cancelled", "rejected")
+        auditMeters.flatMap { it.id.tags }.none { tag ->
+            tag.key == "source" || tag.key == "transport" || tag.key == "lock.name" || tag.key == "endpoint"
+        }.shouldBeTrue()
+
+        registry.find(MicrometerNames.AUDIT_EXPORT_ACCEPTED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "accepted")
+            .functionCounter()
+            ?.count() shouldBeEqualTo 2.0
+        registry.find(MicrometerNames.AUDIT_EXPORT_DROPPED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "queue_full")
+            .functionCounter()
+            ?.count() shouldBeEqualTo 3.0
+        registry.find(MicrometerNames.AUDIT_EXPORT_DROPPED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "closed")
+            .functionCounter()
+            ?.count() shouldBeEqualTo 4.0
+        registry.find(MicrometerNames.AUDIT_EXPORT_DIAGNOSTICS_CLOSED)
+            .gauge()
+            ?.value() shouldBeEqualTo 1.0
+
+        exporter.close()
+    }
+
+    @Test
+    fun `decorator delegates public surface and close is idempotent`() {
+        val registry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(snapshot(accepted = 7))
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+        val event = event()
+
+        exporter.snapshot() shouldBeEqualTo delegate.snapshot()
+        exporter.submit(event) shouldBeEqualTo LeaderAuditSubmitResult.ACCEPTED
+        exporter.observe(LeaderAuditExportObserver { })
+        exporter.close()
+        exporter.close()
+        delegate.closeCount shouldBeEqualTo 1
+        exporter.submit(event) shouldBeEqualTo LeaderAuditSubmitResult.DROPPED_CLOSED
+    }
+
+    @Test
+    fun `duplicate active decorator fails without closing the winner`() {
+        val registry = SimpleMeterRegistry()
+        val winnerDelegate = SnapshotExporter(snapshot())
+        val loserDelegate = SnapshotExporter(snapshot())
+        MicrometerLeaderAuditExporter(winnerDelegate, registry)
+
+        assertFailsWith<IllegalStateException> {
+            MicrometerLeaderAuditExporter(loserDelegate, registry)
+        }
+        winnerDelegate.closeCount shouldBeEqualTo 0
+        loserDelegate.closeCount shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `foreign fixed meter registration fails before ownership transfer`() {
+        val registry = SimpleMeterRegistry()
+        registry.counter(
+            MicrometerNames.AUDIT_EXPORT_ACCEPTED,
+            MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME,
+            "accepted",
+        )
+        val delegate = SnapshotExporter(snapshot())
+
+        assertFailsWith<IllegalStateException> {
+            MicrometerLeaderAuditExporter(delegate, registry)
+        }
+        delegate.closeCount shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `close then replacement keeps meter identity and cumulative offsets`() {
+        val registry = SimpleMeterRegistry()
+        val oldDelegate = SnapshotExporter(snapshot(accepted = 100))
+        val old = MicrometerLeaderAuditExporter(oldDelegate, registry)
+        val meterBefore = registry.find(MicrometerNames.AUDIT_EXPORT_ACCEPTED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "accepted")
+            .meter()
+        meterBefore?.let { meter -> (meter as FunctionCounter).count() shouldBeEqualTo 100.0 }
+
+        old.close()
+        val replacementDelegate = SnapshotExporter(snapshot(accepted = 3))
+        val replacement = MicrometerLeaderAuditExporter(replacementDelegate, registry)
+        val meterAfter = registry.find(MicrometerNames.AUDIT_EXPORT_ACCEPTED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "accepted")
+            .meter()
+        meterAfter shouldBeEqualTo meterBefore
+        (meterAfter as FunctionCounter).count() shouldBeEqualTo 103.0
+        replacement.close()
+    }
+
+    @Test
+    fun `source snapshot fields map to their fixed meter types`() {
+        val registry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(
+            snapshot(
+                retries = 5,
+                terminalFailures = 6,
+                cancellations = 7,
+                executorRejections = 8,
+                schedulerRejections = 9,
+                observerDrops = 10,
+                observerRegistrationDrops = 11,
+                diagnosticsFatalErrors = 12,
+                queued = 2,
+                inFlight = 3,
+            ),
+        )
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+
+        registry.find(MicrometerNames.AUDIT_EXPORT_RETRIES)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "retry")
+            .meter()!!.let { it is FunctionCounter }.shouldBeTrue()
+        registry.find(MicrometerNames.AUDIT_EXPORT_FAILURES)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "failure")
+            .meter()!!.let { it is FunctionCounter }.shouldBeTrue()
+        registry.find(MicrometerNames.AUDIT_EXPORT_QUEUE_DEPTH).meter()!!.let { it is Gauge }.shouldBeTrue()
+        registry.find(MicrometerNames.AUDIT_EXPORT_IN_FLIGHT).meter()!!.let { it is Gauge }.shouldBeTrue()
+        registry.find(MicrometerNames.AUDIT_EXPORT_OBSERVER_DROPPED).meter()!!.let { it is FunctionCounter }.shouldBeTrue()
+        registry.find(MicrometerNames.AUDIT_EXPORT_OBSERVER_REGISTRATION_DROPPED).meter()!!
+            .let { it is FunctionCounter }.shouldBeTrue()
+        registry.find(MicrometerNames.AUDIT_EXPORT_DIAGNOSTICS_FAILURES).meter()!!
+            .let { it is FunctionCounter }.shouldBeTrue()
+        registry.get(MicrometerNames.AUDIT_EXPORT_QUEUE_DEPTH).gauge().value() shouldBeEqualTo 2.0
+        registry.get(MicrometerNames.AUDIT_EXPORT_IN_FLIGHT).gauge().value() shouldBeEqualTo 3.0
+        val rejectionCounter = registry.get(MicrometerNames.AUDIT_EXPORT_REJECTIONS)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "rejected")
+            .functionCounter()
+        rejectionCounter.count() shouldBeEqualTo 17.0
+        exporter.close()
+    }
+
+    @Test
+    fun `java fixture and public decorator descriptors remain stable`() {
+        MicrometerLeaderAuditExporterJavaContractTest.exercise().shouldBeTrue()
+        MicrometerLeaderAuditExporter::class.java.getConstructor(
+            LeaderAuditExporter::class.java,
+            io.micrometer.core.instrument.MeterRegistry::class.java,
+        )
+        MicrometerLeaderAuditExporter::class.java.declaredMethods
+            .filter { Modifier.isPublic(it.modifiers) && !it.isSynthetic }
+            .map { it.name }
+            .toSet() shouldBeEqualTo setOf("submit", "observe", "snapshot", "close")
+    }
+
+    private fun event(): LeaderAuditExportEvent.History = LeaderAuditExportEvent.History.from(
+        LeaderLockHistoryRecord(
+            lockName = "dynamic-lock",
+            token = "secret-token",
+            kind = LockIdentity.AnnotationKind.SINGLE,
+            acquiredAt = Instant.parse("2026-08-19T00:00:00Z"),
+            lockedUntil = Instant.parse("2026-08-19T00:01:00Z"),
+        ),
+        io.bluetape4k.leader.audit.LeaderAuditValueSanitizer.Default,
+    )
+
+    private fun snapshot(
+        queued: Int = 0,
+        inFlight: Int = 0,
+        scheduledRetries: Int = 0,
+        admitted: Int = 0,
+        accepted: Long = 0,
+        droppedQueueFull: Long = 0,
+        droppedClosed: Long = 0,
+        retries: Long = 0,
+        terminalFailures: Long = 0,
+        cancellations: Long = 0,
+        executorRejections: Long = 0,
+        schedulerRejections: Long = 0,
+        observerDrops: Long = 0,
+        observerRegistrationDrops: Long = 0,
+        diagnosticsFatalErrors: Long = 0,
+        diagnosticsClosed: Boolean = false,
+        closed: Boolean = false,
+    ): LeaderAuditExportSnapshot {
+        val companion = LeaderAuditExportSnapshot::class.java.getDeclaredField("Companion").get(null)
+        return createSnapshotMethod.invoke(
+            companion,
+            queued,
+            inFlight,
+            scheduledRetries,
+            admitted,
+            accepted,
+            droppedQueueFull,
+            droppedClosed,
+            retries,
+            terminalFailures,
+            cancellations,
+            executorRejections,
+            schedulerRejections,
+            observerDrops,
+            observerRegistrationDrops,
+            diagnosticsFatalErrors,
+            diagnosticsClosed,
+            closed,
+        ) as LeaderAuditExportSnapshot
+    }
+
+    private class SnapshotExporter(
+        initialSnapshot: LeaderAuditExportSnapshot,
+    ) : LeaderAuditExporter {
+        private val current = AtomicReference(initialSnapshot)
+        private var closed = false
+        var closeCount: Int = 0
+            private set
+
+        override fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult =
+            if (closed) LeaderAuditSubmitResult.DROPPED_CLOSED else LeaderAuditSubmitResult.ACCEPTED
+
+        override fun observe(observer: LeaderAuditExportObserver): AutoCloseable = AutoCloseable { }
+
+        override fun snapshot(): LeaderAuditExportSnapshot = current.get()
+
+        override fun close() {
+            closeCount++
+            closed = true
+        }
+    }
+
+    private companion object {
+        val createSnapshotMethod: Method = run {
+            val companion = LeaderAuditExportSnapshot::class.java.getDeclaredField("Companion").type
+            companion.getDeclaredMethod(
+                "create\$io_github_bluetape4k_leader_bluetape4k_leader_core",
+                Int::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType,
+                Int::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+                Long::class.javaPrimitiveType,
+                Boolean::class.javaPrimitiveType,
+                Boolean::class.javaPrimitiveType,
+            ).apply { isAccessible = true }
+        }
+    }
+}

--- a/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
+++ b/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
@@ -2,7 +2,9 @@ package io.bluetape4k.leader.micrometer.audit
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.leader.audit.LeaderAuditExportEvent
 import io.bluetape4k.leader.audit.LeaderAuditExportObserver
 import io.bluetape4k.leader.audit.LeaderAuditExportSnapshot
@@ -20,6 +22,8 @@ import org.junit.jupiter.api.Test
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.time.Instant
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
 class MicrometerLeaderAuditExporterTest {
@@ -95,17 +99,66 @@ class MicrometerLeaderAuditExporterTest {
     }
 
     @Test
+    fun `close waits for an admitted submit before closing the delegate`() {
+        val registry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(snapshot())
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+        val entered = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        delegate.blockSubmissions(entered, release)
+        val submitFinished = CountDownLatch(1)
+        val closeFinished = CountDownLatch(1)
+
+        val submitThread = Thread {
+            exporter.submit(event())
+            submitFinished.countDown()
+        }
+        val closeThread = Thread {
+            exporter.close()
+            closeFinished.countDown()
+        }
+        submitThread.start()
+        entered.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        closeThread.start()
+        closeFinished.await(100, TimeUnit.MILLISECONDS).shouldBeFalse()
+
+        release.countDown()
+        submitFinished.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        closeFinished.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        submitThread.join(1_000)
+        closeThread.join(1_000)
+        delegate.closeCount shouldBeEqualTo 1
+        exporter.submit(event()) shouldBeEqualTo LeaderAuditSubmitResult.DROPPED_CLOSED
+    }
+
+    @Test
     fun `duplicate active decorator fails without closing the winner`() {
         val registry = SimpleMeterRegistry()
         val winnerDelegate = SnapshotExporter(snapshot())
         val loserDelegate = SnapshotExporter(snapshot())
-        MicrometerLeaderAuditExporter(winnerDelegate, registry)
+        val winner = MicrometerLeaderAuditExporter(winnerDelegate, registry)
 
         assertFailsWith<IllegalStateException> {
             MicrometerLeaderAuditExporter(loserDelegate, registry)
         }
         winnerDelegate.closeCount shouldBeEqualTo 0
         loserDelegate.closeCount shouldBeEqualTo 1
+        winner.close()
+    }
+
+    @Test
+    fun `wrapping the same delegate twice does not close the active owner`() {
+        val registry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(snapshot())
+        val winner = MicrometerLeaderAuditExporter(delegate, registry)
+
+        assertFailsWith<IllegalStateException> {
+            MicrometerLeaderAuditExporter(delegate, registry)
+        }
+        delegate.closeCount shouldBeEqualTo 0
+
+        winner.close()
+        delegate.closeCount shouldBeEqualTo 1
     }
 
     @Test
@@ -166,17 +219,20 @@ class MicrometerLeaderAuditExporterTest {
 
         registry.find(MicrometerNames.AUDIT_EXPORT_RETRIES)
             .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "retry")
-            .meter()!!.let { it is FunctionCounter }.shouldBeTrue()
+            .meter().shouldNotBeNull().let { it is FunctionCounter }.shouldBeTrue()
         registry.find(MicrometerNames.AUDIT_EXPORT_FAILURES)
             .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "failure")
-            .meter()!!.let { it is FunctionCounter }.shouldBeTrue()
-        registry.find(MicrometerNames.AUDIT_EXPORT_QUEUE_DEPTH).meter()!!.let { it is Gauge }.shouldBeTrue()
-        registry.find(MicrometerNames.AUDIT_EXPORT_IN_FLIGHT).meter()!!.let { it is Gauge }.shouldBeTrue()
-        registry.find(MicrometerNames.AUDIT_EXPORT_OBSERVER_DROPPED).meter()!!.let { it is FunctionCounter }.shouldBeTrue()
-        registry.find(MicrometerNames.AUDIT_EXPORT_OBSERVER_REGISTRATION_DROPPED).meter()!!
-            .let { it is FunctionCounter }.shouldBeTrue()
-        registry.find(MicrometerNames.AUDIT_EXPORT_DIAGNOSTICS_FAILURES).meter()!!
-            .let { it is FunctionCounter }.shouldBeTrue()
+            .meter().shouldNotBeNull().let { it is FunctionCounter }.shouldBeTrue()
+        registry.find(MicrometerNames.AUDIT_EXPORT_QUEUE_DEPTH).meter()
+            .shouldNotBeNull().let { it is Gauge }.shouldBeTrue()
+        registry.find(MicrometerNames.AUDIT_EXPORT_IN_FLIGHT).meter()
+            .shouldNotBeNull().let { it is Gauge }.shouldBeTrue()
+        registry.find(MicrometerNames.AUDIT_EXPORT_OBSERVER_DROPPED).meter()
+            .shouldNotBeNull().let { it is FunctionCounter }.shouldBeTrue()
+        registry.find(MicrometerNames.AUDIT_EXPORT_OBSERVER_REGISTRATION_DROPPED).meter()
+            .shouldNotBeNull().let { it is FunctionCounter }.shouldBeTrue()
+        registry.find(MicrometerNames.AUDIT_EXPORT_DIAGNOSTICS_FAILURES).meter()
+            .shouldNotBeNull().let { it is FunctionCounter }.shouldBeTrue()
         registry.get(MicrometerNames.AUDIT_EXPORT_QUEUE_DEPTH).gauge().value() shouldBeEqualTo 2.0
         registry.get(MicrometerNames.AUDIT_EXPORT_IN_FLIGHT).gauge().value() shouldBeEqualTo 3.0
         val rejectionCounter = registry.get(MicrometerNames.AUDIT_EXPORT_REJECTIONS)
@@ -202,11 +258,27 @@ class MicrometerLeaderAuditExporterTest {
 
         delegate.failSnapshotsWith(IllegalStateException("transient snapshot failure"))
 
-        accepted?.count() shouldBeEqualTo 7.0
-        accepted?.count() shouldBeEqualTo 7.0
+        repeat(2) { accepted?.count() shouldBeEqualTo 7.0 }
         diagnosticsClosed?.value() shouldBeEqualTo 0.0
         registry.get(MicrometerNames.AUDIT_EXPORT_QUEUE_DEPTH).gauge().value() shouldBeEqualTo 2.0
         registry.get(MicrometerNames.AUDIT_EXPORT_IN_FLIGHT).gauge().value() shouldBeEqualTo 1.0
+
+        delegate.failSnapshotsWith(null)
+        exporter.close()
+    }
+
+    @Test
+    fun `fatal snapshot error is rethrown from metric polling`() {
+        val registry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(snapshot(accepted = 7))
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+        val accepted = registry.find(MicrometerNames.AUDIT_EXPORT_ACCEPTED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "accepted")
+            .functionCounter()
+            .shouldNotBeNull()
+
+        delegate.failSnapshotsWith(AssertionError("secret-token"))
+        assertFailsWith<AssertionError> { accepted.count() }
 
         delegate.failSnapshotsWith(null)
         exporter.close()
@@ -283,12 +355,20 @@ class MicrometerLeaderAuditExporterTest {
     ) : LeaderAuditExporter {
         private val current = AtomicReference(initialSnapshot)
         private val snapshotFailure = AtomicReference<Throwable?>(null)
+        private var submitEntered: CountDownLatch? = null
+        private var submitRelease: CountDownLatch? = null
         private var closed = false
         var closeCount: Int = 0
             private set
 
         override fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult =
-            if (closed) LeaderAuditSubmitResult.DROPPED_CLOSED else LeaderAuditSubmitResult.ACCEPTED
+            if (closed) {
+                LeaderAuditSubmitResult.DROPPED_CLOSED
+            } else {
+                submitEntered?.countDown()
+                submitRelease?.await(5, TimeUnit.SECONDS)
+                LeaderAuditSubmitResult.ACCEPTED
+            }
 
         override fun observe(observer: LeaderAuditExportObserver): AutoCloseable = AutoCloseable { }
 
@@ -297,6 +377,11 @@ class MicrometerLeaderAuditExporterTest {
 
         fun failSnapshotsWith(failure: Throwable?) {
             snapshotFailure.set(failure)
+        }
+
+        fun blockSubmissions(entered: CountDownLatch, release: CountDownLatch) {
+            submitEntered = entered
+            submitRelease = release
         }
 
         override fun close() {

--- a/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
+++ b/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
@@ -187,6 +187,32 @@ class MicrometerLeaderAuditExporterTest {
     }
 
     @Test
+    fun `transient snapshot failure keeps the last trusted open values`() {
+        val registry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(snapshot(accepted = 7, queued = 2, inFlight = 1))
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+        val accepted = registry.find(MicrometerNames.AUDIT_EXPORT_ACCEPTED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "accepted")
+            .functionCounter()
+        val diagnosticsClosed = registry.find(MicrometerNames.AUDIT_EXPORT_DIAGNOSTICS_CLOSED)
+            .gauge()
+
+        accepted?.count() shouldBeEqualTo 7.0
+        diagnosticsClosed?.value() shouldBeEqualTo 0.0
+
+        delegate.failSnapshotsWith(IllegalStateException("transient snapshot failure"))
+
+        accepted?.count() shouldBeEqualTo 7.0
+        accepted?.count() shouldBeEqualTo 7.0
+        diagnosticsClosed?.value() shouldBeEqualTo 0.0
+        registry.get(MicrometerNames.AUDIT_EXPORT_QUEUE_DEPTH).gauge().value() shouldBeEqualTo 2.0
+        registry.get(MicrometerNames.AUDIT_EXPORT_IN_FLIGHT).gauge().value() shouldBeEqualTo 1.0
+
+        delegate.failSnapshotsWith(null)
+        exporter.close()
+    }
+
+    @Test
     fun `java fixture and public decorator descriptors remain stable`() {
         MicrometerLeaderAuditExporterJavaContractTest.exercise().shouldBeTrue()
         MicrometerLeaderAuditExporter::class.java.getConstructor(
@@ -256,6 +282,7 @@ class MicrometerLeaderAuditExporterTest {
         initialSnapshot: LeaderAuditExportSnapshot,
     ) : LeaderAuditExporter {
         private val current = AtomicReference(initialSnapshot)
+        private val snapshotFailure = AtomicReference<Throwable?>(null)
         private var closed = false
         var closeCount: Int = 0
             private set
@@ -265,7 +292,12 @@ class MicrometerLeaderAuditExporterTest {
 
         override fun observe(observer: LeaderAuditExportObserver): AutoCloseable = AutoCloseable { }
 
-        override fun snapshot(): LeaderAuditExportSnapshot = current.get()
+        override fun snapshot(): LeaderAuditExportSnapshot =
+            snapshotFailure.get()?.let { throw it } ?: current.get()
+
+        fun failSnapshotsWith(failure: Throwable?) {
+            snapshotFailure.set(failure)
+        }
 
         override fun close() {
             closeCount++

--- a/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
+++ b/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
@@ -428,6 +428,65 @@ class MicrometerLeaderAuditExporterTest {
     }
 
     @Test
+    fun `ownership crossing before close preserves the trusted tombstone`() {
+        val registry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(snapshot(accepted = 100))
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+        val owned = registry.find(MicrometerNames.AUDIT_EXPORT_ACCEPTED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "accepted")
+            .meter()
+            .shouldNotBeNull()
+
+        (owned as FunctionCounter).count() shouldBeEqualTo 100.0
+        registry.remove(owned)
+        registry.counter(
+            MicrometerNames.AUDIT_EXPORT_ACCEPTED,
+            MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME,
+            "accepted",
+        )
+        owned.count() shouldBeEqualTo 100.0
+
+        delegate.setSnapshot(snapshot(accepted = 200))
+        exporter.close()
+        owned.count() shouldBeEqualTo 100.0
+    }
+
+    @Test
+    fun `ownership crossing during close preserves the closing tombstone`() {
+        val registry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(snapshot(accepted = 100))
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+        val owned = registry.find(MicrometerNames.AUDIT_EXPORT_ACCEPTED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "accepted")
+            .meter()
+            .shouldNotBeNull()
+
+        (owned as FunctionCounter).count() shouldBeEqualTo 100.0
+        val closeEntered = CountDownLatch(1)
+        val closeRelease = CountDownLatch(1)
+        delegate.blockClose(closeEntered, closeRelease)
+        val closeFinished = CountDownLatch(1)
+        Thread {
+            exporter.close()
+            closeFinished.countDown()
+        }.start()
+        closeEntered.await(1, TimeUnit.SECONDS).shouldBeTrue()
+
+        registry.remove(owned)
+        registry.counter(
+            MicrometerNames.AUDIT_EXPORT_ACCEPTED,
+            MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME,
+            "accepted",
+        )
+        owned.count() shouldBeEqualTo 100.0
+
+        delegate.setSnapshot(snapshot(accepted = 200))
+        closeRelease.countDown()
+        closeFinished.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        owned.count() shouldBeEqualTo 100.0
+    }
+
+    @Test
     fun `foreign meter replacement after close does not double count trusted values`() {
         val registry = SimpleMeterRegistry()
         val delegate = SnapshotExporter(snapshot(accepted = 100))


### PR DESCRIPTION
## 요약

Issue #535의 OBS-03 stacked train에서 core `LeaderAuditExporter`를 Micrometer 고정 metric catalog로 장식합니다.

## Stacked PR train

- Epic: #535
- parent PR: #736 (merged at `d3b1f74acb67f1d2712e7051b79f9d226ea5ce09`)
- 현재 slice: AUD-02 Micrometer decorator
- base: `develop`
- exact head: `ea8c488f0c51466bf233f10f5be23283b1771b81`
- 후속: AUD-03 HTTP/JSONL/OpenTelemetry는 #535 후속 train으로 분리

## 변경 범위

- `MicrometerLeaderAuditExporter(delegate, registry)` exact public constructor와 Java/Kotlin ABI fixture
- 13개 fixed meter ID와 bounded `outcome` tags, source/transport/cardinality redaction
- registry identity manager, delegate ownership token, partial/foreign meter fail-fast와 compromised tombstone
- active/CLOSING/DETACHED trusted snapshot, close/replacement cumulative offset, cancellation/Error propagation
- EN/KO README에 ownership 경계, degraded warning, JSONL/OpenTelemetry 후속 범위 문서화

## 검증

- Micrometer focused audit/Java contract — 21/21 PASS
- leader-micrometer 전체 테스트 — 103/103 PASS (Prometheus scrape 포함)
- `:bluetape4k-leader-micrometer:detekt` — PASS
- `git diff --check` — PASS
- fresh exact-head 7-tier review — 3/3 lane, P0/P1 0, P2는 #734/#735로 분리
- parent core PR #736 — merged SHA `d3b1f74acb67f1d2712e7051b79f9d226ea5ce09`
- hosted CI — run `32205401776` attempt 2: 13개 적용 job PASS, 35개 경로상 SKIPPED/N/A

## DoD Status

Required checks: 13/13; N/A: 35; Blocked: 0

| Check | Status | Evidence |
| --- | --- | --- |
| fixed 13-meter catalog and bounded tags | PASS | focused catalog and tag assertions |
| public Kotlin/Java ABI | PASS | reflection plus Java try-with-resources fixture |
| delegate ownership and constructor cleanup | PASS | duplicate, cross-registry, failure-barrier tests |
| active/CLOSING/DETACHED monotonic lifecycle | PASS | 100→110→200 crossing regression tests |
| cancellation/Error and degraded snapshot paths | PASS | fatal/cancellation rethrow and trusted fallback tests |
| Micrometer full regression | PASS | 103/103 including Prometheus scrape |
| Kotlin static analysis and diff | PASS | detekt, `git diff --check` |
| exact-head independent review | PASS | ea8c488f0c51466bf233f10f5be23283b1771b81, 3/3 lane P0/P1=0, P2 #734/#735 |
| hosted CI | PASS | run 32205401776 attempt 2, 적용 13 PASS, 35 SKIPPED/N/A |

최종 상태: DONE — merged at `b31fec894755da0670a504638834ab67db38311a`

미완료:

- P2 follow-up #734, #735



