### PR TITLE
JDK 25 전용 개발선을 1.0.0으로 올린다

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -60,5 +60,5 @@ centralSnapshotsParallelism=4
 # project version
 #
 projectGroup=io.github.bluetape4k.leader
-baseVersion=0.6.0
+baseVersion=1.0.0
 snapshotVersion=


### PR DESCRIPTION
## 변경 목적

0.x 개발선에서 JDK 25 이상만 지원하는 공개 호환성 경계를 확정하기 위해 baseVersion을 0.6.0에서 1.0.0으로 변경합니다.

정식 배포와 milestone 종료는 포함하지 않으며, 병합 뒤 1.0.0-SNAPSHOT 게시·검증까지만 진행합니다.

## 검증

- root properties에서 version 1.0.0 확인
- Leader BOM publication POM 생성 성공
- BOM과 내부 dependency-management 버전 1.0.0 확인
- 중앙 후보 맵과 전체 publication POM 게이트 통과

## DoD Status

- [x] baseVersion 1.0.0 반영
- [x] BOM POM 생성 검증
- [x] milestone 1.0.0 정렬
- [x] PR CI
- [x] 정확한 HEAD 기준 별도 병합 승인