### PR TITLE
수동 CI 실행도 PR 문맥으로 식별되게 한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: CI
 
+run-name: >-
+  ${{ inputs.run_title
+    || github.event.pull_request.title
+    || github.event.head_commit.message
+    || format('{0} · {1}', github.event_name, github.ref_name) }}
+
 permissions:
   contents: read
   actions: read
@@ -9,6 +15,11 @@ permissions:
 
 on:
   workflow_dispatch:
+    inputs:
+      run_title:
+        description: "수동 실행 제목 (비워두면 이벤트와 ref를 사용합니다)"
+        required: false
+        type: string
   push:
     branches: [develop, main]
   pull_request:

--- a/docs/manual/generated/manifest.json
+++ b/docs/manual/generated/manifest.json
@@ -42,16 +42,12 @@
         "benchmark/README.ko.md"
       ],
       "status": "stable",
-      "testPaths": [
-
-      ],
+      "testPaths": [],
       "title": {
         "en": "Leader election benchmarks",
         "ko": "리더 선출 벤치마크"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-bom",
@@ -66,16 +62,12 @@
         "bluetape4k-leader-bom/build.gradle.kts"
       ],
       "status": "stable",
-      "testPaths": [
-
-      ],
+      "testPaths": [],
       "title": {
         "en": "Leader BOM",
         "ko": "Leader BOM"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-consul",
@@ -99,9 +91,7 @@
         "en": "Consul backend",
         "ko": "Consul 백엔드"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-core",
@@ -125,9 +115,7 @@
         "en": "Leader core library",
         "ko": "Leader 핵심 라이브러리"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-dynamodb",
@@ -151,9 +139,7 @@
         "en": "DynamoDB backend",
         "ko": "DynamoDB 백엔드"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-etcd",
@@ -177,9 +163,7 @@
         "en": "etcd backend",
         "ko": "etcd 백엔드"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-exposed-core",
@@ -203,9 +187,7 @@
         "en": "Exposed shared backend support",
         "ko": "Exposed 공통 백엔드 지원"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-exposed-jdbc",
@@ -229,9 +211,7 @@
         "en": "Exposed JDBC backend",
         "ko": "Exposed JDBC 백엔드"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-exposed-r2dbc",
@@ -255,9 +235,7 @@
         "en": "Exposed R2DBC backend",
         "ko": "Exposed R2DBC 백엔드"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-hazelcast",
@@ -281,9 +259,7 @@
         "en": "Hazelcast backend",
         "ko": "Hazelcast 백엔드"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-k8s",
@@ -307,9 +283,7 @@
         "en": "Kubernetes Lease backend",
         "ko": "Kubernetes Lease 백엔드"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-ktor",
@@ -333,9 +307,7 @@
         "en": "Ktor integration",
         "ko": "Ktor 연동"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-micrometer",
@@ -359,9 +331,7 @@
         "en": "Micrometer integration",
         "ko": "Micrometer 연동"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-mongodb",
@@ -385,9 +355,7 @@
         "en": "MongoDB backend",
         "ko": "MongoDB 백엔드"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-redis-lettuce",
@@ -411,9 +379,7 @@
         "en": "Redis Lettuce backend",
         "ko": "Redis Lettuce 백엔드"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-redis-redisson",
@@ -437,9 +403,7 @@
         "en": "Redis Redisson backend",
         "ko": "Redis Redisson 백엔드"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-spring-boot",
@@ -463,9 +427,7 @@
         "en": "Spring Boot integration",
         "ko": "Spring Boot 연동"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": "io.github.bluetape4k.leader:bluetape4k-leader-zookeeper",
@@ -489,9 +451,7 @@
         "en": "ZooKeeper backend",
         "ko": "ZooKeeper 백엔드"
       },
-      "workshops": [
-
-      ]
+      "workshops": []
     },
     {
       "artifact": null,

--- a/scripts/manual/export_manifest.rb
+++ b/scripts/manual/export_manifest.rb
@@ -27,7 +27,13 @@ module ManualDocs
       if manifest.is_a?(Hash) && manifest["modules"].is_a?(Array)
         manifest = manifest.merge("modules" => manifest["modules"].sort_by { |entry| entry.fetch("id") })
       end
-      JSON.pretty_generate(sort_keys(manifest)) + "\n"
+      compact_empty_containers(JSON.pretty_generate(sort_keys(manifest))) + "\n"
+    end
+
+    def compact_empty_containers(json)
+      json
+        .gsub(/\[\n(?:[ \t]*\n)*[ \t]*\]/, "[]")
+        .gsub(/\{\n(?:[ \t]*\n)*[ \t]*\}/, "{}")
     end
 
     def sort_keys(value)

--- a/scripts/manual/export_manifest_test.rb
+++ b/scripts/manual/export_manifest_test.rb
@@ -27,4 +27,24 @@ class ExportManifestTest < Minitest::Test
       assert exporter.current?
     end
   end
+
+  def test_compacts_empty_containers_for_json_runtime_stability
+    Dir.mktmpdir("manifest-export-empty-containers") do |root|
+      source = File.join(root, "manifest.yaml")
+      output = File.join(root, "manifest.json")
+      File.write(source, <<~YAML)
+        metadata: {}
+        modules: []
+      YAML
+
+      exporter = ManualDocs::ManifestExporter.new(source_path: source, output_path: output)
+      exporter.write
+      rendered = File.read(output)
+
+      assert_includes rendered, "\"metadata\": {}"
+      assert_includes rendered, "\"modules\": []"
+      refute_match(/\[\n(?:[ \t]*\n)*[ \t]*\]/, rendered)
+      refute_match(/\{\n(?:[ \t]*\n)*[ \t]*\}/, rendered)
+    end
+  end
 end


### PR DESCRIPTION
## 변경 내용

- `CI` workflow에 `run-name`을 추가해 PR 실행은 PR 제목, push 실행은 커밋 제목을 표시합니다.
- `workflow_dispatch`에 선택적 `run_title` 입력을 추가해 수동 실행도 PR 제목을 명시할 수 있게 했습니다.
- 입력이 없으면 이벤트와 ref를 fallback으로 사용합니다.
- manual manifest exporter가 JSON runtime별 빈 배열·객체 출력 차이를 정규화하도록 수정하고 생성 스냅샷을 갱신했습니다.

## 원인 및 검증

- 성공 run [32366001846](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32366001846)은 runner image `ubuntu-24.04 20260810.271.1`에서 통과했습니다.
- 실패 run [32366939511](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32366939511)은 `ubuntu-24.04 20260816.277.1`에서 같은 manifest/exporter tree를 검사하다 JSON runtime drift로 실패했습니다.
- 두 run의 exact checkout tree에서 `docs/manual/manifest.yaml`, `docs/manual/generated/manifest.json`, `scripts/manual/export_manifest.rb`는 동일했고, `JSON.pretty_generate`의 empty-container 출력 차이를 Ruby 2.6/3.2/3.4 및 JSON 2.9.1 환경에서 재현했습니다.
- `python3 scripts/ci/validate_manual_contract.py`
- `actionlint .github/workflows/ci.yml`
- `python3 scripts/ci/validate_ci_fanout.py --static`
- Ruby manual suite: 37 tests, 392 assertions
- Ruby 3.2 + JSON 2.9.1 및 Ruby 3.4 exporter check

## DoD Status

- [x] PR/push 실행 제목 보존
- [x] 수동 dispatch 제목 입력 및 fallback
- [x] JSON runtime-independent manifest export 및 회귀 테스트
- [x] 정적 workflow·fan-out·manual/release contract 검증
- [x] GitHub-hosted run-name 표시 확인 — PR run `32366939511`의 `displayTitle`이 PR 제목으로 표시됨
- [x] CI green — exact-head run `32369633568` success
- 호스티드 human review: N/A (1인 개발자 운영)