### PR TITLE
fix(build): virtualthread 2.0.0 snapshot ABI 정합성 고정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ val baseVersion = providers.gradleProperty("baseVersion").get()
 val snapshotVersion = providers.gradleProperty("snapshotVersion").get()
 val bluetape4kVirtualThreadJdk25Version = providers
     .gradleProperty("bluetape4kVirtualThreadJdk25Version")
-    .orElse("1.13.0-SNAPSHOT")
+    .orElse("2.0.0-SNAPSHOT")
     .get()
 
 fun Project.isNonPublishedProject(): Boolean =

--- a/docs/lessons/2026-08-27-issue-810-virtualthread-snapshot-train.md
+++ b/docs/lessons/2026-08-27-issue-810-virtualthread-snapshot-train.md
@@ -1,0 +1,66 @@
+# VirtualThread 2.0.0 snapshot train 정합성
+
+## 맥락
+
+PR #809의 exact-head hosted CI에서 Lettuce와 Redisson을 포함한 여러 모듈이
+`io/bluetape4k/concurrent/virtualthread/api/VirtualThreads`를 찾지 못하고
+초기화에 실패했습니다. Leader의 `gradle.properties`는 이전 `1.13.0`
+snapshot pin을 사용했지만, upstream package-boundary 변경(PR
+`bluetape4k-projects#1523`)은 public API를
+`io.bluetape4k.concurrent.virtualthread.api`로 이동했습니다. 따라서 테스트
+실패는 Leader 코드의 취소 동작이 아니라 서로 다른 ABI train을 섞은
+dependency resolution 문제였습니다.
+
+## 결정
+
+- `bluetape4k-virtualthread-api`, `bluetape4k-virtualthread-jdk25`를 포함해
+  core, coroutine, idgenerator, junit5, testcontainers helper가 같은
+  `2.0.0-20260826.200524-12` immutable snapshot train을 사용하도록
+  정렬합니다.
+- 기본 fallback도 `2.0.0-SNAPSHOT`으로 맞춰 명시적 pin이 없는 환경에서
+  이전 `1.13.0` ABI가 다시 선택되지 않게 합니다.
+- moving snapshot 검증에는 `--refresh-dependencies`를 포함합니다. 캐시된
+  helper jar만 남아 있으면 API jar가 새 package를 제공해도 동일한
+  `NoClassDefFoundError`가 재현될 수 있습니다.
+- Leader에 호환 bridge나 shading을 추가하지 않습니다. package ownership과
+  ServiceLoader 경계를 upstream train에서 관리하고, 소비자는 동일 train을
+  선택해야 합니다.
+
+## 결과
+
+의존성 정렬은 PR #810에서 PR #809 위에 별도 stacked slot으로 전달합니다.
+변경 범위는 root Gradle fallback/pin과 이 lesson으로 제한했습니다. Kotlin
+production/test source는 수정하지 않았습니다.
+
+## 검증
+
+- RED hosted evidence: exact-head run
+  `33039344078`에서 Lettuce job `98414547953`는 309개 중 18개,
+  Redisson job `98415899069`는 42개 중 29개가 동일한 missing-class ABI
+  오류로 실패했습니다.
+- Central snapshot metadata와 jar scan에서 관련 artifact가 모두
+  `2.0.0-20260826.200524-12`이고 API class가 `.api.VirtualThreads`에
+  존재함을 확인했습니다.
+- `--refresh-dependencies` 기준 targeted ToxiProxy 취소 테스트는
+  Lettuce 2개와 Redisson 2개 모두 통과했습니다.
+- 같은 조건의 전체 테스트는 Lettuce 309개, Redisson 291개가 모두
+  통과했습니다.
+- 두 모듈 detekt와 root `./gradlew build -x test`가 통과했습니다. Maven
+  snapshot 전송 중 발생한 일시적 `bad_record_mac`은 재시도 후 성공했으며
+  코드 오류로 분류하지 않았습니다.
+- `git diff --check`와 dependency graph를 통과시켜 변경 파일과 선택된
+  runtime artifact를 재확인했습니다.
+
+## 향후 지침
+
+1. Bluetape snapshot ABI 오류가 보이면 먼저 Central metadata의 timestamp와
+   `dependencyInsight`를 확인하고, API/provider/core/test-helper가 같은
+   train인지 비교합니다.
+2. 선택된 jar를 직접 scan해 package ownership과 ServiceLoader descriptor를
+   확인합니다. 새 package가 필요한 소비자에 옛 pin을 유지한 채 bridge를
+   넣어 문제를 숨기지 않습니다.
+3. moving snapshot의 로컬 검증은 반드시 `--refresh-dependencies`로 수행하고,
+   새 commit의 exact-head hosted CI를 별도로 확인합니다.
+4. TLS 또는 Maven transport 오류는 재시도 가능한 외부 전송 문제인지 먼저
+   분류합니다. 같은 missing-class가 여러 모듈에서 반복되면 테스트별 결함이
+   아니라 공통 ABI train 불일치로 조사합니다.

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,9 +49,11 @@ signing.gnupg.executable=/opt/homebrew/bin/gpg
 # 현재 leader library에는 JDK 21 compatibility island를 유지하는 모듈이 없다.
 # 중앙 immutable catalog가 일치하는 release train을 승격할 때까지
 # 현재 release train은 Maven Central Snapshots의 immutable timestamp 좌표를 사용한다.
-# 개발선에서 새 snapshot을 시험할 때만 -Pbluetape4kVirtualThreadJdk25Version=1.13.0-SNAPSHOT을
+# 2.0.0 package-boundary train의 core와 virtual-thread API/provider 및 test helpers를
+# 같은 timestamp로 정렬해 split-package ABI가 섞이지 않도록 한다.
+# 개발선에서 새 snapshot을 시험할 때만 -Pbluetape4kVirtualThreadJdk25Version=2.0.0-SNAPSHOT을
 # 명시적으로 덮어쓸 수 있으며, release preflight는 해당 suffix를 fail-closed 한다.
-bluetape4kVirtualThreadJdk25Version=1.13.0-20260813.192107-9
+bluetape4kVirtualThreadJdk25Version=2.0.0-20260826.200524-12
 
 # Maven Central Snapshots publish parallelism
 centralSnapshotsParallelism=4


### PR DESCRIPTION
## Summary

Closes #810

PR #809의 exact-head hosted CI에서 발생한 공통 `NoClassDefFoundError`를 이전 virtual-thread API/provider pin과 새 core ABI가 섞인 snapshot train 불일치로 고정하고, 동일 immutable train을 선택하도록 build 경계를 정렬합니다.

## Background

PR #809는 ToxiProxy 기반 Redis 네트워크 중간 취소 회귀를 구현했지만 exact head `4d5c4360df4d7c82193c6a6dcb32cf0e0c17ac2f`의 hosted CI에서 비변경 backend를 포함한 여러 job이 `io/bluetape4k/concurrent/virtualthread/api/VirtualThreads`를 찾지 못했습니다.

- RED CI run: https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33039344078
- Lettuce job `98414547953`: 309개 중 291 pass, 18 fail
- Redisson job `98415899069`: 42개 중 13 pass, 29 fail
- upstream package-boundary 정리: https://github.com/bluetape4k/bluetape4k-projects/pull/1523
- Central snapshot metadata에서 core/API/provider/test helper가 `2.0.0-20260826.200524-12`로 함께 게시됨

## What This Solves

- 오래된 `1.13.0` virtual-thread API/provider pin이 `2.0.0-SNAPSHOT` core와 충돌해 발생하는 공통 linkage failure를 제거합니다.
- moving snapshot을 캐시 잔존 상태에서 검증해 잘못된 green을 얻는 위험을 줄이고, 향후 train 갱신 규칙을 재사용 가능한 lesson으로 남깁니다.
- Leader에 compatibility bridge 또는 shading을 넣지 않고 upstream package ownership 경계를 유지합니다.

## Work Done

- `build.gradle.kts`: 명시적 property가 없을 때의 virtual-thread JDK25 fallback을 `2.0.0-SNAPSHOT`으로 정렬했습니다.
- `gradle.properties`: API/provider pin을 core/coroutine/idgenerator/junit5/testcontainers와 같은 `2.0.0-20260826.200524-12` immutable train으로 갱신하고 갱신 규칙을 기록했습니다.
- `docs/lessons/2026-08-27-issue-810-virtualthread-snapshot-train.md`: 공통 ABI 분류, cache refresh 검증, future-agent 지침을 추가했습니다.
- Kotlin production/test source와 PR #809의 취소 구현은 변경하지 않았습니다.

## Validation

- `./gradlew :bluetape4k-leader-core:dependencies --configuration testRuntimeClasspath --refresh-dependencies`: PASS (선택된 core/API/provider/test helper train 확인)
- Lettuce ToxiProxy targeted (`--refresh-dependencies`): PASS (2/2)
- Redisson ToxiProxy targeted (`--refresh-dependencies`): PASS (2/2)
- Lettuce 전체 테스트: PASS (309/309)
- Redisson 전체 테스트: PASS (291/291)
- 두 Redis 모듈 `detekt`: PASS
- `./gradlew build -x test --refresh-dependencies`: PASS (Maven `bad_record_mac` 일시 전송 오류 후 재시도 성공)
- `git diff --check`: PASS
- `gno update` 및 임시 worktree lesson collection index/search: PASS (검색 1건 read-back 후 collection 제거)
- exact-head hosted CI run `33044419829`: PASS (47/47 jobs success, 실패·취소 0; `cdc43aa1d60a8bbbfb502487a1301095644967d6`)

## Review Notes

- P0/P1: 0
- P2/P3: 없음
- 7-Tier review: Gradle dependency/ABI, module blast-radius, CI fan-out, documentation/operability 경계를 검토했으며 Kotlin source/API 동작 tier는 source 미변경으로 N/A입니다.
- 독립 리뷰: 1인 개발자 lane 정책으로 생략
- `bluetape-kotlin-patterns`: Kotlin source/test 미변경이므로 해당 코드 패턴 항목은 concrete scope evidence와 함께 N/A
- Review/thread read-back: live reviews 0, review threads 0, unresolved blocker 0

## Metadata

- Issue: #810, milestone `1.0.0`, assignee `debop`, labels `bug`, `ci`, `dependencies`, `build`
- PR: #811, head `fix/issue-810-virtualthread-snapshot-pin` at `cdc43aa1d60a8bbbfb502487a1301095644967d6`; base `test/issue-787-toxiproxy-cancellation` at `4d5c4360df4d7c82193c6a6dcb32cf0e0c17ac2f`
- Stack: PR #809 위에 쌓이며, merge 순서는 PR #806 → #809 → #811을 별도 fresh approval로 확인합니다.
- CI: https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33044419829 (manual workflow_dispatch; `gh pr checks`는 non-default stacked branch에 check run을 표시하지 않음)
- Mergeability: `MERGEABLE`, `CLEAN`

## DoD Status

Type C: C-01~C-08 PASS; C-09 PENDING.

Required checks: 15/18 PASS; N/A: 1 (CG-14 human-review subgate, single-developer lane); Blocked: 0; Pending: 3

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01~CG-05 | guidance, history, worktree, policy, ecosystem pattern 확인 | PASS | current guidance hashes, GNO/live GitHub, isolated worktree, scoped Gradle diff | none |
| CG-06 | durable lesson/public documentation contract 확인 | PASS | `docs/lessons/2026-08-27-issue-810-virtualthread-snapshot-train.md` | none |
| CG-07~CG-08 | RED evidence와 sequential Testcontainers/모듈 proof | PASS | RED `33039344078`; local targeted/full 2+2/309/291 | none |
| CG-09~CG-10 | lesson index, final diff, P0/P1 review convergence | PASS | GNO read-back, `git diff --check`, commits `991d8491`, `cdc43aa1` | none |
| CG-11~CG-12 | PR authority와 exact head publish | PASS | approved stacked train scope; remote head equals `cdc43aa1d60a8bbbfb502487a1301095644967d6` | none |
| CG-12A | PR 직전 및 CI 이후 guidance/issue/template refresh | PASS | current hashes, issue #810 live metadata, Korean PR template | none |
| CG-13 | PR 생성 및 live metadata/body 검증 | PASS | PR #811, base/head/labels/milestone/assignee, body 마지막 section `## DoD Status` | none |
| CG-14 | exact-head CI와 review/thread read-back | PASS | run `33044419829`: 47/47 success; reviews 0, threads 0; solo human-review subgate N/A | none |
| CG-15 | merge-ready report | PASS | exact head `cdc43aa1`, `MERGEABLE/CLEAN`, P0/P1=0, CI green | fresh approval requested next |
| CG-16 | fresh merge approval | PENDING | this report is the first merge-ready evidence for PR #811 exact head | wait for explicit approval tied to #811/`cdc43aa1` |
| CG-17~CG-18 | merge/sync/cleanup | PENDING | intentionally not started | execute only after CG-16 |

Final status: PENDING — PR #811 exact-head CI is green and merge-ready; fresh explicit approval is required before merge.