### PR TITLE
refactor(leader-dynamodb): bluetape4k Uuid.V4로 owner ID 생성 표준화

### DIFF
--- a/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/internal/DynamoDbLockClient.kt
+++ b/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/internal/DynamoDbLockClient.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.leader.dynamodb.internal
 
+import io.bluetape4k.idgenerators.uuid.Uuid
 import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.LeaderLease
 import io.bluetape4k.leader.LeaderState
@@ -18,7 +19,6 @@ import software.amazon.awssdk.services.dynamodb.model.KeysAndAttributes
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest
 import java.time.Instant
-import java.util.UUID
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 import kotlin.math.ceil
@@ -54,7 +54,7 @@ internal class DynamoDbLockClient(
         private const val TtlAttr = "#ttl"
         private const val BatchGetLimit = 100
 
-        fun newOwnerId(): String = UUID.randomUUID().toString()
+        fun newOwnerId(): String = Uuid.V4.nextUUID().toString()
     }
 
     /**

--- a/leader-dynamodb/src/test/kotlin/io/bluetape4k/leader/dynamodb/internal/DynamoDbLockClientOwnerIdTest.kt
+++ b/leader-dynamodb/src/test/kotlin/io/bluetape4k/leader/dynamodb/internal/DynamoDbLockClientOwnerIdTest.kt
@@ -43,8 +43,10 @@ class DynamoDbLockClientOwnerIdTest {
         // Then
         ownerIds shouldHaveSize sampleSize
         ownerIds.toSet() shouldHaveSize sampleSize
-        ownerIds.map(UUID::fromString).forEach { ownerId ->
-            ownerId.version() shouldBeEqualTo 4
+        ownerIds.forEach { ownerId ->
+            val parsed = UUID.fromString(ownerId)
+            ownerId shouldBeEqualTo parsed.toString()
+            parsed.version() shouldBeEqualTo 4
         }
     }
 }

--- a/leader-dynamodb/src/test/kotlin/io/bluetape4k/leader/dynamodb/internal/DynamoDbLockClientOwnerIdTest.kt
+++ b/leader-dynamodb/src/test/kotlin/io/bluetape4k/leader/dynamodb/internal/DynamoDbLockClientOwnerIdTest.kt
@@ -1,0 +1,50 @@
+package io.bluetape4k.leader.dynamodb.internal
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.idgenerators.uuid.Uuid
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import java.util.UUID
+import org.junit.jupiter.api.Test
+
+class DynamoDbLockClientOwnerIdTest {
+
+    @Test
+    fun `new owner id delegates to bluetape4k UUID v4 generator`() {
+        // Given
+        val expected = UUID.fromString("123e4567-e89b-42d3-a456-426614174000")
+        mockkObject(Uuid.V4)
+
+        try {
+            every { Uuid.V4.nextUUID() } returns expected
+
+            // When
+            val ownerId = DynamoDbLockClient.newOwnerId()
+
+            // Then
+            ownerId shouldBeEqualTo expected.toString()
+            verify(exactly = 1) { Uuid.V4.nextUUID() }
+        } finally {
+            unmockkObject(Uuid.V4)
+        }
+    }
+
+    @Test
+    fun `new owner ids preserve canonical UUID v4 format and remain unique`() {
+        // Given
+        val sampleSize = 256
+
+        // When
+        val ownerIds = List(sampleSize) { DynamoDbLockClient.newOwnerId() }
+
+        // Then
+        ownerIds shouldHaveSize sampleSize
+        ownerIds.toSet() shouldHaveSize sampleSize
+        ownerIds.map(UUID::fromString).forEach { ownerId ->
+            ownerId.version() shouldBeEqualTo 4
+        }
+    }
+}


### PR DESCRIPTION
## 요약

Issue #771의 DynamoDB owner ID 생성 정책을 bluetape4k `idgenerators` 표준으로 정렬하고, 승인된 exact head를 `develop`에 squash merge했습니다. 기존 UUID 문자열 호환성과 conditional owner 비교 계약은 유지됩니다.

## 배경

Epic #775의 LEAD-06 stacked train slot입니다. 기존 DynamoDB 구현만 JDK `UUID.randomUUID()`를 직접 사용해 ecosystem generator 정책과 불일치했습니다.

## 해결 내용

- `DynamoDbLockClient.newOwnerId()`를 `Uuid.V4.nextUUID().toString()`으로 전환했습니다.
- `bluetape4k.assertions` 기반 테스트로 generator 위임, canonical UUID round-trip, UUID v4 형식, 256개 uniqueness를 고정했습니다.
- 기존 DynamoDB lock protocol, schema, public API, conditional expression은 변경하지 않았습니다.

## 검증

- `./gradlew :bluetape4k-leader-dynamodb:test --tests 'io.bluetape4k.leader.dynamodb.internal.DynamoDbLockClientOwnerIdTest'`: PASS (2/2)
- `./gradlew :bluetape4k-leader-dynamodb:test --rerun-tasks`: PASS (21 suites, 119/119; skipped/failures/errors 0)
- `./gradlew :bluetape4k-leader-dynamodb:check`: PASS
- `./gradlew :bluetape4k-leader-dynamodb:detekt --rerun-tasks`: PASS
- `git diff --check`: PASS
- pre-merge hosted CI [run 32941689490](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32941689490): PASS (12 success, 35 intended skips, 0 failures)
- post-merge [Develop CI run 32944767931](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32944767931): PASS (12 success, 35 path-scoped skips, 0 failures)
- post-merge [Dependency Submission run 32944767903](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32944767903): PASS

## 7-Tier review

- 독립 architecture review: `CLEAR`
- 독립 code review: `APPROVE`
- P0/P1/P2/P3: 0
- transitive `idgenerators` dependency 관찰은 비차단 P3로 기록했습니다.
- 1인 개발자 lane의 live human review는 N/A이며, reviews/comments/thread는 0이고 independent review와 exact-head CI는 통과했습니다.

## 메타데이터

- 관련 이슈: #771, Epic: #775, Train: LEAD-06
- milestone: `1.0.0`, assignee: `debop`, labels: `refactor`, `test`
- merge base: `develop@37bcff6b41f166769dd5d851f90fc28c1f8e92bd`
- approved exact head: `refactor/issue-771-dynamodb-id-generator@f0f53af99d0a56574a30ac7a4bfef024c9e70661`
- squash merge: `develop@9334c9df85a73ff32ee4897c50769d165c9bacff`

Resolves #771

## DoD Status

- 상태: `DONE` — 승인된 PR #789를 exact head 검증 후 squash merge하고 post-merge closeout을 완료했습니다.
- merge commit: `9334c9df85a73ff32ee4897c50769d165c9bacff`
- canonical `develop`: local HEAD와 `origin/develop`가 merge commit과 일치하며 working tree clean
- post-merge CI: 12 success, 35 path-scoped skipped, failures 0; Dependency Submission success
- Issue #771: `CLOSED/COMPLETED`
- Epic #775: LEAD-06을 완료로 반영하고 다음 stacked slot을 LEAD-07 / #773으로 유지
- workflow receipt: `20260826T074647Z-eeee3edf`, `completed`, sequence 16, checksum `31bd4074f84e36bd2f7ad6e51b27e6286fbc2873042190e37270b4ce1837eb0a`
- Required checks: 15/15; N/A: 1 (solo-maintainer human review); Blocked: 0
- 다음 단계: `develop@9334c9df85a73ff32ee4897c50769d165c9bacff` 기준으로 LEAD-07 / #773을 별도 계획·승인 후 진행
