### PR TITLE
[OBS-01] UNKNOWN 원인 reason 계약 추가

### DIFF
--- a/docs/superpowers/plans/2026-08-28-issue-774-observability-plan.md
+++ b/docs/superpowers/plans/2026-08-28-issue-774-observability-plan.md
@@ -1,0 +1,465 @@
+# Issue #774 diagnostics observability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `test-driven-development` and
+> `bluetape-kotlin-patterns` while implementing each task. Follow the task order,
+> keep the child PRs independently verifiable, and record the exact validation
+> output before moving to the next child.
+
+**Goal:** Issue #774의 `UNKNOWN` 원인 신호, backend connectivity 관측성,
+readiness/health/Ktor 해석 규칙을 기존 #766 diagnostics 계약 위에 additive하게
+구현한다. 기존 `UP`, `DOWN`, `UNKNOWN`, `NOT_CHECKED` 상태와 custom provider의
+예외 소유권은 유지하고, 민감정보 없는 저카디널리티 reason만 추가한다.
+
+**Architecture:** `leader-core`가 상태와 reason 불변식, bounded probe 예외 경계,
+기본 provider의 unsupported 의미를 소유한다. `leader-micrometer`는 기존
+instrumented elector의 `MeterRegistry`와 backend-name sanitizer를 재사용하는
+private provider decorator로 active probe 결과만 counter에 기록한다. Spring
+health와 Ktor route는 같은 core 결과를 소비하되 readiness, transport status,
+애플리케이션 pipeline 예외를 서로 합치지 않는다. 문서는 release-pinned manual을
+건드리지 않고 EN/KO draft와 README에 같은 상태 표와 운영 runbook을 기록한다.
+
+**Tech Stack:** Kotlin/JVM, Kotlin `Duration`, Micrometer, Spring Boot Actuator,
+Ktor 3.x, JUnit 5, `io.bluetape4k.assertions`, `MultithreadingTester`, Gradle
+version catalog, `checkBinaryCompatibility`, Kotlin consumer compile, `jar tf`,
+`javap`, repository manual validators.
+
+## 0. 고정 전제와 범위
+
+1. 작업 기준은 `origin/develop`의 작업 시작 시점 SHA이며, 각 child 생성 직전
+   live `origin/develop`와 직전 child의 exact merge head를 다시 읽는다.
+2. PR train 순서는 `OBS-01 -> OBS-02 -> OBS-03 -> OBS-04`다. 다음 child는 직전
+   child가 rebase merge된 commit을 base로 하며, squash merge는 사용하지 않는다.
+3. #766의 helper 도입, provider migration, adapter regression, ABI baseline,
+   consumer compile, packaging 검증을 다시 설계하지 않는다. 새 reason field가
+   실제 public descriptor에 포함되는 child에서 compatibility 검증만 비례하여
+   재실행한다.
+4. 현재 Hazelcast/ZooKeeper처럼 legacy 수동 경계를 가진 provider는 이번
+   train에서 timeout/cancellation 경계를 재작성하지 않는다. 기존 status와
+   `LeaderBackendConnectivity` factory의 기본 reason을 유지하고, migration은
+   별도 이슈로 남긴다.
+5. 새 backend I/O, lock 획득·해제, lease mutation, retry, background polling,
+   executor, dependency, global observer registry를 추가하지 않는다.
+6. 공개 문장(KDoc, README, manual, issue/PR, commit)은 한국어로 작성하고,
+   Kotlin API·enum·명령·URL·metric name은 정확한 원문을 보존한다.
+7. 테스트 예외 검증은 `io.bluetape4k.assertions.assertFailsWith`만 사용한다.
+   JUnit `assertThrows`, `kotlin.test.assertFailsWith`, `shouldThrow`를 새로
+   추가하지 않는다. `!!`와 삼킨 cancellation도 추가하지 않는다.
+8. 1인 개발자 환경이므로 독립 리뷰 lane은 N/A다. 각 child의 7-Tier
+   self-review, source-to-claim read-back, targeted test, exact-head CI가 그
+   증거를 대신한다.
+
+## 1. Acceptance traceability
+
+| 설계 수용 기준 | 계획 task | 검증 증거 |
+| --- | --- | --- |
+| 상태와 reason 조합이 bounded하고 `NOT_CHECKED`가 오염되지 않음 | 2.1 | core invariant 테스트와 public constructor/copy 확인 |
+| 일반 `Exception`만 `PROVIDER_EXCEPTION`으로 정규화되고 cancellation/interruption/`Error`는 재전파 | 2.2 | probe exception matrix, interrupt flag 및 동일 인스턴스 검증 |
+| 기본 provider는 unsupported, helper-backed provider는 unconfirmed를 표현 | 2.3 | provider default/helper callback 테스트; legacy provider migration 제외 증거 |
+| 세 instrumented wrapper가 active diagnostics를 한 번 계측하고 passive는 계측하지 않음 | 3.1 | `SimpleMeterRegistry` count/tag/cardinality 테스트와 concurrent first-use 회귀 |
+| Spring health가 bounded reason detail을 제공하고 기존 status/warning을 보존 | 3.2 | `LeaderBackendHealthIndicatorTest` status/exception/detail matrix |
+| Ktor JSON에 additive `reason`을 포함하고 HTTP/pipeline 경계를 유지 | 4.1 | exact JSON 및 custom exception `StatusPages` 경계 테스트 |
+| EN/KO 문서와 Prometheus 예제가 상태·운영 의미를 일치시킴 | 5.1 | locale parity, PromQL lint/read-back, release pin diff |
+| 각 child가 7-Tier와 공통 품질 gate를 통과 | 6.1 | targeted/module tests, detekt, ABI/consumer/packaging, CI exact head |
+
+## 2. OBS-01 — core reason contract
+
+### 2.1 RED 테스트와 파일 소유
+
+**소유 파일:**
+
+- Modify: `leader-core/src/main/kotlin/io/bluetape4k/leader/diagnostics/LeaderBackendDiagnostics.kt`
+- Modify: `leader-core/src/main/kotlin/io/bluetape4k/leader/diagnostics/LeaderBackendDiagnosticsProbe.kt`
+- Modify: `leader-core/src/main/kotlin/io/bluetape4k/leader/diagnostics/LocalLeaderBackendDiagnostics.kt` only when the additive reason call is required
+- Modify: existing helper-backed provider source only for named reason arguments; do not change its timeout or cancellation algorithm
+- Modify/Create: `leader-core/src/test/kotlin/io/bluetape4k/leader/diagnostics/LeaderBackendDiagnosticsTest.kt`
+- Modify: `leader-core/src/test/kotlin/io/bluetape4k/leader/diagnostics/LeaderBackendDiagnosticsProbeTest.kt`
+- Modify: provider tests only where their public result gains an asserted default reason
+
+먼저 다음 RED 사례를 기존 source에 추가한다.
+
+1. `UP`, `DOWN`, `UNKNOWN`, `NOT_CHECKED` factory 결과가 각각
+   `CONNECTED`, `DISCONNECTED`, `CLIENT_STATE_UNCONFIRMED`, `NOT_CHECKED`를
+   갖는지 검증한다.
+2. `NOT_CHECKED`에 checked time, latency, 또는 다른 reason을 넣으면 실패하고,
+   checked status에 null `checkedAt` 또는 `NOT_CHECKED` reason을 넣으면 실패하는
+   불변식을 검증한다.
+3. probe callback이 일반 `IllegalStateException`을 던지면 결과 status는
+   `UNKNOWN`, reason은 `PROVIDER_EXCEPTION`이고 raw message/class가 모델에
+   저장되지 않는지 검증한다.
+4. callback이 `UNKNOWN`을 반환하면 기본 reason은
+   `CLIENT_STATE_UNCONFIRMED`이며, 명시한 `unknownReason`은 해당 callback에만
+   적용되는지 검증한다.
+5. `unknownReason = NOT_CHECKED`, 음수/무한 timeout은 즉시 실패하고 callback과
+   clock이 호출되지 않는지 검증한다.
+6. `CancellationException`, `InterruptedException`, `Error`가 동일 인스턴스로
+   재전파되고 interruption flag가 복원되는지 기존 #766 matrix로 고정한다.
+7. 기본 `LeaderBackendDiagnosticsProvider.checkConnectivity`가
+   `PROVIDER_UNSUPPORTED`를 반환하고, helper-backed built-in provider가
+   client state를 증명하지 못할 때 `CLIENT_STATE_UNCONFIRMED`를 반환하는지
+   검증한다. legacy 수동 provider는 status와 factory 기본값만 검증한다.
+
+실행하여 RED 증거를 기록한다.
+
+```bash
+./gradlew :bluetape4k-leader-core:test --tests '*LeaderBackendDiagnosticsTest' \
+  --tests '*LeaderBackendDiagnosticsProbeTest' --no-configuration-cache --console=plain
+```
+
+### 2.2 최소 구현
+
+`LeaderBackendConnectivityReason`을 `leader-core` diagnostics package에
+추가한다. enum vocabulary는 다음 여섯 값으로 고정한다.
+
+```kotlin
+NOT_CHECKED,
+CONNECTED,
+DISCONNECTED,
+PROVIDER_UNSUPPORTED,
+PROVIDER_EXCEPTION,
+CLIENT_STATE_UNCONFIRMED,
+```
+
+`LeaderBackendConnectivity`에는 기존 세 property 뒤에 trailing
+`reason`을 추가한다. Kotlin source compatibility를 위해 status에 맞는
+기본값을 사용하고, JVM 호출자는 기존 생성 descriptor를 유지할 수 있도록
+명시적 compatibility constructor/copy overload를 검토한다. data class의
+`equals`, `hashCode`, `toString`, serialization 영향과 public constructor는
+`javap`로 확인한다.
+
+factory 계약은 다음과 같다.
+
+- `notChecked()`는 `NOT_CHECKED` status/reason과 null time/latency만 반환한다.
+- `up()`은 `CONNECTED`, `down()`은 `DISCONNECTED`, `unknown()`은
+  `CLIENT_STATE_UNCONFIRMED`를 기본값으로 사용한다.
+- 명시적인 reason overload가 필요하면 status와 reason의 불일치를
+  `require`로 차단하고, raw exception이나 endpoint를 받지 않는다.
+
+`LeaderBackendDiagnosticsProbe.check`에는 trailing optional
+`unknownReason`을 추가한다. timeout 검증, 단일 clock read, callback 호출 순서,
+cancellation/interruption/`Error` 경계는 기존 구현과 동일하게 둔다. 일반
+`Exception` catch에서 반환하는 결과만 `PROVIDER_EXCEPTION`으로 바꾼다.
+`NOT_CHECKED` callback은 계속 `IllegalArgumentException`으로 거절한다.
+
+기본 provider는 `unknownReason = PROVIDER_UNSUPPORTED`를 전달한다. 이미
+helper-backed인 Local/Mongo/Lettuce/Redisson provider는 callback의 client
+state 미확정을 `CLIENT_STATE_UNCONFIRMED`로 명시한다. Hazelcast/ZooKeeper의
+legacy 수동 timeout/catch 구조는 이 child에서 재작성하지 않으며, 필요한 경우
+factory 기본값으로만 additive 결과를 얻는다.
+
+### 2.3 GREEN 및 core 품질 확인
+
+```bash
+./gradlew :bluetape4k-leader-core:test --tests '*LeaderBackendDiagnosticsTest' \
+  --tests '*LeaderBackendDiagnosticsProbeTest' --no-configuration-cache --console=plain
+./gradlew :bluetape4k-leader-core:detekt --no-configuration-cache --console=plain
+./gradlew :bluetape4k-leader-core:jar --no-configuration-cache --console=plain
+jar tf leader-core/build/libs/*.jar | rg 'LeaderBackendDiagnostics(Probe)?|LeaderBackendConnectivityReason'
+javap -classpath leader-core/build/libs/*.jar \
+  io.bluetape4k.leader.diagnostics.LeaderBackendConnectivity \
+  io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProbe
+```
+
+Kotlin consumer compile fixture가 있다면 새 field를 읽는 consumer와 기존 세
+argument factory 호출을 모두 compile한다. 없으면 기존 `leader-core` test
+source와 `checkBinaryCompatibility` 결과를 대체 증거로 기록하고, child PR에서
+누락을 명시한다. `git diff --check`와 raw assertion 금지 scan도 통과해야 한다.
+
+### 2.4 OBS-01 self-review와 commit
+
+7-Tier 순서로 입력 검증·API/ABI·상태 불변식·예외/취소·동시성·성능/보안·운영
+호환성을 source와 test에 대조한다. 특히 `PROVIDER_EXCEPTION`은 reason enum만
+남기고 로그/metric에 예외 원문을 복사하지 않는지 확인한다. Lore commit에는
+정확한 테스트와 미실행 CI를 기록한다.
+
+## 3. OBS-02 — Micrometer active diagnostics와 Spring detail
+
+### 3.1 RED 테스트와 구현
+
+**소유 파일:**
+
+- Modify: `leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerNames.kt`
+- Modify: `leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/InstrumentedLeaderElectors.kt`
+- Modify: `leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/InstrumentedLeaderElectorsTest.kt`
+- Modify: `leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/observability/LeaderBackendHealthIndicator.kt`
+- Modify: `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/observability/LeaderBackendHealthIndicatorTest.kt`
+
+먼저 failing test로 다음을 고정한다.
+
+1. `leader.backend.connectivity` counter가 active
+   `checkConnectivity` 또는 `diagnostics(probe = true)`마다 정확히 한 번
+   증가한다.
+2. passive `diagnostics()`는 counter를 만들거나 증가시키지 않는다.
+3. `backend.name`, `status`, `reason` 세 tag만 사용하고 backend name은
+   기존 `LeaderMetricTagSanitizer`를 통과한다. exception class/message,
+   endpoint, credential, lock name은 tag에 나타나지 않는다.
+4. 결과가 `UP`, `DOWN`, `UNKNOWN`, `NOT_CHECKED`인 경우 reason과 함께
+   기록되고, custom provider의 일반 exception은 `PROVIDER_EXCEPTION`으로
+   기록한 뒤 원래 exception을 호출자에게 전파한다. `CancellationException`,
+   `InterruptedException`, `Error`도 기존 경계를 유지한다.
+5. blocking, group, suspend instrumented wrapper 모두 같은 decorator를
+   사용하며 provider null 보존과 concurrent first-use meter registration을
+   검증한다.
+6. Spring health detail에 `reason`이 bounded enum name으로 포함되고 기존
+   `UP`/`DOWN`/`UNKNOWN`/`NOT_CHECKED` status와 warning이 유지된다. provider
+   호출 예외에는 raw message가 detail에 들어가지 않는다.
+
+### 3.2 최소 구현
+
+`MicrometerNames`에 counter와 tag key 상수를 추가한다. provider decorator는
+`LeaderBackendDiagnosticsProvider`를 구현하고 다음 규칙을 지킨다.
+
+- `backendDescriptor`는 delegate 그대로 반환한다.
+- `checkConnectivity(timeout)`는 delegate 호출을 `try/finally`로 감싸되,
+  성공 결과에서 status/reason을 읽어 한 번 기록한다.
+- 일반 exception은 `PROVIDER_EXCEPTION`을 기록할 수 있도록 safe fallback을
+  사용하되 delegate가 소유한 예외를 숨기지 않는다. cancellation/interruption/
+  `Error`에는 새로운 catch를 추가하지 않는다.
+- `diagnostics(probe = false)`는 그대로 위임하고 기록하지 않는다.
+- `diagnostics(probe = true)`는 결과의 connectivity를 한 번 기록한다.
+  provider가 custom override에서 예외를 던지는 경우에도 결과를 바꾸지 않는다.
+- backend name은 `LeaderMetricTagOptions.TAG_BACKEND_NAME`을 사용한 기존
+  sanitizer 결과만 metric tag로 사용한다.
+
+세 instrumented class의 `backendDiagnosticsProvider` getter는 delegate
+provider를 decorator로 감싸되 이미 decorator인 provider를 중복 계측하지
+않는다. 각 wrapper의 기존 `LeaderBackendDiagnosticsAware`와 lease/audit
+capability forwarding은 보존한다.
+
+Spring `LeaderBackendHealthIndicator`는 성공한 diagnostics의 reason을
+`withDetail("reason", connectivity.reason.name)`으로 추가한다. null 결과와
+기존 warning/status 분기는 유지한다. reason 외에 exception 원문이나 provider
+payload는 detail에 넣지 않는다.
+
+### 3.3 GREEN 및 Micrometer/Spring 품질 확인
+
+```bash
+./gradlew :bluetape4k-leader-micrometer:test --tests '*InstrumentedLeaderElectorsTest' \
+  --no-configuration-cache --console=plain
+./gradlew :bluetape4k-leader-spring-boot:test --tests '*LeaderBackendHealthIndicatorTest' \
+  --no-configuration-cache --console=plain
+./gradlew :bluetape4k-leader-micrometer:detekt :bluetape4k-leader-spring-boot:detekt \
+  --no-configuration-cache --console=plain
+```
+
+`SimpleMeterRegistry`에서 unique meter 수와 tag set을 직접 읽고, count가
+background scheduler 없이 active 호출 수와 일치하는지 확인한다. Spring
+`ApplicationContextRunner` 또는 기존 indicator fixture를 사용해 auto-config
+기본값과 disabled path를 회귀시킨다. OBS-01 exact head를 dependency로
+사용하는 Kotlin consumer compile 및 `jar tf`/`javap`를 다시 실행한다.
+
+### 3.4 OBS-02 self-review와 commit
+
+metric cardinality, exception disclosure, wrapper parity, coroutine cancellation,
+passive/active 구분을 7-Tier로 확인한다. `leader.backend.connectivity`가
+기존 leader election meter와 이름·tag 충돌을 일으키지 않는지 registry dump로
+확인하고, PR body에 active/passive 증거와 N/A 독립 리뷰를 기록한다.
+
+## 4. OBS-03 — Ktor JSON과 adapter 경계
+
+### 4.1 RED 테스트와 구현
+
+**소유 파일:**
+
+- Modify: `leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderBackendDiagnosticsRoute.kt`
+- Modify: `leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/LeaderBackendDiagnosticsRouteTest.kt`
+- Modify only if required by serialization tests: `leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderJsonSupport.kt`
+
+RED 테스트는 다음을 확인한다.
+
+1. passive JSON에는 `connectivity.reason=NOT_CHECKED`가 있고 기존
+   descriptor/status/checkedAt/latencyMillis field가 그대로 있다.
+2. active `UP`, `DOWN`, `UNKNOWN` JSON에 각 bounded reason이 추가되고
+   field order 및 JSON escaping이 기존 test contract와 일치한다.
+3. active diagnostics 결과는 transport 성공 시 HTTP 200을 유지한다. payload의
+   `status`가 backend 의미를 소유하며, custom provider가 exception을 전파하면
+   application `StatusPages`/pipeline이 HTTP status를 결정한다.
+4. route가 `Dispatchers.IO`에서 실행되는 기존 경계를 보존하고, cancellation과
+   `Error`를 route가 임의의 JSON 오류로 바꾸지 않는다.
+
+`appendConnectivity`에 `reason`을 기존 connectivity field와 함께 additive하게
+직렬화한다. HTTP status, path validation, application-owned exception handling,
+provider timeout/deadline semantics는 변경하지 않는다. strict JSON consumer의
+호환성 위험은 docs에 기록하고 field 제거·rename은 하지 않는다.
+
+### 4.2 GREEN 및 route 품질 확인
+
+```bash
+./gradlew :bluetape4k-leader-ktor:test --tests '*LeaderBackendDiagnosticsRouteTest' \
+  --no-configuration-cache --console=plain
+./gradlew :bluetape4k-leader-ktor:detekt :bluetape4k-leader-ktor:jar \
+  --no-configuration-cache --console=plain
+```
+
+Ktor test application에서 built-in-like provider, custom provider, exception
+provider를 각각 요청하고 response body·HTTP status·application exception을
+읽는다. `reason` 외 데이터에 raw exception/endpoint/credential/lock name이
+없는지 fixture scan을 수행한다. OBS-01/02 API descriptor 및 consumer compile을
+재확인한다.
+
+### 4.3 OBS-03 self-review와 commit
+
+adapter parity를 core/direct, Ktor, Spring 표에 대조하고 readiness signal과
+transport result를 합치지 않는다. route JSON additive compatibility와
+pipeline ownership을 7-Tier self-review 기록에 남긴다.
+
+## 5. OBS-04 — README, manual draft, Prometheus runbook
+
+### 5.1 문서 소유 파일
+
+- Modify: `README.md`, `README.ko.md`
+- Modify: `leader-core/README.md`, `leader-core/README.ko.md`
+- Modify: `leader-micrometer/README.md`, `leader-micrometer/README.ko.md`
+- Modify: `leader-spring-boot/README.md`, `leader-spring-boot/README.ko.md`
+- Modify: `leader-ktor/README.md`, `leader-ktor/README.ko.md`
+- Modify: `examples/prometheus-dashboard/README.md`, `examples/prometheus-dashboard/README.ko.md`
+- Modify: `examples/prometheus-dashboard/provisioning/prometheus/rules/leader-alerts.yml`
+- Modify: `examples/prometheus-dashboard/src/test/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusAssetsTest.kt`
+- Create: `docs/manual/drafts/2026-08-28-issue-774-observability.en.md`
+- Create: `docs/manual/drafts/2026-08-28-issue-774-observability.ko.md`
+- Do not modify: `docs/manual/manifest.yaml`, `docs/manual/generated/manifest.json`
+
+각 EN/KO 문서는 같은 source claim을 설명한다.
+
+1. 상태 표에서 `UP`, `DOWN`, `UNKNOWN`, `NOT_CHECKED`와 six reason vocabulary,
+   ownership/readiness의 분리를 설명한다.
+2. `leader.backend.connectivity`의 세 low-cardinality tag와 passive 미계측,
+   backend-name sanitizer, raw exception/endpoint/credential 금지를 설명한다.
+3. Spring health의 `reason` detail, Ktor HTTP 200 payload와 application-owned
+   pipeline exception을 구분한다.
+4. provider-native timeout은 wall-clock deadline이 아니며, 지연·반복
+   `UNKNOWN` 시 active probe bypass, sampling 완화, client/backend 확인,
+   rollback(기능 flag 비활성화) 순서를 runbook으로 기록한다.
+5. `UNKNOWN`을 자동 `DOWN`이나 page로 승격하지 않고,
+   `DOWN`/`PROVIDER_EXCEPTION` 지속 조건과 기존 AOP backend error를 함께
+   관찰하는 Prometheus alert를 제시한다. lease-extension metric을 새로
+   발명하지 않는다.
+6. #766 built-in/custom provider 해석과 legacy provider migration 범위를
+   명시한다. release-pinned manual은 새 API가 release에 포함된 뒤 별도 gate에서
+   `releaseRef`/`releaseCommit`을 갱신한다.
+
+Prometheus rule은 실제 metric vocabulary만 사용하고 `for` 지속 조건, bounded
+  labels, no-page 또는 warning 정책을 테스트 가능한 형태로 고정한다. 기존
+  alert와 이름 충돌을 피하고 예제 테스트에서 YAML key, expression, docs link를
+  읽어 검증한다.
+
+### 5.2 Writer 및 문서 검증
+
+```bash
+git diff --check
+node /Users/debop/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs \
+  README.ko.md leader-core/README.ko.md leader-micrometer/README.ko.md \
+  leader-spring-boot/README.ko.md leader-ktor/README.ko.md \
+  examples/prometheus-dashboard/README.ko.md \
+  docs/manual/drafts/2026-08-28-issue-774-observability.ko.md
+./gradlew :examples:prometheus-dashboard:test --tests '*PrometheusAssetsTest' \
+  --no-configuration-cache --console=plain
+```
+
+문서 self-review에서 SPW-01~05와 KO-01~07을 source read-back으로 확인한다.
+EN/KO heading·표·명령·metric·release pin을 비교하고, placeholder와 stale
+`UNKNOWN` 단정 문장을 검색한다. `manifest.yaml` diff가 비어 있는지 별도로
+검증한다.
+
+## 6. Stacked PR train, 공통 gate, merge
+
+### 6.1 Child 순서와 base
+
+| 순서 | branch | base | PR 책임 |
+|---:|---|---|---|
+| 1 | `feat/issue-774-obs-01-core-reason` | live `origin/develop` | core reason/helper/provider additive contract |
+| 2 | `feat/issue-774-obs-02-micrometer-health` | OBS-01 exact merge head | Micrometer counter, wrappers, Spring detail |
+| 3 | `feat/issue-774-obs-03-ktor-reason` | OBS-02 exact merge head | Ktor JSON reason와 pipeline parity |
+| 4 | `feat/issue-774-obs-04-docs-runbook` | OBS-03 exact merge head | EN/KO docs, draft manual, Prometheus example |
+
+각 child에서 다음 순서를 지킨다.
+
+1. exact parent SHA, issue #774 상태, labels/milestone/assignee, working tree,
+   user-owned worktree/branch를 다시 읽는다.
+2. RED test와 source change를 같은 작은 commit 단위로 수행하고 각 commit은
+   Lore trailer를 포함한다.
+3. targeted test → module test → detekt → diff/terminology/ABI/consumer/
+   packaging 검증을 순서대로 수행한다. 실패 시 원인을 기록하고 다음 child로
+   진행하지 않는다.
+4. 7-Tier self-review와 PR body의 마지막 `## DoD Status`를 작성한다. PR body와
+   comments는 한국어로 작성하고 `Closes #774` 또는 approved linkage를 유지한다.
+5. PR 생성 후 live head, changed files, checks, review/thread, mergeability,
+   issue linkage, metadata를 읽어 train order를 확인한다.
+
+### 6.2 공통 검증 명령
+
+```bash
+./gradlew test --no-configuration-cache --console=plain
+./gradlew detekt --no-configuration-cache --console=plain
+./gradlew checkBinaryCompatibility --no-configuration-cache --console=plain
+git diff --check
+```
+
+전체 test가 비용·환경상 실행 불가하면 affected module tests와 실패 원인,
+대체 evidence를 명확히 기록한다. Testcontainers를 사용하는 backend test는
+Colima/docker context를 먼저 확인하고 healthy runtime을 재시작하지 않는다.
+skipped/path-filtered CI는 exact-head runtime proof로 세지 않는다.
+
+### 6.3 Merge와 canonical sync gate
+
+merge 직전에 fresh exact-head approval을 별도 gate로 둔다. 승인 전에는 merge나
+auto-merge를 실행하지 않는다. 승인 후에는 다음을 다시 확인한다.
+
+- PR head/base가 plan의 parent SHA와 일치한다.
+- required checks가 exact head에서 성공하고 skipped/N/A 이유가 기록되어 있다.
+- unresolved review/thread, merge conflict, stale issue linkage가 없다.
+- PR body 마지막이 `## DoD Status`이고 변경 파일·테스트·known gap이 최신이다.
+
+GitHub merge는 **rebase merge**로 실행한다. merge commit이 생긴 뒤 canonical
+`develop`을 fast-forward sync하고, checkout 변경이 있으면 path-scoped stash로
+보존한다. 통합이 증명된 이 작업의 worktree만 cleanup하며 user-owned worktree,
+branch, detached provenance ref는 삭제하지 않는다.
+
+## 7. 최종 DoD와 중단 조건
+
+완료 조건은 다음 모두다.
+
+1. OBS-01~04가 순서대로 merge되어 Issue #774와 연결되고, Epic/후속 issue의
+   live 상태가 실제 결과와 일치한다.
+2. core reason 불변식, 예외 경계, Micrometer active-only counter, Spring
+   detail, Ktor additive JSON, EN/KO runbook이 fresh test와 source read-back으로
+   증명된다.
+3. exact-head CI, affected tests, detekt, ABI/consumer/packaging,
+   terminology/diff/manual/example 검증 결과가 보존된다.
+4. `docs/manual/manifest.yaml`은 release train 전 unchanged이고, release 후
+   pin 갱신을 위한 별도 checklist가 남아 있다.
+5. canonical branch와 origin이 같은 SHA이며, cleanup은 proven integrated
+   owned target에 한정된다.
+
+다음 조건이면 해당 child에서 중단하고 `PENDING`으로 보고한다: exact-head
+   CI 미완료, public ABI/JSON 호환성 불명, provider exception/cancellation
+   경계 회귀, raw sensitive tag/detail 노출, 문서 source claim 불일치, 또는
+   user-owned worktree/branch와 scope 충돌. 이슈·PR 생성·merge·branch 삭제가
+   필요한데 authority가 없으면 해당 외부 side effect만 중단하고 로컬 검증을
+   계속한다.
+
+## 8. Plan self-review
+
+- 설계 문서의 모든 목표·대안·상태 표·metric 계약·timeout/runbook·compatibility·
+  stacked order·DoD가 task와 validation에 연결되어 있다.
+- #766 migration 재수행 금지와 legacy provider의 기본 reason 유지가 OBS-01,
+  acceptance, train scope에 반복해서 고정되어 있다.
+- `bluetape4k-assertions`, `bluetape-kotlin-patterns`, `MultithreadingTester`,
+  no-raw-exception-disclosure, no-new-dependency 규칙이 구현 task와 test gate에
+  명시되어 있다.
+- release pin을 변경하지 않는 manual 정책과 release 후 별도 gate가 문서 task와
+  final DoD에 명시되어 있다.
+- 다음 명령으로 plan 자체를 검증한다.
+
+```bash
+git diff --check
+node /Users/debop/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs \
+  docs/superpowers/plans/2026-08-28-issue-774-observability-plan.md
+placeholder_re='T(ODO|BD)|FIX(ME)|fill[[:space:]]+in|la(ter)'
+if rg -n -i "$placeholder_re" \
+  docs/superpowers/plans/2026-08-28-issue-774-observability-plan.md; then
+  exit 1
+fi
+```
+
+검증을 통과한 뒤 plan을 Lore commit으로 저장하고 OBS-01 worktree를 해당
+commit에서 생성한다.

--- a/docs/superpowers/specs/2026-08-28-issue-774-observability-design.md
+++ b/docs/superpowers/specs/2026-08-28-issue-774-observability-design.md
@@ -1,0 +1,310 @@
+# Issue #774 diagnostics 원인 신호와 readiness 정책 설계
+
+> 상태: Issue #774 구현 전 승인된 설계 초안
+>
+> 대상: `bluetape4k-leader`, Issue #774
+>
+> 작성일: 2026-08-28
+
+## 1. 문제와 목표
+
+Issue #766은 `LeaderBackendDiagnosticsProbe`를 추가해 bounded provider probe의
+timeout 검증, `checkedAt` 캡처, 일반 `Exception` 정규화, cancellation/interruption과
+fatal `Error` 경계를 고정했다. 현재 결과에는 네 가지 상태만 있어 운영자는
+`UNKNOWN`이 provider가 active probe를 지원하지 않아서 나온 것인지, client 상태를
+읽었지만 연결을 증명하지 못해서 나온 것인지, probe 예외가 정규화된 것인지
+구분할 수 없다. Spring health와 Ktor route도 이 상태를 서로 다른 transport
+경계에서 소비하지만, readiness와 alert 해석 규칙은 문서로 고정되어 있지 않다.
+
+이번 설계의 목표는 다음과 같다.
+
+1. `UNKNOWN`을 포함한 diagnostics 결과에 민감정보 없는 bounded 원인 코드를
+   추가한다.
+2. `UP`, `DOWN`, `UNKNOWN`, `NOT_CHECKED`의 direct/Ktor/Spring 의미를 하나의
+   표로 고정한다.
+3. active diagnostics 호출을 Micrometer 저카디널리티 counter로 기록하되,
+   자동 polling이나 lock/backend I/O를 새로 만들지 않는다.
+4. provider-native timeout이 호출 thread의 wall-clock deadline을 보장하지
+   않는다는 사실과 운영 우회·rollback 조건을 EN/KO 문서와 runbook에 기록한다.
+5. #766의 built-in/custom provider 및 direct/Ktor/Spring 경계를 운영자가
+   해석할 수 있게 연결한다.
+
+## 2. 현재 구현 근거와 범위 경계
+
+| 근거 | 현재 확인한 사실 | 이번 설계에서의 의미 |
+|---|---|---|
+| `leader-core/.../diagnostics/LeaderBackendDiagnostics.kt` | `LeaderBackendConnectivity`는 `UP`, `DOWN`, `UNKNOWN`, `NOT_CHECKED`를 표현하고 passive `diagnostics()`는 `NOT_CHECKED`를 반환한다. | 상태 이름과 passive 의미는 유지하고, 선택적 원인 코드만 추가한다. |
+| `leader-core/.../diagnostics/LeaderBackendDiagnosticsProbe.kt` | timeout은 양수·유한해야 하며 clock은 callback보다 먼저 읽는다. 일반 `Exception`만 `UNKNOWN`으로 정규화한다. | `PROVIDER_EXCEPTION`을 같은 경계에서 생성하고 cancellation/interruption/`Error`는 계속 재전파한다. |
+| `leader-spring-boot/.../LeaderBackendHealthIndicator.kt` | `UP -> UP`, `DOWN -> DOWN`, `UNKNOWN`/`NOT_CHECKED -> UNKNOWN`; provider 예외는 warning과 함께 `UNKNOWN`으로 처리한다. | health의 기존 fail-closed 매핑을 유지하고 bounded `reason` detail을 추가한다. |
+| `leader-spring-boot/.../LeaderElectionReadinessHealthIndicator.kt` | readiness는 등록된 lock의 JVM-local state와 lease expiry를 읽고 `UP`/`OUT_OF_SERVICE`/`DOWN`/`UNKNOWN`을 결정한다. | backend connectivity health와 lock-state readiness를 하나의 상태로 합치지 않는다. |
+| `leader-ktor/.../LeaderBackendDiagnosticsRoute.kt` | route는 기본적으로 passive JSON을 반환하고, active probe도 transport 성공 시 HTTP 200 payload로 반환한다. pipeline 예외의 status는 애플리케이션이 소유한다. | HTTP 200은 기준 상태 생성 성공을 뜻하고 payload의 `status`가 diagnostics 의미를 갖도록 문서화한다. |
+| `leader-micrometer/.../InstrumentedLeaderElectors.kt` | instrumented elector가 delegate의 diagnostics provider를 전달하지만 active diagnostics 호출을 계측하지 않는다. | provider decorator가 호출 결과를 보존하면서 active 호출마다 counter를 한 번 기록한다. |
+| `examples/prometheus-dashboard` | AOP/history/lease-risk 예제 alert와 lock-name redaction이 이미 존재한다. | 새 backend counter와 `UNKNOWN` 경보 기준을 기존 예제에 추가하되 lease-extension metric을 발명하지 않는다. |
+| `docs/manual/manifest.yaml` | versioned manual은 `releaseRef: 0.5.0`, `releaseCommit: 721a9a3808f67489d2bdb8177734325981c24977`에 고정되어 있다. | 새 API가 포함된 release train 전에는 manifest를 변경하지 않고 draft만 추가한다. |
+
+이번 이슈는 #766의 helper API, provider migration, adapter regression, ABI
+consumer compile, `jar tf`, `javap` 검증을 다시 설계하지 않는다. 새 reason field와
+Micrometer adapter는 additive API이므로 해당 검증은 새 API가 실제로 포함되는
+각 child PR에서 다시 실행한다. versioned manual의 release pin 갱신은 publish
+train이 끝난 뒤의 별도 gate로 남긴다.
+
+## 3. 대안과 선택
+
+### 대안 A — 상태 해석을 문서로만 추가
+
+기존 네 상태를 그대로 두고 `UNKNOWN`의 가능한 원인을 문서에서 설명한다.
+변경량은 작지만 direct/Ktor/Spring 결과에서 원인을 기계적으로 집계할 수
+없고, `PROVIDER_EXCEPTION`과 의도적인 unsupported 결과가 같은 series에
+섞인다. Issue #774의 저카디널리티 원인 신호 목표를 충족하지 못하므로
+채택하지 않는다.
+
+### 대안 B — `LeaderBackendConnectivity`에 bounded reason을 추가하고 기존
+Micrometer decorator에서 active 호출을 계측한다 (권장)
+
+`LeaderBackendConnectivityReason` enum을 `LeaderBackendConnectivity`에
+추가한다. reason은 `NOT_CHECKED`, `CONNECTED`, `DISCONNECTED`,
+`PROVIDER_UNSUPPORTED`, `PROVIDER_EXCEPTION`, `CLIENT_STATE_UNCONFIRMED`로
+제한한다. raw exception class/message, endpoint, credential, lock name은
+저장하지 않는다. `LeaderBackendDiagnosticsProbe.check`는
+`unknownReason` 선택 인자를 받아 provider가 의도적인 unsupported와
+상태 미확정을 구분하게 하고, callback 예외에는 항상
+`PROVIDER_EXCEPTION`을 사용한다.
+
+Micrometer의 `InstrumentedLeaderElector`, `InstrumentedLeaderGroupElector`,
+`InstrumentedSuspendLeaderElector`는 delegate provider를 private decorator로
+감싼다. decorator는 active `checkConnectivity`와
+`diagnostics(probe = true)` 호출을 각각 한 번 기록하며, passive
+`diagnostics()`는 기록하지 않는다. 기존 결과와 예외를 그대로 반환·전파하므로
+관측이 leader ownership이나 probe semantics를 바꾸지 않는다.
+
+이 선택은 core에 framework dependency를 넣지 않고, 기존 decorator가 이미
+보유한 `MeterRegistry`와 backend-name sanitizer를 재사용한다. JSON에는 bounded
+`reason`을 추가하되 기존 field를 제거하지 않는다.
+
+### 대안 C — core 전역 diagnostics observer registry 도입
+
+lease-extension observer와 비슷한 bounded asynchronous event registry를 새로
+도입하고 Micrometer/Spring이 이를 구독한다. 호출 경로를 모두 포괄할 수 있지만
+전역 lifecycle, dispatcher, drop counter, registration ABI가 추가된다. 현재
+Issue #774는 active diagnostics를 기존 decorator에서 계측하는 것으로 충분하며,
+새 전역 dispatch가 probe latency와 운영 surface를 넓히므로 채택하지 않는다.
+
+## 4. 권장 계약
+
+### 4.1 Reason 모델
+
+```kotlin
+enum class LeaderBackendConnectivityReason {
+    NOT_CHECKED,
+    CONNECTED,
+    DISCONNECTED,
+    PROVIDER_UNSUPPORTED,
+    PROVIDER_EXCEPTION,
+    CLIENT_STATE_UNCONFIRMED,
+}
+```
+
+`LeaderBackendConnectivity`는 기존 세 field 뒤에
+`reason: LeaderBackendConnectivityReason`를 추가한다. 기본값은 status에
+따라 결정해 기존 Kotlin 호출을 보존한다.
+
+| status | 기본 reason | 의미 |
+|---|---|---|
+| `NOT_CHECKED` | `NOT_CHECKED` | probe를 요청하지 않은 passive 기준 상태다. 정상 상태를 증명하지 않는다. |
+| `UP` | `CONNECTED` | provider가 연결 가능 상태를 확인했다. ownership이나 lease 획득을 증명하지 않는다. |
+| `DOWN` | `DISCONNECTED` | provider가 client/backend 연결 불가 상태를 확인했다. |
+| `UNKNOWN` | `CLIENT_STATE_UNCONFIRMED` | bounded read-only 검사만으로 연결을 확정하지 못했다. |
+| `UNKNOWN` (callback `Exception`) | `PROVIDER_EXCEPTION` | provider callback의 일반 예외를 안전하게 정규화했다. 예외 원문은 저장하지 않는다. |
+
+`LeaderBackendDiagnosticsProbe.check`는 다음 optional parameter를 제공한다.
+
+```kotlin
+public fun check(
+    timeout: Duration,
+    clock: Clock = Clock.systemUTC(),
+    unknownReason: LeaderBackendConnectivityReason =
+        LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED,
+    probe: (Duration) -> LeaderBackendConnectivityStatus,
+): LeaderBackendConnectivity
+```
+
+`unknownReason`은 `UNKNOWN` callback에만 적용하며 `NOT_CHECKED`일 수 없다.
+일반 `Exception`은 항상 `PROVIDER_EXCEPTION`으로 덮어쓴다. 기존
+`check(timeout, clock) { ... }` 호출은 default로 같은 동작을 얻는다.
+`LeaderBackendDiagnosticsProvider` 기본 구현은
+`unknownReason = PROVIDER_UNSUPPORTED`를 사용한다. built-in provider가
+client 상태를 읽지만 증명을 제공하지 못하는 경우에는
+`CLIENT_STATE_UNCONFIRMED`를 사용한다. OBS-01은 이 reason 계약을 기존
+provider 경계에 연결하되, #766에서 이미 확정한 helper 도입·timeout·취소
+전파 로직을 다시 마이그레이션하는 범위를 포함하지 않는다. 아직 legacy
+수동 경계를 가진 provider는 이번 child에서 reason 기본값만 유지하고,
+별도 provider migration 이슈로 추적한다.
+
+### 4.2 Micrometer metric 계약
+
+새 counter 이름은 `leader.backend.connectivity`로 고정한다. 한 번의 active
+probe 호출은 성공·실패·정규화 결과와 관계없이 하나의 counter 증가를 만든다.
+
+| tag | 허용 값 | cardinality/보호 규칙 |
+|---|---|---|
+| `backend.name` | descriptor의 backend ID | 기존 `LeaderMetricTagOptions.backendName` sanitizer를 사용한다. backend ID에 endpoint·credential·tenant를 넣지 않는다. |
+| `status` | `UP`, `DOWN`, `UNKNOWN`, `NOT_CHECKED` | enum 이름만 사용한다. passive 호출은 metric을 만들지 않는다. |
+| `reason` | 위 enum의 6개 reason | enum 이름만 사용한다. exception class/message와 raw payload는 금지한다. |
+
+tag 값은 Prometheus export에서 lowercase 또는 registry가 제공하는 이름
+변환 결과를 따르며, 소스 계약에서는 enum vocabulary를 기준으로 한다. 기본
+sampling은 active 호출 1회당 1회이며, background polling은 추가하지 않는다.
+고빈도 readiness polling이 필요한 애플리케이션은 외부 scheduler에서 호출
+주기를 제한해야 한다. decorator가 custom provider 예외를 관측할 때도
+`PROVIDER_EXCEPTION`만 기록하고 원래 예외를 다시 던진다. `Error`는 metric
+기록을 시도하지 않고 재전파하여 fatal 상태를 숨기지 않는다.
+
+### 4.3 Adapter 상태 매핑
+
+| source status | core/direct | Ktor diagnostics route | Spring backend health | readiness/alert 해석 |
+|---|---|---|---|---|
+| `UP` | checked connectivity | HTTP 200 JSON `status=UP` | `Status.UP` | backend connectivity는 정상으로 보되 ownership은 별도 확인한다. |
+| `DOWN` | checked failure | HTTP 200 JSON `status=DOWN` | `Status.DOWN` | 지속되면 backend 장애 경보다. 작업 재실행이나 강제 정리는 fencing 확인 뒤에 한다. |
+| `UNKNOWN` | 상태 미확정 또는 `PROVIDER_EXCEPTION` reason | HTTP 200 JSON `status=UNKNOWN` (pipeline 예외가 아닌 경우) | `Status.UNKNOWN`; provider 호출 예외는 기존 warning을 남긴다. | 자동으로 `UP`이나 `DOWN`으로 승격하지 않는다. reason별로 관찰하되 단독 page는 금지한다. |
+| `NOT_CHECKED` | passive 기준 상태 | HTTP 200 JSON `status=NOT_CHECKED` | active backend health에서는 `Status.UNKNOWN`; 정적 endpoint는 passive 결과를 그대로 반환한다. | readiness 통과나 정상 증거로 사용하지 않는다. active probe를 별도로 요청한다. |
+
+Ktor route의 HTTP 200은 diagnostics 기준 상태를 직렬화했다는 transport 결과다.
+본문의 `status`가 backend 의미를 담으며, custom provider가 예외를 전파하면
+`StatusPages` 등 application-owned pipeline이 HTTP status를 결정한다. library는
+custom provider의 HTTP 500을 강제로 바꾸지 않는다.
+
+`LeaderElectionReadinessHealthIndicator`는 lock state와 lease expiry를
+검사하는 별도 signal이다. backend health의 `DOWN`/`UNKNOWN`을 자동으로
+readiness에 합치지 않는다. 애플리케이션이 두 signal을 결합할 때는
+`NOT_CHECKED`를 정상으로 취급하지 않고, `UNKNOWN`은 보수적으로 유지한다.
+
+## 5. 운영 runbook과 실패 모드
+
+### 5.1 Provider-native timeout과 wall-clock deadline
+
+`timeout`은 provider callback에 전달하는 native budget이다. helper는 양수·유한
+값을 검증하고 같은 값을 전달하지만, callback이 이를 무시하거나 backend client가
+취소를 지원하지 않으면 호출 thread가 wall-clock deadline 안에 반환된다고
+보장하지 않는다. 따라서 다음을 운영 계약으로 둔다.
+
+1. `UNKNOWN + CLIENT_STATE_UNCONFIRMED`가 반복되면 provider client lifecycle과
+   native timeout 설정을 먼저 확인한다.
+2. `UNKNOWN + PROVIDER_EXCEPTION`이 증가하면 raw exception을 metric에 넣지
+   말고 애플리케이션의 보호된 구조화 로그와 provider-native 진단을 확인한다.
+3. 실제 wall-clock 상한이 필요하면 caller-owned executor/future timeout 또는
+   backend client의 cancellation API를 애플리케이션이 별도 소유한다. library
+   helper에 thread interrupt나 강제 `Future.cancel`을 추가하지 않는다.
+4. probe가 요청 처리 경로를 지연시키면 active probe를 끄고 passive diagnostics와
+   기존 readiness/state signal로 우회한다. 외부 route는 인증·network policy로
+   보호한다.
+
+### 5.2 Bypass와 rollback trigger
+
+다음 중 하나면 active probe를 bypass한다.
+
+- provider가 native timeout을 무시해 요청 latency budget을 초과한다.
+- `PROVIDER_EXCEPTION`이 지속 증가하지만 backend ownership은 정상이고 probe가
+  장애를 증폭한다.
+- custom provider가 민감정보를 포함한 descriptor/reason을 반환해 sanitizer
+  경계를 통과하지 못한다.
+
+bypass 뒤에는 `backend-health.enabled=false` 또는
+`backendConnectivityCheckEnabled=false`로 active 호출을 중지하고, Ktor/Spring
+route 자체를 외부에 노출하지 않는다. metric series가 사라지는 것은 probe가
+실행되지 않는다는 뜻이므로 `NOT_CHECKED`와 혼동하지 않는다. 다음 release에서
+rollback할 때는 reason field와 counter consumer가 additive schema를 무시하는지
+먼저 확인하고, helper/adapter 코드를 한 child PR 단위로 되돌린다. public field나
+metric 이름을 즉시 삭제하지 않고 deprecation/마이그레이션 기간을 둔다.
+
+### 5.3 주요 실패 모드
+
+| 실패 모드 | 잘못된 해석 | 방어책 |
+|---|---|---|
+| passive `NOT_CHECKED`를 `UP`으로 해석 | probe를 끈 상태가 backend 정상으로 보인다. | Actuator/Ktor payload의 `status`와 active probe 여부를 함께 확인하고 readiness 근거로 사용하지 않는다. |
+| provider-native timeout이 wall-clock을 보장한다고 가정 | request thread가 backend client에서 계속 대기한다. | native budget과 caller deadline을 분리하고, 지연 시 active probe를 bypass한다. |
+| `UNKNOWN`을 즉시 `DOWN`으로 승격 | 일시적인 client 상태 미확정이 장애 page를 만든다. | `reason`별 counter 추세와 기존 AOP `BACKEND_ERROR`를 함께 보고 지속 조건을 둔다. |
+| raw exception/endpoint/lock name을 tag·detail에 복사 | credential과 tenant 식별자가 observability backend에 남는다. | reason enum과 sanitized backend ID만 저장하고 원문은 보호된 로그 정책에 맡긴다. |
+| custom override가 helper를 우회 | built-in과 custom 결과의 예외·reason semantics가 달라진다. | custom escape hatch를 문서에 명시하고 adapter 회귀 테스트에서 그대로 보존한다. |
+
+## 6. Stacked PR train
+
+모든 child는 직전 child의 merge commit을 base로 rebase하고 독립적으로
+검증한다. PR merge는 squash가 아닌 rebase merge를 사용하며, 각 child의
+정확한 head와 CI를 다시 읽은 뒤 별도 승인한다.
+
+| 순서 | Child | 책임 | 독립 DoD |
+|---:|---|---|---|
+| 1 | `OBS-01` | `leader-core` reason enum/field, helper reason mapping, 기존 provider 경계의 reason 연결(단, #766 migration 재수행 제외), core/provider 회귀 | direct 결과의 reason 불변식, exception 경계, ABI/Kotlin consumer 검증 |
+| 2 | `OBS-02` | `leader-micrometer` active diagnostics counter와 세 instrumented wrapper 연결, Spring health reason detail | passive 미계측, active 1회 계측, sanitized low-cardinality tags, Spring mapping 회귀 |
+| 3 | `OBS-03` | Ktor JSON reason field와 HTTP/pipeline 경계 문서·테스트, adapter parity | built-in/custom direct/Ktor/Spring matrix, HTTP 200 payload와 pipeline exception 보존 |
+| 4 | `OBS-04` | EN/KO root/module README, manual drafts, Prometheus example alert/runbook, release pin checklist | 문서 locale parity, PromQL/alert semantics, `releaseRef`/`releaseCommit` 미변경 증거 |
+
+OBS-01과 OBS-02는 production API를 변경하므로 Type A common gates와
+`checkBinaryCompatibility`, Kotlin consumer compile, `jar tf`, `javap`를
+proportional하게 실행한다. OBS-03은 route payload additive change를 포함하고,
+OBS-04는 문서/예제 변경만 수행한다. 1인 개발자 환경이므로 독립 리뷰 lane은
+N/A이며, 각 child에서 7-Tier self-review, source-to-claim read-back, targeted
+test와 exact-head CI로 대체한다.
+
+## 7. 호환성·마이그레이션
+
+- 기존 `LeaderBackendConnectivity` 생성 호출은 trailing default와 JVM
+  compatibility constructor/copy overload로 유지한다. 새 `reason` field는
+  additive이며, `checkBinaryCompatibility`에서 실제 descriptor를 확인한다.
+- custom provider가 이전 factory를 사용하면 status에 맞는 기본 reason을
+  얻는다. `diagnostics()` 또는 `checkConnectivity()`를 직접 override한 provider는
+  기존 반환값·예외 정책을 계속 소유하며, Micrometer decorator는 이를 바꾸지
+  않고 관측만 추가한다.
+- Ktor JSON에 `reason` field가 추가되지만 기존 `descriptor`와
+  `connectivity.status/checkedAt/latencyMillis`는 제거하지 않는다. strict JSON
+  consumer는 additive field를 허용하도록 조정해야 한다.
+- 새 dependency, 새로운 background thread, backend I/O, lock/lease mutation은
+  도입하지 않는다. 기존 `bluetape4k-assertions`, `bluetape4k.support`,
+  `bluetape4k.logging`, `MultithreadingTester` 패턴을 사용한다.
+- versioned manual은 새 API가 release train에 포함되고 release commit이
+  확정된 뒤에만 `manifest.yaml`을 갱신한다. 그 전에는 `docs/manual/drafts/`
+  EN/KO 문서만 유지한다.
+
+## 8. 수용 기준과 DoD
+
+1. reason enum과 status/reason 불변식이 core에서 검증된다.
+2. helper callback의 일반 `Exception`은 `PROVIDER_EXCEPTION`으로 정규화되고,
+   cancellation/interruption/`Error`는 #766과 같은 인스턴스·interrupt 경계를
+   유지한다.
+3. helper-backed built-in provider와 기본 provider가 unsupported와 client
+   state unconfirmed를 구분하며, legacy 수동 provider는 기존 status 계약과
+   기본 reason을 유지한다. custom override는 source-compatible escape hatch로
+   남고, #766 migration 재수행은 범위 밖으로 명시된다.
+4. 세 `InstrumentedLeader*` wrapper의 active diagnostics가
+   `leader.backend.connectivity`에 `backend.name/status/reason`만 사용해 한 번
+   기록되고, passive 기준 상태는 기록하지 않는다.
+5. Spring health detail과 Ktor JSON에 bounded reason이 포함되며 기존 status,
+   warning, application-owned HTTP exception 경계를 보존한다.
+6. EN/KO README와 manual draft가 상태 표, alert 기준, timeout/bypass/rollback
+   runbook, #766 built-in/custom 해석을 같은 내용으로 설명한다.
+7. Prometheus example은 `UNKNOWN`을 자동 page하지 않고
+   `DOWN`/`PROVIDER_EXCEPTION` 지속 조건과 기존 AOP backend error를 연결한다.
+8. 변경 코드와 테스트는 `$bluetape-kotlin-patterns` 및
+   `bluetape4k-assertions` 규칙을 지키며 raw `assertThrows`를 추가하지 않는다.
+9. 각 child에서 targeted test, module test, detekt, ABI/consumer/packaging
+   검사, `git diff --check` 결과를 기록한다. CI와 merge는 exact head 기준으로
+   확인한다.
+10. release train 전에는 versioned `releaseRef`/`releaseCommit`을 바꾸지 않고,
+    release 후 갱신할 별도 gate를 남긴다.
+
+## 9. 설계 self-review와 Writer DoD
+
+- 현재 source, Issue #766/#774, existing Spring/Ktor/Micrometer/example 계약을
+  읽고 source ledger에 연결했다.
+- 대안 세 가지와 선택 이유, status/reason/adapter 매핑, timeout·rollback,
+  실패 모드 다섯 가지, compatibility, stacked order, acceptance/DoD를 포함했다.
+- `UNKNOWN`을 단일 장애 상태로 단정하지 않았고, readiness와 backend health를
+  서로 다른 signal로 유지했다.
+- 공개 API additive change와 ABI/strict JSON 소비자 위험을 명시했다.
+- EN/KO manual의 release pin을 현재 값으로 고정하고, 새 API 포함 release 전
+  갱신하지 않는다는 범위를 분명히 했다.
+- 한국어 technical register를 적용하고 identifier, command, URL, enum 이름을
+  보존했다. 다음 단계에서 `audit-korean-terms.mjs`, `git diff --check`, rendered
+  read-back으로 SPW-01~SPW-05와 KO-01~KO-07을 최종 확인한다.
+- 1인 개발자 환경에 따라 독립 리뷰는 N/A이며, 구현 child마다 7-Tier
+  self-review와 fresh exact-head verification을 필수로 한다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/diagnostics/LeaderBackendDiagnostics.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/diagnostics/LeaderBackendDiagnostics.kt
@@ -34,6 +34,27 @@ enum class LeaderBackendConnectivityStatus {
     NOT_CHECKED,
 }
 
+/** Connectivity 상태를 만든 bounded 원인입니다. */
+enum class LeaderBackendConnectivityReason {
+    /** passive diagnostics로 probe를 실행하지 않았습니다. */
+    NOT_CHECKED,
+
+    /** 기존 client가 연결 가능한 상태임을 확인했습니다. */
+    CONNECTED,
+
+    /** 기존 client가 종료됐거나 연결되지 않은 상태임을 확인했습니다. */
+    DISCONNECTED,
+
+    /** provider가 안전한 bounded connectivity probe를 지원하지 않습니다. */
+    PROVIDER_UNSUPPORTED,
+
+    /** provider callback의 일반 예외를 안전한 UNKNOWN으로 정규화했습니다. */
+    PROVIDER_EXCEPTION,
+
+    /** client 상태를 읽었지만 연결을 증명할 수 없습니다. */
+    CLIENT_STATE_UNCONFIRMED,
+}
+
 /** Lease 만료 계산의 기준 clock입니다. */
 enum class LeaderBackendClockSource {
     /** 애플리케이션 process clock을 사용합니다. */
@@ -149,10 +170,11 @@ data class LeaderBackendDescriptor(
  *
  * Raw exception, credential, endpoint, lock name은 이 모델에 저장하지 않습니다.
  */
-data class LeaderBackendConnectivity(
+data class LeaderBackendConnectivity @JvmOverloads constructor(
     val status: LeaderBackendConnectivityStatus,
     val checkedAt: Instant? = null,
     val latencyMillis: Long? = null,
+    val reason: LeaderBackendConnectivityReason = status.defaultReason(),
 ) : Serializable {
 
     init {
@@ -160,11 +182,32 @@ data class LeaderBackendConnectivity(
             require(latency >= 0L) { "latencyMillis must not be negative: $latency" }
         }
         if (status == LeaderBackendConnectivityStatus.NOT_CHECKED) {
+            require(reason == LeaderBackendConnectivityReason.NOT_CHECKED) {
+                "NOT_CHECKED connectivity must use NOT_CHECKED reason"
+            }
             require(checkedAt == null && latencyMillis == null) {
                 "NOT_CHECKED connectivity must not contain checkedAt or latencyMillis"
             }
         } else {
             require(checkedAt != null) { "$status connectivity requires checkedAt" }
+            require(reason != LeaderBackendConnectivityReason.NOT_CHECKED) {
+                "$status connectivity must not use NOT_CHECKED reason"
+            }
+            val allowedReasons = when (status) {
+                LeaderBackendConnectivityStatus.UP ->
+                    setOf(LeaderBackendConnectivityReason.CONNECTED)
+                LeaderBackendConnectivityStatus.DOWN ->
+                    setOf(LeaderBackendConnectivityReason.DISCONNECTED)
+                LeaderBackendConnectivityStatus.UNKNOWN -> setOf(
+                    LeaderBackendConnectivityReason.PROVIDER_UNSUPPORTED,
+                    LeaderBackendConnectivityReason.PROVIDER_EXCEPTION,
+                    LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED,
+                )
+                LeaderBackendConnectivityStatus.NOT_CHECKED -> emptySet()
+            }
+            require(reason in allowedReasons) {
+                "$status connectivity does not support reason $reason"
+            }
         }
     }
 
@@ -177,17 +220,63 @@ data class LeaderBackendConnectivity(
 
         /** 연결된 상태를 생성합니다. */
         fun up(checkedAt: Instant, latencyMillis: Long? = null): LeaderBackendConnectivity =
-            LeaderBackendConnectivity(LeaderBackendConnectivityStatus.UP, checkedAt, latencyMillis)
+            up(checkedAt, latencyMillis, LeaderBackendConnectivityReason.CONNECTED)
+
+        /** 연결된 상태를 bounded 원인과 함께 생성합니다. */
+        fun up(
+            checkedAt: Instant,
+            latencyMillis: Long? = null,
+            reason: LeaderBackendConnectivityReason,
+        ): LeaderBackendConnectivity =
+            LeaderBackendConnectivity(LeaderBackendConnectivityStatus.UP, checkedAt, latencyMillis, reason)
 
         /** 연결되지 않은 상태를 생성합니다. */
         fun down(checkedAt: Instant, latencyMillis: Long? = null): LeaderBackendConnectivity =
-            LeaderBackendConnectivity(LeaderBackendConnectivityStatus.DOWN, checkedAt, latencyMillis)
+            down(checkedAt, latencyMillis, LeaderBackendConnectivityReason.DISCONNECTED)
+
+        /** 연결되지 않은 상태를 bounded 원인과 함께 생성합니다. */
+        fun down(
+            checkedAt: Instant,
+            latencyMillis: Long? = null,
+            reason: LeaderBackendConnectivityReason,
+        ): LeaderBackendConnectivity =
+            LeaderBackendConnectivity(LeaderBackendConnectivityStatus.DOWN, checkedAt, latencyMillis, reason)
 
         /** 안전한 검사로 상태를 확정하지 못한 결과를 생성합니다. */
         fun unknown(checkedAt: Instant, latencyMillis: Long? = null): LeaderBackendConnectivity =
-            LeaderBackendConnectivity(LeaderBackendConnectivityStatus.UNKNOWN, checkedAt, latencyMillis)
+            unknown(checkedAt, latencyMillis, LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED)
+
+        /** 안전한 검사로 상태를 확정하지 못한 결과를 bounded 원인과 함께 생성합니다. */
+        fun unknown(
+            checkedAt: Instant,
+            latencyMillis: Long? = null,
+            reason: LeaderBackendConnectivityReason,
+        ): LeaderBackendConnectivity =
+            LeaderBackendConnectivity(LeaderBackendConnectivityStatus.UNKNOWN, checkedAt, latencyMillis, reason)
     }
+
+    /** 기존 3-field JVM/Kotlin 호출자의 copy descriptor를 보존합니다. */
+    @Suppress("unused")
+    fun copy(
+        status: LeaderBackendConnectivityStatus,
+        checkedAt: Instant?,
+        latencyMillis: Long?,
+    ): LeaderBackendConnectivity =
+        LeaderBackendConnectivity(
+            status = status,
+            checkedAt = checkedAt,
+            latencyMillis = latencyMillis,
+            reason = if (status == this.status) reason else status.defaultReason(),
+        )
 }
+
+private fun LeaderBackendConnectivityStatus.defaultReason(): LeaderBackendConnectivityReason =
+    when (this) {
+        LeaderBackendConnectivityStatus.UP -> LeaderBackendConnectivityReason.CONNECTED
+        LeaderBackendConnectivityStatus.DOWN -> LeaderBackendConnectivityReason.DISCONNECTED
+        LeaderBackendConnectivityStatus.UNKNOWN -> LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED
+        LeaderBackendConnectivityStatus.NOT_CHECKED -> LeaderBackendConnectivityReason.NOT_CHECKED
+    }
 
 /** 정적 backend descriptor와 선택적인 connectivity 결과입니다. */
 data class LeaderBackendDiagnostics(
@@ -216,7 +305,10 @@ interface LeaderBackendDiagnosticsProvider {
      * 안전한 bounded 검사를 제공하지 않는 구현은 `UNKNOWN`을 반환합니다.
      */
     fun checkConnectivity(timeout: Duration): LeaderBackendConnectivity {
-        return LeaderBackendDiagnosticsProbe.check(timeout) {
+        return LeaderBackendDiagnosticsProbe.check(
+            timeout = timeout,
+            unknownReason = LeaderBackendConnectivityReason.PROVIDER_UNSUPPORTED,
+        ) {
             LeaderBackendConnectivityStatus.UNKNOWN
         }
     }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/diagnostics/LeaderBackendDiagnosticsProbe.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/diagnostics/LeaderBackendDiagnosticsProbe.kt
@@ -26,8 +26,34 @@ public object LeaderBackendDiagnosticsProbe {
         timeout: Duration,
         clock: Clock = Clock.systemUTC(),
         probe: (Duration) -> LeaderBackendConnectivityStatus,
+    ): LeaderBackendConnectivity =
+        check(
+            timeout = timeout,
+            clock = clock,
+            unknownReason = LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED,
+            probe = probe,
+        )
+
+    /**
+     * 기존 client 상태를 한 번 확인하고 caller가 지정한 UNKNOWN 원인으로 매핑합니다.
+     *
+     * 기존 3-argument overload를 보존해 source와 JVM 호출자의 호출 순서를 유지합니다.
+     */
+    public fun check(
+        timeout: Duration,
+        clock: Clock = Clock.systemUTC(),
+        unknownReason: LeaderBackendConnectivityReason =
+            LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED,
+        probe: (Duration) -> LeaderBackendConnectivityStatus,
     ): LeaderBackendConnectivity {
         val validTimeout = timeout.requirePositiveFiniteProbeTimeout()
+        require(
+            unknownReason == LeaderBackendConnectivityReason.PROVIDER_UNSUPPORTED ||
+                unknownReason == LeaderBackendConnectivityReason.PROVIDER_EXCEPTION ||
+                unknownReason == LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED,
+        ) {
+            "unknownReason must describe an UNKNOWN connectivity result: $unknownReason"
+        }
         val checkedAt = clock.instant()
         val status = try {
             probe(validTimeout)
@@ -37,13 +63,17 @@ public object LeaderBackendDiagnosticsProbe {
             Thread.currentThread().interrupt()
             throw interrupted
         } catch (_: Exception) {
-            return LeaderBackendConnectivity.unknown(checkedAt)
+            return LeaderBackendConnectivity.unknown(
+                checkedAt,
+                reason = LeaderBackendConnectivityReason.PROVIDER_EXCEPTION,
+            )
         }
 
         return when (status) {
             LeaderBackendConnectivityStatus.UP -> LeaderBackendConnectivity.up(checkedAt)
             LeaderBackendConnectivityStatus.DOWN -> LeaderBackendConnectivity.down(checkedAt)
-            LeaderBackendConnectivityStatus.UNKNOWN -> LeaderBackendConnectivity.unknown(checkedAt)
+            LeaderBackendConnectivityStatus.UNKNOWN ->
+                LeaderBackendConnectivity.unknown(checkedAt, reason = unknownReason)
             LeaderBackendConnectivityStatus.NOT_CHECKED -> invalidProbeStatus()
         }
     }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/diagnostics/LeaderBackendDiagnosticsProbeTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/diagnostics/LeaderBackendDiagnosticsProbeTest.kt
@@ -67,7 +67,42 @@ class LeaderBackendDiagnosticsProbeTest {
             throw IllegalStateException("provider failure")
         }
 
-        connectivity shouldBeEqualTo LeaderBackendConnectivity.unknown(checkedAt)
+        connectivity shouldBeEqualTo LeaderBackendConnectivity.unknown(
+            checkedAt,
+            reason = LeaderBackendConnectivityReason.PROVIDER_EXCEPTION,
+        )
+    }
+
+    @Test
+    fun `UNKNOWN callback은 caller가 지정한 bounded reason으로 기록한다`() {
+        val connectivity = LeaderBackendDiagnosticsProbe.check(
+            timeout = 100.milliseconds,
+            clock = clock,
+            unknownReason = LeaderBackendConnectivityReason.PROVIDER_UNSUPPORTED,
+        ) {
+            LeaderBackendConnectivityStatus.UNKNOWN
+        }
+
+        connectivity.reason shouldBeEqualTo LeaderBackendConnectivityReason.PROVIDER_UNSUPPORTED
+    }
+
+    @Test
+    fun `unknownReason은 UNKNOWN 전용 reason만 허용한다`() {
+        listOf(
+            LeaderBackendConnectivityReason.NOT_CHECKED,
+            LeaderBackendConnectivityReason.CONNECTED,
+            LeaderBackendConnectivityReason.DISCONNECTED,
+        ).forEach { invalidReason ->
+            assertFailsWith<IllegalArgumentException> {
+                LeaderBackendDiagnosticsProbe.check(
+                    timeout = 100.milliseconds,
+                    clock = clock,
+                    unknownReason = invalidReason,
+                ) {
+                    LeaderBackendConnectivityStatus.UNKNOWN
+                }
+            }
+        }
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/diagnostics/LeaderBackendDiagnosticsTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/diagnostics/LeaderBackendDiagnosticsTest.kt
@@ -85,6 +85,47 @@ class LeaderBackendDiagnosticsTest {
     }
 
     @Test
+    fun `connectivity factory는 status별 bounded reason을 제공한다`() {
+        LeaderBackendConnectivity.notChecked().reason shouldBeEqualTo
+                LeaderBackendConnectivityReason.NOT_CHECKED
+        LeaderBackendConnectivity.up(checkedAt).reason shouldBeEqualTo
+                LeaderBackendConnectivityReason.CONNECTED
+        LeaderBackendConnectivity.down(checkedAt).reason shouldBeEqualTo
+                LeaderBackendConnectivityReason.DISCONNECTED
+        LeaderBackendConnectivity.unknown(checkedAt).reason shouldBeEqualTo
+                LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED
+
+        LeaderBackendConnectivity.unknown(
+            checkedAt = checkedAt,
+            reason = LeaderBackendConnectivityReason.PROVIDER_UNSUPPORTED,
+        ).reason shouldBeEqualTo LeaderBackendConnectivityReason.PROVIDER_UNSUPPORTED
+
+        val preserved = LeaderBackendConnectivity.unknown(
+            checkedAt = checkedAt,
+            reason = LeaderBackendConnectivityReason.PROVIDER_EXCEPTION,
+        )
+        preserved.copy(status = LeaderBackendConnectivityStatus.UNKNOWN).reason shouldBeEqualTo
+                LeaderBackendConnectivityReason.PROVIDER_EXCEPTION
+    }
+
+    @Test
+    fun `connectivity는 NOT_CHECKED reason과 checked status의 reason 혼용을 거부한다`() {
+        assertFailsWith<IllegalArgumentException> {
+            LeaderBackendConnectivity(
+                status = LeaderBackendConnectivityStatus.UP,
+                checkedAt = checkedAt,
+                reason = LeaderBackendConnectivityReason.NOT_CHECKED,
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LeaderBackendConnectivity(
+                status = LeaderBackendConnectivityStatus.NOT_CHECKED,
+                reason = LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED,
+            )
+        }
+    }
+
+    @Test
     fun `default connectivity check는 안전한 UNKNOWN 결과를 반환한다`() {
         val provider = object : LeaderBackendDiagnosticsProvider {
             override val backendDescriptor: LeaderBackendDescriptor = descriptor
@@ -93,6 +134,7 @@ class LeaderBackendDiagnosticsTest {
         val connectivity = provider.checkConnectivity(100.milliseconds)
 
         connectivity.status shouldBeEqualTo LeaderBackendConnectivityStatus.UNKNOWN
+        connectivity.reason shouldBeEqualTo LeaderBackendConnectivityReason.PROVIDER_UNSUPPORTED
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/diagnostics/LocalLeaderBackendDiagnosticsTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/diagnostics/LocalLeaderBackendDiagnosticsTest.kt
@@ -55,6 +55,7 @@ class LocalLeaderBackendDiagnosticsTest {
         val connectivity = LocalLeaderBackendDiagnostics.checkConnectivity(100.milliseconds)
 
         connectivity.status shouldBeEqualTo LeaderBackendConnectivityStatus.UP
+        connectivity.reason shouldBeEqualTo LeaderBackendConnectivityReason.CONNECTED
         connectivity.checkedAt.shouldNotBeNull()
         connectivity.latencyMillis.shouldBeNull()
     }

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderBackendDiagnostics.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderBackendDiagnostics.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.leader.diagnostics.LeaderBackendCapabilities
 import io.bluetape4k.leader.diagnostics.LeaderBackendClockSource
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivity
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityStatus
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityReason
 import io.bluetape4k.leader.diagnostics.LeaderBackendDescriptor
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProbe
@@ -46,7 +47,10 @@ object MongoLeaderBackendDiagnostics : LeaderBackendDiagnosticsProvider {
 
     /** lock collection만으로 bounded 연결 성공을 증명하지 않고 UNKNOWN을 반환합니다. */
     override fun checkConnectivity(timeout: Duration): LeaderBackendConnectivity {
-        return LeaderBackendDiagnosticsProbe.check(timeout) {
+        return LeaderBackendDiagnosticsProbe.check(
+            timeout = timeout,
+            unknownReason = LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED,
+        ) {
             LeaderBackendConnectivityStatus.UNKNOWN
         }
     }

--- a/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderBackendDiagnosticsTest.kt
+++ b/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderBackendDiagnosticsTest.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.leader.diagnostics.LeaderBackendClockSource
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityStatus
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityReason
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
 import io.bluetape4k.leader.diagnostics.LeaderBackendModeSupport
 import io.bluetape4k.leader.diagnostics.LeaderBackendSupport
@@ -35,9 +36,11 @@ class MongoLeaderBackendDiagnosticsTest {
 
     @Test
     fun `MongoDB connectivity는 안전한 bounded probe가 없어 UNKNOWN을 반환한다`() {
-        MongoLeaderBackendDiagnostics
+        val connectivity = MongoLeaderBackendDiagnostics
             .checkConnectivity(100.milliseconds)
-            .status shouldBeEqualTo LeaderBackendConnectivityStatus.UNKNOWN
+
+        connectivity.status shouldBeEqualTo LeaderBackendConnectivityStatus.UNKNOWN
+        connectivity.reason shouldBeEqualTo LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED
     }
 
     @Test

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderBackendDiagnostics.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderBackendDiagnostics.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.leader.diagnostics.LeaderBackendCapabilities
 import io.bluetape4k.leader.diagnostics.LeaderBackendClockSource
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivity
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityStatus
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityReason
 import io.bluetape4k.leader.diagnostics.LeaderBackendDescriptor
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProbe
@@ -23,7 +24,10 @@ class LettuceLeaderBackendDiagnostics(
 
     /** 기존 Lettuce connection의 open 상태만 읽어 연결 상태를 확인합니다. */
     override fun checkConnectivity(timeout: Duration): LeaderBackendConnectivity {
-        return LeaderBackendDiagnosticsProbe.check(timeout) {
+        return LeaderBackendDiagnosticsProbe.check(
+            timeout = timeout,
+            unknownReason = LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED,
+        ) {
             if (connection.isOpen) {
                 LeaderBackendConnectivityStatus.UNKNOWN
             } else {

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderBackendDiagnosticsTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderBackendDiagnosticsTest.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.diagnostics.LeaderBackendClockSource
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityStatus
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityReason
 import io.bluetape4k.leader.diagnostics.LeaderBackendModeSupport
 import io.bluetape4k.leader.diagnostics.LeaderBackendSupport
 import io.bluetape4k.leader.diagnostics.LeaderBackendTtlMode
@@ -47,10 +48,12 @@ class LettuceLeaderBackendDiagnosticsTest {
 
         val unknown = provider.checkConnectivity(100.milliseconds)
         unknown.status shouldBeEqualTo LeaderBackendConnectivityStatus.UNKNOWN
+        unknown.reason shouldBeEqualTo LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED
 
         every { connection.isOpen } returns false
         val down = provider.checkConnectivity(100.milliseconds)
         down.status shouldBeEqualTo LeaderBackendConnectivityStatus.DOWN
+        down.reason shouldBeEqualTo LeaderBackendConnectivityReason.DISCONNECTED
     }
 
     @Test
@@ -58,9 +61,11 @@ class LettuceLeaderBackendDiagnosticsTest {
         val connection = mockk<StatefulRedisConnection<String, String>>()
         every { connection.isOpen } throws IllegalStateException("probe failed")
 
-        LettuceLeaderBackendDiagnostics(connection)
+        val connectivity = LettuceLeaderBackendDiagnostics(connection)
             .checkConnectivity(100.milliseconds)
-            .status shouldBeEqualTo LeaderBackendConnectivityStatus.UNKNOWN
+
+        connectivity.status shouldBeEqualTo LeaderBackendConnectivityStatus.UNKNOWN
+        connectivity.reason shouldBeEqualTo LeaderBackendConnectivityReason.PROVIDER_EXCEPTION
     }
 
     @Test

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderBackendDiagnostics.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderBackendDiagnostics.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.leader.diagnostics.LeaderBackendCapabilities
 import io.bluetape4k.leader.diagnostics.LeaderBackendClockSource
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivity
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityStatus
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityReason
 import io.bluetape4k.leader.diagnostics.LeaderBackendDescriptor
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProbe
@@ -23,7 +24,10 @@ class RedissonLeaderBackendDiagnostics(
 
     /** 기존 Redisson client의 shutdown 상태만 읽어 연결 상태를 확인합니다. */
     override fun checkConnectivity(timeout: Duration): LeaderBackendConnectivity {
-        return LeaderBackendDiagnosticsProbe.check(timeout) {
+        return LeaderBackendDiagnosticsProbe.check(
+            timeout = timeout,
+            unknownReason = LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED,
+        ) {
             if (redissonClient.isShutdown || redissonClient.isShuttingDown) {
                 LeaderBackendConnectivityStatus.DOWN
             } else {

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderBackendDiagnosticsTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderBackendDiagnosticsTest.kt
@@ -8,6 +8,7 @@ import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.diagnostics.LeaderBackendClockSource
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityStatus
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityReason
 import io.bluetape4k.leader.diagnostics.LeaderBackendModeSupport
 import io.bluetape4k.leader.diagnostics.LeaderBackendSupport
 import io.bluetape4k.leader.diagnostics.LeaderBackendTtlMode
@@ -44,14 +45,20 @@ class RedissonLeaderBackendDiagnosticsTest {
         every { client.isShuttingDown } returns false
         val provider = RedissonLeaderBackendDiagnostics(client)
 
-        provider.checkConnectivity(100.milliseconds).status shouldBeEqualTo LeaderBackendConnectivityStatus.UNKNOWN
+        val unknown = provider.checkConnectivity(100.milliseconds)
+        unknown.status shouldBeEqualTo LeaderBackendConnectivityStatus.UNKNOWN
+        unknown.reason shouldBeEqualTo LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED
 
         every { client.isShuttingDown } returns true
-        provider.checkConnectivity(100.milliseconds).status shouldBeEqualTo LeaderBackendConnectivityStatus.DOWN
+        val shuttingDown = provider.checkConnectivity(100.milliseconds)
+        shuttingDown.status shouldBeEqualTo LeaderBackendConnectivityStatus.DOWN
+        shuttingDown.reason shouldBeEqualTo LeaderBackendConnectivityReason.DISCONNECTED
 
         every { client.isShuttingDown } returns false
         every { client.isShutdown } returns true
-        provider.checkConnectivity(100.milliseconds).status shouldBeEqualTo LeaderBackendConnectivityStatus.DOWN
+        val shutdown = provider.checkConnectivity(100.milliseconds)
+        shutdown.status shouldBeEqualTo LeaderBackendConnectivityStatus.DOWN
+        shutdown.reason shouldBeEqualTo LeaderBackendConnectivityReason.DISCONNECTED
     }
 
     @Test
@@ -59,9 +66,11 @@ class RedissonLeaderBackendDiagnosticsTest {
         val client = mockk<RedissonClient>()
         every { client.isShutdown } throws IllegalStateException("probe failed")
 
-        RedissonLeaderBackendDiagnostics(client)
+        val connectivity = RedissonLeaderBackendDiagnostics(client)
             .checkConnectivity(100.milliseconds)
-            .status shouldBeEqualTo LeaderBackendConnectivityStatus.UNKNOWN
+
+        connectivity.status shouldBeEqualTo LeaderBackendConnectivityStatus.UNKNOWN
+        connectivity.reason shouldBeEqualTo LeaderBackendConnectivityReason.PROVIDER_EXCEPTION
     }
 
     @Test


### PR DESCRIPTION
## 요약

Issue #774의 첫 번째 child입니다. #766의 diagnostics 상태·예외·취소 경계를 유지하면서 `UNKNOWN`을 운영 가능한 bounded reason으로 구분합니다.

## 변경 내용

- `LeaderBackendConnectivityReason` six-value vocabulary와 status/reason 불변식을 추가했습니다.
- `LeaderBackendDiagnosticsProbe`에 source-compatible overload를 추가하고 일반 `Exception`을 `PROVIDER_EXCEPTION`으로 정규화합니다.
- 기본 provider는 `PROVIDER_UNSUPPORTED`, helper-backed Local/Mongo/Lettuce/Redisson은 `CLIENT_STATE_UNCONFIRMED`를 사용합니다.
- 기존 3-field JVM constructor와 3-argument `copy` descriptor를 유지했습니다.
- #766 범위인 legacy provider timeout/cancellation migration은 재수행하지 않았습니다.

## 검증

- RED: 새 reason/unknownReason API 부재로 core compile test가 예상대로 실패함
- GREEN: core diagnostics 29개, MongoDB 4개, Lettuce 7개, Redisson 7개 통과
- affected backend full suites 통과: Hazelcast, ZooKeeper, etcd, Consul, DynamoDB, Exposed JDBC 301개, Exposed R2DBC 320개, Kubernetes 포함
- detekt 통과
- `checkBinaryCompatibility` 통과
- `jar tf`, `javap`, `git diff --check`, forbidden assertion scan 통과

설계: `docs/superpowers/specs/2026-08-28-issue-774-observability-design.md`
계획: `docs/superpowers/plans/2026-08-28-issue-774-observability-plan.md`

Refs #774

## DoD Status

- [x] core reason vocabulary와 불변식
- [x] helper exception/cancellation/interruption/Error 경계 회귀
- [x] helper-backed provider reason 연결
- [x] ABI/packaging/detekt/affected backend 테스트
- [x] 1인 개발자 self-review (independent review: N/A)
- [x] hosted exact-head CI
- [ ] OBS-02~OBS-04 후속 child

상태: OBS-01 구현·로컬 검증·hosted exact-head CI 완료, rebase merge 승인 및 후속 child 대기