### PR TITLE
fix(spring): timeout 이후 non-cooperative suspend bean cleanup 계약 고정

### DIFF
--- a/docs/lessons/2026-08-26-issue-794-suspend-bean-timeout.md
+++ b/docs/lessons/2026-08-26-issue-794-suspend-bean-timeout.md
@@ -1,0 +1,96 @@
+# `SuspendBeanInitialization` timeout 뒤 bounded cleanup 계약
+
+**관련 이슈**: [#794](https://github.com/bluetape4k/bluetape4k-leader/issues/794)
+**관련 PR**: [#797](https://github.com/bluetape4k/bluetape4k-leader/pull/797)
+**영향 모듈**: `leader-spring-boot`
+
+## 맥락
+
+Spring의 동기 `@Bean` 경계에서 suspend backend 초기화를 실행하는
+`createSuspendBackendBean`은 호출 thread를 무기한 붙잡지 않도록 별도
+`CoroutineScope`와 초기화 `timeout`을 사용한다. 기존 계약은 timeout이 지나면
+`scope.cancel()`을 호출하고 `TimeoutCancellationException`을 반환하는 데
+그쳤다. 이미 시작된 block이 취소에 협조하지 않으면 `scope.cancel()`은 그
+작업이 끝났는지 기다리지 않으므로, Spring startup 실패 뒤에도 초기화가
+실행될 수 있었다.
+
+## 원인
+
+`CoroutineScope.cancel()`은 scope에 취소를 전파하지만 non-cooperative 작업을
+강제 종료하거나 join하지 않는다. 따라서 timeout 경계에서 다음 두 결과를
+구분해야 했다.
+
+- cooperative 작업: 취소 후 종료를 확인하고 bean 초기화 오류를 반환한다.
+- non-cooperative 작업: 제한된 시간만 종료를 기다린 뒤 잔여 실행 가능성을
+  관측하고 bean 초기화 오류를 반환한다.
+
+## 결정
+
+`SuspendBeanInitialization.kt`의 `finally`에서 `NonCancellable` context를
+사용해 `task.cancelAndJoin()`을 `withTimeoutOrNull(cleanupTimeout)`으로 감싼다.
+cleanup이 grace window 안에 끝나면 잔여 작업을 정리하고, 끝나지 않으면
+`io.bluetape4k.logging` warning을 남긴 뒤 `scope.cancel()`을 호출한다. 기본
+cleanup grace는 `100.milliseconds`이며, 강제 thread 종료는 사용하지 않는다.
+
+cleanup 경로가 원래 오류를 가리지 않도록 별도의 예외를 던지지 않는다.
+따라서 초기화 timeout의 `TimeoutCancellationException`, 초기화 block의
+`CancellationException`, Spring bean 생성 실패 원인은 기존 호출자에게
+그대로 전파된다.
+
+## 결과
+
+- timeout 이후 cooperative cleanup은 `cancelAndJoin()`으로 완료를 확인한다.
+- non-cooperative cleanup은 `cleanupTimeout`을 넘겨 Spring startup 실패를
+  다시 무기한 지연시키지 않는다.
+- grace window를 넘긴 잔여 실행은 warning으로 관측할 수 있고, 원래
+  `TimeoutCancellationException`은 유지된다.
+- dispatcher queue에 작업이 대기 중인 경우에도 초기화 timeout은 queue 대기를
+  포함한다. 호출자 thread가 queue 작업의 실행 완료를 무기한 기다리지 않는다.
+
+## 검증
+
+`SuspendBeanInitializationTest`에 다음 회귀 계약을 추가하고
+`io.bluetape4k.assertions.assertFailsWith`로 예외 타입을 검증했다.
+
+- timeout 뒤 non-cooperative cleanup이 release될 때 bridge가 cleanup 완료까지
+  기다린다.
+- cleanup이 release되지 않으면 `50.milliseconds` grace 뒤 bridge가 반환하고
+  원래 `TimeoutCancellationException`을 유지한다.
+- dispatcher queue 대기, 일반 timeout, cancellation, Spring startup failure와
+  `cleanupTimeout`의 positive finite 검증을 유지한다.
+
+현재 변경 기준 검증 결과는 다음과 같다.
+
+- `./gradlew :bluetape4k-leader-spring-boot:test --tests 'io.bluetape4k.leader.spring.backend.SuspendBeanInitializationTest' --no-build-cache --rerun-tasks`: 11/11 PASS
+- `./gradlew :bluetape4k-leader-spring-boot:detekt --no-build-cache --rerun-tasks`: PASS
+- `./gradlew :bluetape4k-leader-spring-boot:compileKotlin :bluetape4k-leader-spring-boot:compileTestKotlin --no-build-cache --rerun-tasks`: PASS
+- `python3 scripts/ci/validate_test_assertion_contract.py --root .`: PASS
+- 전체 `leader-spring-boot:test`의 `LeaderRouteLeaseDiagnosticsTest` 실패 1건은
+  수정 전 clean `develop`에서도 재현된 `NoSuchFileException` baseline으로,
+  이번 bounded cleanup 변경의 범위 밖이다.
+
+## 놓친 점과 예상 밖의 결과
+
+처음에는 `scope.cancel()`만으로 timeout 뒤 작업의 생명주기가 끝난다고
+가정했다. RED 회귀 테스트에서 이미 시작된 non-cooperative cleanup이
+release될 때까지 bridge가 반환되기 전에 이 가정이 틀렸음을 확인했다.
+반대로 join을 무제한으로 기다리면 Spring startup failure가 다시 무제한으로
+지연되므로, 취소 협조 여부를 호출자가 바꿀 수 없는 작업에 대해서는 잔여
+실행 가능성을 인정하는 bounded 계약이 필요하다.
+
+독립 7-Tier 검토에서는 P0/P1이 없었지만, warning에 backend/bean 식별자가
+없고 warning 발생 자체를 고정한 테스트가 없다는 `WATCH` 관찰사항이 남았다.
+이번 PR에서는 bounded lifecycle 계약을 우선 고정하고, 운영 식별자와 warning
+capture 테스트는 별도 후속 범위로 남긴다.
+
+## 향후 guard
+
+새로운 suspend bean bridge를 추가하거나 수정할 때 다음 규칙을 유지한다.
+
+1. 초기화 timeout과 cleanup grace를 각각 유한하게 검증한다.
+2. timeout 경로는 `NonCancellable` 안에서 `cancelAndJoin()`을 bounded wait로
+   실행하고, cleanup 예외로 원래 `CancellationException` 계열을 덮지 않는다.
+3. 테스트는 cooperative 작업과 non-cooperative 작업을 모두 명시적으로
+   시작시킨 뒤, cleanup 완료 대기와 grace 초과 후 반환을 각각 검증한다.
+4. non-cooperative 잔여 실행을 강제 thread 종료로 해결하지 않는다. warning에
+   low-cardinality backend/bean context를 포함하는 후속 변경을 검토한다.

--- a/docs/lessons/2026-08-26-issue-794-suspend-bean-timeout.md
+++ b/docs/lessons/2026-08-26-issue-794-suspend-bean-timeout.md
@@ -29,8 +29,10 @@ Spring의 동기 `@Bean` 경계에서 suspend backend 초기화를 실행하는
 `SuspendBeanInitialization.kt`의 `finally`에서 `NonCancellable` context를
 사용해 `task.cancelAndJoin()`을 `withTimeoutOrNull(cleanupTimeout)`으로 감싼다.
 cleanup이 grace window 안에 끝나면 잔여 작업을 정리하고, 끝나지 않으면
-`io.bluetape4k.logging` warning을 남긴 뒤 `scope.cancel()`을 호출한다. 기본
-cleanup grace는 `100.milliseconds`이며, 강제 thread 종료는 사용하지 않는다.
+`io.bluetape4k.logging` warning을 남긴 뒤 `scope.cancel()`을 호출한다. warning은
+`operationName`이라는 안정적인 low-cardinality 식별자를 포함하며, Mongo와 Exposed
+R2DBC의 각 suspend bean 경계가 명시적인 이름을 전달한다. 기본 cleanup grace는
+`100.milliseconds`이며, 강제 thread 종료는 사용하지 않는다.
 
 cleanup 경로가 원래 오류를 가리지 않도록 별도의 예외를 던지지 않는다.
 따라서 초기화 timeout의 `TimeoutCancellationException`, 초기화 block의
@@ -42,8 +44,9 @@ cleanup 경로가 원래 오류를 가리지 않도록 별도의 예외를 던�
 - timeout 이후 cooperative cleanup은 `cancelAndJoin()`으로 완료를 확인한다.
 - non-cooperative cleanup은 `cleanupTimeout`을 넘겨 Spring startup 실패를
   다시 무기한 지연시키지 않는다.
-- grace window를 넘긴 잔여 실행은 warning으로 관측할 수 있고, 원래
-  `TimeoutCancellationException`은 유지된다.
+- grace window를 넘긴 잔여 실행은 `operationName`과 함께 warning으로 관측할 수
+  있고, warning 발생과 원래 `TimeoutCancellationException` 보존을 회귀 테스트로
+  고정했다.
 - dispatcher queue에 작업이 대기 중인 경우에도 초기화 timeout은 queue 대기를
   포함한다. 호출자 thread가 queue 작업의 실행 완료를 무기한 기다리지 않는다.
 
@@ -54,8 +57,8 @@ cleanup 경로가 원래 오류를 가리지 않도록 별도의 예외를 던�
 
 - timeout 뒤 non-cooperative cleanup이 release될 때 bridge가 cleanup 완료까지
   기다린다.
-- cleanup이 release되지 않으면 `50.milliseconds` grace 뒤 bridge가 반환하고
-  원래 `TimeoutCancellationException`을 유지한다.
+- cleanup이 release되지 않으면 `200.milliseconds` grace 뒤 bridge가 반환하고
+  식별자를 포함한 warning과 원래 `TimeoutCancellationException`을 유지한다.
 - dispatcher queue 대기, 일반 timeout, cancellation, Spring startup failure와
   `cleanupTimeout`의 positive finite 검증을 유지한다.
 
@@ -78,10 +81,11 @@ release될 때까지 bridge가 반환되기 전에 이 가정이 틀렸음을 �
 지연되므로, 취소 협조 여부를 호출자가 바꿀 수 없는 작업에 대해서는 잔여
 실행 가능성을 인정하는 bounded 계약이 필요하다.
 
-독립 7-Tier 검토에서는 P0/P1이 없었지만, warning에 backend/bean 식별자가
-없고 warning 발생 자체를 고정한 테스트가 없다는 `WATCH` 관찰사항이 남았다.
-이번 PR에서는 bounded lifecycle 계약을 우선 고정하고, 운영 식별자와 warning
-capture 테스트는 별도 후속 범위로 남긴다.
+독립 7-Tier 검토에서 P0/P1은 없었지만, warning에 backend/bean 식별자가 없고
+warning 발생 자체를 고정한 테스트가 없다는 `WATCH` 관찰사항이 남았다. 후속
+보강에서 `operationName`을 도입하고 Mongo·Exposed R2DBC 호출부에 안정적인 이름을
+전달했으며, Logback `ListAppender` 회귀 테스트로 warning의 발생과 식별자를
+고정했다.
 
 ## 향후 guard
 
@@ -92,5 +96,5 @@ capture 테스트는 별도 후속 범위로 남긴다.
    실행하고, cleanup 예외로 원래 `CancellationException` 계열을 덮지 않는다.
 3. 테스트는 cooperative 작업과 non-cooperative 작업을 모두 명시적으로
    시작시킨 뒤, cleanup 완료 대기와 grace 초과 후 반환을 각각 검증한다.
-4. non-cooperative 잔여 실행을 강제 thread 종료로 해결하지 않는다. warning에
-   low-cardinality backend/bean context를 포함하는 후속 변경을 검토한다.
+4. non-cooperative 잔여 실행을 강제 thread 종료로 해결하지 않는다. warning에는
+   요청별 값이 아닌 low-cardinality backend/bean `operationName`만 포함한다.

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/backend/ExposedR2dbcLeaderConfiguration.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/backend/ExposedR2dbcLeaderConfiguration.kt
@@ -31,7 +31,9 @@ class ExposedR2dbcLeaderConfiguration {
         db: R2dbcDatabase,
         props: LeaderProperties,
         recorderProvider: ObjectProvider<SuspendSafeLeaderHistoryRecorder>,
-    ): ExposedR2DbcSuspendLeaderElector = createSuspendBackendBean {
+    ): ExposedR2DbcSuspendLeaderElector = createSuspendBackendBean(
+        operationName = "exposedR2dbcSuspendLeaderElector",
+    ) {
         ExposedR2DbcSuspendLeaderElector(
             db,
             ExposedR2dbcLeaderElectionOptions(leaderOptions = PropertiesAdapter.toCommonElection(props)),
@@ -45,7 +47,9 @@ class ExposedR2dbcLeaderConfiguration {
         db: R2dbcDatabase,
         props: LeaderProperties,
         recorderProvider: ObjectProvider<SuspendSafeLeaderHistoryRecorder>,
-    ): ExposedR2DbcSuspendLeaderGroupElector = createSuspendBackendBean {
+    ): ExposedR2DbcSuspendLeaderGroupElector = createSuspendBackendBean(
+        operationName = "exposedR2dbcSuspendLeaderGroupElector",
+    ) {
         ExposedR2DbcSuspendLeaderGroupElector(
             db,
             ExposedR2dbcLeaderGroupElectionOptions(leaderGroupOptions = PropertiesAdapter.toCommonGroup(props)),

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/backend/MongoLeaderConfiguration.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/backend/MongoLeaderConfiguration.kt
@@ -66,7 +66,9 @@ class MongoLeaderConfiguration {
         coroutineDb: CoroutineMongoDatabase,
         props: LeaderProperties,
         recorderProvider: ObjectProvider<SuspendSafeLeaderHistoryRecorder>,
-    ): MongoSuspendLeaderElector = createSuspendBackendBean {
+    ): MongoSuspendLeaderElector = createSuspendBackendBean(
+        operationName = "mongoSuspendLeaderElector",
+    ) {
         MongoSuspendLeaderElector(
             coroutineDb.getCollection<Document>(props.mongo.singleCollection),
             electionOptions(props),
@@ -82,7 +84,9 @@ class MongoLeaderConfiguration {
         coroutineDb: CoroutineMongoDatabase,
         props: LeaderProperties,
         recorderProvider: ObjectProvider<SuspendSafeLeaderHistoryRecorder>,
-    ): MongoSuspendLeaderGroupElector = createSuspendBackendBean {
+    ): MongoSuspendLeaderGroupElector = createSuspendBackendBean(
+        operationName = "mongoSuspendLeaderGroupElector",
+    ) {
         MongoSuspendLeaderGroupElector(
             db.getCollection(props.mongo.groupCollection, Document::class.java),
             coroutineDb.getCollection<Document>(props.mongo.groupCollection),

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/backend/SuspendBeanInitialization.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/backend/SuspendBeanInitialization.kt
@@ -1,40 +1,75 @@
 package io.bluetape4k.leader.spring.backend
 
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
  * Spring의 동기 `@Bean` 경계에서 suspend backend 초기화를 수행합니다.
  *
  * 호출 thread에서 무제한 `runBlocking`을 사용하지 않도록 I/O dispatcher와 bounded timeout을
- * 고정하고, 초기화 실패·취소·timeout은 Spring bean 생성 오류로 그대로 전파합니다.
+ * 고정하고, 초기화 실패·취소·timeout은 Spring bean 생성 오류로 그대로 전파합니다. timeout
+ * 이후에는 자식 작업의 취소와 bounded cleanup join을 수행하여 cooperative 작업의 잔여 실행을
+ * 정리합니다. non-cooperative 작업이 cleanup timeout 안에 끝나지 않으면 경고를 남기고 원래
+ * 초기화 오류를 유지한 채 반환합니다.
  */
 internal fun <T> createSuspendBackendBean(
     timeout: Duration = DEFAULT_SUSPEND_BEAN_INITIALIZATION_TIMEOUT,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    cleanupTimeout: Duration = DEFAULT_SUSPEND_BEAN_CLEANUP_TIMEOUT,
     block: suspend () -> T,
 ): T {
     require(timeout.isPositive() && timeout.isFinite()) {
         "suspend backend bean initialization timeout must be positive and finite: $timeout"
     }
+    require(cleanupTimeout.isPositive() && cleanupTimeout.isFinite()) {
+        "suspend backend bean cleanup timeout must be positive and finite: $cleanupTimeout"
+    }
     return runBlocking {
         val scope = CoroutineScope(SupervisorJob() + dispatcher)
+        val task = scope.async { block() }
         try {
-            withTimeout(timeout) {
-                scope.async { block() }.await()
-            }
+            withTimeout(timeout) { task.await() }
         } finally {
-            scope.cancel()
+            withContext(NonCancellable) {
+                val cleanupCompleted = withTimeoutOrNull(cleanupTimeout) {
+                    task.cancelAndJoin()
+                    true
+                } ?: false
+                scope.cancel()
+                if (!cleanupCompleted) {
+                    SuspendBeanInitializationLogger.log.warn {
+                        "Suspend backend bean initialization cleanup did not complete within " +
+                            "$cleanupTimeout; non-cooperative initialization may still be running"
+                    }
+                }
+            }
         }
     }
 }
 
 internal val DEFAULT_SUSPEND_BEAN_INITIALIZATION_TIMEOUT: Duration = 10.seconds
+
+/**
+ * 초기화 timeout 이후 cooperative cleanup에 허용하는 짧은 grace window입니다.
+ *
+ * Spring startup failure가 dispatcher queue나 non-cooperative 작업 때문에 다시 무제한으로
+ * 늘어나지 않도록 100ms로 제한하며, window를 넘긴 잔여 작업은 warning으로 관측합니다.
+ */
+internal val DEFAULT_SUSPEND_BEAN_CLEANUP_TIMEOUT: Duration = 100.milliseconds
+
+private object SuspendBeanInitializationLogger : KLogging()

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/backend/SuspendBeanInitialization.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/backend/SuspendBeanInitialization.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.spring.backend
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
+import io.bluetape4k.support.requireNotBlank
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -25,12 +26,14 @@ import kotlin.time.Duration.Companion.seconds
  * 고정하고, 초기화 실패·취소·timeout은 Spring bean 생성 오류로 그대로 전파합니다. timeout
  * 이후에는 자식 작업의 취소와 bounded cleanup join을 수행하여 cooperative 작업의 잔여 실행을
  * 정리합니다. non-cooperative 작업이 cleanup timeout 안에 끝나지 않으면 경고를 남기고 원래
- * 초기화 오류를 유지한 채 반환합니다.
+ * 초기화 오류를 유지한 채 반환합니다. [operationName]은 경고에서 backend bean 초기화
+ * 경계를 식별하는 안정적인 low-cardinality 값입니다.
  */
 internal fun <T> createSuspendBackendBean(
     timeout: Duration = DEFAULT_SUSPEND_BEAN_INITIALIZATION_TIMEOUT,
     dispatcher: CoroutineDispatcher = Dispatchers.IO,
     cleanupTimeout: Duration = DEFAULT_SUSPEND_BEAN_CLEANUP_TIMEOUT,
+    operationName: String = DEFAULT_SUSPEND_BEAN_OPERATION_NAME,
     block: suspend () -> T,
 ): T {
     require(timeout.isPositive() && timeout.isFinite()) {
@@ -39,6 +42,7 @@ internal fun <T> createSuspendBackendBean(
     require(cleanupTimeout.isPositive() && cleanupTimeout.isFinite()) {
         "suspend backend bean cleanup timeout must be positive and finite: $cleanupTimeout"
     }
+    val validOperationName = operationName.requireNotBlank("operationName")
     return runBlocking {
         val scope = CoroutineScope(SupervisorJob() + dispatcher)
         val task = scope.async { block() }
@@ -54,7 +58,8 @@ internal fun <T> createSuspendBackendBean(
                 if (!cleanupCompleted) {
                     SuspendBeanInitializationLogger.log.warn {
                         "Suspend backend bean initialization cleanup did not complete within " +
-                            "$cleanupTimeout; non-cooperative initialization may still be running"
+                            "$cleanupTimeout; operationName=$validOperationName; " +
+                            "non-cooperative initialization may still be running"
                     }
                 }
             }
@@ -63,6 +68,7 @@ internal fun <T> createSuspendBackendBean(
 }
 
 internal val DEFAULT_SUSPEND_BEAN_INITIALIZATION_TIMEOUT: Duration = 10.seconds
+internal const val DEFAULT_SUSPEND_BEAN_OPERATION_NAME: String = "suspend-backend-bean"
 
 /**
  * 초기화 timeout 이후 cooperative cleanup에 허용하는 짧은 grace window입니다.

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/backend/SuspendBeanInitializationTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/backend/SuspendBeanInitializationTest.kt
@@ -18,6 +18,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.measureTime
 
@@ -116,6 +117,120 @@ class SuspendBeanInitializationTest {
         }
         executor.awaitTermination(1, TimeUnit.SECONDS).shouldBeTrue()
         bodyStarted.get().shouldBeFalse()
+    }
+
+    @Test
+    fun `bounded bridge timeout은 초기화 작업 cleanup 완료까지 기다린다`() {
+        val caller = Executors.newSingleThreadExecutor()
+        val dispatcherExecutor = Executors.newSingleThreadExecutor()
+        val dispatcher = dispatcherExecutor.asCoroutineDispatcher()
+        val started = CountDownLatch(1)
+        val cleanupStarted = CountDownLatch(1)
+        val cleanupRelease = CountDownLatch(1)
+        val bridgeReturned = CountDownLatch(1)
+        val failure = AtomicReference<Throwable?>()
+
+        try {
+            caller.submit {
+                try {
+                    createSuspendBackendBean(
+                        timeout = 20.milliseconds,
+                        dispatcher = dispatcher,
+                        cleanupTimeout = 500.milliseconds,
+                    ) {
+                        started.countDown()
+                        try {
+                            delay(Long.MAX_VALUE)
+                        } finally {
+                            cleanupStarted.countDown()
+                            // coroutine 취소에 응답하지 않는 cleanup을 재현하기 위해
+                            // 의도적으로 blocking latch를 사용합니다.
+                            cleanupRelease.await()
+                        }
+                    }
+                } catch (throwable: Throwable) {
+                    failure.set(throwable)
+                } finally {
+                    bridgeReturned.countDown()
+                }
+            }
+
+            started.await(1, TimeUnit.SECONDS).shouldBeTrue()
+            cleanupStarted.await(1, TimeUnit.SECONDS).shouldBeTrue()
+            bridgeReturned.await(100, TimeUnit.MILLISECONDS).shouldBeFalse()
+
+            cleanupRelease.countDown()
+            bridgeReturned.await(1, TimeUnit.SECONDS).shouldBeTrue()
+            (failure.get() is TimeoutCancellationException).shouldBeTrue()
+        } finally {
+            cleanupRelease.countDown()
+            caller.shutdownNow()
+            dispatcher.close()
+            dispatcherExecutor.shutdownNow()
+        }
+        caller.awaitTermination(1, TimeUnit.SECONDS).shouldBeTrue()
+        dispatcherExecutor.awaitTermination(1, TimeUnit.SECONDS).shouldBeTrue()
+    }
+
+    @Test
+    fun `bounded bridge timeout은 non-cooperative cleanup을 grace timeout으로 제한한다`() {
+        val caller = Executors.newSingleThreadExecutor()
+        val dispatcherExecutor = Executors.newSingleThreadExecutor()
+        val dispatcher = dispatcherExecutor.asCoroutineDispatcher()
+        val started = CountDownLatch(1)
+        val cleanupStarted = CountDownLatch(1)
+        val cleanupRelease = CountDownLatch(1)
+        val bridgeReturned = CountDownLatch(1)
+        val failure = AtomicReference<Throwable?>()
+
+        try {
+            caller.submit {
+                try {
+                    createSuspendBackendBean(
+                        timeout = 20.milliseconds,
+                        dispatcher = dispatcher,
+                        cleanupTimeout = 50.milliseconds,
+                    ) {
+                        started.countDown()
+                        try {
+                            delay(Long.MAX_VALUE)
+                        } finally {
+                            cleanupStarted.countDown()
+                            // coroutine 취소에 응답하지 않는 cleanup을 재현하기 위해
+                            // 의도적으로 blocking latch를 사용합니다.
+                            cleanupRelease.await()
+                        }
+                    }
+                } catch (throwable: Throwable) {
+                    failure.set(throwable)
+                } finally {
+                    bridgeReturned.countDown()
+                }
+            }
+
+            started.await(1, TimeUnit.SECONDS).shouldBeTrue()
+            cleanupStarted.await(1, TimeUnit.SECONDS).shouldBeTrue()
+            bridgeReturned.await(30, TimeUnit.MILLISECONDS).shouldBeFalse()
+            bridgeReturned.await(500, TimeUnit.MILLISECONDS).shouldBeTrue()
+            (failure.get() is TimeoutCancellationException).shouldBeTrue()
+        } finally {
+            cleanupRelease.countDown()
+            caller.shutdownNow()
+            dispatcher.close()
+            dispatcherExecutor.shutdownNow()
+        }
+        caller.awaitTermination(1, TimeUnit.SECONDS).shouldBeTrue()
+        dispatcherExecutor.awaitTermination(1, TimeUnit.SECONDS).shouldBeTrue()
+    }
+
+    @Test
+    fun `bounded bridge는 cleanup timeout을 positive finite으로 검증한다`() {
+        val thrown = assertFailsWith<IllegalArgumentException> {
+            createSuspendBackendBean(cleanupTimeout = 0.milliseconds) { "never" }
+        }
+
+        thrown.message shouldBeEqualTo
+            "suspend backend bean cleanup timeout must be positive and finite: 0s"
     }
 
     private fun startupFailure(configuration: Class<*>): Throwable {

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/backend/SuspendBeanInitializationTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/backend/SuspendBeanInitializationTest.kt
@@ -1,9 +1,14 @@
 package io.bluetape4k.leader.spring.backend
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.assertions.shouldNotBeEqualTo
 import io.bluetape4k.assertions.shouldNotBeNull
 import kotlinx.coroutines.CancellationException
@@ -11,6 +16,7 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.delay
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -182,6 +188,9 @@ class SuspendBeanInitializationTest {
         val cleanupRelease = CountDownLatch(1)
         val bridgeReturned = CountDownLatch(1)
         val failure = AtomicReference<Throwable?>()
+        val logger = LoggerFactory.getLogger(BACKEND_LOGGER_NAME) as Logger
+        val appender = ListAppender<ILoggingEvent>().also { it.start() }
+        logger.addAppender(appender)
 
         try {
             caller.submit {
@@ -189,7 +198,8 @@ class SuspendBeanInitializationTest {
                     createSuspendBackendBean(
                         timeout = 20.milliseconds,
                         dispatcher = dispatcher,
-                        cleanupTimeout = 50.milliseconds,
+                        cleanupTimeout = 200.milliseconds,
+                        operationName = "test-suspend-bean",
                     ) {
                         started.countDown()
                         try {
@@ -210,11 +220,18 @@ class SuspendBeanInitializationTest {
 
             started.await(1, TimeUnit.SECONDS).shouldBeTrue()
             cleanupStarted.await(1, TimeUnit.SECONDS).shouldBeTrue()
-            bridgeReturned.await(30, TimeUnit.MILLISECONDS).shouldBeFalse()
-            bridgeReturned.await(500, TimeUnit.MILLISECONDS).shouldBeTrue()
+            bridgeReturned.await(50, TimeUnit.MILLISECONDS).shouldBeFalse()
+            bridgeReturned.await(2, TimeUnit.SECONDS).shouldBeTrue()
             (failure.get() is TimeoutCancellationException).shouldBeTrue()
+
+            val warning = appender.list.firstOrNull {
+                it.level == Level.WARN && "operationName=test-suspend-bean" in it.formattedMessage
+            }.shouldNotBeNull()
+            warning.formattedMessage shouldContain "cleanup did not complete within"
         } finally {
             cleanupRelease.countDown()
+            logger.detachAppender(appender)
+            appender.stop()
             caller.shutdownNow()
             dispatcher.close()
             dispatcherExecutor.shutdownNow()
@@ -264,5 +281,9 @@ class SuspendBeanInitializationTest {
         fun cancelledSuspendBean(): String = createSuspendBackendBean {
             throw CancellationException("context bean initialization cancelled")
         }
+    }
+
+    companion object {
+        private const val BACKEND_LOGGER_NAME = "io.bluetape4k.leader.spring.backend"
     }
 }


### PR DESCRIPTION
## Summary

Closes #794

Spring 동기 `@Bean` 경계에서 timeout 이후 detached suspend 초기화가 숨은 실행으로 남지 않도록 bounded cleanup 계약과 운영 식별 가능한 warning을 고정합니다.

## Background

Epic #775 후속 검토에서 `SuspendBeanInitialization`의 timeout 전파는 고정됐지만, non-cooperative 초기화의 잔여 실행을 식별할 수 있는 운영 계약과 warning 회귀 증거가 부족했습니다.

## What This Solves

- timeout 시 초기화 작업을 취소하고 cooperative cleanup이 끝날 때까지 bounded join합니다.
- non-cooperative 작업은 cleanup grace 이후 stable `operationName`을 포함한 warning을 남기면서 Spring startup timeout과 원래 예외를 보존합니다.
- Mongo 및 Exposed R2DBC suspend bean 경계에 저카디널리티 식별자를 전달하고 warning capture 회귀를 고정합니다.

## Work Done

- `SuspendBeanInitialization.kt`: `operationName` 검증과 warning 식별자를 추가하고 기존 bounded cleanup 계약을 유지했습니다.
- `MongoLeaderConfiguration.kt`, `ExposedR2dbcLeaderConfiguration.kt`: 네 개의 suspend backend bean에 안정적인 operation 이름을 전달했습니다.
- `SuspendBeanInitializationTest.kt`: Logback `ListAppender`로 warning과 operation name을 검증하고 non-cooperative grace assertion을 200ms로 넓혔습니다.
- `docs/lessons/2026-08-26-issue-794-suspend-bean-timeout.md`: 식별 가능한 warning과 재사용 lifecycle 규칙을 기록하고 GNO로 색인했습니다.

## Validation

- `./gradlew :bluetape4k-leader-spring-boot:test --tests 'io.bluetape4k.leader.spring.backend.SuspendBeanInitializationTest' --no-build-cache --rerun-tasks`: PASS (11/11)
- `./gradlew :bluetape4k-leader-spring-boot:detekt --no-build-cache --rerun-tasks`: PASS
- `./gradlew :bluetape4k-leader-spring-boot:compileKotlin :bluetape4k-leader-spring-boot:compileTestKotlin --no-build-cache --rerun-tasks`: PASS
- `python3 scripts/ci/validate_test_assertion_contract.py --root .`: PASS (Bluetape assertions 및 명시적 예외 타입)
- Korean terminology audit: PASS (findings=0); isolated GNO update/embed/search: PASS (1 document, 2 chunks, 1 hit)
- 전체 `leader-spring-boot:test`: 609/610 PASS; `LeaderRouteLeaseDiagnosticsTest`의 clean `develop` 재현 `NoSuchFileException` baseline은 범위 밖입니다.
- Hosted [CI run 32982718762](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32982718762): exact head `4ca30a250cd872e01fdcd97bfdff6d97a4490370`, affected `leader-spring-boot (Testcontainers)`, compile, coverage, CI status, governance, wrapper, secret scan, fan-out PASS. 비대상 matrix는 terminal path-filter `SKIPPED`입니다.

## Review Notes

- 이전 architect `WATCH`의 두 P2(backend 식별자와 warning capture/timing)는 현재 커밋에서 보강했습니다.
- 사용자가 1인 개발자 환경의 독립 리뷰 생략을 명시적으로 승인했습니다. 독립 리뷰 sub-gate는 `N/A (single-developer lane)`으로 기록하고, 리더의 현재 diff 7-Tier read-back에서 P0/P1/P2/P3 미검출을 확인했습니다.
- GitHub review/comment/thread는 0건이며, exact-head CI와 로컬 검증을 병행했습니다. 이 예외는 fresh merge approval을 대체하지 않습니다.

## Metadata

- Issue: #794, milestone `1.0.0`, assignee `debop`, labels `bug,integration,test`
- PR: #797, base `develop` (`ea467b6e01035b075612dbed8038d3012adf4e40`), head `4ca30a250cd872e01fdcd97bfdff6d97a4490370`, assignee `debop`, milestone `1.0.0`
- Live state: OPEN, non-draft, `MERGEABLE`, `CLEAN`

## DoD Status

Required checks: 14/18; N/A: 2; Blocked: 0

Type C gates: C-01~C-08 PASS; C-09 PENDING (CG-16 fresh merge approval 이후)

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01~CG-10 - Pre-PR proof | 가이드·GNO/live issue·worktree 경계·RED/GREEN·lesson·수정 검증 | PASS | commit `4ca30a250cd872e01fdcd97bfdff6d97a4490370`; targeted 11 tests, compile, Detekt, assertion validator, Korean audit/GNO | none |
| CG-11 - PR delivery authority | repository/base/head/branch 권한 확인 | PASS | Epic #775 stacked PR train의 승인된 후속 요청과 `bluetape4k/bluetape4k-leader`, `develop`, `fix/issue-794-suspend-bean-timeout` | none |
| CG-12 - Exact head publication | exact head를 force 없이 원격에 게시 | PASS | local/remote/PR head `4ca30a250cd872e01fdcd97bfdff6d97a4490370` 일치 | none |
| CG-12A - Guidance refresh | current AGENTS, workflow, bugfix, Kotlin patterns, common gates, template, Issue #794 재확인 | PASS | current guidance/read-back 및 no-drift evidence | none |
| CG-13 - PR creation and metadata | PR body/assignee/labels/milestone/head 검증 | PASS | PR #797 OPEN/non-draft, metadata 일치, body 마지막 heading `## DoD Status` | none |
| CG-14 - CI and review | exact-head CI와 최신 review/thread를 검증 | PASS | CI run [32982718762](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/32982718762) success; GitHub reviews/comments/threads 0; independent review `N/A (single-developer lane)` by explicit user approval | none |
| CG-15 - Merge-ready report | exact PR/head, CI/review, remaining risk를 조정 | PASS | current head exact; local 11/11, compile, Detekt, assertion contract, lesson/GNO, hosted CI success; scoped 7-Tier read-back P0/P1/P2/P3=0 | CG-16 fresh merge approval 요청 |
| CG-16 - Fresh merge approval | exact PR/head 기준 사용자 승인 | PENDING | CG-15 미완료로 요청하지 않음 | CG-15 PASS 후에만 fresh approval 요청 |
| CG-17 - Merge | 승인 후 merge 및 live SHA 확인 | PENDING | merge 미승인 | CG-16 이후에만 실행 |
| CG-18 - Sync and cleanup | merge 후 develop sync와 proven cleanup | PENDING | merge 미완료 | CG-17 이후 보존·정리 |

Final status: PENDING (CG-16 fresh merge approval)

Unchecked required items: CG-16, CG-17, CG-18; C-09
