### PR TITLE
#463 전략적 그룹 선출 API를 추가한다

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -23,6 +23,7 @@ Spring Boot 4 자동 구성과 Ktor 3.x 통합을 1급으로 지원합니다.
 - **다양한 실행 모델** — 블로킹, `CompletableFuture`, 가상 스레드, 코루틴 지원
 - **복수 리더(그룹) 지원** — `LeaderGroupElector`으로 분산 세마포어 기반 N개 동시 리더 허용
 - **전략적 선출(Strategic Election)** — 플러그형 후보 레지스트리 + 선출 전략(FIFO, Scored, Weighted); 분산 락 불필요
+- **전략적 그룹 선출** — `GroupElectionStrategy`가 후보 기준 목록에서 결정론적인 top-N을 선택하는 블로킹·코루틴 API
 - **자립형 Redis 테스트 인프라** — Testcontainers 직접 사용, 외부 테스트 유틸 의존 없음
 - **ShedLock 호환 skip 동작** — 락 획득 실패 시 작업을 조용히 건너뜀
 
@@ -108,7 +109,7 @@ JMH이며, 결과는 같은 장비에서 전/후 비교를 하기 위한 기준�
 
 이 matrix는 현재 source tree를 기준으로 검증합니다. 버전별 매뉴얼은 해당 release commit에 고정되어 있으므로 안정판 동작은 매뉴얼을, 개발 중인 capability 선택은 이 matrix를 기준으로 확인하세요.
 
-`State`는 core의 빈 단일 state 기본값 대신 단일(`S`) 또는 그룹(`G`) state snapshot을 실제로 제공하는 백엔드를 표시합니다. `Audit ID`는 단일 리더 state가 호출자 관점의 `LeaderSlot.leaderId`를 보존한다는 뜻입니다 (`supportsAuditLeaderState = true`).
+`State`는 core의 빈 단일 state 기본값 대신 단일(`S`) 또는 그룹(`G`) 상태 기준 정보를 실제로 제공하는 백엔드를 표시합니다. `Audit ID`는 단일 리더 state가 호출자 관점의 `LeaderSlot.leaderId`를 보존한다는 뜻입니다 (`supportsAuditLeaderState = true`).
 
 `autoExtend`는 단일 리더에서만 opt-in으로 동작합니다. Local, Redis, Exposed, MongoDB, Hazelcast, etcd, Consul, DynamoDB, Kubernetes는 공통 extender 계약으로 각 백엔드의 TTL, lease, session을 갱신합니다. Redisson은 항상 명시적인 `leaseTime`으로 락을 획득하고, 활성화된 경우 공통 extender로 연장합니다. ZooKeeper 락은 TTL이 없는 session 기반이므로 `autoExtend = true`를 경고와 함께 무시합니다. 그룹 옵션은 `autoExtend`를 제공하지 않으므로 그룹 slot이 lease보다 오래 유지되어야 한다면 `LockExtender`를 명시적으로 사용하세요.
 
@@ -302,7 +303,7 @@ val election = RedissonLeaderElector(client, options)
 
 `autoExtend` 의미는 백엔드마다 다릅니다. [백엔드 capability matrix](#백엔드-capability-matrix)와 [lease 연장 가이드](docs/manual/ko/core/lease-extension.md)를 기준으로 확인하세요. `@LeaderGroupElection`은 auto-extension을 지원하지 않습니다.
 
-### 상태 스냅샷
+### 상태 기준 정보
 
 ```kotlin
 val single = election.state("daily-report-job")
@@ -316,7 +317,7 @@ println("available=${group.availableSlots}")
 println("leaders=${group.leaders.map { it.leaderId }}")
 ```
 
-상태 API는 진단과 메트릭을 위한 best-effort 스냅샷입니다. 이 값으로 작업 실행 여부를 직접 판단하지 말고, 항상 `runIfLeader`를 사용해 backend가 원자적으로 락을 획득하게 해야 합니다.
+상태 API는 진단과 메트릭을 위한 best-effort 기준 정보입니다. 이 값으로 작업 실행 여부를 직접 판단하지 말고, 항상 `runIfLeader`를 사용해 backend가 원자적으로 락을 획득하게 해야 합니다.
 
 ### 테넌트 네임스페이스
 
@@ -339,7 +340,7 @@ tenantGroup.runIfLeader("aggregation") {
 
 `forTenant()`는 blocking, coroutine, group, virtual-thread elector에서 사용할 수 있습니다. 네임스페이스 구분자 `:`는 예약되어 있으므로 tenant id, custom prefix, tenant-local lock name에는 `:`를 넣을 수 없습니다. 기존 caller-facing lock name이 `batch:daily`처럼 `:`를 포함한다면 tenant scope를 추가하기 전에 이름을 바꾸세요. 생성된 backend lock name은 공통 lock name 제한인 255자를 계속 만족해야 합니다.
 
-Tenant-scoped 상태 스냅샷은 `tenant:acme:daily-report-job` 같은 전체 backend lock name을 반환합니다. 같은 tenant-scoped elector의 `runIfLeader()`에 `state().lockName`을 다시 전달하지 말고, `daily-report-job` 같은 원래 caller-facing lock name을 계속 사용하세요.
+Tenant-scoped 상태 기준 정보는 `tenant:acme:daily-report-job` 같은 전체 backend lock name을 반환합니다. 같은 tenant-scoped elector의 `runIfLeader()`에 `state().lockName`을 다시 전달하지 말고, `daily-report-job` 같은 원래 caller-facing lock name을 계속 사용하세요.
 
 ### 마이그레이션 노트
 
@@ -412,6 +413,8 @@ GET /management/leaderElection
 | `SuspendLeaderGroupElector` | `T?` | 코루틴 복수 리더 (세마포어) |
 | `StrategicLeaderElector` | `T?` | 블로킹 전략적 선출 (후보 레지스트리) |
 | `StrategicSuspendLeaderElector` | `T?` | 코루틴 전략적 선출 (후보 레지스트리) |
+| `StrategicLeaderGroupElector` | `T?` | 블로킹 전략적 그룹 선출 (자문형 top-N 후보 기준 목록) |
+| `StrategicSuspendLeaderGroupElector` | `T?` | 코루틴 전략적 그룹 선출 (자문형 top-N 후보 기준 목록) |
 
 `runIfLeader(lockName, action)` — 선출 성공 시 `action()` 결과, 실패 시 `null` 반환.
 
@@ -522,6 +525,26 @@ val scorer = WeightedScorer(
 )
 val result = election.runIfLeader("job", ScoredElectionStrategy(scorer)) { doWork() }
 ```
+
+### 전략적 그룹 선출 (블로킹/코루틴)
+
+전략적 그룹 선출은 한 번 관찰한 후보 기준 목록을 평가하고, top-N 집합에 포함된 노드에서만 action을 실행합니다. 등록 순서가 중요하면 `FifoGroupElectionStrategy`, 결정론적인 점수 순서가 필요하면 `ScoredGroupElectionStrategy`를 사용하세요.
+
+```kotlin
+import io.bluetape4k.leader.lettuce.LettuceStrategicLeaderGroupElector
+import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+
+val election = LettuceStrategicLeaderGroupElector(connection, nodeId = "node-1")
+election.registerCandidate("batch-shard", CandidateInfo("node-1"), ttl = 5.minutes)
+
+val result = election.runIfLeader(
+    "batch-shard",
+    FifoGroupElectionStrategy,
+    maxLeaders = 2,
+) { processShard() }
+```
+
+`maxLeaders`는 해당 호출이 읽은 후보 기준 목록에 대한 자문형 top-N 한도이며, 전역 분산 동시 실행 상한이 아닙니다. 노드마다 서로 다른 후보 기준 목록을 볼 수 있으므로 합집합은 N을 초과할 수 있습니다. 전역 슬롯 상한이 필요하면 `LeaderGroupElector`를 사용하세요. Redis 전략적 그룹 레지스트리는 전략적 단일 리더와 분리하고, 저장 schema 충돌을 막기 위해 Lettuce는 `leader:strategy:group-candidates:lettuce:v1`, Redisson은 `leader:strategy:group-candidates:redisson:v1` namespace를 사용합니다. 0이 아닌 후보 TTL은 만료 전에 재등록 또는 heartbeat가 필요하고, `Duration.ZERO`는 영구 등록입니다. Local 구현은 프로세스 메모리 수명 동안 후보를 유지하며 TTL을 무시합니다. Lettuce는 후보별 TTL과 index set을 분리하므로, 같은 lockName의 유한 TTL 후보가 만료되어도 영구 후보가 가려지지 않습니다. Custom strategy는 같은 후보 기준 목록의 모든 후보를 winner/elimination으로 중복 없이 완전히 분할해 반환해야 하며, 위반 시 elector가 `IllegalArgumentException`을 즉시 던집니다.
 
 ### 전략적 선출 vs 락 기반 선출
 
@@ -829,7 +852,7 @@ fun myRecorder(): LeaderAopMetricsRecorder = MyCustomRecorder()
 
 ## 게시 metadata 검증
 
-Release, snapshot, publishable module upload task는 Maven publication을
+Release, 개발 버전, publishable module upload task는 Maven publication을
 업로드하기 전에 이 gate를 실행합니다. 단독으로 실행하려면 다음 명령을
 사용합니다.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Spring Boot 4 auto-configuration and Ktor 3.x integration are first-class.
 - **Multiple execution models** — blocking, `CompletableFuture`, virtual threads, coroutines
 - **Multi-leader support** — `LeaderGroupElector` allows N concurrent leaders via distributed semaphore
 - **Strategic election** — pluggable candidate-registry + election strategy (FIFO, scored, weighted); no distributed lock required
+- **Strategic group election** — `GroupElectionStrategy` selects a deterministic top-N candidate list for blocking and coroutine APIs
 - **Self-contained Redis test infrastructure** — Testcontainers, no external test-util dependencies
 - **ShedLock-compatible skip semantics** — action is simply skipped if the lock cannot be acquired
 
@@ -413,6 +414,8 @@ Multiple nodes call `runIfLeader` concurrently — only one acquires the lock an
 | `SuspendLeaderGroupElector` | `T?` | Coroutine multi-leader (semaphore) |
 | `StrategicLeaderElector` | `T?` | Blocking strategic election (candidate registry) |
 | `StrategicSuspendLeaderElector` | `T?` | Coroutine strategic election (candidate registry) |
+| `StrategicLeaderGroupElector` | `T?` | Blocking strategic group election (advisory top-N candidate list) |
+| `StrategicSuspendLeaderGroupElector` | `T?` | Coroutine strategic group election (advisory top-N candidate list) |
 
 `runIfLeader(lockName, action)` — returns `action()` result on success, `null` if not elected.
 
@@ -521,6 +524,26 @@ val scorer = WeightedScorer(
 )
 val result = election.runIfLeader("job", ScoredElectionStrategy(scorer)) { doWork() }
 ```
+
+### Strategic group election (blocking/coroutine)
+
+Strategic group election evaluates one observed candidate snapshot and runs the action only on nodes in the selected top-N set. Use `FifoGroupElectionStrategy` for registration order or `ScoredGroupElectionStrategy` for deterministic score-based ordering:
+
+```kotlin
+import io.bluetape4k.leader.lettuce.LettuceStrategicLeaderGroupElector
+import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+
+val election = LettuceStrategicLeaderGroupElector(connection, nodeId = "node-1")
+election.registerCandidate("batch-shard", CandidateInfo("node-1"), ttl = 5.minutes)
+
+val result = election.runIfLeader(
+    "batch-shard",
+    FifoGroupElectionStrategy,
+    maxLeaders = 2,
+) { processShard() }
+```
+
+`maxLeaders` is an advisory top-N limit for the candidate list read by that invocation; it is not a global distributed concurrency cap. Different nodes can observe different candidate lists and their union can exceed N. Use `LeaderGroupElector` when a hard global slot limit is required. Redis strategic group registries use separate backend-qualified namespaces (`leader:strategy:group-candidates:lettuce:v1` and `leader:strategy:group-candidates:redisson:v1`) from strategic single-leader registries. A non-zero candidate TTL requires re-registration or heartbeat before expiry; `Duration.ZERO` is persistent, while the Local implementation keeps candidates for the process lifetime and ignores TTL. Lettuce keeps the candidate index independent from per-candidate TTLs, so an expiring candidate cannot hide a persistent candidate with the same lock name. Custom strategies must return a complete, non-overlapping winner/elimination partition of the same candidate list, or the elector fails fast with `IllegalArgumentException`.
 
 ### Strategic election vs lock-based election
 

--- a/docs/lessons/2026-08-25-strategic-group-election.md
+++ b/docs/lessons/2026-08-25-strategic-group-election.md
@@ -1,0 +1,21 @@
+# #463 전략적 그룹 선출 구현 교훈
+
+## 결정
+
+- 기존 `LeaderGroupElectionOptions`를 strategic group API에 그대로 재사용하지 않고 `maxLeaders: Int`를 직접 노출했다. strategic API는 후보 기준 top-N이고, 기존 group elector는 전역 distributed slot claim이기 때문이다.
+- custom strategy 결과는 action 전에 core의 `electValidated` 한 곳에서 검증한다. backend별 검증 복제는 계약 drift를 만들 수 있어 제거했다.
+- Lettuce와 Redisson은 저장 자료구조가 다르므로 후보 group namespace를 `lettuce:v1`와 `redisson:v1`로 분리했다.
+- 후보별 TTL과 index 수명은 분리했다. Lettuce index set을 persistent로 유지하고 candidate key만 만료시키며, Redisson 갱신은 잔여 TTL을 보존한다.
+- 점수 입력은 `bluetape4k-core`의 `Double.requireFinite`를 재사용해 NaN/무한을 fail-closed로 처리한다.
+
+## 검증 방식
+
+- 먼저 실패하는 계약 테스트를 작성한 뒤 core, Local, Lettuce, Redisson blocking/coroutine 구현을 순서대로 통과시켰다.
+- mixed-TTL, backend namespace 충돌, custom winner 검증, 결과 갱신, cancellation 경계를 회귀 테스트로 고정했다.
+- 최종 head에서 core 49, Lettuce 51, Redisson 41, 기존 Local group 23 테스트와 detekt/build/ABI를 다시 실행했다.
+
+## 후속 보강
+
+- Local 후보 snapshot의 약한 일관성과 Redis read-modify-write 갱신 경계는 별도 설계 이슈로 분리한다.
+- Redis coroutine adapter의 실제 cancellation 및 SUCCESS/FAILURE 갱신 회귀를 Testcontainers 테스트에 추가한다.
+- public `StrategicGroupElectionResult` 필드 확장은 constructor/copy ABI를 먼저 검토한다.

--- a/docs/superpowers/plans/2026-08-25-strategic-group-election-plan.md
+++ b/docs/superpowers/plans/2026-08-25-strategic-group-election-plan.md
@@ -1,0 +1,143 @@
+# Strategic Group Election API 구현 계획
+
+## 목표
+
+`#463`의 승인된 설계를 기준으로 후보 레지스트리에서 결정론적으로 상위
+N개를 선택하는 blocking/coroutine strategic group API를 추가한다. 기존
+single strategic API, 일반 group API, `ElectionStrategy` ABI와 backend별
+후보 레지스트리 semantics는 유지한다.
+
+## 변경 파일
+
+### leader-core 공개 계약과 전략
+
+- `leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderGroupElector.kt`
+  - 후보 등록/해제/조회/결과 갱신과 blocking `runIfLeader` 계약을 추가한다.
+  - `LeaderGroupElectionOptions`의 `maxLeaders`를 strategy에 전달한다.
+- `leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderGroupElector.kt`
+  - 위 계약의 `suspend` 대응 API를 추가한다.
+- `leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/GroupElectionStrategy.kt`
+  - 기존 `ElectionStrategy`를 변경하지 않고 `(candidates, maxLeaders)` 계약을 추가한다.
+- `leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/StrategicGroupElectionResult.kt`
+  - ordered `winners`, `eliminations`, `scores`, `EMPTY`를 제공한다.
+- `leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/FifoGroupElectionStrategy.kt`
+  - `registeredAt`와 `nodeId` tie-break로 상위 N개를 선택한다.
+- `leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/ScoredGroupElectionStrategy.kt`
+  - 기존 `CandidateScorer`를 한 번씩 적용하고 score/등록 시각/node id 순으로 선택한다.
+
+### Local adapter
+
+- `leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElector.kt`
+- `leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderGroupElector.kt`
+  - 기존 Local strategic registry와 lock/mutex를 재사용한다.
+  - 현재 elector의 `nodeId`가 winner 목록에 있을 때만 action을 실행한다.
+  - 성공/실패 결과 갱신과 `CancellationException` 재전파를 기존 구현과 대칭으로 유지한다.
+
+### Redis adapters
+
+- `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElector.kt`
+- `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElector.kt`
+- `leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElector.kt`
+- `leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElector.kt`
+  - 기존 candidate registry의 TTL, 직렬화, read/update와 backend별 lock-name/coroutine
+    예외 경계를 재사용한다.
+  - 후보 조회 실패는 기존 strategic adapter와 같이 cancellation은 전파하고 그 밖의
+    조회 오류는 경고 후 `null`로 skip한다.
+
+### 테스트
+
+- `leader-core/src/test/kotlin/io/bluetape4k/leader/strategy/StrategicGroupElectionStrategyTest.kt`
+  - 빈 후보, 후보 수 부족, 정확한 N개, FIFO/scored 결정론, tie-break, score map,
+    elimination 분할을 검증한다.
+- `leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElectorTest.kt`
+- `leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderGroupElectorTest.kt`
+  - 선택/비선택 실행, null 반환, success/failure 결과 갱신, 예외와 cancellation을 검증한다.
+- `leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElectorTest.kt`
+- `leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElectorTest.kt`
+- `leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElectorTest.kt`
+- `leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElectorTest.kt`
+  - Redis 후보 TTL과 blocking/coroutine adapter 대칭, 여러 winner의 독립 실행을
+    Testcontainers 기반으로 검증한다.
+
+### 문서
+
+- `README.md`
+- `README.ko.md`
+  - API 표에 strategic group blocking/coroutine 타입을 추가한다.
+  - single/group/strategic single/strategic group 선택 기준과 후보 TTL/read
+    consistency 경계를 설명한다.
+  - Local/Lettuce/Redisson 지원 범위와 동일 registry key 혼용 금지를 명시한다.
+
+## 구현 순서와 TDD 체크포인트
+
+### 1. 전략 계약을 먼저 고정한다
+
+1. `StrategicGroupElectionResultTest`를 먼저 작성해 RED를 확인한다.
+2. `GroupElectionStrategy`, 결과 모델, FIFO/scored 전략을 구현한다.
+3. core 전략 테스트를 실행해 GREEN을 확인한다.
+4. `maxLeaders.requireGe(1, "maxLeaders")`와 기존 bluetape4k `require*` helper 사용을
+   코드 리뷰로 확인한다.
+
+### 2. public elector 계약을 추가한다
+
+1. blocking/coroutine 인터페이스를 추가하고 기존 single API와 JVM descriptor가
+   변하지 않는지 컴파일한다.
+2. KDoc은 한국어 기술 문체로 작성하고 기존 `CandidateInfo`/`CandidateResult` 용어를
+   그대로 사용한다.
+
+### 3. Local 구현을 추가한다
+
+1. 선택 node의 action 실행과 비선택 node의 null 반환 테스트를 RED로 추가한다.
+2. blocking 구현을 기존 `ReentrantLock` 경계에 맞춰 추가한다.
+3. coroutine 구현을 기존 `Mutex`와 cancellation 보존 helper에 맞춰 추가한다.
+4. 결과 갱신과 예외 테스트를 GREEN으로 만든다.
+
+### 4. Lettuce와 Redisson 구현을 추가한다
+
+1. 각 backend의 blocking 테스트를 먼저 추가해 RED를 확인한다.
+2. 기존 `LettuceCandidateRegistry`/`LettuceSuspendCandidateRegistry`와
+   `RedissonCandidateRegistry`를 직접 재사용한다.
+3. coroutine adapter에서 `CancellationException`을 삼키지 않도록 테스트한다.
+4. Redis Testcontainers targeted test를 순차 실행한다.
+
+### 5. 문서와 회귀 검증을 완료한다
+
+1. README 두 locale을 같은 API 표와 선택 규칙으로 갱신한다.
+2. 기존 strategic single/group 테스트를 함께 실행한다.
+3. `git diff --check`, `detekt`, core/Redis targeted test, 필요한 모듈 build를
+   순서대로 실행한다.
+4. 변경된 public symbol, ABI, backend 지원 matrix, 문서 link를 다시 읽는다.
+
+## 검증 명령
+
+아래 Gradle 명령은 저장소의 context-mode redirect 규칙에 따라 실행한다.
+
+```bash
+./gradlew :bluetape4k-leader-core:test \
+  --tests 'io.bluetape4k.leader.strategy.StrategicGroupElectionStrategyTest' \
+  --tests 'io.bluetape4k.leader.local.LocalStrategicLeaderGroupElectorTest' \
+  --tests 'io.bluetape4k.leader.local.LocalStrategicSuspendLeaderGroupElectorTest' \
+  --no-configuration-cache --max-workers=1
+./gradlew :bluetape4k-leader-redis-lettuce:test \
+  --tests 'io.bluetape4k.leader.lettuce.LettuceStrategicLeaderGroupElectorTest' \
+  --tests 'io.bluetape4k.leader.lettuce.LettuceStrategicSuspendLeaderGroupElectorTest' \
+  --no-configuration-cache --max-workers=1
+./gradlew :bluetape4k-leader-redis-redisson:test \
+  --tests 'io.bluetape4k.leader.redisson.RedissonStrategicLeaderGroupElectorTest' \
+  --tests 'io.bluetape4k.leader.redisson.RedissonStrategicSuspendLeaderGroupElectorTest' \
+  --no-configuration-cache --max-workers=1
+./gradlew detekt --no-configuration-cache --max-workers=1
+```
+
+Docker/Testcontainers 검증이 호스트에서 실행되지 않으면 active Colima와
+Docker context를 먼저 확인하고, 실패 원인과 검증 범위를 DoD에 기록한다.
+
+## 위험과 대응
+
+- `winners`의 순서는 선출 우선순위일 뿐 실행 순서가 아니다. 문서와 테스트에서
+  이 구분을 유지한다.
+- 각 backend는 후보 조회 후 action을 시작하므로 atomic claim/fencing을 제공하지
+  않는다. 이 경계를 구현에 숨기지 않고 KDoc/README에 기록한다.
+- Redis 조회 오류 처리에서 cancellation을 일반 오류로 바꾸지 않는다.
+- 기존 `ElectionStrategy`와 public constructor를 수정하지 않아 ABI 위험을 줄인다.
+- 새로운 의존성은 추가하지 않는다.

--- a/docs/superpowers/plans/2026-08-25-strategic-group-election-plan.md
+++ b/docs/superpowers/plans/2026-08-25-strategic-group-election-plan.md
@@ -7,8 +7,8 @@ N개를 선택하는 blocking/coroutine strategic group API를 추가한다. 기
 single strategic API, 일반 group API, `ElectionStrategy` ABI와 backend별
 후보 레지스트리 semantics는 유지한다.
 
-이 API의 `maxLeaders`는 호출이 관찰한 후보 snapshot에 대한 advisory top-N이다.
-분산 snapshot이 다르면 전역 동시 실행 상한이 될 수 없으므로 전역 상한이 필요한
+이 API의 `maxLeaders`는 호출이 관찰한 후보 기준 목록에 대한 advisory top-N이다.
+분산 후보 기준 목록이 다르면 전역 동시 실행 상한이 될 수 없으므로 전역 상한이 필요한
 작업에는 기존 `LeaderGroupElector`를 사용한다.
 
 ## 변경 파일
@@ -17,7 +17,7 @@ single strategic API, 일반 group API, `ElectionStrategy` ABI와 backend별
 
 - `leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderGroupElector.kt`
   - 후보 등록/해제/조회/결과 갱신과 blocking `runIfLeader` 계약을 추가한다.
-  - `LeaderGroupElectionOptions`의 `maxLeaders`를 strategy에 전달한다.
+  - `maxLeaders`를 strategy에 직접 전달하며 전역 slot 옵션을 재사용하지 않는다.
 - `leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderGroupElector.kt`
   - 위 계약의 `suspend` 대응 API를 추가한다.
 - `leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/GroupElectionStrategy.kt`
@@ -26,6 +26,8 @@ single strategic API, 일반 group API, `ElectionStrategy` ABI와 backend별
   - ordered `winners`, `eliminations`, `scores`, `EMPTY`를 제공한다.
 - `leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/StrategicGroupElectionResultValidation.kt`
   - strategy 결과의 nodeId 중복·교집합·누락·입력 외 후보·N 초과를 검증한다.
+  - public `GroupElectionStrategy.electValidated`가 모든 adapter의 단일 검증
+    경계를 제공하므로 backend별 validator 복제를 허용하지 않는다.
 - `leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/FifoGroupElectionStrategy.kt`
   - `registeredAt`와 `nodeId` tie-break로 상위 N개를 선택한다.
 - `leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/ScoredGroupElectionStrategy.kt`
@@ -36,8 +38,8 @@ single strategic API, 일반 group API, `ElectionStrategy` ABI와 backend별
 - `leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElector.kt`
 - `leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderGroupElector.kt`
   - 기존 Local strategic registry와 lock/mutex를 재사용한다.
-  - 현재 elector의 `nodeId`가 관찰된 winner snapshot에 있을 때만 action을 실행한다.
-  - backend snapshot 차이로 전역 실행 수가 `maxLeaders`를 넘을 수 있다는 경계를
+  - 현재 elector의 `nodeId`가 관찰된 winner 기준 목록에 있을 때만 action을 실행한다.
+  - backend 후보 기준 목록 차이로 전역 실행 수가 `maxLeaders`를 넘을 수 있다는 경계를
     KDoc와 README에 명시한다.
   - 성공/실패 결과 갱신과 `CancellationException` 재전파를 기존 구현과 대칭으로 유지한다.
 
@@ -49,6 +51,9 @@ single strategic API, 일반 group API, `ElectionStrategy` ABI와 backend별
 - `leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElector.kt`
   - 기존 candidate registry의 TTL, 직렬화, read/update와 backend별 lock-name/coroutine
     예외 경계를 재사용하되 group 전용 key namespace를 사용한다.
+  - Lettuce group namespace는 `leader:strategy:group-candidates:lettuce:v1`,
+    Redisson group namespace는 `leader:strategy:group-candidates:redisson:v1`로
+    고정해 저장 schema 충돌을 막는다.
   - 후보 조회 실패는 기존 strategic adapter와 같이 cancellation은 전파하고 그 밖의
     조회 오류는 경고 후 `null`로 skip한다.
 
@@ -65,7 +70,11 @@ single strategic API, 일반 group API, `ElectionStrategy` ABI와 backend별
 - `leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElectorTest.kt`
 - `leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElectorTest.kt`
   - Redis 후보 TTL과 blocking/coroutine adapter 대칭, 여러 winner의 독립 실행을
-    Testcontainers 기반으로 검증한다.
+    Testcontainers 기반으로 검증하고, 영구 후보가 유한 TTL 후보 만료에 가려지지 않는
+    mixed-TTL 회귀도 확인한다.
+- Lettuce 후보 index set은 개별 candidate key TTL과 분리해 persistent candidate와
+  finite-TTL candidate를 함께 등록해도 TTL 만료가 persistent candidate를 숨기지
+  않는지 blocking/coroutine 회귀를 검증한다.
 
 ### 문서
 
@@ -80,7 +89,7 @@ single strategic API, 일반 group API, `ElectionStrategy` ABI와 backend별
 
 ### 1. 전략 계약을 먼저 고정한다
 
-1. `StrategicGroupElectionResultTest`를 먼저 작성해 RED를 확인한다.
+1. `StrategicGroupElectionStrategyTest`를 먼저 작성해 RED를 확인한다.
 2. `GroupElectionStrategy`, 결과 모델, FIFO/scored 전략을 구현한다.
 3. core 전략 테스트를 실행해 GREEN을 확인한다.
 4. `maxLeaders.requireGe(1, "maxLeaders")`와 기존 bluetape4k `require*` helper 사용을
@@ -116,8 +125,9 @@ single strategic API, 일반 group API, `ElectionStrategy` ABI와 backend별
 
 1. README 두 locale을 같은 API 표와 선택 규칙으로 갱신한다.
 2. 기존 strategic single/group 테스트를 함께 실행한다.
-3. `git diff --check`, `detekt`, core/Redis targeted test, 필요한 모듈 build를
-   순서대로 실행한다.
+3. `git diff --check`, `detekt`, core/Redis targeted test, 필요한 모듈 build와
+   `ABI_BASE_VERSION=0.5.0 ABI_CURRENT_VERSION=1.0.0 ./gradlew checkBinaryCompatibility`
+   명령을 순서대로 실행한다.
 4. 변경된 public symbol, ABI, backend 지원 matrix, 문서 link를 다시 읽는다.
 
 ## 검증 명령
@@ -139,6 +149,13 @@ single strategic API, 일반 group API, `ElectionStrategy` ABI와 backend별
   --tests 'io.bluetape4k.leader.redisson.RedissonStrategicSuspendLeaderGroupElectorTest' \
   --no-configuration-cache --max-workers=1
 ./gradlew detekt --no-configuration-cache --max-workers=1
+ABI_BASE_VERSION=0.5.0 ABI_CURRENT_VERSION=1.0.0 \
+  ./gradlew checkBinaryCompatibility --no-configuration-cache --max-workers=1
+./gradlew :bluetape4k-leader-core:build \
+  :bluetape4k-leader-redis-lettuce:build \
+  :bluetape4k-leader-redis-redisson:build \
+  -x test --no-configuration-cache --max-workers=1
+git diff --check
 ```
 
 Docker/Testcontainers 검증이 호스트에서 실행되지 않으면 active Colima와

--- a/docs/superpowers/plans/2026-08-25-strategic-group-election-plan.md
+++ b/docs/superpowers/plans/2026-08-25-strategic-group-election-plan.md
@@ -7,6 +7,10 @@ N개를 선택하는 blocking/coroutine strategic group API를 추가한다. 기
 single strategic API, 일반 group API, `ElectionStrategy` ABI와 backend별
 후보 레지스트리 semantics는 유지한다.
 
+이 API의 `maxLeaders`는 호출이 관찰한 후보 snapshot에 대한 advisory top-N이다.
+분산 snapshot이 다르면 전역 동시 실행 상한이 될 수 없으므로 전역 상한이 필요한
+작업에는 기존 `LeaderGroupElector`를 사용한다.
+
 ## 변경 파일
 
 ### leader-core 공개 계약과 전략
@@ -20,6 +24,8 @@ single strategic API, 일반 group API, `ElectionStrategy` ABI와 backend별
   - 기존 `ElectionStrategy`를 변경하지 않고 `(candidates, maxLeaders)` 계약을 추가한다.
 - `leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/StrategicGroupElectionResult.kt`
   - ordered `winners`, `eliminations`, `scores`, `EMPTY`를 제공한다.
+- `leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/StrategicGroupElectionResultValidation.kt`
+  - strategy 결과의 nodeId 중복·교집합·누락·입력 외 후보·N 초과를 검증한다.
 - `leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/FifoGroupElectionStrategy.kt`
   - `registeredAt`와 `nodeId` tie-break로 상위 N개를 선택한다.
 - `leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/ScoredGroupElectionStrategy.kt`
@@ -30,7 +36,9 @@ single strategic API, 일반 group API, `ElectionStrategy` ABI와 backend별
 - `leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElector.kt`
 - `leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderGroupElector.kt`
   - 기존 Local strategic registry와 lock/mutex를 재사용한다.
-  - 현재 elector의 `nodeId`가 winner 목록에 있을 때만 action을 실행한다.
+  - 현재 elector의 `nodeId`가 관찰된 winner snapshot에 있을 때만 action을 실행한다.
+  - backend snapshot 차이로 전역 실행 수가 `maxLeaders`를 넘을 수 있다는 경계를
+    KDoc와 README에 명시한다.
   - 성공/실패 결과 갱신과 `CancellationException` 재전파를 기존 구현과 대칭으로 유지한다.
 
 ### Redis adapters
@@ -40,7 +48,7 @@ single strategic API, 일반 group API, `ElectionStrategy` ABI와 backend별
 - `leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElector.kt`
 - `leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElector.kt`
   - 기존 candidate registry의 TTL, 직렬화, read/update와 backend별 lock-name/coroutine
-    예외 경계를 재사용한다.
+    예외 경계를 재사용하되 group 전용 key namespace를 사용한다.
   - 후보 조회 실패는 기존 strategic adapter와 같이 cancellation은 전파하고 그 밖의
     조회 오류는 경고 후 `null`로 skip한다.
 
@@ -77,6 +85,8 @@ single strategic API, 일반 group API, `ElectionStrategy` ABI와 backend별
 3. core 전략 테스트를 실행해 GREEN을 확인한다.
 4. `maxLeaders.requireGe(1, "maxLeaders")`와 기존 bluetape4k `require*` helper 사용을
    코드 리뷰로 확인한다.
+5. scorer가 `NaN`/무한대를 반환하면 즉시 `IllegalArgumentException`을 반환하도록
+   테스트한다.
 
 ### 2. public elector 계약을 추가한다
 
@@ -90,13 +100,15 @@ single strategic API, 일반 group API, `ElectionStrategy` ABI와 backend별
 1. 선택 node의 action 실행과 비선택 node의 null 반환 테스트를 RED로 추가한다.
 2. blocking 구현을 기존 `ReentrantLock` 경계에 맞춰 추가한다.
 3. coroutine 구현을 기존 `Mutex`와 cancellation 보존 helper에 맞춰 추가한다.
-4. 결과 갱신과 예외 테스트를 GREEN으로 만든다.
+4. 잘못된 custom strategy 결과가 action을 실행하기 전에 거부되는지 검증한다.
+5. 결과 갱신과 예외 테스트를 GREEN으로 만든다.
 
 ### 4. Lettuce와 Redisson 구현을 추가한다
 
 1. 각 backend의 blocking 테스트를 먼저 추가해 RED를 확인한다.
 2. 기존 `LettuceCandidateRegistry`/`LettuceSuspendCandidateRegistry`와
-   `RedissonCandidateRegistry`를 직접 재사용한다.
+   `RedissonCandidateRegistry`의 TTL·직렬화 경로를 재사용하되 group namespace를
+   전달한다.
 3. coroutine adapter에서 `CancellationException`을 삼키지 않도록 테스트한다.
 4. Redis Testcontainers targeted test를 순차 실행한다.
 
@@ -141,3 +153,4 @@ Docker context를 먼저 확인하고, 실패 원인과 검증 범위를 DoD에 
 - Redis 조회 오류 처리에서 cancellation을 일반 오류로 바꾸지 않는다.
 - 기존 `ElectionStrategy`와 public constructor를 수정하지 않아 ABI 위험을 줄인다.
 - 새로운 의존성은 추가하지 않는다.
+- strategic single/group Redis key namespace를 섞지 않는다.

--- a/docs/superpowers/reviews/2026-08-25-strategic-group-election-review.md
+++ b/docs/superpowers/reviews/2026-08-25-strategic-group-election-review.md
@@ -1,0 +1,61 @@
+# #463 전략적 그룹 선출 API 리뷰
+
+## DoD Status
+
+- 상태: `APPROVE` — P0 0건, P1 0건
+- 범위: #463의 core blocking/coroutine 계약, Local adapter, Lettuce/Redisson adapter, 기본 전략, TTL·namespace·ABI 회귀, README와 설계/실행 계획
+- 기준 브랜치: `develop`
+- 작업 브랜치: `design/epic-strategic-01-api`
+
+## 리뷰 결과
+
+### 계약과 API
+
+- `StrategicLeaderGroupElector`와 `StrategicSuspendLeaderGroupElector`는 기존 `LeaderGroupElector`의 전역 slot claim과 분리된 후보 기준 top-N 계약을 제공한다.
+- `maxLeaders`는 직접 `Int`로 받고, 관찰한 후보 기준 목록에서 선택할 최대 수이다. 전역 분산 동시 실행 상한은 기존 `LeaderGroupElector` 계약으로 명확히 분리했다.
+- `GroupElectionStrategy.electValidated`를 core의 공통 검증 경계로 두어 winner/elimination partition, 후보 membership, 중복, score key, `maxLeaders` 불변식을 Local·Lettuce·Redisson이 공유한다.
+- `ScoredGroupElectionStrategy`는 bluetape4k-core의 `Double.requireFinite`를 사용해 NaN/무한 점수를 fail-closed로 거부한다.
+
+### 아키텍처와 backend 경계
+
+- Architect 재검토: `APPROVE`, P0/P1 0건.
+- Lettuce strategic group 후보 key는 `leader:strategy:group-candidates:lettuce:v1`, Redisson은 `leader:strategy:group-candidates:redisson:v1`로 backend/schema 충돌을 차단한다.
+- 기존 single candidate prefix와 registry의 one-argument constructor descriptor는 유지해 ABI 영향을 제한했다.
+- Lettuce index set에는 TTL을 적용하지 않고 candidate key에만 TTL을 적용한다. 따라서 유한 TTL 후보가 만료되어도 같은 lock의 영구 후보가 가려지지 않는다.
+- Redisson 결과 갱신은 남은 TTL을 읽어 동일한 TTL로 다시 저장하므로 성공/실패 카운트 갱신이 후보 만료 정책을 바꾸지 않는다.
+
+### 독립 검토
+
+- 초기 spec review: `ACCEPT`, P0 0건/P1 0건. 지적된 P2 4건(공통 검증 경계, 옵션 KDoc/README, 테스트·ABI 명령, `snapshot` 용어)을 모두 반영했다.
+- 독립 architecture review: 최초 P1 3건(옵션 의미, Redis namespace, validator 중복)을 수선한 뒤 `APPROVE`, P0/P1 0건.
+- 독립 code review: `ACCEPT/APPROVE`, P0/P1 0건. advisory top-N, custom result validation, cancellation 재전파, mixed TTL, ABI/namespace 경계를 확인했다.
+
+## 검증 증거
+
+| 검증 | 결과 |
+| --- | --- |
+| Core strategic/local 회귀 | 49 passing, `BUILD SUCCESSFUL` |
+| Lettuce strategic single/group blocking/coroutine | 51 passing, `BUILD SUCCESSFUL` |
+| Redisson strategic single/group blocking/coroutine | 41 passing, `BUILD SUCCESSFUL` |
+| 기존 Local group 회귀 | 23 passing, `BUILD SUCCESSFUL` |
+| `detekt --no-configuration-cache --max-workers=1` | `BUILD SUCCESSFUL` |
+| core/Lettuce/Redisson module build (`-x test`) | `BUILD SUCCESSFUL` |
+| `checkBinaryCompatibility` (`ABI_BASE_VERSION=0.5.0`, `ABI_CURRENT_VERSION=1.0.0`) | `unknown=0`, unclassified incompatibility 없음, `BUILD SUCCESSFUL` |
+| `git diff --check` | 통과 |
+| `audit-korean-terms.mjs README.ko.md` | findings=0 |
+| Colima/Testcontainers preflight | Colima healthy, Docker context/info 정상 |
+
+Redis 검증은 macOS Colima의 `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock`와 현재 Docker socket을 사용했다. LSP diagnostics 도구는 제공되지 않아 Gradle compile/build, detekt, ABI 검증으로 대체했다.
+
+## 비차단 WATCH
+
+1. Local registry 등록과 선출 snapshot 사이에는 인스턴스 단위의 약한 일관성이 있다. 현재 API가 advisory top-N임을 문서화했으며, 강한 분산 claim은 기존 group elector의 책임으로 남겼다.
+2. Redis 후보 갱신은 기존 read-modify-write 경계를 따른다. 동시 갱신의 atomic merge가 필요한 경우 별도 후속 이슈로 다룬다.
+3. Redis coroutine adapter의 cancellation 및 SUCCESS/FAILURE 결과 갱신을 실제 backend에서 고정하는 회귀 테스트는 후속 보강 대상으로 남긴다.
+4. `StrategicGroupElectionResult`는 새 public data class이므로 향후 필드 추가 시 생성자/copy ABI를 신중히 관리한다.
+
+위 항목은 현재 DoD의 P0/P1 blocker가 아니며, 이번 PR의 merge-ready 판정을 막지 않는다.
+
+## 최종 판정
+
+`APPROVE` — #463 구현은 사용자 승인된 범위와 기존 leader 계약 경계를 만족하며 PR 생성 및 CI 게이트로 진행할 수 있다. 이 문서는 merge 승인 자체를 의미하지 않으며, merge 시점에는 정확한 head·CI·리뷰·thread를 다시 확인한다.

--- a/docs/superpowers/specs/2026-08-25-strategic-group-election-design.md
+++ b/docs/superpowers/specs/2026-08-25-strategic-group-election-design.md
@@ -20,8 +20,8 @@ slot을 획득한 노드를 최대 `maxLeaders`개까지 동시에 통과시킨�
 결정론적으로 선택한다. 선택된 노드만 작업을 실행하고, 나머지는 즉시
 `null`을 반환한다.
 
-이 계약은 **관찰한 후보 snapshot에 대한 advisory top-N 선출**이다. 여러 backend
-호출이 서로 다른 시점의 snapshot을 읽을 수 있으므로 `maxLeaders`는 각 라운드의
+이 계약은 **관찰한 후보 기준 목록에 대한 advisory top-N 선출**이다. 여러 backend
+호출이 서로 다른 시점의 후보 기준 목록을 읽을 수 있으므로 `maxLeaders`는 각 라운드의
 선택 수이지 모든 분산 노드의 전역 동시 실행 상한이 아니다. 전역 상한과 fencing이
 필요한 작업은 기존 `LeaderGroupElector`를 사용해야 한다.
 
@@ -55,8 +55,8 @@ fun interface GroupElectionStrategy {
 `maxLeaders`는 `1` 이상이어야 하며, 구현체는 후보 수보다 큰 값도 허용한다.
 후보가 부족하면 존재하는 후보를 모두 선택한다.
 
-전략이 반환한 결과는 elector가 후보 snapshot과 대조한다. winner와 elimination의
-후보 ID는 입력 snapshot에 있어야 하고 중복·교집합·누락·`maxLeaders` 초과가
+전략이 반환한 결과는 elector가 후보 기준 목록과 대조한다. winner와 elimination의
+후보 ID는 입력 후보 기준 목록에 있어야 하고 중복·교집합·누락·`maxLeaders` 초과가
 있으면 `IllegalArgumentException`으로 즉시 거부한다. 후보 ID의 동일성 기준은
 `nodeId`다. 입력 후보 자체에 중복 ID가 있으면 backend registry 계약 위반으로
 간주하고 같은 예외를 반환한다.
@@ -84,21 +84,18 @@ data class StrategicGroupElectionResult(
 아니다. 안정적인 분류가 필요하면 후속 이슈에서 사유 코드 필드를 별도로
 설계한다.
 
-### 2.3 공통 옵션과 실행 semantics
+### 2.3 실행 인자와 실행 semantics
 
 `runIfLeader`는 기존 strategic API의 후보 등록, TTL, 결과 갱신, cancellation
-semantics를 그대로 유지하며 `LeaderGroupElectionOptions`를 재사용한다.
-선출에 직접 사용하는 필드는 `maxLeaders`다. `options.nodeId`는 무시하고
-elector의 `nodeId`를 현재 후보 ID로 사용한다. `waitTime`, `leaseTime`,
-`minLeaseTime`, `useDbTime`은 기존 생성자 검증은 적용하지만 lock/lease 의미는
-일반 group elector에만 적용하고 strategic candidate registry에는 새 distributed
-claim을 추가하지 않는다.
+semantics를 그대로 유지하며, 의미가 있는 `maxLeaders`만 직접 받는다. 기존
+`LeaderGroupElectionOptions`는 전역 slot/lease 계약을 표현하므로 이 API에서
+재사용하지 않는다.
 
 ```kotlin
 fun <T> runIfLeader(
     lockName: String,
     strategy: GroupElectionStrategy,
-    options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
+    maxLeaders: Int = LeaderGroupElectionOptions.DefaultMaxLeaders,
     action: () -> T,
 ): T?
 ```
@@ -107,10 +104,10 @@ coroutine variant는 같은 인자와 `suspend () -> T` action을 사용한다.
 
 - `registerCandidate`, `unregisterCandidate`, `listCandidates`, `updateResult`는
   기존 `StrategicLeaderElector`와 같은 시그니처와 TTL 전달 규칙을 따른다.
-- 현재 `nodeId`가 관찰된 snapshot의 winner 목록에 없으면 action을 호출하지 않고
+- 현재 `nodeId`가 관찰된 후보 기준 목록의 winner 목록에 없으면 action을 호출하지 않고
   `null`을 반환한다.
-- 현재 `nodeId`가 관찰된 snapshot의 winner 목록에 있으면 해당 호출에서 action을
-  한 번 호출하고 그 결과를 반환한다. 서로 다른 snapshot에서 여러 node가 선택될
+- 현재 `nodeId`가 관찰된 후보 기준 목록의 winner 목록에 있으면 해당 호출에서 action을
+  한 번 호출하고 그 결과를 반환한다. 서로 다른 후보 기준 목록에서 여러 node가 선택될
   수 있으며, 이는 이 API의 비범위인 전역 동시 실행 보장과 구분한다.
 - action 성공 시 `CandidateResult.SUCCESS`, 일반 예외 시 `FAILURE`를 best-effort로
   기록한다. TTL이 action 전후에 만료되면 결과 갱신은 no-op일 수 있다.
@@ -144,11 +141,16 @@ coroutine variant는 같은 인자와 `suspend () -> T` action을 사용한다.
   결과 갱신 경로를 재사용한다.
 - strategic single과 strategic group은 backend별 별도 key namespace를 사용해
   같은 `lockName`을 우연히 공유해도 후보 집합과 결과 갱신을 섞지 않는다.
+  Group namespace는 저장 schema 충돌을 막기 위해
+  `leader:strategy:group-candidates:lettuce:v1`와
+  `leader:strategy:group-candidates:redisson:v1`로 backend/schema를 명시한다.
 - 후보 목록 조회와 선택은 backend별 read consistency 범위 안에서 수행한다.
   이 API는 후보 선택과 action 실행 사이에 새로운 distributed atomic claim을
   제공하지 않으며, `maxLeaders`의 전역 동시 실행 상한을 보장하지 않는다.
 - TTL이 만료된 후보는 기존 레지스트리 조회 결과에 포함되지 않으며, 한
-  라운드에서 읽은 후보 목록은 해당 라운드의 선택 입력으로 고정한다.
+  라운드에서 읽은 후보 목록은 해당 라운드의 선택 입력으로 고정한다. Lettuce
+  index set은 후보별 TTL과 독립적으로 유지해 영구 후보와 유한 TTL 후보가 같은
+  `lockName`에 함께 등록되어도 유한 후보 만료가 영구 후보를 가리지 않게 한다.
 - `Duration.ZERO`는 만료되지 않는 후보 등록이다. 유한 TTL 후보는 호출자가
   재등록/heartbeat해야 하며 권장 cadence는 TTL보다 짧게 잡는다. Local은
   기존 구현과 같이 TTL을 저장하지 않고 프로세스 메모리 수명으로 유지한다.
@@ -162,6 +164,8 @@ coroutine variant는 같은 인자와 `suspend () -> T` action을 사용한다.
   메서드와 JVM descriptor를 변경하지 않는다.
 - 새 public 타입과 KDoc은 기존 bluetape4k Kotlin 패턴, `requireGe` 계열
   검증 helper, `CandidateInfo`/`CandidateScorer` 재사용 규칙을 따른다.
+- 모든 adapter는 core의 public `GroupElectionStrategy.electValidated` helper를
+  사용해 결과 불변식을 한 곳에서 검증한다.
 - 별도 의존성이나 새 serialization 포맷을 추가하지 않는다.
 - 단일 strategic election과 strategic group election은 key namespace로
   구조적으로 격리되며, 사용 가이드에서도 두 실행 모델의 선택 기준을 구분한다.
@@ -174,7 +178,7 @@ coroutine variant는 같은 인자와 `suspend () -> T` action을 사용한다.
 | 결정론 | FIFO의 `registeredAt`/`nodeId` tie-break, scored의 score/`registeredAt`/`nodeId` tie-break |
 | 실행 | 선택된 node만 action 실행, 비선택 node는 `null`과 action 미실행 |
 | 상태 | 성공·실패 `updateResult`, 예외 전파, coroutine cancellation 재전파 |
-| backend | Local unit, Lettuce Redis integration, Redisson Redis integration의 blocking/coroutine 대칭 |
+| backend | Local unit, Lettuce/Redisson Redis integration의 blocking/coroutine 대칭 및 mixed-TTL 회귀 |
 | 문서 | README.md와 README.ko.md의 API 표, 선택 가이드, 지원 backend 범위 일치 |
 | 회귀 | 기존 strategic single 및 기존 group 테스트와 ABI/Detekt/build 통과 |
 
@@ -195,6 +199,6 @@ coroutine variant는 같은 인자와 `suspend () -> T` action을 사용한다.
   `StrategicSuspendLeaderElector`, Local/Lettuce/Redisson strategic elector
 - 기존 단일 전략: `ElectionStrategy`, `ElectionResult`,
   `FifoElectionStrategy`, `ScoredElectionStrategy`
-- 공통 group 옵션: `LeaderGroupElectionOptions`
+- 기존 group slot 계약 참고: `LeaderGroupElectionOptions` (strategic API에는 재사용하지 않음)
 - 선행 계약 검토: [#681](https://github.com/bluetape4k/bluetape4k-leader/issues/681)
 - 요구사항 원문: [#463](https://github.com/bluetape4k/bluetape4k-leader/issues/463)

--- a/docs/superpowers/specs/2026-08-25-strategic-group-election-design.md
+++ b/docs/superpowers/specs/2026-08-25-strategic-group-election-design.md
@@ -1,0 +1,176 @@
+# Strategic Group Election API 설계 사양
+
+상태: 승인된 설계
+
+작성일: 2026-08-25
+
+이슈: [#463](https://github.com/bluetape4k/bluetape4k-leader/issues/463)
+
+트레인: `STRATEGIC-01`
+
+## 1. 목적과 현재 계약
+
+현재 `LeaderGroupElector`/`SuspendLeaderGroupElector`는 분산 세마포어의
+slot을 획득한 노드를 최대 `maxLeaders`개까지 동시에 통과시킨다. 반면
+`StrategicLeaderElector`/`StrategicSuspendLeaderElector`는 후보 레지스트리의
+`CandidateInfo`를 `ElectionStrategy`로 평가해 단일 후보만 선택한다.
+
+`#463`은 두 모델을 후보 집합 기준으로 결합한다. 호출자는 후보를 등록하고,
+매 선출 라운드마다 같은 후보 목록과 `maxLeaders`에서 최대 N개의 후보를
+결정론적으로 선택한다. 선택된 노드만 작업을 실행하고, 나머지는 즉시
+`null`을 반환한다.
+
+범위는 다음 구현체로 한정한다.
+
+| 실행 모델 | 지원 백엔드 |
+| --- | --- |
+| blocking | `LocalStrategicLeaderGroupElector`, `LettuceStrategicLeaderGroupElector`, `RedissonStrategicLeaderGroupElector` |
+| coroutine | `LocalStrategicSuspendLeaderGroupElector`, `LettuceStrategicSuspendLeaderGroupElector`, `RedissonStrategicSuspendLeaderGroupElector` |
+
+Exposed, MongoDB, DynamoDB, etcd, Consul, Kubernetes, Hazelcast, ZooKeeper와
+기존 `ElectionStrategy` ABI 변경은 이 설계의 범위가 아니다.
+
+## 2. 확정 결정
+
+### 2.1 별도 strategy 계약
+
+기존 `ElectionStrategy.elect(List<CandidateInfo>)`는 단일 승자 계약이므로
+그 시그니처를 변경하지 않는다. 새 `GroupElectionStrategy`는
+`maxLeaders`를 명시적으로 받아 복수 승자 결과를 반환한다.
+
+```kotlin
+fun interface GroupElectionStrategy {
+    fun elect(
+        candidates: List<CandidateInfo>,
+        maxLeaders: Int,
+    ): StrategicGroupElectionResult
+}
+```
+
+`maxLeaders`는 `1` 이상이어야 하며, 구현체는 후보 수보다 큰 값도 허용한다.
+후보가 부족하면 존재하는 후보를 모두 선택한다.
+
+### 2.2 결과 모델
+
+```kotlin
+data class StrategicGroupElectionResult(
+    val winners: List<CandidateInfo>,
+    val eliminations: List<Elimination>,
+    val scores: Map<String, Double> = emptyMap(),
+) : Serializable
+```
+
+결과 불변식은 다음과 같다.
+
+- `winners`는 선출 우선순위가 높은 순서로 정렬된 목록이다.
+- 한 결과에서 `winners`의 `nodeId`는 중복되지 않는다.
+- `winners`와 `eliminations`는 같은 후보를 동시에 포함하지 않는다.
+- 모든 입력 후보는 `winners` 또는 `eliminations` 중 정확히 한 곳에 기록된다.
+- 빈 후보 목록은 `StrategicGroupElectionResult.EMPTY`를 반환한다.
+- `scores`는 점수 전략이 계산한 후보만 `nodeId` 키로 담고, FIFO 전략은 빈 맵을 반환한다.
+
+`Elimination.reason`은 진단용 사람이 읽는 문자열이며 안정적인 파싱 계약이
+아니다. 안정적인 분류가 필요하면 후속 이슈에서 사유 코드 필드를 별도로
+설계한다.
+
+### 2.3 공통 옵션과 실행 semantics
+
+`runIfLeader`는 기존 strategic API의 후보 등록, TTL, 결과 갱신, cancellation
+semantics를 그대로 유지하며 `LeaderGroupElectionOptions`를 재사용한다.
+선출에 직접 사용하는 필드는 `maxLeaders`다. `waitTime`, `leaseTime`,
+`minLeaseTime`, `useDbTime`의 lock/lease 의미는 일반 group elector에만
+적용되고 strategic candidate registry에는 새 distributed claim을 추가하지
+않는다.
+
+```kotlin
+fun <T> runIfLeader(
+    lockName: String,
+    strategy: GroupElectionStrategy,
+    options: LeaderGroupElectionOptions = LeaderGroupElectionOptions.Default,
+    action: () -> T,
+): T?
+```
+
+coroutine variant는 같은 인자와 `suspend () -> T` action을 사용한다.
+
+- `registerCandidate`, `unregisterCandidate`, `listCandidates`, `updateResult`는
+  기존 `StrategicLeaderElector`와 같은 시그니처와 TTL 전달 규칙을 따른다.
+- 현재 `nodeId`가 선택된 목록에 없으면 action을 호출하지 않고 `null`을 반환한다.
+- 현재 `nodeId`가 선택되면 action을 정확히 한 번 호출하고 그 결과를 반환한다.
+- action 성공 시 `CandidateResult.SUCCESS`, 일반 예외 시 `FAILURE`를 기록한다.
+- `CancellationException`은 결과 갱신으로 삼키지 않고 기존 구현과 동일하게
+  재전파한다. 결과 갱신 자체의 일반 예외는 경고 로그 후 action 결과를 보존한다.
+
+### 2.4 결정론적 내장 전략
+
+#### `FifoGroupElectionStrategy`
+
+`registeredAt` 오름차순, 동률이면 `nodeId` 사전순으로 전체 후보를 정렬하고
+앞에서 `maxLeaders`개를 winner로 선택한다. 나머지는
+`registered later` 또는 `nodeId lexicographically after winner` 의미의
+진단 사유로 elimination에 기록한다.
+
+#### `ScoredGroupElectionStrategy`
+
+기존 `CandidateScorer`를 재사용한다. 각 후보 점수를 한 번 계산한 뒤 점수
+내림차순, 동점이면 `registeredAt` 오름차순, 다시 동률이면 `nodeId` 사전순으로
+정렬하고 앞에서 `maxLeaders`개를 선택한다. 결과의 `scores`에는 모든 입력
+후보의 점수를 기록한다.
+
+## 3. 백엔드 경계
+
+- Local은 기존 `ConcurrentHashMap` 후보 레지스트리와 lock/mutex 보호를
+  재사용한다.
+- Lettuce와 Redisson은 기존 후보 레지스트리의 TTL, 직렬화, 후보 목록 조회,
+  결과 갱신 경로를 재사용한다.
+- 후보 목록 조회와 선택은 backend별 read consistency 범위 안에서 수행한다.
+  이 API는 후보 선택과 action 실행 사이에 새로운 distributed atomic claim을
+  제공하지 않는다.
+- TTL이 만료된 후보는 기존 레지스트리 조회 결과에 포함되지 않으며, 한
+  라운드에서 읽은 후보 목록은 해당 라운드의 선택 입력으로 고정한다.
+- 지원하지 않는 backend에 전략적 group adapter를 추가하는 작업은 별도
+  issue로 분리한다.
+
+## 4. 호환성과 공개 API 원칙
+
+- 기존 `ElectionStrategy`, `StrategicLeaderElector`,
+  `StrategicSuspendLeaderElector`, `LeaderGroupElectionOptions`의 기존
+  메서드와 JVM descriptor를 변경하지 않는다.
+- 새 public 타입과 KDoc은 기존 bluetape4k Kotlin 패턴, `requireGe` 계열
+  검증 helper, `CandidateInfo`/`CandidateScorer` 재사용 규칙을 따른다.
+- 별도 의존성이나 새 serialization 포맷을 추가하지 않는다.
+- 단일 strategic election과 strategic group election을 같은 registry key에
+  섞어 호출하지 않는 사용 가이드를 README와 README.ko에 함께 추가한다.
+
+## 5. 수용 기준과 테스트 표
+
+| 영역 | 검증 |
+| --- | --- |
+| 전략 결과 | 빈 후보, 후보 수가 N보다 적은 경우, 정확히 N개, 중복 후보 방지 |
+| 결정론 | FIFO의 `registeredAt`/`nodeId` tie-break, scored의 score/`registeredAt`/`nodeId` tie-break |
+| 실행 | 선택된 node만 action 실행, 비선택 node는 `null`과 action 미실행 |
+| 상태 | 성공·실패 `updateResult`, 예외 전파, coroutine cancellation 재전파 |
+| backend | Local unit, Lettuce Redis integration, Redisson Redis integration의 blocking/coroutine 대칭 |
+| 문서 | README.md와 README.ko.md의 API 표, 선택 가이드, 지원 backend 범위 일치 |
+| 회귀 | 기존 strategic single 및 기존 group 테스트와 ABI/Detekt/build 통과 |
+
+## 6. 비범위와 후속 이슈
+
+- 선택된 여러 노드에 대한 순차 실행, quorum, weighted capacity는 지원하지
+  않는다. `winners` 순서는 관찰 가능한 우선순위이며 실행 순서를 보장하지
+  않는다.
+- action을 시작한 뒤 lease를 자동 연장하는 별도 watchdog은 추가하지 않는다.
+- candidate registry 읽기와 action 시작 사이의 fencing token 또는 atomic claim은
+  별도 설계가 필요하다.
+- Exposed/R2DBC group contract와 추가 strategic backend adapter는 현재
+  트레인 이후 issue로 분리한다.
+
+## 7. 설계 근거
+
+- 현재 API와 구현: `StrategicLeaderElector`,
+  `StrategicSuspendLeaderElector`, Local/Lettuce/Redisson strategic elector
+- 기존 단일 전략: `ElectionStrategy`, `ElectionResult`,
+  `FifoElectionStrategy`, `ScoredElectionStrategy`
+- 공통 group 옵션: `LeaderGroupElectionOptions`
+- 선행 계약 검토: [#681](https://github.com/bluetape4k/bluetape4k-leader/issues/681)
+- 요구사항 원문: [#463](https://github.com/bluetape4k/bluetape4k-leader/issues/463)

--- a/docs/superpowers/specs/2026-08-25-strategic-group-election-design.md
+++ b/docs/superpowers/specs/2026-08-25-strategic-group-election-design.md
@@ -20,6 +20,11 @@ slot을 획득한 노드를 최대 `maxLeaders`개까지 동시에 통과시킨�
 결정론적으로 선택한다. 선택된 노드만 작업을 실행하고, 나머지는 즉시
 `null`을 반환한다.
 
+이 계약은 **관찰한 후보 snapshot에 대한 advisory top-N 선출**이다. 여러 backend
+호출이 서로 다른 시점의 snapshot을 읽을 수 있으므로 `maxLeaders`는 각 라운드의
+선택 수이지 모든 분산 노드의 전역 동시 실행 상한이 아니다. 전역 상한과 fencing이
+필요한 작업은 기존 `LeaderGroupElector`를 사용해야 한다.
+
 범위는 다음 구현체로 한정한다.
 
 | 실행 모델 | 지원 백엔드 |
@@ -50,6 +55,12 @@ fun interface GroupElectionStrategy {
 `maxLeaders`는 `1` 이상이어야 하며, 구현체는 후보 수보다 큰 값도 허용한다.
 후보가 부족하면 존재하는 후보를 모두 선택한다.
 
+전략이 반환한 결과는 elector가 후보 snapshot과 대조한다. winner와 elimination의
+후보 ID는 입력 snapshot에 있어야 하고 중복·교집합·누락·`maxLeaders` 초과가
+있으면 `IllegalArgumentException`으로 즉시 거부한다. 후보 ID의 동일성 기준은
+`nodeId`다. 입력 후보 자체에 중복 ID가 있으면 backend registry 계약 위반으로
+간주하고 같은 예외를 반환한다.
+
 ### 2.2 결과 모델
 
 ```kotlin
@@ -77,10 +88,11 @@ data class StrategicGroupElectionResult(
 
 `runIfLeader`는 기존 strategic API의 후보 등록, TTL, 결과 갱신, cancellation
 semantics를 그대로 유지하며 `LeaderGroupElectionOptions`를 재사용한다.
-선출에 직접 사용하는 필드는 `maxLeaders`다. `waitTime`, `leaseTime`,
-`minLeaseTime`, `useDbTime`의 lock/lease 의미는 일반 group elector에만
-적용되고 strategic candidate registry에는 새 distributed claim을 추가하지
-않는다.
+선출에 직접 사용하는 필드는 `maxLeaders`다. `options.nodeId`는 무시하고
+elector의 `nodeId`를 현재 후보 ID로 사용한다. `waitTime`, `leaseTime`,
+`minLeaseTime`, `useDbTime`은 기존 생성자 검증은 적용하지만 lock/lease 의미는
+일반 group elector에만 적용하고 strategic candidate registry에는 새 distributed
+claim을 추가하지 않는다.
 
 ```kotlin
 fun <T> runIfLeader(
@@ -95,9 +107,13 @@ coroutine variant는 같은 인자와 `suspend () -> T` action을 사용한다.
 
 - `registerCandidate`, `unregisterCandidate`, `listCandidates`, `updateResult`는
   기존 `StrategicLeaderElector`와 같은 시그니처와 TTL 전달 규칙을 따른다.
-- 현재 `nodeId`가 선택된 목록에 없으면 action을 호출하지 않고 `null`을 반환한다.
-- 현재 `nodeId`가 선택되면 action을 정확히 한 번 호출하고 그 결과를 반환한다.
-- action 성공 시 `CandidateResult.SUCCESS`, 일반 예외 시 `FAILURE`를 기록한다.
+- 현재 `nodeId`가 관찰된 snapshot의 winner 목록에 없으면 action을 호출하지 않고
+  `null`을 반환한다.
+- 현재 `nodeId`가 관찰된 snapshot의 winner 목록에 있으면 해당 호출에서 action을
+  한 번 호출하고 그 결과를 반환한다. 서로 다른 snapshot에서 여러 node가 선택될
+  수 있으며, 이는 이 API의 비범위인 전역 동시 실행 보장과 구분한다.
+- action 성공 시 `CandidateResult.SUCCESS`, 일반 예외 시 `FAILURE`를 best-effort로
+  기록한다. TTL이 action 전후에 만료되면 결과 갱신은 no-op일 수 있다.
 - `CancellationException`은 결과 갱신으로 삼키지 않고 기존 구현과 동일하게
   재전파한다. 결과 갱신 자체의 일반 예외는 경고 로그 후 action 결과를 보존한다.
 
@@ -117,17 +133,25 @@ coroutine variant는 같은 인자와 `suspend () -> T` action을 사용한다.
 정렬하고 앞에서 `maxLeaders`개를 선택한다. 결과의 `scores`에는 모든 입력
 후보의 점수를 기록한다.
 
+`CandidateScorer`가 `NaN` 또는 무한대를 반환하면 `IllegalArgumentException`으로
+실패한다. 유한 점수만 순위와 `scores`에 사용한다.
+
 ## 3. 백엔드 경계
 
 - Local은 기존 `ConcurrentHashMap` 후보 레지스트리와 lock/mutex 보호를
   재사용한다.
 - Lettuce와 Redisson은 기존 후보 레지스트리의 TTL, 직렬화, 후보 목록 조회,
   결과 갱신 경로를 재사용한다.
+- strategic single과 strategic group은 backend별 별도 key namespace를 사용해
+  같은 `lockName`을 우연히 공유해도 후보 집합과 결과 갱신을 섞지 않는다.
 - 후보 목록 조회와 선택은 backend별 read consistency 범위 안에서 수행한다.
   이 API는 후보 선택과 action 실행 사이에 새로운 distributed atomic claim을
-  제공하지 않는다.
+  제공하지 않으며, `maxLeaders`의 전역 동시 실행 상한을 보장하지 않는다.
 - TTL이 만료된 후보는 기존 레지스트리 조회 결과에 포함되지 않으며, 한
   라운드에서 읽은 후보 목록은 해당 라운드의 선택 입력으로 고정한다.
+- `Duration.ZERO`는 만료되지 않는 후보 등록이다. 유한 TTL 후보는 호출자가
+  재등록/heartbeat해야 하며 권장 cadence는 TTL보다 짧게 잡는다. Local은
+  기존 구현과 같이 TTL을 저장하지 않고 프로세스 메모리 수명으로 유지한다.
 - 지원하지 않는 backend에 전략적 group adapter를 추가하는 작업은 별도
   issue로 분리한다.
 
@@ -139,8 +163,8 @@ coroutine variant는 같은 인자와 `suspend () -> T` action을 사용한다.
 - 새 public 타입과 KDoc은 기존 bluetape4k Kotlin 패턴, `requireGe` 계열
   검증 helper, `CandidateInfo`/`CandidateScorer` 재사용 규칙을 따른다.
 - 별도 의존성이나 새 serialization 포맷을 추가하지 않는다.
-- 단일 strategic election과 strategic group election을 같은 registry key에
-  섞어 호출하지 않는 사용 가이드를 README와 README.ko에 함께 추가한다.
+- 단일 strategic election과 strategic group election은 key namespace로
+  구조적으로 격리되며, 사용 가이드에서도 두 실행 모델의 선택 기준을 구분한다.
 
 ## 5. 수용 기준과 테스트 표
 
@@ -156,9 +180,9 @@ coroutine variant는 같은 인자와 `suspend () -> T` action을 사용한다.
 
 ## 6. 비범위와 후속 이슈
 
-- 선택된 여러 노드에 대한 순차 실행, quorum, weighted capacity는 지원하지
-  않는다. `winners` 순서는 관찰 가능한 우선순위이며 실행 순서를 보장하지
-  않는다.
+- 전역 동시 실행 상한을 위한 atomic claim, 선택된 여러 노드의 순차 실행,
+  quorum, weighted capacity는 지원하지 않는다. `winners` 순서는 관찰 가능한
+  우선순위이며 실행 순서를 보장하지 않는다.
 - action을 시작한 뒤 lease를 자동 연장하는 별도 watchdog은 추가하지 않는다.
 - candidate registry 읽기와 action 시작 사이의 fencing token 또는 atomic claim은
   별도 설계가 필요하다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderGroupElector.kt
@@ -1,0 +1,47 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.GroupElectionStrategy
+import kotlin.time.Duration
+
+/**
+ * `StrategicLeaderGroupElector`는 후보 레지스트리에서 여러 leader를 전략적으로
+ * 선택하는 blocking API입니다.
+ *
+ * `LeaderGroupElector`의 distributed slot claim과 달리 후보 기준 목록을
+ * 읽고 `GroupElectionStrategy`로 결정론적인 winner 집합을 계산합니다. 따라서
+ * `maxLeaders`는 관찰한 후보 기준 목록의 top-N이며 전역 동시 실행 상한이 아닙니다.
+ * 새로운 distributed atomic claim은 제공하지 않습니다.
+ */
+interface StrategicLeaderGroupElector {
+
+    /** 상태 조회와 후보 식별에 사용하는 노드 ID입니다. */
+    val nodeId: String
+
+    /** 후보를 등록하고 backend가 지원하는 경우 TTL을 적용합니다. */
+    fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO)
+
+    /** 후보를 등록 해제합니다. */
+    fun unregisterCandidate(lockName: String, nodeId: String)
+
+    /** 현재 backend에서 관찰되는 후보 목록을 반환합니다. */
+    fun listCandidates(lockName: String): List<CandidateInfo>
+
+    /** 후보 작업의 성공 또는 실패 결과를 registry에 반영합니다. */
+    fun updateResult(lockName: String, nodeId: String, result: CandidateResult)
+
+    /**
+     * winner 목록에 현재 `nodeId`가 포함된 경우에만 action을 실행합니다.
+     * 선택되지 않은 node는 action을 실행하지 않고 `null`을 반환합니다.
+     *
+     * `maxLeaders`는 관찰한 후보 기준 목록에서 선택할 최대 수이며 1 이상이어야
+     * 합니다. 전역 분산 동시 실행 상한이 필요하면 `LeaderGroupElector`를 사용하세요.
+     */
+    fun <T> runIfLeader(
+        lockName: String,
+        strategy: GroupElectionStrategy,
+        maxLeaders: Int = LeaderGroupElectionOptions.DefaultMaxLeaders,
+        action: () -> T,
+    ): T?
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderGroupElector.kt
@@ -1,0 +1,47 @@
+package io.bluetape4k.leader.coroutines
+
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.GroupElectionStrategy
+import kotlin.time.Duration
+
+/**
+ * `StrategicSuspendLeaderGroupElector`는 후보 레지스트리에서 여러 leader를
+ * 전략적으로 선택하는 coroutine API입니다.
+ *
+ * 후보 기준 목록을 읽고 `GroupElectionStrategy`로 winner 집합을 계산합니다.
+ * 따라서 `maxLeaders`는 관찰한 후보 기준 목록의 top-N이며 전역 동시 실행 상한이
+ * 아닙니다. 새로운 distributed atomic claim은 제공하지 않습니다.
+ */
+interface StrategicSuspendLeaderGroupElector {
+
+    /** 상태 조회와 후보 식별에 사용하는 노드 ID입니다. */
+    val nodeId: String
+
+    /** 후보를 등록하고 backend가 지원하는 경우 TTL을 적용합니다. */
+    suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO)
+
+    /** 후보를 등록 해제합니다. */
+    suspend fun unregisterCandidate(lockName: String, nodeId: String)
+
+    /** 현재 backend에서 관찰되는 후보 목록을 반환합니다. */
+    suspend fun listCandidates(lockName: String): List<CandidateInfo>
+
+    /** 후보 작업의 성공 또는 실패 결과를 registry에 반영합니다. */
+    suspend fun updateResult(lockName: String, nodeId: String, result: CandidateResult)
+
+    /**
+     * winner 목록에 현재 `nodeId`가 포함된 경우에만 action을 실행합니다.
+     * 선택되지 않은 node는 action을 실행하지 않고 `null`을 반환합니다.
+     *
+     * `maxLeaders`는 관찰한 후보 기준 목록에서 선택할 최대 수이며 1 이상이어야
+     * 합니다. 전역 분산 동시 실행 상한이 필요하면 `SuspendLeaderGroupElector`를 사용하세요.
+     */
+    suspend fun <T> runIfLeader(
+        lockName: String,
+        strategy: GroupElectionStrategy,
+        maxLeaders: Int = LeaderGroupElectionOptions.DefaultMaxLeaders,
+        action: suspend () -> T,
+    ): T?
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElector.kt
@@ -1,0 +1,98 @@
+package io.bluetape4k.leader.local
+
+import io.bluetape4k.idgenerators.uuid.Uuid
+import io.bluetape4k.leader.StrategicLeaderGroupElector
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.GroupElectionStrategy
+import io.bluetape4k.leader.strategy.electValidated
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import kotlinx.coroutines.CancellationException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+import kotlin.time.Duration
+
+/**
+ * `LocalStrategicLeaderGroupElector`는 JVM 메모리에서 후보를 등록하고 전략적으로
+ * 여러 leader를 선택하는 blocking elector입니다.
+ */
+class LocalStrategicLeaderGroupElector(
+    override val nodeId: String = Uuid.V7.nextIdAsString(),
+) : StrategicLeaderGroupElector {
+
+    companion object : KLogging()
+
+    private val registry = ConcurrentHashMap<String, ConcurrentHashMap<String, CandidateInfo>>()
+    private val locks = ConcurrentHashMap<String, ReentrantLock>()
+
+    private fun candidatesFor(lockName: String): ConcurrentHashMap<String, CandidateInfo> =
+        registry.computeIfAbsent(lockName) { ConcurrentHashMap() }
+
+    private fun lockFor(lockName: String): ReentrantLock =
+        locks.computeIfAbsent(lockName) { ReentrantLock() }
+
+    override fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+        candidatesFor(lockName)[info.nodeId] = info
+    }
+
+    override fun unregisterCandidate(lockName: String, nodeId: String) {
+        candidatesFor(lockName).remove(nodeId)
+    }
+
+    override fun listCandidates(lockName: String): List<CandidateInfo> =
+        candidatesFor(lockName).values.toList()
+
+    override fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
+        candidatesFor(lockName).computeIfPresent(nodeId) { _, current -> current.withResult(result) }
+    }
+
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
+    override fun <T> runIfLeader(
+        lockName: String,
+        strategy: GroupElectionStrategy,
+        maxLeaders: Int,
+        action: () -> T,
+    ): T? {
+        val result = lockFor(lockName).withLock {
+            val snapshot = listCandidates(lockName)
+            strategy.electValidated(snapshot, maxLeaders)
+        }
+        if (result.winners.isEmpty()) return null
+
+        val total = result.winners.size + result.eliminations.size
+        log.info {
+            "[$lockName] 전략적 그룹 선출: ${result.winners.joinToString { it.nodeId }} " +
+                "(전략: ${strategy::class.simpleName}, 후보: ${total}명)"
+        }
+        if (result.scores.isNotEmpty()) {
+            log.debug {
+                val scoreText = result.scores.entries
+                    .sortedByDescending { it.value }
+                    .joinToString(", ") { (id, score) -> "$id=%.2f".format(score) }
+                "[$lockName] 점수: $scoreText"
+            }
+        }
+        result.eliminations.forEach { elimination ->
+            log.debug { "[$lockName] 탈락: ${elimination.candidate.nodeId} — ${elimination.reason}" }
+        }
+
+        if (result.winners.none { it.nodeId == nodeId }) return null
+
+        return try {
+            val value = action()
+            runCatching { updateResult(lockName, nodeId, CandidateResult.SUCCESS) }
+                .onFailure { log.warn(it) { "[$lockName] successCount 업데이트 실패 — 무시됨" } }
+            value
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            runCatching { updateResult(lockName, nodeId, CandidateResult.FAILURE) }
+                .onFailure { log.warn(it) { "[$lockName] failureCount 업데이트 실패 — 무시됨" } }
+            throw e
+        }
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderGroupElector.kt
@@ -1,0 +1,106 @@
+package io.bluetape4k.leader.local
+
+import io.bluetape4k.idgenerators.uuid.Uuid
+import io.bluetape4k.leader.coroutines.StrategicSuspendLeaderGroupElector
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.GroupElectionStrategy
+import io.bluetape4k.leader.strategy.electValidated
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration
+
+/**
+ * `LocalStrategicSuspendLeaderGroupElector`는 JVM 메모리에서 후보를 등록하고
+ * 전략적으로 여러 leader를 선택하는 coroutine elector입니다.
+ */
+class LocalStrategicSuspendLeaderGroupElector(
+    override val nodeId: String = Uuid.V7.nextIdAsString(),
+) : StrategicSuspendLeaderGroupElector {
+
+    companion object : KLogging()
+
+    private val registry = ConcurrentHashMap<String, ConcurrentHashMap<String, CandidateInfo>>()
+    private val mutexes = ConcurrentHashMap<String, Mutex>()
+
+    private fun candidatesFor(lockName: String): ConcurrentHashMap<String, CandidateInfo> =
+        registry.computeIfAbsent(lockName) { ConcurrentHashMap() }
+
+    private fun mutexFor(lockName: String): Mutex =
+        mutexes.computeIfAbsent(lockName) { Mutex() }
+
+    override suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+        candidatesFor(lockName)[info.nodeId] = info
+    }
+
+    override suspend fun unregisterCandidate(lockName: String, nodeId: String) {
+        candidatesFor(lockName).remove(nodeId)
+    }
+
+    override suspend fun listCandidates(lockName: String): List<CandidateInfo> =
+        candidatesFor(lockName).values.toList()
+
+    override suspend fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
+        candidatesFor(lockName).computeIfPresent(nodeId) { _, current -> current.withResult(result) }
+    }
+
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
+    override suspend fun <T> runIfLeader(
+        lockName: String,
+        strategy: GroupElectionStrategy,
+        maxLeaders: Int,
+        action: suspend () -> T,
+    ): T? {
+        val result = mutexFor(lockName).withLock {
+            val snapshot = listCandidates(lockName)
+            strategy.electValidated(snapshot, maxLeaders)
+        }
+        if (result.winners.isEmpty()) return null
+
+        val total = result.winners.size + result.eliminations.size
+        log.info {
+            "[$lockName] 전략적 그룹 선출: ${result.winners.joinToString { it.nodeId }} " +
+                "(전략: ${strategy::class.simpleName}, 후보: ${total}명)"
+        }
+        if (result.scores.isNotEmpty()) {
+            log.debug {
+                val scoreText = result.scores.entries
+                    .sortedByDescending { it.value }
+                    .joinToString(", ") { (id, score) -> "$id=%.2f".format(score) }
+                "[$lockName] 점수: $scoreText"
+            }
+        }
+        result.eliminations.forEach { elimination ->
+            log.debug { "[$lockName] 탈락: ${elimination.candidate.nodeId} — ${elimination.reason}" }
+        }
+
+        if (result.winners.none { it.nodeId == nodeId }) return null
+
+        return try {
+            val value = action()
+            updateStrategicResultPreservingCancellation(
+                lockName = lockName,
+                result = CandidateResult.SUCCESS,
+                update = { updateResult(lockName, nodeId, CandidateResult.SUCCESS) },
+                onFailure = { exception, message -> log.warn(exception) { message } },
+            )
+            value
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            updateStrategicResultPreservingCancellation(
+                lockName = lockName,
+                result = CandidateResult.FAILURE,
+                update = { updateResult(lockName, nodeId, CandidateResult.FAILURE) },
+                onFailure = { exception, message -> log.warn(exception) { message } },
+            )
+            throw e
+        }
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/GroupElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/GroupElectionStrategy.kt
@@ -1,0 +1,37 @@
+package io.bluetape4k.leader.strategy
+
+import io.bluetape4k.support.requireGe
+
+/**
+ * `GroupElectionStrategy`는 후보 목록에서 전략적으로 복수 leader를 선택합니다.
+ *
+ * `ElectionStrategy`의 단일 승자 계약과 ABI를 유지하기 위해 group 선출은
+ * 별도 계약으로 제공합니다. 반환되는 winner 순서는 선출 우선순위입니다.
+ */
+fun interface GroupElectionStrategy {
+
+    /**
+     * 주어진 후보 목록에서 최대 `maxLeaders`개의 후보를 결정론적으로 선택합니다.
+     *
+     * @param candidates 같은 선출 라운드에서 평가할 후보 목록입니다.
+     * @param maxLeaders 선택할 수 있는 최대 leader 수입니다.
+     * @return winner, elimination, score를 담은 선출 결과입니다.
+     */
+    fun elect(candidates: List<CandidateInfo>, maxLeaders: Int): StrategicGroupElectionResult
+}
+
+/**
+ * 전략을 실행하고 반환 결과를 후보 기준 목록과 함께 검증합니다.
+ *
+ * Local 및 Redis adapter는 이 공통 경계를 사용해 winner/elimination partition,
+ * 후보 ID, `maxLeaders`, score 키 불변식을 동일하게 적용합니다.
+ */
+fun GroupElectionStrategy.electValidated(
+    candidates: List<CandidateInfo>,
+    maxLeaders: Int,
+): StrategicGroupElectionResult {
+    maxLeaders.requireGe(1, "maxLeaders")
+    return elect(candidates, maxLeaders).also {
+        it.validateAgainst(candidates, maxLeaders)
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/StrategicGroupElectionResult.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/StrategicGroupElectionResult.kt
@@ -1,0 +1,27 @@
+package io.bluetape4k.leader.strategy
+
+import java.io.Serializable
+
+/**
+ * `StrategicGroupElectionResult`는 strategic group 선출 결과입니다.
+ *
+ * `winners`는 선출 우선순위가 높은 순서로 정렬되며, `eliminations`는 선택되지
+ * 않은 후보를 담습니다. `scores`는 점수 전략이 계산한 후보별 점수입니다.
+ */
+data class StrategicGroupElectionResult(
+    val winners: List<CandidateInfo>,
+    val eliminations: List<Elimination>,
+    val scores: Map<String, Double> = emptyMap(),
+) : Serializable {
+
+    companion object {
+        private const val serialVersionUID = 1L
+
+        /** 후보가 없어 아무도 선택되지 않은 결과입니다. */
+        @JvmField
+        val EMPTY = StrategicGroupElectionResult(
+            winners = emptyList(),
+            eliminations = emptyList(),
+        )
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/StrategicGroupElectionResultValidation.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/StrategicGroupElectionResultValidation.kt
@@ -1,0 +1,51 @@
+package io.bluetape4k.leader.strategy
+
+import io.bluetape4k.support.requireGe
+
+/**
+ * custom strategy가 반환한 결과를 한 번 읽은 후보 기준 목록과 대조합니다.
+ *
+ * 이 검증은 action을 실행하기 전에 수행해 입력 외 후보, 중복 winner,
+ * winner/elimination 교집합, 누락 후보, N 초과를 설정 오류로 즉시 드러냅니다.
+ */
+internal fun StrategicGroupElectionResult.validateAgainst(
+    candidates: List<CandidateInfo>,
+    maxLeaders: Int,
+) {
+    maxLeaders.requireGe(1, "maxLeaders")
+
+    val candidateIds = candidates.map(CandidateInfo::nodeId)
+    require(candidateIds.size == candidateIds.toSet().size) {
+        "Candidate nodeId must be unique: $candidateIds"
+    }
+    val candidateIdSet = candidateIds.toSet()
+
+    val winnerIds = winners.map(CandidateInfo::nodeId)
+    require(winnerIds.size <= maxLeaders) {
+        "Winner count must not exceed maxLeaders: winners=${winnerIds.size}, maxLeaders=$maxLeaders"
+    }
+    require(winnerIds.size == winnerIds.toSet().size) {
+        "Winner nodeId must be unique: $winnerIds"
+    }
+    require(winnerIds.all(candidateIdSet::contains)) {
+        "Winner nodeId must be present in candidates: $winnerIds"
+    }
+
+    val eliminationIds = eliminations.map { it.candidate.nodeId }
+    require(eliminationIds.size == eliminationIds.toSet().size) {
+        "Elimination nodeId must be unique: $eliminationIds"
+    }
+    require(eliminationIds.all(candidateIdSet::contains)) {
+        "Elimination nodeId must be present in candidates: $eliminationIds"
+    }
+    require(winnerIds.intersect(eliminationIds.toSet()).isEmpty()) {
+        "Winner and elimination nodeId must not overlap: winners=$winnerIds, eliminations=$eliminationIds"
+    }
+    require((winnerIds + eliminationIds).toSet() == candidateIdSet) {
+        "Every candidate must be a winner or elimination: candidates=$candidateIds, " +
+            "winners=$winnerIds, eliminations=$eliminationIds"
+    }
+    require(scores.keys.all(candidateIdSet::contains)) {
+        "Score nodeId must be present in candidates: ${scores.keys}"
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/FifoGroupElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/FifoGroupElectionStrategy.kt
@@ -1,0 +1,38 @@
+package io.bluetape4k.leader.strategy.strategies
+
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.Elimination
+import io.bluetape4k.leader.strategy.GroupElectionStrategy
+import io.bluetape4k.leader.strategy.StrategicGroupElectionResult
+import io.bluetape4k.support.requireGe
+
+/**
+ * `FifoGroupElectionStrategy`는 등록 순서가 빠른 후보부터 최대 N개를 선택합니다.
+ *
+ * `registeredAt`이 같으면 `nodeId` 사전순으로 결과를 고정합니다.
+ */
+object FifoGroupElectionStrategy : GroupElectionStrategy {
+
+    override fun elect(
+        candidates: List<CandidateInfo>,
+        maxLeaders: Int,
+    ): StrategicGroupElectionResult {
+        maxLeaders.requireGe(1, "maxLeaders")
+        if (candidates.isEmpty()) return StrategicGroupElectionResult.EMPTY
+
+        val ordered = candidates.sortedWith(
+            compareBy(CandidateInfo::registeredAt).thenBy(CandidateInfo::nodeId)
+        )
+        val winners = ordered.take(maxLeaders)
+        val boundary = winners.last()
+        val eliminations = ordered.drop(maxLeaders).map { candidate ->
+            val reason = if (candidate.registeredAt > boundary.registeredAt) {
+                "registered later (${candidate.registeredAt} > ${boundary.registeredAt})"
+            } else {
+                "nodeId lexicographically after boundary (${candidate.nodeId} > ${boundary.nodeId})"
+            }
+            Elimination(candidate, reason)
+        }
+        return StrategicGroupElectionResult(winners, eliminations)
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/ScoredGroupElectionStrategy.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/strategy/strategies/ScoredGroupElectionStrategy.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.leader.strategy.strategies
+
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateScorer
+import io.bluetape4k.leader.strategy.Elimination
+import io.bluetape4k.leader.strategy.GroupElectionStrategy
+import io.bluetape4k.leader.strategy.StrategicGroupElectionResult
+import io.bluetape4k.support.requireFinite
+import io.bluetape4k.support.requireGe
+
+/**
+ * `ScoredGroupElectionStrategy`는 후보 점수와 결정론적 tie-break로 최대 N개를 선택합니다.
+ *
+ * 점수는 `CandidateScorer`로 후보마다 한 번 계산하며, 점수 내림차순,
+ * `registeredAt` 오름차순, `nodeId` 사전순으로 결과를 정렬합니다.
+ * @property scorer 후보 점수를 계산하는 전략 객체입니다.
+ */
+class ScoredGroupElectionStrategy(
+    val scorer: CandidateScorer,
+) : GroupElectionStrategy {
+
+    override fun elect(
+        candidates: List<CandidateInfo>,
+        maxLeaders: Int,
+    ): StrategicGroupElectionResult {
+        maxLeaders.requireGe(1, "maxLeaders")
+        if (candidates.isEmpty()) return StrategicGroupElectionResult.EMPTY
+
+        val scores = candidates.associateWith {
+            scorer.score(it, candidates).requireFinite("score") {
+                "Candidate score must be finite: nodeId=${it.nodeId}"
+            }
+        }
+        val ordered = candidates.sortedWith(
+            compareByDescending<CandidateInfo> { scores.getValue(it) }
+                .thenBy(CandidateInfo::registeredAt)
+                .thenBy(CandidateInfo::nodeId)
+        )
+        val winners = ordered.take(maxLeaders)
+        val boundary = winners.last()
+        val boundaryScore = scores.getValue(boundary)
+        val eliminations = ordered.drop(maxLeaders).map { candidate ->
+            val score = scores.getValue(candidate)
+            val reason = if (score < boundaryScore) {
+                "score below boundary (%.2f < %.2f)".format(score, boundaryScore)
+            } else {
+                "tied score — ranked lower by registeredAt/nodeId (score: %.2f)".format(score)
+            }
+            Elimination(candidate, reason)
+        }
+        return StrategicGroupElectionResult(
+            winners = winners,
+            eliminations = eliminations,
+            scores = scores.mapKeys { it.key.nodeId },
+        )
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElectorTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElectorTest.kt
@@ -1,0 +1,115 @@
+package io.bluetape4k.leader.local
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.GroupElectionStrategy
+import io.bluetape4k.leader.strategy.StrategicGroupElectionResult
+import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+class LocalStrategicLeaderGroupElectorTest {
+
+    private val lockName = "strategic-group-" + Base58.randomString(8)
+    private lateinit var node1: LocalStrategicLeaderGroupElector
+    private lateinit var node2: LocalStrategicLeaderGroupElector
+    private lateinit var node3: LocalStrategicLeaderGroupElector
+
+    @BeforeEach
+    fun setup() {
+        node1 = LocalStrategicLeaderGroupElector("node-1")
+        node2 = LocalStrategicLeaderGroupElector("node-2")
+        node3 = LocalStrategicLeaderGroupElector("node-3")
+    }
+
+    private fun registerAll() {
+        val t0 = Instant.parse("2026-01-01T00:00:00Z")
+        val candidates = listOf(
+            CandidateInfo("node-1", registeredAt = t0),
+            CandidateInfo("node-2", registeredAt = t0.plusSeconds(1)),
+            CandidateInfo("node-3", registeredAt = t0.plusSeconds(2)),
+        )
+        listOf(node1, node2, node3).forEach { elector ->
+            candidates.forEach { elector.registerCandidate(lockName, it) }
+        }
+    }
+
+    @Test
+    fun `top two winner만 action을 실행하고 세 번째 node는 null을 반환한다`() {
+        registerAll()
+        val counter = AtomicInteger(0)
+        val r1 = node1.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) { counter.incrementAndGet() }
+        val r2 = node2.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) { counter.incrementAndGet() }
+        val r3 = node3.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) { counter.incrementAndGet() }
+
+        r1 shouldBeEqualTo 1
+        r2 shouldBeEqualTo 2
+        r3.shouldBeNull()
+        counter.get() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `선택되지 않은 node는 successCount를 갱신하지 않는다`() {
+        registerAll()
+        node3.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) {
+            error("실행되면 안 됨")
+        }.shouldBeNull()
+
+        node3.listCandidates(lockName)
+            .first { it.nodeId == node3.nodeId }
+            .successCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `선택된 node의 action 예외는 failureCount를 갱신하고 재전파한다`() {
+        registerAll()
+
+        assertFailsWith<IllegalStateException> {
+            node1.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) {
+                error("boom")
+            }
+        }
+
+        node1.listCandidates(lockName)
+            .first { it.nodeId == node1.nodeId }
+            .failureCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `CancellationException은 결과를 갱신하지 않고 재전파한다`() {
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        assertFailsWith<CancellationException> {
+            node1.runIfLeader(lockName, FifoGroupElectionStrategy) {
+                throw CancellationException("cancel")
+            }
+        }
+
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.successCount shouldBeEqualTo 0L
+        candidate.failureCount shouldBeEqualTo 0L
+        (candidate.lastCompletionTime == null).shouldBeTrue()
+    }
+
+    @Test
+    fun `custom strategy가 후보 기준 목록 밖의 winner를 반환하면 action 전에 거부한다`() {
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+        val invalidStrategy = GroupElectionStrategy { _, _ ->
+            StrategicGroupElectionResult(
+                winners = listOf(CandidateInfo("ghost")),
+                eliminations = emptyList(),
+            )
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            node1.runIfLeader(lockName, invalidStrategy) { error("실행되면 안 됨") }
+        }
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderGroupElectorTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderGroupElectorTest.kt
@@ -1,0 +1,90 @@
+package io.bluetape4k.leader.local
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+class LocalStrategicSuspendLeaderGroupElectorTest {
+
+    private val lockName = "strategic-suspend-group-" + Base58.randomString(8)
+    private lateinit var node1: LocalStrategicSuspendLeaderGroupElector
+    private lateinit var node2: LocalStrategicSuspendLeaderGroupElector
+    private lateinit var node3: LocalStrategicSuspendLeaderGroupElector
+
+    @BeforeEach
+    fun setup() {
+        node1 = LocalStrategicSuspendLeaderGroupElector("node-1")
+        node2 = LocalStrategicSuspendLeaderGroupElector("node-2")
+        node3 = LocalStrategicSuspendLeaderGroupElector("node-3")
+    }
+
+    private suspend fun registerAll() {
+        val t0 = Instant.parse("2026-01-01T00:00:00Z")
+        val candidates = listOf(
+            CandidateInfo("node-1", registeredAt = t0),
+            CandidateInfo("node-2", registeredAt = t0.plusSeconds(1)),
+            CandidateInfo("node-3", registeredAt = t0.plusSeconds(2)),
+        )
+        listOf(node1, node2, node3).forEach { elector ->
+            candidates.forEach { elector.registerCandidate(lockName, it) }
+        }
+    }
+
+    @Test
+    fun `top two coroutine winner만 action을 실행한다`() = runTest {
+        registerAll()
+        val counter = AtomicInteger(0)
+        val results = coroutineScope {
+            listOf(node1, node2, node3).map { elector ->
+                async {
+                    elector.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) {
+                        counter.incrementAndGet()
+                    }
+                }
+            }.awaitAll()
+        }
+
+        results.filterNotNull().size shouldBeEqualTo 2
+        results[2].shouldBeNull()
+        counter.get() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `선택된 coroutine action 예외는 failureCount를 갱신한다`() = runTest {
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        assertFailsWith<IllegalStateException> {
+            node1.runIfLeader(lockName, FifoGroupElectionStrategy) { error("boom") }
+        }
+
+        node1.listCandidates(lockName).single().failureCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `coroutine CancellationException은 failureCount 없이 재전파한다`() = runSuspendIO {
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        assertFailsWith<CancellationException> {
+            node1.runIfLeader(lockName, FifoGroupElectionStrategy) {
+                throw CancellationException("cancel")
+            }
+        }
+
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.successCount shouldBeEqualTo 0L
+        candidate.failureCount shouldBeEqualTo 0L
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/strategy/StrategicGroupElectionStrategyTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/strategy/StrategicGroupElectionStrategyTest.kt
@@ -1,0 +1,116 @@
+package io.bluetape4k.leader.strategy
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import io.bluetape4k.leader.strategy.strategies.ScoredGroupElectionStrategy
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class StrategicGroupElectionStrategyTest {
+
+    private val t0 = Instant.parse("2026-01-01T00:00:00Z")
+
+    private fun candidate(
+        id: String,
+        registeredAt: Instant = t0,
+        successCount: Long = 0,
+        failureCount: Long = 0,
+    ) = CandidateInfo(
+        nodeId = id,
+        registeredAt = registeredAt,
+        successCount = successCount,
+        failureCount = failureCount,
+    )
+
+    @Test
+    fun `FIFO는 maxLeaders 순서대로 winner를 선택하고 나머지를 elimination으로 분리한다`() {
+        val candidates = listOf(
+            candidate("c", t0.plusSeconds(20)),
+            candidate("a", t0),
+            candidate("b", t0.plusSeconds(10)),
+        )
+
+        val result = FifoGroupElectionStrategy.elect(candidates, maxLeaders = 2)
+
+        result.winners.map(CandidateInfo::nodeId) shouldBeEqualTo listOf("a", "b")
+        result.eliminations.map { it.candidate.nodeId } shouldBeEqualTo listOf("c")
+        result.scores.isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun `FIFO는 registeredAt 동률을 nodeId 사전순으로 결정한다`() {
+        val candidates = listOf(
+            candidate("z"),
+            candidate("a"),
+            candidate("m"),
+        )
+
+        val result = FifoGroupElectionStrategy.elect(candidates, maxLeaders = 2)
+
+        result.winners.map(CandidateInfo::nodeId) shouldBeEqualTo listOf("a", "m")
+        result.eliminations.single().candidate.nodeId shouldBeEqualTo "z"
+    }
+
+    @Test
+    fun `후보가 없으면 EMPTY 결과를 반환한다`() {
+        FifoGroupElectionStrategy.elect(emptyList(), maxLeaders = 2) shouldBeEqualTo
+            StrategicGroupElectionResult.EMPTY
+    }
+
+    @Test
+    fun `후보 수가 maxLeaders보다 작으면 모든 후보를 선택한다`() {
+        val candidates = listOf(candidate("a"), candidate("b", t0.plusSeconds(1)))
+
+        val result = FifoGroupElectionStrategy.elect(candidates, maxLeaders = 5)
+
+        result.winners.map(CandidateInfo::nodeId) shouldBeEqualTo listOf("a", "b")
+        result.eliminations.isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun `scored 전략은 score 내림차순 후 등록 시각과 nodeId로 tie-break한다`() {
+        val candidates = listOf(
+            candidate("later", t0.plusSeconds(10), successCount = 10),
+            candidate("tie-b", t0.plusSeconds(5), successCount = 5),
+            candidate("tie-a", t0, successCount = 5),
+        )
+        val strategy = ScoredGroupElectionStrategy(CandidateScorer { it, _ -> it.successCount.toDouble() })
+
+        val result = strategy.elect(candidates, maxLeaders = 2)
+
+        result.winners.map(CandidateInfo::nodeId) shouldBeEqualTo listOf("later", "tie-a")
+        result.eliminations.single().candidate.nodeId shouldBeEqualTo "tie-b"
+        result.scores shouldBeEqualTo mapOf("later" to 10.0, "tie-b" to 5.0, "tie-a" to 5.0)
+    }
+
+    @Test
+    fun `maxLeaders가 0이면 Bluetape 검증 예외를 반환한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            FifoGroupElectionStrategy.elect(listOf(candidate("a")), maxLeaders = 0)
+        }
+    }
+
+    @Test
+    fun `scorer가 NaN을 반환하면 전략을 거부한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            ScoredGroupElectionStrategy(CandidateScorer { _, _ -> Double.NaN })
+                .elect(listOf(candidate("a")), maxLeaders = 1)
+        }
+    }
+
+    @Test
+    fun `electValidated는 결과가 후보 전체를 분할하지 않으면 거부한다`() {
+        val invalidStrategy = GroupElectionStrategy { _, _ ->
+            StrategicGroupElectionResult(
+                winners = listOf(candidate("a")),
+                eliminations = emptyList(),
+            )
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            invalidStrategy.electValidated(listOf(candidate("a"), candidate("b")), maxLeaders = 1)
+        }
+    }
+}

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt
@@ -17,15 +17,23 @@ import kotlin.time.Duration
  */
 internal class LettuceCandidateRegistry(
     private val connection: StatefulRedisConnection<String, String>,
+    private val keyPrefix: String = DEFAULT_KEY_PREFIX,
 ) {
+    /** 기존 internal JVM constructor descriptor를 보존합니다. */
+    internal constructor(connection: StatefulRedisConnection<String, String>) : this(
+        connection,
+        DEFAULT_KEY_PREFIX,
+    )
+
     companion object: KLogging() {
-        private const val KEY_PREFIX = "leader:strategy:candidates"
+        internal const val DEFAULT_KEY_PREFIX = "leader:strategy:candidates"
+        internal const val GROUP_KEY_PREFIX = "leader:strategy:group-candidates:lettuce:v1"
     }
 
     private val sync = connection.sync()
 
     private fun indexKey(lockName: String) =
-        "$KEY_PREFIX:$lockName"
+        "$keyPrefix:$lockName"
 
     private fun candidateKey(lockName: String, nodeId: String) =
         "${indexKey(lockName)}:$nodeId"
@@ -43,8 +51,9 @@ internal class LettuceCandidateRegistry(
         if (ttl == Duration.ZERO) sync.set(key, value)
         else sync.psetex(key, ttl.inWholeMilliseconds, value)
         sync.sadd(indexKey, info.nodeId)
-        if (ttl == Duration.ZERO) sync.persist(indexKey)
-        else sync.pexpire(indexKey, ttl.inWholeMilliseconds)
+        // 후보별 TTL은 candidate key에만 적용한다. index set까지 만료시키면
+        // 유한 TTL 후보가 영구 후보를 같은 lockName에서 가릴 수 있다.
+        sync.persist(indexKey)
     }
 
     /**

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElector.kt
@@ -1,0 +1,93 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.idgenerators.uuid.Uuid
+import io.bluetape4k.leader.StrategicLeaderGroupElector
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.GroupElectionStrategy
+import io.bluetape4k.leader.strategy.electValidated
+import io.bluetape4k.leader.validateLockName
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import io.lettuce.core.api.StatefulRedisConnection
+import kotlinx.coroutines.CancellationException
+import kotlin.time.Duration
+
+/**
+ * `LettuceStrategicLeaderGroupElector`는 Redis Lettuce 후보 기준 목록에서
+ * 결정론적인 top-N leader를 선택하는 blocking API입니다.
+ *
+ * `maxLeaders`는 관찰한 후보 기준 목록의 선택 수이며 전역 동시 실행 상한이 아닙니다.
+ */
+class LettuceStrategicLeaderGroupElector(
+    connection: StatefulRedisConnection<String, String>,
+    override val nodeId: String = Uuid.V7.nextBase62(),
+) : StrategicLeaderGroupElector {
+
+    companion object : KLogging()
+
+    private val registry = LettuceCandidateRegistry(
+        connection,
+        LettuceCandidateRegistry.GROUP_KEY_PREFIX,
+    )
+
+    override fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
+        registry.registerCandidate(lockName, info, ttl)
+
+    override fun unregisterCandidate(lockName: String, nodeId: String) =
+        registry.unregisterCandidate(lockName, nodeId)
+
+    override fun listCandidates(lockName: String): List<CandidateInfo> =
+        registry.listCandidates(lockName)
+
+    override fun updateResult(lockName: String, nodeId: String, result: CandidateResult) =
+        registry.updateResult(lockName, nodeId, result)
+
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
+    override fun <T> runIfLeader(
+        lockName: String,
+        strategy: GroupElectionStrategy,
+        maxLeaders: Int,
+        action: () -> T,
+    ): T? {
+        validateLockName(lockName)
+        val candidates = runCatching { listCandidates(lockName) }
+            .onFailure { log.warn(it) { "[$lockName] 후보 목록 조회 실패 — 전략적 그룹 선출 skip" } }
+            .getOrElse { return null }
+        val result = strategy.electValidated(candidates, maxLeaders)
+        if (result.winners.isEmpty()) return null
+
+        log.info {
+            "[$lockName] 전략적 그룹 선출: ${result.winners.joinToString { it.nodeId }} " +
+                "(전략: ${strategy::class.simpleName}, 후보: ${result.winners.size + result.eliminations.size}명)"
+        }
+        if (result.scores.isNotEmpty()) {
+            log.debug {
+                val scoreText = result.scores.entries
+                    .sortedByDescending { it.value }
+                    .joinToString(", ") { (id, score) -> "$id=%.2f".format(score) }
+                "[$lockName] 점수: $scoreText"
+            }
+        }
+        result.eliminations.forEach { elimination ->
+            log.debug { "[$lockName] 탈락: ${elimination.candidate.nodeId} — ${elimination.reason}" }
+        }
+
+        if (result.winners.none { it.nodeId == nodeId }) return null
+
+        return try {
+            val value = action()
+            runCatching { updateResult(lockName, nodeId, CandidateResult.SUCCESS) }
+                .onFailure { log.warn(it) { "[$lockName] successCount 업데이트 실패 — 무시됨" } }
+            value
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            runCatching { updateResult(lockName, nodeId, CandidateResult.FAILURE) }
+                .onFailure { log.warn(it) { "[$lockName] failureCount 업데이트 실패 — 무시됨" } }
+            throw e
+        }
+    }
+}

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElector.kt
@@ -1,0 +1,109 @@
+@file:OptIn(ExperimentalLettuceCoroutinesApi::class)
+
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.idgenerators.uuid.Uuid
+import io.bluetape4k.leader.coroutines.StrategicSuspendLeaderGroupElector
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.GroupElectionStrategy
+import io.bluetape4k.leader.strategy.electValidated
+import io.bluetape4k.leader.validateLockName
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import io.lettuce.core.ExperimentalLettuceCoroutinesApi
+import io.lettuce.core.api.StatefulRedisConnection
+import kotlinx.coroutines.CancellationException
+import kotlin.time.Duration
+
+/**
+ * `LettuceStrategicSuspendLeaderGroupElector`는 Redis Lettuce 후보 기준 목록에서
+ * 결정론적인 top-N leader를 선택하는 coroutine API입니다.
+ *
+ * `maxLeaders`는 관찰한 후보 기준 목록의 선택 수이며 전역 동시 실행 상한이 아닙니다.
+ */
+class LettuceStrategicSuspendLeaderGroupElector(
+    connection: StatefulRedisConnection<String, String>,
+    override val nodeId: String = Uuid.V7.nextBase62(),
+) : StrategicSuspendLeaderGroupElector {
+
+    companion object : KLogging()
+
+    private val registry = LettuceSuspendCandidateRegistry(
+        connection,
+        LettuceSuspendCandidateRegistry.GROUP_KEY_PREFIX,
+    )
+
+    override suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
+        registry.registerCandidate(lockName, info, ttl)
+
+    override suspend fun unregisterCandidate(lockName: String, nodeId: String) =
+        registry.unregisterCandidate(lockName, nodeId)
+
+    override suspend fun listCandidates(lockName: String): List<CandidateInfo> =
+        registry.listCandidates(lockName)
+
+    override suspend fun updateResult(lockName: String, nodeId: String, result: CandidateResult) =
+        registry.updateResult(lockName, nodeId, result)
+
+    @Suppress("ReturnCount", "TooGenericExceptionCaught", "ThrowsCount")
+    override suspend fun <T> runIfLeader(
+        lockName: String,
+        strategy: GroupElectionStrategy,
+        maxLeaders: Int,
+        action: suspend () -> T,
+    ): T? {
+        validateLockName(lockName)
+        val candidates = try {
+            listCandidates(lockName)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            log.warn(e) { "[$lockName] 후보 목록 조회 실패 — 전략적 그룹 선출 skip" }
+            return null
+        }
+        val result = strategy.electValidated(candidates, maxLeaders)
+        if (result.winners.isEmpty()) return null
+
+        log.info {
+            "[$lockName] 전략적 그룹 선출: ${result.winners.joinToString { it.nodeId }} " +
+                "(전략: ${strategy::class.simpleName}, 후보: ${result.winners.size + result.eliminations.size}명)"
+        }
+        if (result.scores.isNotEmpty()) {
+            log.debug {
+                val scoreText = result.scores.entries
+                    .sortedByDescending { it.value }
+                    .joinToString(", ") { (id, score) -> "$id=%.2f".format(score) }
+                "[$lockName] 점수: $scoreText"
+            }
+        }
+        result.eliminations.forEach { elimination ->
+            log.debug { "[$lockName] 탈락: ${elimination.candidate.nodeId} — ${elimination.reason}" }
+        }
+
+        if (result.winners.none { it.nodeId == nodeId }) return null
+
+        return try {
+            val value = action()
+            updateStrategicResultPreservingCancellation(
+                lockName = lockName,
+                result = CandidateResult.SUCCESS,
+                update = { updateResult(lockName, nodeId, CandidateResult.SUCCESS) },
+                onFailure = { exception, message -> log.warn(exception) { message } },
+            )
+            value
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            updateStrategicResultPreservingCancellation(
+                lockName = lockName,
+                result = CandidateResult.FAILURE,
+                update = { updateResult(lockName, nodeId, CandidateResult.FAILURE) },
+                onFailure = { exception, message -> log.warn(exception) { message } },
+            )
+            throw e
+        }
+    }
+}

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt
@@ -23,15 +23,23 @@ import kotlin.time.Duration
  */
 internal class LettuceSuspendCandidateRegistry(
     connection: StatefulRedisConnection<String, String>,
+    private val keyPrefix: String = DEFAULT_KEY_PREFIX,
 ) {
+    /** 기존 internal JVM constructor descriptor를 보존합니다. */
+    internal constructor(connection: StatefulRedisConnection<String, String>) : this(
+        connection,
+        DEFAULT_KEY_PREFIX,
+    )
+
     companion object: KLogging() {
-        private const val KEY_PREFIX = "leader:strategy:candidates"
+        internal const val DEFAULT_KEY_PREFIX = "leader:strategy:candidates"
+        internal const val GROUP_KEY_PREFIX = "leader:strategy:group-candidates:lettuce:v1"
     }
 
     private val cmds: RedisCoroutinesCommands<String, String> = connection.coroutines()
 
     private fun indexKey(lockName: String) =
-        "$KEY_PREFIX:$lockName"
+        "$keyPrefix:$lockName"
 
     private fun candidateKey(lockName: String, nodeId: String) =
         "${indexKey(lockName)}:$nodeId"
@@ -49,8 +57,9 @@ internal class LettuceSuspendCandidateRegistry(
         if (ttl == Duration.ZERO) cmds.set(key, value)
         else cmds.psetex(key, ttl.inWholeMilliseconds, value)
         cmds.sadd(indexKey, info.nodeId)
-        if (ttl == Duration.ZERO) cmds.persist(indexKey)
-        else cmds.pexpire(indexKey, ttl.inWholeMilliseconds)
+        // 후보별 TTL은 candidate key에만 적용한다. index set까지 만료시키면
+        // 유한 TTL 후보가 영구 후보를 같은 lockName에서 가릴 수 있다.
+        cmds.persist(indexKey)
     }
 
     /**

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElectorTest.kt
@@ -1,0 +1,105 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.GroupElectionStrategy
+import io.bluetape4k.leader.strategy.StrategicGroupElectionResult
+import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import org.awaitility.kotlin.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class LettuceStrategicLeaderGroupElectorTest : AbstractLettuceLeaderTest() {
+
+    private lateinit var node1: LettuceStrategicLeaderGroupElector
+    private lateinit var node2: LettuceStrategicLeaderGroupElector
+    private lateinit var node3: LettuceStrategicLeaderGroupElector
+
+    @BeforeEach
+    fun setup() {
+        node1 = LettuceStrategicLeaderGroupElector(connection, "node-1")
+        node2 = LettuceStrategicLeaderGroupElector(connection, "node-2")
+        node3 = LettuceStrategicLeaderGroupElector(connection, "node-3")
+    }
+
+    @Test
+    fun `top two Redis winner만 action을 실행한다`() {
+        val lockName = randomName()
+        val t0 = Instant.parse("2026-01-01T00:00:00Z")
+        val candidates = listOf(
+            CandidateInfo("node-1", registeredAt = t0),
+            CandidateInfo("node-2", registeredAt = t0.plusSeconds(1)),
+            CandidateInfo("node-3", registeredAt = t0.plusSeconds(2)),
+        )
+        listOf(node1, node2, node3).forEach { elector ->
+            candidates.forEach { elector.registerCandidate(lockName, it) }
+        }
+
+        val counter = AtomicInteger(0)
+        node1.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) { counter.incrementAndGet() }
+            .shouldNotBeNull()
+        node2.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) { counter.incrementAndGet() }
+            .shouldNotBeNull()
+        node3.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) { counter.incrementAndGet() }
+            .shouldBeNull()
+
+        counter.get() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `Redis candidate TTL은 strategic group 실행 후에도 유지된다`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId), 500.milliseconds)
+        node1.runIfLeader(lockName, FifoGroupElectionStrategy) { "ok" }
+
+        node1.listCandidates(lockName).size shouldBeEqualTo 1
+        await.atMost(2.seconds).withPollInterval(50.milliseconds)
+            .until { node1.listCandidates(lockName).isEmpty() }
+    }
+
+    @Test
+    fun `strategic single과 group 후보 레지스트리는 key namespace를 공유하지 않는다`() {
+        val lockName = randomName()
+        val single = LettuceStrategicLeaderElector(connection, "single-node")
+        single.registerCandidate(lockName, CandidateInfo("single-node"))
+        node1.registerCandidate(lockName, CandidateInfo("group-node"))
+
+        single.listCandidates(lockName).map { it.nodeId } shouldBeEqualTo listOf("single-node")
+        node1.listCandidates(lockName).map { it.nodeId } shouldBeEqualTo listOf("group-node")
+    }
+
+    @Test
+    fun `영구 후보는 유한 TTL 후보 만료 후에도 조회된다`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("persistent-node"))
+        node1.registerCandidate(lockName, CandidateInfo("finite-node"), 300.milliseconds)
+
+        await.atMost(2.seconds).withPollInterval(50.milliseconds)
+            .until {
+                node1.listCandidates(lockName).map { it.nodeId } == listOf("persistent-node")
+            }
+    }
+
+    @Test
+    fun `custom strategy가 후보 기준 목록 밖 winner를 반환하면 action 전에 거부한다`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+        val invalidStrategy = GroupElectionStrategy { _, _ ->
+            StrategicGroupElectionResult(
+                winners = listOf(CandidateInfo("ghost")),
+                eliminations = emptyList(),
+            )
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            node1.runIfLeader(lockName, invalidStrategy) { error("실행되면 안 됨") }
+        }
+    }
+}

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElectorTest.kt
@@ -1,0 +1,96 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.awaitility.untilSuspending
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.GroupElectionStrategy
+import io.bluetape4k.leader.strategy.StrategicGroupElectionResult
+import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import org.awaitility.kotlin.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class LettuceStrategicSuspendLeaderGroupElectorTest : AbstractLettuceLeaderTest() {
+
+    private lateinit var node1: LettuceStrategicSuspendLeaderGroupElector
+    private lateinit var node2: LettuceStrategicSuspendLeaderGroupElector
+    private lateinit var node3: LettuceStrategicSuspendLeaderGroupElector
+
+    @BeforeEach
+    fun setup() {
+        node1 = LettuceStrategicSuspendLeaderGroupElector(connection, "node-1")
+        node2 = LettuceStrategicSuspendLeaderGroupElector(connection, "node-2")
+        node3 = LettuceStrategicSuspendLeaderGroupElector(connection, "node-3")
+    }
+
+    @Test
+    fun `top two Redis coroutine winner만 action을 실행한다`() = runSuspendIO {
+        val lockName = randomName()
+        val t0 = Instant.parse("2026-01-01T00:00:00Z")
+        val candidates = listOf(
+            CandidateInfo("node-1", registeredAt = t0),
+            CandidateInfo("node-2", registeredAt = t0.plusSeconds(1)),
+            CandidateInfo("node-3", registeredAt = t0.plusSeconds(2)),
+        )
+        listOf(node1, node2, node3).forEach { elector ->
+            candidates.forEach { elector.registerCandidate(lockName, it) }
+        }
+
+        val counter = AtomicInteger(0)
+        node1.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) { counter.incrementAndGet() }
+            .shouldNotBeNull()
+        node2.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) { counter.incrementAndGet() }
+            .shouldNotBeNull()
+        node3.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) { counter.incrementAndGet() }
+            .shouldBeNull()
+
+        counter.get() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `Redis coroutine candidate TTL은 실행 후에도 유지된다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId), 500.milliseconds)
+        node1.runIfLeader(lockName, FifoGroupElectionStrategy) { "ok" }
+
+        node1.listCandidates(lockName).size shouldBeEqualTo 1
+        await.atMost(2.seconds).withPollInterval(50.milliseconds) untilSuspending {
+            node1.listCandidates(lockName).isEmpty()
+        }
+    }
+
+    @Test
+    fun `영구 후보는 유한 TTL 후보 만료 후에도 조회된다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("persistent-node"))
+        node1.registerCandidate(lockName, CandidateInfo("finite-node"), 300.milliseconds)
+
+        await.atMost(2.seconds).withPollInterval(50.milliseconds) untilSuspending {
+            node1.listCandidates(lockName).map { it.nodeId } == listOf("persistent-node")
+        }
+    }
+
+    @Test
+    fun `custom strategy가 후보 기준 목록 밖 winner를 반환하면 action 전에 거부한다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+        val invalidStrategy = GroupElectionStrategy { _, _ ->
+            StrategicGroupElectionResult(
+                winners = listOf(CandidateInfo("ghost")),
+                eliminations = emptyList(),
+            )
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            node1.runIfLeader(lockName, invalidStrategy) { error("실행되면 안 됨") }
+        }
+    }
+}

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
@@ -15,11 +15,22 @@ import java.util.concurrent.TimeUnit
  * 정상 lock contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.
  * @property redissonClient Redis Redisson backend 호출과 상태 계산에 사용하는 속성입니다.
  */
-internal class RedissonCandidateRegistry(private val redissonClient: RedissonClient) {
+internal class RedissonCandidateRegistry(
+    private val redissonClient: RedissonClient,
+    private val keyPrefix: String = DEFAULT_KEY_PREFIX,
+) {
+    /** 기존 internal JVM constructor descriptor를 보존합니다. */
+    internal constructor(redissonClient: RedissonClient) : this(
+        redissonClient,
+        DEFAULT_KEY_PREFIX,
+    )
 
-    companion object: KLogging()
+    companion object: KLogging() {
+        internal const val DEFAULT_KEY_PREFIX = "leader:strategy:candidates"
+        internal const val GROUP_KEY_PREFIX = "leader:strategy:group-candidates:redisson:v1"
+    }
 
-    private fun cacheKey(lockName: String) = "leader:strategy:candidates:$lockName"
+    private fun cacheKey(lockName: String) = "$keyPrefix:$lockName"
 
     private fun mapCacheFor(lockName: String) =
         redissonClient.getMapCache<String, CandidateInfo>(cacheKey(lockName))

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElector.kt
@@ -1,0 +1,91 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.idgenerators.uuid.Uuid
+import io.bluetape4k.leader.StrategicLeaderGroupElector
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.GroupElectionStrategy
+import io.bluetape4k.leader.strategy.electValidated
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import kotlinx.coroutines.CancellationException
+import org.redisson.api.RedissonClient
+import kotlin.time.Duration
+
+/**
+ * `RedissonStrategicLeaderGroupElector`는 Redis Redisson 후보 기준 목록에서
+ * 결정론적인 top-N leader를 선택하는 blocking API입니다.
+ *
+ * `maxLeaders`는 관찰한 후보 기준 목록의 선택 수이며 전역 동시 실행 상한이 아닙니다.
+ */
+class RedissonStrategicLeaderGroupElector(
+    redissonClient: RedissonClient,
+    override val nodeId: String = Uuid.V7.nextBase62(),
+) : StrategicLeaderGroupElector {
+
+    companion object : KLogging()
+
+    private val registry = RedissonCandidateRegistry(
+        redissonClient,
+        RedissonCandidateRegistry.GROUP_KEY_PREFIX,
+    )
+
+    override fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
+        registry.registerCandidate(lockName, info, ttl)
+
+    override fun unregisterCandidate(lockName: String, nodeId: String) =
+        registry.unregisterCandidate(lockName, nodeId)
+
+    override fun listCandidates(lockName: String): List<CandidateInfo> =
+        registry.listCandidates(lockName)
+
+    override fun updateResult(lockName: String, nodeId: String, result: CandidateResult) =
+        registry.updateResult(lockName, nodeId, result)
+
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
+    override fun <T> runIfLeader(
+        lockName: String,
+        strategy: GroupElectionStrategy,
+        maxLeaders: Int,
+        action: () -> T,
+    ): T? {
+        val candidates = runCatching { listCandidates(lockName) }
+            .onFailure { log.warn(it) { "[$lockName] 후보 목록 조회 실패 — 전략적 그룹 선출 skip" } }
+            .getOrElse { return null }
+        val result = strategy.electValidated(candidates, maxLeaders)
+        if (result.winners.isEmpty()) return null
+
+        log.info {
+            "[$lockName] 전략적 그룹 선출: ${result.winners.joinToString { it.nodeId }} " +
+                "(전략: ${strategy::class.simpleName}, 후보: ${result.winners.size + result.eliminations.size}명)"
+        }
+        if (result.scores.isNotEmpty()) {
+            log.debug {
+                val scoreText = result.scores.entries
+                    .sortedByDescending { it.value }
+                    .joinToString(", ") { (id, score) -> "$id=%.2f".format(score) }
+                "[$lockName] 점수: $scoreText"
+            }
+        }
+        result.eliminations.forEach { elimination ->
+            log.debug { "[$lockName] 탈락: ${elimination.candidate.nodeId} — ${elimination.reason}" }
+        }
+
+        if (result.winners.none { it.nodeId == nodeId }) return null
+
+        return try {
+            val value = action()
+            runCatching { updateResult(lockName, nodeId, CandidateResult.SUCCESS) }
+                .onFailure { log.warn(it) { "[$lockName] successCount 업데이트 실패 — 무시됨" } }
+            value
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            runCatching { updateResult(lockName, nodeId, CandidateResult.FAILURE) }
+                .onFailure { log.warn(it) { "[$lockName] failureCount 업데이트 실패 — 무시됨" } }
+            throw e
+        }
+    }
+}

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElector.kt
@@ -1,0 +1,106 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.idgenerators.uuid.Uuid
+import io.bluetape4k.leader.coroutines.StrategicSuspendLeaderGroupElector
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.GroupElectionStrategy
+import io.bluetape4k.leader.strategy.electValidated
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.info
+import io.bluetape4k.logging.warn
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.redisson.api.RedissonClient
+import kotlin.time.Duration
+
+/**
+ * `RedissonStrategicSuspendLeaderGroupElector`는 Redis Redisson 후보 기준 목록에서
+ * 결정론적인 top-N leader를 선택하는 coroutine API입니다.
+ *
+ * `maxLeaders`는 관찰한 후보 기준 목록의 선택 수이며 전역 동시 실행 상한이 아닙니다.
+ */
+class RedissonStrategicSuspendLeaderGroupElector(
+    redissonClient: RedissonClient,
+    override val nodeId: String = Uuid.V7.nextBase62(),
+) : StrategicSuspendLeaderGroupElector {
+
+    companion object : KLogging()
+
+    private val registry = RedissonCandidateRegistry(
+        redissonClient,
+        RedissonCandidateRegistry.GROUP_KEY_PREFIX,
+    )
+
+    override suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
+        withContext(Dispatchers.IO) { registry.registerCandidate(lockName, info, ttl) }
+
+    override suspend fun unregisterCandidate(lockName: String, nodeId: String) =
+        withContext(Dispatchers.IO) { registry.unregisterCandidate(lockName, nodeId) }
+
+    override suspend fun listCandidates(lockName: String): List<CandidateInfo> =
+        withContext(Dispatchers.IO) { registry.listCandidates(lockName) }
+
+    override suspend fun updateResult(lockName: String, nodeId: String, result: CandidateResult) =
+        withContext(Dispatchers.IO) { registry.updateResult(lockName, nodeId, result) }
+
+    @Suppress("ReturnCount", "TooGenericExceptionCaught", "ThrowsCount")
+    override suspend fun <T> runIfLeader(
+        lockName: String,
+        strategy: GroupElectionStrategy,
+        maxLeaders: Int,
+        action: suspend () -> T,
+    ): T? {
+        val candidates = try {
+            listCandidates(lockName)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            log.warn(e) { "[$lockName] 후보 목록 조회 실패 — 전략적 그룹 선출 skip" }
+            return null
+        }
+        val result = strategy.electValidated(candidates, maxLeaders)
+        if (result.winners.isEmpty()) return null
+
+        log.info {
+            "[$lockName] 전략적 그룹 선출: ${result.winners.joinToString { it.nodeId }} " +
+                "(전략: ${strategy::class.simpleName}, 후보: ${result.winners.size + result.eliminations.size}명)"
+        }
+        if (result.scores.isNotEmpty()) {
+            log.debug {
+                val scoreText = result.scores.entries
+                    .sortedByDescending { it.value }
+                    .joinToString(", ") { (id, score) -> "$id=%.2f".format(score) }
+                "[$lockName] 점수: $scoreText"
+            }
+        }
+        result.eliminations.forEach { elimination ->
+            log.debug { "[$lockName] 탈락: ${elimination.candidate.nodeId} — ${elimination.reason}" }
+        }
+
+        if (result.winners.none { it.nodeId == nodeId }) return null
+
+        return try {
+            val value = action()
+            updateStrategicResultPreservingCancellation(
+                lockName = lockName,
+                result = CandidateResult.SUCCESS,
+                update = { updateResult(lockName, nodeId, CandidateResult.SUCCESS) },
+                onFailure = { exception, message -> log.warn(exception) { message } },
+            )
+            value
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            updateStrategicResultPreservingCancellation(
+                lockName = lockName,
+                result = CandidateResult.FAILURE,
+                update = { updateResult(lockName, nodeId, CandidateResult.FAILURE) },
+                onFailure = { exception, message -> log.warn(exception) { message } },
+            )
+            throw e
+        }
+    }
+}

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElectorTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElectorTest.kt
@@ -1,0 +1,105 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.GroupElectionStrategy
+import io.bluetape4k.leader.strategy.StrategicGroupElectionResult
+import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import org.awaitility.kotlin.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class RedissonStrategicLeaderGroupElectorTest : AbstractRedissonLeaderTest() {
+
+    private lateinit var node1: RedissonStrategicLeaderGroupElector
+    private lateinit var node2: RedissonStrategicLeaderGroupElector
+    private lateinit var node3: RedissonStrategicLeaderGroupElector
+
+    @BeforeEach
+    fun setup() {
+        node1 = RedissonStrategicLeaderGroupElector(redissonClient, "node-1")
+        node2 = RedissonStrategicLeaderGroupElector(redissonClient, "node-2")
+        node3 = RedissonStrategicLeaderGroupElector(redissonClient, "node-3")
+    }
+
+    @Test
+    fun `top two Redisson winner만 action을 실행한다`() {
+        val lockName = randomName()
+        val t0 = Instant.parse("2026-01-01T00:00:00Z")
+        val candidates = listOf(
+            CandidateInfo("node-1", registeredAt = t0),
+            CandidateInfo("node-2", registeredAt = t0.plusSeconds(1)),
+            CandidateInfo("node-3", registeredAt = t0.plusSeconds(2)),
+        )
+        listOf(node1, node2, node3).forEach { elector ->
+            candidates.forEach { elector.registerCandidate(lockName, it) }
+        }
+
+        val counter = AtomicInteger(0)
+        node1.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) { counter.incrementAndGet() }
+            .shouldNotBeNull()
+        node2.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) { counter.incrementAndGet() }
+            .shouldNotBeNull()
+        node3.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) { counter.incrementAndGet() }
+            .shouldBeNull()
+
+        counter.get() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `Redisson candidate TTL은 strategic group 실행 후에도 유지된다`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId), 500.milliseconds)
+        node1.runIfLeader(lockName, FifoGroupElectionStrategy) { "ok" }
+
+        node1.listCandidates(lockName).size shouldBeEqualTo 1
+        await.atMost(2.seconds).withPollInterval(50.milliseconds)
+            .until { node1.listCandidates(lockName).isEmpty() }
+    }
+
+    @Test
+    fun `strategic single과 group 후보 레지스트리는 key namespace를 공유하지 않는다`() {
+        val lockName = randomName()
+        val single = RedissonStrategicLeaderElector(redissonClient, "single-node")
+        single.registerCandidate(lockName, CandidateInfo("single-node"))
+        node1.registerCandidate(lockName, CandidateInfo("group-node"))
+
+        single.listCandidates(lockName).map { it.nodeId } shouldBeEqualTo listOf("single-node")
+        node1.listCandidates(lockName).map { it.nodeId } shouldBeEqualTo listOf("group-node")
+    }
+
+    @Test
+    fun `Redisson 영구 후보는 유한 TTL 후보 만료 후에도 조회된다`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("persistent-node"))
+        node1.registerCandidate(lockName, CandidateInfo("finite-node"), 300.milliseconds)
+
+        await.atMost(2.seconds).withPollInterval(50.milliseconds)
+            .until {
+                node1.listCandidates(lockName).map { it.nodeId } == listOf("persistent-node")
+            }
+    }
+
+    @Test
+    fun `custom strategy가 후보 기준 목록 밖 winner를 반환하면 action 전에 거부한다`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+        val invalidStrategy = GroupElectionStrategy { _, _ ->
+            StrategicGroupElectionResult(
+                winners = listOf(CandidateInfo("ghost")),
+                eliminations = emptyList(),
+            )
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            node1.runIfLeader(lockName, invalidStrategy) { error("실행되면 안 됨") }
+        }
+    }
+}

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElectorTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElectorTest.kt
@@ -1,0 +1,97 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.awaitility.untilSuspending
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.GroupElectionStrategy
+import io.bluetape4k.leader.strategy.StrategicGroupElectionResult
+import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import org.awaitility.kotlin.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class RedissonStrategicSuspendLeaderGroupElectorTest : AbstractRedissonLeaderTest() {
+
+    private lateinit var node1: RedissonStrategicSuspendLeaderGroupElector
+    private lateinit var node2: RedissonStrategicSuspendLeaderGroupElector
+    private lateinit var node3: RedissonStrategicSuspendLeaderGroupElector
+
+    @BeforeEach
+    fun setup() {
+        node1 = RedissonStrategicSuspendLeaderGroupElector(redissonClient, "node-1")
+        node2 = RedissonStrategicSuspendLeaderGroupElector(redissonClient, "node-2")
+        node3 = RedissonStrategicSuspendLeaderGroupElector(redissonClient, "node-3")
+    }
+
+    @Test
+    fun `top two Redisson coroutine winner만 action을 실행한다`() = runSuspendIO {
+        val lockName = randomName()
+        val t0 = Instant.parse("2026-01-01T00:00:00Z")
+        val candidates = listOf(
+            CandidateInfo("node-1", registeredAt = t0),
+            CandidateInfo("node-2", registeredAt = t0.plusSeconds(1)),
+            CandidateInfo("node-3", registeredAt = t0.plusSeconds(2)),
+        )
+        listOf(node1, node2, node3).forEach { elector ->
+            candidates.forEach { elector.registerCandidate(lockName, it) }
+        }
+
+        val counter = AtomicInteger(0)
+        node1.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) { counter.incrementAndGet() }
+            .shouldNotBeNull()
+        node2.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) { counter.incrementAndGet() }
+            .shouldNotBeNull()
+        node3.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) { counter.incrementAndGet() }
+            .shouldBeNull()
+
+        counter.get() shouldBeEqualTo 2
+    }
+
+    @Test
+    fun `Redisson coroutine candidate TTL은 실행 후에도 유지된다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId), 500.milliseconds)
+        node1.runIfLeader(lockName, FifoGroupElectionStrategy) { "ok" }
+
+        node1.listCandidates(lockName).size shouldBeEqualTo 1
+        await.atMost(2.seconds).withPollInterval(50.milliseconds) untilSuspending {
+            node1.listCandidates(lockName).isEmpty()
+            }
+    }
+
+    @Test
+    fun `Redisson coroutine 영구 후보는 유한 TTL 후보 만료 후에도 조회된다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("persistent-node"))
+        node1.registerCandidate(lockName, CandidateInfo("finite-node"), 300.milliseconds)
+
+        await.atMost(2.seconds).withPollInterval(50.milliseconds)
+            .untilSuspending {
+                node1.listCandidates(lockName).map { it.nodeId } == listOf("persistent-node")
+            }
+    }
+
+    @Test
+    fun `custom strategy가 후보 기준 목록 밖 winner를 반환하면 action 전에 거부한다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+        val invalidStrategy = GroupElectionStrategy { _, _ ->
+            StrategicGroupElectionResult(
+                winners = listOf(CandidateInfo("ghost")),
+                eliminations = emptyList(),
+            )
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            node1.runIfLeader(lockName, invalidStrategy) { error("실행되면 안 됨") }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #463

전략적 후보 목록에서 deterministic top-N leader를 선택하는 blocking/coroutine API를 추가합니다. 기존 `LeaderGroupElector`의 전역 distributed slot claim과 `StrategicLeaderElector`의 단일 winner 계약은 그대로 유지합니다.

## Work Done

- core에 `StrategicLeaderGroupElector`, `StrategicSuspendLeaderGroupElector`, `GroupElectionStrategy`, `StrategicGroupElectionResult`를 추가했습니다.
- FIFO/scored built-in strategy와 `GroupElectionStrategy.electValidated` 공통 검증 경계를 추가했습니다.
- Local, Redis Lettuce, Redis Redisson의 blocking/coroutine adapter를 추가했습니다.
- Lettuce/Redisson strategic group namespace를 backend/schema별 `v1` key로 분리했습니다.
- Lettuce index 수명과 candidate TTL을 분리하고, Redisson 결과 갱신에서 잔여 TTL을 보존했습니다.
- custom winner 검증, mixed-TTL, namespace, 결과 갱신, cancellation 경계 회귀를 추가했습니다.
- README 두 locale, 설계/계획, review artifact, lessons를 갱신했습니다.

## Contract Notes

- `maxLeaders`는 관찰한 후보 기준 목록의 advisory top-N이며 전역 분산 동시 실행 상한이 아닙니다.
- 전역 slot claim과 fencing이 필요한 작업은 기존 `LeaderGroupElector`를 사용합니다.
- 점수는 bluetape4k-core의 `Double.requireFinite`로 fail-closed 검증합니다.

## Validation

- Core strategic/local regression: PASS (49 tests)
- Lettuce strategic single/group blocking/coroutine Testcontainers suite: PASS (51 tests)
- Redisson strategic single/group blocking/coroutine Testcontainers suite: PASS (41 tests)
- Existing Local group regression: PASS (23 tests)
- `./gradlew detekt --no-configuration-cache --max-workers=1`: PASS
- affected module build (`core`, `redis-lettuce`, `redis-redisson`, `-x test`): PASS
- `ABI_BASE_VERSION=0.5.0 ABI_CURRENT_VERSION=1.0.0 ./gradlew checkBinaryCompatibility --no-configuration-cache --max-workers=1`: PASS (`unknown=0`)
- `git diff --check`: PASS
- `audit-korean-terms.mjs README.ko.md`: PASS (`findings=0`)

Redis checks used healthy Colima/Testcontainers with `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock`.

## Review Notes

- 독립 spec review: ACCEPT, P0/P1 0건
- 독립 architecture review: APPROVE, P0/P1 0건
- 독립 code review: APPROVE, P0/P1 0건
- P2 WATCH: Local snapshot 약한 일관성, Redis read-modify-write 경쟁, Redis coroutine 실제 cancellation/result 갱신 회귀 보강, public result ABI 확장 주의
- 단일 개발자 범위에서 별도 human review는 필요하지 않습니다.

## Metadata

- Issue: #463, milestone `1.0.0`, assignee `debop`
- Head: `e88321b5221338790bd5d98a9e61ee97075f6817`
- Base: `develop` (`668732cc0b49497c6bc15e2fe7471bbfa7818198`)
- Branch: `design/epic-strategic-01-api`
- Workflow: Type A completion `complete=true`, required components/checks/main verification complete

## DoD Status

Required checks: 17/17; Blocked: 0; P0/P1: 0

| Check | Status | Evidence | Next action |
|---|---|---|---|
| Approved spec/plan and TDD implementation | PASS | docs/specs, docs/plans, core/Local tests | none |
| Backend adapter and schema/TTL isolation | PASS | Lettuce 51, Redisson 41, mixed-TTL/namespace tests | none |
| Static/build/ABI verification | PASS | detekt, affected builds, ABI `unknown=0` | none |
| Independent review | PASS | spec/architect/code-review artifacts, P0/P1 0 | none |
| Exact-head PR CI/review readback | PASS | PR #783 head `e88321b5`, hosted run `32863369989` 47/47 PASS, reviews/threads 0건 | none |
| Fresh merge approval and merge | PENDING | separate gate | request approval after CI green |

Final status: MERGE-READY; fresh merge approval remains separate.
