### PR TITLE
refactor(example-webhook-poller): event ID 생성기를 bluetape4k 표준으로 통일

### DIFF
--- a/examples/webhook-poller/README.ko.md
+++ b/examples/webhook-poller/README.ko.md
@@ -68,6 +68,13 @@ MONGO_URL=mongodb://localhost:27017 ./gradlew :examples:webhook-poller:run
 
 가짜 이벤트 10건을 collection 에 insert 후 폴러 3개를 동시 실행. 각 이벤트가 정확히 1번만 처리됨을 검증.
 
+### Event ID 형식
+
+데모는 `evt-<sequence>-<UUID v4>` 형식의 event ID를 사용한다. sequence는 예제
+출력을 읽기 쉽게 만들고, `Uuid.V4.nextUUID()`는 매 실행마다 새로운 correlation·dedup
+suffix를 제공한다. 데모는 insert 전에 collection을 비우므로 매번 새로운 suffix를
+생성해도 unique `eventId` index와 충돌하지 않으며 MongoDB document field는 유지된다.
+
 ## Configuration Options
 
 | 파라미터 | 기본값 | 설명 |

--- a/examples/webhook-poller/README.md
+++ b/examples/webhook-poller/README.md
@@ -68,6 +68,14 @@ MONGO_URL=mongodb://localhost:27017 ./gradlew :examples:webhook-poller:run
 
 Inserts 10 fake events into a fresh collection, then runs 3 pollers concurrently. Expected: each event handled exactly once, no duplicates.
 
+### Event ID format
+
+The demo uses `evt-<sequence>-<UUID v4>` event IDs. The sequence keeps the sample
+output readable, while `Uuid.V4.nextUUID()` supplies a fresh correlation and
+deduplication suffix on every run. The demo clears its collections before
+inserting events, and fresh suffixes keep reruns compatible with the unique
+`eventId` index without changing the MongoDB document field.
+
 ## Configuration Options
 
 | Parameter | Default | Description |

--- a/examples/webhook-poller/src/main/kotlin/io/bluetape4k/leader/examples/webhook/WebhookPollerDemo.kt
+++ b/examples/webhook-poller/src/main/kotlin/io/bluetape4k/leader/examples/webhook/WebhookPollerDemo.kt
@@ -1,10 +1,10 @@
 package io.bluetape4k.leader.examples.webhook
 
 import com.mongodb.kotlin.client.coroutine.MongoClient
+import io.bluetape4k.idgenerators.uuid.Uuid
 import io.bluetape4k.leader.mongodb.MongoSuspendLeaderElector
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.info
-import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
@@ -28,6 +28,11 @@ object WebhookPollerDemo: KLogging() {
     private const val DEMO_EVENT_COUNT = 10
     private const val DEMO_INSTANCE_COUNT = 3
 
+    /**
+     * 데모 event ID에 읽기 쉬운 sequence와 매 실행마다 새로운 UUID v4 suffix를 결합합니다.
+     */
+    internal fun newEventId(index: Int): String = "evt-$index-${Uuid.V4.nextUUID()}"
+
     @JvmStatic
     fun main(args: Array<String>) = runBlocking {
         val mongoUrl = System.getenv("MONGO_URL") ?: "mongodb://localhost:27017"
@@ -44,7 +49,7 @@ object WebhookPollerDemo: KLogging() {
 
             // Insert fake events.
             val pendingEvents = (1..DEMO_EVENT_COUNT).map { idx ->
-                WebhookEvent(eventId = "evt-$idx-${UUID.randomUUID()}", payload = "payload-$idx")
+                WebhookEvent(eventId = newEventId(idx), payload = "payload-$idx")
             }
             eventCollection.insertMany(pendingEvents.map { it.toDocument() })
             log.info { "[demo] inserted $DEMO_EVENT_COUNT events" }

--- a/examples/webhook-poller/src/test/kotlin/io/bluetape4k/leader/examples/webhook/WebhookPollerDemoEventIdTest.kt
+++ b/examples/webhook-poller/src/test/kotlin/io/bluetape4k/leader/examples/webhook/WebhookPollerDemoEventIdTest.kt
@@ -1,0 +1,56 @@
+package io.bluetape4k.leader.examples.webhook
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
+import io.bluetape4k.idgenerators.uuid.Uuid
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import java.util.UUID
+import org.junit.jupiter.api.Test
+
+class WebhookPollerDemoEventIdTest {
+
+    @Test
+    fun `demo event id delegates to bluetape4k UUID v4 generator`() {
+        // Given
+        val expected = UUID.fromString("123e4567-e89b-42d3-a456-426614174000")
+        mockkObject(Uuid.V4)
+
+        try {
+            every { Uuid.V4.nextUUID() } returns expected
+
+            // When
+            val eventId = WebhookPollerDemo.newEventId(index = 1)
+
+            // Then
+            eventId shouldBeEqualTo "evt-1-${expected}"
+            verify(exactly = 1) { Uuid.V4.nextUUID() }
+        } finally {
+            unmockkObject(Uuid.V4)
+        }
+    }
+
+    @Test
+    fun `reruns produce unique canonical UUID v4 event ids`() {
+        // Given
+        val eventsPerRun = 256
+
+        // When
+        val firstRun = List(eventsPerRun) { WebhookPollerDemo.newEventId(index = 1) }
+        val secondRun = List(eventsPerRun) { WebhookPollerDemo.newEventId(index = 1) }
+        val allEventIds = firstRun + secondRun
+
+        // Then
+        allEventIds shouldHaveSize eventsPerRun * 2
+        allEventIds.toSet() shouldHaveSize eventsPerRun * 2
+        allEventIds.forEach { eventId ->
+            eventId.startsWith("evt-1-") shouldBeEqualTo true
+            val uuidText = eventId.removePrefix("evt-1-")
+            val parsed = UUID.fromString(uuidText)
+            uuidText shouldBeEqualTo parsed.toString()
+            parsed.version() shouldBeEqualTo 4
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #773

`examples/webhook-poller`의 event ID 생성을 bluetape4k ecosystem UUID generator로 통일해 workshop 예제가 권장 correlation·deduplication 패턴을 직접 보여 주도록 합니다.

## Background

LEAD-07은 Epic #775의 stacked PR train에서 LEAD-06 다음으로 실행하는 Type-B fast-track입니다. 기존 데모는 `UUID.randomUUID()`를 직접 호출해 publishable leader ecosystem과 ID 생성 정책이 달랐습니다.

## What This Solves

- 예제 독자가 JDK raw UUID 대신 `Uuid.V4.nextUUID()`를 사용하도록 표준 패턴을 고정합니다.
- sequence 가독성, canonical UUID v4 suffix, MongoDB `eventId` 필드와 unique index, rerun 동작을 함께 검증합니다.

## Work Done

- `WebhookPollerDemo.newEventId(index)`가 `Uuid.V4.nextUUID()`를 위임하도록 변경하고 기존 `evt-<sequence>-<UUID>` 출력과 Mongo document field를 유지했습니다.
- `bluetape4k-assertions` 기반 테스트로 generator 위임, canonical UUID v4, 두 실행 512개 ID uniqueness를 고정했습니다.
- EN/KO workshop README에 event ID 형식과 rerun/unique-index 의미를 같은 내용으로 설명했습니다.

## Validation

- `./gradlew :examples:webhook-poller:test --tests 'io.bluetape4k.leader.examples.webhook.WebhookPollerDemoEventIdTest' --no-build-cache --no-configuration-cache --no-daemon`: PASS (2/2)
- `./gradlew :examples:webhook-poller:test --rerun-tasks --no-build-cache --no-configuration-cache --no-daemon`: PASS (13/13, failures/errors/skipped 0)
- `./gradlew :examples:webhook-poller:check --rerun-tasks --no-build-cache --no-configuration-cache --no-daemon`: PASS
- `./gradlew :examples:webhook-poller:detekt --rerun-tasks --no-build-cache --no-configuration-cache --no-daemon`: PASS
- `git diff HEAD^ HEAD --check`: PASS
- RED compile guard: PASS (helper 부재 시 unresolved reference로 예상 실패)

## Review Notes

- P0/P1: 0
- P2/P3: 0; transitive `leader-core` `api` dependency 관찰사항은 비차단
- 독립 code-review: `APPROVE`; architecture review: `CLEAR`
- Review evidence: exact HEAD `643879f07e26b9e296232e656586c96c47193b2b` 기준 독립 리뷰 artifact

## Metadata

- Issue: #773, milestone `1.0.0`, assignee `debop`
- PR: #791, milestone `1.0.0`, assignee `debop`
- Base: `develop@837bea23e93f813406a6f41ba5374d783abcc979`
- Head: `refactor/issue-773-webhook-id-generator@643879f07e26b9e296232e656586c96c47193b2b`
- Merge: `cafe856132c07fce814d6a5389b2c21c34155e99` (squash)
- CI: PR [CI run 32953841241](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32953841241), [README run 32953841281](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32953841281), post-merge [Develop CI run 32954660647](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32954660647), [README run 32954660755](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32954660755), [Dependency Submission run 32954660633](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32954660633) — all exact-head/merge-head checks success

## DoD Status

Required checks: 18/18; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01..CG-10 - Pre-PR proof | AGENTS, GNO/live issue, isolated worktree, ecosystem reuse, RED/GREEN, sequential Testcontainers, Kotlin checklist, independent review, exact commit | PASS | `643879f07e26b9e296232e656586c96c47193b2b`; 2/2 + 13/13; check/detekt/diff check; P0/P1/P2/P3=0 | none |
| CG-11 - PR delivery authority | Approved Epic #775 stacked train scope names repo, base, and head | PASS | `bluetape4k/bluetape4k-leader`, `develop`, `refactor/issue-773-webhook-id-generator` | none |
| CG-12 - Exact head publication | Push the converged authorized branch without force | PASS | remote branch SHA matches `643879f07e26b9e296232e656586c96c47193b2b` | none |
| CG-12A - Guidance refresh | Re-read current AGENTS hierarchy, selected skills, common gates, PR template, and Issue #773 immediately before PR creation | PASS | Current SHA snapshot and Issue #773 metadata read; no drift | none |
| CG-13 - PR creation/readback | Create PR with Korean body, labels, milestone, assignee, and final DoD heading | PASS | PR #791 live readback confirms exact base/head, labels `refactor`,`test`,`example`, milestone `1.0.0`, assignee `debop`, and final `## DoD Status` heading | none |
| CG-14 - Exact-head CI/review | Wait for exact-head CI, reread reviews/threads, and record the applicable single-developer human-review scope | PASS | CI run `32953841241` and README run `32953841281` success at `643879f07e26b9e296232e656586c96c47193b2b`; changed example test pass; PR `MERGEABLE/CLEAN`; review comments/threads 0; independent code-review `APPROVE`, architecture `CLEAR`; human-review subgate `N/A (single-developer lane, user-approved)` | none |
| CG-15 - Merge-ready report | Reconcile fresh CI/review evidence and report exact PR/head | PASS | User-visible merge-ready report named PR #791/head `643879f07e26b9e296232e656586c96c47193b2b`, CI, review, N/A, and blocked counts | none |
| CG-16 - Fresh merge approval | Obtain explicit approval after CG-15 | PASS | User issued fresh approval after the merge-ready report | none |
| CG-17 - Merge verification | Merge approved exact PR and verify live state/SHA | PASS | PR #791 `MERGED`; squash merge SHA `cafe856132c07fce814d6a5389b2c21c34155e99`; PR head/base readback exact | none |
| CG-18 - Canonical sync/cleanup | Fast-forward canonical develop and preserve/delete only proven targets | PASS | Post-merge CI success; local/origin `develop` both `cafe856132c07fce814d6a5389b2c21c34155e99`; clean feature worktree removed, local branch retained, remote branch auto-deleted | none |

Final status: DONE — exact-head review/CI, fresh-approved merge, post-merge CI, canonical sync, and cleanup boundary all verified.

Unchecked required items: none
