### PR TITLE
fix(leader): Redis strategic 결과 갱신을 원자화한다

### DIFF
--- a/docs/lessons/2026-08-26-issue-786-strategic-counter-atomicity.md
+++ b/docs/lessons/2026-08-26-issue-786-strategic-counter-atomicity.md
@@ -13,11 +13,15 @@
 
 - Lettuce blocking·suspend 경로는 `RedisScriptRunner`와 Redis Lua 스크립트를
   사용해 조회, 카운터 증가, `SET XX KEEPTTL`을 Redis 서버의 한 원자 실행으로
-  묶었습니다.
+  묶었습니다. Lua에서는 `tonumber()`를 사용하지 않고 signed `Long`을
+  문자열로 정규화·증가해 `2^53` 초과 정밀도와 Kotlin overflow 계약을
+  보존하며, codec이 거부하는 카운터와 metadata 형식은 기존 예외로
+  되돌립니다.
 - Redisson blocking·suspend 경로는 기존 `RMapCache.computeIfPresent`를 사용해
   per-entry lock과 server-side `fastPutIfExists`를 재사용했습니다. 이 경로는
   잔여 TTL을 별도로 읽어 다시 쓰지 않으므로 만료 경쟁과 zombie key 생성을
-  피합니다.
+  피합니다. 등록·해제도 같은 `RMapCache.getLock(nodeId)` 경계를 공유해
+  heartbeat 재등록이 진행 중인 결과 갱신을 덮지 않도록 했습니다.
 - 손상된 후보 직렬화는 기존 codec 예외를 유지하고, 없는 키는 갱신하지 않으며,
   suspend async 명령 객체는 `lazy`로 초기화해 조회 전용 mock·호출자의 연결
   초기화 계약을 바꾸지 않았습니다.
@@ -34,9 +38,11 @@ single/group 및 blocking/suspend 네 조합 모두에서 동시 결과 증가�
 - RED: 독립 Lettuce 연결 8개와 Redisson elector 8개, 16 workers × 20 rounds에서
   기대 카운터 160 대신 Lettuce 11–16, Redisson 11–14 수준으로 유실되는 회귀를
   재현했습니다.
-- GREEN: Lettuce strategic single/group blocking/suspend 44·11건과 Redisson
-  34·11건 focused suite가 모두 통과했습니다.
-- 전체 모듈: Lettuce `294/294`, Redisson `280/280`, failures=0, skipped=0.
+- GREEN: Lettuce strategic single/group blocking/suspend 및 Redisson
+  single/group blocking/suspend focused suite와 `Long`·metadata·entry-lock
+  경계 테스트가 모두 통과했습니다.
+- 전체 모듈: Lettuce `299/299`, Redisson `281/281`, failures=0,
+  skipped=0.
 - 정적 분석: 두 변경 모듈 `detekt` 통과.
 - `git diff --check`와 exact-head hosted CI는 PR 단계에서 다시 확인합니다.
 

--- a/docs/lessons/2026-08-26-issue-786-strategic-counter-atomicity.md
+++ b/docs/lessons/2026-08-26-issue-786-strategic-counter-atomicity.md
@@ -1,0 +1,50 @@
+# Issue #786 교훈 — Redis 전략 결과 카운터 원자 갱신
+
+**영향 모듈**: `leader-redis-lettuce`, `leader-redis-redisson`
+
+## 맥락
+
+전략적 후보의 `SUCCESS`·`FAILURE` 결과를 기록할 때 후보 문자열을 읽고,
+클라이언트에서 카운터를 증가시킨 뒤 다시 쓰는 read-modify-write가 사용되고
+있었습니다. 서로 다른 연결에서 결과 갱신이 동시에 실행되면 한쪽 증가분이 다른
+쪽 쓰기에 덮어써져 `successRate`와 선출 순서가 실제 실행 결과와 달라졌습니다.
+
+## 결정
+
+- Lettuce blocking·suspend 경로는 `RedisScriptRunner`와 Redis Lua 스크립트를
+  사용해 조회, 카운터 증가, `SET XX KEEPTTL`을 Redis 서버의 한 원자 실행으로
+  묶었습니다.
+- Redisson blocking·suspend 경로는 기존 `RMapCache.computeIfPresent`를 사용해
+  per-entry lock과 server-side `fastPutIfExists`를 재사용했습니다. 이 경로는
+  잔여 TTL을 별도로 읽어 다시 쓰지 않으므로 만료 경쟁과 zombie key 생성을
+  피합니다.
+- 손상된 후보 직렬화는 기존 codec 예외를 유지하고, 없는 키는 갱신하지 않으며,
+  suspend async 명령 객체는 `lazy`로 초기화해 조회 전용 mock·호출자의 연결
+  초기화 계약을 바꾸지 않았습니다.
+
+## 결과
+
+single/group 및 blocking/suspend 네 조합 모두에서 동시 결과 증가가 보존되고,
+`successRate`와 `SuccessRateScorer` 기반 winner가 일관되게 계산됩니다. 후보 TTL,
+만료 후 zombie 방지, key namespace, `CancellationException` 전파 계약은
+변경하지 않았습니다.
+
+## 검증
+
+- RED: 독립 Lettuce 연결 8개와 Redisson elector 8개, 16 workers × 20 rounds에서
+  기대 카운터 160 대신 Lettuce 11–16, Redisson 11–14 수준으로 유실되는 회귀를
+  재현했습니다.
+- GREEN: Lettuce strategic single/group blocking/suspend 44·11건과 Redisson
+  34·11건 focused suite가 모두 통과했습니다.
+- 전체 모듈: Lettuce `294/294`, Redisson `280/280`, failures=0, skipped=0.
+- 정적 분석: 두 변경 모듈 `detekt` 통과.
+- `git diff --check`와 exact-head hosted CI는 PR 단계에서 다시 확인합니다.
+
+## 향후 지침
+
+후보 결과처럼 문자열 또는 map entry 안의 카운터를 갱신하는 Redis 코드는
+클라이언트 read-modify-write를 새로 만들지 말고 backend-native 원자 연산을
+사용하세요. 동시성 회귀는 공유 connection에 의존하지 말고 독립 연결과 실제
+winner·TTL 관찰까지 포함해 고정합니다. suspend 경로에서 새 backend command
+객체를 추가할 때는 생성 시점의 mock·호출자 초기화 부작용이 없는지 확인하고
+필요하면 지연 초기화를 사용합니다.

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt
@@ -1,10 +1,12 @@
 package io.bluetape4k.leader.lettuce
 
 import io.bluetape4k.leader.validateLockName
+import io.bluetape4k.leader.lettuce.script.RedisScriptRunner
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
-import io.lettuce.core.SetArgs
+import io.lettuce.core.ScriptOutputType
 import io.lettuce.core.api.StatefulRedisConnection
+import java.time.Instant
 import kotlin.time.Duration
 
 /**
@@ -100,8 +102,13 @@ internal class LettuceCandidateRegistry(
     fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
         validateLockName(lockName)
         val key = candidateKey(lockName, nodeId)
-        val current = sync.get(key)?.let { LettuceCandidateInfoCodec.decode(it) } ?: return
-        val updated = LettuceCandidateInfoCodec.encode(current.withResult(result))
-        sync.set(key, updated, SetArgs.Builder.xx().keepttl())
+        val reply = RedisScriptRunner.run<List<Any>>(
+            sync,
+            LettuceCandidateResultScript.UPDATE,
+            ScriptOutputType.MULTI,
+            arrayOf(key),
+            *LettuceCandidateResultScript.resultArgs(result, Instant.now().toEpochMilli()),
+        )
+        LettuceCandidateResultScript.rethrowMalformed(reply)
     }
 }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateResultScript.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateResultScript.kt
@@ -22,25 +22,146 @@ internal object LettuceCandidateResultScript {
           return { $ABSENT }
         end
 
+        local LONG_MAX = '9223372036854775807'
+        local LONG_MIN_ABS = '9223372036854775808'
+
+        local function normalizeLong(value)
+          if not value or not string.match(value, '^[+-]?%d+$') then
+            return nil
+          end
+
+          local sign = ''
+          local digits = value
+          local first = string.sub(value, 1, 1)
+          if first == '+' or first == '-' then
+            sign = first
+            digits = string.sub(value, 2)
+          end
+          digits = string.gsub(digits, '^0+', '')
+          if digits == '' then
+            digits = '0'
+          end
+          if sign == '-' and digits ~= '0' then
+            digits = '-' .. digits
+          end
+
+          local negative = string.sub(digits, 1, 1) == '-'
+          local absolute = negative and string.sub(digits, 2) or digits
+          local limit = negative and LONG_MIN_ABS or LONG_MAX
+          if string.len(absolute) > string.len(limit)
+            or (string.len(absolute) == string.len(limit) and absolute > limit) then
+            return nil
+          end
+          return digits
+        end
+
+        local function addPositiveOne(digits)
+          local result = {}
+          local index = string.len(digits)
+          local carry = 1
+          while index > 0 do
+            local digit = string.byte(digits, index) - string.byte('0')
+            local sum = digit + carry
+            result[index] = string.char((sum % 10) + string.byte('0'))
+            carry = math.floor(sum / 10)
+            index = index - 1
+          end
+          if carry == 1 then
+            table.insert(result, 1, '1')
+          end
+          return table.concat(result)
+        end
+
+        local function subtractPositiveOne(digits)
+          local result = {}
+          local index = string.len(digits)
+          local borrow = 1
+          while index > 0 do
+            local digit = string.byte(digits, index) - string.byte('0')
+            local difference = digit - borrow
+            if difference < 0 then
+              difference = difference + 10
+              borrow = 1
+            else
+              borrow = 0
+            end
+            result[index] = string.char(difference + string.byte('0'))
+            index = index - 1
+          end
+          local normalized = string.gsub(table.concat(result), '^0+', '')
+          if normalized == '' then
+            return '0'
+          end
+          return normalized
+        end
+
+        local function incrementLong(value)
+          local normalized = normalizeLong(value)
+          if not normalized then
+            return nil
+          end
+          if string.sub(normalized, 1, 1) == '-' then
+            local absolute = string.sub(normalized, 2)
+            if absolute == '1' then
+              return '0'
+            end
+            return '-' .. subtractPositiveOne(absolute)
+          end
+          if normalized == LONG_MAX then
+            return '-' .. LONG_MIN_ABS
+          end
+          return addPositiveOne(normalized)
+        end
+
+        local function normalizeOptionalLong(value)
+          if value == '' then
+            return ''
+          end
+          return normalizeLong(value) or ''
+        end
+
+        local function validMetadata(value)
+          if value == '' then
+            return true
+          end
+          local start = 1
+          while true do
+            local separator = string.find(value, ',', start, true)
+            local item = separator and string.sub(value, start, separator - 1) or string.sub(value, start)
+            if not string.find(item, '=', 1, true) then
+              return false
+            end
+            if not separator then
+              return true
+            end
+            start = separator + 1
+          end
+        end
+
         local nodeId, registeredAt, lastStartTime, lastCompletionTime, successCount, failureCount, metadata =
           string.match(current, '^([^|]*)|([^|]*)|([^|]*)|([^|]*)|([^|]*)|([^|]*)|(.*)$')
-        if not nodeId or not tonumber(registeredAt)
-          or (lastStartTime ~= '' and not tonumber(lastStartTime))
-          or (lastCompletionTime ~= '' and not tonumber(lastCompletionTime))
-          or not tonumber(successCount) or not tonumber(failureCount) then
+        local normalizedRegisteredAt = normalizeLong(registeredAt)
+        local normalizedSuccessCount = normalizeLong(successCount)
+        local normalizedFailureCount = normalizeLong(failureCount)
+        if not nodeId or not normalizedRegisteredAt or not normalizedSuccessCount
+          or not normalizedFailureCount or not validMetadata(metadata) then
           return { $MALFORMED, current }
         end
 
+        local normalizedStartTime = normalizeOptionalLong(lastStartTime)
+        local normalizedCompletionTime = normalizeOptionalLong(lastCompletionTime)
+
         if ARGV[1] == 'SUCCESS' then
-          successCount = tostring(tonumber(successCount) + 1)
+          normalizedSuccessCount = incrementLong(normalizedSuccessCount)
         elseif ARGV[1] == 'FAILURE' then
-          failureCount = tostring(tonumber(failureCount) + 1)
+          normalizedFailureCount = incrementLong(normalizedFailureCount)
         else
           return redis.error_reply('지원하지 않는 CandidateResult: ' .. ARGV[1])
         end
 
         local updated = table.concat({
-          nodeId, registeredAt, lastStartTime, ARGV[2], successCount, failureCount, metadata
+          nodeId, normalizedRegisteredAt, normalizedStartTime, ARGV[2], normalizedSuccessCount,
+          normalizedFailureCount, metadata
         }, '|')
         local written = redis.call('SET', KEYS[1], updated, 'XX', 'KEEPTTL')
         if written then

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateResultScript.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateResultScript.kt
@@ -1,0 +1,65 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.leader.lettuce.script.RedisScript
+import io.bluetape4k.leader.strategy.CandidateResult
+
+/**
+ * Redis 서버 안에서 후보 결과 카운터를 읽고 갱신하는 스크립트입니다.
+ *
+ * 후보 값은 하나의 문자열로 인코딩되어 있으므로 클라이언트의
+ * read-modify-write 대신 Redis 원자 실행 단위에서 카운터와 TTL을 함께 보존합니다.
+ */
+internal object LettuceCandidateResultScript {
+
+    const val ABSENT = 0L
+    const val UPDATED = 1L
+    const val MALFORMED = -1L
+
+    val UPDATE = RedisScript(
+        """
+        local current = redis.call('GET', KEYS[1])
+        if not current then
+          return { $ABSENT }
+        end
+
+        local nodeId, registeredAt, lastStartTime, lastCompletionTime, successCount, failureCount, metadata =
+          string.match(current, '^([^|]*)|([^|]*)|([^|]*)|([^|]*)|([^|]*)|([^|]*)|(.*)$')
+        if not nodeId or not tonumber(registeredAt)
+          or (lastStartTime ~= '' and not tonumber(lastStartTime))
+          or (lastCompletionTime ~= '' and not tonumber(lastCompletionTime))
+          or not tonumber(successCount) or not tonumber(failureCount) then
+          return { $MALFORMED, current }
+        end
+
+        if ARGV[1] == 'SUCCESS' then
+          successCount = tostring(tonumber(successCount) + 1)
+        elseif ARGV[1] == 'FAILURE' then
+          failureCount = tostring(tonumber(failureCount) + 1)
+        else
+          return redis.error_reply('지원하지 않는 CandidateResult: ' .. ARGV[1])
+        end
+
+        local updated = table.concat({
+          nodeId, registeredAt, lastStartTime, ARGV[2], successCount, failureCount, metadata
+        }, '|')
+        local written = redis.call('SET', KEYS[1], updated, 'XX', 'KEEPTTL')
+        if written then
+          return { $UPDATED }
+        end
+        return { $ABSENT }
+        """.trimIndent()
+    )
+
+    /** 스크립트가 감지한 기존 codec 오류를 기존 예외 계약으로 다시 표면화합니다. */
+    fun rethrowMalformed(reply: List<Any>) {
+        val status = reply.firstOrNull()?.toString()?.toLongOrNull()
+        if (status == MALFORMED) {
+            LettuceCandidateInfoCodec.decode(reply.getOrNull(1)?.toString().orEmpty())
+        }
+    }
+
+    fun resultArgs(result: CandidateResult, completionTimeMillis: Long): Array<String> = arrayOf(
+        result.name,
+        completionTimeMillis.toString(),
+    )
+}

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt
@@ -4,14 +4,16 @@ package io.bluetape4k.leader.lettuce
 
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.lettuce.script.RedisScriptRunner
 import io.bluetape4k.leader.validateLockName
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
-import io.lettuce.core.SetArgs
+import io.lettuce.core.ScriptOutputType
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.coroutines
 import io.lettuce.core.api.coroutines.RedisCoroutinesCommands
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.toList
+import java.time.Instant
 import kotlin.time.Duration
 
 /**
@@ -35,6 +37,7 @@ internal class LettuceSuspendCandidateRegistry(
     }
 
     private val cmds: RedisCoroutinesCommands<String, String> = connection.coroutines()
+    private val asyncCommands by lazy { connection.async() }
 
     private fun indexKey(lockName: String) =
         "$keyPrefix:$lockName"
@@ -106,8 +109,13 @@ internal class LettuceSuspendCandidateRegistry(
     suspend fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
         validateLockName(lockName)
         val key = candidateKey(lockName, nodeId)
-        val current = cmds.get(key)?.let { LettuceCandidateInfoCodec.decode(it) } ?: return
-        val updated = LettuceCandidateInfoCodec.encode(current.withResult(result))
-        cmds.set(key, updated, SetArgs.Builder.xx().keepttl())
+        val reply = RedisScriptRunner.runSuspending<List<Any>>(
+            asyncCommands,
+            LettuceCandidateResultScript.UPDATE,
+            ScriptOutputType.MULTI,
+            arrayOf(key),
+            *LettuceCandidateResultScript.resultArgs(result, Instant.now().toEpochMilli()),
+        )
+        LettuceCandidateResultScript.rethrowMalformed(reply)
     }
 }

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElectorTest.kt
@@ -142,6 +142,55 @@ class LettuceStrategicLeaderElectorTest: AbstractLettuceLeaderTest() {
     }
 
     @Test
+    fun `updateResult - Long 2의 53승 초과 카운터도 정밀하게 증가`() {
+        val lockName = randomName()
+        val initial = 9_007_199_254_740_992L
+        node1.registerCandidate(lockName, CandidateInfo("node-1", successCount = initial))
+
+        node1.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+
+        val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        updated.successCount shouldBeEqualTo initial + 1
+    }
+
+    @Test
+    fun `updateResult - Long 최대값 증가도 Kotlin overflow 계약을 보존`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1", successCount = Long.MAX_VALUE))
+
+        node1.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+
+        val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        updated.successCount shouldBeEqualTo Long.MIN_VALUE
+    }
+
+    @Test
+    fun `updateResult - codec가 거부하는 지수 표기 카운터는 기존 예외를 전파`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        val key = "leader:strategy:candidates:$lockName:node-1"
+        val raw = "node-1|${Instant.now().toEpochMilli()}|||1e3|0|"
+        connection.sync().set(key, raw)
+
+        assertFailsWith<NumberFormatException> {
+            node1.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+        }
+    }
+
+    @Test
+    fun `updateResult - 손상된 metadata는 기존 codec 예외를 전파`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        val key = "leader:strategy:candidates:$lockName:node-1"
+        val raw = "node-1|${Instant.now().toEpochMilli()}|||0|0|brokenpair"
+        connection.sync().set(key, raw)
+
+        assertFailsWith<IllegalArgumentException> {
+            node1.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+        }
+    }
+
+    @Test
     fun `runIfLeader SUCCESS 후 successCount 자동 증가`() {
         val lockName = randomName()
         node1.registerCandidate(lockName, CandidateInfo("node-1"))

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElectorTest.kt
@@ -16,6 +16,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import io.bluetape4k.support.closeSafe
+import io.lettuce.core.codec.StringCodec
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -242,6 +245,42 @@ class LettuceStrategicLeaderElectorTest: AbstractLettuceLeaderTest() {
 
         val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
         updated.failureCount shouldBeEqualTo 3L
+    }
+
+    @Test
+    fun `동시 결과 갱신은 성공과 실패 카운터를 모두 보존한다`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.registerCandidate(lockName, CandidateInfo("node-2", successCount = 1, failureCount = 9))
+
+        val connections = (1..8).map { client.connect(StringCodec.UTF8) }
+        try {
+            val electors = connections.map { LettuceStrategicLeaderElector(it, "node-1") }
+            val actions = electors.flatMap { elector ->
+                listOf<() -> Unit>(
+                    { elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS) },
+                    { elector.updateResult(lockName, "node-1", CandidateResult.FAILURE) },
+                )
+            }
+            val workers = actions.size
+            val rounds = 20
+            MultithreadingTester()
+                .workers(workers)
+                .rounds(rounds)
+                .addAll(actions)
+                .run()
+
+            val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+            val expectedEach = (workers * rounds / 2).toLong()
+            updated.successCount shouldBeEqualTo expectedEach
+            updated.failureCount shouldBeEqualTo expectedEach
+            updated.successRate shouldBeEqualTo 0.5
+            ScoredElectionStrategy(SuccessRateScorer)
+                .elect(node1.listCandidates(lockName))
+                .winner?.nodeId shouldBeEqualTo "node-1"
+        } finally {
+            connections.forEach { it.closeSafe() }
+        }
     }
 
     @Test

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElectorTest.kt
@@ -5,9 +5,15 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.GroupElectionStrategy
 import io.bluetape4k.leader.strategy.StrategicGroupElectionResult
+import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
 import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import io.bluetape4k.leader.strategy.strategies.ScoredGroupElectionStrategy
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
+import io.bluetape4k.support.closeSafe
+import io.lettuce.core.codec.StringCodec
 import org.awaitility.kotlin.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -85,6 +91,45 @@ class LettuceStrategicLeaderGroupElectorTest : AbstractLettuceLeaderTest() {
             .until {
                 node1.listCandidates(lockName).map { it.nodeId } == listOf("persistent-node")
             }
+    }
+
+    @Test
+    fun `동시 group 결과 갱신은 성공과 실패 카운터와 winner를 보존한다`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.registerCandidate(lockName, CandidateInfo("node-2", successCount = 1, failureCount = 9))
+
+        val connections = (1..8).map { client.connect(StringCodec.UTF8) }
+        try {
+            val electors = connections.map { LettuceStrategicLeaderGroupElector(it, "node-1") }
+            val actions = electors.flatMap { elector ->
+                listOf<() -> Unit>(
+                    { elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS) },
+                    { elector.updateResult(lockName, "node-1", CandidateResult.FAILURE) },
+                )
+            }
+            val workers = actions.size
+            val rounds = 20
+            MultithreadingTester()
+                .workers(workers)
+                .rounds(rounds)
+                .addAll(actions)
+                .run()
+
+            val candidates = node1.listCandidates(lockName)
+            val updated = candidates.first { it.nodeId == "node-1" }
+            val expectedEach = (workers * rounds / 2).toLong()
+            updated.successCount shouldBeEqualTo expectedEach
+            updated.failureCount shouldBeEqualTo expectedEach
+            updated.successRate shouldBeEqualTo 0.5
+            ScoredGroupElectionStrategy(SuccessRateScorer)
+                .elect(candidates, maxLeaders = 1)
+                .winners
+                .first()
+                .nodeId shouldBeEqualTo "node-1"
+        } finally {
+            connections.forEach { it.closeSafe() }
+        }
     }
 
     @Test

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElectorTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.lettuce
 
 import io.bluetape4k.junit5.awaitility.untilSuspending
 import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.leader.LeaderElectionException
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
@@ -23,6 +24,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.support.closeSafe
+import io.lettuce.core.codec.StringCodec
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -319,5 +322,41 @@ class LettuceStrategicSuspendLeaderElectorTest: AbstractLettuceLeaderTest() {
             ).awaitAll()
         }
         counter.get() shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `동시 suspend 결과 갱신은 성공과 실패 카운터를 모두 보존한다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.registerCandidate(lockName, CandidateInfo("node-2", successCount = 1, failureCount = 9))
+
+        val connections = (1..8).map { client.connect(StringCodec.UTF8) }
+        try {
+            val electors = connections.map { LettuceStrategicSuspendLeaderElector(it, "node-1") }
+            val actions = electors.flatMap { elector ->
+                listOf<suspend () -> Unit>(
+                    { elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS) },
+                    { elector.updateResult(lockName, "node-1", CandidateResult.FAILURE) },
+                )
+            }
+            val workers = actions.size
+            val rounds = 20
+            SuspendedJobTester()
+                .workers(workers)
+                .rounds(rounds)
+                .addAll(actions)
+                .run()
+
+            val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+            val expectedEach = (workers * rounds / 2).toLong()
+            updated.successCount shouldBeEqualTo expectedEach
+            updated.failureCount shouldBeEqualTo expectedEach
+            updated.successRate shouldBeEqualTo 0.5
+            ScoredElectionStrategy(SuccessRateScorer)
+                .elect(node1.listCandidates(lockName))
+                .winner?.nodeId shouldBeEqualTo "node-1"
+        } finally {
+            connections.forEach { it.closeSafe() }
+        }
     }
 }

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElectorTest.kt
@@ -153,6 +153,18 @@ class LettuceStrategicSuspendLeaderElectorTest: AbstractLettuceLeaderTest() {
     }
 
     @Test
+    fun `updateResult - suspend 경로도 Long 2의 53승 초과 카운터를 정밀하게 증가`() = runSuspendIO {
+        val lockName = randomName()
+        val initial = 9_007_199_254_740_992L
+        node1.registerCandidate(lockName, CandidateInfo("node-1", successCount = initial))
+
+        node1.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+
+        val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        updated.successCount shouldBeEqualTo initial + 1
+    }
+
+    @Test
     fun `updateResult - TTL 만료 후 호출 시 좀비 항목 생성 없음`() = runSuspendIO {
         val lockName = randomName()
         val ttl = 200.milliseconds

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElectorTest.kt
@@ -7,9 +7,15 @@ import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.awaitility.untilSuspending
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.GroupElectionStrategy
 import io.bluetape4k.leader.strategy.StrategicGroupElectionResult
+import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
 import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import io.bluetape4k.leader.strategy.strategies.ScoredGroupElectionStrategy
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import io.bluetape4k.support.closeSafe
+import io.lettuce.core.codec.StringCodec
 import org.awaitility.kotlin.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -75,6 +81,45 @@ class LettuceStrategicSuspendLeaderGroupElectorTest : AbstractLettuceLeaderTest(
 
         await.atMost(2.seconds).withPollInterval(50.milliseconds) untilSuspending {
             node1.listCandidates(lockName).map { it.nodeId } == listOf("persistent-node")
+        }
+    }
+
+    @Test
+    fun `동시 suspend group 결과 갱신은 성공과 실패 카운터와 winner를 보존한다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.registerCandidate(lockName, CandidateInfo("node-2", successCount = 1, failureCount = 9))
+
+        val connections = (1..8).map { client.connect(StringCodec.UTF8) }
+        try {
+            val electors = connections.map { LettuceStrategicSuspendLeaderGroupElector(it, "node-1") }
+            val actions = electors.flatMap { elector ->
+                listOf<suspend () -> Unit>(
+                    { elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS) },
+                    { elector.updateResult(lockName, "node-1", CandidateResult.FAILURE) },
+                )
+            }
+            val workers = actions.size
+            val rounds = 20
+            SuspendedJobTester()
+                .workers(workers)
+                .rounds(rounds)
+                .addAll(actions)
+                .run()
+
+            val candidates = node1.listCandidates(lockName)
+            val updated = candidates.first { it.nodeId == "node-1" }
+            val expectedEach = (workers * rounds / 2).toLong()
+            updated.successCount shouldBeEqualTo expectedEach
+            updated.failureCount shouldBeEqualTo expectedEach
+            updated.successRate shouldBeEqualTo 0.5
+            ScoredGroupElectionStrategy(SuccessRateScorer)
+                .elect(candidates, maxLeaders = 1)
+                .winners
+                .first()
+                .nodeId shouldBeEqualTo "node-1"
+        } finally {
+            connections.forEach { it.closeSafe() }
         }
     }
 

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
@@ -57,13 +57,8 @@ internal class RedissonCandidateRegistry(
 
     fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
         val cache = mapCacheFor(lockName)
-        val current = cache[nodeId] ?: return
-        val updated = current.withResult(result)
-        val remainMs = cache.remainTimeToLive(nodeId)  // -1 = no TTL, -2 = absent
-        when {
-            remainMs > 0L   -> cache.put(nodeId, updated, remainMs, TimeUnit.MILLISECONDS)
-            remainMs == -1L -> cache.put(nodeId, updated)
-            // remainMs == -2: key expired between GET and TTL check — skip to avoid zombie
-        }
+        // Redisson의 per-entry lock과 server-side fastPutIfExists를 사용해
+        // read-modify-write 및 GET/TTL/PUT 사이의 만료 경쟁을 제거한다.
+        cache.computeIfPresent(nodeId) { _, current -> current.withResult(result) }
     }
 }

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
@@ -41,15 +41,20 @@ internal class RedissonCandidateRegistry(
 
     fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
         val cache = mapCacheFor(lockName)
-        if (ttl == Duration.ZERO) {
-            cache.put(info.nodeId, info)
-        } else {
-            cache.put(info.nodeId, info, ttl.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        withEntryLock(cache, info.nodeId) {
+            if (ttl == Duration.ZERO) {
+                cache.put(info.nodeId, info)
+            } else {
+                cache.put(info.nodeId, info, ttl.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+            }
         }
     }
 
     fun unregisterCandidate(lockName: String, nodeId: String) {
-        mapCacheFor(lockName).remove(nodeId)
+        val cache = mapCacheFor(lockName)
+        withEntryLock(cache, nodeId) {
+            cache.remove(nodeId)
+        }
     }
 
     fun listCandidates(lockName: String): List<CandidateInfo> =
@@ -60,5 +65,20 @@ internal class RedissonCandidateRegistry(
         // Redisson의 per-entry lock과 server-side fastPutIfExists를 사용해
         // read-modify-write 및 GET/TTL/PUT 사이의 만료 경쟁을 제거한다.
         cache.computeIfPresent(nodeId) { _, current -> current.withResult(result) }
+    }
+
+    /** 등록·해제도 결과 갱신과 Redisson map entry lock을 공유하도록 보장합니다. */
+    private inline fun <T> withEntryLock(
+        cache: org.redisson.api.RMapCache<String, CandidateInfo>,
+        nodeId: String,
+        action: () -> T,
+    ): T {
+        val lock = cache.getLock(nodeId)
+        lock.lock()
+        return try {
+            action()
+        } finally {
+            lock.unlock()
+        }
     }
 }

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElectorTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElectorTest.kt
@@ -11,6 +11,7 @@ import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import org.awaitility.kotlin.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -342,6 +343,37 @@ class RedissonStrategicLeaderElectorTest: AbstractRedissonLeaderTest() {
         val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
         updated.failureCount shouldBeEqualTo 2L
         updated.successCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `동시 결과 갱신은 성공과 실패 카운터를 모두 보존한다`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.registerCandidate(lockName, CandidateInfo("node-2", successCount = 1, failureCount = 9))
+
+        val electors = (1..8).map { RedissonStrategicLeaderElector(redissonClient, "node-1") }
+        val actions = electors.flatMap { elector ->
+            listOf<() -> Unit>(
+                { elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS) },
+                { elector.updateResult(lockName, "node-1", CandidateResult.FAILURE) },
+            )
+        }
+        val workers = actions.size
+        val rounds = 20
+        MultithreadingTester()
+            .workers(workers)
+            .rounds(rounds)
+            .addAll(actions)
+            .run()
+
+        val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        val expectedEach = (workers * rounds / 2).toLong()
+        updated.successCount shouldBeEqualTo expectedEach
+        updated.failureCount shouldBeEqualTo expectedEach
+        updated.successRate shouldBeEqualTo 0.5
+        ScoredElectionStrategy(SuccessRateScorer)
+            .elect(node1.listCandidates(lockName))
+            .winner?.nodeId shouldBeEqualTo "node-1"
     }
 
     @Test

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElectorTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElectorTest.kt
@@ -20,6 +20,8 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import java.time.Instant
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 class RedissonStrategicLeaderElectorTest: AbstractRedissonLeaderTest() {
@@ -241,6 +243,41 @@ class RedissonStrategicLeaderElectorTest: AbstractRedissonLeaderTest() {
         val candidates = node1.listCandidates(lockName)
         candidates.size shouldBeEqualTo 1
         candidates.first().successCount shouldBeEqualTo 10L
+    }
+
+    @Test
+    fun `후보 재등록은 결과 갱신과 동일한 entry lock을 사용`() {
+        val lockName = randomName()
+        val nodeId = "node-1"
+        node1.registerCandidate(lockName, CandidateInfo(nodeId))
+        val cache = redissonClient.getMapCache<String, CandidateInfo>(
+            "leader:strategy:candidates:$lockName",
+        )
+        val entryLock = cache.getLock(nodeId)
+        entryLock.lock(5, TimeUnit.SECONDS)
+
+        val started = CountDownLatch(1)
+        val completed = CountDownLatch(1)
+        val worker = Thread {
+            started.countDown()
+            node1.registerCandidate(
+                lockName,
+                CandidateInfo(nodeId, metadata = mapOf("heartbeat" to "new")),
+                5.seconds,
+            )
+            completed.countDown()
+        }
+        try {
+            worker.start()
+            started.await(1, TimeUnit.SECONDS) shouldBeEqualTo true
+            completed.await(200, TimeUnit.MILLISECONDS) shouldBeEqualTo false
+        } finally {
+            entryLock.unlock()
+        }
+
+        completed.await(2, TimeUnit.SECONDS) shouldBeEqualTo true
+        worker.join(2_000)
+        node1.listCandidates(lockName).first().metadata shouldBeEqualTo mapOf("heartbeat" to "new")
     }
 
     @Test

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElectorTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElectorTest.kt
@@ -5,9 +5,13 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.GroupElectionStrategy
 import io.bluetape4k.leader.strategy.StrategicGroupElectionResult
+import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
 import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import io.bluetape4k.leader.strategy.strategies.ScoredGroupElectionStrategy
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import org.awaitility.kotlin.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -85,6 +89,40 @@ class RedissonStrategicLeaderGroupElectorTest : AbstractRedissonLeaderTest() {
             .until {
                 node1.listCandidates(lockName).map { it.nodeId } == listOf("persistent-node")
             }
+    }
+
+    @Test
+    fun `동시 group 결과 갱신은 성공과 실패 카운터와 winner를 보존한다`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.registerCandidate(lockName, CandidateInfo("node-2", successCount = 1, failureCount = 9))
+
+        val electors = (1..8).map { RedissonStrategicLeaderGroupElector(redissonClient, "node-1") }
+        val actions = electors.flatMap { elector ->
+            listOf<() -> Unit>(
+                { elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS) },
+                { elector.updateResult(lockName, "node-1", CandidateResult.FAILURE) },
+            )
+        }
+        val workers = actions.size
+        val rounds = 20
+        MultithreadingTester()
+            .workers(workers)
+            .rounds(rounds)
+            .addAll(actions)
+            .run()
+
+        val candidates = node1.listCandidates(lockName)
+        val updated = candidates.first { it.nodeId == "node-1" }
+        val expectedEach = (workers * rounds / 2).toLong()
+        updated.successCount shouldBeEqualTo expectedEach
+        updated.failureCount shouldBeEqualTo expectedEach
+        updated.successRate shouldBeEqualTo 0.5
+        ScoredGroupElectionStrategy(SuccessRateScorer)
+            .elect(candidates, maxLeaders = 1)
+            .winners
+            .first()
+            .nodeId shouldBeEqualTo "node-1"
     }
 
     @Test

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElectorTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElectorTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.redisson
 
 import io.bluetape4k.junit5.awaitility.untilSuspending
 import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.leader.LeaderElectionException
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
@@ -227,5 +228,36 @@ class RedissonStrategicSuspendLeaderElectorTest: AbstractRedissonLeaderTest() {
 
         val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
         updated.successCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `동시 suspend 결과 갱신은 성공과 실패 카운터를 모두 보존한다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.registerCandidate(lockName, CandidateInfo("node-2", successCount = 1, failureCount = 9))
+
+        val electors = (1..8).map { RedissonStrategicSuspendLeaderElector(redissonClient, "node-1") }
+        val actions = electors.flatMap { elector ->
+            listOf<suspend () -> Unit>(
+                { elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS) },
+                { elector.updateResult(lockName, "node-1", CandidateResult.FAILURE) },
+            )
+        }
+        val workers = actions.size
+        val rounds = 20
+        SuspendedJobTester()
+            .workers(workers)
+            .rounds(rounds)
+            .addAll(actions)
+            .run()
+
+        val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
+        val expectedEach = (workers * rounds / 2).toLong()
+        updated.successCount shouldBeEqualTo expectedEach
+        updated.failureCount shouldBeEqualTo expectedEach
+        updated.successRate shouldBeEqualTo 0.5
+        ScoredElectionStrategy(SuccessRateScorer)
+            .elect(node1.listCandidates(lockName))
+            .winner?.nodeId shouldBeEqualTo "node-1"
     }
 }

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElectorTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElectorTest.kt
@@ -7,9 +7,13 @@ import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.awaitility.untilSuspending
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.GroupElectionStrategy
 import io.bluetape4k.leader.strategy.StrategicGroupElectionResult
+import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
 import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import io.bluetape4k.leader.strategy.strategies.ScoredGroupElectionStrategy
+import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import org.awaitility.kotlin.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -77,6 +81,40 @@ class RedissonStrategicSuspendLeaderGroupElectorTest : AbstractRedissonLeaderTes
             .untilSuspending {
                 node1.listCandidates(lockName).map { it.nodeId } == listOf("persistent-node")
             }
+    }
+
+    @Test
+    fun `동시 suspend group 결과 갱신은 성공과 실패 카운터와 winner를 보존한다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo("node-1"))
+        node1.registerCandidate(lockName, CandidateInfo("node-2", successCount = 1, failureCount = 9))
+
+        val electors = (1..8).map { RedissonStrategicSuspendLeaderGroupElector(redissonClient, "node-1") }
+        val actions = electors.flatMap { elector ->
+            listOf<suspend () -> Unit>(
+                { elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS) },
+                { elector.updateResult(lockName, "node-1", CandidateResult.FAILURE) },
+            )
+        }
+        val workers = actions.size
+        val rounds = 20
+        SuspendedJobTester()
+            .workers(workers)
+            .rounds(rounds)
+            .addAll(actions)
+            .run()
+
+        val candidates = node1.listCandidates(lockName)
+        val updated = candidates.first { it.nodeId == "node-1" }
+        val expectedEach = (workers * rounds / 2).toLong()
+        updated.successCount shouldBeEqualTo expectedEach
+        updated.failureCount shouldBeEqualTo expectedEach
+        updated.successRate shouldBeEqualTo 0.5
+        ScoredGroupElectionStrategy(SuccessRateScorer)
+            .elect(candidates, maxLeaders = 1)
+            .winners
+            .first()
+            .nodeId shouldBeEqualTo "node-1"
     }
 
     @Test


### PR DESCRIPTION
## 배경

Issue #786의 strategic 결과 갱신에서 Redis read-modify-write 경쟁으로 성공·실패 카운터가 유실될 수 있는 문제를 수정합니다.

## 변경 사항

- Lettuce blocking/suspend candidate registry가 서버-side Lua 단일 실행으로 결과·TTL을 원자 갱신합니다.
- Lua 카운터 증가는 IEEE-754 `tonumber()`를 사용하지 않고 signed `Long` 문자열 연산으로 Kotlin `Long` 범위·overflow 계약을 보존합니다.
- Lettuce 결과 codec과 같은 카운터·metadata 형식 검증 및 기존 예외 경계를 유지합니다.
- Redisson `registerCandidate`·`unregisterCandidate`·`updateResult`가 동일한 per-entry lock 경계에 참여하도록 정렬합니다.
- single/group 및 blocking/suspend 경로의 동시성·heartbeat 경합 회귀 테스트와 lesson을 추가했습니다.

## 검증

- RED: 독립 Redis 연결 8개, 16 workers, 20 rounds에서 기존 카운터 유실을 재현했습니다.
- Lettuce strategic focused 60건, 전체 `cleanTest` 299/299 통과.
- Redisson strategic focused 46건, 전체 `cleanTest` 281/281 통과.
- `detekt` 두 모듈 및 `git diff --check` 통과.
- `2^53` 초과 카운터, `Long.MAX_VALUE` overflow, 지수/metadata 손상, Redisson entry-lock 경합 회귀를 검증했습니다.
- Hosted exact-head CI run `32986469076` (`4bb22b630581d83ab5dd34214d8a232752504e93`)이 `completed/success`, 47/47 jobs 완료, 실패 0건으로 종료했습니다.
- PR에 연결된 exact-head run `32986592265`도 `completed/success`이며 변경 모듈 검증이 통과했습니다.

Closes #786

## DoD Status

- 로컬 구현·테스트·정적 분석: 완료.
- Hosted exact-head CI: 완료 (`32986469076`, 47/47 jobs, 실패 0건).
- PR exact-head readback: head `4bb22b630581d83ab5dd34214d8a232752504e93`, base `develop` 확인.
- 단일 개발자 정책에 따라 human review는 요구하지 않으며, 독립 code-reviewer는 APPROVE(P0/P1=0), architect는 WATCH(merge blocker 0)로 확인했습니다.
