### PR TITLE
feat(leader-core): audit export 입력 cardinality와 처리 비용 상한 고정

### DIFF
--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -137,6 +137,9 @@
   fun `attribute candidate scan is bounded before sorting`() { /* input cardinality guard */ }
 
   @Test
+  fun `bounded scan does not read source size before iteration`() { /* Map size guard */ }
+
+  @Test
   fun `oversized input bytes stop the attribute scan before sanitizer work`() { /* UTF-8 budget guard */ }
 
   @Test

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -256,8 +256,10 @@
   `MAX_ATTRIBUTE_KEY_BYTES=128`, `MAX_ATTRIBUTE_VALUE_BYTES=512`,
   `MAX_ATTRIBUTES_TOTAL_BYTES=8192`, `MAX_INPUT_ATTRIBUTES=32`,
   `MAX_INPUT_ATTRIBUTES_TOTAL_BYTES=8192`를 public constant로 고정한다. 입력 attribute는
-  insertion order로 cardinality와 UTF-8 누적 budget을 먼저 검사하고, 상한을 넘는 항목에서
-  bounded scan을 중단한 뒤 후보만 sanitizer·정렬한다. `MAX_TEXT_FIELD_BYTES`는
+  `Map` API는 유지하되 iteration order가 보장되지 않으므로 재현 가능한 cutoff가 필요한
+  caller는 `LinkedHashMap`/`linkedMapOf`를 전달한다. 전달된 map의 insertion order로
+  cardinality와 UTF-8 누적 budget을 먼저 검사하고, 상한을 넘는 항목에서 bounded scan을
+  중단한 뒤 후보만 sanitizer·정렬한다. `MAX_TEXT_FIELD_BYTES`는
   `lockName`, `nodeId`, `slotId`, `leaderId`에 적용하고 `errorType`/`errorMessage`는 전용
   bound를 사용한다. UTF-8 code point
   경계 truncate, `lockName/nodeId/slotId/leaderId`의 text bound, attribute 정렬·collision·
@@ -725,7 +727,7 @@
 **Files:**
 
 - Create: `leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportBoundaryContractTest.kt`
-- Create: `leader-core/src/test/java/io/bluetape4k/leader/audit/LeaderAuditExportJavaContractTest.java`
+- Create: `leader-core/src/test/java/io/bluetape4k/leader/audit/LeaderAuditExportJavaContractFixture.java`
 - Modify: audit public types의 KDoc files from Tasks 1–3
 
 - [ ] **Step 1: Write failing public boundary checks**

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -802,7 +802,7 @@
   ```bash
   git add leader-core/src/main/kotlin/io/bluetape4k/leader/audit \
     leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportBoundaryContractTest.kt \
-    leader-core/src/test/java/io/bluetape4k/leader/audit/LeaderAuditExportJavaContractTest.java
+    leader-core/src/test/java/io/bluetape4k/leader/audit/LeaderAuditExportJavaContractFixture.java
   git commit -m $'OBS-03 core exporter public ABI와 KDoc를 고정한다\n\nConstraint: 기존 core public contract와 binary compatibility를 유지한다.\nRejected: 편의용 overload와 raw record exposure | JVM descriptor와 redaction 경계 확대\nConfidence: high\nScope-risk: moderate\nDirective: 후속 transport는 이 stable event boundary를 사용한다.\nTested: ABI boundary contract test and diff check\nNot-tested: Micrometer/HTTP integration은 후속 slice에서 검증한다.'
   ```
 

--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -134,6 +134,12 @@
   }
 
   @Test
+  fun `attribute candidate scan is bounded before sorting`() { /* input cardinality guard */ }
+
+  @Test
+  fun `oversized input bytes stop the attribute scan before sanitizer work`() { /* UTF-8 budget guard */ }
+
+  @Test
   fun `event and attributes are immutable snapshots without public copy mutation`() {
       val source = mutableMapOf("key" to "value")
       val event = LeaderAuditExportEvent.Lifecycle.from(
@@ -248,7 +254,10 @@
   `LeaderAuditExportEvent`와 sanitizer는 `MAX_ERROR_MESSAGE_BYTES=4096`,
   `MAX_ERROR_TYPE_BYTES=128`, `MAX_TEXT_FIELD_BYTES=256`, `MAX_ATTRIBUTES=32`,
   `MAX_ATTRIBUTE_KEY_BYTES=128`, `MAX_ATTRIBUTE_VALUE_BYTES=512`,
-  `MAX_ATTRIBUTES_TOTAL_BYTES=8192`를 public constant로 고정한다. `MAX_TEXT_FIELD_BYTES`는
+  `MAX_ATTRIBUTES_TOTAL_BYTES=8192`, `MAX_INPUT_ATTRIBUTES=32`,
+  `MAX_INPUT_ATTRIBUTES_TOTAL_BYTES=8192`를 public constant로 고정한다. 입력 attribute는
+  insertion order로 cardinality와 UTF-8 누적 budget을 먼저 검사하고, 상한을 넘는 항목에서
+  bounded scan을 중단한 뒤 후보만 sanitizer·정렬한다. `MAX_TEXT_FIELD_BYTES`는
   `lockName`, `nodeId`, `slotId`, `leaderId`에 적용하고 `errorType`/`errorMessage`는 전용
   bound를 사용한다. UTF-8 code point
   경계 truncate, `lockName/nodeId/slotId/leaderId`의 text bound, attribute 정렬·collision·
@@ -725,7 +734,7 @@
 
   | Type | Exact public surface |
   |---|---|
-  | `LeaderAuditExportEvent` | sealed event boundary plus outer-class public static final UTF-8 constants `MAX_ERROR_MESSAGE_BYTES=4096`, `MAX_ERROR_TYPE_BYTES=128`, `MAX_TEXT_FIELD_BYTES=256`, `MAX_ATTRIBUTES=32`, `MAX_ATTRIBUTE_KEY_BYTES=128`, `MAX_ATTRIBUTE_VALUE_BYTES=512`, `MAX_ATTRIBUTES_TOTAL_BYTES=8192`; Java reads exact `LeaderAuditExportEvent.MAX_*` fields |
+  | `LeaderAuditExportEvent` | sealed event boundary plus outer-class public static final UTF-8 constants `MAX_ERROR_MESSAGE_BYTES=4096`, `MAX_ERROR_TYPE_BYTES=128`, `MAX_TEXT_FIELD_BYTES=256`, `MAX_ATTRIBUTES=32`, `MAX_ATTRIBUTE_KEY_BYTES=128`, `MAX_ATTRIBUTE_VALUE_BYTES=512`, `MAX_ATTRIBUTES_TOTAL_BYTES=8192`, `MAX_INPUT_ATTRIBUTES=32`, `MAX_INPUT_ATTRIBUTES_TOTAL_BYTES=8192`; Java reads exact `LeaderAuditExportEvent.MAX_*` fields |
   | `LeaderAuditExportEvent.History` | `from(LeaderLockHistoryRecord, LeaderAuditValueSanitizer): History`; private constructor; no `token`/`LeaderLease` field |
   | `LeaderAuditExportEvent.Lifecycle` | `from(LeaderElectionEvent, Map<String,String>, LeaderAuditValueSanitizer): Lifecycle`; private constructor; no `LeaderLease` field |
   | `LeaderAuditLifecycleOutcome` | enum values `ELECTED`, `REVOKED`, `SKIPPED` only |

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -122,8 +122,11 @@ v1 bound 상수는 `MAX_ERROR_MESSAGE_BYTES=4096`, `MAX_ERROR_TYPE_BYTES=128`,
 `MAX_TEXT_FIELD_BYTES=256`, `MAX_ATTRIBUTES=32`, `MAX_ATTRIBUTE_KEY_BYTES=128`,
 `MAX_ATTRIBUTE_VALUE_BYTES=512`, `MAX_ATTRIBUTES_TOTAL_BYTES=8192`로 고정한다.
 factory 입력도 `MAX_INPUT_ATTRIBUTES=32`, `MAX_INPUT_ATTRIBUTES_TOTAL_BYTES=8192`로
-고정한다. 입력 scan은 insertion order로 이 상한까지만 읽고, 남은 UTF-8 budget을 넘는
-항목을 만나면 scan을 중단한 뒤 이미 수집한 bounded 후보만 sanitizer와 정렬에 전달한다.
+고정한다. public `Map` API는 유지하되 `Map` 자체는 iteration order를 보장하지 않으므로,
+cutoff 선택을 재현해야 하는 caller는 `LinkedHashMap`/`linkedMapOf` 같은 insertion-ordered
+map을 전달해야 한다. 입력 scan은 전달된 `Map.entries` 순서로 이 상한까지만 읽고, 남은
+UTF-8 budget을 넘는 항목을 만나면 scan을 중단한 뒤 이미 수집한 bounded 후보만 sanitizer와
+정렬에 전달한다.
 따라서 임의 크기의 map을 먼저 복사하거나 전체 sanitizer/sort 비용을 발생시키지 않는다.
 입력 상한 초과는 예외가 아니라 best-effort bounded scan으로 처리한다.
 `MAX_TEXT_FIELD_BYTES`는 `lockName`, `nodeId`, `slotId`, `leaderId`에 적용하고,

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -121,6 +121,11 @@ leader identity, attribute, error message를 우회해 복원할 수 없다. eve
 v1 bound 상수는 `MAX_ERROR_MESSAGE_BYTES=4096`, `MAX_ERROR_TYPE_BYTES=128`,
 `MAX_TEXT_FIELD_BYTES=256`, `MAX_ATTRIBUTES=32`, `MAX_ATTRIBUTE_KEY_BYTES=128`,
 `MAX_ATTRIBUTE_VALUE_BYTES=512`, `MAX_ATTRIBUTES_TOTAL_BYTES=8192`로 고정한다.
+factory 입력도 `MAX_INPUT_ATTRIBUTES=32`, `MAX_INPUT_ATTRIBUTES_TOTAL_BYTES=8192`로
+고정한다. 입력 scan은 insertion order로 이 상한까지만 읽고, 남은 UTF-8 budget을 넘는
+항목을 만나면 scan을 중단한 뒤 이미 수집한 bounded 후보만 sanitizer와 정렬에 전달한다.
+따라서 임의 크기의 map을 먼저 복사하거나 전체 sanitizer/sort 비용을 발생시키지 않는다.
+입력 상한 초과는 예외가 아니라 best-effort bounded scan으로 처리한다.
 `MAX_TEXT_FIELD_BYTES`는 `lockName`, `nodeId`, `slotId`, `leaderId`에 적용하고,
 `errorType`과 `errorMessage`는 각각 전용 bound를 사용한다. `LeaderAuditField` enum은
 `LOCK_NAME`, `KIND`, `NODE_ID`, `SLOT_ID`, `LEADER_ID`, `ERROR_TYPE`, `ERROR_MESSAGE`,
@@ -131,9 +136,10 @@ v1 bound 상수는 `MAX_ERROR_MESSAGE_BYTES=4096`, `MAX_ERROR_TYPE_BYTES=128`,
 모든 byte bound는 UTF-8 기준이며 over-limit 문자열은 code point를 자르지 않는 최대
 prefix로 truncate하고 ellipsis를 추가하지 않는다. attribute는 sanitized key의 UTF-8
 byte와 원본 key의 UTF-8 byte를 순서대로 정렬한 뒤 key/value 개별 bound와 aggregate
-bound를 적용하며, 한도를 넘는 후속 entry는 drop한다. sanitize 후 key collision은 이
-secondary key 순서에서 먼저 온 entry만 유지하므로 입력 Map의 insertion order에 영향을
-받지 않는다. `Raw(maxBytes)`는 양수 byte 값과 비민감 field allow-list를 생성 시 검증하고,
+bound를 적용하며, 한도를 넘는 후속 entry는 drop한다. 입력 scan 상한 안에서 sanitize 후
+key collision은 이 secondary key 순서에서 먼저 온 entry만 유지하고, 상한을 초과한
+후속 entry는 insertion order 기준으로 읽지 않는다. `Raw(maxBytes)`는 양수 byte 값과
+비민감 field allow-list를 생성 시 검증하고,
 허용되지 않은 field는 `IllegalArgumentException`으로 거부한다.
 
 ### Exporter와 admission

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
@@ -50,6 +50,12 @@ sealed interface LeaderAuditExportEvent {
 
         /** attributes key/value 합계의 최대 UTF-8 byte 수입니다. */
         const val MAX_ATTRIBUTES_TOTAL_BYTES: Int = 8192
+
+        /** factory가 sanitizer에 전달할 수 있는 입력 attribute의 최대 항목 수입니다. */
+        const val MAX_INPUT_ATTRIBUTES: Int = MAX_ATTRIBUTES
+
+        /** factory가 sanitizer에 전달할 수 있는 입력 attribute의 최대 UTF-8 byte 수입니다. */
+        const val MAX_INPUT_ATTRIBUTES_TOTAL_BYTES: Int = MAX_ATTRIBUTES_TOTAL_BYTES
     }
 
     /**
@@ -233,7 +239,19 @@ private fun sanitizeAttributes(
     source: Map<String, String>,
     sanitizer: LeaderAuditValueSanitizer,
 ): Map<String, String> {
-    val candidates = source.entries
+    var inputBytes = 0
+    val candidates = source.entries.asSequence()
+        .take(LeaderAuditExportEvent.MAX_INPUT_ATTRIBUTES)
+        .takeWhile { entry ->
+            val entryBytes = entry.key.utf8SizeAtMost(LeaderAuditExportEvent.MAX_INPUT_ATTRIBUTES_TOTAL_BYTES) +
+                entry.value.utf8SizeAtMost(LeaderAuditExportEvent.MAX_INPUT_ATTRIBUTES_TOTAL_BYTES)
+            if (entryBytes > LeaderAuditExportEvent.MAX_INPUT_ATTRIBUTES_TOTAL_BYTES - inputBytes) {
+                false
+            } else {
+                inputBytes += entryBytes
+                true
+            }
+        }
         .map { entry ->
             val sanitizedKey = bounded(
                 sanitizer,
@@ -249,10 +267,11 @@ private fun sanitizeAttributes(
             )
             Triple(entry.key, sanitizedKey, sanitizedValue)
         }
-        .sortedWith { left, right ->
-            compareUtf8(left.second, right.second).takeUnless { it == 0 }
-                ?: compareUtf8(left.first, right.first)
-        }
+        .toCollection(ArrayList(minOf(source.size, LeaderAuditExportEvent.MAX_INPUT_ATTRIBUTES)))
+    candidates.sortWith { left, right ->
+        compareUtf8(left.second, right.second).takeUnless { it == 0 }
+            ?: compareUtf8(left.first, right.first)
+    }
 
     val result = LinkedHashMap<String, String>()
     var totalBytes = 0
@@ -267,6 +286,24 @@ private fun sanitizeAttributes(
 }
 
 private fun String.utf8Size(): Int = toByteArray(Charsets.UTF_8).size
+
+private fun String.utf8SizeAtMost(limit: Int): Int {
+    var total = 0
+    var index = 0
+    while (index < length) {
+        val codePoint = codePointAt(index)
+        val byteCount = when {
+            codePoint <= 0x7f -> 1
+            codePoint <= 0x7ff -> 2
+            codePoint <= 0xffff -> 3
+            else -> 4
+        }
+        if (total > limit - byteCount) return limit + 1
+        total += byteCount
+        index += Character.charCount(codePoint)
+    }
+    return total
+}
 
 private fun compareUtf8(left: String, right: String): Int {
     val leftBytes = left.toByteArray(Charsets.UTF_8)

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
@@ -104,7 +104,9 @@ sealed interface LeaderAuditExportEvent {
              *
              * metadata는 insertion order로 `MAX_INPUT_ATTRIBUTES`와
              * `MAX_INPUT_ATTRIBUTES_TOTAL_BYTES`까지만 scan하며, 남은 budget을 넘는 항목을
-             * 만나면 scan을 중단합니다. 따라서 전체 입력 map을 materialize하지 않습니다.
+             * 만나면 scan을 중단합니다. `Map` 자체는 iteration order를 보장하지 않으므로
+             * cutoff 선택을 재현해야 하면 `LinkedHashMap` 또는 `linkedMapOf`를 전달해야
+             * 합니다. 따라서 전체 입력 map을 materialize하지 않습니다.
              *
              * @param record 내부 history record입니다.
              * @param sanitizer 문자열 redaction 정책입니다.
@@ -184,10 +186,12 @@ sealed interface LeaderAuditExportEvent {
              * attributes는 insertion order로 `MAX_INPUT_ATTRIBUTES`와
              * `MAX_INPUT_ATTRIBUTES_TOTAL_BYTES`까지만 scan하며, 남은 budget을 넘는
              * 항목을 만나면 scan을 중단합니다. 따라서 전체 입력 map을 materialize하지
-             * 않습니다.
+             * 않습니다. `Map` 자체는 iteration order를 보장하지 않으므로 cutoff 선택을
+             * 재현해야 하면 `LinkedHashMap` 또는 `linkedMapOf`를 전달해야 합니다.
              *
              * @param event 내부 lifecycle event입니다.
-             * @param attributes 호출자가 제공한 context입니다.
+             * @param attributes 호출자가 제공한 context입니다. 재현 가능한 cutoff가 필요하면
+             * insertion-ordered map을 사용해야 합니다.
              * @param sanitizer 문자열 redaction 정책입니다.
              * @return immutable bounded lifecycle event입니다.
              */

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
@@ -102,6 +102,10 @@ sealed interface LeaderAuditExportEvent {
             /**
              * history record를 token-free export event로 변환합니다.
              *
+             * metadata는 insertion order로 `MAX_INPUT_ATTRIBUTES`와
+             * `MAX_INPUT_ATTRIBUTES_TOTAL_BYTES`까지만 scan하며, 남은 budget을 넘는 항목을
+             * 만나면 scan을 중단합니다. 따라서 전체 입력 map을 materialize하지 않습니다.
+             *
              * @param record 내부 history record입니다.
              * @param sanitizer 문자열 redaction 정책입니다.
              * @return immutable bounded history event입니다.
@@ -176,6 +180,11 @@ sealed interface LeaderAuditExportEvent {
         companion object {
             /**
              * election event를 token-free export event로 변환합니다.
+             *
+             * attributes는 insertion order로 `MAX_INPUT_ATTRIBUTES`와
+             * `MAX_INPUT_ATTRIBUTES_TOTAL_BYTES`까지만 scan하며, 남은 budget을 넘는
+             * 항목을 만나면 scan을 중단합니다. 따라서 전체 입력 map을 materialize하지
+             * 않습니다.
              *
              * @param event 내부 lifecycle event입니다.
              * @param attributes 호출자가 제공한 context입니다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
@@ -280,7 +280,7 @@ private fun sanitizeAttributes(
             )
             Triple(entry.key, sanitizedKey, sanitizedValue)
         }
-        .toCollection(ArrayList(minOf(source.size, LeaderAuditExportEvent.MAX_INPUT_ATTRIBUTES)))
+        .toCollection(ArrayList(LeaderAuditExportEvent.MAX_INPUT_ATTRIBUTES))
     candidates.sortWith { left, right ->
         compareUtf8(left.second, right.second).takeUnless { it == 0 }
             ?: compareUtf8(left.first, right.first)

--- a/leader-core/src/test/java/io/bluetape4k/leader/audit/LeaderAuditExportJavaContractFixture.java
+++ b/leader-core/src/test/java/io/bluetape4k/leader/audit/LeaderAuditExportJavaContractFixture.java
@@ -15,6 +15,11 @@ public final class LeaderAuditExportJavaContractFixture {
     public static boolean exercise() {
         ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
         try {
+            if (LeaderAuditExportEvent.MAX_INPUT_ATTRIBUTES != 32 ||
+                LeaderAuditExportEvent.MAX_INPUT_ATTRIBUTES_TOTAL_BYTES != 8192) {
+                return false;
+            }
+
             Executor executor = Runnable::run;
             LeaderAuditExportOptions options = new LeaderAuditExportOptions(
                 8,

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportBoundaryContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportBoundaryContractTest.kt
@@ -20,6 +20,8 @@ class LeaderAuditExportBoundaryContractTest {
         eventType.getField("MAX_ATTRIBUTE_KEY_BYTES").getInt(null) shouldBeEqualTo 128
         eventType.getField("MAX_ATTRIBUTE_VALUE_BYTES").getInt(null) shouldBeEqualTo 512
         eventType.getField("MAX_ATTRIBUTES_TOTAL_BYTES").getInt(null) shouldBeEqualTo 8192
+        eventType.getField("MAX_INPUT_ATTRIBUTES").getInt(null) shouldBeEqualTo 32
+        eventType.getField("MAX_INPUT_ATTRIBUTES_TOTAL_BYTES").getInt(null) shouldBeEqualTo 8192
 
         LeaderAuditExportEvent.History.Companion::class.java.getMethod(
             "from",

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
@@ -138,6 +138,37 @@ class LeaderAuditExportEventTest {
     }
 
     @Test
+    fun `attribute candidate scan is bounded before sorting`() {
+        val attributes = buildMap {
+            repeat(LeaderAuditExportEvent.MAX_ATTRIBUTES) { index ->
+                put("z-$index", "value-$index")
+            }
+            repeat(16) { index ->
+                put("a-$index", "value-$index")
+            }
+        }
+
+        val event = lifecycleWithAttributes(attributes, LeaderAuditValueSanitizer.Truncate(maxBytes = 128))
+
+        event.attributes.keys.all { it.startsWith("z-") }.shouldBeTrue()
+    }
+
+    @Test
+    fun `oversized input bytes stop the attribute scan before sanitizer work`() {
+        val attributes = linkedMapOf(
+            "oversized" to "가".repeat(LeaderAuditExportEvent.MAX_INPUT_ATTRIBUTES_TOTAL_BYTES),
+            "tail" to "tail",
+        )
+
+        val event = lifecycleWithAttributes(
+            attributes,
+            LeaderAuditValueSanitizer.Truncate(maxBytes = 128),
+        )
+
+        event.attributes.isEmpty().shouldBeTrue()
+    }
+
+    @Test
     fun `event and attributes are immutable snapshots without public copy mutation`() {
         val source = mutableMapOf("key" to "value")
         val event = LeaderAuditExportEvent.Lifecycle.from(

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
@@ -157,6 +157,25 @@ class LeaderAuditExportEventTest {
     }
 
     @Test
+    fun `bounded scan does not read source size before iteration`() {
+        val backing = linkedMapOf(
+            "z-0" to "value-0",
+            "z-1" to "value-1",
+        )
+        val attributes = object : Map<String, String> by backing {
+            override val size: Int
+                get() = error("bounded scan must not read source size")
+        }
+
+        val event = lifecycleWithAttributes(
+            attributes,
+            LeaderAuditValueSanitizer.Truncate(maxBytes = 128),
+        )
+
+        event.attributes.size.shouldBeEqualTo(backing.size)
+    }
+
+    @Test
     fun `oversized input bytes stop the attribute scan before sanitizer work`() {
         val attributes = linkedMapOf(
             "oversized" to "가".repeat(LeaderAuditExportEvent.MAX_INPUT_ATTRIBUTES_TOTAL_BYTES),

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
@@ -150,6 +150,9 @@ class LeaderAuditExportEventTest {
 
         val event = lifecycleWithAttributes(attributes, LeaderAuditValueSanitizer.Truncate(maxBytes = 128))
 
+        event.attributes.size.shouldBeEqualTo(LeaderAuditExportEvent.MAX_INPUT_ATTRIBUTES)
+        event.attributes.containsKey("z-0").shouldBeTrue()
+        event.attributes.containsKey("a-0").shouldBeFalse()
         event.attributes.keys.all { it.startsWith("z-") }.shouldBeTrue()
     }
 


### PR DESCRIPTION
## Summary

Closes #729

AUD-01에서 audit export event가 출력 상한에 도달하기 전에 전체 attribute map을 materialize하고 정렬하던 비용 공백을 해결합니다. 입력 cardinality와 UTF-8 scan 비용을 고정하면서 기존 redaction·collision·출력 상한 계약을 유지합니다.

## Background

Epic #535 OBS-03의 core contract를 검토하는 과정에서 `LeaderAuditExportEvent.History.from`과 `Lifecycle.from`이 임의 크기의 입력을 모두 sanitizer와 sort에 전달하는 문제가 확인되었습니다. Issue #729는 callback thread의 입력 처리 비용과 결과 determinism 경계를 별도로 고정하도록 요구합니다.

## What This Solves

- sanitizer와 sort 전에 입력 후보를 최대 32개·8192 UTF-8 bytes로 제한합니다.
- oversized entry에서 bounded scan을 중단하고, 임의 `Map.size` 구현의 숨은 전체 순회도 호출하지 않습니다.
- bounded 후보의 collision·aggregate output limit·UTF-8 ordering을 유지하고, 재현 가능한 cutoff에는 insertion-ordered map을 사용하도록 공개 계약을 명시합니다.

## Work Done

- `LeaderAuditExportEvent`: public input-bound constants와 allocation-free UTF-8 pre-scan, 고정 후보 버퍼, factory KDoc을 추가했습니다.
- 테스트/ABI fixture: cardinality·oversized UTF-8·비정상 `Map.size`·collision ordering과 Java-visible constants를 검증합니다.
- spec/plan: input ordering 조건, bounded-cost contract, 실제 Java fixture 경로와 regression test 목록을 정합화했습니다.

## Validation

- `./gradlew :bluetape4k-leader-core:test --tests 'io.bluetape4k.leader.audit.LeaderAuditExportEventTest' --tests 'io.bluetape4k.leader.audit.LeaderAuditExportBoundaryContractTest'`: PASS (17/17)
- `./gradlew :bluetape4k-leader-core:test --rerun-tasks`: PASS (804/804, `BUILD SUCCESSFUL`, exact head `71fe2602`)
- `./gradlew :bluetape4k-leader-core:detekt`: PASS
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 0 (세 독립 fresh lane 모두 exact head `71fe2602`에서 CLEAR)
- Review evidence: local exact-head review reports from `obs_01_postfix_code_review`, `audit_task2_review`, `core_dispatcher_worker`

## Metadata

- Issue: #729, milestone `0.6.0`, assignee `debop`
- PR: #743, head `71fe26026a8c23f7c32e5f99f6aec8f8232c6073`, base `develop`
- Labels: `enhancement`, `performance`
- CI: PR #743 exact head hosted run [`32255125143`](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32255125143) — 47/47 PASS, 실패 0, SKIPPED/N/A 0

## DoD Status

Required checks: 12/12; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-01 - Root cause | 전체 map materialization과 unbounded sanitizer/sort 경계를 재현·확정 | PASS | Issue #729, RED candidate-scan test, source trace | 없음 |
| C-02 - Issue gate | 승인된 #729 범위와 issue metadata를 확인 | PASS | `gh issue view 729`: CLOSED, `debop`, `0.6.0`, `enhancement/performance` | 없음 |
| C-03 - Regression RED | 기존 full-map 정렬을 드러내는 cardinality test를 RED로 고정 | PASS | focused RED에서 `a-*`가 선택되는 intended behavioral failure | 없음 |
| C-04 - Surgical fix | bounded scan, UTF-8 budget, fixed candidate buffer를 구현 | PASS | commits `89f6c1fa`, `a16f8e94`, `c12b66da`, `b96977d8`, `bb4e04a3`, `71fe2602` | 없음 |
| C-05 - GREEN / blast radius | focused/full test·detekt·ABI·diff 검증 | PASS | 17/17 focused, 804/804 full, detekt, Java fixture, diff-check | 없음 |
| C-06 - Lesson gate | 별도 lesson 필요성 판정 | N/A | narrow bounded-cost defect; durable contract는 승인 spec/plan과 KDoc에 기록 | 새 lesson 없음 |
| C-07 / CG-14 - CI and review | exact PR head hosted CI와 live review/thread 수렴 | PASS | run `32255125143`: 47/47 PASS, 실패 0; live reviews/comments 0; 세 독립 fresh lane CLEAR; human review는 1인 개발자 정책상 N/A | 없음 |
| C-08 / CG-15 - Merge readiness | CI·mergeability·DoD를 재확인해 merge-ready 보고 | PASS | exact head `71fe2602`; `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`; metadata/DoD 재확인 | 없음 |
| C-09 / CG-16~18 - Closeout | fresh merge approval, merge, sync, safe cleanup | PASS | fresh approval; squash merge commit `1fffcb86dd7c8b99315440dca05222de19206554`; canonical `develop` 및 `origin/develop` 동기화; merged target worktree 삭제 완료; unrelated worktrees 보존 | 없음 |
| CG-11 - PR authority | 승인된 repo/base/head와 PR 생성 범위를 확인 | PASS | `bluetape4k/bluetape4k-leader`, `develop`, `fix/issue-729-audit-cardinality`; user-approved train | 없음 |
| CG-12 - Exact head publish | force 없이 exact branch를 publish하고 SHA 대조 | PASS | local/remote `71fe26026a8c23f7c32e5f99f6aec8f8232c6073` 일치 | 없음 |
| CG-12A - Guidance refresh | AGENTS/leaf/common-gates/template/Issue를 PR 직전 재독 | PASS | current SHA snapshot, AGENTS parity, Issue #729 live metadata no-drift | 없음 |
| CG-13 - PR create/read-back | Korean body, assignee/milestone/labels, final heading을 live read-back | PASS | PR #743 live read-back: exact head/base, `debop`, `0.6.0`, `enhancement/performance`, `## DoD Status` | 없음 |

Final status: DONE

Unchecked required items: 없음

