### PR TITLE
test(leader-micrometer): 부분 meter 등록 복구와 scrape 비교 경계를 고정한다

### DIFF
--- a/docs/lessons/2026-08-20-issue-734-meter-registration-recovery.md
+++ b/docs/lessons/2026-08-20-issue-734-meter-registration-recovery.md
@@ -1,0 +1,55 @@
+# Issue #734 Micrometer meter 등록 복구와 scrape 비교 교훈
+
+## Context
+
+AUD-02 Micrometer decorator는 하나의 `MeterRegistry`에 13개 고정 meter ID를
+등록하고 close/replacement 세대에서도 meter identity와 cumulative 값을 유지한다.
+이번 slice의 목표는 등록 도중 일부 meter만 성공한 뒤 재시도하는 경계를 고정하고,
+scrape hot path에서 cumulative 비교를 위해 임시 collection을 만들지 않는 것이다.
+
+## Root Cause
+
+manager는 부분 등록 뒤에도 이미 등록한 소유 meter가 남아 있는 상태를 보존하지만,
+custom failing `MeterRegistry`를 사용하는 회귀 테스트가 없어 다음 acquire가 누락된
+ID만 채우는지, 기존 identity를 유지하는지, foreign meter를 제거하지 않는지 증거가
+없었다. 또한 `CumulativeValues.isNotLessThan`이 11개 비교 결과를 `listOf(...).all`
+로 묶어 scrape마다 Boolean list를 만들고 있었다.
+
+## Decision
+
+- 부분 등록 실패 뒤 manager-owned meter와 identity를 보존하고 다음 acquire에서
+  누락된 fixed ID만 등록하는 계약을 custom registry fixture로 고정한다.
+- fixed catalog가 13개인지, duplicate registration과 `MeterRegistry.remove`가
+  발생하지 않는지 함께 검증해 ownership 경계를 보존한다.
+- cumulative 비교는 각 scalar 조건을 `&&`로 직접 연결해 allocation-free 경로로
+  유지한다.
+- 동작 계약은 `MicrometerLeaderAuditExporter` KDoc과 EN/KO README에 같은 의미로
+  기록한다.
+
+## Outcome
+
+부분 등록 복구는 기존 manager 상태를 재사용하면서 누락된 meter만 보충하고 foreign
+meter를 건드리지 않는다. scrape 비교는 임시 Boolean collection 없이 11개 누적
+필드를 scalar short-circuit로 비교한다.
+
+## Verification
+
+- RED: 기존 `listOf(...).all` 구현에서 allocation-free source contract가 실패했다.
+- focused `MicrometerLeaderAuditExporterTest`: 23 tests PASS.
+- `:bluetape4k-leader-micrometer:test`: 105 tests PASS.
+- `:bluetape4k-leader-micrometer:detekt`: PASS.
+- `git diff --check`: PASS.
+
+## Surprise and miss
+
+부분 등록 동작 자체는 이미 manager의 `ensureMeters()`에 구현되어 있었고, 이번 결함은
+재시도·identity·foreign removal을 한 번에 입증하는 custom registry 회귀 증거가 없었던
+점이었다. source contract 테스트는 모듈 worktree 기준 상대 경로를 사용해야 하므로
+테스트 실행 위치와 파일 경계를 함께 고정했다.
+
+## Future guard
+
+새 fixed meter를 추가하거나 registration lifecycle을 바꿀 때는 부분 실패 지점과
+재시도 후 meter identity를 같은 custom registry fixture에서 확인한다. scrape hot path의
+누적 비교·tag projection에는 임시 collection을 추가하지 않고, allocation-free 요구가
+변경되면 source contract와 benchmark 또는 profiler 근거를 함께 갱신한다.

--- a/leader-micrometer/README.ko.md
+++ b/leader-micrometer/README.ko.md
@@ -282,6 +282,10 @@ degraded로 표시한 뒤 delegate reference를 분리하고 원래 예외를 �
 기록한 뒤 정상 반환하며, 예외를 새로 만들지 않습니다.
 degraded 경로는 `leader.audit.export.meter-source-degraded` fixed warning을 사용하며
 snapshot payload나 exception message를 로그에 남기지 않습니다.
+고정 catalog를 일부만 등록한 뒤 registration이 실패하면 manager는 이미 등록한 소유
+meter와 identity를 보존합니다. 다음 acquire에서는 누락된 ID만 등록하고 foreign meter는
+제거하지 않습니다. 각 scrape의 cumulative 비교는 scalar 연산으로 수행하므로 hot path에서
+임시 Boolean collection을 만들지 않습니다.
 open generation에서 metric polling 중 `delegate.snapshot()`을 읽지 못하면
 decorator는 마지막으로 신뢰한 cumulative·gauge 값을 유지하고
 `diagnosticsClosed=0`을 보존하며 해당 generation에서 fixed warning을 최대 한 번만

--- a/leader-micrometer/README.md
+++ b/leader-micrometer/README.md
@@ -282,6 +282,11 @@ snapshot returns a lower cumulative value, it keeps the trusted baseline and
 returns normally with the degraded warning; no exception is fabricated.
 The degraded path uses the fixed `leader.audit.export.meter-source-degraded` warning
 and never logs snapshot payloads or exception messages.
+If registration fails after only part of the fixed catalog is installed, the manager
+keeps the owned meters and their identities; the next acquire registers only the
+missing IDs and never removes a foreign meter. The cumulative comparison used by
+each scrape is scalar and allocation-free, so the hot path does not build a
+temporary Boolean collection.
 During an open generation, if a metric poll cannot read `delegate.snapshot()`, the
 decorator keeps the last trusted cumulative and gauge values, leaves
 `diagnosticsClosed=0`, and emits the fixed warning at most once for that generation.

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
@@ -38,6 +38,8 @@ import java.util.concurrent.atomic.AtomicReference
  * 참조하지 않습니다. v1 metric은 aggregate snapshot만 알 수 있으므로 `outcome` 외
  * `source`/`transport` 차원은 생성하지 않습니다.
  * wrapper 수명 동안 caller는 fixed meter ID를 직접 제거하거나 재등록하지 않아야 합니다.
+ * meter 등록이 부분적으로 실패하면 manager가 이미 등록한 소유 meter와 identity를
+ * 보존하고 다음 acquire에서 누락된 fixed ID만 보충하며 foreign meter는 제거하지 않습니다.
  * manager는 acquire 또는 metric read에서 관찰한 identity crossing만 compromised로 잠그며,
  * foreign meter를 제거하지 않습니다. compromised registry의 복구에는 새
  * `MeterRegistry` identity가 필요합니다.
@@ -742,19 +744,17 @@ private fun LeaderAuditExportSnapshot.isNotLessThan(other: LeaderAuditExportSnap
 
 private fun MicrometerLeaderAuditExporter.CumulativeValues.isNotLessThan(
     other: MicrometerLeaderAuditExporter.CumulativeValues,
-): Boolean = listOf(
-    accepted >= other.accepted,
-    droppedQueueFull >= other.droppedQueueFull,
-    droppedClosed >= other.droppedClosed,
-    retries >= other.retries,
-    failures >= other.failures,
-    cancellations >= other.cancellations,
-    executorRejections >= other.executorRejections,
-    schedulerRejections >= other.schedulerRejections,
-    observerDrops >= other.observerDrops,
-    observerRegistrationDrops >= other.observerRegistrationDrops,
-    diagnosticsFailures >= other.diagnosticsFailures,
-).all { it }
+): Boolean = accepted >= other.accepted &&
+    droppedQueueFull >= other.droppedQueueFull &&
+    droppedClosed >= other.droppedClosed &&
+    retries >= other.retries &&
+    failures >= other.failures &&
+    cancellations >= other.cancellations &&
+    executorRejections >= other.executorRejections &&
+    schedulerRejections >= other.schedulerRejections &&
+    observerDrops >= other.observerDrops &&
+    observerRegistrationDrops >= other.observerRegistrationDrops &&
+    diagnosticsFailures >= other.diagnosticsFailures
 
 private fun LeaderAuditExportSnapshot.asDetached(): MicrometerLeaderAuditExporter.DetachedSnapshot =
     MicrometerLeaderAuditExporter.DetachedSnapshot(

--- a/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
+++ b/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
@@ -21,11 +21,14 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.junit.jupiter.api.Test
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
+import java.nio.file.Files
+import java.nio.file.Path
 import java.time.Instant
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
+import java.util.function.ToDoubleFunction
 
 class MicrometerLeaderAuditExporterTest {
 
@@ -261,6 +264,50 @@ class MicrometerLeaderAuditExporterTest {
         construction.join(1_000)
         failure.get().shouldNotBeNull()
         delegate.closeCount shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `partial meter registration retries only missing catalog without duplicate or foreign removal`() {
+        val registry = FailingMeterRegistry(failOnSuccessfulAttempt = 5)
+        val failedDelegate = SnapshotExporter(snapshot())
+
+        assertFailsWith<IllegalStateException> {
+            MicrometerLeaderAuditExporter(failedDelegate, registry)
+        }
+        failedDelegate.closeCount shouldBeEqualTo 1
+        val acceptedMeterBefore = registry.find(MicrometerNames.AUDIT_EXPORT_ACCEPTED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "accepted")
+            .meter()
+            .shouldNotBeNull()
+
+        registry.allowRegistration()
+        val recovered = MicrometerLeaderAuditExporter(SnapshotExporter(snapshot()), registry)
+        val acceptedMeterAfter = registry.find(MicrometerNames.AUDIT_EXPORT_ACCEPTED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "accepted")
+            .meter()
+            .shouldNotBeNull()
+
+        registry.meters.count { it.id.name.startsWith("leader.audit.export.") } shouldBeEqualTo 13
+        acceptedMeterAfter shouldBeEqualTo acceptedMeterBefore
+        registry.duplicateRegistrationIds shouldBeEqualTo 0
+        registry.removeCalls shouldBeEqualTo 0
+
+        recovered.close()
+    }
+
+    @Test
+    fun `cumulative monotonicity comparison does not allocate a boolean list`() {
+        val source = Files.readString(
+            Path.of(
+                "src/main/kotlin/" +
+                    "io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt",
+            ),
+        )
+        val comparison = source
+            .substringAfter("private fun MicrometerLeaderAuditExporter.CumulativeValues.isNotLessThan")
+            .substringBefore("\n\nprivate fun LeaderAuditExportSnapshot.asDetached")
+
+        comparison.contains("listOf(").shouldBeFalse()
     }
 
     @Test
@@ -659,6 +706,47 @@ class MicrometerLeaderAuditExporterTest {
             closeRelease?.await(5, TimeUnit.SECONDS)
             closeCount++
             closed = true
+        }
+    }
+
+    private class FailingMeterRegistry(
+        private val failOnSuccessfulAttempt: Int,
+    ) : SimpleMeterRegistry() {
+        private var failRegistration = true
+        private val successfulIds = mutableSetOf<Meter.Id>()
+        var duplicateRegistrationIds: Int = 0
+            private set
+        var removeCalls: Int = 0
+            private set
+
+        override fun <T : Any> newFunctionCounter(
+            id: Meter.Id,
+            obj: T,
+            countFunction: ToDoubleFunction<T>,
+        ): FunctionCounter {
+            if (failRegistration && successfulIds.size + 1 == failOnSuccessfulAttempt) {
+                throw IllegalStateException("injected meter registration failure")
+            }
+            if (!successfulIds.add(id)) duplicateRegistrationIds++
+            return super.newFunctionCounter(id, obj, countFunction)
+        }
+
+        override fun <T : Any> newGauge(
+            id: Meter.Id,
+            obj: T?,
+            valueFunction: ToDoubleFunction<T>,
+        ): Gauge {
+            if (!successfulIds.add(id)) duplicateRegistrationIds++
+            return super.newGauge(id, obj, valueFunction)
+        }
+
+        override fun remove(meter: Meter): Meter? {
+            removeCalls++
+            return super.remove(meter)
+        }
+
+        fun allowRegistration() {
+            failRegistration = false
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #734

부분 meter 등록 실패 뒤에도 기존 소유 meter identity를 보존하고 누락된
catalog만 복구하며, scrape 비교가 할당 없는 scalar 경로를 사용하도록
고정합니다.

## Background

Issue #734는 AUD-02 Micrometer decorator의 partial registration recovery와
scrape 비교 비용 경계를 후속 검증 대상으로 분리했습니다.

## What This Solves

- 부분 등록 실패 후 retry가 duplicate meter를 만들거나 foreign meter를
  제거하는 위험
- 매 scrape마다 collection allocation이 발생하는 비교 경로

## Work Done

- `RegistryManager`가 이미 등록한 meter identity를 유지하고 missing catalog만
  보충하는 recovery 경로와 ownership guard를 고정했습니다.
- 11개 cumulative field의 scalar monotonic comparison, identity 보존,
  duplicate/removal 부재를 회귀 테스트로 검증했습니다.
- English/Korean Micrometer README와 reusable lesson을 함께 갱신했습니다.

## Validation

- `./gradlew :bluetape4k-leader-micrometer:test --tests 'io.bluetape4k.leader.micrometer.audit.MicrometerLeaderAuditExporterTest'`: PASS (23 tests)
- `./gradlew :bluetape4k-leader-micrometer:test`: PASS (105 tests)
- `./gradlew :bluetape4k-leader-micrometer:detekt`: PASS
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 없음
- Review evidence: local receipt `20260820T063908Z-0343873e`, sequence 18, independent reviewer no findings

## Metadata

- Issue: #734, milestone `0.6.0`, assignee `debop`
- PR: #747, head `cce0f37a76a8e9f788ec0803f80f32a0d461cc0f`
- CI: [PR #747](https://github.com/bluetape4k/bluetape4k-leader/pull/747)의 run [32358096861](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32358096861)이 exact head에서 완료되었고, 변경 모듈 및 Testcontainers 경로가 PASS입니다. 경로 필터로 무관한 job은 의도적으로 SKIPPED입니다.

## DoD Status

Required checks: 8/8; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01..CG-10 - Local convergence | guidance, scoped diff, tests, detekt, lesson, review, commit | PASS | parent receipt sequence 18; head `cce0f37a76a8e9f788ec0803f80f32a0d461cc0f` | none |
| CG-11 - PR delivery authority | repository `bluetape4k/bluetape4k-leader`, base `develop`, head `fix/issue-734-meter-registration-recovery` | PASS | current user approval and stacked train request | none |
| CG-12 - Exact head publish | publish parent branch without force | PASS | remote head read-back must equal `cce0f37a76a8e9f788ec0803f80f32a0d461cc0f` | repair mismatch before PR |
| CG-12A - Guidance refresh | re-read current AGENTS, GitHub skill, common gates, PR template, and Issue #734 | PASS | current hashes recorded in session evidence | none |
| CG-13 - PR create/read-back | create draft PR and reconcile metadata/body | PASS | [PR #747](https://github.com/bluetape4k/bluetape4k-leader/pull/747), head `cce0f37a76a8e9f788ec0803f80f32a0d461cc0f`, metadata read-back PASS | none |
| CG-14 - Hosted CI/review | wait for exact-head checks and current review threads | PASS | CI run [32358096861](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32358096861) PASS; hosted human review는 현재 사용자가 1인 개발자 예외로 N/A 승인; review/thread/request 0건 | none |
| CG-15 - Merge-ready report | reconcile CI/review and exact head | PASS | exact head `cce0f37a76a8e9f788ec0803f80f32a0d461cc0f`, base `develop`, `MERGEABLE/CLEAN`, P0/P1=0 | parent merge 실행 |
| CG-16 - Fresh merge approval | obtain approval after CG-15 | PASS | current user approval: 1인 개발자 hosted human review N/A 및 stacked train 진행 승인 | none |
| CG-17 - Merge verification | merge and verify SHA | PASS | [PR #747](https://github.com/bluetape4k/bluetape4k-leader/pull/747) merged with merge commit `a9d205be3746a0e535175d17eaadb3fd60110d7a`; remote `develop` matches | none |
| CG-18 - Sync/cleanup | sync and delete only proven merged targets | PENDING | child #748 remains open and uses the parent lineage; parent worktree/branch is preserved until child closeout | cleanup after child merge and exact sync |

Final status: PASS (parent merged; child hosted CI and train closeout remain)

Unchecked required items: CG-18