### PR TITLE
fix(spring): backend health probe 예외를 안전하게 정규화

### DIFF
--- a/leader-spring-boot/README.ko.md
+++ b/leader-spring-boot/README.ko.md
@@ -682,6 +682,8 @@ bluetape4k:
 
 `UP`과 `DOWN`은 같은 이름의 Spring health status로 매핑됩니다. `UNKNOWN`과 `NOT_CHECKED`는 Spring `UNKNOWN`으로 매핑됩니다. 두 surface는 `bluetape4k.leader.observability.state-provider-bean`과 같은 elector 선택 규칙을 사용합니다. 선택된 elector가 `LeaderBackendDiagnosticsProvider`를 노출하지 않으면 typed endpoint와 health indicator를 등록하지 않습니다.
 
+활성 backend probe가 일반 provider 예외를 던지면 health indicator는 이를 `UNKNOWN`으로 정규화하고 `error` 키, 예외 class/message/cause, endpoint, token, credential을 Actuator detail에 복사하지 않습니다. `management.endpoint.health.show-details=always`여도 이 계약을 유지하며 indicator의 allow-list detail만 반환합니다. 치명적인 JVM `Error`는 정규화하지 않고 재전파합니다. Probe는 실제 backend I/O를 수행하므로 실패 내용을 정제하더라도 endpoint 접근은 계속 보호해야 합니다.
+
 다른 management endpoint와 동일하게 인증과 network policy로 보호하세요. Backend가 정상이라는 결과는 probe 시점의 연결 가능성만 의미하며, 현재 프로세스가 leader lease를 보유한다는 증거가 아닙니다.
 
 ## 마이그레이션 노트

--- a/leader-spring-boot/README.md
+++ b/leader-spring-boot/README.md
@@ -702,6 +702,8 @@ bluetape4k:
 
 `UP` and `DOWN` map directly to Spring health statuses. `UNKNOWN` and `NOT_CHECKED` map to Spring `UNKNOWN`. Both surfaces use the same elector selection as `bluetape4k.leader.observability.state-provider-bean`; when the selected elector does not expose a `LeaderBackendDiagnosticsProvider`, the typed endpoint and health indicator are not registered.
 
+If the active backend probe throws an ordinary provider exception, the health indicator reports `UNKNOWN` without copying the `error` key, exception class/message/cause, endpoint, token, or credential into Actuator details. This remains true when `management.endpoint.health.show-details=always`; only the indicator's allow-listed details are returned. Fatal JVM `Error` values are not normalized and are rethrown. Keep the endpoint protected even with sanitized failures because the probe still performs live backend I/O.
+
 Protect these Actuator surfaces with the same authentication and network policy as other management endpoints. A healthy backend only proves connectivity at the time of the probe; it does not prove that this process currently owns a leader lease.
 
 ## Migration Notes

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/observability/LeaderBackendHealthIndicator.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/observability/LeaderBackendHealthIndicator.kt
@@ -1,10 +1,13 @@
 package io.bluetape4k.leader.spring.observability
 
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityStatus
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
 import org.springframework.boot.health.contributor.AbstractHealthIndicator
 import org.springframework.boot.health.contributor.Health
 import org.springframework.boot.health.contributor.Status
+import java.util.concurrent.CancellationException
 import kotlin.time.Duration
 
 /** 선택된 leader backend에 opt-in connectivity probe를 실행하는 health indicator입니다. */
@@ -14,24 +17,39 @@ class LeaderBackendHealthIndicator(
 ) : AbstractHealthIndicator("Leader backend connectivity health check failed") {
 
     override fun doHealthCheck(builder: Health.Builder) {
-        val diagnostics = provider.diagnostics(probe = true, timeout = timeout)
-        val connectivity = diagnostics.connectivity
-
-        when (connectivity.status) {
-            LeaderBackendConnectivityStatus.UP -> builder.up()
-            LeaderBackendConnectivityStatus.DOWN -> builder.down()
-            LeaderBackendConnectivityStatus.UNKNOWN,
-            LeaderBackendConnectivityStatus.NOT_CHECKED,
-            -> builder.status(Status.UNKNOWN)
+        val diagnostics = try {
+            provider.diagnostics(probe = true, timeout = timeout)
+        } catch (_: CancellationException) {
+            null
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            null
+        } catch (_: Exception) {
+            null
         }
-        builder
-            .withDetail(DETAIL_BACKEND, diagnostics.descriptor.backendId)
-            .withDetail(DETAIL_CONNECTIVITY, connectivity.status.name)
-        connectivity.checkedAt?.let { builder.withDetail(DETAIL_CHECKED_AT, it) }
-        connectivity.latencyMillis?.let { builder.withDetail(DETAIL_LATENCY_MILLIS, it) }
+
+        if (diagnostics == null) {
+            builder.status(Status.UNKNOWN)
+            log.warn { "leader.spring.health backend probe failed; status=UNKNOWN" }
+        } else {
+            val connectivity = diagnostics.connectivity
+
+            when (connectivity.status) {
+                LeaderBackendConnectivityStatus.UP -> builder.up()
+                LeaderBackendConnectivityStatus.DOWN -> builder.down()
+                LeaderBackendConnectivityStatus.UNKNOWN,
+                LeaderBackendConnectivityStatus.NOT_CHECKED,
+                -> builder.status(Status.UNKNOWN)
+            }
+            builder
+                .withDetail(DETAIL_BACKEND, diagnostics.descriptor.backendId)
+                .withDetail(DETAIL_CONNECTIVITY, connectivity.status.name)
+            connectivity.checkedAt?.let { builder.withDetail(DETAIL_CHECKED_AT, it) }
+            connectivity.latencyMillis?.let { builder.withDetail(DETAIL_LATENCY_MILLIS, it) }
+        }
     }
 
-    private companion object {
+    private companion object : KLogging() {
         const val DETAIL_BACKEND = "backend"
         const val DETAIL_CONNECTIVITY = "connectivity"
         const val DETAIL_CHECKED_AT = "checkedAt"

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/observability/LeaderBackendHealthIndicatorTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/observability/LeaderBackendHealthIndicatorTest.kt
@@ -1,8 +1,12 @@
 package io.bluetape4k.leader.spring.observability
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.leader.LeaderElector
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsAware
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivity
@@ -10,17 +14,27 @@ import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityStatus
 import io.bluetape4k.leader.diagnostics.LeaderBackendDescriptor
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
 import io.bluetape4k.leader.diagnostics.LocalLeaderBackendDiagnostics
+import io.bluetape4k.leader.spring.LeaderTestApplication
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.beans.factory.getBean
 import org.springframework.beans.factory.getBeansOfType
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.health.contributor.HealthIndicator
 import org.springframework.boot.health.contributor.Status
+import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.FilteredClassLoader
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 import java.time.Instant
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicInteger
@@ -105,6 +119,104 @@ class LeaderBackendHealthIndicatorTest {
         }
     }
 
+    @Test
+    fun `provider Exception은 UNKNOWN으로 정규화하고 원문 health detail을 노출하지 않는다`() {
+        val rawMessage = RAW_PROBE_MESSAGE
+        val health = LeaderBackendHealthIndicator(
+            ThrowingDiagnosticsElector(IllegalStateException(rawMessage)),
+            100.milliseconds,
+        ).health()
+
+        health.status shouldBeEqualTo Status.UNKNOWN
+        health.details.keys.none { it in SENSITIVE_DETAIL_KEYS }.shouldBeTrue()
+        health.details.values.none { it.toString().contains(rawMessage) }.shouldBeTrue()
+    }
+
+    @Test
+    fun `provider CancellationException도 UNKNOWN으로 정규화하고 원문을 노출하지 않는다`() {
+        val health = LeaderBackendHealthIndicator(
+            ThrowingDiagnosticsElector(CancellationException(RAW_PROBE_MESSAGE)),
+            100.milliseconds,
+        ).health()
+
+        health.status shouldBeEqualTo Status.UNKNOWN
+        health.details.keys.none { it in SENSITIVE_DETAIL_KEYS }.shouldBeTrue()
+        health.details.values.none { it.toString().contains(RAW_PROBE_MESSAGE) }.shouldBeTrue()
+    }
+
+    @Test
+    fun `provider InterruptedException은 UNKNOWN으로 정규화하고 interrupt flag를 복원한다`() {
+        Thread.interrupted()
+        try {
+            val health = LeaderBackendHealthIndicator(
+                ThrowingDiagnosticsElector(InterruptedException(RAW_PROBE_MESSAGE)),
+                100.milliseconds,
+            ).health()
+
+            health.status shouldBeEqualTo Status.UNKNOWN
+            health.details.keys.none { it in SENSITIVE_DETAIL_KEYS }.shouldBeTrue()
+            health.details.values.none { it.toString().contains(RAW_PROBE_MESSAGE) }.shouldBeTrue()
+            Thread.currentThread().isInterrupted.shouldBeTrue()
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `provider Error는 재전파한다`() {
+        val fatal = AssertionError("fatal backend probe")
+
+        val thrown = assertFailsWith<AssertionError> {
+            LeaderBackendHealthIndicator(ThrowingDiagnosticsElector(fatal), 100.milliseconds).health()
+        }
+
+        thrown shouldBeSameInstanceAs fatal
+    }
+
+    @Nested
+    @SpringBootTest(
+        classes = [LeaderTestApplication::class, ThrowingActuatorElectorConfig::class],
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = [
+            "bluetape4k.leader.observability.backend-health.enabled=true",
+            "management.endpoint.health.show-details=always",
+            "management.endpoints.web.exposure.include=health",
+        ],
+    )
+    inner class ActuatorHealthDetailsTest {
+        @LocalServerPort
+        private var port: Int = 0
+
+        @Test
+        fun `show-details가 always여도 provider 원문을 health 응답에 노출하지 않는다`() {
+            val request = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:$port/actuator/health"))
+                .GET()
+                .build()
+            val response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString())
+
+            response.statusCode() shouldBeEqualTo 200
+            response.body().shouldContain("\"status\":\"UNKNOWN\"")
+            val body = response.body()
+            SENSITIVE_DETAIL_KEYS.forEach { key ->
+                body.contains("\"$key\"").shouldBeFalse()
+            }
+            SENSITIVE_RAW_VALUES.forEach { value ->
+                body.contains(value).shouldBeFalse()
+            }
+
+            val leaderBackend = ObjectMapper().readTree(body).path("components").path("leaderBackend")
+            leaderBackend.isObject.shouldBeTrue()
+            leaderBackend.path("status").asText() shouldBeEqualTo "UNKNOWN"
+            val leaderBackendFields = mutableSetOf<String>()
+            val fields = leaderBackend.fieldNames()
+            while (fields.hasNext()) {
+                leaderBackendFields += fields.next()
+            }
+            leaderBackendFields shouldBeEqualTo setOf("status")
+        }
+    }
+
     private fun runner(): ApplicationContextRunner = ApplicationContextRunner()
         .withConfiguration(AutoConfigurations.of(LeaderBackendHealthAutoConfiguration::class.java))
         .withUserConfiguration(DiagnosticsElectorConfig::class.java)
@@ -125,6 +237,14 @@ class LeaderBackendHealthIndicatorTest {
     class NullDiagnosticsAwareElectorConfig {
         @Bean
         fun testLeaderElector(): LeaderElector = DiagnosticsAwareElector(null)
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableAutoConfiguration
+    class ThrowingActuatorElectorConfig {
+        @Bean
+        fun testLeaderElector(): ThrowingDiagnosticsElector =
+            ThrowingDiagnosticsElector(IllegalStateException(RAW_PROBE_MESSAGE))
     }
 
     class DiagnosticsAwareElector(
@@ -151,6 +271,14 @@ class LeaderBackendHealthIndicatorTest {
         }
     }
 
+    class ThrowingDiagnosticsElector(
+        private val failure: Throwable,
+    ) : PlainLeaderElector(), LeaderBackendDiagnosticsProvider {
+        override val backendDescriptor: LeaderBackendDescriptor = LocalLeaderBackendDiagnostics.backendDescriptor
+
+        override fun checkConnectivity(timeout: Duration): LeaderBackendConnectivity = throw failure
+    }
+
     open class PlainLeaderElector : LeaderElector {
         override fun <T> runIfLeader(lockName: String, action: () -> T): T? = action()
 
@@ -159,5 +287,32 @@ class LeaderBackendHealthIndicatorTest {
             executor: Executor,
             action: () -> CompletableFuture<T>,
         ): CompletableFuture<T?> = action().thenApply { it }
+    }
+
+    private companion object {
+        const val RAW_PROBE_MESSAGE =
+            "probe failed endpoint=https://redis-prod.example:6380 token=secret credential=credential cause=connection"
+
+        val SENSITIVE_DETAIL_KEYS = setOf(
+            "error",
+            "exception",
+            "exceptionClass",
+            "class",
+            "message",
+            "cause",
+            "stackTrace",
+            "endpoint",
+            "token",
+            "credential",
+        )
+
+        val SENSITIVE_RAW_VALUES = setOf(
+            RAW_PROBE_MESSAGE,
+            "IllegalStateException",
+            "redis-prod.example",
+            "token=secret",
+            "credential=credential",
+            "cause=connection",
+        )
     }
 }


### PR DESCRIPTION
## Summary

Closes #742

Spring backend health probe가 provider 예외를 Spring의 기본 raw error detail 경계까지 전달하지 않도록 정규화합니다. Actuator `show-details=always`에서도 민감한 provider 원문을 노출하지 않고, 치명적인 `Error`는 숨기지 않습니다.

## Background

기존 `LeaderBackendHealthIndicator`는 `diagnostics(probe = true, ...)` 예외를 직접 Spring `AbstractHealthIndicator` 경계로 전달했습니다. 그 결과 `DOWN`과 함께 `error`, 예외 class/message/cause 및 backend 연결 정보가 health 응답에 포함될 수 있었습니다.

## What This Solves

- 일반 provider 예외와 취소·인터럽트 예외를 명시적 `UNKNOWN`으로 정규화하고, 인터럽트 상태를 복원합니다.
- Actuator 응답에서 `error`, exception class/message/cause, endpoint, token, credential 및 synthetic raw 값을 차단하면서 indicator의 allow-list detail만 유지합니다.
- fatal JVM `Error`는 계속 재전파하고, 실패 원문 없는 warning만 기록합니다.

## Work Done

- `LeaderBackendHealthIndicator`: 예외 경계를 정리하고 UNKNOWN 상태·sanitized warning·허용 detail을 적용했습니다.
- `LeaderBackendHealthIndicatorTest`: ordinary/cancellation/interruption/Error 경로와 실제 HTTP `show-details=always` JSON allow-list를 회귀 검증했습니다.
- `README.md`/`README.ko.md`: 상태·비노출 필드·fatal Error·endpoint 보호 계약을 정렬했습니다.

## Validation

- `./gradlew :bluetape4k-leader-spring-boot:test --tests 'io.bluetape4k.leader.spring.observability.LeaderBackendHealthIndicatorTest' --no-daemon --no-configuration-cache --max-workers=1`: PASS (11 passing)
- `./gradlew :bluetape4k-leader-spring-boot:test --no-daemon --no-configuration-cache --max-workers=1`: PASS (569 passing)
- `./gradlew detekt --no-daemon --no-configuration-cache --max-workers=1`: PASS
- `./gradlew :bluetape4k-leader-spring-boot:build -x test --no-daemon --no-configuration-cache --max-workers=1`: PASS
- `git diff --check`: PASS

## Review Notes

- P0/P1: 없음
- P2/P3: 없음
- 독립 코드 리뷰: APPROVE (P0/P1/P2/P3 모두 0)
- 독립 아키텍처 리뷰: P0/P1 차단 없음; Hazelcast/ZooKeeper provider fatal 처리는 #738 범위로 유지

## Metadata

- Issue: #742, milestone `1.0.0`, assignee `debop`
- PR: #764, head `e4d39d06103354fb18670e7a342862a7987a5b7a`, base `develop`
- Merge commit: `7423ba531368b0ab241acdf3c9c3d31cd150d80f`
- CI: [run 32724576976](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32724576976) hosted checks 전체 성공을 확인했습니다.

## DoD Status

Required checks: 12/12; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| Type-C classification | Issue #742 live metadata와 완료 조건을 확인하고 bugfix 범위를 고정 | PASS | live Issue #742, milestone `1.0.0`, labels/assignee read-back | 없음 |
| RED regression | 기존 provider Exception이 raw health fallback으로 이어지는 경로 재현 | PASS | RED targeted run: DOWN/raw detail 관찰 | 없음 |
| Exception normalization | ordinary/cancellation/interruption 예외를 UNKNOWN으로 정규화 | PASS | targeted 11 passing; explicit `Status.UNKNOWN` assertion | 없음 |
| Fatal Error contract | JVM `Error` 원본 재전파 | PASS | targeted fatal Error same-instance assertion | 없음 |
| HTTP redaction | `show-details=always` 실제 JSON의 금지 키·값과 `leaderBackend` allow-list 검증 | PASS | nested Actuator HTTP regression | 없음 |
| EN/KO docs | 상태·비노출·fatal Error 계약을 양 언어 문서에 반영 | PASS | README diff/read-back and independent docs PASS | 없음 |
| Full module tests | Spring Boot 모듈 전체 회귀 실행 | PASS | 569 passing | 없음 |
| Static/build checks | detekt와 AOT/build 검증 | PASS | root/module detekt and module build PASS | 없음 |
| Independent review | code-reviewer 및 architect lane 결과 통합 | PASS | APPROVE; no P0/P1/P2/P3 | 없음 |
| Workflow receipt | Bluetape Type-C receipt topology/checks/evidence/main completion | PASS | run `20260824T105152Z-1221af33`, sequence 19, completed | 없음 |
| PR metadata | branch push와 PR metadata read-back | PASS | PR #764 exact head/base/labels/milestone/assignee 확인 | 없음 |
| Hosted CI | PR head에 대한 GitHub checks 확인 | PASS | [CI run 32724576976](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32724576976): required jobs and `CI Status` pass; path-filtered unrelated jobs skipped as intended | 없음 |

Final status: DONE — squash merged into `develop`; Issue #742 closed

Unchecked required items: 없음
