### PR TITLE
build: 0.5.0 바이너리 호환성 게이트의 미분류 공개 변경 해소

### DIFF
--- a/docs/lessons/2026-08-25-public-bridge-abi-classifier.md
+++ b/docs/lessons/2026-08-25-public-bridge-abi-classifier.md
@@ -12,8 +12,9 @@ release gate에서 숨길 수 있다.
 ## 결정
 
 - public bridge member에는 blanket ignore를 적용하지 않는다.
-- 현재 허용하는 synthetic accessor는 `SYNTHETIC`과 `access$`를 모두 포함한
-  member로 제한한다.
+- 현재 허용하는 synthetic accessor는 등록된 클래스의 전체 JVM descriptor가
+  일치하는 경우로만 제한한다. `SYNTHETIC`과 `access$` 문자열만으로는
+  분류하지 않는다.
 - 향후 의도된 compiler-generated bridge를 허용해야 한다면 class와 JVM
   descriptor를 함께 고정한 exact allowlist 또는 실제 published consumer
   linkage fixture를 먼저 추가한다.

--- a/docs/lessons/2026-08-27-issue-805-abi-baseline-serialization.md
+++ b/docs/lessons/2026-08-27-issue-805-abi-baseline-serialization.md
@@ -1,0 +1,52 @@
+# 2026-08-27 Issue #805 ABI 기준선과 직렬화 경계
+
+## 맥락
+
+Issue #805에서 바이너리 호환성 게이트가 `0.4.0`/`0.5.0`을 스크립트
+기본값으로 고정하고 있어 현재 `1.0.0` checkout에서 평범한 Gradle 실행이
+존재하지 않는 `0.5.0` jar를 찾았다. 게시된 `0.4.0`과 `0.5.0`을 직접
+비교하면 Redis Lettuce/Redisson 네 클래스의 public JVM bridge block 네 개가
+미분류로 남았고, `CandidateInfo`와 `ExtendOutcome`에는 별도의 Java
+serialization 계약 변경이 있었다.
+
+## 결정
+
+- 기준선은 명시적 `ABI_BASE_VERSION`이 없으면 현재 `gradle.properties`의
+  버전보다 낮은 최신 Git release tag로 계산하고, 현재 버전은 Gradle 속성에서
+  계산한다. release workflow의 명시적 환경 변수는 그대로 우선한다.
+- Redis bridge와 compiler synthetic accessor는 문자열/flag 전체를 무시하지
+  않고 클래스와 전체 japicmp descriptor를 함께 exact allowlist로 관리한다.
+  allowlist 밖의 public 변경은 계속 `unknown`으로 남긴다.
+- 0.4.0 `CandidateInfo` payload는 현재 명시 UID `1L`과 일치하지 않으므로
+  `InvalidClassException`으로 거부한다. `ExtendOutcome`은 0.4.0에 없던
+  serialization 표면을 새 계약으로 시작하며 concrete outcome의 UID는 `1L`로
+  고정한다. 두 변경을 ABI 분류기에서 blanket ignore하지 않는다.
+
+## 결과
+
+게시된 `0.5.0` jar와 `0.4.0` 기준선 비교는 `artifacts=16,
+ignored=23, unknown=0`으로 통과한다. 현재 `1.0.0` 기본 경로도
+`artifacts=16, ignored=10, unknown=0`으로 통과한다. 이전 consumer가
+erased `Object` descriptor로 bridge를 호출하는 linkage fixture와 0.4.0
+`CandidateInfo` byte fixture가 각각 실제 실패/거부 경계를 고정한다.
+
+## 검증
+
+- RED: 새 Python 회귀가 version resolution, exact descriptor, consumer linkage
+  계약의 미구현 상태에서 실패했다.
+- GREEN: `python3 -m unittest -v scripts/compatibility/check_binary_api_test.py`
+  — 15개 통과.
+- Kotlin serialization fixture 3개, leader-core 940개, Lettuce 309개,
+  Redisson 291개 테스트가 통과했다.
+- `ruff check`, `py_compile`, `detekt --no-configuration-cache`,
+  `git diff --check`가 통과했다. configuration-cache를 켠 `detekt`는
+  `detektProductionSourceGuard`가 Gradle `Project`를 역직렬화하지 못하는
+  기존 guard 오류로 실패했으며 코드 detekt 결과와 분리했다.
+
+## 향후 지침
+
+ABI release gate의 버전 기본값을 다시 하드코딩하지 않는다. 새 compiler
+bridge/accessor는 실제 published descriptor와 소비자 linkage fixture를
+확인한 뒤 클래스·descriptor 단위로만 등록한다. Java serialization 모델을
+변경할 때는 이전 payload, 현재 UID, 지원/거부 마이그레이션 정책을 함께
+테스트하고 migration 문서에 기록한다.

--- a/docs/migration/0.5.0-binary-compatibility.md
+++ b/docs/migration/0.5.0-binary-compatibility.md
@@ -41,9 +41,19 @@
 ./gradlew checkBinaryCompatibility --no-configuration-cache --console=plain
 ```
 
-이 검사는 게시 가능한 16개 라이브러리 아티팩트를 `0.4.0` Maven Central
-기준선과 비교한다. `examples/*`, `benchmark`, BOM은 게시되는 런타임
-아티팩트가 아니므로 제외한다.
+이 검사는 `gradle.properties`의 현재 버전과 현재 버전보다 낮은 최신 Git
+릴리스 태그를 자동으로 선택해 게시 가능한 16개 라이브러리 아티팩트를
+비교한다. `examples/*`, `benchmark`, BOM은 게시되는 런타임 아티팩트가
+아니므로 제외한다. 릴리스 workflow는 동일한 정책을 명시적인
+`ABI_BASE_VERSION`/`ABI_CURRENT_VERSION`으로 고정한다.
+
+과거 릴리스 비교를 재현할 때는 버전을 명시한다.
+
+```bash
+ABI_BASE_VERSION=0.4.0 ABI_CURRENT_VERSION=0.5.0 \
+  ./gradlew checkBinaryCompatibility -PbaseVersion=0.5.0 -PsnapshotVersion= \
+  --no-configuration-cache --console=plain
+```
 
 ## 분류
 
@@ -51,15 +61,62 @@
 분류한다.
 
 - Kotlin 컴파일러가 생성한 inline/lambda 클래스와 AspectJ closure 클래스
-- Kotlin 컴파일러가 생성한 synthetic accessor 메서드(`access$...`)로, 다른
-  생성 클래스에 private 구현 세부 사항을 노출하는 메서드
-- 제네릭 Kotlin override에 대해 생성되는 JVM bridge 메서드
+- 릴리스별로 확인한 클래스와 전체 JVM descriptor가 코드에 등록된
+  synthetic accessor 메서드(`access$...`)
+- Redis 구현체에서 기존 erased JVM descriptor가 유지되고 `BRIDGE` 플래그와
+  generic metadata만 달라진 정확한 메서드 집합
 - `io.bluetape4k.leader.*.internal` 아래의 클래스
 
-그 밖의 `!` 보고는 명령을 실패하게 하며, 해당 항목을 복원하거나 명시적인
-마이그레이션 결정과 함께 이 문서에 추가해야 한다. Serializable model의
-`serialVersionUID` 진단은 메타데이터 변경으로 원시 보고서에 남긴다. 이는
-API 진입점 제거가 아니며 바이너리 게이트를 조용히 통과시키지 않는다.
+allowlist에 없는 public constructor, method, bridge, 또는 accessor는 모두
+`unknown`으로 남겨 명령을 실패하게 한다. 따라서 `SYNTHETIC`이나
+`access$`라는 문자열만으로 분류하지 않는다. 새로운 항목은 소비자 linkage
+fixture 또는 명시적인 복원/마이그레이션 결정과 함께 추가해야 한다.
+
+## 0.4.0 -> 0.5.0 분류 결과
+
+Issue [#805](https://github.com/bluetape4k/bluetape4k-leader/issues/805)의
+`ABI inventory: artifacts=16, ignored=19, unknown=4`를 다음과 같이
+재현하고 분류했다.
+
+게시된 `0.5.0` 아티팩트를 사용한 수정 후 결과는
+`artifacts=16, ignored=23, unknown=0`이며,
+`Binary API compatibility gate passed`를 반환한다.
+
+| 클래스 | 보고된 JVM descriptor | 결정 |
+| --- | --- | --- |
+| `LettuceLeaderElector`, `LettuceLeaderGroupElector` | `runAsyncIfLeader(...)`, `runAsyncIfLeaderResult(...)`의 `PUBLIC BRIDGE` descriptor | erased descriptor는 유지되고 bridge/generic 표시만 변경되므로 클래스별 정확한 allowlist로 분류 |
+| `RedissonLeaderElector`, `RedissonLeaderGroupElector` | 같은 두 `PUBLIC BRIDGE` descriptor | 위와 동일한 descriptor fixture로 분류 |
+| `RedissonLeaderElector` | `access$releaseLockAsync(...)` synthetic accessor | `private inline` 구현 변경으로 사라진 compiler accessor이며 클래스와 descriptor를 함께 allowlist |
+
+Redis bridge 변경에는 기존 consumer가 `Object` erased descriptor로 호출하는
+linkage fixture를 사용했다. 기존 bridge가 제거된 경우는 여전히
+`NoSuchMethodException`으로 실패하므로 public method 제거를 숨기지 않는다.
+
+그 밖의 0.4.0 -> 0.5.0 synthetic accessor는 다음 클래스와 descriptor만
+허용한다.
+
+- `ConsulLeaderGroupElectorKt`와 `ConsulSuspendLeaderGroupElectorKt`의
+  `access$remainingMillis(long)`
+- `ExposedR2DbcSuspendLeaderGroupElector`의
+  `access$getCachedActiveCount$p(...)`
+- `LettuceSuspendCandidateRegistry`의
+  `access$scanKeys(...)`
+
+### Serializable 경계
+
+- 0.4.0 `CandidateInfo`는 compiler 기본 UID
+  `5155212047249715215`를 사용했다. 현재는 명시적 UID `1L`을 사용하므로
+  저장해 둔 0.4.0 payload는 `InvalidClassException`으로 거부된다. 기존
+  Java serialization payload를 계속 사용해야 한다면 0.5.0으로 올리기 전에
+  읽어 새 형식으로 다시 저장해야 하며, 자동 호환으로 간주하지 않는다.
+- 0.4.0 `ExtendOutcome`은 `Serializable`을 구현하지 않았다. 0.5.0부터
+  concrete outcome(`Extended`, `Rejected`, `NotHeld`, `WrongThread`,
+  `BackendError`)에 명시적 UID `1L`을 부여해 새 직렬화 계약을 시작했다.
+  0.4.0에서 저장한 `ExtendOutcome` payload는 지원하지 않는다.
+
+이 두 변경은 public API 제거가 아니라 명시적인 저장 형식 경계다. 원시
+japicmp 진단은 계속 보고하며, 분류기에서 Serializable 차이를 blanket
+ignore하지 않는다.
 
 현재 `0.5.0`에 대해 의도적인 public 재컴파일 요구 사항은 승인되지 않았다.
 
@@ -96,5 +153,5 @@ ABI_BASE_VERSION=0.5.0 ABI_CURRENT_VERSION=1.0.0 \
   ./gradlew checkBinaryCompatibility
 ```
 
-현재 실행 결과는 `artifacts=16, ignored=7, unknown=0`이며,
+현재 실행 결과는 `artifacts=16, ignored=10, unknown=0`이며,
 `Binary API compatibility gate passed`를 반환했다.

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderSerializationCompatibilityTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderSerializationCompatibilityTest.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.leader.strategy.CandidateInfo
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InvalidClassException
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.io.ObjectStreamClass
+import java.util.Base64
+import org.junit.jupiter.api.Test
+
+class LeaderSerializationCompatibilityTest {
+
+    @Test
+    fun `0_4_0 CandidateInfo payload fails closed after the explicit UID change`() {
+        val exception = assertFailsWith<InvalidClassException> {
+            ObjectInputStream(
+                ByteArrayInputStream(Base64.getDecoder().decode(LEGACY_CANDIDATE_INFO)),
+            ).use { input -> input.readObject() }
+        }
+
+        exception.message.orEmpty().contains("serialVersionUID").shouldBeTrue()
+    }
+
+    @Test
+    fun `current serializable outcomes expose the explicit UID policy`() {
+        ObjectStreamClass.lookup(CandidateInfo::class.java).serialVersionUID shouldBeEqualTo 1L
+        ObjectStreamClass.lookup(ExtendOutcome.Extended::class.java).serialVersionUID shouldBeEqualTo 1L
+        ObjectStreamClass.lookup(ExtendOutcome.Rejected::class.java).serialVersionUID shouldBeEqualTo 1L
+        ObjectStreamClass.lookup(ExtendOutcome.NotHeld::class.java).serialVersionUID shouldBeEqualTo 1L
+        ObjectStreamClass.lookup(ExtendOutcome.WrongThread::class.java).serialVersionUID shouldBeEqualTo 1L
+        ObjectStreamClass.lookup(ExtendOutcome.BackendError::class.java).serialVersionUID shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `current ExtendOutcome remains serializable`() {
+        val original: ExtendOutcome = ExtendOutcome.WrongThread
+        val bytes = ByteArrayOutputStream().use { output ->
+            ObjectOutputStream(output).use { stream -> stream.writeObject(original) }
+            output.toByteArray()
+        }
+
+        val restored = ObjectInputStream(ByteArrayInputStream(bytes)).use { input ->
+            input.readObject() as ExtendOutcome
+        }
+        restored shouldBeEqualTo original
+    }
+
+    companion object {
+        private const val LEGACY_CANDIDATE_INFO =
+            "rO0ABXNyACtpby5ibHVldGFwZTRrLmxlYWRlci5zdHJhdGVneS5DYW5kaWRhdGVJbmZvR4r+CyIiMA8CAAdKAAxmYWlsdXJlQ291bnRKAAxzdWNjZXNzQ291bnRMABJsYXN0Q29tcGxldGlvblRpbWV0ABNMamF2YS90aW1lL0luc3RhbnQ7TAANbGFzdFN0YXJ0VGltZXEAfgABTAAIbWV0YWRhdGF0AA9MamF2YS91dGlsL01hcDtMAAZub2RlSWR0ABJMamF2YS9sYW5nL1N0cmluZztMAAxyZWdpc3RlcmVkQXRxAH4AAXhwAAAAAAAAAAIAAAAAAAAAB3NyAA1qYXZhLnRpbWUuU2VylV2EuhsiSLIMAAB4cHcNAgAAAABpWdilAAAAAHhzcQB+AAV3DQIAAAAAaViHJQAAAAB4c3IAEWphdmEudXRpbC5Db2xsU2VyV46rtjobqBEDAAFJAAN0YWd4cAAAAAN3BAAAAAJ0AAR6b25ldAAGbGVnYWN5eHQAC2xlZ2FjeS1ub2Rlc3EAfgAFdw0CAAAAAGlXNaUAAAAAeA=="
+    }
+}

--- a/scripts/compatibility/check_binary_api.py
+++ b/scripts/compatibility/check_binary_api.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Compare published JVM artifacts with the previous release.
 
-The release gate intentionally reports every japicmp incompatibility, then
-filters only compiler-generated Kotlin/AspectJ classes, synthetic accessor
-methods, JVM class-file format changes, and explicitly retired Kotlin-internal
-facades. A new public incompatibility must therefore be classified in the
-migration notes or the command fails.
+The release gate reports every japicmp incompatibility, then filters only
+compiler-generated classes, exact historical JVM descriptors, JVM class-file
+format changes, and explicitly retired Kotlin-internal facades. A new public
+incompatibility must therefore be classified in the migration notes or the
+command fails.
 """
 
 from __future__ import annotations
@@ -15,8 +15,8 @@ import re
 import subprocess
 import sys
 import urllib.request
+from collections.abc import Mapping
 from pathlib import Path
-
 
 # Maven Central path for projectGroup=io.github.bluetape4k.leader.
 REPOSITORY = "io/github/bluetape4k/leader"
@@ -49,9 +49,192 @@ LEGACY_INTERNAL_JVM_FACADES = frozenset(
     },
 )
 
+# These methods were emitted by Kotlin compiler changes between released
+# versions.  Keep the allowlist keyed by the owning class and the complete
+# japicmp descriptor: a generic ``SYNTHETIC``/``access$`` rule would hide a
+# genuinely linkable public method.
+KNOWN_SYNTHETIC_ACCESSORS: dict[str, frozenset[str]] = {
+    "io.bluetape4k.leader.consul.ConsulLeaderGroupElectorKt": frozenset(
+        {"PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) long access$remainingMillis(long)"}
+    ),
+    "io.bluetape4k.leader.consul.ConsulSuspendLeaderGroupElectorKt": frozenset(
+        {"PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) long access$remainingMillis(long)"}
+    ),
+    "io.bluetape4k.leader.exposed.jdbc.lock.ExposedJdbcLockKt": frozenset(
+        {
+            "PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) java.time.Instant "
+            + "access$dbCurrentTimestamp(org.jetbrains.exposed.v1.jdbc.JdbcTransaction)"
+        }
+    ),
+    "io.bluetape4k.leader.exposed.r2dbc.ExposedR2DbcSuspendLeaderGroupElector": frozenset(
+        {
+            "PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) "
+            + "java.util.concurrent.atomic.AtomicInteger "
+            + "access$getCachedActiveCount$p(io.bluetape4k.leader.exposed.r2dbc.ExposedR2DbcSuspendLeaderGroupElector)"
+        }
+    ),
+    "io.bluetape4k.leader.exposed.r2dbc.lock.ExposedR2dbcLock": frozenset(
+        {
+            "PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) java.lang.Object "
+            + "access$currentTime(io.bluetape4k.leader.exposed.r2dbc.lock.ExposedR2dbcLock, "
+            + "org.jetbrains.exposed.v1.r2dbc.R2dbcTransaction, kotlin.coroutines.Continuation)"
+        }
+    ),
+    "io.bluetape4k.leader.ktor.LeaderElectionManagementRouteKt": frozenset(
+        {
+            "PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) java.lang.String "
+            + "access$toJson(io.bluetape4k.leader.ktor.LeaderElectionManagementRegistry, "
+            + "io.bluetape4k.leader.coroutines.SuspendLeaderElector)"
+        }
+    ),
+    "io.bluetape4k.leader.lettuce.LettuceSuspendCandidateRegistry": frozenset(
+        {
+            "PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) java.lang.Object "
+            + "access$scanKeys(io.bluetape4k.leader.lettuce.LettuceSuspendCandidateRegistry, "
+            + "java.lang.String, kotlin.coroutines.Continuation)"
+        }
+    ),
+    "io.bluetape4k.leader.LeaderLeaseAutoExtender": frozenset(
+        {
+            "PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) java.lang.Object "
+            + "access$start_dWUq8MI$doSuspendTick(java.util.concurrent.atomic.AtomicBoolean, "
+            + "java.util.concurrent.atomic.AtomicReference, "
+            + "io.bluetape4k.leader.internal.SuspendExtendDelegate, long, long, "
+            + "io.bluetape4k.leader.internal.BackendErrorClassifier, kotlin.coroutines.Continuation)"
+        }
+    ),
+    "io.bluetape4k.leader.spring.aop.LeaderElectionAspect": frozenset(
+        {
+            "PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) java.util.concurrent.ConcurrentHashMap "
+            + "access$getMetadataCache$p(io.bluetape4k.leader.spring.aop.LeaderElectionAspect)",
+            "PUBLIC(-) STATIC(-) FINAL(-) "
+            + "SYNTHETIC(-) io.bluetape4k.leader.spring.aop.internal.AdviceMetadata "
+            + "access$resolveMetadata(io.bluetape4k.leader.spring.aop.LeaderElectionAspect, "
+            + "java.lang.reflect.Method, java.lang.Object)",
+        }
+    ),
+    "io.bluetape4k.leader.spring.route.mvc.LeaderMvcRouteGuardFactory": frozenset(
+        {
+            "PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) "
+            + "io.bluetape4k.leader.spring.properties.LeaderRouteGuardProperties "
+            + "access$getProperties$p(io.bluetape4k.leader.spring.route.mvc.LeaderMvcRouteGuardFactory)",
+            "PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) "
+            + "io.bluetape4k.leader.spring.route.LeaderRouteAuthorityRuntime "
+            + "access$getRuntime$p(io.bluetape4k.leader.spring.route.mvc.LeaderMvcRouteGuardFactory)",
+        }
+    ),
+}
+
+KNOWN_REDIS_BRIDGE_METHODS: dict[str, frozenset[str]] = {
+    class_name: frozenset(
+        {
+            "PUBLIC(-) BRIDGE(-) java.util.concurrent.CompletableFuture<T> "
+            + "runAsyncIfLeader(io.bluetape4k.leader.LeaderSlot, java.util.concurrent.Executor, "
+            + "kotlin.jvm.functions.Function0<? extends java.util.concurrent.CompletableFuture<? extends T>>)",
+            "PUBLIC(-) BRIDGE(-) "
+            + "java.util.concurrent.CompletableFuture<io.bluetape4k.leader.LeaderRunResult<T>> "
+            + "runAsyncIfLeaderResult(io.bluetape4k.leader.LeaderSlot, java.util.concurrent.Executor, "
+            + "kotlin.jvm.functions.Function0<? extends java.util.concurrent.CompletableFuture<? extends T>>)",
+        }
+    )
+    for class_name in (
+        "io.bluetape4k.leader.lettuce.LettuceLeaderElector",
+        "io.bluetape4k.leader.lettuce.LettuceLeaderGroupElector",
+        "io.bluetape4k.leader.redisson.RedissonLeaderGroupElector",
+    )
+}
+KNOWN_REDIS_BRIDGE_METHODS["io.bluetape4k.leader.redisson.RedissonLeaderElector"] = frozenset(
+    {
+        *KNOWN_REDIS_BRIDGE_METHODS["io.bluetape4k.leader.lettuce.LettuceLeaderElector"],
+        "PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) void "
+        + "access$releaseLockAsync(io.bluetape4k.leader.redisson.RedissonLeaderElector, "
+        + "org.redisson.api.RLock, long, long)",
+    }
+)
+
+VERSION_PATTERN = re.compile(r"^v?(?P<release>\d+(?:\.\d+){1,3})(?:[-+][0-9A-Za-z.-]+)?$")
+
 
 def env_path(name: str, default: Path) -> Path:
     return Path(os.environ.get(name, str(default))).expanduser()
+
+
+def _gradle_properties(root: Path) -> dict[str, str]:
+    properties_file = root / "gradle.properties"
+    if not properties_file.is_file():
+        raise ValueError(f"Missing Gradle version properties: {properties_file}")
+    properties: dict[str, str] = {}
+    for raw_line in properties_file.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        properties[key.strip()] = value.strip()
+    return properties
+
+
+def _release_version(value: str) -> tuple[int, ...] | None:
+    match = VERSION_PATTERN.fullmatch(value.strip())
+    if match is None:
+        return None
+    return tuple(int(part) for part in match.group("release").split("."))
+
+
+def _previous_release_tag(root: Path, current_version: str) -> str:
+    current_release = _release_version(current_version)
+    if current_release is None:
+        raise ValueError(f"Current version is not a release version: {current_version}")
+    result = subprocess.run(
+        ["git", "tag", "--list", "--sort=-v:refname"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"exit {result.returncode}"
+        raise ValueError(f"Unable to read release tags for ABI baseline: {detail}")
+    candidates: list[tuple[tuple[int, ...], str]] = []
+    for raw_tag in result.stdout.splitlines():
+        tag = raw_tag.strip()
+        release = _release_version(tag)
+        if release is None:
+            continue
+        if release >= current_release:
+            continue
+        candidates.append((release, tag))
+    if not candidates:
+        raise ValueError(
+            f"Could not resolve a previous release tag for ABI baseline before {current_version}"
+        )
+    return max(candidates)[1]
+
+
+def resolve_versions(root: Path, environ: Mapping[str, str] | None = None) -> tuple[str, str]:
+    """Resolve the ABI baseline/current versions, failing closed on ambiguity."""
+
+    values = os.environ if environ is None else environ
+    properties: dict[str, str] | None = None
+
+    current_version = values.get("ABI_CURRENT_VERSION", "").strip()
+    if not current_version:
+        properties = _gradle_properties(root)
+        base_version = properties.get("baseVersion", "").strip()
+        if not base_version:
+            raise ValueError("Missing baseVersion in gradle.properties")
+        current_version = f"{base_version}{properties.get('snapshotVersion', '').strip()}"
+
+    base_version = values.get("ABI_BASE_VERSION", "").strip()
+    if not base_version:
+        base_version = _previous_release_tag(root, current_version).removeprefix("v")
+
+    if not base_version or not current_version:
+        raise ValueError("Binary compatibility baseline and current versions are required")
+    if _release_version(base_version) is None:
+        raise ValueError(f"Base version is not a release version: {base_version}")
+    if _release_version(current_version) is None:
+        raise ValueError(f"Current version is not a release version: {current_version}")
+    return base_version, current_version
 
 
 def download(url: str, target: Path) -> None:
@@ -93,6 +276,13 @@ def block_class_name(block: str) -> str:
     return first.partition("  (")[0].split()[-1]
 
 
+def _member_descriptor(line: str) -> str | None:
+    marker = "REMOVED METHOD:"
+    if marker not in line:
+        return None
+    return " ".join(line.partition(marker)[2].strip().split())
+
+
 def is_intentionally_ignored(block: str) -> str | None:
     name = block_class_name(block)
     header = block.splitlines()[0]
@@ -106,9 +296,23 @@ def is_intentionally_ignored(block: str) -> str | None:
     ]
     if "REMOVED CLASS:" in header and name in LEGACY_INTERNAL_JVM_FACADES:
         return "legacy Kotlin-internal JVM facade"
-    if incompatible_members and all(
-        "SYNTHETIC" in line and "access$" in line
+    member_descriptors = {
+        descriptor
         for line in incompatible_members
+        if (descriptor := _member_descriptor(line)) is not None
+    }
+    if (
+        member_descriptors
+        and len(member_descriptors) == len(incompatible_members)
+        and name in KNOWN_REDIS_BRIDGE_METHODS
+        and member_descriptors <= KNOWN_REDIS_BRIDGE_METHODS[name]
+    ):
+        return "known Redis JVM bridge descriptor"
+    if (
+        member_descriptors
+        and len(member_descriptors) == len(incompatible_members)
+        and name in KNOWN_SYNTHETIC_ACCESSORS
+        and member_descriptors <= KNOWN_SYNTHETIC_ACCESSORS[name]
     ):
         return "compiler-generated synthetic accessor"
     if not incompatible_members and has_class_file_format_change:
@@ -124,8 +328,12 @@ def is_intentionally_ignored(block: str) -> str | None:
 
 def main() -> int:
     root = Path(__file__).resolve().parents[2]
-    base_version = os.environ.get("ABI_BASE_VERSION", "0.4.0")
-    current_version = os.environ.get("ABI_CURRENT_VERSION", "0.5.0")
+    current_artifact_root = env_path("ABI_CURRENT_DIR", root)
+    try:
+        base_version, current_version = resolve_versions(root)
+    except ValueError as error:
+        print(f"Binary compatibility version resolution failed: {error}", file=sys.stderr)
+        return 2
     japicmp_version = os.environ.get("ABI_JAPICMP_VERSION", "0.26.1")
     work = env_path("ABI_WORK_DIR", Path(os.environ.get("TMPDIR", "/tmp")) / "bluetape4k-leader-abi")
     old_dir = env_path("ABI_BASE_DIR", work / f"old-{base_version}")
@@ -145,7 +353,13 @@ def main() -> int:
             old_dir / filename,
             f"https://repo.maven.apache.org/maven2/{REPOSITORY}/{maven_artifact}/{base_version}/{filename}",
         )
-        current = root / artifact / "build" / "libs" / f"{maven_artifact}-{current_version}{suffix}.jar"
+        current = (
+            current_artifact_root
+            / artifact
+            / "build"
+            / "libs"
+            / f"{maven_artifact}-{current_version}{suffix}.jar"
+        )
         if not current.is_file():
             print(f"Missing current artifact: {current}", file=sys.stderr)
             return 2

--- a/scripts/compatibility/check_binary_api_test.py
+++ b/scripts/compatibility/check_binary_api_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Regression tests for binary-compatibility report classification."""
 
 from __future__ import annotations
@@ -10,9 +9,11 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent))
 
+import check_binary_api
 from check_binary_api import is_intentionally_ignored
 
 
@@ -63,6 +64,127 @@ class BinaryApiClassificationTest(unittest.TestCase):
 """
 
         self.assertIsNone(is_intentionally_ignored(block))
+
+    def test_known_redis_bridge_descriptor_change_is_allowlisted(self) -> None:
+        block = """***! MODIFIED CLASS: PUBLIC FINAL io.bluetape4k.leader.lettuce.LettuceLeaderElector  (not serializable)
+\t===  CLASS FILE FORMAT VERSION: 65.0 <- 65.0
+\t===  UNCHANGED SUPERCLASS: java.lang.Object (<- java.lang.Object)
+\t---! REMOVED METHOD: PUBLIC(-) BRIDGE(-) java.util.concurrent.CompletableFuture<T> runAsyncIfLeader(io.bluetape4k.leader.LeaderSlot, java.util.concurrent.Executor, kotlin.jvm.functions.Function0<? extends java.util.concurrent.CompletableFuture<? extends T>>)
+\t\tGENERIC TEMPLATES: --- T:java.lang.Object
+\t---! REMOVED METHOD: PUBLIC(-) BRIDGE(-) java.util.concurrent.CompletableFuture<io.bluetape4k.leader.LeaderRunResult<T>> runAsyncIfLeaderResult(io.bluetape4k.leader.LeaderSlot, java.util.concurrent.Executor, kotlin.jvm.functions.Function0<? extends java.util.concurrent.CompletableFuture<? extends T>>)
+\t\tGENERIC TEMPLATES: --- T:java.lang.Object
+"""
+
+        self.assertEqual(
+            is_intentionally_ignored(block),
+            "known Redis JVM bridge descriptor",
+        )
+
+    def test_known_redisson_accessor_and_bridge_descriptors_are_allowlisted_together(self) -> None:
+        block = """***! MODIFIED CLASS: PUBLIC FINAL io.bluetape4k.leader.redisson.RedissonLeaderElector  (not serializable)
+\t===  CLASS FILE FORMAT VERSION: 65.0 <- 65.0
+\t===  UNCHANGED SUPERCLASS: java.lang.Object (<- java.lang.Object)
+\t---! REMOVED METHOD: PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) void access$releaseLockAsync(io.bluetape4k.leader.redisson.RedissonLeaderElector, org.redisson.api.RLock, long, long)
+\t---! REMOVED METHOD: PUBLIC(-) BRIDGE(-) java.util.concurrent.CompletableFuture<T> runAsyncIfLeader(io.bluetape4k.leader.LeaderSlot, java.util.concurrent.Executor, kotlin.jvm.functions.Function0<? extends java.util.concurrent.CompletableFuture<? extends T>>)
+\t\tGENERIC TEMPLATES: --- T:java.lang.Object
+\t---! REMOVED METHOD: PUBLIC(-) BRIDGE(-) java.util.concurrent.CompletableFuture<io.bluetape4k.leader.LeaderRunResult<T>> runAsyncIfLeaderResult(io.bluetape4k.leader.LeaderSlot, java.util.concurrent.Executor, kotlin.jvm.functions.Function0<? extends java.util.concurrent.CompletableFuture<? extends T>>)
+\t\tGENERIC TEMPLATES: --- T:java.lang.Object
+"""
+
+        self.assertEqual(
+            is_intentionally_ignored(block),
+            "known Redis JVM bridge descriptor",
+        )
+
+    def test_known_bridge_class_with_an_extra_member_stays_unclassified(self) -> None:
+        block = """***! MODIFIED CLASS: PUBLIC FINAL io.bluetape4k.leader.lettuce.LettuceLeaderElector  (not serializable)
+\t---! REMOVED METHOD: PUBLIC(-) BRIDGE(-) java.util.concurrent.CompletableFuture<T> runAsyncIfLeader(io.bluetape4k.leader.LeaderSlot, java.util.concurrent.Executor, kotlin.jvm.functions.Function0<? extends java.util.concurrent.CompletableFuture<? extends T>>)
+\t---! REMOVED METHOD: PUBLIC(-) BRIDGE(-) java.lang.String unrelated(java.lang.String)
+"""
+
+        self.assertIsNone(is_intentionally_ignored(block))
+
+    def test_unrelated_synthetic_accessor_stays_unclassified(self) -> None:
+        block = """***! MODIFIED CLASS: PUBLIC FINAL io.example.PublicApi  (not serializable)
+\t---! REMOVED METHOD: PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) java.lang.String access$unrelated(java.lang.String)
+"""
+
+        self.assertIsNone(is_intentionally_ignored(block))
+
+    def test_version_resolution_uses_current_gradle_version_and_previous_release_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "gradle.properties").write_text(
+                "baseVersion=1.0.0\nsnapshotVersion=\n",
+                encoding="utf-8",
+            )
+            git_tags = subprocess.CompletedProcess(
+                ["git"],
+                0,
+                stdout="0.5.0\n0.4.0\n",
+                stderr="",
+            )
+            with patch("check_binary_api.subprocess.run", return_value=git_tags):
+                self.assertEqual(
+                    self._resolve_versions(root, environ={}),
+                    ("0.5.0", "1.0.0"),
+                )
+
+    def test_version_resolution_preserves_explicit_environment_overrides(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "gradle.properties").write_text(
+                "baseVersion=1.0.0\nsnapshotVersion=\n",
+                encoding="utf-8",
+            )
+            with patch("check_binary_api.subprocess.run") as git_run:
+                self.assertEqual(
+                    self._resolve_versions(
+                        root,
+                        environ={
+                            "ABI_BASE_VERSION": "0.4.0",
+                            "ABI_CURRENT_VERSION": "0.5.0",
+                        },
+                    ),
+                    ("0.4.0", "0.5.0"),
+                )
+                git_run.assert_not_called()
+
+    def test_version_resolution_fails_closed_without_previous_release_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "gradle.properties").write_text(
+                "baseVersion=1.0.0\nsnapshotVersion=\n",
+                encoding="utf-8",
+            )
+            git_tags = subprocess.CompletedProcess(
+                ["git"],
+                0,
+                stdout="",
+                stderr="",
+            )
+            with patch("check_binary_api.subprocess.run", return_value=git_tags), self.assertRaisesRegex(
+                ValueError,
+                "baseline",
+            ):
+                self._resolve_versions(root, environ={})
+
+    def test_version_resolution_fails_closed_for_invalid_current_version(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            (root / "gradle.properties").write_text(
+                "baseVersion=not-a-release\nsnapshotVersion=\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "release version"):
+                self._resolve_versions(root, environ={})
+
+    def _resolve_versions(self, root: Path, environ: dict[str, str]) -> tuple[str, str]:
+        self.assertTrue(
+            hasattr(check_binary_api, "resolve_versions"),
+            "version resolution helper must be implemented before this regression can pass",
+        )
+        return check_binary_api.resolve_versions(root, environ=environ)
 
     def test_public_bridge_is_linkable_by_an_existing_consumer(self) -> None:
         javac = shutil.which("javac")
@@ -202,6 +324,151 @@ public final class Consumer {
             )
             self.assertNotEqual(new_run.returncode, 0)
             self.assertIn("NoSuchMethodException", new_run.stderr)
+
+    def test_public_bridge_flag_change_keeps_an_existing_consumer_linkable(self) -> None:
+        javac = shutil.which("javac")
+        java = shutil.which("java")
+        javap = shutil.which("javap")
+        self.assertIsNotNone(javac, "JDK javac is required for the linkage fixture")
+        self.assertIsNotNone(java, "JDK java is required for the linkage fixture")
+        self.assertIsNotNone(javap, "JDK javap is required for the linkage fixture")
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            old_sources = root / "old-sources" / "fixture"
+            new_sources = root / "new-sources" / "fixture"
+            consumer_sources = root / "consumer-sources" / "fixture"
+            old_classes = root / "old-classes"
+            new_classes = root / "new-classes"
+            consumer_classes = root / "consumer-classes"
+            for directory in (old_sources, new_sources, consumer_sources):
+                directory.mkdir(parents=True)
+
+            (old_sources / "GenericApi.java").write_text(
+                """package fixture;
+
+public interface GenericApi<T> {
+    T value();
+}
+""",
+                encoding="utf-8",
+            )
+            (old_sources / "PublicApi.java").write_text(
+                """package fixture;
+
+public final class PublicApi implements GenericApi<String> {
+    @Override
+    public String value() {
+        return "old";
+    }
+}
+""",
+                encoding="utf-8",
+            )
+            (new_sources / "PublicApi.java").write_text(
+                """package fixture;
+
+public final class PublicApi {
+    public Object value() {
+        return "new";
+    }
+}
+""",
+                encoding="utf-8",
+            )
+            (consumer_sources / "Consumer.java").write_text(
+                """package fixture;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public final class Consumer {
+    public static void main(String[] args) throws Throwable {
+        MethodHandle value = MethodHandles.lookup().findVirtual(
+            PublicApi.class,
+            "value",
+            MethodType.methodType(Object.class)
+        );
+        System.out.print((Object) value.invoke(new PublicApi()));
+    }
+}
+""",
+                encoding="utf-8",
+            )
+
+            subprocess.run(
+                [
+                    javac,
+                    "-d",
+                    old_classes,
+                    old_sources / "GenericApi.java",
+                    old_sources / "PublicApi.java",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            subprocess.run(
+                [javac, "-d", new_classes, new_sources / "PublicApi.java"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            subprocess.run(
+                [
+                    javac,
+                    "-cp",
+                    old_classes,
+                    "-d",
+                    consumer_classes,
+                    consumer_sources / "Consumer.java",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            old_bytecode = subprocess.run(
+                [javap, "-v", "-classpath", old_classes, "fixture.PublicApi"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            new_bytecode = subprocess.run(
+                [javap, "-v", "-classpath", new_classes, "fixture.PublicApi"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            self.assertIn("ACC_BRIDGE", old_bytecode)
+            self.assertNotIn("ACC_BRIDGE", new_bytecode)
+
+            old_run = subprocess.run(
+                [
+                    java,
+                    "-cp",
+                    f"{old_classes}{os.pathsep}{consumer_classes}",
+                    "fixture.Consumer",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(old_run.stdout, "old")
+
+            new_run = subprocess.run(
+                [
+                    java,
+                    "-cp",
+                    f"{new_classes}{os.pathsep}{consumer_classes}",
+                    "fixture.Consumer",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(new_run.stdout, "new")
 
     def test_unrelated_public_class_removal_stays_unclassified(self) -> None:
         block = """---! REMOVED CLASS: PUBLIC(-) FINAL(-) io.example.RemovedPublicApi  (not serializable)


### PR DESCRIPTION
## Summary

Closes #805

0.4.0에서 0.5.0으로 넘어가는 바이너리 호환성 게이트가 실제 소비자 위험과
Kotlin compiler-generated false positive를 구분하지 못하던 문제를 해소합니다.
정확한 class·descriptor 기준과 serialization fixture를 고정해 release gate를
fail-closed로 유지합니다.

## Background

issue #805에서 0.4.0 Maven baseline과 0.5.0 artifact 비교 결과가
`artifacts=16 ignored=19 unknown=4`로 실패했습니다. `CandidateInfo`와
`ExtendOutcome`의 public `Serializable` 변경, Redis public bridge, compiler
accessor가 한 inventory에 섞여 있어 blanket ignore 없이 분류와 회귀 증거가
필요했습니다.

## What This Solves

- 현재 Gradle 버전과 직전 유효 Git release tag를 동적으로 선택해 release
  baseline drift를 줄입니다.
- public ABI 변경은 class와 전체 JVM descriptor를 함께 확인하고, 실제
  소비자 linkage 및 old-bytecode serialization fixture 없이 무시하지 않습니다.
- 0.4.0→0.5.0의 known synthetic accessor와 Redis bridge만 exact allowlist로
  분류해 실제 public linkage 오류를 숨기지 않습니다.

## Work Done

- `scripts/compatibility/check_binary_api.py`: 버전 해석, historical artifact
  비교, exact class/descriptor allowlist, fail-closed unknown 검사를 추가했습니다.
- `scripts/compatibility/check_binary_api_test.py`: 버전 override/missing tag,
  consumer linkage, bridge flag-only 변경, unrelated public/synthetic 변경 회귀를
  검증합니다.
- `LeaderSerializationCompatibilityTest.kt`: 0.4.0 `CandidateInfo` payload의
  거부 동작과 현재 UID 1 정책, `WrongThread` round-trip을 고정했습니다.
- `docs/migration/0.5.0-binary-compatibility.md` 및 lessons 문서에 분류·UID·
  release gate 경계를 기록했습니다.

## Validation

- `python3 -m unittest -v scripts/compatibility/check_binary_api_test.py`: PASS (16/16)
- `ruff check scripts/compatibility/check_binary_api.py scripts/compatibility/check_binary_api_test.py`: PASS
- `./gradlew :bluetape4k-leader-core:cleanTest :bluetape4k-leader-core:test --tests 'io.bluetape4k.leader.LeaderSerializationCompatibilityTest' --no-build-cache --no-daemon --console=plain`: PASS (3/3)
- `./gradlew :bluetape4k-leader-core:cleanTest :bluetape4k-leader-core:test --no-build-cache --no-daemon --console=plain`: PASS (940 tests)
- `./gradlew :bluetape4k-leader-redis-lettuce:cleanTest :bluetape4k-leader-redis-lettuce:test --no-build-cache --no-daemon --console=plain`: PASS (309 tests)
- `./gradlew :bluetape4k-leader-redis-redisson:cleanTest :bluetape4k-leader-redis-redisson:test --no-build-cache --no-daemon --console=plain`: PASS (291 tests)
- `./gradlew checkBinaryCompatibility --no-configuration-cache --no-daemon --no-build-cache --console=plain`: PASS (default baseline `artifacts=16 ignored=10 unknown=0`)
- historical 0.4.0→0.5.0 gate with published artifacts: PASS (`artifacts=16 ignored=23 unknown=0`)
- `./gradlew detekt --no-configuration-cache --no-daemon --console=plain`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: configuration-cache를 사용하는 detekt 경로는 기존
  `detektProductionSourceGuard` Project 역직렬화 오류로 별도 추적합니다.
- Human-review subgate: `N/A (single-developer lane)` — 추가 maintainer/reviewer가
  범위에 없고, exact-head local review와 전체 CI evidence를 확보했습니다.
- Review evidence: exact-head local diff review, bluetape workflow receipt
  `20260827T095543Z-aa022795` (required checks 6/6, completion verified)

## Metadata

- Issue: #805 (CLOSED), milestone `1.0.0`, assignee `debop`
- PR: #815 (MERGED), head `33b3ed503b31edf4915701f2843cffd5e13adbbd`, merge `c5888bf8527d550f41dfa8cec9dd46b7330f4b89`, milestone `1.0.0`, assignee `debop`
- CI: [run 33066020006](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33066020006) — exact head `33b3ed503b31edf4915701f2843cffd5e13adbbd`, 47/47 jobs `SUCCESS`

## DoD Status

Required checks: 6/6; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| WF-01 - Root cause | 0.4.0→0.5.0 inventory와 공개 API 경계를 분류 | PASS | issue #805 분석 및 workflow receipt | none |
| WF-02 - Red regression | unknown/legacy serialization 위험을 회귀 fixture로 고정 | PASS | Python 16/16, Kotlin serialization 3/3 | none |
| WF-03 - Compatibility fix | exact class·descriptor allowlist와 동적 baseline 적용 | PASS | historical gate `unknown=0` | none |
| WF-04 - Serialization policy | UID 정책과 old payload 거부 동작 문서화 | PASS | migration/lesson 문서 및 fixture | none |
| WF-05 - Targeted validation | 변경 모듈과 classifier를 clean 검증 | PASS | core 940, Lettuce 309, Redisson 291 | none |
| WF-06 - Broader validation | 정적 분석 및 기본 gate 검증 | PASS | detekt no-config-cache, default gate `unknown=0` | none |
| CG-11 - Authority | 승인된 계획의 target repo/base/head로 PR 전달 | PASS | `bluetape4k/bluetape4k-leader`, `develop`, `fix/issue-805-abi-gate` | none |
| CG-12 - Exact-head push | isolated branch를 원격에 push하고 SHA 대조 | PASS | local/remote `33b3ed503b31edf4915701f2843cffd5e13adbbd` | none |
| CG-12A - Guidance refresh | AGENTS hierarchy, selected skills, gates, template, issue 재확인 | PASS | current hashes 및 issue #805 live metadata | none |
| CG-13 - PR metadata | PR 생성 후 assignee/labels/milestone/body를 read-back | PASS | `gh pr view 815`: Korean body, `debop`, `bug/test/maintenance/build`, milestone `1.0.0` | none |
| CG-14 - Exact-head CI/review | exact head checks·reviews·threads 확인 | PASS | run `33066020006` 47/47 `SUCCESS`, reviews 0건, unresolved threads 0건 | none |
| CG-15 - Merge-ready report | CG-14 충족 후 병합 가능 상태 보고 | PASS | PR `MERGEABLE/CLEAN`, head SHA 및 base `develop` 재확인 | none |
| CG-16 - Merge approval | 병합 전 새 사용자 승인 확보 | PASS | 사용자의 fresh `승인` 후 exact head 재검증 | none |
| CG-17 - Merge | 승인된 경우에만 develop에 병합 | PASS | PR #815 `merged=true`, squash merge `c5888bf8527d550f41dfa8cec9dd46b7330f4b89` | none |
| CG-18 - Sync/cleanup | 병합 후 canonical sync와 안전한 cleanup | PASS | canonical `develop` 및 `origin/develop`가 `c5888bf8527d550f41dfa8cec9dd46b7330f4b89`; clean task worktree removed; local branch ref retained for recovery | none |

Final status: DONE

Unchecked required items: none
