### PR TITLE
JDK 25 SNAPSHOT 소비자의 중앙 BOM 참조를 갱신한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ env:
   JAVA_VERSION: '25'
   JAVA_DISTRIBUTION: 'temurin'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-  BLUETAPE4K_DEPENDENCIES_CATALOG_REF: '45235aa22184b6a2280f530fb90c82a94e31c59d'
+  BLUETAPE4K_DEPENDENCIES_CATALOG_REF: '91f9ea9336b5ea991f5675323a1cf25ccfd6f5ed'
 
 jobs:
   # ── 0. 시크릿 스캔 ────────────────────────────────────────────────────────

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k = "1.11.1-SNAPSHOT"  # https://central.sonatype.com/artifact/io.github.bluetape4k/bluetape4k-bom
-bluetape4k-exposed = "1.12.0-SNAPSHOT"  # https://mvnrepository.com/artifact/io.github.bluetape4k.exposed/bluetape4k-exposed-bom
+bluetape4k = "2.0.0-SNAPSHOT"  # https://central.sonatype.com/artifact/io.github.bluetape4k/bluetape4k-bom
+bluetape4k-exposed = "2.0.0-SNAPSHOT"  # https://mvnrepository.com/artifact/io.github.bluetape4k.exposed/bluetape4k-exposed-bom
 
 kotlinx-benchmark = "0.4.17"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-benchmark-runtime
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-        .orElse("45235aa22184b6a2280f530fb90c82a94e31c59d")
+        .orElse("91f9ea9336b5ea991f5675323a1cf25ccfd6f5ed")
     .get()
 require(bluetape4kDependenciesCatalogRef.matches(Regex("[0-9a-f]{40}|[0-9a-f]{64}"))) {
     "bluetape4k-dependencies catalog ref must be an immutable Git commit SHA: " +


### PR DESCRIPTION
## 변경 목적

중앙 `bluetape4k-dependencies`가 병합된 `91f9ea9336b5ea991f5675323a1cf25ccfd6f5ed` catalog를 사용하도록 이 저장소의 소비자 경계를 갱신합니다.

- `settings.gradle.kts` 기본 catalog ref와 CI ref를 동일한 immutable merge SHA로 정렬
- 체크인 catalog에 남은 `bluetape4k-bom`/`bluetape4k-exposed-bom` SNAPSHOT alias를 JDK 25 개발선으로 정렬(해당 alias가 없는 저장소는 추가하지 않음)
- 안정 tag/release, GitHub Release, milestone close, Pages/manual 안정 전환은 수행하지 않음

## 검증

- `git diff --check` 통과
- settings/CI catalog ref parity 확인
- 중앙 merge SHA의 BOM alias와 upstream SNAPSHOT 좌표 확인
- PR CI에서 전체 저장소 빌드와 publication POM을 재검증할 예정

## DoD Status

- [x] 중앙 merge SHA 기반 immutable catalog ref 반영
- [x] 내부 bluetape4k BOM SNAPSHOT 참조 갱신
- [x] 안정 릴리스 작업 제외
- [ ] exact-head PR CI 통과
- [ ] 정확한 HEAD 기준 별도 병합 승인