### PR TITLE
test(leader): Redis strategic group 취소 경계 회귀 고정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ val baseVersion = providers.gradleProperty("baseVersion").get()
 val snapshotVersion = providers.gradleProperty("snapshotVersion").get()
 val bluetape4kVirtualThreadJdk25Version = providers
     .gradleProperty("bluetape4kVirtualThreadJdk25Version")
-    .orElse("1.13.0-SNAPSHOT")
+    .orElse("2.0.0-SNAPSHOT")
     .get()
 
 fun Project.isNonPublishedProject(): Boolean =

--- a/docs/lessons/2026-08-27-issue-810-virtualthread-snapshot-train.md
+++ b/docs/lessons/2026-08-27-issue-810-virtualthread-snapshot-train.md
@@ -1,0 +1,66 @@
+# VirtualThread 2.0.0 snapshot train 정합성
+
+## 맥락
+
+PR #809의 exact-head hosted CI에서 Lettuce와 Redisson을 포함한 여러 모듈이
+`io/bluetape4k/concurrent/virtualthread/api/VirtualThreads`를 찾지 못하고
+초기화에 실패했습니다. Leader의 `gradle.properties`는 이전 `1.13.0`
+snapshot pin을 사용했지만, upstream package-boundary 변경(PR
+`bluetape4k-projects#1523`)은 public API를
+`io.bluetape4k.concurrent.virtualthread.api`로 이동했습니다. 따라서 테스트
+실패는 Leader 코드의 취소 동작이 아니라 서로 다른 ABI train을 섞은
+dependency resolution 문제였습니다.
+
+## 결정
+
+- `bluetape4k-virtualthread-api`, `bluetape4k-virtualthread-jdk25`를 포함해
+  core, coroutine, idgenerator, junit5, testcontainers helper가 같은
+  `2.0.0-20260826.200524-12` immutable snapshot train을 사용하도록
+  정렬합니다.
+- 기본 fallback도 `2.0.0-SNAPSHOT`으로 맞춰 명시적 pin이 없는 환경에서
+  이전 `1.13.0` ABI가 다시 선택되지 않게 합니다.
+- moving snapshot 검증에는 `--refresh-dependencies`를 포함합니다. 캐시된
+  helper jar만 남아 있으면 API jar가 새 package를 제공해도 동일한
+  `NoClassDefFoundError`가 재현될 수 있습니다.
+- Leader에 호환 bridge나 shading을 추가하지 않습니다. package ownership과
+  ServiceLoader 경계를 upstream train에서 관리하고, 소비자는 동일 train을
+  선택해야 합니다.
+
+## 결과
+
+의존성 정렬은 PR #810에서 PR #809 위에 별도 stacked slot으로 전달합니다.
+변경 범위는 root Gradle fallback/pin과 이 lesson으로 제한했습니다. Kotlin
+production/test source는 수정하지 않았습니다.
+
+## 검증
+
+- RED hosted evidence: exact-head run
+  `33039344078`에서 Lettuce job `98414547953`는 309개 중 18개,
+  Redisson job `98415899069`는 42개 중 29개가 동일한 missing-class ABI
+  오류로 실패했습니다.
+- Central snapshot metadata와 jar scan에서 관련 artifact가 모두
+  `2.0.0-20260826.200524-12`이고 API class가 `.api.VirtualThreads`에
+  존재함을 확인했습니다.
+- `--refresh-dependencies` 기준 targeted ToxiProxy 취소 테스트는
+  Lettuce 2개와 Redisson 2개 모두 통과했습니다.
+- 같은 조건의 전체 테스트는 Lettuce 309개, Redisson 291개가 모두
+  통과했습니다.
+- 두 모듈 detekt와 root `./gradlew build -x test`가 통과했습니다. Maven
+  snapshot 전송 중 발생한 일시적 `bad_record_mac`은 재시도 후 성공했으며
+  코드 오류로 분류하지 않았습니다.
+- `git diff --check`와 dependency graph를 통과시켜 변경 파일과 선택된
+  runtime artifact를 재확인했습니다.
+
+## 향후 지침
+
+1. Bluetape snapshot ABI 오류가 보이면 먼저 Central metadata의 timestamp와
+   `dependencyInsight`를 확인하고, API/provider/core/test-helper가 같은
+   train인지 비교합니다.
+2. 선택된 jar를 직접 scan해 package ownership과 ServiceLoader descriptor를
+   확인합니다. 새 package가 필요한 소비자에 옛 pin을 유지한 채 bridge를
+   넣어 문제를 숨기지 않습니다.
+3. moving snapshot의 로컬 검증은 반드시 `--refresh-dependencies`로 수행하고,
+   새 commit의 exact-head hosted CI를 별도로 확인합니다.
+4. TLS 또는 Maven transport 오류는 재시도 가능한 외부 전송 문제인지 먼저
+   분류합니다. 같은 missing-class가 여러 모듈에서 반복되면 테스트별 결함이
+   아니라 공통 ABI train 불일치로 조사합니다.

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,9 +49,11 @@ signing.gnupg.executable=/opt/homebrew/bin/gpg
 # 현재 leader library에는 JDK 21 compatibility island를 유지하는 모듈이 없다.
 # 중앙 immutable catalog가 일치하는 release train을 승격할 때까지
 # 현재 release train은 Maven Central Snapshots의 immutable timestamp 좌표를 사용한다.
-# 개발선에서 새 snapshot을 시험할 때만 -Pbluetape4kVirtualThreadJdk25Version=1.13.0-SNAPSHOT을
+# 2.0.0 package-boundary train의 core와 virtual-thread API/provider 및 test helpers를
+# 같은 timestamp로 정렬해 split-package ABI가 섞이지 않도록 한다.
+# 개발선에서 새 snapshot을 시험할 때만 -Pbluetape4kVirtualThreadJdk25Version=2.0.0-SNAPSHOT을
 # 명시적으로 덮어쓸 수 있으며, release preflight는 해당 suffix를 fail-closed 한다.
-bluetape4kVirtualThreadJdk25Version=1.13.0-20260813.192107-9
+bluetape4kVirtualThreadJdk25Version=2.0.0-20260826.200524-12
 
 # Maven Central Snapshots publish parallelism
 centralSnapshotsParallelism=4

--- a/leader-redis-lettuce/build.gradle.kts
+++ b/leader-redis-lettuce/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit.jupiter)
+    testImplementation(libs.testcontainers.toxiproxy)
 
     // T7 PR 2 — Abstract*ContractTest 사용
     testImplementation(testFixtures(project(":bluetape4k-leader-core")))

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElector.kt
@@ -16,6 +16,8 @@ import io.bluetape4k.logging.warn
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.api.StatefulRedisConnection
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlin.time.Duration
 
 /**
@@ -56,6 +58,7 @@ class LettuceStrategicSuspendLeaderGroupElector(
         action: suspend () -> T,
     ): T? {
         validateLockName(lockName)
+        currentCoroutineContext().ensureActive()
         val candidates = try {
             listCandidates(lockName)
         } catch (e: CancellationException) {
@@ -87,6 +90,7 @@ class LettuceStrategicSuspendLeaderGroupElector(
 
         return try {
             val value = action()
+            currentCoroutineContext().ensureActive()
             updateStrategicResultPreservingCancellation(
                 lockName = lockName,
                 result = CandidateResult.SUCCESS,

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicGroupToxiproxyCancellationTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicGroupToxiproxyCancellationTest.kt
@@ -1,0 +1,185 @@
+@file:OptIn(ExperimentalLettuceCoroutinesApi::class)
+
+package io.bluetape4k.leader.lettuce
+
+import eu.rekawek.toxiproxy.Proxy
+import eu.rekawek.toxiproxy.ToxiproxyClient
+import eu.rekawek.toxiproxy.model.Toxic
+import eu.rekawek.toxiproxy.model.ToxicDirection
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import io.bluetape4k.testcontainers.infra.ToxiproxyServer
+import io.bluetape4k.testcontainers.storage.RedisServer
+import io.lettuce.core.ExperimentalLettuceCoroutinesApi
+import io.lettuce.core.RedisClient
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.codec.StringCodec
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.yield
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.testcontainers.containers.Network
+import org.testcontainers.toxiproxy.ToxiproxyContainer
+import java.util.UUID
+
+/**
+ * Lettuce strategic group의 Redis 후보 조회·결과 갱신 I/O 대기 중 취소 회귀입니다.
+ *
+ * ToxiProxy는 응답을 무기한 보류하고, 테스트는 실제 [kotlinx.coroutines.Job] 취소를
+ * 겹쳐서 `CancellationException`이 일반 `FAILURE`로 변환되지 않는지 검증합니다.
+ */
+@Execution(ExecutionMode.SAME_THREAD)
+class LettuceStrategicGroupToxiproxyCancellationTest {
+
+    @Test
+    fun `후보 조회 응답이 보류된 동안 Job 취소는 action 전에 재전파된다`() = runSuspendIO {
+        withRedisProxy { redis, toxiproxy, proxy ->
+            withClients(redis, toxiproxy) { connection, observerConnection ->
+                val lockName = randomLockName()
+                val elector = LettuceStrategicSuspendLeaderGroupElector(connection, NODE_ID)
+                val observer = LettuceStrategicSuspendLeaderGroupElector(observerConnection, NODE_ID)
+                elector.registerCandidate(lockName, CandidateInfo(NODE_ID))
+                val toxic = proxy.toxics().timeout(
+                    "hold-candidate-response",
+                    ToxicDirection.DOWNSTREAM,
+                    0,
+                )
+
+                try {
+                    val actionInvoked = CompletableDeferred<Unit>()
+                    coroutineScope {
+                        val deferred = async(start = CoroutineStart.UNDISPATCHED) {
+                            elector.runIfLeader(lockName, FifoGroupElectionStrategy) {
+                                actionInvoked.complete(Unit)
+                                "unexpected"
+                            }
+                        }
+                        delay(CANCEL_SETTLE_MILLIS)
+                        deferred.cancel(CancellationException("cancel during candidate lookup"))
+                        assertFailsWith<CancellationException> { deferred.await() }
+                    }
+
+                    actionInvoked.isCompleted shouldBeEqualTo false
+                } finally {
+                    removeToxic(toxic)
+                }
+
+                val candidate = observer.listCandidates(lockName).single()
+                candidate.successCount shouldBeEqualTo 0L
+                candidate.failureCount shouldBeEqualTo 0L
+            }
+        }
+    }
+
+    @Test
+    fun `결과 갱신 응답이 보류된 동안 Job 취소는 FAILURE로 변환되지 않는다`() = runSuspendIO {
+        withRedisProxy { redis, toxiproxy, proxy ->
+            withClients(redis, toxiproxy) { connection, observerConnection ->
+                val lockName = randomLockName()
+                val elector = LettuceStrategicSuspendLeaderGroupElector(connection, NODE_ID)
+                val observer = LettuceStrategicSuspendLeaderGroupElector(observerConnection, NODE_ID)
+                elector.registerCandidate(lockName, CandidateInfo(NODE_ID))
+
+                var toxic: Toxic? = null
+                try {
+                    coroutineScope {
+                        val toxicInstalled = CompletableDeferred<Unit>()
+                        val deferred = async(start = CoroutineStart.UNDISPATCHED) {
+                            elector.runIfLeader(lockName, FifoGroupElectionStrategy) {
+                                toxic = proxy.toxics().timeout(
+                                    "hold-result-response",
+                                    ToxicDirection.DOWNSTREAM,
+                                    0,
+                                )
+                                toxicInstalled.complete(Unit)
+                                "success-before-cancel"
+                            }
+                        }
+                        toxicInstalled.await()
+                        repeat(CANCEL_SETTLE_ROUNDS) {
+                            yield()
+                            delay(CANCEL_SETTLE_MILLIS / CANCEL_SETTLE_ROUNDS)
+                        }
+                        deferred.cancel(CancellationException("cancel during result update"))
+                        assertFailsWith<CancellationException> { deferred.await() }
+                    }
+                } finally {
+                    removeToxic(toxic)
+                }
+
+                val candidate = observer.listCandidates(lockName).single()
+                candidate.failureCount shouldBeEqualTo 0L
+            }
+        }
+    }
+
+    private suspend fun <T> withRedisProxy(block: suspend (RedisServer, ToxiproxyContainer, Proxy) -> T): T =
+        Network.newNetwork().use { network ->
+            RedisServer(reuse = false)
+                .withNetwork(network)
+                .withNetworkAliases(REDIS_ALIAS)
+                .use { redis ->
+                    ToxiproxyServer(reuse = false)
+                        .withNetwork(network)
+                        .use { toxiproxy ->
+                            redis.start()
+                            toxiproxy.start()
+                            val proxy = createRedisProxy(toxiproxy)
+                            try {
+                                block(redis, toxiproxy, proxy)
+                            } finally {
+                                runCatching { proxy.delete() }
+                            }
+                        }
+                }
+        }
+
+    private suspend fun <T> withClients(
+        redis: RedisServer,
+        toxiproxy: ToxiproxyContainer,
+        block: suspend (StatefulRedisConnection<String, String>, StatefulRedisConnection<String, String>) -> T,
+    ): T {
+        val operationClient = RedisClient.create("redis://${toxiproxy.host}:${toxiproxy.getMappedPort(PROXY_PORT)}")
+        val observerClient = RedisClient.create(redis.url)
+        val operationConnection = operationClient.connect(StringCodec.UTF8)
+        val observerConnection = observerClient.connect(StringCodec.UTF8)
+        return try {
+            block(operationConnection, observerConnection)
+        } finally {
+            runCatching { operationConnection.close() }
+            runCatching { observerConnection.close() }
+            runCatching { operationClient.shutdown() }
+            runCatching { observerClient.shutdown() }
+        }
+    }
+
+    private fun createRedisProxy(toxiproxy: ToxiproxyContainer): Proxy =
+        ToxiproxyClient(toxiproxy.host, toxiproxy.controlPort).createProxy(
+            "redis-strategic-${UUID.randomUUID()}",
+            "0.0.0.0:$PROXY_PORT",
+            "$REDIS_ALIAS:${RedisServer.PORT}",
+        )
+
+    private fun removeToxic(toxic: Toxic?) {
+        runCatching { toxic?.remove() }
+    }
+
+    private fun randomLockName(): String = "toxiproxy:lettuce:${UUID.randomUUID()}"
+
+    private companion object {
+        const val NODE_ID = "toxiproxy-lettuce-node"
+        const val REDIS_ALIAS = "redis"
+        const val PROXY_PORT = 8666
+        const val CANCEL_SETTLE_MILLIS = 250L
+        const val CANCEL_SETTLE_ROUNDS = 5
+    }
+}

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElectorTest.kt
@@ -18,6 +18,7 @@ import org.awaitility.kotlin.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Instant
+import java.util.concurrent.CancellationException
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -68,6 +69,54 @@ class LettuceStrategicLeaderGroupElectorTest : AbstractLettuceLeaderTest() {
         node1.listCandidates(lockName).size shouldBeEqualTo 1
         await.atMost(2.seconds).withPollInterval(50.milliseconds)
             .until { node1.listCandidates(lockName).isEmpty() }
+    }
+
+    @Test
+    fun `group action CancellationException은 failureCount를 증가시키지 않고 재전파한다`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+        val cancellation = CancellationException("group action cancelled")
+
+        val thrown = assertFailsWith<CancellationException> {
+            node1.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 1) {
+                throw cancellation
+            }
+        }
+
+        thrown.message shouldBeEqualTo cancellation.message
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.failureCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `group action 예외는 failureCount를 증가시키고 예외를 전파한다`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+        val failure = IllegalStateException("group action failed")
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            node1.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 1) {
+                throw failure
+            }
+        }
+
+        thrown.message shouldBeEqualTo failure.message
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.successCount shouldBeEqualTo 0L
+        candidate.failureCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `group action 성공은 successCount를 증가시키고 failureCount를 건드리지 않는다`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        node1.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 1) { "ok" }
+            .shouldBeEqualTo("ok")
+
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.successCount shouldBeEqualTo 1L
+        candidate.failureCount shouldBeEqualTo 0L
     }
 
     @Test

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElectorTest.kt
@@ -16,10 +16,19 @@ import io.bluetape4k.leader.strategy.strategies.ScoredGroupElectionStrategy
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
 import io.bluetape4k.support.closeSafe
 import io.lettuce.core.codec.StringCodec
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.job
 import org.awaitility.kotlin.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -71,6 +80,104 @@ class LettuceStrategicSuspendLeaderGroupElectorTest : AbstractLettuceLeaderTest(
         await.atMost(2.seconds).withPollInterval(50.milliseconds) untilSuspending {
             node1.listCandidates(lockName).isEmpty()
         }
+    }
+
+    @Test
+    fun `실제 Job cancelAndJoin은 group failureCount를 증가시키지 않는다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        coroutineScope {
+            val actionStarted = CompletableDeferred<Unit>()
+            val deferred = async {
+                node1.runIfLeader(lockName, FifoGroupElectionStrategy) {
+                    actionStarted.complete(Unit)
+                    awaitCancellation()
+                }
+            }
+            actionStarted.await()
+            deferred.cancelAndJoin()
+            deferred.isCancelled shouldBeEqualTo true
+        }
+
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.failureCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `결과 갱신 직전 Job 취소는 CancellationException을 재전파하고 카운터를 갱신하지 않는다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+        val cancellation = CancellationException("cancel before result update")
+
+        coroutineScope {
+            val deferred = async {
+                node1.runIfLeader(lockName, FifoGroupElectionStrategy) {
+                    currentCoroutineContext().job.cancel(cancellation)
+                    "cancelled"
+                }
+            }
+            assertFailsWith<CancellationException> { deferred.await() }
+        }
+
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.successCount shouldBeEqualTo 0L
+        candidate.failureCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `후보 조회 전 Job 취소는 action을 실행하지 않고 CancellationException을 재전파한다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+        val actionInvoked = AtomicBoolean(false)
+        val cancellation = CancellationException("cancel before candidate lookup")
+
+        coroutineScope {
+            val deferred = async {
+                currentCoroutineContext().job.cancel(cancellation)
+                node1.runIfLeader(lockName, FifoGroupElectionStrategy) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+            }
+            assertFailsWith<CancellationException> { deferred.await() }
+        }
+
+        actionInvoked.get() shouldBeEqualTo false
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.successCount shouldBeEqualTo 0L
+        candidate.failureCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `group action 예외는 failureCount를 증가시키고 예외를 전파한다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+        val failure = IllegalStateException("group action failed")
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            node1.runIfLeader(lockName, FifoGroupElectionStrategy) {
+                throw failure
+            }
+        }
+
+        thrown.message shouldBeEqualTo failure.message
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.successCount shouldBeEqualTo 0L
+        candidate.failureCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `group action 성공은 successCount를 증가시키고 failureCount를 건드리지 않는다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        node1.runIfLeader(lockName, FifoGroupElectionStrategy) { "ok" }
+            .shouldBeEqualTo("ok")
+
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.successCount shouldBeEqualTo 1L
+        candidate.failureCount shouldBeEqualTo 0L
     }
 
     @Test

--- a/leader-redis-redisson/build.gradle.kts
+++ b/leader-redis-redisson/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     testImplementation(bt4k.bluetape4k.virtualthread.jdk25)
     testImplementation(libs.testcontainers)
     testImplementation(libs.testcontainers.junit.jupiter)
+    testImplementation(libs.testcontainers.toxiproxy)
 
     // T8 PR 3 — Abstract*ContractTest 사용
     testImplementation(testFixtures(project(":bluetape4k-leader-core")))

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
@@ -4,11 +4,16 @@ import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.logging.KLogging
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.withContext
 import org.redisson.api.RedissonClient
+import org.redisson.api.RMapCache
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * `RedissonCandidateRegistry`는 Redis Redisson backend의 leader election, lock lease, ownership 확인을 담당합니다.
@@ -16,6 +21,7 @@ import java.util.concurrent.TimeUnit
  * 정상 lock contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.
  * @property redissonClient Redis Redisson backend 호출과 상태 계산에 사용하는 속성입니다.
  */
+@Suppress("TooManyFunctions")
 internal class RedissonCandidateRegistry(
     private val redissonClient: RedissonClient,
     private val keyPrefix: String = DEFAULT_KEY_PREFIX,
@@ -29,6 +35,7 @@ internal class RedissonCandidateRegistry(
     companion object: KLogging() {
         internal const val DEFAULT_KEY_PREFIX = "leader:strategy:candidates"
         internal const val GROUP_KEY_PREFIX = "leader:strategy:group-candidates:redisson:v1"
+        private val suspendLockThreadIds = AtomicLong()
     }
 
     private fun cacheKey(lockName: String): String {
@@ -67,6 +74,43 @@ internal class RedissonCandidateRegistry(
         cache.computeIfPresent(nodeId) { _, current -> current.withResult(result) }
     }
 
+    /**
+     * Redisson `RFuture`를 coroutine cancellation과 연결한 후보 등록입니다.
+     * 동기 `put`을 `Dispatchers.IO`에서 감싸면 네트워크 대기 중 취소가 호출자에게
+     * 즉시 전파되지 않으므로, suspend strategic 경로는 이 메서드를 사용합니다.
+     */
+    suspend fun registerCandidateSuspending(lockName: String, info: CandidateInfo, ttl: Duration) {
+        val cache = mapCacheFor(lockName)
+        withEntryLockSuspending(cache, info.nodeId) {
+            if (ttl == Duration.ZERO) {
+                cache.putAsync(info.nodeId, info).await()
+            } else {
+                cache.putAsync(info.nodeId, info, ttl.inWholeMilliseconds, TimeUnit.MILLISECONDS).await()
+            }
+        }
+    }
+
+    /** Redisson `RFuture` 기반 후보 해제입니다. */
+    suspend fun unregisterCandidateSuspending(lockName: String, nodeId: String) {
+        val cache = mapCacheFor(lockName)
+        withEntryLockSuspending(cache, nodeId) {
+            cache.removeAsync(nodeId).await()
+        }
+    }
+
+    /** Redisson `RFuture` 기반 후보 조회입니다. */
+    suspend fun listCandidatesSuspending(lockName: String): List<CandidateInfo> =
+        mapCacheFor(lockName).readAllValuesAsync().await().toList()
+
+    /** Redisson `RFuture` 기반 결과 갱신입니다. */
+    suspend fun updateResultSuspending(lockName: String, nodeId: String, result: CandidateResult) {
+        val cache = mapCacheFor(lockName)
+        withEntryLockSuspending(cache, nodeId) {
+            val current = cache.getAsync(nodeId).await() ?: return@withEntryLockSuspending
+            cache.fastPutIfExistsAsync(nodeId, current.withResult(result)).await()
+        }
+    }
+
     /** 등록·해제도 결과 갱신과 Redisson map entry lock을 공유하도록 보장합니다. */
     private inline fun <T> withEntryLock(
         cache: org.redisson.api.RMapCache<String, CandidateInfo>,
@@ -79,6 +123,26 @@ internal class RedissonCandidateRegistry(
             action()
         } finally {
             lock.unlock()
+        }
+    }
+
+    private suspend inline fun <T> withEntryLockSuspending(
+        cache: RMapCache<String, CandidateInfo>,
+        nodeId: String,
+        crossinline action: suspend () -> T,
+    ): T {
+        val lock = cache.getLock(nodeId)
+        // Redisson lock ownership is thread-id based. A dispatcher thread may
+        // host multiple suspended coroutines, so allocate one id per logical
+        // lock hold instead of reusing the physical thread id.
+        val threadId = suspendLockThreadIds.incrementAndGet()
+        lock.lockAsync(threadId).await()
+        return try {
+            action()
+        } finally {
+            withContext(NonCancellable) {
+                lock.unlockAsync(threadId).await()
+            }
         }
     }
 }

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElector.kt
@@ -12,10 +12,8 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.withContext
 import org.redisson.api.RedissonClient
 import kotlin.time.Duration
 
@@ -38,16 +36,16 @@ class RedissonStrategicSuspendLeaderGroupElector(
     )
 
     override suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
-        withContext(Dispatchers.IO) { registry.registerCandidate(lockName, info, ttl) }
+        registry.registerCandidateSuspending(lockName, info, ttl)
 
     override suspend fun unregisterCandidate(lockName: String, nodeId: String) =
-        withContext(Dispatchers.IO) { registry.unregisterCandidate(lockName, nodeId) }
+        registry.unregisterCandidateSuspending(lockName, nodeId)
 
     override suspend fun listCandidates(lockName: String): List<CandidateInfo> =
-        withContext(Dispatchers.IO) { registry.listCandidates(lockName) }
+        registry.listCandidatesSuspending(lockName)
 
     override suspend fun updateResult(lockName: String, nodeId: String, result: CandidateResult) =
-        withContext(Dispatchers.IO) { registry.updateResult(lockName, nodeId, result) }
+        registry.updateResultSuspending(lockName, nodeId, result)
 
     @Suppress("ReturnCount", "TooGenericExceptionCaught", "ThrowsCount")
     override suspend fun <T> runIfLeader(

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElector.kt
@@ -13,6 +13,8 @@ import io.bluetape4k.logging.info
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import org.redisson.api.RedissonClient
 import kotlin.time.Duration
@@ -55,6 +57,7 @@ class RedissonStrategicSuspendLeaderGroupElector(
         action: suspend () -> T,
     ): T? {
         validateLockName(lockName)
+        currentCoroutineContext().ensureActive()
         val candidates = try {
             listCandidates(lockName)
         } catch (e: CancellationException) {
@@ -86,6 +89,7 @@ class RedissonStrategicSuspendLeaderGroupElector(
 
         return try {
             val value = action()
+            currentCoroutineContext().ensureActive()
             updateStrategicResultPreservingCancellation(
                 lockName = lockName,
                 result = CandidateResult.SUCCESS,

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicCandidateLookupFailureTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicCandidateLookupFailureTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.CancellationException
 import org.junit.jupiter.api.Test
 import org.redisson.api.RMapCache
 import org.redisson.api.RedissonClient
+import org.redisson.misc.CompletableFutureWrapper
 import java.util.concurrent.atomic.AtomicBoolean
 
 class RedissonStrategicCandidateLookupFailureTest {
@@ -166,6 +167,7 @@ class RedissonStrategicCandidateLookupFailureTest {
         val cache = mockk<RMapCache<String, CandidateInfo>>()
         every { client.getMapCache<String, CandidateInfo>(any<String>()) } returns cache
         every { cache.readAllValues() } throws failure
+        every { cache.readAllValuesAsync() } returns CompletableFutureWrapper(failure)
         return client
     }
 }

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicGroupToxiproxyCancellationTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicGroupToxiproxyCancellationTest.kt
@@ -1,0 +1,201 @@
+package io.bluetape4k.leader.redisson
+
+import eu.rekawek.toxiproxy.Proxy
+import eu.rekawek.toxiproxy.ToxiproxyClient
+import eu.rekawek.toxiproxy.model.Toxic
+import eu.rekawek.toxiproxy.model.ToxicDirection
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import io.bluetape4k.testcontainers.infra.ToxiproxyServer
+import io.bluetape4k.testcontainers.storage.RedisServer
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.yield
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.testcontainers.containers.Network
+import org.testcontainers.toxiproxy.ToxiproxyContainer
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+/**
+ * Redisson strategic group의 Redis 후보 조회·결과 갱신 I/O 대기 중 취소 회귀입니다.
+ *
+ * ToxiProxy는 응답을 무기한 보류하고, 테스트는 실제 [kotlinx.coroutines.Job] 취소를
+ * 겹쳐서 `CancellationException`이 일반 `FAILURE`로 변환되지 않는지 검증합니다.
+ */
+@Execution(ExecutionMode.SAME_THREAD)
+class RedissonStrategicGroupToxiproxyCancellationTest {
+
+    @Test
+    fun `후보 조회 응답이 보류된 동안 Job 취소는 action 전에 재전파된다`() = runSuspendIO {
+        withRedisProxy { redis, toxiproxy, proxy ->
+            withClients(redis, toxiproxy) { redisson, observerRedisson ->
+                val lockName = randomLockName()
+                val elector = RedissonStrategicSuspendLeaderGroupElector(redisson, NODE_ID)
+                val observer = RedissonStrategicSuspendLeaderGroupElector(observerRedisson, NODE_ID)
+                elector.registerCandidate(lockName, CandidateInfo(NODE_ID))
+                val toxic = proxy.toxics().timeout(
+                    "hold-candidate-response",
+                    ToxicDirection.DOWNSTREAM,
+                    0,
+                )
+
+                try {
+                    val actionInvoked = CompletableDeferred<Unit>()
+                    coroutineScope {
+                        val deferred = async(start = CoroutineStart.UNDISPATCHED) {
+                            elector.runIfLeader(lockName, FifoGroupElectionStrategy) {
+                                actionInvoked.complete(Unit)
+                                "unexpected"
+                            }
+                        }
+                        delay(CANCEL_SETTLE_MILLIS)
+                        deferred.cancel(CancellationException("cancel during candidate lookup"))
+                        assertFailsWith<CancellationException> { deferred.await() }
+                    }
+
+                    actionInvoked.isCompleted shouldBeEqualTo false
+                } finally {
+                    removeToxic(toxic)
+                }
+
+                val candidate = observer.listCandidates(lockName).single()
+                candidate.successCount shouldBeEqualTo 0L
+                candidate.failureCount shouldBeEqualTo 0L
+            }
+        }
+    }
+
+    @Test
+    fun `결과 갱신 응답이 보류된 동안 Job 취소는 FAILURE로 변환되지 않는다`() = runSuspendIO {
+        withRedisProxy { redis, toxiproxy, proxy ->
+            withClients(redis, toxiproxy) { redisson, observerRedisson ->
+                val lockName = randomLockName()
+                val elector = RedissonStrategicSuspendLeaderGroupElector(redisson, NODE_ID)
+                val observer = RedissonStrategicSuspendLeaderGroupElector(observerRedisson, NODE_ID)
+                elector.registerCandidate(lockName, CandidateInfo(NODE_ID))
+
+                var toxic: Toxic? = null
+                try {
+                    coroutineScope {
+                        val toxicInstalled = CompletableDeferred<Unit>()
+                        val deferred = async(start = CoroutineStart.UNDISPATCHED) {
+                            elector.runIfLeader(lockName, FifoGroupElectionStrategy) {
+                                toxic = proxy.toxics().timeout(
+                                    "hold-result-response",
+                                    ToxicDirection.DOWNSTREAM,
+                                    0,
+                                )
+                                toxicInstalled.complete(Unit)
+                                "success-before-cancel"
+                            }
+                        }
+                        toxicInstalled.await()
+                        repeat(CANCEL_SETTLE_ROUNDS) {
+                            yield()
+                            delay(CANCEL_SETTLE_MILLIS / CANCEL_SETTLE_ROUNDS)
+                        }
+                        deferred.cancel(CancellationException("cancel during result update"))
+                        assertFailsWith<CancellationException> { deferred.await() }
+                    }
+                } finally {
+                    removeToxic(toxic)
+                }
+
+                val candidate = observer.listCandidates(lockName).single()
+                candidate.failureCount shouldBeEqualTo 0L
+            }
+        }
+    }
+
+    private suspend fun <T> withRedisProxy(block: suspend (RedisServer, ToxiproxyContainer, Proxy) -> T): T =
+        Network.newNetwork().use { network ->
+            RedisServer(reuse = false)
+                .withNetwork(network)
+                .withNetworkAliases(REDIS_ALIAS)
+                .use { redis ->
+                    ToxiproxyServer(reuse = false)
+                        .withNetwork(network)
+                        .use { toxiproxy ->
+                            redis.start()
+                            toxiproxy.start()
+                            val proxy = createRedisProxy(toxiproxy)
+                            try {
+                                block(redis, toxiproxy, proxy)
+                            } finally {
+                                runCatching { proxy.delete() }
+                            }
+                        }
+                }
+        }
+
+    private suspend fun <T> withClients(
+        redis: RedisServer,
+        toxiproxy: ToxiproxyContainer,
+        block: suspend (RedissonClient, RedissonClient) -> T,
+    ): T {
+        val operationClient = createRedisson("redis://${toxiproxy.host}:${toxiproxy.getMappedPort(PROXY_PORT)}")
+        val observerClient = createRedisson(redis.url)
+        return try {
+            block(operationClient, observerClient)
+        } finally {
+            shutdown(operationClient)
+            shutdown(observerClient)
+        }
+    }
+
+    private fun shutdown(client: RedissonClient) {
+        runCatching { client.shutdown(0, REDISSON_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS) }
+    }
+
+    private fun createRedisson(address: String): RedissonClient =
+        Redisson.create(
+            RedisServer.Launcher.RedissonLib.getRedissonConfig(
+                address = address,
+                connectionPoolSize = 8,
+                minimumIdleSize = 2,
+                threads = 4,
+                nettyThreads = 4,
+            ).apply {
+                useSingleServer().apply {
+                    timeout = REDIS_COMMAND_TIMEOUT_MILLIS
+                    connectTimeout = REDIS_COMMAND_TIMEOUT_MILLIS
+                    retryAttempts = 0
+                }
+            },
+        )
+
+    private fun createRedisProxy(toxiproxy: ToxiproxyContainer): Proxy =
+        ToxiproxyClient(toxiproxy.host, toxiproxy.controlPort).createProxy(
+            "redis-strategic-${UUID.randomUUID()}",
+            "0.0.0.0:$PROXY_PORT",
+            "$REDIS_ALIAS:${RedisServer.PORT}",
+        )
+
+    private fun removeToxic(toxic: Toxic?) {
+        runCatching { toxic?.remove() }
+    }
+
+    private fun randomLockName(): String = "toxiproxy:redisson:${UUID.randomUUID()}"
+
+    private companion object {
+        const val NODE_ID = "toxiproxy-redisson-node"
+        const val REDIS_ALIAS = "redis"
+        const val PROXY_PORT = 8666
+        const val REDIS_COMMAND_TIMEOUT_MILLIS = 3_000
+        const val REDISSON_SHUTDOWN_TIMEOUT_SECONDS = 1L
+        const val CANCEL_SETTLE_MILLIS = 250L
+        const val CANCEL_SETTLE_ROUNDS = 5
+    }
+}

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElectorTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElectorTest.kt
@@ -16,6 +16,7 @@ import org.awaitility.kotlin.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Instant
+import java.util.concurrent.CancellationException
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -66,6 +67,54 @@ class RedissonStrategicLeaderGroupElectorTest : AbstractRedissonLeaderTest() {
         node1.listCandidates(lockName).size shouldBeEqualTo 1
         await.atMost(2.seconds).withPollInterval(50.milliseconds)
             .until { node1.listCandidates(lockName).isEmpty() }
+    }
+
+    @Test
+    fun `group action CancellationException은 failureCount를 증가시키지 않고 재전파한다`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+        val cancellation = CancellationException("group action cancelled")
+
+        val thrown = assertFailsWith<CancellationException> {
+            node1.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 1) {
+                throw cancellation
+            }
+        }
+
+        thrown.message shouldBeEqualTo cancellation.message
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.failureCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `group action 예외는 failureCount를 증가시키고 예외를 전파한다`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+        val failure = IllegalStateException("group action failed")
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            node1.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 1) {
+                throw failure
+            }
+        }
+
+        thrown.message shouldBeEqualTo failure.message
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.successCount shouldBeEqualTo 0L
+        candidate.failureCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `group action 성공은 successCount를 증가시키고 failureCount를 건드리지 않는다`() {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        node1.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 1) { "ok" }
+            .shouldBeEqualTo("ok")
+
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.successCount shouldBeEqualTo 1L
+        candidate.failureCount shouldBeEqualTo 0L
     }
 
     @Test

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElectorTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElectorTest.kt
@@ -14,10 +14,19 @@ import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
 import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
 import io.bluetape4k.leader.strategy.strategies.ScoredGroupElectionStrategy
 import io.bluetape4k.junit5.coroutines.SuspendedJobTester
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.job
 import org.awaitility.kotlin.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -69,6 +78,73 @@ class RedissonStrategicSuspendLeaderGroupElectorTest : AbstractRedissonLeaderTes
         await.atMost(2.seconds).withPollInterval(50.milliseconds) untilSuspending {
             node1.listCandidates(lockName).isEmpty()
             }
+    }
+
+    @Test
+    fun `실제 Job cancelAndJoin은 group failureCount를 증가시키지 않는다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        coroutineScope {
+            val actionStarted = CompletableDeferred<Unit>()
+            val deferred = async {
+                node1.runIfLeader(lockName, FifoGroupElectionStrategy) {
+                    actionStarted.complete(Unit)
+                    awaitCancellation()
+                }
+            }
+            actionStarted.await()
+            deferred.cancelAndJoin()
+            deferred.isCancelled shouldBeEqualTo true
+        }
+
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.failureCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `결과 갱신 직전 Job 취소는 CancellationException을 재전파하고 카운터를 갱신하지 않는다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+        val cancellation = CancellationException("cancel before result update")
+
+        coroutineScope {
+            val deferred = async {
+                node1.runIfLeader(lockName, FifoGroupElectionStrategy) {
+                    currentCoroutineContext().job.cancel(cancellation)
+                    "cancelled"
+                }
+            }
+            assertFailsWith<CancellationException> { deferred.await() }
+        }
+
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.successCount shouldBeEqualTo 0L
+        candidate.failureCount shouldBeEqualTo 0L
+    }
+
+    @Test
+    fun `후보 조회 전 Job 취소는 action을 실행하지 않고 CancellationException을 재전파한다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+        val actionInvoked = AtomicBoolean(false)
+        val cancellation = CancellationException("cancel before candidate lookup")
+
+        coroutineScope {
+            val deferred = async {
+                currentCoroutineContext().job.cancel(cancellation)
+                node1.runIfLeader(lockName, FifoGroupElectionStrategy) {
+                    actionInvoked.set(true)
+                    "must-not-run"
+                }
+            }
+            assertFailsWith<CancellationException> { deferred.await() }
+        }
+
+        actionInvoked.get() shouldBeEqualTo false
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.successCount shouldBeEqualTo 0L
+        candidate.failureCount shouldBeEqualTo 0L
     }
 
     @Test
@@ -131,5 +207,36 @@ class RedissonStrategicSuspendLeaderGroupElectorTest : AbstractRedissonLeaderTes
         assertFailsWith<IllegalArgumentException> {
             node1.runIfLeader(lockName, invalidStrategy) { error("실행되면 안 됨") }
         }
+    }
+
+    @Test
+    fun `group action 예외는 failureCount를 증가시키고 예외를 전파한다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+        val failure = IllegalStateException("group action failed")
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            node1.runIfLeader(lockName, FifoGroupElectionStrategy) {
+                throw failure
+            }
+        }
+
+        thrown.message shouldBeEqualTo failure.message
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.successCount shouldBeEqualTo 0L
+        candidate.failureCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `group action 성공은 successCount를 증가시키고 failureCount를 건드리지 않는다`() = runSuspendIO {
+        val lockName = randomName()
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        node1.runIfLeader(lockName, FifoGroupElectionStrategy) { "ok" }
+            .shouldBeEqualTo("ok")
+
+        val candidate = node1.listCandidates(lockName).single()
+        candidate.successCount shouldBeEqualTo 1L
+        candidate.failureCount shouldBeEqualTo 0L
     }
 }


### PR DESCRIPTION
## 범위

Epic #775의 Issue #787을 위한 첫 번째 stacked PR입니다. Lettuce·Redisson strategic group coroutine이 후보 조회와 결과 갱신 전에 취소를 관찰하고, blocking·suspend 결과 카운터 회귀를 실제 Redis Testcontainers로 고정합니다.

## 구현

- Lettuce/Redisson suspend group adapter에 후보 조회 전과 action 결과 기록 전 `ensureActive()` 경계를 추가했습니다.
- `CancellationException`은 일반 실패 카운터로 변환하지 않고 호출자에게 재전파합니다.
- blocking·suspend group의 정상 성공, 일반 예외, 실제 `cancelAndJoin()`, TTL 보존, 만료 후보 정리 회귀를 추가했습니다.
- 테스트 예외 검증은 `io.bluetape4k.assertions.assertFailsWith`를 사용했습니다.

## 검증

- Lettuce 전체 테스트: 307개 통과
- Redisson 전체 테스트: 289개 통과
- 두 Redis 모듈 `detekt`: 통과
- 두 Redis 모듈 `build -x test`: 통과
- `git diff --check`: 통과

## 범위 경계

네트워크 I/O 중간 취소 fault-injection은 후속 stacked PR에서 `ToxiProxyServer` 지연/드롭 toxic과 실제 `Job.cancel()`을 결합해 보강합니다. 이 PR은 해당 후속 PR의 base입니다.

- Base: `develop`
- Head: `test/issue-787-strategic-cancel`
- Epic: Refs #775
- Issue: Refs #787
- 독립 리뷰: 1인 개발자 정책으로 생략

## DoD Status

Required checks: 5/5 local checks PASS; hosted exact-head CI와 merge는 별도 게이트입니다.

Final status: PENDING — PR2 ToxiProxy 회귀와 exact-head CI, fresh merge approval을 남겼습니다.

Unchecked required items: PR2 network fault-injection, hosted exact-head CI, merge approval