### PR TITLE
JVM audit payload 경계를 factory-only로 고정해 raw 생성 경로를 차단한다

### DIFF
--- a/docs/lessons/2026-08-20-issue-731-jvm-factory-only-snapshot.md
+++ b/docs/lessons/2026-08-20-issue-731-jvm-factory-only-snapshot.md
@@ -1,0 +1,66 @@
+# Issue #731 — Kotlin private nested class의 JVM factory-only 경계
+
+## 맥락
+
+OBS-03의 `LeaderAuditExportEvent.History`와 `Lifecycle`은 sanitizer를 거친
+immutable event payload만 외부 exporter에 전달해야 합니다. 기존 소스는 nested
+`Snapshot` class를 `private`로 선언했지만, JVM bytecode에는 raw field를 받는
+public constructor가 남아 있었습니다. 따라서 Kotlin 소스의 가시성만 확인하면
+factory-only construction 계약을 놓칠 수 있습니다.
+
+## 원인
+
+Kotlin의 private nested class와 primary constructor의 가시성은 별개입니다.
+`private class Snapshot(...)`은 nested type을 숨기지만 primary constructor를
+private로 만들지 않습니다. 여기에 constructor를 명시적으로 private로 바꾸면
+Kotlin compiler가 `DefaultConstructorMarker` synthetic bridge를 추가하므로,
+bridge descriptor에도 raw field type이 남지 않는지 별도로 확인해야 합니다.
+
+## 결정
+
+- `History.Snapshot`과 `Lifecycle.Snapshot`의 primary constructor를 명시적으로
+  `private`로 고정합니다.
+- constructor에는 raw `String`, `Map`, `Instant`, `LeaderLease`, history
+  record를 전달하지 않고, outer factory가 sanitizer를 적용한 뒤 만드는 private
+  `SnapshotData` interface만 전달합니다.
+- Kotlin 테스트는 유일한 non-synthetic constructor가 private인지 확인하고,
+  public/synthetic constructor descriptor에 금지된 raw type이 없는지 검사합니다.
+- Java same-package fixture는 동일한 규칙을 reflection으로 재검증합니다.
+
+## 결과
+
+`History`와 `Lifecycle`은 기존 public factory와 sanitized immutable event
+계약을 유지하면서, nested event payload의 non-synthetic constructor를 private로
+제한합니다. Kotlin이 생성하는 synthetic bridge에는 `SnapshotData`와
+`DefaultConstructorMarker`만 남아 raw event field descriptor가 외부 surface로
+노출되지 않습니다.
+
+## 검증
+
+- RED: 새 nested constructor visibility 테스트가 수정 전 `0 passing, 1 failing`으로
+  실패했고, `Expected <false> to be <true>, but was not`을 확인했습니다.
+- GREEN: `LeaderAuditExportEventTest`와
+  `LeaderAuditExportBoundaryContractTest`가 `19 passing`으로 통과했습니다.
+- `javap -p -s`에서 두 private constructor descriptor가
+  `SnapshotData`만 받고, public synthetic bridge에는 raw field type이 없음을
+  확인했습니다.
+- `./gradlew :bluetape4k-leader-core:test --no-daemon --rerun-tasks`: `806 passing`.
+- `./gradlew :bluetape4k-leader-core:detekt --no-daemon --rerun-tasks`: 통과.
+- `git diff --check`: 통과.
+
+## 놀라움과 복구
+
+처음에는 constructor에 `private`만 추가하면 충분하다고 판단했지만, Kotlin
+compiler가 outer factory에서 private constructor를 호출할 수 없다고 거부했고,
+companion factory를 추가한 뒤에는 `DefaultConstructorMarker` bridge에 raw field
+descriptor가 남았습니다. constructor 입력을 opaque `SnapshotData`로 좁히고
+Kotlin·Java descriptor 검사를 함께 추가해 두 경계를 분리했습니다.
+
+## 향후 지침
+
+Kotlin에서 factory-only payload를 만들 때는 nested class의 `private` 선언만
+검사하지 말고 primary constructor visibility와 compiler synthetic bridge를
+함께 확인합니다. public API 또는 security boundary에 raw payload가 없어야 하면
+`javap`와 same-package Java reflection fixture를 유지하고, `String`·`Map`·
+`Instant`·token·`LeaderLease` 같은 내부 입력 타입이 constructor descriptor에
+다시 나타나는지 회귀 테스트로 고정합니다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEvent.kt
@@ -66,19 +66,37 @@ sealed interface LeaderAuditExportEvent {
      */
     class History private constructor(snapshot: Snapshot) : LeaderAuditExportEvent {
 
-        /** factory가 검증·정제한 값만 보관하는 opaque construction payload입니다. */
-        private class Snapshot(
-            val occurredAt: Instant,
-            val lockName: String,
-            val kind: LockIdentity.AnnotationKind,
-            val status: LeaderHistoryStatus,
-            val nodeId: String?,
-            val slotId: String?,
-            val durationMs: Long?,
-            val errorType: String?,
-            val errorMessage: String?,
-            val attributes: Map<String, String>,
-        )
+        /** factory가 검증·정제한 값만 전달하는 opaque construction payload입니다. */
+        private interface SnapshotData {
+            val occurredAt: Instant
+            val lockName: String
+            val kind: LockIdentity.AnnotationKind
+            val status: LeaderHistoryStatus
+            val nodeId: String?
+            val slotId: String?
+            val durationMs: Long?
+            val errorType: String?
+            val errorMessage: String?
+            val attributes: Map<String, String>
+        }
+
+        /** raw field를 JVM constructor descriptor에 노출하지 않는 immutable snapshot입니다. */
+        private class Snapshot private constructor(data: SnapshotData) {
+            val occurredAt: Instant = data.occurredAt
+            val lockName: String = data.lockName
+            val kind: LockIdentity.AnnotationKind = data.kind
+            val status: LeaderHistoryStatus = data.status
+            val nodeId: String? = data.nodeId
+            val slotId: String? = data.slotId
+            val durationMs: Long? = data.durationMs
+            val errorType: String? = data.errorType
+            val errorMessage: String? = data.errorMessage
+            val attributes: Map<String, String> = data.attributes
+
+            companion object {
+                fun create(data: SnapshotData): Snapshot = Snapshot(data)
+            }
+        }
 
         override val occurredAt: Instant = snapshot.occurredAt
         override val lockName: String = snapshot.lockName
@@ -119,30 +137,33 @@ sealed interface LeaderAuditExportEvent {
                 val exportNow = Instant.now()
                 val occurredAt = record.finishedAt ?: record.acquiredAt
                 return History(
-                    Snapshot(
-                        occurredAt = occurredAt,
-                        lockName = bounded(
-                            sanitizer,
-                            LeaderAuditField.LOCK_NAME,
-                            record.lockName,
-                            MAX_TEXT_FIELD_BYTES,
-                        ),
-                        kind = record.kind,
-                        status = record.effectiveStatus(exportNow),
-                        nodeId = record.nodeId?.let {
-                            bounded(sanitizer, LeaderAuditField.NODE_ID, it, MAX_TEXT_FIELD_BYTES)
+                    Snapshot.create(
+                        object : SnapshotData {
+                            override val occurredAt: Instant = occurredAt
+                            override val lockName: String = bounded(
+                                sanitizer,
+                                LeaderAuditField.LOCK_NAME,
+                                record.lockName,
+                                MAX_TEXT_FIELD_BYTES,
+                            )
+                            override val kind: LockIdentity.AnnotationKind = record.kind
+                            override val status: LeaderHistoryStatus = record.effectiveStatus(exportNow)
+                            override val nodeId: String? = record.nodeId?.let {
+                                bounded(sanitizer, LeaderAuditField.NODE_ID, it, MAX_TEXT_FIELD_BYTES)
+                            }
+                            override val slotId: String? = record.slotId?.let {
+                                bounded(sanitizer, LeaderAuditField.SLOT_ID, it, MAX_TEXT_FIELD_BYTES)
+                            }
+                            override val durationMs: Long? = record.durationMs
+                            override val errorType: String? = record.errorType?.let {
+                                bounded(sanitizer, LeaderAuditField.ERROR_TYPE, it, MAX_ERROR_TYPE_BYTES)
+                            }
+                            override val errorMessage: String? = record.errorMessage?.let {
+                                bounded(sanitizer, LeaderAuditField.ERROR_MESSAGE, it, MAX_ERROR_MESSAGE_BYTES)
+                            }
+                            override val attributes: Map<String, String> =
+                                sanitizeAttributes(record.metadata, sanitizer)
                         },
-                        slotId = record.slotId?.let {
-                            bounded(sanitizer, LeaderAuditField.SLOT_ID, it, MAX_TEXT_FIELD_BYTES)
-                        },
-                        durationMs = record.durationMs,
-                        errorType = record.errorType?.let {
-                            bounded(sanitizer, LeaderAuditField.ERROR_TYPE, it, MAX_ERROR_TYPE_BYTES)
-                        },
-                        errorMessage = record.errorMessage?.let {
-                            bounded(sanitizer, LeaderAuditField.ERROR_MESSAGE, it, MAX_ERROR_MESSAGE_BYTES)
-                        },
-                        attributes = sanitizeAttributes(record.metadata, sanitizer),
                     ),
                 )
             }
@@ -159,15 +180,29 @@ sealed interface LeaderAuditExportEvent {
      */
     class Lifecycle private constructor(snapshot: Snapshot) : LeaderAuditExportEvent {
 
-        /** factory가 검증·정제한 값만 보관하는 opaque construction payload입니다. */
-        private class Snapshot(
-            val occurredAt: Instant,
-            val lockName: String,
-            val outcome: LeaderAuditLifecycleOutcome,
-            val leaderId: String?,
-            val leaseExpiry: Instant?,
-            val attributes: Map<String, String>,
-        )
+        /** factory가 검증·정제한 값만 전달하는 opaque construction payload입니다. */
+        private interface SnapshotData {
+            val occurredAt: Instant
+            val lockName: String
+            val outcome: LeaderAuditLifecycleOutcome
+            val leaderId: String?
+            val leaseExpiry: Instant?
+            val attributes: Map<String, String>
+        }
+
+        /** raw field를 JVM constructor descriptor에 노출하지 않는 immutable snapshot입니다. */
+        private class Snapshot private constructor(data: SnapshotData) {
+            val occurredAt: Instant = data.occurredAt
+            val lockName: String = data.lockName
+            val outcome: LeaderAuditLifecycleOutcome = data.outcome
+            val leaderId: String? = data.leaderId
+            val leaseExpiry: Instant? = data.leaseExpiry
+            val attributes: Map<String, String> = data.attributes
+
+            companion object {
+                fun create(data: SnapshotData): Snapshot = Snapshot(data)
+            }
+        }
 
         override val occurredAt: Instant = snapshot.occurredAt
         override val lockName: String = snapshot.lockName
@@ -202,24 +237,26 @@ sealed interface LeaderAuditExportEvent {
             ): Lifecycle {
                 val elected = event as? LeaderElectionEvent.Elected
                 return Lifecycle(
-                    Snapshot(
-                        occurredAt = Instant.now(),
-                        lockName = bounded(
-                            sanitizer,
-                            LeaderAuditField.LOCK_NAME,
-                            event.lockName,
-                            MAX_TEXT_FIELD_BYTES,
-                        ),
-                        outcome = when (event) {
-                            is LeaderElectionEvent.Elected -> LeaderAuditLifecycleOutcome.ELECTED
-                            is LeaderElectionEvent.Revoked -> LeaderAuditLifecycleOutcome.REVOKED
-                            is LeaderElectionEvent.Skipped -> LeaderAuditLifecycleOutcome.SKIPPED
+                    Snapshot.create(
+                        object : SnapshotData {
+                            override val occurredAt: Instant = Instant.now()
+                            override val lockName: String = bounded(
+                                sanitizer,
+                                LeaderAuditField.LOCK_NAME,
+                                event.lockName,
+                                MAX_TEXT_FIELD_BYTES,
+                            )
+                            override val outcome: LeaderAuditLifecycleOutcome = when (event) {
+                                is LeaderElectionEvent.Elected -> LeaderAuditLifecycleOutcome.ELECTED
+                                is LeaderElectionEvent.Revoked -> LeaderAuditLifecycleOutcome.REVOKED
+                                is LeaderElectionEvent.Skipped -> LeaderAuditLifecycleOutcome.SKIPPED
+                            }
+                            override val leaderId: String? = elected?.leaderId?.let {
+                                bounded(sanitizer, LeaderAuditField.LEADER_ID, it, MAX_TEXT_FIELD_BYTES)
+                            }
+                            override val leaseExpiry: Instant? = elected?.leaseExpiry
+                            override val attributes: Map<String, String> = sanitizeAttributes(attributes, sanitizer)
                         },
-                        leaderId = elected?.leaderId?.let {
-                            bounded(sanitizer, LeaderAuditField.LEADER_ID, it, MAX_TEXT_FIELD_BYTES)
-                        },
-                        leaseExpiry = elected?.leaseExpiry,
-                        attributes = sanitizeAttributes(attributes, sanitizer),
                     ),
                 )
             }

--- a/leader-core/src/test/java/io/bluetape4k/leader/audit/LeaderAuditExportJavaContractFixture.java
+++ b/leader-core/src/test/java/io/bluetape4k/leader/audit/LeaderAuditExportJavaContractFixture.java
@@ -1,6 +1,12 @@
 package io.bluetape4k.leader.audit;
 
+import io.bluetape4k.leader.LeaderLease;
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -20,6 +26,9 @@ public final class LeaderAuditExportJavaContractFixture {
                 return false;
             }
             if (!exerciseKindSanitizer()) {
+                return false;
+            }
+            if (!exerciseFactoryOnlySnapshots()) {
                 return false;
             }
 
@@ -102,6 +111,39 @@ public final class LeaderAuditExportJavaContractFixture {
             return false;
         } catch (IllegalArgumentException expected) {
             return true;
+        }
+    }
+
+    private static boolean exerciseFactoryOnlySnapshots() {
+        try {
+            for (Class<?> eventType : new Class<?>[] {
+                LeaderAuditExportEvent.History.class,
+                LeaderAuditExportEvent.Lifecycle.class
+            }) {
+                Class<?> snapshotType = Class.forName(eventType.getName() + "$Snapshot");
+                Constructor<?>[] constructors = snapshotType.getDeclaredConstructors();
+                Constructor<?>[] nonSyntheticConstructors = java.util.Arrays.stream(constructors)
+                    .filter(constructor -> !constructor.isSynthetic())
+                    .toArray(Constructor<?>[]::new);
+                if (nonSyntheticConstructors.length != 1 ||
+                    !Modifier.isPrivate(nonSyntheticConstructors[0].getModifiers())) {
+                    return false;
+                }
+                for (Constructor<?> constructor : constructors) {
+                    if ((Modifier.isPublic(constructor.getModifiers()) || constructor.isSynthetic()) &&
+                        java.util.Arrays.stream(constructor.getParameterTypes()).anyMatch(
+                            parameterType -> parameterType == String.class ||
+                                parameterType == Instant.class ||
+                                parameterType == Map.class ||
+                                parameterType == LeaderLease.class ||
+                                parameterType == LeaderLockHistoryRecord.class)) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        } catch (ReflectiveOperationException e) {
+            return false;
         }
     }
 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/LeaderAuditExportEventTest.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.leader.LeaderElectionEvent
+import io.bluetape4k.leader.LeaderLease
 import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.leader.history.LeaderHistoryStatus
 import io.bluetape4k.leader.history.LeaderLockHistoryRecord
@@ -226,6 +227,36 @@ class LeaderAuditExportEventTest {
             eventType.declaredConstructors
                 .filter { Modifier.isPublic(it.modifiers) && it.isSynthetic }
                 .all { constructor -> constructor.parameterTypes.none(rawTypes::contains) }
+                .shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `nested snapshot constructors are private factory-only payloads`() {
+        val forbiddenRawTypes = setOf(
+            String::class.java,
+            Instant::class.java,
+            Map::class.java,
+            LeaderLease::class.java,
+            LeaderLockHistoryRecord::class.java,
+        )
+        listOf(
+            LeaderAuditExportEvent.History::class.java,
+            LeaderAuditExportEvent.Lifecycle::class.java,
+        ).forEach { eventType ->
+            val snapshotType = eventType.declaredClasses.single { it.simpleName == "Snapshot" }
+            val constructors = snapshotType.declaredConstructors
+            val nonSyntheticConstructors = constructors.filterNot { it.isSynthetic }
+            nonSyntheticConstructors.size shouldBeEqualTo 1
+            Modifier.isPrivate(nonSyntheticConstructors.single().modifiers).shouldBeTrue()
+            constructors
+                .filter { !it.isSynthetic && !Modifier.isPrivate(it.modifiers) }
+                .isEmpty()
+                .shouldBeTrue()
+            constructors
+                .filter { Modifier.isPublic(it.modifiers) || it.isSynthetic }
+                .flatMap { it.parameterTypes.asList() }
+                .none { it in forbiddenRawTypes }
                 .shouldBeTrue()
         }
     }


### PR DESCRIPTION
Closes #731

## Summary

`LeaderAuditExportEvent`의 opaque `Snapshot` payload를 JVM factory-only API로 고정해 Java/Kotlin 호출자가 raw payload 생성 경로에 접근하지 못하도록 합니다.

## Background

기존 `Snapshot` 경계는 Kotlin 내부 factory를 통해서만 생성한다는 의도와 달리 JVM synthetic bridge 및 private 데이터 경계가 다시 노출될 여지가 있었습니다. 이 PR은 opaque payload의 생성 표면과 Java reflection 계약을 명시적으로 고정합니다.

## What This Solves

- `Snapshot` 생성자는 private으로 유지하고 외부 생성 경로를 factory로 제한합니다.
- `SnapshotData`의 raw payload 필드가 public JVM descriptor에 노출되지 않는 계약을 고정합니다.
- Kotlin 및 Java reflection 계약 테스트로 synthetic bridge, 접근 제한, raw 타입 누출을 검증합니다.
- audit export 경계와 immutable sanitizer 동작을 lesson 문서에 기록합니다.

## Validation

- focused tests: `LeaderAuditExportEventTest`, `LeaderAuditExportBoundaryContractTest` — 19/19 PASS
- full `:bluetape4k-leader-core:test` — 806/806 PASS
- `:bluetape4k-leader-core:detekt` — PASS
- `javap -p -s` JVM descriptor inspection — PASS
- PR CI run `32385182372` — 47/47 checks PASS, including module, Testcontainers, coverage, and contract checks
- `git diff --check` — PASS

## Review Notes

- 독립 replacement reviewer가 실제 4개 파일 diff를 읽고 P0/P1/P2/P3 모두 0으로 판정했습니다.
- 1인 유지보수자 scope에 따라 exact-head self-review를 수행해 [PR review comment](https://github.com/bluetape4k/bluetape4k-leader/pull/752#pullrequestreview-4988856105)에 기록했습니다.
- self-review 후 추가 수정 사항과 unresolved review thread는 없습니다.
- LSP는 사용할 수 없어 detekt, 컴파일, 테스트, `javap` 결과를 대체 증거로 사용했습니다.

## Metadata

- Issue: #731 (`OPEN`)
- Pull request: #752 (`OPEN`, ready for review)
- Milestone: `1.0.0`
- Assignee: `debop`
- Labels: `security`, `java`
- Base: `develop`
- Head: `fix/issue-731-audit-snapshot-jvm-surface`
- Head SHA: `eec6acd7f93eda0177bc4d340227d4bd9d975062`
- CI: https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32385182372

## DoD Status

- Product evidence `C-01`~`C-09`: PASS
- Delivery gates `CG-10`~`CG-18`: PASS
- Merge: PASS — squash merge `edd1ecc1a756d69fde60ad813b357a85b02f8cc2`
- Issue #731: CLOSED through PR #752
- Default branch sync: PASS — local `develop` and `origin/develop` equal `17411bc9bf00fd60efda110a4d1defd3b6fb5652`; merge SHA `edd1ecc1a756d69fde60ad813b357a85b02f8cc2` is an ancestor and the concurrent follow-up commit was preserved
- CI: `47/47` checks PASS on approved head; post-merge core test `806 passing`; detekt PASS
- Receipt: run `20260820T145201Z-f66d5440` completed at sequence `23`; completion-check PASS; main verification recorded
- Cleanup: merged worktree removed; local feature branch retained; remote feature ref was removed by repository auto-delete behavior
- Aggregate DoD scope: Required checks `35/35`; N/A `1`; Blocked `0`; Pending `0`
- Final status: DONE