### PR TITLE
fix: detektProductionSourceGuard를 configuration-cache 호환으로 수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,8 @@ jobs:
           python3 scripts/ci/validate_test_assertion_contract_test.py
           python3 scripts/ci/validate_timing_contract.py
           python3 scripts/ci/validate_timing_contract_test.py
+          python3 scripts/ci/validate_detekt_configuration_cache.py
+          python3 scripts/ci/validate_detekt_configuration_cache_test.py
           python3 scripts/compatibility/check_binary_api_test.py
 
   # ── 2-B. 매뉴얼/릴리스 provenance 계약 검증 ─────────────────────────────

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.compile.JavaCompile
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import java.io.File
 import java.util.concurrent.TimeUnit
 
 plugins {
@@ -491,6 +492,17 @@ if (detektRequested) {
     val moduleDetektTasks = subprojects.mapNotNull { subproject ->
         subproject.tasks.findByName("detekt") as? Detekt
     }
+    val productionSourceRoots = subprojects.associate { subproject ->
+        subproject.path to buildList {
+            add(subproject.file("src/main/kotlin").absolutePath)
+            if (subproject.path in reusableTestcontainersExamplePaths) {
+                add(rootProject.file("examples/shared/src/main/kotlin").absolutePath)
+            }
+        }
+    }
+    val productionSourceRootFiles = productionSourceRoots.values
+        .flatten()
+        .map(::File)
     val reportMerge = tasks.register<ReportMergeTask>("reportMerge") {
         val file = layout.buildDirectory.asFile.get().resolve("reports/detekt/merged.xml")
         output.set(file)
@@ -501,28 +513,25 @@ if (detektRequested) {
     val detektProductionSourceGuard = tasks.register("detektProductionSourceGuard") {
         group = "verification"
         description = "Fails when no Kotlin production sources are available for Detekt."
+        inputs.files(productionSourceRootFiles)
         doLast {
-            val sourceModules = subprojects
-                .mapNotNull { subproject ->
-                    val sourceRoots = buildList {
-                        add(subproject.file("src/main/kotlin"))
-                        if (subproject.path in reusableTestcontainersExamplePaths) {
-                            add(rootProject.file("examples/shared/src/main/kotlin"))
+            val task = this
+            val sourceModules = productionSourceRoots.mapNotNull { (modulePath, sourceRootPaths) ->
+                val files = sourceRootPaths
+                    .asSequence()
+                    .map(::File)
+                    .flatMap { sourceRoot ->
+                        sourceRoot.walkTopDown().filter { sourceFile ->
+                            sourceFile.isFile && sourceFile.extension in setOf("kt", "kts")
                         }
-                    }
-                    val files = sourceRoots
-                        .flatMap { sourceRoot ->
-                            subproject.fileTree(sourceRoot) {
-                                include("**/*.kt", "**/*.kts")
-                            }.files
-                        }.toSet()
-                    files.size.takeIf { it > 0 }?.let { count -> subproject.path to count }
-                }
+                    }.toSet()
+                files.size.takeIf { it > 0 }?.let { count -> modulePath to count }
+            }
             val productionSources = sourceModules.sumOf { (_, count) -> count }
             check(productionSources > 0) {
                 "Detekt expected at least one Kotlin production source file, but found none"
             }
-            logger.lifecycle(
+            task.logger.lifecycle(
                 "Detekt production modules: ${sourceModules.joinToString { (path, count) -> "$path=$count" }}",
             )
         }

--- a/docs/lessons/2026-08-27-issue-703-detekt-configuration-cache.md
+++ b/docs/lessons/2026-08-27-issue-703-detekt-configuration-cache.md
@@ -1,0 +1,42 @@
+# Issue #703: Detekt configuration cache guard 교훈
+
+## 문제
+
+`detektProductionSourceGuard`의 `doLast`가 실행 시점에 `subprojects`,
+`rootProject`, `Project.fileTree`, script `logger`를 참조하면 Gradle
+configuration cache가 script receiver를 직렬화하려고 시도한다. 기본
+`./gradlew detekt`가 guard 단계에서 실패하고 `--no-configuration-cache`만
+통과하는 상태는 CI가 회귀를 가린다.
+
+## 적용한 규칙
+
+- 프로젝트 모델에서 필요한 source root의 절대 경로와 모듈 경로만 구성 단계에
+  불변 자료로 계산한다.
+- guard task가 source root 디렉터리를 입력으로 선언해 파일 변경 시 캐시가
+  무효화되도록 한다.
+- `doLast`에서는 캡처된 문자열을 `File`로 순회하고 명시적인 task logger만
+  사용한다. 실행 action 안에서 Gradle `Project`나 script receiver를 다시
+  조회하지 않는다.
+- production source가 하나도 없을 때 실패하는 기존 규칙과 모듈별 진단
+  로그 형식은 유지한다.
+
+## 검증
+
+정적 guard 계약 회귀 테스트와 실제 Gradle 명령을 함께 실행한다.
+
+- `./gradlew detekt --no-daemon --console=plain`
+- `./gradlew detekt --no-configuration-cache --no-daemon --console=plain`
+- `./gradlew detektProductionSourceGuard --no-daemon --console=plain`
+- `./gradlew detektProductionSourceGuard --no-configuration-cache --no-daemon --console=plain`
+
+두 Detekt 명령과 두 guard 명령은 `BUILD SUCCESSFUL`이며, 기본 Detekt 실행은
+configuration cache 재사용까지 확인했다. 최신 develop에 이미 반영된
+diagnostics probe의 기존 예외 전파 테스트도 함께 통과해 이번 build guard
+수정이 core 동작을 건드리지 않음을 확인했다.
+
+## 재발 방지
+
+새로운 Gradle task action은 구성 단계의 `Project` 객체를 캡처하지 않고,
+입력 프로퍼티와 task receiver를 통해서만 실행 데이터를 읽는다. 기본 명령과
+`--no-configuration-cache` 명령을 모두 정기적으로 실행해 CI의 비구성 캐시
+경로가 기본 configuration-cache 회귀를 가리지 않도록 한다.

--- a/scripts/ci/validate_detekt_configuration_cache.py
+++ b/scripts/ci/validate_detekt_configuration_cache.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Detekt production-source guard의 configuration-cache 계약을 검증한다."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+GUARD_MARKER = "val detektProductionSourceGuard = tasks.register"
+FORBIDDEN_ACTION_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\bsubprojects\b"), "subprojects 참조"),
+    (re.compile(r"\brootProject\b"), "rootProject 참조"),
+    (re.compile(r"\.fileTree\s*\("), "Project.fileTree 호출"),
+    (re.compile(r"\b(?:subproject|project)\.file\s*\("), "Project.file 호출"),
+)
+
+
+def _guard_action(source: str) -> str:
+    guard_start = source.find(GUARD_MARKER)
+    if guard_start < 0:
+        raise ValueError(f"{GUARD_MARKER!r}를 찾을 수 없습니다")
+
+    action_start = source.find("doLast {", guard_start)
+    if action_start < 0:
+        raise ValueError("detektProductionSourceGuard의 doLast를 찾을 수 없습니다")
+
+    action_end = source.find("gradle.projectsEvaluated", action_start)
+    if action_end < 0:
+        raise ValueError("detektProductionSourceGuard의 doLast 경계를 찾을 수 없습니다")
+    return source[action_start:action_end]
+
+
+def validate_source(root: Path) -> list[str]:
+    path = root.resolve() / "build.gradle.kts"
+    if path.is_symlink() or not path.is_file():
+        return [f"{path}: build.gradle.kts가 없습니다"]
+
+    source = path.read_text(encoding="utf-8")
+    try:
+        action = _guard_action(source)
+    except ValueError as error:
+        return [f"{path}: {error}"]
+
+    violations = [
+        f"{path}: Detekt guard doLast에서 {description}을 제거하십시오"
+        for pattern, description in FORBIDDEN_ACTION_PATTERNS
+        if pattern.search(action)
+    ]
+    if "doLast { task ->" not in action and "val task = this" not in action:
+        violations.append(f"{path}: doLast는 task receiver를 명시적으로 받아야 합니다")
+    if "task.logger.lifecycle(" not in action:
+        violations.append(f"{path}: 실행 로깅은 task.logger를 사용해야 합니다")
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[2])
+    args = parser.parse_args()
+    violations = validate_source(args.root)
+    if violations:
+        for violation in violations:
+            print(f"::error::{violation}")
+        return 1
+    print("Detekt configuration-cache guard contract OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/validate_detekt_configuration_cache_test.py
+++ b/scripts/ci/validate_detekt_configuration_cache_test.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Detekt configuration-cache guard 계약 테스트."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from validate_detekt_configuration_cache import validate_source
+
+
+class DetektConfigurationCacheContractTest(unittest.TestCase):
+    def test_current_guard_is_execution_safe(self) -> None:
+        violations = validate_source(Path(__file__).resolve().parents[2])
+
+        self.assertEqual(violations, [])
+
+    def test_rejects_gradle_project_capture_inside_task_action(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "build.gradle.kts").write_text(
+                """
+                val detektProductionSourceGuard = tasks.register("detektProductionSourceGuard") {
+                    doLast {
+                        val files = subprojects.flatMap { it.fileTree(rootProject.file("src")) }
+                        logger.lifecycle(files.toString())
+                    }
+                }
+
+                gradle.projectsEvaluated {
+                }
+                """,
+                encoding="utf-8",
+            )
+
+            violations = validate_source(root)
+
+            self.assertEqual(len(violations), 5)
+            self.assertTrue(any("subprojects" in violation for violation in violations))
+            self.assertTrue(any("rootProject" in violation for violation in violations))
+            self.assertTrue(any("Project.fileTree" in violation for violation in violations))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #703

Issue #702에서 중복 보고된 기본 Detekt configuration-cache 실패를 해결합니다. `detektProductionSourceGuard`가 구성 단계에서 계산한 불변 source root만 실행 단계로 전달하도록 경계를 고정해 기본 `./gradlew detekt`와 기존 source guard를 함께 유지합니다.

## Background

기본 `./gradlew detekt --no-daemon --console=plain`이 `detektProductionSourceGuard` 실행 시 Gradle script receiver와 `subprojects`를 캡처해 configuration cache 저장·복원 단계에서 실패했습니다. `--no-configuration-cache` 통과는 증상을 숨기는 진단 경로일 뿐 기본 CI 계약을 충족하지 못했습니다.

## What This Solves

- 기본 configuration-cache 경로에서 `detektProductionSourceGuard`가 안정적으로 실행됩니다.
- production source가 없을 때 실패하는 기존 guard와 모듈별 source-count 진단 로그를 유지합니다.
- 동일한 Gradle Project/script receiver 캡처가 재발하지 않도록 CI 정적 계약과 음성 fixture를 추가합니다.

## Work Done

- `build.gradle.kts`: 구성 단계에서 source root 절대 경로를 계산하고 task input으로 선언했으며, `doLast`는 캡처된 경로와 명시적 task logger만 사용합니다.
- `.github/workflows/ci.yml`: 기존 `ci-contract`에 Detekt configuration-cache validator와 테스트를 연결했습니다.
- `scripts/ci/validate_detekt_configuration_cache.py` 및 `_test.py`: Project receiver 캡처 금지 규칙과 회귀 fixture를 추가했습니다.
- `docs/lessons/2026-08-27-issue-703-detekt-configuration-cache.md`: 원인, 경계 규칙, 검증 및 재발 방지 지침을 기록했습니다.

## Validation

- 구현 전 validator fixture: FAIL (guard의 `subprojects`/`rootProject`/Project file API/암시적 logger receiver를 의도대로 검출)
- `python3 scripts/ci/validate_detekt_configuration_cache.py`: PASS
- `python3 scripts/ci/validate_detekt_configuration_cache_test.py`: PASS (2/2)
- `./gradlew detekt --no-daemon --console=plain`: PASS (`BUILD SUCCESSFUL`, configuration cache reused)
- `./gradlew detekt --no-configuration-cache --no-daemon --console=plain`: PASS
- `./gradlew detektProductionSourceGuard` 및 `--no-configuration-cache`: PASS
- `./gradlew :bluetape4k-leader-core:test --no-configuration-cache --no-daemon --console=plain`: PASS (953 tests, failures/errors/skips 0)
- `./gradlew :bluetape4k-leader-core:test --tests '*LeaderBackendDiagnosticsProbeTest' --no-daemon --console=plain`: PASS (10/10)
- CI fan-out/matrix/assertion/timing validators 및 `actionlint .github/workflows/ci.yml`: PASS
- `git diff --check`: PASS
- exact-head hosted CI run `33087410229`: PASS (47/47 jobs success, failures/skips 0)

## Review Notes

- P0/P1: 0
- P2/P3: 없음
- 독립 code-reviewer: APPROVE. configuration-cache 경계, 기존 guard 계약, CI validator와 테스트를 검토했으며 차단 이슈가 없습니다.
- LSP diagnostics: leaf runtime에서 사용할 수 없어 Gradle/actionlint 및 테스트 증적으로 대체했습니다.
- GitHub reviews/comments/threads: 0; 단일 개발자 human-review subgate는 N/A

## Metadata

- Issue: #703 (duplicate report: #702), milestone `1.0.0`, assignee `debop`; #703 `CLOSED`, #702 remains `OPEN` as the duplicate tracking issue
- PR: #818 `MERGED`, rebase merge `841461565ba5179b9bf1278a89c18c7c925925fa`; head `fix/issue-703-detekt-configuration-cache` at `7ea2b87316b99a0885a54a6321cb310317163212`; canonical `develop` at `841461565ba5179b9bf1278a89c18c7c925925fa` (pre-merge base `86d40f4f8cd7f018e536ad54fb8aa03a222ca45d`)
- Labels: `bug`, `ci`, `maintenance`, `build`
- CI: https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33087410229 (exact head 47/47 success)
- GNO: canonical `gno update` added the lesson to `bluetape4k-docs`; `gno embed --collection bluetape4k-docs` embedded 215 chunks and representative search returned the lesson path
- Cleanup: integrated feature worktree removed; local and remote feature refs retained; unrelated worktrees preserved

## DoD Status

Required checks: 18/18; N/A: 1; Blocked: 0; Pending: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01~CG-05 | guidance, issue, worktree, policy, ecosystem pattern 확인 | PASS | 현재 guidance hash, live issue #702/#703, 격리 worktree, 승인된 Type C 범위 | none |
| CG-06 | reusable lesson 작성·index 시도 | PASS | `docs/lessons/2026-08-27-issue-703-detekt-configuration-cache.md`, canonical GNO update/embed/search 완료 | none |
| CG-07~CG-08 | root cause 및 RED/GREEN 회귀 증적 | PASS | 구현 전 validator FAIL, 수정 후 validator/Gradle 두 경로 PASS | none |
| CG-09~CG-10 | diff·commit·독립 리뷰 수렴 | PASS | commit `7ea2b87316b99a0885a54a6321cb310317163212`, reviewer APPROVE, P0/P1=0 | none |
| CG-11~CG-12 | PR authority와 exact head publish | PASS | 승인된 repository/base/head와 remote branch SHA 일치 | none |
| CG-12A | PR 직전 guidance/issue/template refresh | PASS | 최신 guidance·issue·PR template 재확인 | none |
| CG-13 | PR 생성 및 live metadata/body 검증 | PASS | PR #818, base/head SHA, labels, milestone, assignee, body 마지막 `## DoD Status` read-back | none |
| CG-14 | exact-head CI와 review/thread read-back | PASS | run `33087410229`: 47/47 success; reviews/comments/threads 0; 독립 reviewer APPROVE; human-review subgate N/A | none |
| CG-15 | merge-ready report | PASS | exact head `7ea2b87316b99a0885a54a6321cb310317163212`, base `develop@86d40f4f`, `MERGEABLE/CLEAN`, P0/P1=0 | none |
| CG-16 | fresh merge approval | PASS | 사용자가 exact PR/head에 대해 별도 승인을 제공하고 승인 직전 live read-back을 통과함 | none |
| CG-17 | merge verification | PASS | PR #818 `MERGED`; rebase merge SHA `841461565ba5179b9bf1278a89c18c7c925925fa`; head/base/metadata live read-back exact | none |
| CG-18 | canonical sync/cleanup | PASS | canonical `develop`과 `origin/develop`이 `841461565ba5179b9bf1278a89c18c7c925925fa`로 일치; `git cherry` 통합 증명; GNO update/embed/search 완료; feature worktree만 제거하고 refs 보존 | none |

Final status: DONE — exact-head CI/review, fresh-approved rebase merge, issue #703 closeout, canonical sync, GNO 재색인, cleanup boundary를 모두 검증했습니다.

Unchecked required items: none
