### PR TITLE
fix(leader-core): audit sanitizer KIND 입력을 canonical 값으로 제한

### DIFF
--- a/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
+++ b/docs/superpowers/plans/2026-08-18-issue-535-audit-export-plan.md
@@ -23,6 +23,12 @@
 
 ## Task 1: 안전한 core audit event와 redaction policy
 
+`LeaderAuditField.KIND`는 `LockIdentity.AnnotationKind.SINGLE.name` 또는
+`LockIdentity.AnnotationKind.GROUP.name`만 허용한다. `Default`, `Hash`, `Truncate`,
+`Raw` 모든 sanitizer는 다른 문자열을 `IllegalArgumentException`으로 fail-fast하며,
+canonical 값은 기존 mode별 출력 정책을 그대로 적용한다. 이 검증은 Kotlin 호출과
+Java fixture에서 같은 public `sanitize` 경계로 확인한다.
+
 **Files:**
 
 - Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt`
@@ -170,7 +176,10 @@
           allowList = setOf(LeaderAuditField.KIND),
           maxBytes = 16,
       )
-      raw.sanitize(LeaderAuditField.KIND, "ACQUIRED").shouldBeEqualTo("ACQUIRED")
+      raw.sanitize(LeaderAuditField.KIND, "SINGLE").shouldBeEqualTo("SINGLE")
+      assertFailsWith<IllegalArgumentException> {
+          raw.sanitize(LeaderAuditField.KIND, "ACQUIRED")
+      }
       LeaderAuditField.values().filter { it != LeaderAuditField.KIND }.forEach { field ->
           assertFailsWith<IllegalArgumentException> {
               raw.sanitize(field, SECRET_SENTINEL)
@@ -201,7 +210,7 @@
       val mutableAllowList = mutableSetOf(LeaderAuditField.KIND)
       val copied = LeaderAuditValueSanitizer.Raw(mutableAllowList, maxBytes = 16)
       mutableAllowList.clear()
-      copied.sanitize(LeaderAuditField.KIND, "ACQUIRED").shouldBeEqualTo("ACQUIRED")
+      copied.sanitize(LeaderAuditField.KIND, "GROUP").shouldBeEqualTo("GROUP")
   }
   ```
 

--- a/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
+++ b/docs/superpowers/specs/2026-08-18-issue-535-audit-export-design.md
@@ -133,7 +133,10 @@ UTF-8 budget을 넘는 항목을 만나면 scan을 중단한 뒤 이미 수집�
 `errorType`과 `errorMessage`는 각각 전용 bound를 사용한다. `LeaderAuditField` enum은
 `LOCK_NAME`, `KIND`, `NODE_ID`, `SLOT_ID`, `LEADER_ID`, `ERROR_TYPE`, `ERROR_MESSAGE`,
 `ATTRIBUTE_KEY`, `ATTRIBUTE_VALUE`만 제공한다. `RAW_ALLOWED_FIELDS`는 `KIND` 하나로
-고정하며 `Raw` 생성자는 빈 allow-list, 이 집합 밖의 allow-list, `maxBytes <= 0`을 모두
+고정하며 `KIND`의 외부 표현은 `LockIdentity.AnnotationKind.SINGLE.name` 또는
+`LockIdentity.AnnotationKind.GROUP.name`만 허용한다. 모든 sanitizer mode는 `KIND`에
+다른 문자열이 들어오면 `IllegalArgumentException`으로 fail-fast한다. `Raw` 생성자는
+빈 allow-list, 이 집합 밖의 allow-list, `maxBytes <= 0`을 모두
 `IllegalArgumentException`으로 거부한다. 생성 시 allow-list를 방어적으로 복사하므로
 생성 뒤 원본 컬렉션 변경도 정책을 바꾸지 않는다.
 모든 byte bound는 UTF-8 기준이며 over-limit 문자열은 code point를 자르지 않는 최대

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditValueSanitizer.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditValueSanitizer.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.leader.audit
 
+import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.support.truncateUtf8
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
@@ -10,6 +11,8 @@ import java.util.Collections
  *
  * 임의 lambda를 공개하지 않고 제한된 정책만 제공하여 token, credential, raw
  * high-cardinality 값을 실수로 export하는 경계를 고정합니다.
+ * 모든 정책은 `KIND` 입력을 `SINGLE` 또는 `GROUP` canonical name으로 먼저 검증하며,
+ * 그 밖의 값은 `IllegalArgumentException`으로 거부합니다.
  */
 sealed interface LeaderAuditValueSanitizer {
 
@@ -17,7 +20,7 @@ sealed interface LeaderAuditValueSanitizer {
      * field의 값을 정책에 따라 변환합니다.
      *
      * @param field 변환 대상 field입니다.
-     * @param value 원본 문자열입니다.
+     * @param value 원본 문자열입니다. `KIND`는 `SINGLE` 또는 `GROUP`만 허용합니다.
      * @return 정책이 허용하는 외부 표현입니다.
      */
     fun sanitize(field: LeaderAuditField, value: String): String
@@ -27,16 +30,20 @@ sealed interface LeaderAuditValueSanitizer {
      * 고정된 문자열로 치환합니다.
      */
     data object Default : LeaderAuditValueSanitizer {
-        override fun sanitize(field: LeaderAuditField, value: String): String =
-            if (field == LeaderAuditField.KIND) value else AUDIT_REDACTED
+        override fun sanitize(field: LeaderAuditField, value: String): String {
+            requireValidKind(field, value)
+            return if (field == LeaderAuditField.KIND) value else AUDIT_REDACTED
+        }
     }
 
     /**
      * SHA-256 hex digest로 값을 변환하는 명시적 opt-in 정책입니다.
      */
     data object Hash : LeaderAuditValueSanitizer {
-        override fun sanitize(field: LeaderAuditField, value: String): String =
-            sha256Hex(value)
+        override fun sanitize(field: LeaderAuditField, value: String): String {
+            requireValidKind(field, value)
+            return sha256Hex(value)
+        }
     }
 
     /**
@@ -49,8 +56,10 @@ sealed interface LeaderAuditValueSanitizer {
             require(maxBytes > 0) { "maxBytes must be positive: $maxBytes" }
         }
 
-        override fun sanitize(field: LeaderAuditField, value: String): String =
-            value.truncateUtf8(maxBytes)
+        override fun sanitize(field: LeaderAuditField, value: String): String {
+            requireValidKind(field, value)
+            return value.truncateUtf8(maxBytes)
+        }
     }
 
     /**
@@ -75,6 +84,7 @@ sealed interface LeaderAuditValueSanitizer {
         }
 
         override fun sanitize(field: LeaderAuditField, value: String): String {
+            requireValidKind(field, value)
             require(field in copiedAllowList) {
                 "Raw export is not allowed for field=$field; allowList=$copiedAllowList"
             }
@@ -109,6 +119,17 @@ private fun sha256Hex(value: String): String {
         digest.forEach { byte ->
             append(HEX_DIGITS[(byte.toInt() ushr NIBBLE_SHIFT) and NIBBLE_MASK])
             append(HEX_DIGITS[byte.toInt() and NIBBLE_MASK])
+        }
+    }
+}
+
+private fun requireValidKind(field: LeaderAuditField, value: String) {
+    if (field == LeaderAuditField.KIND) {
+        require(
+            value == LockIdentity.AnnotationKind.SINGLE.name ||
+                value == LockIdentity.AnnotationKind.GROUP.name,
+        ) {
+            "KIND must be SINGLE or GROUP"
         }
     }
 }

--- a/leader-core/src/test/java/io/bluetape4k/leader/audit/LeaderAuditExportJavaContractFixture.java
+++ b/leader-core/src/test/java/io/bluetape4k/leader/audit/LeaderAuditExportJavaContractFixture.java
@@ -19,6 +19,9 @@ public final class LeaderAuditExportJavaContractFixture {
                 LeaderAuditExportEvent.MAX_INPUT_ATTRIBUTES_TOTAL_BYTES != 8192) {
                 return false;
             }
+            if (!exerciseKindSanitizer()) {
+                return false;
+            }
 
             Executor executor = Runnable::run;
             LeaderAuditExportOptions options = new LeaderAuditExportOptions(
@@ -71,6 +74,19 @@ public final class LeaderAuditExportJavaContractFixture {
             return false;
         } finally {
             scheduler.shutdownNow();
+        }
+    }
+
+    private static boolean exerciseKindSanitizer() {
+        String single = LeaderAuditValueSanitizer.Default.INSTANCE.sanitize(LeaderAuditField.KIND, "SINGLE");
+        if (!"SINGLE".equals(single)) {
+            return false;
+        }
+        try {
+            LeaderAuditValueSanitizer.Default.INSTANCE.sanitize(LeaderAuditField.KIND, "ACQUIRED");
+            return false;
+        } catch (IllegalArgumentException expected) {
+            return true;
         }
     }
 }

--- a/leader-core/src/test/java/io/bluetape4k/leader/audit/LeaderAuditExportJavaContractFixture.java
+++ b/leader-core/src/test/java/io/bluetape4k/leader/audit/LeaderAuditExportJavaContractFixture.java
@@ -82,6 +82,21 @@ public final class LeaderAuditExportJavaContractFixture {
         if (!"SINGLE".equals(single)) {
             return false;
         }
+        String hash = LeaderAuditValueSanitizer.Hash.INSTANCE.sanitize(LeaderAuditField.KIND, "SINGLE");
+        if (!"8316f8178707dee9ea8c0e44178b4993a37244112fd60a0be23dae005a3dca01".equals(hash)) {
+            return false;
+        }
+        String truncated = new LeaderAuditValueSanitizer.Truncate(16)
+            .sanitize(LeaderAuditField.KIND, "GROUP");
+        if (!"GROUP".equals(truncated)) {
+            return false;
+        }
+        String raw = new LeaderAuditValueSanitizer.Raw(
+            java.util.Set.of(LeaderAuditField.KIND), 16
+        ).sanitize(LeaderAuditField.KIND, "SINGLE");
+        if (!"SINGLE".equals(raw)) {
+            return false;
+        }
         try {
             LeaderAuditValueSanitizer.Default.INSTANCE.sanitize(LeaderAuditField.KIND, "ACQUIRED");
             return false;

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
@@ -311,6 +311,7 @@ class BoundedLeaderAuditExporterTest {
         exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
         recovered.await(5, TimeUnit.SECONDS).shouldBeTrue()
         deliveryFuture.complete(LeaderAuditDeliveryResult.SUCCESS).shouldBeTrue()
+        awaitAdmissionReleased(exporter)
         exporter.snapshot().admitted.shouldBeEqualTo(0)
         exporter.snapshot().executorRejections.shouldBeEqualTo(1)
         exporter.close()

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
@@ -269,15 +269,26 @@ class LeaderAuditExportEventTest {
             }
         }
 
-        sanitizers.forEach { sanitizer ->
-            listOf("SINGLE", "GROUP").forEach { validKind ->
-                sanitizer.sanitize(LeaderAuditField.KIND, validKind)
-            }
-        }
         LeaderAuditValueSanitizer.Default.sanitize(LeaderAuditField.KIND, "SINGLE")
             .shouldBeEqualTo("SINGLE")
         LeaderAuditValueSanitizer.Default.sanitize(LeaderAuditField.KIND, "GROUP")
             .shouldBeEqualTo("GROUP")
+        LeaderAuditValueSanitizer.Hash.sanitize(LeaderAuditField.KIND, "SINGLE")
+            .shouldBeEqualTo("8316f8178707dee9ea8c0e44178b4993a37244112fd60a0be23dae005a3dca01")
+        LeaderAuditValueSanitizer.Hash.sanitize(LeaderAuditField.KIND, "GROUP")
+            .shouldBeEqualTo("19dcd0dd3a4354caf10d7df393630c700e650115f829d883c706b0ac0bddf6d8")
+        LeaderAuditValueSanitizer.Truncate(maxBytes = 16)
+            .sanitize(LeaderAuditField.KIND, "SINGLE")
+            .shouldBeEqualTo("SINGLE")
+        LeaderAuditValueSanitizer.Truncate(maxBytes = 16)
+            .sanitize(LeaderAuditField.KIND, "GROUP")
+            .shouldBeEqualTo("GROUP")
+        val raw = LeaderAuditValueSanitizer.Raw(
+            allowList = setOf(LeaderAuditField.KIND),
+            maxBytes = 16,
+        )
+        raw.sanitize(LeaderAuditField.KIND, "SINGLE").shouldBeEqualTo("SINGLE")
+        raw.sanitize(LeaderAuditField.KIND, "GROUP").shouldBeEqualTo("GROUP")
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
@@ -241,12 +241,43 @@ class LeaderAuditExportEventTest {
             allowList = setOf(LeaderAuditField.KIND),
             maxBytes = 16,
         )
-        raw.sanitize(LeaderAuditField.KIND, "ACQUIRED").shouldBeEqualTo("ACQUIRED")
+        raw.sanitize(LeaderAuditField.KIND, "SINGLE").shouldBeEqualTo("SINGLE")
         LeaderAuditField.values().filter { it != LeaderAuditField.KIND }.forEach { field ->
             assertFailsWith<IllegalArgumentException> {
                 raw.sanitize(field, secretSentinel)
             }
         }
+    }
+
+    @Test
+    fun `kind sanitizer rejects arbitrary values and preserves valid classifications`() {
+        val sanitizers = listOf<LeaderAuditValueSanitizer>(
+            LeaderAuditValueSanitizer.Default,
+            LeaderAuditValueSanitizer.Hash,
+            LeaderAuditValueSanitizer.Truncate(maxBytes = 16),
+            LeaderAuditValueSanitizer.Raw(
+                allowList = setOf(LeaderAuditField.KIND),
+                maxBytes = 16,
+            ),
+        )
+
+        listOf(secretSentinel, "ACQUIRED", "single", "").forEach { invalidKind ->
+            sanitizers.forEach { sanitizer ->
+                assertFailsWith<IllegalArgumentException> {
+                    sanitizer.sanitize(LeaderAuditField.KIND, invalidKind)
+                }
+            }
+        }
+
+        sanitizers.forEach { sanitizer ->
+            listOf("SINGLE", "GROUP").forEach { validKind ->
+                sanitizer.sanitize(LeaderAuditField.KIND, validKind)
+            }
+        }
+        LeaderAuditValueSanitizer.Default.sanitize(LeaderAuditField.KIND, "SINGLE")
+            .shouldBeEqualTo("SINGLE")
+        LeaderAuditValueSanitizer.Default.sanitize(LeaderAuditField.KIND, "GROUP")
+            .shouldBeEqualTo("GROUP")
     }
 
     @Test
@@ -296,7 +327,7 @@ class LeaderAuditExportEventTest {
         val mutableAllowList = mutableSetOf(LeaderAuditField.KIND)
         val copied = LeaderAuditValueSanitizer.Raw(mutableAllowList, maxBytes = 16)
         mutableAllowList.clear()
-        copied.sanitize(LeaderAuditField.KIND, "ACQUIRED").shouldBeEqualTo("ACQUIRED")
+        copied.sanitize(LeaderAuditField.KIND, "GROUP").shouldBeEqualTo("GROUP")
     }
 
     private fun recordWithTokenAndOversizedMetadata(): LeaderLockHistoryRecord =


### PR DESCRIPTION
## Summary

Closes #730

OBS-03 AUD-01의 public `LeaderAuditValueSanitizer`가 `KIND`에 임의 문자열을
통과시키지 않도록 canonical 분류 경계를 고정합니다. 유효한 `SINGLE`/`GROUP`
출력과 Kotlin/Java ABI를 유지하면서 잘못된 입력은 모든 sanitizer mode에서
fail-fast로 거절합니다.

## Background

Issue #730은 typed `AnnotationKind`를 사용하는 event factory와 달리 직접
호출 가능한 `sanitize(LeaderAuditField.KIND, String)` 경계가 arbitrary value를
허용하는 문제를 다룹니다. Parent #535의 OBS-03 audit export train에서
`Raw` allow-list와 direct sanitizer의 계약을 일치시킬 필요가 확인되었습니다.

## What This Solves

- `KIND`가 `SINGLE` 또는 `GROUP` canonical 값만 받도록 제한합니다.
- invalid secret/sentinel, 빈 문자열, 대소문자 변형, 임의 classification이
  `Default`·`Hash`·`Truncate`·`Raw` 어느 경로에서도 출력되지 않게 합니다.
- 유효한 값의 기존 redaction/hash/truncate/raw 결과와 Java-visible ABI를
  회귀 없이 고정합니다.

## Work Done

- `LeaderAuditValueSanitizer`: 모든 sanitizer 구현이 공유하는 canonical KIND
  검증과 raw 값을 포함하지 않는 `IllegalArgumentException`을 추가했습니다.
- Kotlin tests: invalid matrix와 `SINGLE`/`GROUP`의 mode별 valid output을
  고정하고, Java fixture에서 public JVM 경계를 검증했습니다.
- `docs/superpowers/specs/`·`plans/`: `KIND` allow-list와 fail-fast 계약을
  구현·수용 기준과 정합화했습니다.
- 기존 executor-rejection 비동기 permit 관찰을 안정화해 core gate의
  재현성을 보강했습니다.

## Validation

- `./gradlew :bluetape4k-leader-core:test --tests 'io.bluetape4k.leader.audit.LeaderAuditExportEventTest' --tests 'io.bluetape4k.leader.audit.BoundedLeaderAuditExporterTest'`: PASS (18/18)
- `./gradlew :bluetape4k-leader-core:test --rerun-tasks`: PASS (805/805, `BUILD SUCCESSFUL`)
- `./gradlew :bluetape4k-leader-core:detekt`: PASS (`BUILD SUCCESSFUL`)
- `git diff --check origin/develop...HEAD`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: P2 증거 공백은 후속 Issue #744에서 deterministic full-batch
  executor-rejection recovery로 보강 예정; P3 없음
- Review evidence: exact head `fb1c7ccc522b191fb2903784cbd9690e5ca27b96`에 대한
  `audit_task2_review`·`core_dispatcher_worker` CLEAR와
  `obs_01_postfix_code_review`의 P2 follow-up 확인

## Metadata

- Issue: #730, milestone `0.6.0`, assignee `debop`
- PR: #745, head `fb1c7ccc522b191fb2903784cbd9690e5ca27b96`, base `develop`, milestone `0.6.0`, assignee `debop`
- Labels: `enhancement`, `security`
- CI: PR #745 exact head hosted run [`32265246099`](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32265246099) — 47/47 PASS, 실패 0, SKIPPED/N/A 0

## DoD Status

Required checks: 12/12; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-01 - Root cause | direct sanitizer의 arbitrary KIND 경계를 재현·확정 | PASS | Issue #730, RED invalid-KIND test, source trace | 없음 |
| C-02 - Issue gate | 승인된 #730 범위와 live metadata를 확인 | PASS | `gh issue view 730`: CLOSED, `debop`, `0.6.0`, `enhancement/security` | 없음 |
| C-03 - Regression RED | invalid KIND가 기존 구현에서 통과함을 RED로 고정 | PASS | production fix 전 `Expected IllegalArgumentException but no exception was thrown` | 없음 |
| C-04 - Surgical fix | 네 sanitizer mode에 canonical KIND 검증과 secret-safe 오류를 적용 | PASS | commit `ee2b08e918d50a4275f5de89a5b28d089ad3ae24` | 없음 |
| C-05 - GREEN / blast radius | valid output, Java ABI, focused/full test, detekt, diff 검증 | PASS | commits `07ebe6467a9c1a23470bb9f9f876b273771a8ecb`, `fb1c7ccc`; 18/18 focused, 805/805 full | 없음 |
| C-06 - Lesson gate | 별도 lesson 필요성을 검토 | N/A | 기존 sanitizer/redaction 규칙 재사용; 새 운영·복구 지침 없음 | 새 lesson 없음 |
| C-07 / CG-14 - CI and review | exact PR head hosted CI와 live review/thread를 수렴 | PASS | run [`32265246099`](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32265246099): 47/47 PASS, 실패 0, SKIPPED 0; live reviews/comments 0; 독립 local review P0/P1=0 | 없음 |
| C-08 / CG-15 - Merge readiness | CI·mergeability·DoD를 재확인해 merge-ready 보고 | PASS | exact head `fb1c7ccc`; `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN`; fresh approval 후 merge 진행 | 없음 |
| C-09 / CG-16~18 - Closeout | fresh merge approval, merge, sync, safe cleanup | PASS | fresh approval; squash merge commit `3f423e83f4a62212e5d12896d32fd70fe0633937`; canonical `develop`/`origin/develop` 동기화; 대상 worktree·local branch 삭제; unrelated worktrees 보존 | 없음 |
| CG-11 - PR authority | 승인된 repo/base/head의 PR 생성 범위를 확인 | PASS | `bluetape4k/bluetape4k-leader`, `develop`, `fix/issue-730-audit-kind`; 승인된 stacked train | 없음 |
| CG-12 - Exact head publish | force 없이 branch를 publish하고 SHA 대조 | PASS | local/remote `fb1c7ccc522b191fb2903784cbd9690e5ca27b96` 일치 | 없음 |
| CG-12A - Guidance refresh | AGENTS/leaf/common-gates/template/Issue를 PR 직전 재독 | PASS | `/Users/debop/.codex/AGENTS.md`, `/Users/debop/work/bluetape4k/AGENTS.md`, repo `AGENTS.md`, selected skills, common-gates, PR template, Issue #730 live read-back | no-drift |
| CG-13 - PR create/read-back | Korean body, assignee/milestone/labels, final heading을 live read-back | PASS | PR #745 live read-back: exact head/base, `debop`, `0.6.0`, `enhancement/security`, `## DoD Status` | 없음 |

Final status: DONE

Unchecked required items: 없음
