### PR TITLE
bug(diagnostics): Hazelcast/ZooKeeper fatal Error 전파 보장

### DIFF
--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderBackendDiagnostics.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderBackendDiagnostics.kt
@@ -26,17 +26,15 @@ class HazelcastLeaderBackendDiagnostics(
             "probe timeout must be positive and finite: $timeout"
         }
         val checkedAt = Clock.systemUTC().instant()
-        return runCatching { hazelcast.lifecycleService.isRunning }
-            .fold(
-                onSuccess = { running ->
-                    if (running) {
-                        LeaderBackendConnectivity.unknown(checkedAt)
-                    } else {
-                        LeaderBackendConnectivity.down(checkedAt)
-                    }
-                },
-                onFailure = { LeaderBackendConnectivity.unknown(checkedAt) },
-            )
+        return try {
+            if (hazelcast.lifecycleService.isRunning) {
+                LeaderBackendConnectivity.unknown(checkedAt)
+            } else {
+                LeaderBackendConnectivity.down(checkedAt)
+            }
+        } catch (_: Exception) {
+            LeaderBackendConnectivity.unknown(checkedAt)
+        }
     }
 
     private companion object {

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderBackendDiagnosticsTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderBackendDiagnosticsTest.kt
@@ -2,8 +2,10 @@ package io.bluetape4k.leader.hazelcast
 
 import com.hazelcast.core.HazelcastInstance
 import com.hazelcast.core.LifecycleService
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBe
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.leader.diagnostics.LeaderBackendClockSource
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityStatus
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
@@ -50,6 +52,33 @@ class HazelcastLeaderBackendDiagnosticsTest {
 
         provider.checkConnectivity(100.milliseconds).status shouldBeEqualTo LeaderBackendConnectivityStatus.UNKNOWN
         provider.checkConnectivity(100.milliseconds).status shouldBeEqualTo LeaderBackendConnectivityStatus.DOWN
+    }
+
+    @Test
+    fun `lifecycle Exception은 UNKNOWN으로 정규화한다`() {
+        val lifecycle = mockk<LifecycleService>()
+        val hazelcast = mockk<HazelcastInstance>()
+        every { hazelcast.lifecycleService } returns lifecycle
+        every { lifecycle.isRunning } throws IllegalStateException("probe failed")
+
+        HazelcastLeaderBackendDiagnostics(hazelcast)
+            .checkConnectivity(100.milliseconds)
+            .status shouldBeEqualTo LeaderBackendConnectivityStatus.UNKNOWN
+    }
+
+    @Test
+    fun `lifecycle Error는 동일 인스턴스로 재전파한다`() {
+        val fatal = AssertionError("fatal Hazelcast probe")
+        val lifecycle = mockk<LifecycleService>()
+        val hazelcast = mockk<HazelcastInstance>()
+        every { hazelcast.lifecycleService } returns lifecycle
+        every { lifecycle.isRunning } throws fatal
+
+        val thrown = assertFailsWith<AssertionError> {
+            HazelcastLeaderBackendDiagnostics(hazelcast).checkConnectivity(100.milliseconds)
+        }
+
+        thrown shouldBeSameInstanceAs fatal
     }
 
     @Test

--- a/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperLeaderBackendDiagnostics.kt
+++ b/leader-zookeeper/src/main/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperLeaderBackendDiagnostics.kt
@@ -26,17 +26,15 @@ class ZooKeeperLeaderBackendDiagnostics(
             "probe timeout must be positive and finite: $timeout"
         }
         val checkedAt = Clock.systemUTC().instant()
-        return runCatching { client.zookeeperClient.isConnected }
-            .fold(
-                onSuccess = { connected ->
-                    if (connected) {
-                        LeaderBackendConnectivity.up(checkedAt)
-                    } else {
-                        LeaderBackendConnectivity.down(checkedAt)
-                    }
-                },
-                onFailure = { LeaderBackendConnectivity.unknown(checkedAt) },
-            )
+        return try {
+            if (client.zookeeperClient.isConnected) {
+                LeaderBackendConnectivity.up(checkedAt)
+            } else {
+                LeaderBackendConnectivity.down(checkedAt)
+            }
+        } catch (_: Exception) {
+            LeaderBackendConnectivity.unknown(checkedAt)
+        }
     }
 
     private companion object {

--- a/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperLeaderBackendDiagnosticsTest.kt
+++ b/leader-zookeeper/src/test/kotlin/io/bluetape4k/leader/zookeeper/ZooKeeperLeaderBackendDiagnosticsTest.kt
@@ -1,7 +1,9 @@
 package io.bluetape4k.leader.zookeeper
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBe
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.leader.diagnostics.LeaderBackendClockSource
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityStatus
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
@@ -44,6 +46,33 @@ class ZooKeeperLeaderBackendDiagnosticsTest {
 
         provider.checkConnectivity(100.milliseconds).status shouldBeEqualTo LeaderBackendConnectivityStatus.UP
         provider.checkConnectivity(100.milliseconds).status shouldBeEqualTo LeaderBackendConnectivityStatus.DOWN
+    }
+
+    @Test
+    fun `Curator Exception은 UNKNOWN으로 정규화한다`() {
+        val zookeeperClient = mockk<CuratorZookeeperClient>()
+        val client = mockk<CuratorFramework>()
+        every { client.zookeeperClient } returns zookeeperClient
+        every { zookeeperClient.isConnected } throws IllegalStateException("probe failed")
+
+        ZooKeeperLeaderBackendDiagnostics(client)
+            .checkConnectivity(100.milliseconds)
+            .status shouldBeEqualTo LeaderBackendConnectivityStatus.UNKNOWN
+    }
+
+    @Test
+    fun `Curator Error는 동일 인스턴스로 재전파한다`() {
+        val fatal = AssertionError("fatal ZooKeeper probe")
+        val zookeeperClient = mockk<CuratorZookeeperClient>()
+        val client = mockk<CuratorFramework>()
+        every { client.zookeeperClient } returns zookeeperClient
+        every { zookeeperClient.isConnected } throws fatal
+
+        val thrown = assertFailsWith<AssertionError> {
+            ZooKeeperLeaderBackendDiagnostics(client).checkConnectivity(100.milliseconds)
+        }
+
+        thrown shouldBeSameInstanceAs fatal
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #738

Hazelcast와 ZooKeeper backend diagnostics가 치명적인 `Error`를 정상적인
`UNKNOWN` 상태로 숨기지 않고 원래 인스턴스 그대로 전파하도록 수정합니다.

## Background

Issue #738은 provider 상태 probe의 예외 경계를 명확히 하도록 요구합니다.
예상 가능한 provider `Exception`은 기존 상태 매핑을 유지해야 하지만,
JVM fatal `Error`는 진단 계층이 흡수하면 안 됩니다.

## What This Solves

- Hazelcast/ZooKeeper probe에서 `AssertionError` 등 fatal `Error`가 `UNKNOWN`으로 변환되는 문제
- 정상적인 provider `Exception`의 `UNKNOWN` 매핑과 기존 `UP`/`DOWN` 상태 계약의 회귀 위험

## Work Done

- Hazelcast와 ZooKeeper diagnostics의 `runCatching` catch-all을 `try/catch (Exception)` 경계로 교체했습니다.
- 두 backend에 ordinary `Exception` 상태 매핑과 fatal `Error` 동일 인스턴스 재전파 회귀 테스트를 추가했습니다.
- 기존 `require(timeout.isFinite() && timeout > Duration.ZERO)` 입력 검증과 backend 상태 의미는 유지했습니다.

## Validation

- `./gradlew :bluetape4k-leader-hazelcast:test --rerun-tasks --no-daemon --no-configuration-cache --max-workers=1`: PASS (117 tests)
- `./gradlew :bluetape4k-leader-zookeeper:test --rerun-tasks --no-daemon --no-configuration-cache --max-workers=1`: PASS (100 tests)
- targeted diagnostics tests: PASS (Hazelcast 5/5, ZooKeeper 5/5)
- `./gradlew detekt --no-daemon --no-configuration-cache --max-workers=1`: PASS
- affected module `build -x test`: PASS (Hazelcast, ZooKeeper)
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0건
- P2/P3: 공통 SPI KDoc의 `Exception`/`Error` 경계 명시와 provider 중복 제거는 후속 개선으로 관찰합니다.
- Review evidence: 독립 `code-reviewer` 및 `architect` 검토에서 blocker 0건; architect 결과는 WATCH이며 현재 수정 범위에는 차단 사유가 없습니다.

## Metadata

- Issue: #738, milestone `1.0.0`, assignee `debop`
- PR: #765, head `fc8af996ac850bd7377074b0afdd5063c007dfb6`, base `develop`
- Labels: `bug`, `integration`, `test`
- CI: [CI run 32731471779](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32731471779) exact-head checks 14 PASS / 33 path-scoped SKIPPED / 0 FAIL

## DoD Status

Required checks: 15/15; N/A: 2; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-01 - Root cause | `runCatching`이 `Error`까지 포착하는 원인을 확인 | PASS | Hazelcast/ZooKeeper probe 구현 및 RED 로그 | none |
| C-02 - Issue scope | Issue #738 acceptance criteria와 변경 범위를 대조 | PASS | live Issue #738 metadata/body readback | none |
| C-03 - RED | fatal `Error` 재전파 회귀 테스트를 수정 전 실행 | PASS | 두 backend에서 `Expected AssertionError but no exception was thrown` 확인 | none |
| C-04 - Surgical fix | `Exception`만 상태 매핑하도록 두 probe를 수정 | PASS | 변경 파일 4개, production 파일 2개 | none |
| C-05 - GREEN / blast radius | targeted/full tests, Detekt, affected builds 실행 | PASS | Hazelcast 117/117, ZooKeeper 100/100 및 build/detekt PASS | none |
| C-06 - Lesson | 기존 backend diagnostics 예외 경계 lesson을 재사용 | PASS | `docs/lessons/2026-07-15-issues-531-536-spring-operations.md` | none |
| CG-11 - Execution authority | PR 대상 repository/base/head에 대한 사용자 승인 반영 | PASS | `bluetape4k/bluetape4k-leader`, `develop`, `fix/issue-738-fatal-probe` 승인 | none |
| CG-12 - Exact-head push | 승인된 head를 원격에 push | PASS | remote branch OID `fc8af996ac850bd7377074b0afdd5063c007dfb6` | none |
| CG-12A - Guidance refresh | PR 생성 직전 guidance, skill, common gates, template, Issue를 재확인 | PASS | current-scope hash/readback 및 no-drift 확인 | none |
| CG-13 - PR metadata/body | 한국어 본문, 이슈 연결, assignee/labels/milestone 반영 | PASS | PR #765 readback: title/body/head/base 확인; `Closes #738` 및 final `## DoD Status` 확인 | none |
| CG-14 - Exact-head CI/review | exact-head hosted checks와 review/thread 상태 확인 | PASS | CI run 32731471779: 14 PASS, 33 path-scoped SKIPPED, 0 FAIL; PR reviews/comments 0건; independent review P0/P1 0건; 단일 개발자 범위에서 human review N/A | none |
| CG-15 - Merge-ready | mergeability와 DoD를 재판정 | PASS | PR #765 exact head `fc8af996ac850bd7377074b0afdd5063c007dfb6`, base `develop`, `MERGEABLE`, `CLEAN`; CI Status PASS | fresh merge approval required |
| CG-16 - Fresh merge approval | merge 직전 별도 사용자 승인 | PASS | 사용자 merge 승인 readback 후 실행 | none |
| CG-17 - Merge | 승인된 exact head를 `develop`에 merge | PASS | PR #765 `MERGED`, merge commit `b05b883943b2255378e13f20c4be343b42bcf449`; Issue #738 CLOSED | none |
| CG-18 - Sync / cleanup | canonical sync 및 stale worktree 정리 | PASS | local/origin `develop` parity at `b05b883943b2255378e13f20c4be343b42bcf449`; 대상 worktree/branch 제거, unrelated worktrees 보존 | none |

Final status: DONE (merge, canonical sync, Issue closure, and scoped cleanup verified)

Unchecked required items: none
