### PR TITLE
fix(leader): strategic lock-name 검증 경계 정렬

### DIFF
--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElector.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.leader.local
 import io.bluetape4k.idgenerators.uuid.Uuid
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.StrategicLeaderElector
+import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.ElectionStrategy
@@ -33,8 +34,10 @@ class LocalStrategicLeaderElector(
     private val registry = ConcurrentHashMap<String, ConcurrentHashMap<String, CandidateInfo>>()
     private val locks = ConcurrentHashMap<String, ReentrantLock>()
 
-    private fun candidatesFor(lockName: String): ConcurrentHashMap<String, CandidateInfo> =
-        registry.computeIfAbsent(lockName) { ConcurrentHashMap() }
+    private fun candidatesFor(lockName: String): ConcurrentHashMap<String, CandidateInfo> {
+        validateLockName(lockName)
+        return registry.computeIfAbsent(lockName) { ConcurrentHashMap() }
+    }
 
     private fun lockFor(lockName: String): ReentrantLock =
         locks.computeIfAbsent(lockName) { ReentrantLock() }
@@ -60,6 +63,7 @@ class LocalStrategicLeaderElector(
         options: LeaderElectionOptions,
         action: () -> T,
     ): T? {
+        validateLockName(lockName)
         // 선출 단계만 lockName 단위 락으로 보호
         val result = lockFor(lockName).withLock {
             strategy.elect(listCandidates(lockName))

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElector.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.local
 
 import io.bluetape4k.idgenerators.uuid.Uuid
 import io.bluetape4k.leader.StrategicLeaderGroupElector
+import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.GroupElectionStrategy
@@ -29,8 +30,10 @@ class LocalStrategicLeaderGroupElector(
     private val registry = ConcurrentHashMap<String, ConcurrentHashMap<String, CandidateInfo>>()
     private val locks = ConcurrentHashMap<String, ReentrantLock>()
 
-    private fun candidatesFor(lockName: String): ConcurrentHashMap<String, CandidateInfo> =
-        registry.computeIfAbsent(lockName) { ConcurrentHashMap() }
+    private fun candidatesFor(lockName: String): ConcurrentHashMap<String, CandidateInfo> {
+        validateLockName(lockName)
+        return registry.computeIfAbsent(lockName) { ConcurrentHashMap() }
+    }
 
     private fun lockFor(lockName: String): ReentrantLock =
         locks.computeIfAbsent(lockName) { ReentrantLock() }
@@ -57,6 +60,7 @@ class LocalStrategicLeaderGroupElector(
         maxLeaders: Int,
         action: () -> T,
     ): T? {
+        validateLockName(lockName)
         val result = lockFor(lockName).withLock {
             val snapshot = listCandidates(lockName)
             strategy.electValidated(snapshot, maxLeaders)

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElector.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.leader.local
 import io.bluetape4k.idgenerators.uuid.Uuid
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.coroutines.StrategicSuspendLeaderElector
+import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.ElectionStrategy
@@ -33,8 +34,10 @@ class LocalStrategicSuspendLeaderElector(
     private val registry = ConcurrentHashMap<String, ConcurrentHashMap<String, CandidateInfo>>()
     private val mutexes = ConcurrentHashMap<String, Mutex>()
 
-    private fun candidatesFor(lockName: String): ConcurrentHashMap<String, CandidateInfo> =
-        registry.computeIfAbsent(lockName) { ConcurrentHashMap() }
+    private fun candidatesFor(lockName: String): ConcurrentHashMap<String, CandidateInfo> {
+        validateLockName(lockName)
+        return registry.computeIfAbsent(lockName) { ConcurrentHashMap() }
+    }
 
     private fun mutexFor(lockName: String): Mutex =
         mutexes.computeIfAbsent(lockName) { Mutex() }
@@ -60,6 +63,7 @@ class LocalStrategicSuspendLeaderElector(
         options: LeaderElectionOptions,
         action: suspend () -> T,
     ): T? {
+        validateLockName(lockName)
         // 선출 단계만 lockName 단위 뮤텍스로 보호
         val result = mutexFor(lockName).withLock {
             strategy.elect(listCandidates(lockName))

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderGroupElector.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.local
 
 import io.bluetape4k.idgenerators.uuid.Uuid
 import io.bluetape4k.leader.coroutines.StrategicSuspendLeaderGroupElector
+import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.GroupElectionStrategy
@@ -29,8 +30,10 @@ class LocalStrategicSuspendLeaderGroupElector(
     private val registry = ConcurrentHashMap<String, ConcurrentHashMap<String, CandidateInfo>>()
     private val mutexes = ConcurrentHashMap<String, Mutex>()
 
-    private fun candidatesFor(lockName: String): ConcurrentHashMap<String, CandidateInfo> =
-        registry.computeIfAbsent(lockName) { ConcurrentHashMap() }
+    private fun candidatesFor(lockName: String): ConcurrentHashMap<String, CandidateInfo> {
+        validateLockName(lockName)
+        return registry.computeIfAbsent(lockName) { ConcurrentHashMap() }
+    }
 
     private fun mutexFor(lockName: String): Mutex =
         mutexes.computeIfAbsent(lockName) { Mutex() }
@@ -57,6 +60,7 @@ class LocalStrategicSuspendLeaderGroupElector(
         maxLeaders: Int,
         action: suspend () -> T,
     ): T? {
+        validateLockName(lockName)
         val result = mutexFor(lockName).withLock {
             val snapshot = listCandidates(lockName)
             strategy.electValidated(snapshot, maxLeaders)

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalLockNameConformanceTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalLockNameConformanceTest.kt
@@ -1,0 +1,121 @@
+package io.bluetape4k.leader.local
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.contract.AbstractLockNameConformanceTest
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
+import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import org.junit.jupiter.api.Test
+
+private val invalidLockNames = listOf(
+    "",
+    "   ",
+    "a" + "b".repeat(255),
+    ".leading-dot",
+    "has.dot",
+    "has space",
+    "has@at",
+    "has#hash",
+    "-leading-hyphen",
+    ":leading-colon",
+    "_leading-underscore",
+)
+
+/** Local blocking strategic electors가 공통 lock-name 계약을 따르는지 검증합니다. */
+class LocalBlockingLockNameConformanceTest : AbstractLockNameConformanceTest() {
+
+    private val single = LocalStrategicLeaderElector("contract-blocking-single")
+    private val group = LocalStrategicLeaderGroupElector("contract-blocking-group")
+
+    override fun validateLockName(lockName: String) {
+        val candidate = CandidateInfo("contract-${System.nanoTime()}")
+        var singleRegistered = false
+        var groupRegistered = false
+        try {
+            single.registerCandidate(lockName, candidate)
+            singleRegistered = true
+            group.registerCandidate(lockName, candidate)
+            groupRegistered = true
+        } finally {
+            if (singleRegistered) {
+                single.unregisterCandidate(lockName, candidate.nodeId)
+            }
+            if (groupRegistered) {
+                group.unregisterCandidate(lockName, candidate.nodeId)
+            }
+        }
+    }
+
+    @Test
+    fun `단일 및 그룹 runIfLeader는 잘못된 lockName을 즉시 거부한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            single.runIfLeader("", FifoElectionStrategy) { error("실행되면 안 됨") }
+        }
+        assertFailsWith<IllegalArgumentException> {
+            group.runIfLeader(" ", FifoGroupElectionStrategy) { error("실행되면 안 됨") }
+        }
+    }
+
+    @Test
+    fun `단일 및 그룹 후보 등록은 전체 invalid corpus를 거부한다`() {
+        invalidLockNames.forEach { lockName ->
+            val candidate = CandidateInfo("contract-${System.nanoTime()}")
+            assertFailsWith<IllegalArgumentException> {
+                single.registerCandidate(lockName, candidate)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                group.registerCandidate(lockName, candidate)
+            }
+        }
+    }
+}
+
+/** Local suspend strategic electors가 공통 lock-name 계약을 따르는지 검증합니다. */
+class LocalSuspendLockNameConformanceTest : AbstractLockNameConformanceTest() {
+
+    private val single = LocalStrategicSuspendLeaderElector("contract-suspend-single")
+    private val group = LocalStrategicSuspendLeaderGroupElector("contract-suspend-group")
+
+    override fun validateLockName(lockName: String) = runSuspendIO {
+        val candidate = CandidateInfo("contract-${System.nanoTime()}")
+        var singleRegistered = false
+        var groupRegistered = false
+        try {
+            single.registerCandidate(lockName, candidate)
+            singleRegistered = true
+            group.registerCandidate(lockName, candidate)
+            groupRegistered = true
+        } finally {
+            if (singleRegistered) {
+                single.unregisterCandidate(lockName, candidate.nodeId)
+            }
+            if (groupRegistered) {
+                group.unregisterCandidate(lockName, candidate.nodeId)
+            }
+        }
+    }
+
+    @Test
+    fun `단일 및 그룹 suspend runIfLeader는 잘못된 lockName을 즉시 거부한다`() = runSuspendIO {
+        assertFailsWith<IllegalArgumentException> {
+            single.runIfLeader("", FifoElectionStrategy) { error("실행되면 안 됨") }
+        }
+        assertFailsWith<IllegalArgumentException> {
+            group.runIfLeader(" ", FifoGroupElectionStrategy) { error("실행되면 안 됨") }
+        }
+    }
+
+    @Test
+    fun `단일 및 그룹 suspend 후보 등록은 전체 invalid corpus를 거부한다`() = runSuspendIO {
+        invalidLockNames.forEach { lockName ->
+            val candidate = CandidateInfo("contract-${System.nanoTime()}")
+            assertFailsWith<IllegalArgumentException> {
+                single.registerCandidate(lockName, candidate)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                group.registerCandidate(lockName, candidate)
+            }
+        }
+    }
+}

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.redisson
 
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.logging.KLogging
 import org.redisson.api.RedissonClient
 import kotlin.time.Duration
@@ -30,7 +31,10 @@ internal class RedissonCandidateRegistry(
         internal const val GROUP_KEY_PREFIX = "leader:strategy:group-candidates:redisson:v1"
     }
 
-    private fun cacheKey(lockName: String) = "$keyPrefix:$lockName"
+    private fun cacheKey(lockName: String): String {
+        validateLockName(lockName)
+        return "$keyPrefix:$lockName"
+    }
 
     private fun mapCacheFor(lockName: String) =
         redissonClient.getMapCache<String, CandidateInfo>(cacheKey(lockName))

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElector.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.leader.StrategicLeaderElector
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.ElectionStrategy
+import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
@@ -49,6 +50,7 @@ class RedissonStrategicLeaderElector(
         options: LeaderElectionOptions,
         action: () -> T,
     ): T? {
+        validateLockName(lockName)
         val candidates = runCatching { listCandidates(lockName) }
             .onFailure { log.warn(it) { "[$lockName] 후보 목록 조회 실패 — 선출 skip" } }
             .getOrElse { return null }

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElector.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.GroupElectionStrategy
 import io.bluetape4k.leader.strategy.electValidated
+import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
@@ -51,6 +52,7 @@ class RedissonStrategicLeaderGroupElector(
         maxLeaders: Int,
         action: () -> T,
     ): T? {
+        validateLockName(lockName)
         val candidates = runCatching { listCandidates(lockName) }
             .onFailure { log.warn(it) { "[$lockName] 후보 목록 조회 실패 — 전략적 그룹 선출 skip" } }
             .getOrElse { return null }

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElector.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.leader.coroutines.StrategicSuspendLeaderElector
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.ElectionStrategy
+import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
@@ -51,6 +52,7 @@ class RedissonStrategicSuspendLeaderElector(
         options: LeaderElectionOptions,
         action: suspend () -> T,
     ): T? {
+        validateLockName(lockName)
         val candidates = try {
             listCandidates(lockName)
         } catch (e: CancellationException) {

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElector.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.GroupElectionStrategy
 import io.bluetape4k.leader.strategy.electValidated
+import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
@@ -53,6 +54,7 @@ class RedissonStrategicSuspendLeaderGroupElector(
         maxLeaders: Int,
         action: suspend () -> T,
     ): T? {
+        validateLockName(lockName)
         val candidates = try {
             listCandidates(lockName)
         } catch (e: CancellationException) {

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLockNameConformanceTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLockNameConformanceTest.kt
@@ -1,0 +1,171 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.contract.AbstractLockNameConformanceTest
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
+import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.redisson.api.RedissonClient
+
+private val invalidLockNames = listOf(
+    "",
+    "   ",
+    "a" + "b".repeat(255),
+    ".leading-dot",
+    "has.dot",
+    "has space",
+    "has@at",
+    "has#hash",
+    "-leading-hyphen",
+    ":leading-colon",
+    "_leading-underscore",
+)
+
+/** Redisson blocking strategic electors가 실제 key 생성 전에 이름을 검증하는지 확인합니다. */
+class RedissonBlockingLockNameConformanceTest : AbstractLockNameConformanceTest() {
+
+    private val single = RedissonStrategicLeaderElector(
+        AbstractRedissonLeaderTest.redissonClient,
+        "contract-blocking-single",
+    )
+    private val group = RedissonStrategicLeaderGroupElector(
+        AbstractRedissonLeaderTest.redissonClient,
+        "contract-blocking-group",
+    )
+
+    override fun validateLockName(lockName: String) {
+        val candidate = CandidateInfo("contract-${System.nanoTime()}")
+        var singleRegistered = false
+        var groupRegistered = false
+        try {
+            single.registerCandidate(lockName, candidate)
+            singleRegistered = true
+            group.registerCandidate(lockName, candidate)
+            groupRegistered = true
+        } finally {
+            if (singleRegistered) {
+                single.unregisterCandidate(lockName, candidate.nodeId)
+            }
+            if (groupRegistered) {
+                group.unregisterCandidate(lockName, candidate.nodeId)
+            }
+        }
+    }
+
+    @Test
+    fun `단일 및 그룹 runIfLeader는 잘못된 lockName을 즉시 거부한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            single.runIfLeader("", FifoElectionStrategy) { error("실행되면 안 됨") }
+        }
+        assertFailsWith<IllegalArgumentException> {
+            group.runIfLeader(" ", FifoGroupElectionStrategy) { error("실행되면 안 됨") }
+        }
+    }
+
+    @Test
+    fun `단일 및 그룹 후보 등록은 전체 invalid corpus를 거부한다`() {
+        invalidLockNames.forEach { lockName ->
+            val candidate = CandidateInfo("contract-${System.nanoTime()}")
+            assertFailsWith<IllegalArgumentException> {
+                single.registerCandidate(lockName, candidate)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                group.registerCandidate(lockName, candidate)
+            }
+        }
+    }
+}
+
+/** Redisson suspend strategic electors가 실제 key 생성 전에 이름을 검증하는지 확인합니다. */
+class RedissonSuspendLockNameConformanceTest : AbstractLockNameConformanceTest() {
+
+    private val single = RedissonStrategicSuspendLeaderElector(
+        AbstractRedissonLeaderTest.redissonClient,
+        "contract-suspend-single",
+    )
+    private val group = RedissonStrategicSuspendLeaderGroupElector(
+        AbstractRedissonLeaderTest.redissonClient,
+        "contract-suspend-group",
+    )
+
+    override fun validateLockName(lockName: String) = runSuspendIO {
+        val candidate = CandidateInfo("contract-${System.nanoTime()}")
+        var singleRegistered = false
+        var groupRegistered = false
+        try {
+            single.registerCandidate(lockName, candidate)
+            singleRegistered = true
+            group.registerCandidate(lockName, candidate)
+            groupRegistered = true
+        } finally {
+            if (singleRegistered) {
+                single.unregisterCandidate(lockName, candidate.nodeId)
+            }
+            if (groupRegistered) {
+                group.unregisterCandidate(lockName, candidate.nodeId)
+            }
+        }
+    }
+
+    @Test
+    fun `단일 및 그룹 suspend runIfLeader는 잘못된 lockName을 즉시 거부한다`() = runSuspendIO {
+        assertFailsWith<IllegalArgumentException> {
+            single.runIfLeader("", FifoElectionStrategy) { error("실행되면 안 됨") }
+        }
+        assertFailsWith<IllegalArgumentException> {
+            group.runIfLeader(" ", FifoGroupElectionStrategy) { error("실행되면 안 됨") }
+        }
+    }
+
+    @Test
+    fun `단일 및 그룹 suspend 후보 등록은 전체 invalid corpus를 거부한다`() = runSuspendIO {
+        invalidLockNames.forEach { lockName ->
+            val candidate = CandidateInfo("contract-${System.nanoTime()}")
+            assertFailsWith<IllegalArgumentException> {
+                single.registerCandidate(lockName, candidate)
+            }
+            assertFailsWith<IllegalArgumentException> {
+                group.registerCandidate(lockName, candidate)
+            }
+        }
+    }
+}
+
+class RedissonLockNameValidationOrderingTest {
+
+    @Test
+    fun `blocking strategic invalid lockName은 Redisson map cache 전에 거부된다`() {
+        val client = mockk<RedissonClient>(relaxed = true)
+        val single = RedissonStrategicLeaderElector(client)
+        val group = RedissonStrategicLeaderGroupElector(client)
+
+        assertFailsWith<IllegalArgumentException> {
+            single.runIfLeader("", FifoElectionStrategy) { error("실행되면 안 됨") }
+        }
+        assertFailsWith<IllegalArgumentException> {
+            group.runIfLeader(" ", FifoGroupElectionStrategy) { error("실행되면 안 됨") }
+        }
+
+        verify(exactly = 0) { client.getMapCache<String, CandidateInfo>(any<String>()) }
+    }
+
+    @Test
+    fun `suspend strategic invalid lockName은 Redisson map cache 전에 거부된다`() = runSuspendIO {
+        val client = mockk<RedissonClient>(relaxed = true)
+        val single = RedissonStrategicSuspendLeaderElector(client)
+        val group = RedissonStrategicSuspendLeaderGroupElector(client)
+
+        assertFailsWith<IllegalArgumentException> {
+            single.runIfLeader("", FifoElectionStrategy) { error("실행되면 안 됨") }
+        }
+        assertFailsWith<IllegalArgumentException> {
+            group.runIfLeader(" ", FifoGroupElectionStrategy) { error("실행되면 안 됨") }
+        }
+
+        verify(exactly = 0) { client.getMapCache<String, CandidateInfo>(any<String>()) }
+    }
+}


### PR DESCRIPTION
## 요약

Fixes #776

Local 및 Redisson strategic 선출의 blocking/suspend, single/group 경로가 공통 `leader-core` `validateLockName` 계약을 상태·키 생성과 fallback보다 먼저 적용하도록 정렬했습니다.

## 원인

- Local strategic electors는 후보 registry와 lock/mutex 생성 전에 공통 lock-name 검증을 호출하지 않았습니다.
- Redisson strategic electors는 후보 key 접근과 `runCatching`/예외 fallback 전에 검증하지 않아 invalid 이름이 `null`로 숨겨질 수 있었습니다.

## 변경 내용

- Local strategic blocking/suspend single/group 4개 경로에 후보 등록 및 `runIfLeader` 선행 검증을 추가했습니다.
- Redisson candidate registry key boundary와 strategic blocking/suspend single/group 4개 `runIfLeader` 진입점에 선행 검증을 추가했습니다.
- 공통 conformance fixture를 사용해 유효 이름, blank/space, 255/256자, 허용되지 않는 문자·시작 패턴을 검증합니다.
- Redisson mock ordering 테스트로 invalid `runIfLeader`에서 `getMapCache`가 호출되지 않음을 검증합니다.
- 예외 검증은 `io.bluetape4k.assertions.assertFailsWith`를 사용했습니다.

## 범위 경계

- 정상 lock contention의 `null` 반환, action 예외, cancellation, TTL/result semantics와 public API/ABI/dependency를 변경하지 않았습니다.
- Redisson backend 조회 오류를 contention `null`과 구분하는 기존 P1은 Issue #785 범위입니다.
- 결과 카운터 원자성은 #786, group coroutine 취소 대칭은 #787에서 추적합니다.

## 검증

- TDD RED: 기존 Local 경로가 256자·invalid 시작 패턴·invalid `runIfLeader`를 거부하지 않음을 재현했습니다.
- TDD GREEN: Local focused conformance `44 passing`.
- Redisson focused conformance/order `46 passing`.
- `leader-core` 전체 회귀 `927 passing` (병합 후 `develop`에서 `937 passing`).
- `leader-redis-redisson` 전체 회귀 `268 passing` (`--no-daemon`, Testcontainers 포함).
- `:bluetape4k-leader-core:detekt` 및 `:bluetape4k-leader-redis-redisson:detekt` 통과.
- 독립 7-Tier code review: `CLEAR`, P0/P1/P2/P3 `0`.

## 기준 및 head

- 승인된 계획 기준: `develop@cafe856132c07fce814d6a5389b2c21c34155e99`.
- PR 생성 시 live `develop`: `440e4f4e65a88eefdb822a5f3c1a7d44cd104046` (`#792` 포함); 해당 커밋은 승인 기준의 후속 ancestor입니다.
- 현재 head: `d8b1912c41c7dda509544dade79a2e6138a98164`.
- 병합 결과: `develop@27a04daff63112e2a79ab2eb300e166bb25b6b81` (rebase merge, 2026-08-26).

## DoD Status

| 항목 | 상태 | 증거 |
|---|---|---|
| Type-C 범위·비중복성 | PASS | #776 범위만 수정, #785/#786/#787 비중복 |
| Local/Redisson blocking·suspend single/group | PASS | 공통 validator 선행 경계 및 fixture |
| bluetape4k-assertions | PASS | 신규 예외 검증 전체에 `assertFailsWith` 사용 |
| 7-Tier 및 Kotlin patterns | PASS | 독립 code-reviewer `APPROVE`, architect `CLEAR`, P0/P1/P2/P3=0 |
| 로컬 회귀·정적 검사 | PASS | 병합 전 927 + 268 tests, focused 44 + 46, detekt; 병합 후 core 937 + Redisson 268 tests, detekt |
| hosted exact-head CI | PASS | run [32962062725](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32962062725): 47 checks 중 46 pass, 0 fail/pending, manual/release contract 1 skipped |
| merge / canonical sync / cleanup | PASS | PR #793 merged; root `develop`와 `origin/develop`가 `27a04daff63112e2a79ab2eb300e166bb25b6b81`에서 일치, 통합 작업 트리 정리 완료 |

PR #793은 명시적 승인에 따라 병합되었으며 auto-merge는 활성화하지 않았습니다.