### PR TITLE
test(leader): bluetape4k assertions로 잔여 Kotlin assert 전환

### DIFF
--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LockExtenderTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LockExtenderTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.leader
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.leader.coroutines.LockHandleElement
 import io.bluetape4k.leader.internal.ExtendDelegate
@@ -117,9 +118,7 @@ class LockExtenderTest {
         LockStateHolder.withPushed(realHandle(delegate = delegate)) {
             LockExtender.extendActiveLock(45.seconds)
         }
-        assert(delegate.extendCalledWith == 45.seconds) {
-            "Expected delegate.extend called with 45s, got ${delegate.extendCalledWith}"
-        }
+        delegate.extendCalledWith shouldBeEqualTo 45.seconds
     }
 
     @Test
@@ -199,21 +198,21 @@ class LockExtenderTest {
         val delegate = FakeDelegate(ExtendOutcome.Extended(expireAt))
         LockStateHolder.withPushed(realHandle(delegate = delegate)) {
             val outcome = LockExtender.extendActiveLockDetailed(60.seconds)
-            assert(outcome is ExtendOutcome.Extended) { "Expected Extended, got $outcome" }
+            outcome.shouldBeInstanceOf<ExtendOutcome.Extended>()
         }
     }
 
     @Test
     fun `extendActiveLockDetailed returns NotHeld when outside scope`() {
         val outcome = LockExtender.extendActiveLockDetailed(30.seconds)
-        assert(outcome is ExtendOutcome.NotHeld) { "Expected NotHeld, got $outcome" }
+        outcome.shouldBeInstanceOf<ExtendOutcome.NotHeld>()
     }
 
     @Test
     fun `extendActiveLockDetailed returns NotHeld for FailOpen scope`() {
         LockStateHolder.withPushed(failOpenHandle()) {
             val outcome = LockExtender.extendActiveLockDetailed(30.seconds)
-            assert(outcome is ExtendOutcome.NotHeld) { "Expected NotHeld, got $outcome" }
+            outcome.shouldBeInstanceOf<ExtendOutcome.NotHeld>()
         }
     }
 
@@ -222,7 +221,7 @@ class LockExtenderTest {
         val delegate = FakeDelegate(ExtendOutcome.WrongThread)
         LockStateHolder.withPushed(realHandle(delegate = delegate)) {
             val outcome = LockExtender.extendActiveLockDetailed(30.seconds)
-            assert(outcome is ExtendOutcome.WrongThread) { "Expected WrongThread, got $outcome" }
+            outcome.shouldBeInstanceOf<ExtendOutcome.WrongThread>()
         }
     }
 
@@ -232,8 +231,7 @@ class LockExtenderTest {
         val delegate = FakeDelegate(ExtendOutcome.BackendError(cause))
         LockStateHolder.withPushed(realHandle(delegate = delegate)) {
             val outcome = LockExtender.extendActiveLockDetailed(30.seconds)
-            assert(outcome is ExtendOutcome.BackendError) { "Expected BackendError, got $outcome" }
-            assert((outcome as ExtendOutcome.BackendError).cause === cause)
+            outcome.shouldBeInstanceOf<ExtendOutcome.BackendError>().cause shouldBeSameInstanceAs cause
         }
     }
 
@@ -295,7 +293,7 @@ class LockExtenderTest {
         val delegate = FakeDelegate(ExtendOutcome.Extended(Instant.now().plusSeconds(30)))
         withContext(LockHandleElement(realHandle(delegate = delegate))) {
             val outcome = LockExtender.extendActiveLockDetailedSuspend(30.seconds)
-            assert(outcome is ExtendOutcome.Extended) { "Expected Extended, got $outcome" }
+            outcome.shouldBeInstanceOf<ExtendOutcome.Extended>()
         }
     }
 
@@ -304,7 +302,7 @@ class LockExtenderTest {
         val delegate = FakeSuspendDelegate(ExtendOutcome.Extended(Instant.now().plusSeconds(30)))
         withContext(LockHandleElement(realHandle(delegate = delegate))) {
             val outcome = LockExtender.extendActiveLockDetailedSuspend(30.seconds)
-            assert(outcome is ExtendOutcome.Extended) { "Expected Extended, got $outcome" }
+            outcome.shouldBeInstanceOf<ExtendOutcome.Extended>()
         }
 
         delegate.suspendExtendCalls.get() shouldBeEqualTo 1
@@ -317,7 +315,7 @@ class LockExtenderTest {
         val delegate = FakeSuspendDelegate(ExtendOutcome.NotHeld)
         withContext(LockHandleElement(realHandle(delegate = delegate))) {
             val outcome = LockExtender.extendActiveLockDetailedSuspend(30.seconds)
-            assert(outcome is ExtendOutcome.NotHeld) { "Expected NotHeld, got $outcome" }
+            outcome.shouldBeInstanceOf<ExtendOutcome.NotHeld>()
         }
 
         delegate.lastExtendDeadline.get() shouldBeEqualTo Instant.EPOCH
@@ -345,7 +343,7 @@ class LockExtenderTest {
         val delegate = FakeSuspendDelegate(ExtendOutcome.Extended(Instant.now().plusSeconds(30)))
         LockStateHolder.withPushed(realHandle(delegate = delegate)) {
             val outcome = LockExtender.extendActiveLockDetailed(30.seconds)
-            assert(outcome is ExtendOutcome.BackendError) { "Expected BackendError, got $outcome" }
+            outcome.shouldBeInstanceOf<ExtendOutcome.BackendError>()
         }
 
         delegate.syncExtendCalls.get() shouldBeEqualTo 1
@@ -355,7 +353,7 @@ class LockExtenderTest {
     @Test
     fun `extendActiveLockDetailedSuspend returns NotHeld when outside scope`() = runTest {
         val outcome = LockExtender.extendActiveLockDetailedSuspend(30.seconds)
-        assert(outcome is ExtendOutcome.NotHeld) { "Expected NotHeld, got $outcome" }
+        outcome.shouldBeInstanceOf<ExtendOutcome.NotHeld>()
     }
 
     @Test
@@ -363,7 +361,7 @@ class LockExtenderTest {
         val delegate = FakeDelegate(ExtendOutcome.Extended(Instant.now()))
         withContext(LockHandleElement(realHandle("lock-a", delegate))) {
             val outcome = LockExtender.extendActiveLockDetailedSuspend("lock-b", 30.seconds)
-            assert(outcome is ExtendOutcome.NotHeld) { "Expected NotHeld, got $outcome" }
+            outcome.shouldBeInstanceOf<ExtendOutcome.NotHeld>()
         }
     }
 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/ReactorOperatorNegativeTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/ReactorOperatorNegativeTest.kt
@@ -1,6 +1,9 @@
 package io.bluetape4k.leader
 
 import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.leader.coroutines.LockHandleElement
 import io.bluetape4k.leader.internal.ExtendDelegate
 import io.bluetape4k.leader.internal.LockStateHolder
@@ -105,7 +108,7 @@ class ReactorOperatorNegativeTest {
             }
             .block()
 
-        assert(result == "value") { "Expected 'value', got $result" }
+        result shouldBeEqualTo "value"
     }
 
     /**
@@ -124,7 +127,7 @@ class ReactorOperatorNegativeTest {
             }
             .block()
 
-        assert(result == false) { "Expected false, got $result" }
+        result.shouldBeFalse()
     }
 
     /**
@@ -146,7 +149,7 @@ class ReactorOperatorNegativeTest {
             }
             .block()
 
-        assert(result == true) { "Expected true, got $result" }
+        result.shouldBeTrue()
     }
 
     /**
@@ -171,6 +174,6 @@ class ReactorOperatorNegativeTest {
         }
 
         // On same thread, ThreadLocal is visible
-        assert(sawLocked == true) { "Expected true (same-thread synchronous Mono), got $sawLocked" }
+        sawLocked.shouldBeTrue()
     }
 }

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectCaptureInvariantTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspectCaptureInvariantTest.kt
@@ -3,6 +3,8 @@ package io.bluetape4k.leader.spring.aop
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.leader.AopScopeAccess
 import io.bluetape4k.leader.LeaderElector
 import io.bluetape4k.leader.LeaderElectorFactory
@@ -27,7 +29,7 @@ import org.junit.jupiter.api.TestInstance
  * ## 검증 항목
  * - [CaptureInvariantException] 은 [IllegalStateException] 서브타입 (SPI 계약)
  * - [AopScopeAccess.pollCapture] 는 set 없으면 null 반환 (single elector 정상 동작)
- * - [AopScopeAccess.pollCapture] 는 set 후 한 번만 값 반환 (poll semantics — idempotent)
+ * - [AopScopeAccess.pollCapture] 는 set 후 첫 호출이 값을 소비하고 두 번째 호출은 null 반환
  * - single elector action body 에서 pollCapture() == null 은 CaptureInvariantException 으로
  *   이어지지 않아야 함 (single elector 는 CaptureScope 미사용 → null 이 정상)
  *
@@ -46,7 +48,6 @@ class LeaderElectionAspectCaptureInvariantTest {
     fun `CaptureInvariantException 은 IllegalStateException 서브타입`() {
         val ex = CaptureInvariantException("test message")
         ex.shouldBeInstanceOf<IllegalStateException>()
-        // assert(ex is IllegalStateException) { "CaptureInvariantException must extend IllegalStateException" }
         ex.message shouldBeEqualTo "test message"
     }
 
@@ -62,20 +63,21 @@ class LeaderElectionAspectCaptureInvariantTest {
     @Test
     fun `pollCapture - set 없으면 null 반환 (single elector 정상)`() {
         val result = AopScopeAccess.pollCapture()
-        assert(result == null) { "pollCapture without set must return null" }
+        result.shouldBeNull()
     }
 
     @Test
-    fun `pollCapture - poll 은 exactly-once semantics — 두 번째 호출은 null`() {
+    fun `pollCapture - set 후 첫 호출이 값을 소비하고 두 번째 호출은 null`() {
         val syntheticReal = AopScopeAccess.createSyntheticReal("test-lock", "testFactory")
-        // Simulate set via LeaderLockHandleCapture (done via elector CaptureScope in production)
-        // Here we test poll() idempotency by calling twice without set
-        val first = AopScopeAccess.pollCapture()
-        val second = AopScopeAccess.pollCapture()
-        assert(first == null) { "first poll without set must be null" }
-        assert(second == null) { "second poll must also be null" }
-        // Synthetic handle is valid
-        assert(syntheticReal.lockName == "test-lock")
+        AopScopeAccess.setCapture(syntheticReal)
+        try {
+            val first = AopScopeAccess.pollCapture()
+            val second = AopScopeAccess.pollCapture()
+            first shouldBeSameInstanceAs syntheticReal
+            second.shouldBeNull()
+        } finally {
+            AopScopeAccess.clearCapture()
+        }
     }
 
     // ── Single elector action body: pollCapture null 은 CaptureInvariantException 미발생 ──


### PR DESCRIPTION
## Summary

Closes #769

잔여 Kotlin `assert(...)` 21개를 `bluetape4k-assertions`의 의미 기반 matcher로 전환해 테스트 실패가 runner 설정에 좌우되지 않도록 합니다. LEAD-02와 #781이 반영된 `develop` exact head 위에 독립적인 LEAD-03 stacked PR로 제공합니다.

## Background

Issue #769는 `leader-core`와 `leader-spring-boot` 테스트에 남은 raw assertion 21개를 식별했습니다. 기존 테스트가 이미 `assertFailsWith`, `shouldBeEqualTo`, `shouldBeTrue/False`를 사용하고 있어 같은 ecosystem 계약으로 잔여 호출을 정리할 수 있습니다.

## What This Solves

- Kotlin `assert` 비활성화로 negative path와 nullable/result 검증이 무시될 위험을 제거합니다.
- 예외 타입, `BackendError.cause` 참조 동일성, Spring capture의 one-shot 소비 경계를 약화하지 않고 이름 있는 assertion으로 고정합니다.
- 모듈별 `$bluetape-kotlin-patterns`와 7-Tier 검토 증거를 다음 train slot으로 전달합니다.

## Work Done

- `leader-core/.../LockExtenderTest.kt`: duration, sealed outcome, cause identity, suspend 분기를 `bluetape4k-assertions` matcher로 전환했습니다.
- `leader-core/.../ReactorOperatorNegativeTest.kt`: 문자열 결과와 nullable Boolean 검증을 의도 기반 matcher로 전환했습니다.
- `leader-spring-boot/.../LeaderElectionAspectCaptureInvariantTest.kt`: null matcher와 실제 capture facade의 set→first identity→second null→finally clear 계약을 검증하고 stale comment/중복 factory assertion을 제거했습니다.

## Validation

- `./gradlew :bluetape4k-leader-core:test --rerun-tasks --tests 'io.bluetape4k.leader.LockExtenderTest' --tests 'io.bluetape4k.leader.ReactorOperatorNegativeTest'`: PASS (36/36)
- `./gradlew :bluetape4k-leader-spring-boot:test --rerun-tasks --tests 'io.bluetape4k.leader.spring.aop.LeaderElectionAspectCaptureInvariantTest'`: PASS (최종 wording 반영 후 6/6)
- `./gradlew :bluetape4k-leader-core:test --rerun-tasks`: PASS (839 tests)
- `./gradlew :bluetape4k-leader-spring-boot:test --rerun-tasks`: PASS (585 tests)
- `./gradlew :bluetape4k-leader-core:detekt :bluetape4k-leader-spring-boot:detekt --rerun-tasks`: PASS
- 세 변경 파일의 금지 assertion scan: PASS (raw/JUnit/Kotlin `assert` 및 `shouldThrow` 0건); `git diff --check`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 0 — architect가 제안한 one-shot 용어 및 중복 factory assertion 정리를 반영했습니다.
- Review evidence: 독립 `code-reviewer` APPROVE(0 findings), architect 최종 CLEAR(P0/P1/P2/P3 모두 0), workflow receipt `seven-tier-review` sequence 18

## Metadata

- Issue: #769, milestone `1.0.0`, assignee `debop`
- PR: #782, head `c62613cb5e60d44c4a474fdb6eda232f56707b91`
- Base: `develop@bf1f7d1be1ed5a058945dd350dcfc2ffdc11f8cb`
- Head: `test/issue-769-bluetape-assertions@c62613cb5e60d44c4a474fdb6eda232f56707b91`
- CI: [PR run 32854016822](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32854016822) 46 success/1 path-scoped skip; [post-merge run 32856468194](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32856468194) 46 success/1 path-scoped skip at merge SHA
- Merge: squash commit `668732cc0b49497c6bc15e2fe7471bbfa7818198`

## DoD Status

Required checks: 12/13; N/A: 4; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|---|---|---|---|---|
| CG-01/02/03/05 | guidance, GNO/GitHub evidence, exact predecessor, isolated stacked scope | PASS | current guidance refresh, Issue #769, develop base `bf1f7d1`, isolated worktree and 3 changed paths | none |
| CG-04/06 | policy/public API/docs/release scope | N/A | test-only changes; no production API, docs, publication, release, or nightly workflow path | none |
| CG-07/08 | targeted/full regression and serialized heavyweight checks | PASS | core 36 targeted/839 full; Spring 6 targeted/585 full; Detekt after sequential tests | none |
| CG-09 | durable lesson gate | N/A | no new reusable production decision or public behavior; assertion migration is fully captured by Issue/PR evidence | none |
| CG-10 | final diff and independent 7-Tier convergence | PASS | P0/P1/P2/P3 모두 0; receipt `seven-tier-review` sequence 18; final diff 3 files | none |
| CG-11/12 | PR authority and exact branch publication | PASS | approved Epic/train scope; remote branch points to `c62613cb5e60d44c4a474fdb6eda232f56707b91` | none |
| CG-12A | guidance/skill/common-gate/issue refresh immediately before PR | PASS | `.bluetape/lead03-cg12a-refresh.md`, current hashes and live Issue #769 metadata | none |
| CG-13 | create PR and live metadata/body read-back | PASS | PR #782 live read-back confirms Korean body, `Closes #769`, labels `refactor,test,maintenance`, milestone `1.0.0`, assignee `debop`, base `develop`, head `c62613cb5e60d44c4a474fdb6eda232f56707b91`, and final `## DoD Status` heading | none |
| CG-14 | exact-head CI and review/thread read-back | PASS | [run 32854016822](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32854016822) at exact head: 46 success, 1 path-scoped manual/release contract skipped, 0 failed; `CI Status` success; review/thread APIs all empty; human-review subgate `N/A (single-developer lane)` | none |
| CG-15 | merge-ready report | PASS | pre-merge report pinned PR #782 exact head `c62613cb5e60d44c4a474fdb6eda232f56707b91` with `CLEAN/MERGEABLE`, green CI, and local/independent review evidence | completed by CG-16/17 merge verification |
| CG-16/17 | fresh merge approval and merge | PASS | user approval, `gh pr merge --squash --match-head-commit c62613cb`, PR #782 `MERGED`, squash commit `668732cc0b49497c6bc15e2fe7471bbfa7818198` | none |
| CG-18 | canonical sync and cleanup | PENDING | local `develop` and `origin/develop` both equal `668732cc0b49497c6bc15e2fe7471bbfa7818198`; feature worktree preserved and remote branch was auto-removed by GitHub | cleanup only with separate explicit authorization |

Final status: `MERGED` (post-merge CI and canonical develop sync passed; cleanup remains pending by policy)

Unchecked required items: CG-18
