### PR TITLE
fix(leader): strategic 후보 조회 백엔드 오류를 contention null과 구분

### DIFF
--- a/docs/lessons/2026-08-26-issue-785-strategic-backend-error-propagation.md
+++ b/docs/lessons/2026-08-26-issue-785-strategic-backend-error-propagation.md
@@ -1,0 +1,43 @@
+# Issue #785 교훈 — 전략적 후보 조회 오류와 contention 분리
+
+## 맥락
+
+Redis Lettuce와 Redisson의 전략적 single/group elector가 후보 목록을 읽을 때
+`runCatching` 또는 `catch(Throwable)`로 모든 실패를 `null`로 바꾸고 있었습니다.
+후보가 실제로 없어 선출되지 않은 정상 contention과 Redis 연결·codec·backend 장애를
+같은 결과로 처리하면 작업이 실행되지 않은 이유를 운영자가 구분할 수 없습니다.
+
+## 결정
+
+후보 조회 경계에서는 `CancellationException`을 먼저 재전파하고, 일반 `Exception`은
+로그를 남긴 뒤 그대로 던집니다. `Error`는 잡지 않아 프로세스 수준 신호를
+contention으로 축소하지 않습니다. 후보 목록이 정상적으로 비어 있거나 전략이
+승자를 선택하지 못한 경우의 `null`, action 이후 결과 업데이트의 best-effort 정책,
+후보 TTL과 key namespace는 그대로 유지했습니다. Lettuce registry의 손상된
+`CandidateInfo` decode도 후보 하나를 조용히 제외하지 않고 조회 오류로 전파하도록
+정렬했습니다.
+
+## 결과
+
+8개 경로(Lettuce/Redisson × blocking/suspend × single/group)가 동일한 예외 경계를
+공유합니다. backend 오류는 action 전에 호출자에게 보이고, cancellation은 취소
+상태를 보존하며, 정상 no-winner만 기존 `null` 계약을 유지합니다.
+
+## 검증
+
+- RED: 초기 회귀 5개 기준으로 Lettuce 4개, Redisson 5개가 기존 fallback에서
+  기대한 예외 없이 실패했습니다(기존 suspend cancellation 테스트 1개는 이미 통과).
+- GREEN: MockK 기반 unavailable/codec lookup fixture로 Lettuce 8개와 Redisson 8개가
+  모두 통과했습니다. 일반 예외·cancellation·`Error`·손상 codec 데이터 전파와
+  action 미실행을 함께 확인했습니다.
+- rebase 후 전체 모듈 suite도 Lettuce 290개, Redisson 276개가 통과했고 두 모듈
+  detekt와 `git diff --check`가 성공했습니다. hosted exact-head 검증은 PR 단계에서
+  다시 수집합니다.
+
+## 다음 변경자 지침
+
+후보·락·lease 조회처럼 backend 장애와 정상 경쟁을 함께 반환할 수 있는 경계에
+`runCatching { ... }.getOrElse { return null }` 또는 `catch(Throwable) -> null`을
+추가하지 마세요. 결과 타입을 확장하지 않는 한 예외 분류를 코드 경계에서
+명시하고, 각 blocking/suspend/backend 조합에 cancellation·`Error`·일반 예외
+회귀를 고정하세요.

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt
@@ -3,8 +3,6 @@ package io.bluetape4k.leader.lettuce
 import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
-import io.bluetape4k.logging.KLogging
-import io.bluetape4k.logging.warn
 import io.lettuce.core.SetArgs
 import io.lettuce.core.api.StatefulRedisConnection
 import kotlin.time.Duration
@@ -25,7 +23,7 @@ internal class LettuceCandidateRegistry(
         DEFAULT_KEY_PREFIX,
     )
 
-    companion object: KLogging() {
+    companion object {
         internal const val DEFAULT_KEY_PREFIX = "leader:strategy:candidates"
         internal const val GROUP_KEY_PREFIX = "leader:strategy:group-candidates:lettuce:v1"
     }
@@ -85,9 +83,7 @@ internal class LettuceCandidateRegistry(
                     return@mapNotNull null
                 }
                 val raw = kv.value
-                runCatching { LettuceCandidateInfoCodec.decode(raw) }
-                    .onFailure { log.warn(it) { "[$lockName] CandidateInfo 디코딩 실패 — 항목 skip: key=${kv.key}" } }
-                    .getOrNull()
+                LettuceCandidateInfoCodec.decode(raw)
             }
             .also {
                 if (staleNodeIds.isNotEmpty()) {

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElector.kt
@@ -49,6 +49,7 @@ class LettuceStrategicLeaderElector(
      *
      * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
      */
+    @Suppress("ReturnCount", "TooGenericExceptionCaught", "ThrowsCount")
     override fun <T> runIfLeader(
         lockName: String,
         strategy: ElectionStrategy,
@@ -57,9 +58,14 @@ class LettuceStrategicLeaderElector(
     ): T? {
         // 정책 위반은 정상 contention이 아니므로 후보 조회 실패 fallback보다 먼저 전파합니다.
         validateLockName(lockName)
-        val candidates = runCatching { listCandidates(lockName) }
-            .onFailure { log.warn(it) { "[$lockName] 후보 목록 조회 실패 — 선출 skip" } }
-            .getOrElse { return null }
+        val candidates = try {
+            listCandidates(lockName)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "[$lockName] 후보 목록 조회 실패 — 선출 중단" }
+            throw e
+        }
         val result = strategy.elect(candidates)
         val winner = result.winner ?: return null
 

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElector.kt
@@ -45,7 +45,7 @@ class LettuceStrategicLeaderGroupElector(
     override fun updateResult(lockName: String, nodeId: String, result: CandidateResult) =
         registry.updateResult(lockName, nodeId, result)
 
-    @Suppress("ReturnCount", "TooGenericExceptionCaught")
+    @Suppress("ReturnCount", "TooGenericExceptionCaught", "ThrowsCount")
     override fun <T> runIfLeader(
         lockName: String,
         strategy: GroupElectionStrategy,
@@ -53,9 +53,14 @@ class LettuceStrategicLeaderGroupElector(
         action: () -> T,
     ): T? {
         validateLockName(lockName)
-        val candidates = runCatching { listCandidates(lockName) }
-            .onFailure { log.warn(it) { "[$lockName] 후보 목록 조회 실패 — 전략적 그룹 선출 skip" } }
-            .getOrElse { return null }
+        val candidates = try {
+            listCandidates(lockName)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "[$lockName] 후보 목록 조회 실패 — 전략적 그룹 선출 중단" }
+            throw e
+        }
         val result = strategy.electValidated(candidates, maxLeaders)
         if (result.winners.isEmpty()) return null
 

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElector.kt
@@ -52,6 +52,7 @@ class LettuceStrategicSuspendLeaderElector(
      *
      * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
      */
+    @Suppress("ReturnCount", "TooGenericExceptionCaught", "ThrowsCount")
     override suspend fun <T> runIfLeader(
         lockName: String,
         strategy: ElectionStrategy,
@@ -64,9 +65,9 @@ class LettuceStrategicSuspendLeaderElector(
             listCandidates(lockName)
         } catch (e: CancellationException) {
             throw e
-        } catch (e: Throwable) {
-            log.warn(e) { "[$lockName] 후보 목록 조회 실패 — 선출 skip" }
-            return null
+        } catch (e: Exception) {
+            log.warn(e) { "[$lockName] 후보 목록 조회 실패 — 선출 중단" }
+            throw e
         }
         val result = strategy.elect(candidates)
         val winner = result.winner ?: return null

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElector.kt
@@ -60,9 +60,9 @@ class LettuceStrategicSuspendLeaderGroupElector(
             listCandidates(lockName)
         } catch (e: CancellationException) {
             throw e
-        } catch (e: Throwable) {
-            log.warn(e) { "[$lockName] 후보 목록 조회 실패 — 전략적 그룹 선출 skip" }
-            return null
+        } catch (e: Exception) {
+            log.warn(e) { "[$lockName] 후보 목록 조회 실패 — 전략적 그룹 선출 중단" }
+            throw e
         }
         val result = strategy.electValidated(candidates, maxLeaders)
         if (result.winners.isEmpty()) return null

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt
@@ -5,8 +5,6 @@ package io.bluetape4k.leader.lettuce
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.validateLockName
-import io.bluetape4k.logging.KLogging
-import io.bluetape4k.logging.warn
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.SetArgs
 import io.lettuce.core.api.StatefulRedisConnection
@@ -31,7 +29,7 @@ internal class LettuceSuspendCandidateRegistry(
         DEFAULT_KEY_PREFIX,
     )
 
-    companion object: KLogging() {
+    companion object {
         internal const val DEFAULT_KEY_PREFIX = "leader:strategy:candidates"
         internal const val GROUP_KEY_PREFIX = "leader:strategy:group-candidates:lettuce:v1"
     }
@@ -90,9 +88,7 @@ internal class LettuceSuspendCandidateRegistry(
                     kv.key.removePrefix("${indexKey(lockName)}:").takeIf { it.isNotBlank() }?.let(staleNodeIds::add)
                     return@mapNotNull null
                 }
-                runCatching { LettuceCandidateInfoCodec.decode(kv.getValue()) }
-                    .onFailure { log.warn(it) { "[$lockName] CandidateInfo 디코딩 실패 — 항목 skip: key=${kv.key}" } }
-                    .getOrNull()
+                LettuceCandidateInfoCodec.decode(kv.getValue())
             }
             .toList()
             .also {

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicCandidateLookupFailureTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicCandidateLookupFailureTest.kt
@@ -1,0 +1,197 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
+import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import io.lettuce.core.KeyValue
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.reactive.RedisReactiveCommands
+import io.lettuce.core.api.sync.RedisCommands
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
+import java.util.concurrent.atomic.AtomicBoolean
+
+class LettuceStrategicCandidateLookupFailureTest {
+
+    @Test
+    fun `blocking single candidate lookup backend exception is rethrown`() {
+        val failure = IllegalStateException("lettuce candidate lookup failed")
+        val actionInvoked = AtomicBoolean(false)
+        val connection = blockingConnection(failure)
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            LettuceStrategicLeaderElector(connection, "node-1")
+                .runIfLeader("issue-785-single", FifoElectionStrategy) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+        }
+
+        thrown shouldBeEqualTo failure
+        actionInvoked.get().shouldBeFalse()
+    }
+
+    @Test
+    fun `blocking single candidate lookup cancellation is rethrown`() {
+        val cancellation = CancellationException("lettuce candidate lookup cancelled")
+        val actionInvoked = AtomicBoolean(false)
+        val connection = blockingConnection(cancellation)
+
+        val thrown = assertFailsWith<CancellationException> {
+            LettuceStrategicLeaderElector(connection, "node-1")
+                .runIfLeader("issue-785-single-cancel", FifoElectionStrategy) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+        }
+
+        thrown shouldBeEqualTo cancellation
+        actionInvoked.get().shouldBeFalse()
+    }
+
+    @Test
+    fun `blocking group candidate lookup Error is rethrown`() {
+        val failure = AssertionError("lettuce candidate lookup error")
+        val actionInvoked = AtomicBoolean(false)
+        val connection = blockingConnection(failure)
+
+        val thrown = assertFailsWith<AssertionError> {
+            LettuceStrategicLeaderGroupElector(connection, "node-1")
+                .runIfLeader("issue-785-group", FifoGroupElectionStrategy, maxLeaders = 1) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+        }
+
+        thrown shouldBeEqualTo failure
+        actionInvoked.get().shouldBeFalse()
+    }
+
+    @Test
+    fun `blocking single candidate codec failure is rethrown`() {
+        val actionInvoked = AtomicBoolean(false)
+        val connection = blockingCodecFailureConnection()
+
+        val thrown = assertFailsWith<IllegalArgumentException> {
+            LettuceStrategicLeaderElector(connection, "node-1")
+                .runIfLeader("issue-785-codec", FifoElectionStrategy) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+        }
+
+        thrown.message shouldBeEqualTo "CandidateInfo 인코딩 형식 오류: malformed"
+        actionInvoked.get().shouldBeFalse()
+    }
+
+    @Test
+    fun `suspend single candidate lookup cancellation is rethrown`() = runSuspendIO {
+        val cancellation = CancellationException("lettuce suspend candidate lookup cancelled")
+        val actionInvoked = AtomicBoolean(false)
+        val connection = suspendConnection(cancellation)
+
+        val thrown = assertFailsWith<CancellationException> {
+            LettuceStrategicSuspendLeaderElector(connection, "node-1")
+                .runIfLeader("issue-785-suspend-single", FifoElectionStrategy) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+        }
+
+        thrown shouldBeEqualTo cancellation
+        actionInvoked.get().shouldBeFalse()
+    }
+
+    @Test
+    fun `suspend group candidate lookup backend exception is rethrown`() = runSuspendIO {
+        val failure = IllegalStateException("lettuce suspend candidate lookup failed")
+        val actionInvoked = AtomicBoolean(false)
+        val connection = suspendConnection(failure)
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            LettuceStrategicSuspendLeaderGroupElector(connection, "node-1")
+                .runIfLeader("issue-785-suspend-group", FifoGroupElectionStrategy, maxLeaders = 1) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+        }
+
+        thrown shouldBeEqualTo failure
+        actionInvoked.get().shouldBeFalse()
+    }
+
+    @Test
+    fun `suspend group candidate lookup Error is rethrown`() = runSuspendIO {
+        val failure = AssertionError("lettuce suspend candidate lookup error")
+        val actionInvoked = AtomicBoolean(false)
+        val connection = suspendConnection(failure)
+
+        val thrown = assertFailsWith<AssertionError> {
+            LettuceStrategicSuspendLeaderGroupElector(connection, "node-1")
+                .runIfLeader("issue-785-suspend-group-error", FifoGroupElectionStrategy, maxLeaders = 1) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+        }
+
+        thrown shouldBeEqualTo failure
+        actionInvoked.get().shouldBeFalse()
+    }
+
+    @Test
+    fun `suspend group candidate codec failure is rethrown`() = runSuspendIO {
+        val actionInvoked = AtomicBoolean(false)
+        val connection = suspendCodecFailureConnection()
+
+        val thrown = assertFailsWith<IllegalArgumentException> {
+            LettuceStrategicSuspendLeaderGroupElector(connection, "node-1")
+                .runIfLeader("issue-785-codec-group", FifoGroupElectionStrategy, maxLeaders = 1) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+        }
+
+        thrown.message shouldBeEqualTo "CandidateInfo 인코딩 형식 오류: malformed"
+        actionInvoked.get().shouldBeFalse()
+    }
+
+    private fun blockingConnection(failure: Throwable): StatefulRedisConnection<String, String> {
+        val connection = mockk<StatefulRedisConnection<String, String>>()
+        val commands = mockk<RedisCommands<String, String>>()
+        every { connection.sync() } returns commands
+        every { commands.smembers(any()) } throws failure
+        return connection
+    }
+
+    private fun blockingCodecFailureConnection(): StatefulRedisConnection<String, String> {
+        val connection = mockk<StatefulRedisConnection<String, String>>()
+        val commands = mockk<RedisCommands<String, String>>()
+        every { connection.sync() } returns commands
+        every { commands.smembers(any()) } returns setOf("node-1")
+        every { commands.mget(any<String>()) } returns listOf(KeyValue.just("ignored", "malformed"))
+        return connection
+    }
+
+    private fun suspendConnection(failure: Throwable): StatefulRedisConnection<String, String> {
+        val connection = mockk<StatefulRedisConnection<String, String>>()
+        val reactive = mockk<RedisReactiveCommands<String, String>>()
+        every { connection.reactive() } returns reactive
+        every { reactive.smembers(any()) } returns Flux.error(failure)
+        return connection
+    }
+
+    private fun suspendCodecFailureConnection(): StatefulRedisConnection<String, String> {
+        val connection = mockk<StatefulRedisConnection<String, String>>()
+        val reactive = mockk<RedisReactiveCommands<String, String>>()
+        every { connection.reactive() } returns reactive
+        every { reactive.smembers(any()) } returns Flux.just("node-1")
+        every { reactive.mget(any<String>()) } returns Flux.just(KeyValue.just("ignored", "malformed"))
+        return connection
+    }
+}

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElector.kt
@@ -44,6 +44,7 @@ class RedissonStrategicLeaderElector(
     override fun updateResult(lockName: String, nodeId: String, result: CandidateResult) =
         registry.updateResult(lockName, nodeId, result)
 
+    @Suppress("ReturnCount", "TooGenericExceptionCaught", "ThrowsCount")
     override fun <T> runIfLeader(
         lockName: String,
         strategy: ElectionStrategy,
@@ -51,9 +52,14 @@ class RedissonStrategicLeaderElector(
         action: () -> T,
     ): T? {
         validateLockName(lockName)
-        val candidates = runCatching { listCandidates(lockName) }
-            .onFailure { log.warn(it) { "[$lockName] 후보 목록 조회 실패 — 선출 skip" } }
-            .getOrElse { return null }
+        val candidates = try {
+            listCandidates(lockName)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "[$lockName] 후보 목록 조회 실패 — 선출 중단" }
+            throw e
+        }
         val result = strategy.elect(candidates)
         val winner = result.winner ?: return null
 

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElector.kt
@@ -45,7 +45,7 @@ class RedissonStrategicLeaderGroupElector(
     override fun updateResult(lockName: String, nodeId: String, result: CandidateResult) =
         registry.updateResult(lockName, nodeId, result)
 
-    @Suppress("ReturnCount", "TooGenericExceptionCaught")
+    @Suppress("ReturnCount", "TooGenericExceptionCaught", "ThrowsCount")
     override fun <T> runIfLeader(
         lockName: String,
         strategy: GroupElectionStrategy,
@@ -53,9 +53,14 @@ class RedissonStrategicLeaderGroupElector(
         action: () -> T,
     ): T? {
         validateLockName(lockName)
-        val candidates = runCatching { listCandidates(lockName) }
-            .onFailure { log.warn(it) { "[$lockName] 후보 목록 조회 실패 — 전략적 그룹 선출 skip" } }
-            .getOrElse { return null }
+        val candidates = try {
+            listCandidates(lockName)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log.warn(e) { "[$lockName] 후보 목록 조회 실패 — 전략적 그룹 선출 중단" }
+            throw e
+        }
         val result = strategy.electValidated(candidates, maxLeaders)
         if (result.winners.isEmpty()) return null
 

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElector.kt
@@ -46,6 +46,7 @@ class RedissonStrategicSuspendLeaderElector(
     override suspend fun updateResult(lockName: String, nodeId: String, result: CandidateResult) =
         withContext(Dispatchers.IO) { registry.updateResult(lockName, nodeId, result) }
 
+    @Suppress("ReturnCount", "TooGenericExceptionCaught", "ThrowsCount")
     override suspend fun <T> runIfLeader(
         lockName: String,
         strategy: ElectionStrategy,
@@ -57,9 +58,9 @@ class RedissonStrategicSuspendLeaderElector(
             listCandidates(lockName)
         } catch (e: CancellationException) {
             throw e
-        } catch (e: Throwable) {
-            log.warn(e) { "[$lockName] 후보 목록 조회 실패 — 선출 skip" }
-            return null
+        } catch (e: Exception) {
+            log.warn(e) { "[$lockName] 후보 목록 조회 실패 — 선출 중단" }
+            throw e
         }
         val result = strategy.elect(candidates)
         val winner = result.winner ?: return null

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElector.kt
@@ -59,9 +59,9 @@ class RedissonStrategicSuspendLeaderGroupElector(
             listCandidates(lockName)
         } catch (e: CancellationException) {
             throw e
-        } catch (e: Throwable) {
-            log.warn(e) { "[$lockName] 후보 목록 조회 실패 — 전략적 그룹 선출 skip" }
-            return null
+        } catch (e: Exception) {
+            log.warn(e) { "[$lockName] 후보 목록 조회 실패 — 전략적 그룹 선출 중단" }
+            throw e
         }
         val result = strategy.electValidated(candidates, maxLeaders)
         if (result.winners.isEmpty()) return null

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicCandidateLookupFailureTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicCandidateLookupFailureTest.kt
@@ -1,0 +1,171 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
+import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.Test
+import org.redisson.api.RMapCache
+import org.redisson.api.RedissonClient
+import java.util.concurrent.atomic.AtomicBoolean
+
+class RedissonStrategicCandidateLookupFailureTest {
+
+    @Test
+    fun `blocking single candidate lookup backend exception is rethrown`() {
+        val failure = IllegalStateException("redisson candidate lookup failed")
+        val actionInvoked = AtomicBoolean(false)
+        val client = redissonClient(failure)
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            RedissonStrategicLeaderElector(client, "node-1")
+                .runIfLeader("issue-785-single", FifoElectionStrategy) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+        }
+
+        thrown.message shouldBeEqualTo failure.message
+        actionInvoked.get().shouldBeFalse()
+    }
+
+    @Test
+    fun `blocking single candidate lookup cancellation is rethrown`() {
+        val cancellation = CancellationException("redisson candidate lookup cancelled")
+        val actionInvoked = AtomicBoolean(false)
+        val client = redissonClient(cancellation)
+
+        val thrown = assertFailsWith<CancellationException> {
+            RedissonStrategicLeaderElector(client, "node-1")
+                .runIfLeader("issue-785-single-cancel", FifoElectionStrategy) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+        }
+
+        thrown.message shouldBeEqualTo cancellation.message
+        actionInvoked.get().shouldBeFalse()
+    }
+
+    @Test
+    fun `blocking group candidate lookup Error is rethrown`() {
+        val failure = AssertionError("redisson candidate lookup error")
+        val actionInvoked = AtomicBoolean(false)
+        val client = redissonClient(failure)
+
+        val thrown = assertFailsWith<AssertionError> {
+            RedissonStrategicLeaderGroupElector(client, "node-1")
+                .runIfLeader("issue-785-group", FifoGroupElectionStrategy, maxLeaders = 1) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+        }
+
+        thrown.message shouldBeEqualTo failure.message
+        actionInvoked.get().shouldBeFalse()
+    }
+
+    @Test
+    fun `blocking single candidate codec failure is rethrown`() {
+        val failure = IllegalStateException("redisson codec decode failed")
+        val actionInvoked = AtomicBoolean(false)
+        val client = redissonClient(failure)
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            RedissonStrategicLeaderElector(client, "node-1")
+                .runIfLeader("issue-785-codec", FifoElectionStrategy) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+        }
+
+        thrown.message shouldBeEqualTo failure.message
+        actionInvoked.get().shouldBeFalse()
+    }
+
+    @Test
+    fun `suspend single candidate lookup cancellation is rethrown`() = runSuspendIO {
+        val cancellation = CancellationException("redisson suspend candidate lookup cancelled")
+        val actionInvoked = AtomicBoolean(false)
+        val client = redissonClient(cancellation)
+
+        val thrown = assertFailsWith<CancellationException> {
+            RedissonStrategicSuspendLeaderElector(client, "node-1")
+                .runIfLeader("issue-785-suspend-single", FifoElectionStrategy) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+        }
+
+        thrown.message shouldBeEqualTo cancellation.message
+        actionInvoked.get().shouldBeFalse()
+    }
+
+    @Test
+    fun `suspend group candidate lookup backend exception is rethrown`() = runSuspendIO {
+        val failure = IllegalStateException("redisson suspend candidate lookup failed")
+        val actionInvoked = AtomicBoolean(false)
+        val client = redissonClient(failure)
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            RedissonStrategicSuspendLeaderGroupElector(client, "node-1")
+                .runIfLeader("issue-785-suspend-group", FifoGroupElectionStrategy, maxLeaders = 1) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+        }
+
+        thrown.message shouldBeEqualTo failure.message
+        actionInvoked.get().shouldBeFalse()
+    }
+
+    @Test
+    fun `suspend group candidate lookup Error is rethrown`() = runSuspendIO {
+        val failure = AssertionError("redisson suspend candidate lookup error")
+        val actionInvoked = AtomicBoolean(false)
+        val client = redissonClient(failure)
+
+        val thrown = assertFailsWith<AssertionError> {
+            RedissonStrategicSuspendLeaderGroupElector(client, "node-1")
+                .runIfLeader("issue-785-suspend-group-error", FifoGroupElectionStrategy, maxLeaders = 1) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+        }
+
+        thrown.message shouldBeEqualTo failure.message
+        actionInvoked.get().shouldBeFalse()
+    }
+
+    @Test
+    fun `suspend group candidate codec failure is rethrown`() = runSuspendIO {
+        val failure = IllegalStateException("redisson suspend codec decode failed")
+        val actionInvoked = AtomicBoolean(false)
+        val client = redissonClient(failure)
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            RedissonStrategicSuspendLeaderGroupElector(client, "node-1")
+                .runIfLeader("issue-785-codec-group", FifoGroupElectionStrategy, maxLeaders = 1) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+        }
+
+        thrown.message shouldBeEqualTo failure.message
+        actionInvoked.get().shouldBeFalse()
+    }
+
+    private fun redissonClient(failure: Throwable): RedissonClient {
+        val client = mockk<RedissonClient>()
+        val cache = mockk<RMapCache<String, CandidateInfo>>()
+        every { client.getMapCache<String, CandidateInfo>(any<String>()) } returns cache
+        every { cache.readAllValues() } throws failure
+        return client
+    }
+}


### PR DESCRIPTION
## 요약

Issue #785의 strategic 후보 조회에서 백엔드 장애를 정상 contention의 `null`과 구분하도록 Lettuce/Redisson blocking·suspend single/group 경계를 정리했습니다.

## 구현

- 8개 strategic elector의 후보 조회에서 `CancellationException`을 우선 재전파하고 일반 `Exception`은 로그 후 재전파합니다.
- `Error`와 백엔드 예외를 contention `null`로 축소하지 않으며, 정상 no-winner 결과의 `null` 계약은 유지합니다.
- Lettuce blocking/suspend candidate registry의 malformed codec 값을 직접 decode해 fail-fast로 전파합니다. stale 값 부재 정리 동작은 유지합니다.
- Redisson `readAllValues()` 경계의 codec/backend 예외를 별도 fallback 없이 전파하도록 회귀 계약을 고정했습니다.
- Lettuce/Redisson 각 8개 회귀 테스트와 한국어 lesson을 추가했습니다.
- 관련 이슈: #785
- Epic: #775
- merge base: `develop@27a04daff63112e2a79ab2eb300e166bb25b6b81`
- exact head: `fix/issue-785-strategic-backend-errors@7a2f8ec9420add5c1ed2d402e48febe5bcf5a320`

## 검증

- RED: 기존 fallback에서 Lettuce 5개 중 4개, Redisson 5개 중 5개 회귀가 의도대로 실패
- focused strategic regression: Lettuce 8/8, Redisson 8/8
- 전체 모듈 테스트: Lettuce 290/290, Redisson 276/276
- `:bluetape4k-leader-redis-lettuce:detekt`, `:bluetape4k-leader-redis-redisson:detekt`: 성공
- `git diff --check origin/develop...HEAD`: 성공
- 독립 아키텍처 검토: `CLEAR`, 독립 코드 검토: `APPROVE`, P0/P1: 0
- hosted exact-head CI [run 32971508636](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32971508636): 19 success, 28 path-scoped skipped, 0 failed; `headSha=7a2f8ec9420add5c1ed2d402e48febe5bcf5a320`

Resolves #785

## DoD Status

- 상태: `PENDING` — 구현·로컬 검증·독립 검토·hosted exact-head CI를 완료했고, 신선한 merge 승인만 남아 있습니다.
- 변경 범위: 승인된 strategic elector/registry, 회귀 테스트, lesson 13개 파일
- human review: 1인 개발자 정책으로 불필요하며 독립 AI 검토는 `CLEAR`/`APPROVE`로 완료
- 다음 게이트: 별도 merge 승인 후 exact head/base/checks/reviews/threads/mergeability 재확인 → squash merge
