### PR TITLE
[AUD-03] JDK HTTP audit export adapter 추가

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -656,6 +656,41 @@ GET /actuator/leaderElection
 Actuator, Ktor management route, Micrometer, logging, tracing, custom dashboard는 framework별 event
 contract를 새로 만들지 말고 이 core event stream을 adapter로 사용해야 합니다.
 
+### HTTP/webhook sink로 audit export
+
+정제한 history 또는 lifecycle event를 전달할 때는 core의
+`HttpLeaderAuditExporter`와 애플리케이션이 소유한 `LeaderAuditPayloadEncoder`를
+조합합니다.
+
+```kotlin
+val endpoint = LeaderAuditTrustedHttpsEndpoint.trusted(
+    URI("https://audit.example.test/v1/leader-events"),
+)
+val client = HttpClient.newBuilder()
+    .followRedirects(HttpClient.Redirect.NEVER)
+    .build()
+val exporter = MicrometerLeaderAuditExporter(
+    delegate = HttpLeaderAuditExporter(
+        client = client,
+        endpoint = endpoint,
+        headers = mapOf("Authorization" to "Bearer ${System.getenv("AUDIT_WEBHOOK_TOKEN")}"),
+        encoder = LeaderAuditPayloadEncoder { event ->
+            LeaderAuditHttpPayload.of("text/plain; charset=utf-8", event.toString().toByteArray())
+        },
+        exportOptions = exportOptions,
+        httpOptions = LeaderAuditHttpOptions.defaults(),
+    ),
+    registry = meterRegistry,
+)
+```
+
+adapter는 `POST`, bounded retry, `BodyHandlers.discarding()`을 사용합니다. 허용하는
+header는 `Content-Type`과 `Authorization`뿐이며 redirect는 끕니다.
+`LeaderAuditTrustedHttpsEndpoint`는 HTTPS 문법을 확인하고 endpoint allow-list와
+DNS/SSRF 정책을 호출자가 소유한다는 책임 경계를 남깁니다. `submit`의
+`ACCEPTED`는 admission만 뜻하므로 수신 서버는 idempotency를 제공해야 합니다.
+JSONL과 OpenTelemetry transport는 애플리케이션이 선택하는 별도 범위입니다.
+
 `bluetape4k.leader.observability.lock-names`는 첫 runtime event가 관측되기 전에 JVM-local status registry를 seed합니다. Listener-aware elector는 lifecycle event를 관측하면서 이름을 추가할 수도 있습니다. fallback `LeaderElectionEventPublisher`는 publisher 전용이며 `LeaderElector` candidate가 되지 않으므로 기존 elector injection은 안정적으로 유지됩니다.
 
 Spring diagnostics, readiness, Actuator endpoint는 blocking과 suspend `LeaderElectionState` bean을

--- a/README.md
+++ b/README.md
@@ -655,6 +655,40 @@ GET /actuator/leaderElection
 routes, Micrometer, logging, tracing, and custom dashboards should adapt from this core event stream instead of
 introducing framework-specific event contracts.
 
+### Audit export to an HTTP/webhook sink
+
+For sanitized history or lifecycle delivery, compose the core
+`HttpLeaderAuditExporter` with an application-owned `LeaderAuditPayloadEncoder`:
+
+```kotlin
+val endpoint = LeaderAuditTrustedHttpsEndpoint.trusted(
+    URI("https://audit.example.test/v1/leader-events"),
+)
+val client = HttpClient.newBuilder()
+    .followRedirects(HttpClient.Redirect.NEVER)
+    .build()
+val exporter = MicrometerLeaderAuditExporter(
+    delegate = HttpLeaderAuditExporter(
+        client = client,
+        endpoint = endpoint,
+        headers = mapOf("Authorization" to "Bearer ${System.getenv("AUDIT_WEBHOOK_TOKEN")}"),
+        encoder = LeaderAuditPayloadEncoder { event ->
+            LeaderAuditHttpPayload.of("text/plain; charset=utf-8", event.toString().toByteArray())
+        },
+        exportOptions = exportOptions,
+        httpOptions = LeaderAuditHttpOptions.defaults(),
+    ),
+    registry = meterRegistry,
+)
+```
+
+The adapter uses `POST`, bounded retries, and `BodyHandlers.discarding()`. Only
+`Content-Type` and `Authorization` headers are accepted; redirects are disabled.
+`LeaderAuditTrustedHttpsEndpoint` validates the HTTPS syntax and records that the
+caller owns endpoint allow-list and DNS/SSRF policy. `submit` returning `ACCEPTED`
+means admission only, so receivers should be idempotent. JSONL and OpenTelemetry
+transports remain separate application choices.
+
 `bluetape4k.leader.observability.lock-names` seeds the JVM-local status registry before the first runtime event. Listener-aware electors can also add names as they observe lifecycle events. The fallback `LeaderElectionEventPublisher` is publisher-only and never becomes a `LeaderElector` candidate, so existing elector injection remains stable.
 
 Spring diagnostics, readiness, and the Actuator endpoint select from both blocking and suspend

--- a/docs/lessons/2026-08-26-issue-535-audit-export.md
+++ b/docs/lessons/2026-08-26-issue-535-audit-export.md
@@ -1,0 +1,60 @@
+# Issue #535 AUD-03 audit export lesson
+
+날짜: 2026-08-26
+
+## 배경
+
+leader election history와 lifecycle event를 외부 sink로 전달하는 범위에서
+HTTP/webhook transport를 추가했다. 선출 hot path가 네트워크 지연이나 receiver
+장애를 직접 기다리지 않도록 기존 bounded exporter의 admission·retry·close 계약에
+JDK `HttpClient.sendAsync` one-shot delivery만 연결했다.
+
+## 결정
+
+1. `leader-core`에 새 HTTP/serialization dependency를 넣지 않고
+   `LeaderAuditPayloadEncoder`를 주입한다. JSON, JSONL, OpenTelemetry의 wire
+   format과 수명은 호출자 또는 후속 adapter가 선택한다.
+2. production target은 `LeaderAuditTrustedHttpsEndpoint`로 감싼 HTTPS URI만
+   받는다. URI syntax와 credential/query/fragment 경계는 라이브러리가 검사하고,
+   DNS rebinding·private network·SSRF 정책은 allow-list 또는 egress proxy를
+   소유한 호출자에게 남긴다.
+3. payload는 생성·읽기 양쪽에서 방어적으로 복사하고 hard 1 MiB 및 설정 가능한
+   기본 64 KiB bound를 적용한다. response는 `BodyHandlers.discarding()`으로
+   retention을 0 byte로 제한한다.
+4. 2xx는 성공, 408/429/5xx와 I/O/timeout은 retryable, 나머지 non-2xx는
+   terminal로 분류한다. `ACCEPTED`는 admission일 뿐 delivered가 아니며, retry는
+   at-least-once이므로 receiver idempotency가 필요하다.
+5. header는 `Content-Type`과 `Authorization`만 허용하고, redirect는
+   `HttpClient.Redirect.NEVER`를 요구한다. credential, body, endpoint, exception
+   message는 로그·metric·observer payload로 복사하지 않는다.
+
+## 배운 점
+
+- 기존 `BoundedLeaderAuditExporter`를 재사용하면 queue permit, scheduler ownership,
+  close cancellation, late completion 처리를 transport 코드에서 다시 만들지 않아도 된다.
+- Kotlin `internal` delivery와 public facade를 분리하면 public ABI에 bounded core
+  구현 세부를 노출하지 않으면서 Java `HttpClient` 호출 경계를 테스트할 수 있다.
+- `Content-Type`처럼 encoder와 header map이 동시에 표현할 수 있는 값은 현재
+  encoder 우선순위를 명시했더라도 public API가 굳기 전에 단일 책임을 재검토해야 한다.
+- deterministic `HttpClient` stub은 status·future·cancellation 분류를 빠르게
+  고정하지만 실제 TLS handshake, timeout, body discard 상호작용을 대신하지 않는다.
+- delivery 경계에서 `CancellationException`은 일반 예외와 분리해 다시 전파하고,
+  비-I/O 비동기 예외는 retryable로 과대 분류하지 않아야 한다. 두 경계는 회귀
+  테스트로 고정했다.
+
+## 다음 조치
+
+- 1.0.0 전 in-process TLS loopback smoke와 실제 cancellation/timeout 상호작용을
+  추가한다.
+- retry마다 재생성되는 encoder payload를 receiver가 안전하게 deduplicate할 수
+  있도록 stable delivery ID 또는 별도 idempotency SPI를 설계한다.
+- Spring/Ktor integration에서 caller trust wrapper를 임의 URI에 자동 적용하지
+  않도록 configuration 경계를 설계한다.
+
+## 검증
+
+- HTTP focused suite: 10 tests PASS
+- `leader-core` full test: BUILD SUCCESSFUL
+- `leader-core` detekt: BUILD SUCCESSFUL
+- Korean terminology audit: 6 files, findings=0
+- `git diff --check`: PASS

--- a/docs/manual/drafts/2026-08-18-audit-export.en.md
+++ b/docs/manual/drafts/2026-08-18-audit-export.en.md
@@ -1,0 +1,138 @@
+---
+title: "Audit export to an HTTP/webhook sink"
+locale: en
+status: unreleased
+sourceReleaseRef: 0.5.0
+sourceReleaseCommit: 721a9a3808f67489d2bdb8177734325981c24977
+---
+
+# Audit export to an HTTP/webhook sink
+
+> Unreleased draft for Issue #535 (OBS-03). The HTTP adapter is newer than the
+> pinned `0.5.0` manual and must not be presented as part of that release until
+> the release manifest is updated.
+
+## What this adds
+
+`leader-core` can deliver sanitized `LeaderAuditExportEvent` values to a webhook
+without coupling leader election to network latency. `HttpLeaderAuditExporter`
+uses JDK `java.net.http.HttpClient`; the application supplies the payload encoder,
+executor, scheduler, endpoint trust decision, and receiver idempotency policy.
+
+The exporter reuses the bounded core pipeline. `submit` is non-blocking admission:
+`ACCEPTED` means that the event entered the bounded pipeline, not that the receiver
+accepted the HTTP request.
+
+## Prerequisites
+
+- JDK 21 or newer, as required by the leader project.
+- `io.github.bluetape4k.leader:bluetape4k-leader-core`.
+- An HTTPS receiver and an application-owned allow-list or egress proxy.
+- A serializer if the receiver expects JSON. `leader-core` adds no JSON dependency.
+
+## Minimal composition
+
+```kotlin
+val scheduler = Executors.newSingleThreadScheduledExecutor()
+val executor = Executors.newVirtualThreadPerTaskExecutor()
+val endpoint = LeaderAuditTrustedHttpsEndpoint.trusted(
+    URI("https://audit.example.test/v1/leader-events"),
+)
+val exporter = HttpLeaderAuditExporter(
+    client = HttpClient.newBuilder()
+        .followRedirects(HttpClient.Redirect.NEVER)
+        .build(),
+    endpoint = endpoint,
+    headers = mapOf("Authorization" to "Bearer ${System.getenv("AUDIT_WEBHOOK_TOKEN")}"),
+    encoder = LeaderAuditPayloadEncoder { event ->
+        LeaderAuditHttpPayload.of(
+            contentType = "text/plain; charset=utf-8",
+            body = event.toString().toByteArray(),
+        )
+    },
+    exportOptions = LeaderAuditExportOptions(
+        queueCapacity = 256,
+        maxInFlight = 8,
+        maxAttempts = 3,
+        attemptTimeout = Duration.ofSeconds(5),
+        initialBackoff = Duration.ofMillis(100),
+        maxBackoff = Duration.ofSeconds(5),
+        executor = executor,
+        scheduler = scheduler,
+    ),
+    httpOptions = LeaderAuditHttpOptions.defaults(),
+)
+
+try {
+    val event = /* create a sanitized History or Lifecycle event */
+    exporter.submit(event)
+} finally {
+    exporter.close()
+    executor.close()
+    scheduler.shutdown()
+}
+```
+
+Wrap the exporter with `MicrometerLeaderAuditExporter` when queue depth, admission,
+retry, failure, and cancellation counters should be exported. Register an observer
+with `observe` when an application needs fixed low-cardinality lifecycle outcomes
+without owning another exporter.
+
+## HTTP contract
+
+The adapter creates one `POST` request per delivery attempt and applies the
+`attemptTimeout` from `LeaderAuditExportOptions`. A payload is copied on creation and
+again when read through `body()`. The default configured payload limit is 64 KiB; the
+absolute limit is 1 MiB. A payload over the configured limit is terminalized before a
+request is created.
+
+Only `Content-Type` and `Authorization` can be supplied as headers. Names and values
+reject control characters; `Host`, `Content-Length`, `Connection`,
+`Transfer-Encoding`, and all unknown headers are rejected. Response bodies use
+`BodyHandlers.discarding()`: this bounds response retention in the adapter but does not
+truncate bytes while they are arriving on the network.
+
+| Response or failure | Delivery result | Bounded pipeline action |
+|---|---|---|
+| 2xx | `SUCCESS` | Finish the item |
+| 408, 429, 5xx | `RETRYABLE_FAILURE` | Retry until `maxAttempts` |
+| Other non-2xx | `TERMINAL_FAILURE` | Do not retry |
+| I/O or timeout failure | `RETRYABLE_FAILURE` | Retry until `maxAttempts` |
+| Encoder/request validation failure | `TERMINAL_FAILURE` | Do not create a request |
+
+Retries are at-least-once. The receiver must use an idempotency key or equivalent
+deduplication rule when duplicate deliveries are unsafe.
+
+## Endpoint trust and privacy
+
+`LeaderAuditTrustedHttpsEndpoint.trusted(uri)` accepts only an absolute hierarchical
+HTTPS URI without user-info, query, fragment, or control characters. This is an
+explicit responsibility boundary, not a DNS or SSRF firewall. The caller owns endpoint
+allow-listing, DNS rebinding decisions, and private/link-local/ULA/CGNAT policy; use a
+static trusted target or an egress proxy for those controls.
+
+The adapter never logs the endpoint, authorization value, payload body, or exception
+message. Sanitized events must be created before they reach the encoder. JSONL files,
+OpenTelemetry, durable outbox, and framework auto-configuration are separate follow-up
+work.
+
+## Shutdown and diagnosis
+
+Call `HttpLeaderAuditExporter.close()` before shutting down the caller-owned executor
+or scheduler. Close cancels queued, scheduled, and in-flight work and prevents a late
+HTTP completion from scheduling another retry. The exporter does not shut down either
+executor. Inspect `snapshot()` and the fixed Micrometer catalog for queue saturation,
+retries, terminal failures, cancellations, and rejection counts; these values contain
+no dynamic lock, identity, endpoint, or error fields.
+
+If delivery is repeatedly retryable, check receiver availability and timeout budget.
+If responses are terminal 4xx, fix the payload or authorization policy rather than
+blindly retrying. If the endpoint is rejected at construction, correct the explicit
+HTTPS URI or caller trust configuration. A successful `submit` alone is not evidence
+that the receiver has processed an event.
+
+## Next learning step
+
+Read the core observability and failure guides, then compare the Micrometer decorator
+with the framework-neutral observer. JSONL and OpenTelemetry transports remain
+follow-up designs rather than implicit behavior of this adapter.

--- a/docs/manual/drafts/2026-08-18-audit-export.ko.md
+++ b/docs/manual/drafts/2026-08-18-audit-export.ko.md
@@ -1,0 +1,135 @@
+---
+title: "HTTP/webhook sink으로 audit export하기"
+locale: ko
+status: unreleased
+sourceReleaseRef: 0.5.0
+sourceReleaseCommit: 721a9a3808f67489d2bdb8177734325981c24977
+---
+
+# HTTP/webhook sink으로 audit export하기
+
+> Issue #535(OBS-03)를 위한 미배포 초안입니다. HTTP adapter는 고정한 `0.5.0`
+> 매뉴얼보다 새 API이므로 release manifest를 갱신하기 전에는 해당 배포본의
+> 기능으로 안내하지 않습니다.
+
+## 추가되는 기능
+
+`leader-core`는 정제한 `LeaderAuditExportEvent`를 네트워크 지연과 leader
+election을 결합하지 않고 webhook으로 전달할 수 있습니다.
+`HttpLeaderAuditExporter`는 JDK `java.net.http.HttpClient`를 사용하며 payload
+encoder, executor, scheduler, endpoint trust 결정, 수신 서버의 idempotency 정책은
+애플리케이션이 제공합니다.
+
+exporter는 bounded core pipeline을 재사용합니다. `submit`은 non-blocking
+admission이므로 `ACCEPTED`는 event가 bounded pipeline에 들어갔다는 뜻이지 수신
+서버가 HTTP 요청을 처리했다는 뜻이 아닙니다.
+
+## 사전 조건
+
+- 프로젝트가 요구하는 JDK 21 이상.
+- `io.github.bluetape4k.leader:bluetape4k-leader-core`.
+- HTTPS 수신 서버와 애플리케이션이 관리하는 allow-list 또는 egress proxy.
+- 수신 서버가 JSON을 요구한다면 serializer. `leader-core`는 JSON 의존성을 추가하지 않습니다.
+
+## 최소 조합
+
+```kotlin
+val scheduler = Executors.newSingleThreadScheduledExecutor()
+val executor = Executors.newVirtualThreadPerTaskExecutor()
+val endpoint = LeaderAuditTrustedHttpsEndpoint.trusted(
+    URI("https://audit.example.test/v1/leader-events"),
+)
+val exporter = HttpLeaderAuditExporter(
+    client = HttpClient.newBuilder()
+        .followRedirects(HttpClient.Redirect.NEVER)
+        .build(),
+    endpoint = endpoint,
+    headers = mapOf("Authorization" to "Bearer ${System.getenv("AUDIT_WEBHOOK_TOKEN")}"),
+    encoder = LeaderAuditPayloadEncoder { event ->
+        LeaderAuditHttpPayload.of(
+            contentType = "text/plain; charset=utf-8",
+            body = event.toString().toByteArray(),
+        )
+    },
+    exportOptions = LeaderAuditExportOptions(
+        queueCapacity = 256,
+        maxInFlight = 8,
+        maxAttempts = 3,
+        attemptTimeout = Duration.ofSeconds(5),
+        initialBackoff = Duration.ofMillis(100),
+        maxBackoff = Duration.ofSeconds(5),
+        executor = executor,
+        scheduler = scheduler,
+    ),
+    httpOptions = LeaderAuditHttpOptions.defaults(),
+)
+
+try {
+    val event = /* 정제한 History 또는 Lifecycle event 생성 */
+    exporter.submit(event)
+} finally {
+    exporter.close()
+    executor.close()
+    scheduler.shutdown()
+}
+```
+
+queue depth, admission, retry, failure, cancellation counter를 export하려면
+`MicrometerLeaderAuditExporter`로 감쌉니다. 별도 exporter를 소유하지 않고 고정된
+low-cardinality lifecycle 결과만 필요하면 `observe`에 observer를 등록합니다.
+
+## HTTP 계약
+
+adapter는 delivery attempt마다 `POST` 요청 하나를 만들고
+`LeaderAuditExportOptions.attemptTimeout`을 적용합니다. payload는 생성할 때 복사하고
+`body()`로 읽을 때도 복사합니다. 기본 payload limit은 64 KiB이고 절대 상한은 1 MiB입니다.
+설정한 limit을 넘은 payload는 요청을 만들기 전에 terminal 처리합니다.
+
+header로 전달할 수 있는 이름은 `Content-Type`과 `Authorization`뿐입니다. 이름과
+값에는 control character를 넣을 수 없으며 `Host`, `Content-Length`, `Connection`,
+`Transfer-Encoding`과 모든 미지의 header는 거부합니다. 응답 body는
+`BodyHandlers.discarding()`으로 처리합니다. 따라서 adapter가 응답 body를 보관하지는
+않지만 네트워크로 들어오는 byte를 중간에 자른다는 뜻은 아닙니다.
+
+| 응답 또는 실패 | Delivery 결과 | Bounded pipeline 동작 |
+|---|---|---|
+| 2xx | `SUCCESS` | 항목 종료 |
+| 408, 429, 5xx | `RETRYABLE_FAILURE` | `maxAttempts`까지 재시도 |
+| 그 밖의 non-2xx | `TERMINAL_FAILURE` | 재시도하지 않음 |
+| I/O 또는 timeout 실패 | `RETRYABLE_FAILURE` | `maxAttempts`까지 재시도 |
+| Encoder/request 검증 실패 | `TERMINAL_FAILURE` | 요청을 만들지 않음 |
+
+재시도는 at-least-once 전달입니다. 중복 전달이 안전하지 않다면 수신 서버가
+idempotency key 또는 동등한 중복 제거 규칙을 제공해야 합니다.
+
+## Endpoint trust와 privacy
+
+`LeaderAuditTrustedHttpsEndpoint.trusted(uri)`는 user-info, query, fragment,
+control character가 없는 absolute hierarchical HTTPS URI만 받습니다. 이는 DNS나
+SSRF firewall이 아니라 명시적인 책임 경계입니다. endpoint allow-list, DNS rebinding
+판단, private/link-local/ULA/CGNAT 정책은 호출자가 소유합니다. 이런 통제가 필요하면
+고정된 trusted target이나 egress proxy를 사용하세요.
+
+adapter는 endpoint, Authorization 값, payload body, exception message를 로그에
+남기지 않습니다. encoder에 전달하는 event도 먼저 정제해야 합니다. JSONL 파일,
+OpenTelemetry, durable outbox, framework auto-configuration은 별도 후속 작업입니다.
+
+## 종료와 진단
+
+호출자가 소유한 executor나 scheduler를 종료하기 전에
+`HttpLeaderAuditExporter.close()`를 호출하세요. close는 queued, scheduled,
+in-flight 작업을 취소하고 늦게 도착한 HTTP 완료가 새 retry를 예약하지 못하게 합니다.
+exporter는 executor를 종료하지 않습니다. `snapshot()`과 고정된 Micrometer catalog로
+queue 포화, retry, terminal failure, cancellation, rejection을 확인하세요. 이 값에는
+동적인 lock, identity, endpoint, error field가 없습니다.
+
+Delivery가 계속 retryable이면 수신 서버 상태와 timeout 예산을 확인합니다. terminal
+4xx라면 무조건 재시도하지 말고 payload 또는 authorization 정책을 수정합니다.
+생성 단계에서 endpoint가 거부되면 명시한 HTTPS URI와 호출자 trust 설정을 고칩니다.
+`submit` 성공만으로 수신 서버가 event를 처리했다는 근거를 만들 수 없습니다.
+
+## 다음 학습 단계
+
+core observability와 failure guide를 읽은 뒤 Micrometer decorator와
+framework-neutral observer를 비교하세요. JSONL과 OpenTelemetry transport는 이
+adapter가 암묵적으로 제공하지 않는 후속 설계입니다.

--- a/docs/review/2026-08-26-issue-535-audit-export-review.md
+++ b/docs/review/2026-08-26-issue-535-audit-export-review.md
@@ -1,0 +1,110 @@
+# Issue #535 AUD-03 HTTP audit export 구현 검토
+
+## 검토 범위와 판정
+
+- 대상: `leader-core` JDK HTTP/webhook audit export adapter와 호출자 문서
+- 이슈: #535 `feat: leader event용 pluggable audit export adapter 추가`
+- Train: OBS-03, 선행 AUD-01/AUD-02 머지 head `837bea23e93f813406a6f41ba5374d783abcc979`
+- 검토 기준: 승인된 Issue #535 설계·계획, 현재 working-tree diff, `leader-core` 기존 bounded exporter 계약
+- 최종 로컬 판정: **WATCH (PR 생성 가능)**
+- 심각도: **P0=0, P1=0, P2=3, P3=1**
+
+P0/P1 merge 차단 결함은 확인되지 않았다. P2는 공개 API가 굳기 전 보강할
+후속 위험으로 남겼으며, 이번 범위에서 새 serialization dependency, JSONL/
+OpenTelemetry transport, framework auto-configuration을 추가하지 않았다.
+
+초기 독립 code-review에서 제기된 P2 5건 중 취소 예외 전파와 비-I/O 비동기
+예외 분류는 구현과 회귀 테스트로 보강했다. 최신 재검토 결과에는 아래의
+idempotency, Content-Type 책임 중복, 실제 TLS 통합 검증 공백만 남겼다.
+
+## 변경 경계
+
+이번 변경은 다음 18개 파일에 한정된다.
+
+- `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/`: payload encoder,
+  bounded options, trusted HTTPS endpoint, JDK `HttpClient` delivery, exporter facade
+- `leader-core/src/test/kotlin/io/bluetape4k/leader/audit/http/`: delivery와 lifecycle 계약 테스트
+- 루트·`leader-core`·`leader-micrometer` README의 EN/KO 호출자 예제
+- release-pinned manual에 영향을 주지 않는 `docs/manual/drafts/` EN/KO 초안
+- 본 리뷰와 `docs/lessons/2026-08-26-issue-535-audit-export.md`
+
+settings, BOM, 의존성, CI/Nightly, backend election 경로는 변경하지 않았다.
+
+## 7관점 검토 결과
+
+| 관점 | 결과 | 근거와 조치 |
+|---|---|---|
+| 정확성 | PASS | 2xx 성공, 408/429/5xx·I/O/timeout retryable, 그 밖의 non-2xx terminal 분류를 `HttpLeaderAuditDelivery`와 테스트로 고정했다. |
+| API·계약 | PASS | 공개 생성자는 계획의 6개 인자를 유지하고, payload/options/endpoint는 fail-fast·방어적 복사를 제공한다. 기존 `LeaderAuditExporter` surface는 delegate로 재사용한다. |
+| 동시성·취소 | PASS | `sendAsync`만 사용하며 반환 future 취소를 underlying future에 전달한다. bounded exporter의 close가 in-flight와 retry를 취소하고 late completion을 무시하는 테스트가 통과했다. |
+| 보안·관찰성 | PASS | HTTPS-only trusted wrapper, redirect `NEVER`, header allow-list와 CR/LF·forbidden header 거부, response body discard, secret/body/error 비로깅을 고정했다. DNS/SSRF는 caller-owned 경계로 명시했다. |
+| 성능·안정성 | PASS | request body와 response body retention이 bounded되고, `submit`은 기존 non-blocking bounded admission을 호출한다. HTTP 소스에서 `runBlocking`, `GlobalScope`, `Thread.sleep`, `delay`, `synchronized`, `@Synchronized`를 찾지 못했다. |
+| 테스트·검증 | PASS | focused HTTP 10 tests, 전체 `leader-core` test, `leader-core` detekt, diff/용어 감사를 fresh output으로 확인했다. 실제 외부 receiver는 호출하지 않았다. |
+| 문서·운영 | PASS | 루트/모듈 README와 manual draft의 EN/KO parity, executor·scheduler close 순서, idempotency·trust 책임을 기술했다. release manifest의 고정 0.5.0 manual은 변경하지 않았다. |
+
+독립 검토 lane도 같은 diff를 read-only로 확인했다. 아키텍처 lane은
+`P0=0/P1=0/P2=3/P3=1`, `WATCH`를 보고했고, code-review lane은 보안·API·Kotlin·
+테스트·성능 관점의 최종 결과를 별도로 제공했다. 1인 개발자 정책에 따라
+human reviewer 대기나 승인을 추가하지 않았다.
+
+## 요구사항 추적성
+
+| 요구사항 | 구현 근거 | 검증 |
+|---|---|---|
+| serialization dependency 없이 payload encoder 주입 | `LeaderAuditPayloadEncoder`, `LeaderAuditHttpPayload` | `HttpLeaderAuditDeliveryTest` encoder/body 계약 |
+| payload hard 1 MiB·설정 bound·방어적 복사 | `LeaderAuditHttpOptions`, `LeaderAuditHttpPayload.of/body` | oversized, lower-bound, aliasing negative test |
+| 명시적 trusted HTTPS endpoint | `LeaderAuditTrustedHttpsEndpoint.trusted` | HTTP/user-info/query/fragment/control negative test |
+| POST와 request timeout | `HttpLeaderAuditDelivery.buildRequest` | method, timeout, body length assertion |
+| bounded HTTP 결과 분류 | `classifyStatus`, `classifySynchronousFailure` | 2xx/408/429/5xx/4xx/I/O matrix |
+| response retention 0 byte | `HttpResponse.BodyHandlers.discarding()` | body handler subscriber test |
+| header/redirect boundary | `normalizeHeaders`, `followRedirects()==NEVER` guard | allow-list, CR/LF, forbidden/unknown, redirect negative tests |
+| cancellation과 close race | `sendRequest` cancellation bridge + `BoundedLeaderAuditExporter` | delivery future cancel, exporter close/late 503 test |
+| existing bounded exporter semantics 보존 | `HttpLeaderAuditExporter` delegate composition | admission/release/close 상태 기준 데이터 테스트 |
+| 호출자 문서와 release pin parity | 루트·모듈 README, manual draft | Korean terminology audit, `git diff --check` |
+
+## 발견 항목과 후속 조치
+
+| 심각도 | 항목 | 현재 조치 | 후속 |
+|---|---|---|---|
+| P2 | retry attempt마다 encoder가 다시 실행되고 안정적인 delivery ID가 없다. | manual에 at-least-once와 receiver idempotency 책임을 명시했다. | 1.0.0 전 stable delivery ID 또는 명시적 idempotency SPI를 별도 설계한다. |
+| P2 | `Content-Type`이 headers와 payload encoder 양쪽에 표현되고 encoder 값이 최종 승리한다. | 동작과 테스트에서 encoder 우선순위를 고정하고 README에 encoder 책임을 설명했다. | public API가 굳기 전 header 단일 책임 여부를 별도 결정한다. |
+| P2 | 실제 JDK HTTPS/TLS loopback, timeout, body discard, cancellation 상호작용은 stub으로만 검증했다. | deterministic stub으로 callback/classification을 검증하고 범위를 명시했다. | 1.0.0 전 in-process TLS receiver smoke를 추가한다. |
+| P3 | `Trusted`는 DNS/SSRF 검증 결과가 아니라 caller trust assertion이다. | KDoc/manual에 private/link-local/ULA/CGNAT·DNS rebinding 비목표와 egress proxy 경계를 명시했다. | Spring/Ktor 설정이 임의 URI를 내부에서 trust하지 않도록 후속 integration 설계를 고정한다. |
+
+위 항목은 현재 P1 이하의 기능 결함이나 데이터 유출 증거가 아니므로 PR 생성
+차단으로 승격하지 않는다. 후속 작업 없이 이번 adapter가 실제 receiver의
+중복 제거를 보장한다고 주장하지 않는다.
+
+## 성능·안정성 스캔
+
+- 대상 소스: `leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/*.kt`
+- `rg -n 'GlobalScope|runBlocking|Thread\.sleep|delay\(|synchronized|@Synchronized|runCatching' ...`: HTTP 소스에서 결과 0건
+- queue/retry는 새 구현이 아니라 `BoundedLeaderAuditExporter`의 기존 bounded permit,
+  caller-owned executor/scheduler와 연결된다.
+- 별도 benchmark나 throughput SLA는 추가하지 않았다. 이번 성능 주장은
+  non-blocking admission과 finite body/response retention에 한정한다.
+
+## 검증 증거
+
+- `./gradlew :bluetape4k-leader-core:test --tests 'io.bluetape4k.leader.audit.http.*' --no-build-cache --no-daemon --console=plain`: **10 tests PASS**
+- `./gradlew :bluetape4k-leader-core:test --no-build-cache --no-daemon --console=plain`: **BUILD SUCCESSFUL**
+- `./gradlew :bluetape4k-leader-core:detekt --no-daemon --console=plain`: **BUILD SUCCESSFUL**
+- `git diff --check`: **PASS**
+- `./gradlew projects --no-daemon --console=plain`: **BUILD SUCCESSFUL**, no new project/module registration
+- `node /Users/debop/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs leader-core/README.ko.md leader-micrometer/README.ko.md README.ko.md docs/manual/drafts/2026-08-18-audit-export.ko.md docs/review/2026-08-26-issue-535-audit-export-review.md docs/lessons/2026-08-26-issue-535-audit-export.md`: **6 files, findings=0**
+- `javap`로 payload/exporter의 public ABI와 redirect/body handler boundary를 확인했다.
+
+실제 외부 HTTPS receiver, 인증서 체인, DNS/SSRF 정책, JSON serializer 통합은
+호출자 환경과 후속 transport 범위이므로 이 검토에서 테스트하지 않았다.
+
+## Writer gate와 PR 진입 조건
+
+- SPW-01: 이슈·선행 head·설계/계획·local source/test를 대조했다.
+- SPW-02: 구현·검증 편차, P2/P3, rollback 경계를 기록했다.
+- SPW-03: reader-facing prose는 한국어로 작성하고 API/명령/status token은 보존했다.
+- SPW-04: README EN/KO와 pinned manual 경계를 read-back했다.
+- SPW-05: terminology audit와 `git diff --check`를 통과했다.
+
+로컬 review gate는 `P0=0/P1=0`으로 종료한다. 다음 gate는 Lore commit,
+PR 생성, exact-head hosted CI 확인이며, merge는 fresh exact-head 승인 이후에만
+수행한다.

--- a/leader-core/README.ko.md
+++ b/leader-core/README.ko.md
@@ -89,6 +89,64 @@ election.runIfLeader("nightly-sync") { syncToRemote() }
 handle.close()
 ```
 
+### Audit export와 HTTP/webhook 전달
+
+`LeaderAuditExporter`는 이미 정제한 history 또는 lifecycle event를 bounded 비동기
+파이프라인으로 전달합니다. `submit`은 admission 결과만 반환하므로 `ACCEPTED`는
+수신 서버가 요청을 받았다는 뜻이 아닙니다. `LeaderAuditExportOptions`에 넘긴 executor와
+scheduler를 종료하기 전에 exporter를 먼저 닫으세요.
+
+JDK adapter는 직렬화를 애플리케이션에 맡기고 명시적으로 신뢰한 HTTPS endpoint만
+받습니다. Redirect는 끄고 응답 body는 폐기하며, 요청 header는 `Content-Type`과
+`Authorization`만 허용합니다. Endpoint wrapper는 URI 문법과 책임 경계를 확인할 뿐이므로
+DNS, SSRF, private-network, DNS rebinding 정책은 호출자나 egress proxy가 소유합니다.
+
+```kotlin
+val scheduler = Executors.newSingleThreadScheduledExecutor()
+val executor = Executors.newVirtualThreadPerTaskExecutor()
+val endpoint = LeaderAuditTrustedHttpsEndpoint.trusted(
+    URI("https://audit.example.test/v1/leader-events"),
+)
+val client = HttpClient.newBuilder()
+    .followRedirects(HttpClient.Redirect.NEVER)
+    .build()
+val exporter = HttpLeaderAuditExporter(
+    client = client,
+    endpoint = endpoint,
+    headers = mapOf("Authorization" to "Bearer ${System.getenv("AUDIT_WEBHOOK_TOKEN")}"),
+    encoder = LeaderAuditPayloadEncoder { event ->
+        LeaderAuditHttpPayload.of(
+            contentType = "text/plain; charset=utf-8",
+            body = event.toString().toByteArray(),
+        )
+    },
+    exportOptions = LeaderAuditExportOptions(
+        queueCapacity = 256,
+        maxInFlight = 8,
+        maxAttempts = 3,
+        attemptTimeout = Duration.ofSeconds(5),
+        initialBackoff = Duration.ofMillis(100),
+        maxBackoff = Duration.ofSeconds(5),
+        executor = executor,
+        scheduler = scheduler,
+    ),
+    httpOptions = LeaderAuditHttpOptions.defaults(),
+)
+
+try {
+    exporter.submit(event)
+} finally {
+    exporter.close()
+    executor.close()
+    scheduler.shutdown()
+}
+```
+
+수신 서버가 JSON을 요구하면 주입한 `LeaderAuditPayloadEncoder`에서 애플리케이션의
+직렬화기를 사용하세요. JSONL 파일과 OpenTelemetry exporter는 별도 transport이며
+`leader-core`가 의존성을 추가하지 않습니다. 재시도는 at-least-once 전달이므로
+수신 서버도 idempotency를 제공해야 합니다.
+
 ### 옵션 클래스
 
 ```kotlin

--- a/leader-core/README.md
+++ b/leader-core/README.md
@@ -91,6 +91,65 @@ election.runIfLeader("nightly-sync") { syncToRemote() }
 handle.close()
 ```
 
+### Audit export and HTTP/webhook delivery
+
+`LeaderAuditExporter` sends already-sanitized history or lifecycle events through a
+bounded, asynchronous pipeline. `submit` only reports admission: `ACCEPTED` does not
+mean that the receiver has accepted the request. Close the exporter before shutting
+down the executor or scheduler supplied in `LeaderAuditExportOptions`.
+
+The JDK adapter keeps serialization in the application and accepts only an explicitly
+trusted HTTPS endpoint. Redirects are disabled, response bodies are discarded, and the
+only request headers allowed by the adapter are `Content-Type` and `Authorization`.
+The endpoint wrapper is a syntax and responsibility boundary; DNS, SSRF, private-network,
+and DNS-rebinding policy remains with the caller or its egress proxy.
+
+```kotlin
+val scheduler = Executors.newSingleThreadScheduledExecutor()
+val executor = Executors.newVirtualThreadPerTaskExecutor()
+val endpoint = LeaderAuditTrustedHttpsEndpoint.trusted(
+    URI("https://audit.example.test/v1/leader-events"),
+)
+val client = HttpClient.newBuilder()
+    .followRedirects(HttpClient.Redirect.NEVER)
+    .build()
+val exporter = HttpLeaderAuditExporter(
+    client = client,
+    endpoint = endpoint,
+    headers = mapOf("Authorization" to "Bearer ${System.getenv("AUDIT_WEBHOOK_TOKEN")}"),
+    encoder = LeaderAuditPayloadEncoder { event ->
+        LeaderAuditHttpPayload.of(
+            contentType = "text/plain; charset=utf-8",
+            body = event.toString().toByteArray(),
+        )
+    },
+    exportOptions = LeaderAuditExportOptions(
+        queueCapacity = 256,
+        maxInFlight = 8,
+        maxAttempts = 3,
+        attemptTimeout = Duration.ofSeconds(5),
+        initialBackoff = Duration.ofMillis(100),
+        maxBackoff = Duration.ofSeconds(5),
+        executor = executor,
+        scheduler = scheduler,
+    ),
+    httpOptions = LeaderAuditHttpOptions.defaults(),
+)
+
+try {
+    exporter.submit(event)
+} finally {
+    exporter.close()
+    executor.close()
+    scheduler.shutdown()
+}
+```
+
+Use a real serializer in the injected `LeaderAuditPayloadEncoder` when the receiver
+expects JSON. JSONL files and OpenTelemetry exporters are separate transports and are
+not added by `leader-core`. A receiver should also provide idempotency for retries and
+should treat delivery attempts as at-least-once.
+
 ### Options
 
 ```kotlin

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditDelivery.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditDelivery.kt
@@ -1,0 +1,229 @@
+@file:Suppress("SwallowedException", "TooGenericExceptionCaught")
+
+package io.bluetape4k.leader.audit.http
+
+import io.bluetape4k.leader.audit.LeaderAuditDelivery
+import io.bluetape4k.leader.audit.LeaderAuditDeliveryResult
+import io.bluetape4k.leader.audit.LeaderAuditExportEvent
+import io.bluetape4k.leader.audit.LeaderAuditExportOptions
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
+import io.bluetape4k.support.requireNotBlank
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.util.LinkedHashMap
+import java.util.Locale
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletionException
+import java.util.concurrent.ExecutionException
+
+/**
+ * JDK `HttpClient` 기반의 one-shot audit delivery입니다.
+ *
+ * 응답 body는 보존하지 않고, status 408/429/5xx와 비동기 I/O 실패만 retryable로
+ * 분류합니다. 반환 future 취소는 underlying request 취소로 전달됩니다.
+ */
+internal class HttpLeaderAuditDelivery(
+    private val client: HttpClient,
+    private val endpoint: LeaderAuditTrustedHttpsEndpoint,
+    headers: Map<String, String>,
+    private val encoder: LeaderAuditPayloadEncoder,
+    exportOptions: LeaderAuditExportOptions,
+    private val httpOptions: LeaderAuditHttpOptions,
+) : LeaderAuditDelivery {
+
+    private val attemptTimeout: Duration = exportOptions.attemptTimeout
+    private val headers: Map<String, String> = normalizeHeaders(headers)
+
+    init {
+        require(client.followRedirects() == HttpClient.Redirect.NEVER) {
+            "HttpClient.followRedirects must be NEVER"
+        }
+    }
+
+    override fun deliver(event: LeaderAuditExportEvent): CompletableFuture<LeaderAuditDeliveryResult> =
+        encodeOrNull(event)?.let { payload ->
+            val body = payload.body()
+            if (body.size > httpOptions.maxPayloadBytes) {
+                HttpLeaderAuditDeliveryLogger.log.warn {
+                    "Leader audit payload exceeded configured HTTP bound; delivery is terminal"
+                }
+                terminalFailure()
+            } else {
+                deliverPayload(payload, body)
+            }
+        } ?: terminalFailure()
+
+    private fun encodeOrNull(event: LeaderAuditExportEvent): LeaderAuditHttpPayload? = try {
+        encoder.encode(event)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        HttpLeaderAuditDeliveryLogger.log.warn {
+            "Leader audit payload encoder failed; delivery is terminal"
+        }
+        null
+    }
+
+    private fun deliverPayload(
+        payload: LeaderAuditHttpPayload,
+        body: ByteArray,
+    ): CompletableFuture<LeaderAuditDeliveryResult> {
+        val request = buildRequestOrNull(payload, body)
+        return request?.let(::sendRequest) ?: terminalFailure()
+    }
+
+    private fun buildRequestOrNull(payload: LeaderAuditHttpPayload, body: ByteArray): HttpRequest? = try {
+        buildRequest(payload, body)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        HttpLeaderAuditDeliveryLogger.log.warn {
+            "Leader audit HTTP request validation failed; delivery is terminal"
+        }
+        null
+    }
+
+    private fun sendRequest(request: HttpRequest): CompletableFuture<LeaderAuditDeliveryResult> {
+        val requestFuture = try {
+            client.sendAsync(request, HttpResponse.BodyHandlers.discarding())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            HttpLeaderAuditDeliveryLogger.log.warn {
+                "Leader audit HTTP request failed before enqueue; delivery classification applied"
+            }
+            return CompletableFuture.completedFuture(classifySynchronousFailure(e))
+        }
+
+        val result = CompletableFuture<LeaderAuditDeliveryResult>()
+        result.whenComplete { _, failure ->
+            if (failure is CancellationException || result.isCancelled) {
+                requestFuture.cancel(true)
+            }
+        }
+        requestFuture.whenComplete { response, failure ->
+            if (failure != null) {
+                val cause = failure.unwrapCompletionFailure()
+                if (cause is CancellationException) {
+                    result.cancel(false)
+                } else if (cause is Error) {
+                    result.completeExceptionally(cause)
+                } else {
+                    val classification = classifyFailure(cause)
+                    if (classification == LeaderAuditDeliveryResult.RETRYABLE_FAILURE) {
+                        HttpLeaderAuditDeliveryLogger.log.warn {
+                            "Leader audit HTTP I/O failure; delivery is retryable"
+                        }
+                    } else {
+                        HttpLeaderAuditDeliveryLogger.log.warn {
+                            "Leader audit HTTP failure; delivery is terminal"
+                        }
+                    }
+                    result.complete(classification)
+                }
+            } else {
+                val classification = classifyStatus(response.statusCode())
+                if (classification != LeaderAuditDeliveryResult.SUCCESS) {
+                    HttpLeaderAuditDeliveryLogger.log.warn {
+                        "Leader audit HTTP response was classified as $classification"
+                    }
+                }
+                result.complete(classification)
+            }
+        }
+        return result
+    }
+
+    private fun terminalFailure(): CompletableFuture<LeaderAuditDeliveryResult> =
+        CompletableFuture.completedFuture(LeaderAuditDeliveryResult.TERMINAL_FAILURE)
+
+    private fun buildRequest(payload: LeaderAuditHttpPayload, body: ByteArray): HttpRequest {
+        val builder = HttpRequest.newBuilder(endpoint.uri)
+            .timeout(attemptTimeout)
+            .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+        headers.forEach { (name, value) -> builder.setHeader(name, value) }
+        builder.setHeader("Content-Type", payload.contentType)
+        return builder.build()
+    }
+
+    private fun classifyStatus(status: Int): LeaderAuditDeliveryResult = when {
+        status in HTTP_SUCCESS_STATUSES -> LeaderAuditDeliveryResult.SUCCESS
+        status == HTTP_REQUEST_TIMEOUT_STATUS ||
+            status == HTTP_TOO_MANY_REQUESTS_STATUS ||
+            status in HTTP_SERVER_ERROR_STATUSES -> LeaderAuditDeliveryResult.RETRYABLE_FAILURE
+        else -> LeaderAuditDeliveryResult.TERMINAL_FAILURE
+    }
+
+    private fun classifySynchronousFailure(failure: Exception): LeaderAuditDeliveryResult {
+        return classifyFailure(failure)
+    }
+
+    private fun classifyFailure(failure: Throwable): LeaderAuditDeliveryResult {
+        val cause = failure.unwrapCompletionFailure()
+        return if (cause is java.io.IOException || cause is java.util.concurrent.TimeoutException) {
+            LeaderAuditDeliveryResult.RETRYABLE_FAILURE
+        } else {
+            LeaderAuditDeliveryResult.TERMINAL_FAILURE
+        }
+    }
+
+    private object HttpLeaderAuditDeliveryLogger : KLogging()
+}
+
+private val HTTP_ALLOWED_HEADERS = setOf("content-type", "authorization")
+private val HTTP_FORBIDDEN_HEADERS = setOf("host", "content-length", "connection", "transfer-encoding")
+private val HTTP_SUCCESS_STATUSES = 200..299
+private val HTTP_SERVER_ERROR_STATUSES = 500..599
+private const val HTTP_REQUEST_TIMEOUT_STATUS: Int = 408
+private const val HTTP_TOO_MANY_REQUESTS_STATUS: Int = 429
+private const val HTTP_CONTROL_CHARACTER_MIN_CODE: Int = 0x20
+private const val HTTP_DELETE_CHARACTER_CODE: Int = 0x7f
+
+private fun normalizeHeaders(input: Map<String, String>): Map<String, String> {
+    val normalized = LinkedHashMap<String, String>(input.size)
+    input.forEach { (rawName, rawValue) ->
+        val name = rawName.requireNotBlank("header name")
+        require(!name.containsHttpControlCharacter()) {
+            "header name must not contain control characters"
+        }
+        val lowerName = name.lowercase(Locale.ROOT)
+        require(lowerName !in HTTP_FORBIDDEN_HEADERS) {
+            "header is forbidden: $name"
+        }
+        require(lowerName in HTTP_ALLOWED_HEADERS) {
+            requireHeaderAllowed(name)
+        }
+        val value = rawValue.requireNotBlank("header value")
+        require(!value.containsHttpControlCharacter()) {
+            "header value must not contain control characters"
+        }
+        val canonical = when (lowerName) {
+            "content-type" -> "Content-Type"
+            "authorization" -> "Authorization"
+            else -> error("unreachable header allow-list branch")
+        }
+        require(normalized.put(canonical, value) == null) {
+            "duplicate header name: $canonical"
+        }
+    }
+    return normalized.toMap()
+}
+
+private fun requireHeaderAllowed(name: String): Nothing =
+    throw IllegalArgumentException("header is not allow-listed: $name")
+
+private fun String.containsHttpControlCharacter(): Boolean = any {
+    it.code < HTTP_CONTROL_CHARACTER_MIN_CODE || it.code == HTTP_DELETE_CHARACTER_CODE
+}
+
+private fun Throwable.unwrapCompletionFailure(): Throwable {
+    var current = this
+    while (current is CompletionException || current is ExecutionException) {
+        current = current.cause ?: break
+    }
+    return current
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditExporter.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditExporter.kt
@@ -1,0 +1,52 @@
+package io.bluetape4k.leader.audit.http
+
+import io.bluetape4k.leader.audit.LeaderAuditExportEvent
+import io.bluetape4k.leader.audit.LeaderAuditExportObserver
+import io.bluetape4k.leader.audit.LeaderAuditExportOptions
+import io.bluetape4k.leader.audit.LeaderAuditExportSnapshot
+import io.bluetape4k.leader.audit.LeaderAuditExporter
+import io.bluetape4k.leader.audit.LeaderAuditSubmitResult
+import io.bluetape4k.leader.audit.internal.BoundedLeaderAuditExporter
+import java.net.http.HttpClient
+
+/**
+ * bounded core exporter에 JDK HTTP/webhook delivery를 연결하는 public exporter입니다.
+ *
+ * `endpoint`는 [LeaderAuditTrustedHttpsEndpoint.trusted]로 명시적으로 구성해야 하며,
+ * HTTP serialization은 [encoder]가 소유합니다. `exportOptions.executor`와
+ * `exportOptions.scheduler`는 caller 소유이므로 이 exporter를 먼저 `close`한 다음
+ * 외부 실행기를 종료해야 합니다. `ACCEPTED`는 전달 성공이 아닌 admission입니다.
+ */
+class HttpLeaderAuditExporter(
+    client: HttpClient,
+    endpoint: LeaderAuditTrustedHttpsEndpoint,
+    headers: Map<String, String>,
+    encoder: LeaderAuditPayloadEncoder,
+    exportOptions: LeaderAuditExportOptions,
+    httpOptions: LeaderAuditHttpOptions,
+) : LeaderAuditExporter {
+
+    private val delegate: LeaderAuditExporter = BoundedLeaderAuditExporter(
+        delivery = HttpLeaderAuditDelivery(
+            client = client,
+            endpoint = endpoint,
+            headers = headers,
+            encoder = encoder,
+            exportOptions = exportOptions,
+            httpOptions = httpOptions,
+        ),
+        options = exportOptions,
+    )
+
+    /** bounded pipeline에 event를 제출합니다. */
+    override fun submit(event: LeaderAuditExportEvent): LeaderAuditSubmitResult = delegate.submit(event)
+
+    /** delivery/admission observation을 등록합니다. */
+    override fun observe(observer: LeaderAuditExportObserver): AutoCloseable = delegate.observe(observer)
+
+    /** 현재 bounded exporter snapshot을 반환합니다. */
+    override fun snapshot(): LeaderAuditExportSnapshot = delegate.snapshot()
+
+    /** queued/retry/in-flight work를 취소하고 exporter를 멱등적으로 닫습니다. */
+    override fun close() = delegate.close()
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/LeaderAuditHttpOptions.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/LeaderAuditHttpOptions.kt
@@ -1,0 +1,28 @@
+package io.bluetape4k.leader.audit.http
+
+import io.bluetape4k.support.requireInRange
+
+/**
+ * HTTP audit delivery의 payload bound를 정의합니다.
+ *
+ * 응답 body는 항상 `BodyHandlers.discarding()`으로 폐기되며, 이 옵션은 request body의
+ * retention bound만 제어합니다. 네트워크 ingress truncation을 보장하지 않습니다.
+ */
+class LeaderAuditHttpOptions(
+    /** encoder payload에 적용할 최대 byte 수입니다. */
+    val maxPayloadBytes: Int,
+) {
+
+    init {
+        maxPayloadBytes.requireInRange(1, HARD_MAX_PAYLOAD_BYTES, "maxPayloadBytes")
+    }
+
+    companion object {
+        /** 기본 payload bound(64 KiB)를 반환합니다. */
+        @JvmStatic
+        fun defaults(): LeaderAuditHttpOptions = LeaderAuditHttpOptions(DEFAULT_MAX_PAYLOAD_BYTES)
+    }
+}
+
+private const val DEFAULT_MAX_PAYLOAD_BYTES: Int = 64 * 1024
+private const val HARD_MAX_PAYLOAD_BYTES: Int = 1024 * 1024

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/LeaderAuditPayloadEncoder.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/LeaderAuditPayloadEncoder.kt
@@ -1,0 +1,53 @@
+package io.bluetape4k.leader.audit.http
+
+import io.bluetape4k.support.requireLe
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.leader.audit.LeaderAuditExportEvent
+
+/**
+ * 정제된 audit event를 HTTP 요청 payload로 변환하는 함수형 계약입니다.
+ *
+ * encoder는 JSON 같은 wire format을 선택하지만 core에는 serialization dependency를
+ * 추가하지 않습니다. 반환 payload는 생성 시점에 caller 입력 배열을 복사합니다.
+ */
+fun interface LeaderAuditPayloadEncoder {
+
+    /** 하나의 sanitized event를 immutable HTTP payload로 인코딩합니다. */
+    fun encode(event: LeaderAuditExportEvent): LeaderAuditHttpPayload
+}
+
+/**
+ * HTTP 요청 body와 content type을 함께 보관하는 bounded immutable payload입니다.
+ *
+ * body 크기는 항상 1 MiB 이하이며, `body()`는 매번 방어적 복사본을 반환합니다.
+ */
+class LeaderAuditHttpPayload private constructor(
+    /** HTTP `Content-Type` 값입니다. */
+    val contentType: String,
+    private val bytes: ByteArray,
+) {
+
+    /** 요청 전송에 사용할 body의 방어적 복사본을 반환합니다. */
+    fun body(): ByteArray = bytes.copyOf()
+
+    companion object {
+        /** 검증·복사된 payload를 생성합니다. */
+        @JvmStatic
+        fun of(contentType: String, body: ByteArray): LeaderAuditHttpPayload {
+            val validContentType = contentType.requireNotBlank("contentType")
+            require(!validContentType.containsHttpControlCharacter()) {
+                "contentType must not contain control characters"
+            }
+            body.size.requireLe(HARD_MAX_PAYLOAD_BYTES, "body.bytes")
+            return LeaderAuditHttpPayload(validContentType, body.copyOf())
+        }
+    }
+}
+
+private const val HARD_MAX_PAYLOAD_BYTES: Int = 1024 * 1024
+private const val HTTP_CONTROL_CHARACTER_MIN_CODE: Int = 0x20
+private const val HTTP_DELETE_CHARACTER_CODE: Int = 0x7f
+
+private fun String.containsHttpControlCharacter(): Boolean = any {
+    it.code < HTTP_CONTROL_CHARACTER_MIN_CODE || it.code == HTTP_DELETE_CHARACTER_CODE
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/LeaderAuditTrustedHttpsEndpoint.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/http/LeaderAuditTrustedHttpsEndpoint.kt
@@ -1,0 +1,48 @@
+package io.bluetape4k.leader.audit.http
+
+import io.bluetape4k.support.requireNotBlank
+import io.bluetape4k.support.requireNotNull
+import java.net.URI
+
+/**
+ * caller가 allow-list와 DNS/SSRF trust를 확인했음을 표현하는 HTTPS endpoint wrapper입니다.
+ *
+ * 이 wrapper는 HTTPS URI 문법과 credential/query 경계를 검사하지만 hostname을 IP에
+ * 고정하거나 DNS rebinding, private/link-local/ULA/CGNAT 주소를 차단하지 않습니다.
+ * 그 trust 정책은 caller 또는 별도 egress proxy가 소유합니다.
+ */
+class LeaderAuditTrustedHttpsEndpoint private constructor(
+    /** 검증된 HTTPS target URI입니다. */
+    val uri: URI,
+) {
+
+    companion object {
+        /** 명시적으로 신뢰한 HTTPS endpoint를 생성합니다. */
+        @JvmStatic
+        fun trusted(uri: URI): LeaderAuditTrustedHttpsEndpoint {
+            val scheme = uri.scheme.requireNotNull("uri.scheme")
+            scheme.requireNotBlank("uri.scheme")
+            require(scheme.equals("https", ignoreCase = true)) {
+                "uri.scheme must be https"
+            }
+            require(uri.isAbsolute && !uri.isOpaque) {
+                "uri must be an absolute hierarchical URI"
+            }
+            uri.host.requireNotBlank("uri.host")
+            require(uri.userInfo == null) { "uri must not contain user-info" }
+            require(uri.query == null) { "uri must not contain a query" }
+            require(uri.fragment == null) { "uri must not contain a fragment" }
+            require(!uri.toString().containsHttpControlCharacter()) {
+                "uri must not contain control characters"
+            }
+            return LeaderAuditTrustedHttpsEndpoint(uri)
+        }
+    }
+}
+
+private const val HTTP_CONTROL_CHARACTER_MIN_CODE: Int = 0x20
+private const val HTTP_DELETE_CHARACTER_CODE: Int = 0x7f
+
+private fun String.containsHttpControlCharacter(): Boolean = any {
+    it.code < HTTP_CONTROL_CHARACTER_MIN_CODE || it.code == HTTP_DELETE_CHARACTER_CODE
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditDeliveryTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditDeliveryTest.kt
@@ -1,0 +1,345 @@
+package io.bluetape4k.leader.audit.http
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.audit.LeaderAuditDeliveryResult
+import io.bluetape4k.leader.audit.LeaderAuditExportEvent
+import io.bluetape4k.leader.audit.LeaderAuditExportOptions
+import io.bluetape4k.leader.audit.LeaderAuditValueSanitizer
+import io.bluetape4k.leader.history.LeaderHistoryStatus
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.net.Authenticator
+import java.net.CookieHandler
+import java.net.ProxySelector
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpHeaders
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.net.http.HttpResponse.BodyHandler
+import java.net.http.HttpResponse.PushPromiseHandler
+import java.nio.ByteBuffer
+import java.security.NoSuchAlgorithmException
+import java.time.Duration
+import java.util.Optional
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.Flow
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLParameters
+
+class HttpLeaderAuditDeliveryTest {
+
+    private val schedulers = mutableListOf<ScheduledExecutorService>()
+
+    @AfterEach
+    fun tearDown() {
+        schedulers.forEach { it.shutdownNow() }
+    }
+
+    @Test
+    fun `success statuses are mapped without retaining response body`() {
+        listOf(200, 202, 204, 299).forEach { status ->
+            val responseFuture = CompletableFuture<HttpResponse<Void>>()
+            val client = StubHttpClient(responseFuture)
+            val delivery = delivery(client)
+
+            val result = delivery.deliver(event())
+            client.bodyHandler.shouldNotBeNull()
+            val capturedBodyHandler = client.bodyHandler
+            capturedBodyHandler.shouldNotBeNull()
+            assertDiscardingBodyHandler(capturedBodyHandler)
+            responseFuture.complete(response(status))
+
+            result.join().shouldBeEqualTo(LeaderAuditDeliveryResult.SUCCESS)
+        }
+    }
+
+    @Test
+    fun `retryable statuses and asynchronous IO failure are classified`() {
+        listOf(408, 429, 500, 503, 599).forEach { status ->
+            val responseFuture = CompletableFuture<HttpResponse<Void>>()
+            val result = delivery(StubHttpClient(responseFuture)).deliver(event())
+            responseFuture.complete(response(status))
+            result.join().shouldBeEqualTo(LeaderAuditDeliveryResult.RETRYABLE_FAILURE)
+        }
+
+        val responseFuture = CompletableFuture<HttpResponse<Void>>()
+        val result = delivery(StubHttpClient(responseFuture)).deliver(event())
+        responseFuture.completeExceptionally(java.io.IOException("socket-secret"))
+        result.join().shouldBeEqualTo(LeaderAuditDeliveryResult.RETRYABLE_FAILURE)
+    }
+
+    @Test
+    fun `non IO asynchronous failure is terminal and encoder cancellation propagates`() {
+        val responseFuture = CompletableFuture<HttpResponse<Void>>()
+        val result = delivery(StubHttpClient(responseFuture)).deliver(event())
+        responseFuture.completeExceptionally(IllegalArgumentException("request-secret"))
+        result.join().shouldBeEqualTo(LeaderAuditDeliveryResult.TERMINAL_FAILURE)
+
+        val cancelledEncoder = LeaderAuditPayloadEncoder { throw CancellationException("cancelled") }
+        assertFailsWith<CancellationException> {
+            delivery(StubHttpClient(CompletableFuture()), encoder = cancelledEncoder).deliver(event())
+        }
+    }
+
+    @Test
+    fun `request uses POST timeout and immutable allow-listed headers`() {
+        val responseFuture = CompletableFuture<HttpResponse<Void>>()
+        val client = StubHttpClient(responseFuture)
+        val result = delivery(
+            client = client,
+            headers = mapOf(
+                "content-type" to "application/ignored",
+                "Authorization" to "Bearer ${WEBHOOK_TOKEN_PLACEHOLDER}",
+            ),
+            encoder = LeaderAuditPayloadEncoder {
+                LeaderAuditHttpPayload.of("application/audit+json", "audit".toByteArray())
+            },
+        ).deliver(event())
+
+        val request = client.request.shouldNotBeNull()
+        request.method().shouldBeEqualTo("POST")
+        request.timeout().orElse(null).shouldNotBeNull().shouldBeEqualTo(Duration.ofSeconds(1))
+        request.headers().firstValue("Content-Type").orElse(null)
+            .shouldBeEqualTo("application/audit+json")
+        request.headers().firstValue("Authorization").orElse(null)
+            .shouldBeEqualTo("Bearer ${WEBHOOK_TOKEN_PLACEHOLDER}")
+        request.bodyPublisher().orElse(null).shouldNotBeNull().contentLength().shouldBeEqualTo(5)
+
+        responseFuture.complete(response(204))
+        result.join().shouldBeEqualTo(LeaderAuditDeliveryResult.SUCCESS)
+    }
+
+    @Test
+    fun `other client errors are terminal and encoder failure is isolated`() {
+        listOf(400, 401, 403, 404, 499).forEach { status ->
+            val responseFuture = CompletableFuture<HttpResponse<Void>>()
+            val result = delivery(StubHttpClient(responseFuture)).deliver(event())
+            responseFuture.complete(response(status))
+            result.join().shouldBeEqualTo(LeaderAuditDeliveryResult.TERMINAL_FAILURE)
+        }
+
+        val client = StubHttpClient(CompletableFuture())
+        val failedEncoder = LeaderAuditPayloadEncoder { throw IllegalStateException("encoder-secret") }
+        val result = delivery(client, encoder = failedEncoder).deliver(event())
+        result.join().shouldBeEqualTo(LeaderAuditDeliveryResult.TERMINAL_FAILURE)
+        client.request.shouldBeNull()
+    }
+
+    @Test
+    fun `payload is immutable and configured lower bound is checked before request`() {
+        val source = byteArrayOf(1, 2, 3)
+        val payload = LeaderAuditHttpPayload.of("text/plain", source)
+        source[0] = 9
+        payload.body()[0].shouldBeEqualTo(1)
+        val returned = payload.body()
+        returned[1] = 8
+        payload.body()[1].shouldBeEqualTo(2)
+
+        val client = StubHttpClient(CompletableFuture())
+        val result = delivery(
+            client,
+            httpOptions = LeaderAuditHttpOptions(2),
+            encoder = LeaderAuditPayloadEncoder { payload },
+        ).deliver(event())
+        result.join().shouldBeEqualTo(LeaderAuditDeliveryResult.TERMINAL_FAILURE)
+        client.request.shouldBeNull()
+    }
+
+    @Test
+    fun `hard payload bound and unsafe endpoint, header, client contracts fail fast`() {
+        assertFailsWith<IllegalArgumentException> {
+            LeaderAuditHttpPayload.of("text/plain", ByteArray(1024 * 1024 + 1))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LeaderAuditHttpPayload.of("text\nplain", byteArrayOf())
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LeaderAuditHttpOptions(0)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LeaderAuditHttpOptions(1024 * 1024 + 1)
+        }
+
+        listOf(
+            URI("http://audit.example.test/hook"),
+            URI("https://user:password@audit.example.test/hook"),
+            URI("https://audit.example.test/hook?token=secret"),
+            URI("https://audit.example.test/hook#fragment"),
+        ).forEach { unsafe ->
+            assertFailsWith<IllegalArgumentException> {
+                LeaderAuditTrustedHttpsEndpoint.trusted(unsafe)
+            }
+        }
+
+        val endpoint = LeaderAuditTrustedHttpsEndpoint.trusted(URI("https://audit.example.test/hook"))
+        assertFailsWith<IllegalArgumentException> {
+            delivery(StubHttpClient(CompletableFuture()), endpoint = endpoint, headers = mapOf("Host" to "evil"))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            delivery(StubHttpClient(CompletableFuture()), endpoint = endpoint, headers = mapOf("X-Api-Key" to "secret"))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            delivery(StubHttpClient(CompletableFuture()), endpoint = endpoint, headers = mapOf("Authorization" to "Bearer\nsecret"))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            delivery(StubHttpClient(CompletableFuture(), redirect = HttpClient.Redirect.ALWAYS), endpoint = endpoint)
+        }
+    }
+
+    @Test
+    fun `cancelled delivery future cancels the underlying HTTP request`() {
+        val responseFuture = CompletableFuture<HttpResponse<Void>>()
+        val client = StubHttpClient(responseFuture)
+        val result = delivery(client).deliver(event())
+
+        result.cancel(true).shouldBeTrue()
+        responseFuture.isCancelled.shouldBeTrue()
+        result.isCancelled.shouldBeTrue()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun assertDiscardingBodyHandler(handler: BodyHandler<*>) {
+        val subscriber = (handler as BodyHandler<Void>).apply(responseInfo())
+        subscriber.onSubscribe(object : Flow.Subscription {
+            override fun request(n: Long) = Unit
+
+            override fun cancel() = Unit
+        })
+        subscriber.onNext(listOf(ByteBuffer.wrap("response-secret".toByteArray())))
+        subscriber.onComplete()
+        subscriber.getBody().toCompletableFuture().join().shouldBeNull()
+    }
+
+    private fun delivery(
+        client: HttpClient,
+        endpoint: LeaderAuditTrustedHttpsEndpoint = LeaderAuditTrustedHttpsEndpoint.trusted(
+            URI("https://audit.example.test/hook"),
+        ),
+        headers: Map<String, String> = mapOf("Authorization" to "Bearer ${WEBHOOK_TOKEN_PLACEHOLDER}"),
+        encoder: LeaderAuditPayloadEncoder = LeaderAuditPayloadEncoder {
+            LeaderAuditHttpPayload.of("text/plain", "audit".toByteArray())
+        },
+        httpOptions: LeaderAuditHttpOptions = LeaderAuditHttpOptions.defaults(),
+    ): HttpLeaderAuditDelivery = HttpLeaderAuditDelivery(
+        client = client,
+        endpoint = endpoint,
+        headers = headers,
+        encoder = encoder,
+        exportOptions = exportOptions(),
+        httpOptions = httpOptions,
+    )
+
+    private fun exportOptions(): LeaderAuditExportOptions = LeaderAuditExportOptions(
+        queueCapacity = 8,
+        maxInFlight = 2,
+        maxAttempts = 2,
+        attemptTimeout = Duration.ofSeconds(1),
+        initialBackoff = Duration.ofMillis(1),
+        maxBackoff = Duration.ofSeconds(1),
+        executor = Executor { it.run() },
+        scheduler = Executors.newSingleThreadScheduledExecutor().also(schedulers::add),
+    )
+
+    private fun event(): LeaderAuditExportEvent.History = LeaderAuditExportEvent.History.from(
+        record = LeaderLockHistoryRecord(
+            lockName = "lock",
+            token = "token",
+            kind = LockIdentity.AnnotationKind.SINGLE,
+            acquiredAt = java.time.Instant.parse("2026-08-18T00:00:00Z"),
+            lockedUntil = java.time.Instant.parse("2026-08-18T00:01:00Z"),
+            status = LeaderHistoryStatus.ACQUIRED,
+        ),
+        sanitizer = LeaderAuditValueSanitizer.Default,
+    )
+
+    private class StubHttpClient(
+        private val responseFuture: CompletableFuture<HttpResponse<Void>>,
+        private val redirect: HttpClient.Redirect = HttpClient.Redirect.NEVER,
+    ) : HttpClient() {
+        var request: HttpRequest? = null
+        var bodyHandler: BodyHandler<*>? = null
+
+        override fun cookieHandler(): Optional<CookieHandler> = Optional.empty()
+
+        override fun connectTimeout(): Optional<Duration> = Optional.of(Duration.ofSeconds(1))
+
+        override fun followRedirects(): Redirect = redirect
+
+        override fun proxy(): Optional<ProxySelector> = Optional.empty()
+
+        override fun sslContext(): SSLContext = try {
+            SSLContext.getDefault()
+        } catch (e: NoSuchAlgorithmException) {
+            throw AssertionError(e)
+        }
+
+        override fun sslParameters(): SSLParameters = SSLParameters()
+
+        override fun authenticator(): Optional<Authenticator> = Optional.empty()
+
+        override fun version(): Version = Version.HTTP_1_1
+
+        override fun executor(): Optional<Executor> = Optional.empty()
+
+        override fun <T> send(request: HttpRequest, responseBodyHandler: BodyHandler<T>): HttpResponse<T> {
+            throw UnsupportedOperationException("send is not used by async delivery")
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T> sendAsync(
+            request: HttpRequest,
+            responseBodyHandler: BodyHandler<T>,
+        ): CompletableFuture<HttpResponse<T>> {
+            this.request = request
+            bodyHandler = responseBodyHandler
+            return responseFuture as CompletableFuture<HttpResponse<T>>
+        }
+
+        override fun <T> sendAsync(
+            request: HttpRequest,
+            responseBodyHandler: BodyHandler<T>,
+            pushPromiseHandler: PushPromiseHandler<T>,
+        ): CompletableFuture<HttpResponse<T>> = sendAsync(request, responseBodyHandler)
+    }
+
+    private fun response(status: Int): HttpResponse<Void> = object : HttpResponse<Void> {
+        override fun statusCode(): Int = status
+
+        override fun request(): HttpRequest = HttpRequest.newBuilder(URI("https://audit.example.test/hook")).build()
+
+        override fun previousResponse(): Optional<HttpResponse<Void>> = Optional.empty()
+
+        override fun headers(): HttpHeaders = HttpHeaders.of(emptyMap()) { _, _ -> true }
+
+        override fun body(): Void? = null
+
+        override fun sslSession(): Optional<javax.net.ssl.SSLSession> = Optional.empty()
+
+        override fun uri(): URI = URI("https://audit.example.test/hook")
+
+        override fun version(): HttpClient.Version = HttpClient.Version.HTTP_1_1
+    }
+
+    private fun responseInfo(): HttpResponse.ResponseInfo = object : HttpResponse.ResponseInfo {
+        override fun statusCode(): Int = 204
+
+        override fun headers(): HttpHeaders = HttpHeaders.of(emptyMap()) { _, _ -> true }
+
+        override fun version(): HttpClient.Version = HttpClient.Version.HTTP_1_1
+    }
+
+    private companion object {
+        const val WEBHOOK_TOKEN_PLACEHOLDER = "\${WEBHOOK_TOKEN}"
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditExporterTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/http/HttpLeaderAuditExporterTest.kt
@@ -1,0 +1,185 @@
+package io.bluetape4k.leader.audit.http
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.leader.LockIdentity
+import io.bluetape4k.leader.audit.LeaderAuditExportEvent
+import io.bluetape4k.leader.audit.LeaderAuditExportOptions
+import io.bluetape4k.leader.audit.LeaderAuditSubmitResult
+import io.bluetape4k.leader.audit.LeaderAuditValueSanitizer
+import io.bluetape4k.leader.history.LeaderHistoryStatus
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.net.Authenticator
+import java.net.CookieHandler
+import java.net.ProxySelector
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.net.http.HttpHeaders
+import java.net.http.HttpResponse.BodyHandler
+import java.net.http.HttpResponse.PushPromiseHandler
+import java.time.Duration
+import java.util.Optional
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLParameters
+
+class HttpLeaderAuditExporterTest {
+
+    private val schedulers = mutableListOf<ScheduledExecutorService>()
+
+    @AfterEach
+    fun tearDown() {
+        schedulers.forEach { it.shutdownNow() }
+    }
+
+    @Test
+    fun `exporter delegates bounded admission and HTTP completion`() {
+        val responseFuture = CompletableFuture<HttpResponse<Void>>()
+        val client = StubHttpClient(responseFuture)
+        val exporter = exporter(client)
+
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        client.requestReady.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        client.request.shouldNotBeNull().uri().shouldBeEqualTo(URI("https://audit.example.test/hook"))
+        responseFuture.complete(response(202))
+        awaitAdmissionReleased(exporter)
+        exporter.snapshot().accepted.shouldBeEqualTo(1)
+        exporter.snapshot().admitted.shouldBeEqualTo(0)
+        exporter.close()
+    }
+
+    @Test
+    fun `close cancels in flight request and late completion cannot schedule retry`() {
+        val responseFuture = CompletableFuture<HttpResponse<Void>>()
+        val client = StubHttpClient(responseFuture)
+        val exporter = exporter(client)
+
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        client.requestReady.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        exporter.close()
+        responseFuture.isCancelled.shouldBeTrue()
+        responseFuture.complete(response(503))
+
+        val snapshot = exporter.snapshot()
+        snapshot.closed.shouldBeTrue()
+        snapshot.scheduledRetries.shouldBeEqualTo(0)
+        snapshot.admitted.shouldBeEqualTo(0)
+        snapshot.cancellations.shouldBeEqualTo(1)
+    }
+
+    private fun exporter(client: HttpClient): HttpLeaderAuditExporter = HttpLeaderAuditExporter(
+        client = client,
+        endpoint = LeaderAuditTrustedHttpsEndpoint.trusted(URI("https://audit.example.test/hook")),
+        headers = mapOf("Authorization" to "Bearer ${WEBHOOK_TOKEN_PLACEHOLDER}"),
+        encoder = LeaderAuditPayloadEncoder {
+            LeaderAuditHttpPayload.of("text/plain", "audit".toByteArray())
+        },
+        exportOptions = LeaderAuditExportOptions(
+            queueCapacity = 8,
+            maxInFlight = 2,
+            maxAttempts = 2,
+            attemptTimeout = Duration.ofSeconds(1),
+            initialBackoff = Duration.ofMillis(1),
+            maxBackoff = Duration.ofSeconds(1),
+            executor = Executor { it.run() },
+            scheduler = Executors.newSingleThreadScheduledExecutor().also(schedulers::add),
+        ),
+        httpOptions = LeaderAuditHttpOptions.defaults(),
+    )
+
+    private fun event(): LeaderAuditExportEvent.History = LeaderAuditExportEvent.History.from(
+        record = LeaderLockHistoryRecord(
+            lockName = "lock",
+            token = "token",
+            kind = LockIdentity.AnnotationKind.SINGLE,
+            acquiredAt = java.time.Instant.parse("2026-08-18T00:00:00Z"),
+            lockedUntil = java.time.Instant.parse("2026-08-18T00:01:00Z"),
+            status = LeaderHistoryStatus.ACQUIRED,
+        ),
+        sanitizer = LeaderAuditValueSanitizer.Default,
+    )
+
+    private fun awaitAdmissionReleased(exporter: HttpLeaderAuditExporter) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (exporter.snapshot().admitted != 0 && System.nanoTime() < deadline) {
+            Thread.onSpinWait()
+        }
+    }
+
+    private class StubHttpClient(
+        private val responseFuture: CompletableFuture<HttpResponse<Void>>,
+    ) : HttpClient() {
+        val requestReady = CountDownLatch(1)
+        var request: HttpRequest? = null
+
+        override fun cookieHandler(): Optional<CookieHandler> = Optional.empty()
+
+        override fun connectTimeout(): Optional<Duration> = Optional.of(Duration.ofSeconds(1))
+
+        override fun followRedirects(): Redirect = Redirect.NEVER
+
+        override fun proxy(): Optional<ProxySelector> = Optional.empty()
+
+        override fun sslContext(): SSLContext = SSLContext.getDefault()
+
+        override fun sslParameters(): SSLParameters = SSLParameters()
+
+        override fun authenticator(): Optional<Authenticator> = Optional.empty()
+
+        override fun version(): Version = Version.HTTP_1_1
+
+        override fun executor(): Optional<Executor> = Optional.empty()
+
+        override fun <T> send(request: HttpRequest, responseBodyHandler: BodyHandler<T>): HttpResponse<T> {
+            throw UnsupportedOperationException("send is not used by async delivery")
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T> sendAsync(
+            request: HttpRequest,
+            responseBodyHandler: BodyHandler<T>,
+        ): CompletableFuture<HttpResponse<T>> {
+            this.request = request
+            requestReady.countDown()
+            return responseFuture as CompletableFuture<HttpResponse<T>>
+        }
+
+        override fun <T> sendAsync(
+            request: HttpRequest,
+            responseBodyHandler: BodyHandler<T>,
+            pushPromiseHandler: PushPromiseHandler<T>,
+        ): CompletableFuture<HttpResponse<T>> = sendAsync(request, responseBodyHandler)
+    }
+
+    private fun response(status: Int): HttpResponse<Void> = object : HttpResponse<Void> {
+        override fun statusCode(): Int = status
+
+        override fun request(): HttpRequest = HttpRequest.newBuilder(URI("https://audit.example.test/hook")).build()
+
+        override fun previousResponse(): Optional<HttpResponse<Void>> = Optional.empty()
+
+        override fun headers(): HttpHeaders = HttpHeaders.of(emptyMap()) { _, _ -> true }
+
+        override fun body(): Void? = null
+
+        override fun sslSession(): Optional<javax.net.ssl.SSLSession> = Optional.empty()
+
+        override fun uri(): URI = URI("https://audit.example.test/hook")
+
+        override fun version(): HttpClient.Version = HttpClient.Version.HTTP_1_1
+    }
+
+    private companion object {
+        const val WEBHOOK_TOKEN_PLACEHOLDER = "\${WEBHOOK_TOKEN}"
+    }
+}

--- a/leader-micrometer/README.ko.md
+++ b/leader-micrometer/README.ko.md
@@ -249,6 +249,33 @@ exporter.submit(event)
 exporter.close() // delegate를 정확히 한 번 소유하고 닫습니다.
 ```
 
+core 모듈의 JDK HTTP transport와 Micrometer decorator를 조합하면 webhook 결과와
+queue gauge를 함께 export할 수 있습니다.
+
+```kotlin
+val exporter = MicrometerLeaderAuditExporter(
+    delegate = HttpLeaderAuditExporter(
+        client = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build(),
+        endpoint = LeaderAuditTrustedHttpsEndpoint.trusted(
+            URI("https://audit.example.test/v1/leader-events"),
+        ),
+        headers = mapOf("Authorization" to "Bearer ${System.getenv("AUDIT_WEBHOOK_TOKEN")}"),
+        encoder = LeaderAuditPayloadEncoder { event ->
+            LeaderAuditHttpPayload.of("text/plain; charset=utf-8", event.toString().toByteArray())
+        },
+        exportOptions = exportOptions,
+        httpOptions = LeaderAuditHttpOptions.defaults(),
+    ),
+    registry = registry,
+)
+```
+
+`HttpLeaderAuditExporter`는 신뢰한 HTTPS endpoint만 받고 redirect를 끄며 응답 body를
+폐기합니다. 직렬화, endpoint allow-list, idempotency는 애플리케이션의 책임입니다.
+이 모듈은 메트릭만 추가하고 JSON 또는 OpenTelemetry transport는 추가하지 않습니다.
+
 decorator는 고정 aggregate metric catalog 하나만 제공합니다. lock name,
 leader ID, endpoint, error message, `source`, `transport`를 tag로 복사하지
 않습니다. 유일한 tag는 아래의 제한된 `outcome` 값입니다. registry는 close 후
@@ -275,13 +302,13 @@ non-owning observation이 필요하면 같은 delegate를 두 번 wrapping하지
 
 dropped meter는 두 개의 outcome-tagged ID를 가지므로 고정 catalog는 총 13개
 meter ID입니다. Counter 값은 detached generation offset과 active delegate
-snapshot을 합산해 replacement 후에도 감소하지 않습니다. close 중 delegate
-close 중 snapshot이 예외를 던지면 마지막으로 신뢰한 offset을 유지하고 source를
-degraded로 표시한 뒤 delegate reference를 분리하고 원래 예외를 전달합니다. snapshot이
+기준 데이터 값을 합산해 replacement 후에도 감소하지 않습니다. close 중 delegate
+기준 데이터를 읽다가 예외가 나면 마지막으로 신뢰한 offset을 유지하고 source를
+degraded로 표시한 뒤 delegate reference를 분리하고 원래 예외를 전달합니다. 기준 데이터가
 더 낮은 cumulative 값을 반환하는 경우에는 trusted baseline을 유지하고 degraded warning만
 기록한 뒤 정상 반환하며, 예외를 새로 만들지 않습니다.
 degraded 경로는 `leader.audit.export.meter-source-degraded` fixed warning을 사용하며
-snapshot payload나 exception message를 로그에 남기지 않습니다.
+응답 payload나 exception message를 로그에 남기지 않습니다.
 고정 catalog를 일부만 등록한 뒤 registration이 실패하면 manager는 이미 등록한 소유
 meter와 identity를 보존합니다. 다음 acquire에서는 누락된 ID만 등록하고 foreign meter는
 제거하지 않습니다. 각 scrape의 cumulative 비교는 scalar 연산으로 수행하므로 hot path에서

--- a/leader-micrometer/README.md
+++ b/leader-micrometer/README.md
@@ -249,6 +249,34 @@ exporter.submit(event)
 exporter.close() // owns and closes delegate exactly once
 ```
 
+The core module supplies the JDK HTTP transport. Compose it with the Micrometer
+decorator when webhook outcomes and queue gauges should be exported together:
+
+```kotlin
+val exporter = MicrometerLeaderAuditExporter(
+    delegate = HttpLeaderAuditExporter(
+        client = HttpClient.newBuilder()
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build(),
+        endpoint = LeaderAuditTrustedHttpsEndpoint.trusted(
+            URI("https://audit.example.test/v1/leader-events"),
+        ),
+        headers = mapOf("Authorization" to "Bearer ${System.getenv("AUDIT_WEBHOOK_TOKEN")}"),
+        encoder = LeaderAuditPayloadEncoder { event ->
+            LeaderAuditHttpPayload.of("text/plain; charset=utf-8", event.toString().toByteArray())
+        },
+        exportOptions = exportOptions,
+        httpOptions = LeaderAuditHttpOptions.defaults(),
+    ),
+    registry = registry,
+)
+```
+
+`HttpLeaderAuditExporter` accepts only a trusted HTTPS endpoint, disables redirects,
+and discards response bodies. Serialization, endpoint allow-listing, and idempotency
+remain application responsibilities; this module adds metrics but no JSON or
+OpenTelemetry transport.
+
 The decorator publishes one fixed, aggregate metric catalog. It never copies lock
 names, leader IDs, endpoints, error messages, `source`, or `transport` into tags.
 The only tag is `outcome`, with the bounded values shown below. A registry keeps


### PR DESCRIPTION
## 요약

Closes #535

leader election history/lifecycle event를 기존 bounded exporter 계약으로 전달하는 JDK `HttpClient` 기반 HTTP/webhook adapter를 추가했습니다. 새 serialization dependency 없이 caller가 payload encoder를 주입하며, production endpoint는 명시적으로 신뢰한 HTTPS URI만 받습니다.

## 구현 범위

- `LeaderAuditPayloadEncoder`와 immutable `LeaderAuditHttpPayload`의 hard 1 MiB/설정 bound/방어적 복사
- `LeaderAuditTrustedHttpsEndpoint`의 HTTPS-only URI 및 credential/query/fragment/control-character 검증
- `HttpLeaderAuditDelivery`의 POST, timeout, `BodyHandlers.discarding()`, 2xx/408/429/5xx/I/O 분류, cancellation 전파, allow-listed headers, `Redirect.NEVER`
- `HttpLeaderAuditExporter`의 기존 `BoundedLeaderAuditExporter` 위임으로 admission/retry/close semantics 보존
- 루트·core·Micrometer README, manual draft, review artifact, 한국어 lesson 갱신

## 검증

- HTTP focused: 10 tests PASS
- `leader-core` 전체: 893 tests PASS
- `leader-micrometer` affected tests PASS
- `leader-core:detekt` PASS
- `./gradlew projects`: PASS, module/BOM/CI 변경 없음
- 한국어 terminology audit: 6 files, findings=0
- `git diff --check`: PASS

독립 architecture/code-review 결과는 `WATCH`, P0=0/P1=0/P2=3/P3=1이며 merge 차단 blocker는 없습니다. P2는 stable delivery id/idempotency SPI, `Content-Type` 책임 단일화, 실제 HTTPS/TLS loopback 통합 검증 후속으로 문서화했습니다. `TrustedHttpsEndpoint`의 DNS/SSRF 판단은 caller-owned trust boundary입니다.

## DoD Status

- [x] 승인된 Issue #535 AUD-03 범위 구현 및 테스트
- [x] public API/보안/취소/close 경계 검증
- [x] EN/KO README·manual draft·review·lesson parity
- [x] Lore commit `97e9b171` 및 원격 branch push
- [x] local runtime workflow `completed` 및 receipt `verify` PASS
- [ ] exact-head hosted CI 및 merge: PR 이후 수행
