### PR TITLE
fix(leader-micrometer): decorator close 후 delegate 보유와 재진입 교착을 차단

### DIFF
--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporter.kt
@@ -43,6 +43,10 @@ import java.util.concurrent.atomic.AtomicReference
  * manager는 acquire 또는 metric read에서 관찰한 identity crossing만 compromised로 잠그며,
  * foreign meter를 제거하지 않습니다. compromised registry의 복구에는 새
  * `MeterRegistry` identity가 필요합니다.
+ * close 이후 `snapshot()`은 delegate를 다시 호출하지 않고 delegate가 제공한 terminal
+ * snapshot만 반환합니다. terminal snapshot을 얻지 못하면 `IllegalStateException`을 던집니다.
+ * delegate lifecycle callback에서 같은 decorator의 `close()`를 재진입하거나 delegate
+ * close callback에서 `snapshot()`을 재진입하면 교착 대신 `IllegalStateException`을 던집니다.
  */
 class MicrometerLeaderAuditExporter(
     delegate: LeaderAuditExporter,
@@ -55,6 +59,8 @@ class MicrometerLeaderAuditExporter(
     private val submissionsDrained = AtomicReference<CountDownLatch?>(null)
     private val closeCompleted = CountDownLatch(1)
     private val closeFailure = AtomicReference<Throwable?>(null)
+    private val closingThread = AtomicReference<Thread?>(null)
+    private val lifecycleCallDepth = ThreadLocal.withInitial { 0 }
 
     init {
         registration = acquireRegistration(registry, delegate)
@@ -85,7 +91,7 @@ class MicrometerLeaderAuditExporter(
     override fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult {
         if (!admitLifecycleCall()) return LeaderAuditSubmitResult.DROPPED_CLOSED
         return try {
-            registration.delegate.submit(event)
+            registration.delegate().submit(event)
         } finally {
             releaseLifecycleCall()
         }
@@ -94,29 +100,56 @@ class MicrometerLeaderAuditExporter(
     override fun observe(observer: LeaderAuditExportObserver): AutoCloseable {
         if (!admitLifecycleCall()) return AutoCloseable { }
         return try {
-            registration.delegate.observe(observer)
+            registration.delegate().observe(observer)
         } finally {
             releaseLifecycleCall()
         }
     }
 
-    override fun snapshot(): LeaderAuditExportSnapshot = registration.delegate.snapshot()
+    override fun snapshot(): LeaderAuditExportSnapshot {
+        if (!admitLifecycleCall()) {
+            if (closingThread.get() === Thread.currentThread()) {
+                throw IllegalStateException(REENTRANT_SNAPSHOT_MESSAGE)
+            }
+            awaitCloseCompletion()
+            return registration.closedSnapshot(closeFailure.get())
+        }
+        return try {
+            registration.delegate().snapshot()
+        } finally {
+            releaseLifecycleCall()
+        }
+    }
 
     override fun close() {
-        if (lifecycleState.compareAndSet(LifecycleState.OPEN, LifecycleState.CLOSING)) {
-            awaitAdmittedCalls()
-            try {
-                registration.close()
-            } catch (failure: Throwable) {
-                closeFailure.set(failure)
-                throw failure
-            } finally {
-                lifecycleState.set(LifecycleState.CLOSED)
-                closeCompleted.countDown()
+        try {
+            val currentThread = Thread.currentThread()
+            rejectReentrantClose(currentThread)
+            if (lifecycleState.compareAndSet(LifecycleState.OPEN, LifecycleState.CLOSING)) {
+                closingThread.set(currentThread)
+                awaitAdmittedCalls()
+                try {
+                    registration.close()
+                } catch (failure: Throwable) {
+                    closeFailure.set(failure)
+                    throw failure
+                } finally {
+                    lifecycleState.set(LifecycleState.CLOSED)
+                    closeCompleted.countDown()
+                    closingThread.compareAndSet(currentThread, null)
+                }
+            } else {
+                awaitCloseCompletion()
+                closeFailure.get()?.let { throw it }
             }
-        } else {
-            awaitCloseCompletion()
-            closeFailure.get()?.let { throw it }
+        } finally {
+            if (lifecycleCallDepth.get() == 0) lifecycleCallDepth.remove()
+        }
+    }
+
+    private fun rejectReentrantClose(currentThread: Thread) {
+        if (lifecycleCallDepth.get() > 0 || closingThread.get() === currentThread) {
+            throw IllegalStateException(REENTRANT_CLOSE_MESSAGE)
         }
     }
 
@@ -125,12 +158,27 @@ class MicrometerLeaderAuditExporter(
         if (admitted) {
             admittedCalls.incrementAndGet()
             admitted = lifecycleState.get() == LifecycleState.OPEN
-            if (!admitted) releaseLifecycleCall()
+            if (admitted) {
+                lifecycleCallDepth.set(lifecycleCallDepth.get() + 1)
+            } else {
+                releaseAdmittedCall()
+            }
         }
         return admitted
     }
 
     private fun releaseLifecycleCall() {
+        val depth = lifecycleCallDepth.get()
+        check(depth > 0) { "lifecycle call depth must be positive" }
+        if (depth == 1) {
+            lifecycleCallDepth.remove()
+        } else {
+            lifecycleCallDepth.set(depth - 1)
+        }
+        releaseAdmittedCall()
+    }
+
+    private fun releaseAdmittedCall() {
         if (admittedCalls.decrementAndGet() == 0) submissionsDrained.get()?.countDown()
     }
 
@@ -168,17 +216,30 @@ class MicrometerLeaderAuditExporter(
 
     private class Registration(
         val manager: RegistryManager,
-        val delegate: LeaderAuditExporter,
+        delegate: LeaderAuditExporter,
         private val ownershipToken: Any,
     ) : AutoCloseable {
         private val closed = AtomicBoolean(false)
+        private val delegateReference = AtomicReference<LeaderAuditExporter?>(delegate)
+        private val detachedSnapshot = AtomicReference<LeaderAuditExportSnapshot?>(null)
+
+        fun delegate(): LeaderAuditExporter = checkNotNull(delegateReference.get()) {
+            "delegate is detached"
+        }
+
+        fun closedSnapshot(closeFailure: Throwable?): LeaderAuditExportSnapshot =
+            detachedSnapshot.get() ?: throw IllegalStateException(CLOSED_SNAPSHOT_UNAVAILABLE_MESSAGE, closeFailure)
 
         override fun close() {
             if (closed.compareAndSet(false, true)) {
+                val ownedDelegate = delegateReference.get() ?: return
                 try {
-                    manager.close(delegate)
+                    val result = manager.close(ownedDelegate)
+                    result.snapshot?.let(detachedSnapshot::set)
+                    result.failure?.let { throw it }
                 } finally {
-                    DelegateOwnershipStore.release(delegate, ownershipToken)
+                    delegateReference.compareAndSet(ownedDelegate, null)
+                    DelegateOwnershipStore.release(ownedDelegate, ownershipToken)
                 }
             }
         }
@@ -293,12 +354,15 @@ class MicrometerLeaderAuditExporter(
                 Registration(this, delegate, ownershipToken)
             }
 
-        fun close(delegate: LeaderAuditExporter) {
+        fun close(delegate: LeaderAuditExporter): CloseResult {
             var primary: Throwable? = null
             var finalSnapshot: LeaderAuditExportSnapshot? = null
             var closeEntryFailure: Throwable? = null
+            var registrationSnapshot: LeaderAuditExportSnapshot? = null
             synchronized(lock) {
-                if (activeDelegate !== delegate || state != ManagerState.OPEN) return
+                if (activeDelegate !== delegate || state != ManagerState.OPEN) {
+                    return CloseResult(null, null)
+                }
                 try {
                     closingSnapshot = delegate.snapshot()
                 } catch (failure: Throwable) {
@@ -325,19 +389,18 @@ class MicrometerLeaderAuditExporter(
                     if (!compromised) {
                         val closeEntry = closingSnapshot
                         val final = finalSnapshot
-                        val trustedCumulative = closeEntry
-                            ?.cumulativeValues()
-                            ?.takeIf { it.isNotLessThan(lastTrustedCumulative) }
-                            ?: lastTrustedCumulative
-                        val trustedGauge = closeEntry?.gaugeValues() ?: lastTrustedGauge
-                        if (closeEntry == null ||
-                            !closeEntry.cumulativeValues().isNotLessThan(lastTrustedCumulative)
-                        ) {
+                        val trustedCloseEntry = closeEntry?.takeIf {
+                            it.cumulativeValues().isNotLessThan(lastTrustedCumulative)
+                        }
+                        val trustedCumulative = trustedCloseEntry?.cumulativeValues() ?: lastTrustedCumulative
+                        val trustedGauge = trustedCloseEntry?.gaugeValues() ?: lastTrustedGauge
+                        if (trustedCloseEntry == null) {
                             markSourceDegraded()
                         }
                         if (final != null && final.cumulativeValues().isNotLessThan(trustedCumulative)) {
                             offsets = offsets + final.cumulativeValues()
                             detachedSnapshot = final.asDetached()
+                            registrationSnapshot = final.takeIf(LeaderAuditExportSnapshot::isTerminal)
                         } else {
                             markSourceDegraded()
                             offsets = offsets + trustedCumulative
@@ -364,7 +427,7 @@ class MicrometerLeaderAuditExporter(
                     state = ManagerState.DETACHED
                 }
             }
-            if (primary != null) throw primary
+            return CloseResult(registrationSnapshot, primary)
         }
 
         fun counter(descriptor: MetricDescriptor): Double = synchronized(lock) {
@@ -517,6 +580,11 @@ class MicrometerLeaderAuditExporter(
         DETACHED,
     }
 
+    private data class CloseResult(
+        val snapshot: LeaderAuditExportSnapshot?,
+        val failure: Throwable?,
+    )
+
     private enum class LifecycleState {
         OPEN,
         CLOSING,
@@ -628,6 +696,11 @@ class MicrometerLeaderAuditExporter(
             "MeterRegistry already contains a foreign or compromised leader audit meter"
         const val OWNERSHIP_CONFLICT_WARNING = "leader.audit.export.meter-ownership-conflict"
         const val SOURCE_DEGRADED_MESSAGE = "leader.audit.export.meter-source-degraded"
+        const val REENTRANT_CLOSE_MESSAGE =
+            "close() cannot be called reentrantly from a delegate lifecycle callback"
+        const val REENTRANT_SNAPSHOT_MESSAGE =
+            "snapshot() cannot be called reentrantly from a delegate close callback"
+        const val CLOSED_SNAPSHOT_UNAVAILABLE_MESSAGE = "closed delegate snapshot is unavailable"
 
         val TerminalSnapshot = DetachedSnapshot(
             cumulative = CumulativeValues.ZERO,
@@ -755,6 +828,14 @@ private fun MicrometerLeaderAuditExporter.CumulativeValues.isNotLessThan(
     observerDrops >= other.observerDrops &&
     observerRegistrationDrops >= other.observerRegistrationDrops &&
     diagnosticsFailures >= other.diagnosticsFailures
+
+private fun LeaderAuditExportSnapshot.isTerminal(): Boolean =
+    queued == 0 &&
+        inFlight == 0 &&
+        scheduledRetries == 0 &&
+        admitted == 0 &&
+        diagnosticsClosed &&
+        closed
 
 private fun LeaderAuditExportSnapshot.asDetached(): MicrometerLeaderAuditExporter.DetachedSnapshot =
     MicrometerLeaderAuditExporter.DetachedSnapshot(

--- a/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
+++ b/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/audit/MicrometerLeaderAuditExporterTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.leader.micrometer.audit
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.leader.audit.LeaderAuditExportEvent
@@ -104,6 +105,185 @@ class MicrometerLeaderAuditExporterTest {
         exporter.close()
         delegate.closeCount shouldBeEqualTo 1
         exporter.submit(event) shouldBeEqualTo LeaderAuditSubmitResult.DROPPED_CLOSED
+    }
+
+    @Test
+    fun `close releases the delegate and publishes a terminal snapshot`() {
+        val registry = SimpleMeterRegistry()
+        val openSnapshot = snapshot(
+            queued = 3,
+            inFlight = 2,
+            scheduledRetries = 1,
+            admitted = 4,
+            accepted = 7,
+            droppedClosed = 5,
+        )
+        val terminalSnapshot = snapshot(accepted = 7, droppedClosed = 5, diagnosticsClosed = true, closed = true)
+        val delegate = SnapshotExporter(openSnapshot)
+        delegate.scriptSnapshots({ openSnapshot }, { terminalSnapshot })
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+        val registration = privateField(exporter, "registration").get(exporter)
+        val delegateReference = privateField(registration, "delegateReference").get(registration) as AtomicReference<*>
+
+        (delegateReference.get() === delegate).shouldBeTrue()
+
+        exporter.close()
+
+        (delegateReference.get() == null).shouldBeTrue()
+        containsStrongReference(exporter, delegate).shouldBeFalse()
+        exporter.snapshot().apply {
+            queued shouldBeEqualTo 0
+            inFlight shouldBeEqualTo 0
+            scheduledRetries shouldBeEqualTo 0
+            admitted shouldBeEqualTo 0
+            accepted shouldBeEqualTo 7
+            droppedClosed shouldBeEqualTo 5
+            diagnosticsClosed.shouldBeTrue()
+            closed.shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `reentrant close from submit fails without deadlock and keeps the decorator open`() {
+        val registry = SimpleMeterRegistry()
+        val delegate = SnapshotExporter(snapshot())
+        lateinit var exporter: MicrometerLeaderAuditExporter
+        delegate.runOnSubmit { exporter.close() }
+        exporter = MicrometerLeaderAuditExporter(delegate, registry)
+        val failure = AtomicReference<Throwable?>(null)
+        val finished = CountDownLatch(1)
+        val submitThread = Thread {
+            try {
+                exporter.submit(event())
+            } catch (thrown: Throwable) {
+                failure.set(thrown)
+            } finally {
+                finished.countDown()
+            }
+        }.apply {
+            isDaemon = true
+        }
+
+        submitThread.start()
+
+        finished.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        val thrown = failure.get().shouldNotBeNull()
+        thrown.shouldBeInstanceOf<IllegalStateException>()
+        thrown.message shouldBeEqualTo "close() cannot be called reentrantly from a delegate lifecycle callback"
+
+        delegate.runOnSubmit(null)
+        exporter.submit(event()) shouldBeEqualTo LeaderAuditSubmitResult.ACCEPTED
+        exporter.close()
+    }
+
+    @Test
+    fun `reentrant snapshot from delegate close fails without deadlock`() {
+        val registry = SimpleMeterRegistry()
+        val openSnapshot = snapshot(accepted = 7)
+        val terminalSnapshot = snapshot(accepted = 7, diagnosticsClosed = true, closed = true)
+        val delegate = SnapshotExporter(openSnapshot)
+        delegate.scriptSnapshots({ openSnapshot }, { terminalSnapshot })
+        lateinit var exporter: MicrometerLeaderAuditExporter
+        delegate.runOnClose { exporter.snapshot() }
+        exporter = MicrometerLeaderAuditExporter(delegate, registry)
+        val failure = AtomicReference<Throwable?>(null)
+        val finished = CountDownLatch(1)
+        val closeThread = Thread {
+            try {
+                exporter.close()
+            } catch (thrown: Throwable) {
+                failure.set(thrown)
+            } finally {
+                finished.countDown()
+            }
+        }.apply {
+            isDaemon = true
+        }
+
+        closeThread.start()
+
+        finished.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        val thrown = failure.get().shouldNotBeNull()
+        thrown.shouldBeInstanceOf<IllegalStateException>()
+        thrown.message shouldBeEqualTo "snapshot() cannot be called reentrantly from a delegate close callback"
+        exporter.snapshot() shouldBeEqualTo terminalSnapshot
+    }
+
+    @Test
+    fun `close without a terminal snapshot exposes explicit closed semantics`() {
+        val registry = SimpleMeterRegistry()
+        val closeEntry = snapshot(queued = 2, inFlight = 1, accepted = 7)
+        val finalSnapshotFailure = IllegalStateException("final snapshot failure")
+        val delegate = SnapshotExporter(closeEntry)
+        delegate.scriptSnapshots({ closeEntry }, { throw finalSnapshotFailure })
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+
+        val closeFailure = assertFailsWith<IllegalStateException> { exporter.close() }
+
+        closeFailure shouldBeEqualTo finalSnapshotFailure
+        val snapshotFailure = assertFailsWith<IllegalStateException> { exporter.snapshot() }
+        snapshotFailure.message shouldBeEqualTo "closed delegate snapshot is unavailable"
+        snapshotFailure.cause shouldBeEqualTo closeFailure
+    }
+
+    @Test
+    fun `regressive terminal snapshot is not exposed after close`() {
+        val registry = SimpleMeterRegistry()
+        val closeEntry = snapshot(accepted = 100)
+        val regressiveTerminal = snapshot(accepted = 40, diagnosticsClosed = true, closed = true)
+        val delegate = SnapshotExporter(closeEntry)
+        delegate.scriptSnapshots({ closeEntry }, { regressiveTerminal })
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+
+        exporter.close()
+
+        registry.find(MicrometerNames.AUDIT_EXPORT_ACCEPTED)
+            .tag(MicrometerNames.AUDIT_EXPORT_TAG_OUTCOME, "accepted")
+            .functionCounter()
+            ?.count() shouldBeEqualTo 100.0
+        val snapshotFailure = assertFailsWith<IllegalStateException> { exporter.snapshot() }
+        snapshotFailure.message shouldBeEqualTo "closed delegate snapshot is unavailable"
+    }
+
+    @Test
+    fun `close waits for an admitted snapshot and publishes the terminal state`() {
+        val registry = SimpleMeterRegistry()
+        val openSnapshot = snapshot(accepted = 7)
+        val delegate = SnapshotExporter(openSnapshot)
+        val exporter = MicrometerLeaderAuditExporter(delegate, registry)
+        val snapshotEntered = CountDownLatch(1)
+        val snapshotRelease = CountDownLatch(1)
+        delegate.scriptSnapshots(
+            { openSnapshot },
+            { snapshot(accepted = 7, diagnosticsClosed = true, closed = true) },
+        )
+        delegate.blockNextSnapshot(snapshotEntered, snapshotRelease)
+        val snapshotFinished = CountDownLatch(1)
+        val closeFinished = CountDownLatch(1)
+        val snapshotThread = Thread {
+            exporter.snapshot()
+            snapshotFinished.countDown()
+        }
+        val closeThread = Thread {
+            exporter.close()
+            closeFinished.countDown()
+        }
+
+        snapshotThread.start()
+        snapshotEntered.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        closeThread.start()
+        try {
+            closeFinished.await(200, TimeUnit.MILLISECONDS).shouldBeFalse()
+            delegate.closeCount shouldBeEqualTo 0
+        } finally {
+            snapshotRelease.countDown()
+        }
+
+        snapshotFinished.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        closeFinished.await(1, TimeUnit.SECONDS).shouldBeTrue()
+        snapshotThread.join(1_000)
+        closeThread.join(1_000)
+        exporter.snapshot().closed.shouldBeTrue()
     }
 
     @Test
@@ -356,6 +536,9 @@ class MicrometerLeaderAuditExporterTest {
         val repeated = assertFailsWith<IllegalStateException> { exporter.close() }
         repeated shouldBeEqualTo thrown
         delegate.closeCount shouldBeEqualTo 1
+        val snapshotFailure = assertFailsWith<IllegalStateException> { exporter.snapshot() }
+        snapshotFailure.message shouldBeEqualTo "closed delegate snapshot is unavailable"
+        snapshotFailure.cause shouldBeEqualTo thrown
 
         val replacementDelegate = SnapshotExporter(snapshot(accepted = 3))
         val replacement = MicrometerLeaderAuditExporter(replacementDelegate, registry)
@@ -782,6 +965,9 @@ class MicrometerLeaderAuditExporterTest {
     ) : LeaderAuditExporter {
         private val current = AtomicReference(initialSnapshot)
         private val snapshotFailure = AtomicReference<Throwable?>(null)
+        private val nextSnapshot = AtomicReference<(() -> LeaderAuditExportSnapshot)?>(null)
+        private val submitAction = AtomicReference<(() -> Unit)?>(null)
+        private val closeAction = AtomicReference<(() -> Unit)?>(null)
         private var scriptedSnapshots: ArrayDeque<() -> LeaderAuditExportSnapshot>? = null
         private var closeFailure: Throwable? = null
         private var submitEntered: CountDownLatch? = null
@@ -798,13 +984,15 @@ class MicrometerLeaderAuditExporterTest {
             } else {
                 submitEntered?.countDown()
                 submitRelease?.await(5, TimeUnit.SECONDS)
+                submitAction.get()?.invoke()
                 LeaderAuditSubmitResult.ACCEPTED
             }
 
         override fun observe(observer: LeaderAuditExportObserver): AutoCloseable = AutoCloseable { }
 
         override fun snapshot(): LeaderAuditExportSnapshot =
-            scriptedSnapshots?.pollFirst()?.invoke()
+            nextSnapshot.getAndSet(null)?.invoke()
+                ?: scriptedSnapshots?.pollFirst()?.invoke()
                 ?: snapshotFailure.get()?.let { throw it }
                 ?: current.get()
 
@@ -824,6 +1012,22 @@ class MicrometerLeaderAuditExporterTest {
             current.set(snapshot)
         }
 
+        fun blockNextSnapshot(entered: CountDownLatch, release: CountDownLatch) {
+            nextSnapshot.set {
+                entered.countDown()
+                release.await(5, TimeUnit.SECONDS)
+                current.get()
+            }
+        }
+
+        fun runOnSubmit(action: (() -> Unit)?) {
+            submitAction.set(action)
+        }
+
+        fun runOnClose(action: (() -> Unit)?) {
+            closeAction.set(action)
+        }
+
         fun blockSubmissions(entered: CountDownLatch, release: CountDownLatch) {
             submitEntered = entered
             submitRelease = release
@@ -839,6 +1043,7 @@ class MicrometerLeaderAuditExporterTest {
             closeRelease?.await(5, TimeUnit.SECONDS)
             closeCount++
             closed = true
+            closeAction.get()?.invoke()
             closeFailure?.let { throw it }
         }
     }


### PR DESCRIPTION
## Summary

Closes #754

Micrometer audit decorator의 종료 경계를 고정해 closed delegate 보유와 lifecycle callback 재진입 교착을 제거합니다.

## Background

Issue #754는 `Registration.delegate`의 strong reference, close 이후 delegate 재호출, admitted lifecycle call 중 재진입 close 교착을 지적했습니다.

## What This Solves

- close 완료 후 wrapper가 delegate를 보유하지 않아 delegate resource 회수가 가능해집니다.
- concurrent `submit`/`observe`/`snapshot` 호출은 drain된 뒤 종료되고, 동일 스레드 lifecycle 재진입은 deterministic failure가 됩니다.
- after-close snapshot은 trusted cumulative 값과 terminal 조건을 모두 만족한 경우만 반환하며, 불일치 시 명시적 closed semantics를 사용합니다.

## Work Done

- `Registration`을 atomic delegate reference와 detached snapshot으로 변경하고 ownership token release를 유지했습니다.
- close-entry/final snapshot의 monotonicity·terminal 검증과 snapshot/close admission 경계를 추가했습니다.
- delegate retention, reentrant close/snapshot, admitted snapshot drain, terminal snapshot regression 회귀 테스트를 추가했습니다.

## Validation

- `./gradlew :bluetape4k-leader-micrometer:test --tests 'io.bluetape4k.leader.micrometer.audit.MicrometerLeaderAuditExporterTest' --no-build-cache`: PASS (32 passing)
- `./gradlew :bluetape4k-leader-micrometer:test --no-build-cache`: PASS (114 passing)
- `./gradlew :bluetape4k-leader-micrometer:detekt --rerun-tasks --no-build-cache`: PASS
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 0
- Review evidence: 독립 `code-reviewer` 최종 판정 `APPROVE`

## Metadata

- Issue: #754, milestone `1.0.0`, assignee `debop`
- PR: #757, head `e6678e39ef69c220e552e2e7c5fa5394c9ce749d`, milestone `1.0.0`, assignee `debop`
- CI: exact-head GitHub run `32575596761` success (`https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32575596761`)

## DoD Status

Required checks: 13/18; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01~CG-10 - Pre-PR proof | 가이드, scope, RED/GREEN, module 검증, Detekt, 리뷰, 커밋 | PASS | commit `e6678e39ef69c220e552e2e7c5fa5394c9ce749d`, 32/114 tests, Detekt, review APPROVE | none |
| CG-11 - PR delivery authority | 승인된 repository/base/head 확인 | PASS | `bluetape4k/bluetape4k-leader`, `develop`, `fix/issue-754-micrometer-close` | none |
| CG-12 - Exact head publication | force 없이 exact head push | PASS | remote branch head matches `e6678e39ef69c220e552e2e7c5fa5394c9ce749d` | none |
| CG-12A - Guidance refresh | PR 직전 guidance·issue metadata 재확인 | PASS | current AGENTS/skills/common-gates/template and Issue #754 metadata reread | none |
| CG-13 - PR creation and metadata | PR 생성, assignee/labels/milestone/body 검증 | PASS | PR #757 live metadata: head/base/assignee/labels/milestone match; final heading `## DoD Status` | none |
| CG-14 - CI and review | exact-head CI와 리뷰 재확인; 1인 개발자 정책으로 human review N/A | PASS | run `32575596761` success; required fan-out `leader-micrometer`, `spring-boot`, `examples-prometheus-dashboard` success; CI Status intended skips verified; reviews/comments 없음; independent code-reviewer P0/P1=0 | none |
| CG-15 - Merge-ready report | exact PR/head와 CI evidence 재조정 | PASS | PR #757 exact head/base, `mergeable=true`, `mergeable_state=clean`, checks/reviews/comments/metadata fresh-read 완료 | none |
| CG-16 - Fresh merge approval | exact PR/head 기준 새 merge approval | PENDING | not requested yet | wait for user approval |
| CG-17 - Merge | 승인 후 live merge verification | PENDING | not authorized yet | do not merge yet |
| CG-18 - Sync and cleanup | merge 후 develop sync와 proven cleanup | PENDING | merge not complete | preserve worktree |

Final status: PENDING (CG-16 fresh merge approval)

Unchecked required items: CG-16, CG-17, CG-18
