### PR TITLE
[OBS-02] active diagnostics를 Micrometer와 Spring health에 연결

### DIFF
--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/InstrumentedLeaderElectors.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/InstrumentedLeaderElectors.kt
@@ -9,16 +9,22 @@ import io.bluetape4k.leader.coroutines.SuspendLeaderElector
 import io.bluetape4k.leader.coroutines.SuspendLeaderLeaseAcquirer
 import io.bluetape4k.leader.coroutines.SuspendLeaderLeaseAcquirerSupport
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsAware
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivity
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityReason
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityStatus
+import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnostics
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
 import kotlin.time.TimeSource
 import kotlin.time.toJavaDuration
 
@@ -38,7 +44,7 @@ class InstrumentedLeaderElector private constructor(
 ): LeaderElector by delegate, LeaderLeaseAcquirerSupport, LeaderBackendDiagnosticsAware {
 
     override val backendDiagnosticsProvider: LeaderBackendDiagnosticsProvider?
-        get() = delegate.resolveBackendDiagnosticsProvider()
+        get() = instrumentedBackendDiagnosticsProvider
 
     override val supportsAuditLeaderState: Boolean
         get() = delegate.supportsAuditLeaderState
@@ -54,6 +60,10 @@ class InstrumentedLeaderElector private constructor(
     }
 
     private val metrics = InstrumentedLeaderMetrics(registry)
+
+    private val instrumentedBackendDiagnosticsProvider: LeaderBackendDiagnosticsProvider? by lazy {
+        delegate.resolveBackendDiagnosticsProvider()?.instrumented(registry, tagSanitizer)
+    }
 
     constructor(
         delegate: LeaderElector,
@@ -128,9 +138,13 @@ class InstrumentedLeaderGroupElector private constructor(
 ): LeaderGroupElector by delegate, LeaderBackendDiagnosticsAware {
 
     override val backendDiagnosticsProvider: LeaderBackendDiagnosticsProvider?
-        get() = delegate.resolveBackendDiagnosticsProvider()
+        get() = instrumentedBackendDiagnosticsProvider
 
     private val metrics = InstrumentedLeaderMetrics(registry)
+
+    private val instrumentedBackendDiagnosticsProvider: LeaderBackendDiagnosticsProvider? by lazy {
+        delegate.resolveBackendDiagnosticsProvider()?.instrumented(registry, tagSanitizer)
+    }
 
     constructor(
         delegate: LeaderGroupElector,
@@ -205,7 +219,7 @@ class InstrumentedSuspendLeaderElector private constructor(
 ): SuspendLeaderElector by delegate, SuspendLeaderLeaseAcquirerSupport, LeaderBackendDiagnosticsAware {
 
     override val backendDiagnosticsProvider: LeaderBackendDiagnosticsProvider?
-        get() = delegate.resolveBackendDiagnosticsProvider()
+        get() = instrumentedBackendDiagnosticsProvider
 
     override val supportsAuditLeaderState: Boolean
         get() = delegate.supportsAuditLeaderState
@@ -221,6 +235,10 @@ class InstrumentedSuspendLeaderElector private constructor(
     }
 
     private val metrics = InstrumentedLeaderMetrics(registry)
+
+    private val instrumentedBackendDiagnosticsProvider: LeaderBackendDiagnosticsProvider? by lazy {
+        delegate.resolveBackendDiagnosticsProvider()?.instrumented(registry, tagSanitizer)
+    }
 
     constructor(
         delegate: SuspendLeaderElector,
@@ -266,6 +284,100 @@ private fun Any.resolveBackendDiagnosticsProvider(): LeaderBackendDiagnosticsPro
         is LeaderBackendDiagnosticsAware -> backendDiagnosticsProvider
         else -> null
     }
+
+private fun LeaderBackendDiagnosticsProvider.instrumented(
+    registry: MeterRegistry,
+    tagSanitizer: LeaderMetricTagSanitizer,
+): LeaderBackendDiagnosticsProvider =
+    if (this is InstrumentedLeaderBackendDiagnosticsProvider) {
+        this
+    } else {
+        InstrumentedLeaderBackendDiagnosticsProvider(this, registry, tagSanitizer)
+    }
+
+private class InstrumentedLeaderBackendDiagnosticsProvider(
+    private val delegate: LeaderBackendDiagnosticsProvider,
+    registry: MeterRegistry,
+    tagSanitizer: LeaderMetricTagSanitizer,
+) : LeaderBackendDiagnosticsProvider {
+
+    private val metrics = BackendConnectivityMetrics(registry, tagSanitizer) {
+        delegate.backendDescriptor.backendId
+    }
+
+    override val backendDescriptor
+        get() = delegate.backendDescriptor
+
+    override fun checkConnectivity(timeout: Duration): LeaderBackendConnectivity = recordActiveProbe(
+        probe = { delegate.checkConnectivity(timeout) },
+        connectivity = { it },
+    )
+
+    override fun diagnostics(probe: Boolean, timeout: Duration): LeaderBackendDiagnostics {
+        if (!probe) {
+            return delegate.diagnostics(probe = false, timeout = timeout)
+        }
+        return recordActiveProbe(
+            probe = { delegate.diagnostics(probe = true, timeout = timeout) },
+            connectivity = { it.connectivity },
+        )
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun <T> recordActiveProbe(
+        probe: () -> T,
+        connectivity: (T) -> LeaderBackendConnectivity,
+    ): T = try {
+        probe().also { metrics.record(connectivity(it)) }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: InterruptedException) {
+        throw e
+    } catch (e: Exception) {
+        metrics.record(
+            status = LeaderBackendConnectivityStatus.UNKNOWN,
+            reason = LeaderBackendConnectivityReason.PROVIDER_EXCEPTION,
+        )
+        throw e
+    }
+}
+
+private class BackendConnectivityMetrics(
+    private val registry: MeterRegistry,
+    private val tagSanitizer: LeaderMetricTagSanitizer,
+    private val backendName: () -> String,
+) {
+
+    private val counters = ConcurrentHashMap<ConnectivityMetricKey, Counter>()
+
+    fun record(connectivity: LeaderBackendConnectivity) {
+        record(connectivity.status, connectivity.reason)
+    }
+
+    fun record(status: LeaderBackendConnectivityStatus, reason: LeaderBackendConnectivityReason) {
+        val key = ConnectivityMetricKey(
+            backendName = tagSanitizer.sanitize(
+                LeaderMetricTagOptions.TAG_BACKEND_NAME,
+                backendName(),
+            ),
+            status = status.name,
+            reason = reason.name,
+        )
+        counters.computeIfAbsent(key) {
+            Counter.builder(MicrometerNames.METER_BACKEND_CONNECTIVITY)
+                .tag(LeaderMetricTagOptions.TAG_BACKEND_NAME, it.backendName)
+                .tag(MicrometerNames.TAG_BACKEND_STATUS, it.status)
+                .tag(MicrometerNames.TAG_BACKEND_REASON, it.reason)
+                .register(registry)
+        }.increment()
+    }
+}
+
+private data class ConnectivityMetricKey(
+    val backendName: String,
+    val status: String,
+    val reason: String,
+)
 
 private class InstrumentedLeaderMetrics(
     private val registry: MeterRegistry,

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerNames.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/MicrometerNames.kt
@@ -202,6 +202,12 @@ internal object MicrometerNames {
      */
     const val TAG_EVENT = "event"
 
+    /** Backend connectivity 상태 tag입니다. */
+    const val TAG_BACKEND_STATUS = "status"
+
+    /** Backend connectivity bounded reason tag입니다. */
+    const val TAG_BACKEND_REASON = "reason"
+
     // --- Sentinel values ---
 
     /**
@@ -235,6 +241,9 @@ internal object MicrometerNames {
      * `METER_LEADER_EVENTS` 값은 Micrometer observability 계약에서 사용하는 설정 또는 상태 항목입니다.
      */
     const val METER_LEADER_EVENTS = "leader.election.events"
+
+    /** Backend connectivity probe 결과를 세는 low-cardinality counter입니다. */
+    const val METER_BACKEND_CONNECTIVITY = "leader.backend.connectivity"
 
     // --- History / Audit meter names ---
 

--- a/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/InstrumentedLeaderElectorsTest.kt
+++ b/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/InstrumentedLeaderElectorsTest.kt
@@ -11,18 +11,25 @@ import io.bluetape4k.assertions.shouldBe
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsAware
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivity
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityReason
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityStatus
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
 import io.bluetape4k.leader.diagnostics.LocalLeaderBackendDiagnostics
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class InstrumentedLeaderElectorsTest {
@@ -87,6 +94,231 @@ class InstrumentedLeaderElectorsTest {
             InstrumentedLeaderElector(StubLeaderElector(elected = true), registry)
         (wrapperWithoutProvider as? LeaderBackendDiagnosticsAware)
             ?.backendDiagnosticsProvider
+            .shouldBeNull()
+    }
+
+    @Test
+    fun `active diagnostics emits one bounded connectivity counter with sanitized backend tags`() {
+        val provider = RecordingDiagnosticsProvider(
+            connectivity = LeaderBackendConnectivity.up(Instant.EPOCH),
+            backendName = "redis-prod.example:6380/token",
+        )
+        val delegate = object :
+            LeaderElector by StubLeaderElector(elected = true),
+            LeaderBackendDiagnosticsProvider by provider {}
+        val election = InstrumentedLeaderElector(
+            delegate = delegate,
+            registry = registry,
+            tagOptions = LeaderMetricTagOptions(
+                backendName = LeaderMetricTagRule(redactedValue = "redacted-backend"),
+            ),
+        )
+
+        val decorated = (election as LeaderBackendDiagnosticsAware).backendDiagnosticsProvider
+            .shouldNotBeNull()
+        decorated.checkConnectivity(100.milliseconds)
+
+        val meter = registry.find(MicrometerNames.METER_BACKEND_CONNECTIVITY).counter()
+            .shouldNotBeNull()
+        meter.count() shouldBeEqualTo 1.0
+        meter.id.tags.map { it.key }.toSet() shouldBeEqualTo setOf(
+            LeaderMetricTagOptions.TAG_BACKEND_NAME,
+            MicrometerNames.TAG_BACKEND_STATUS,
+            MicrometerNames.TAG_BACKEND_REASON,
+        )
+        meter.id.getTag(LeaderMetricTagOptions.TAG_BACKEND_NAME) shouldBeEqualTo "redacted-backend"
+        meter.id.getTag(MicrometerNames.TAG_BACKEND_STATUS) shouldBeEqualTo LeaderBackendConnectivityStatus.UP.name
+        meter.id.getTag(MicrometerNames.TAG_BACKEND_REASON) shouldBeEqualTo LeaderBackendConnectivityReason.CONNECTED.name
+    }
+
+    @Test
+    fun `passive diagnostics does not create connectivity counter`() {
+        val provider = RecordingDiagnosticsProvider()
+        val delegate = object :
+            LeaderElector by StubLeaderElector(elected = true),
+            LeaderBackendDiagnosticsProvider by provider {}
+        val election = InstrumentedLeaderElector(delegate, registry)
+
+        (election as LeaderBackendDiagnosticsAware).backendDiagnosticsProvider
+            .shouldNotBeNull()
+            .diagnostics()
+
+        registry.find(MicrometerNames.METER_BACKEND_CONNECTIVITY).meters().isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun `active diagnostics records one counter for each execution model`() {
+        val blockingDelegate = object :
+            LeaderElector by StubLeaderElector(elected = true),
+            LeaderBackendDiagnosticsProvider by RecordingDiagnosticsProvider() {}
+        val groupDelegate = object :
+            LeaderGroupElector by StubLeaderGroupElector(elected = true),
+            LeaderBackendDiagnosticsProvider by RecordingDiagnosticsProvider() {}
+        val suspendDelegate = object :
+            SuspendLeaderElector by StubSuspendLeaderElector(elected = true),
+            LeaderBackendDiagnosticsProvider by RecordingDiagnosticsProvider() {}
+        val wrappers = listOf<LeaderBackendDiagnosticsAware>(
+            InstrumentedLeaderElector(blockingDelegate, registry),
+            InstrumentedLeaderGroupElector(groupDelegate, registry),
+            InstrumentedSuspendLeaderElector(suspendDelegate, registry),
+        )
+
+        wrappers.forEach { wrapper ->
+            wrapper.backendDiagnosticsProvider
+                .shouldNotBeNull()
+                .diagnostics(probe = true, timeout = 100.milliseconds)
+        }
+
+        registry.find(MicrometerNames.METER_BACKEND_CONNECTIVITY)
+            .tag(LeaderMetricTagOptions.TAG_BACKEND_NAME, "test-backend")
+            .tag(MicrometerNames.TAG_BACKEND_STATUS, LeaderBackendConnectivityStatus.UP.name)
+            .tag(MicrometerNames.TAG_BACKEND_REASON, LeaderBackendConnectivityReason.CONNECTED.name)
+            .counter()
+            .shouldNotBeNull()
+            .count() shouldBeEqualTo 3.0
+    }
+
+    @Test
+    fun `concurrent active diagnostics creates one meter and counts every probe`() {
+        val provider = RecordingDiagnosticsProvider()
+        val delegate = object :
+            LeaderElector by StubLeaderElector(elected = true),
+            LeaderBackendDiagnosticsProvider by provider {}
+        val election = InstrumentedLeaderElector(delegate, registry)
+        val decorated = (election as LeaderBackendDiagnosticsAware).backendDiagnosticsProvider
+            .shouldNotBeNull()
+
+        MultithreadingTester()
+            .workers(8)
+            .rounds(25)
+            .add { decorated.checkConnectivity(100.milliseconds) }
+            .run()
+
+        registry.find(MicrometerNames.METER_BACKEND_CONNECTIVITY)
+            .tag(MicrometerNames.TAG_BACKEND_REASON, LeaderBackendConnectivityReason.CONNECTED.name)
+            .counter()
+            .shouldNotBeNull()
+            .count() shouldBeEqualTo 200.0
+        registry.find(MicrometerNames.METER_BACKEND_CONNECTIVITY)
+            .tag(MicrometerNames.TAG_BACKEND_REASON, LeaderBackendConnectivityReason.CONNECTED.name)
+            .meters()
+            .size shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `decorated provider preserves exception identity and records bounded fallback reason`() {
+        val failure = IllegalStateException("endpoint=https://redis-prod.example token=secret")
+        val provider = RecordingDiagnosticsProvider(failure = failure)
+        val delegate = object :
+            LeaderElector by StubLeaderElector(elected = true),
+            LeaderBackendDiagnosticsProvider by provider {}
+        val decorated = (InstrumentedLeaderElector(delegate, registry) as LeaderBackendDiagnosticsAware)
+            .backendDiagnosticsProvider
+            .shouldNotBeNull()
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            decorated.checkConnectivity(100.milliseconds)
+        }
+
+        thrown shouldBeSameInstanceAs failure
+        registry.find(MicrometerNames.METER_BACKEND_CONNECTIVITY)
+            .tag(MicrometerNames.TAG_BACKEND_REASON, LeaderBackendConnectivityReason.PROVIDER_EXCEPTION.name)
+            .counter()
+            .shouldNotBeNull()
+            .count() shouldBeEqualTo 1.0
+    }
+
+    @Test
+    fun `active diagnostics preserves ordinary exception identity and records one fallback`() {
+        val failure = IllegalArgumentException("endpoint=https://redis-prod.example token=secret")
+        val provider = RecordingDiagnosticsProvider(failure = failure)
+        val delegate = object :
+            LeaderElector by StubLeaderElector(elected = true),
+            LeaderBackendDiagnosticsProvider by provider {}
+        val decorated = (InstrumentedLeaderElector(delegate, registry) as LeaderBackendDiagnosticsAware)
+            .backendDiagnosticsProvider
+            .shouldNotBeNull()
+
+        val thrown = assertFailsWith<IllegalArgumentException> {
+            decorated.diagnostics(probe = true, timeout = 100.milliseconds)
+        }
+
+        thrown shouldBeSameInstanceAs failure
+        registry.find(MicrometerNames.METER_BACKEND_CONNECTIVITY)
+            .tag(MicrometerNames.TAG_BACKEND_REASON, LeaderBackendConnectivityReason.PROVIDER_EXCEPTION.name)
+            .counter()
+            .shouldNotBeNull()
+            .count() shouldBeEqualTo 1.0
+    }
+
+    @Test
+    fun `interruption and Error are rethrown without fallback metric`() {
+        val failures = listOf<Throwable>(
+            InterruptedException("interrupted"),
+            AssertionError("fatal"),
+        )
+
+        failures.forEach { failure ->
+            val provider = RecordingDiagnosticsProvider(failure = failure)
+            val delegate = object :
+                LeaderElector by StubLeaderElector(elected = true),
+                LeaderBackendDiagnosticsProvider by provider {}
+            val decorated = (InstrumentedLeaderElector(delegate, registry) as LeaderBackendDiagnosticsAware)
+                .backendDiagnosticsProvider
+                .shouldNotBeNull()
+
+            val thrown = assertFailsWith<Throwable> {
+                decorated.checkConnectivity(100.milliseconds)
+            }
+
+            thrown shouldBeSameInstanceAs failure
+        }
+
+        registry.find(MicrometerNames.METER_BACKEND_CONNECTIVITY)
+            .tag(MicrometerNames.TAG_BACKEND_REASON, LeaderBackendConnectivityReason.PROVIDER_EXCEPTION.name)
+            .counter()
+            .shouldBeNull()
+    }
+
+    @Test
+    fun `decorating an instrumented provider does not double count`() {
+        val provider = RecordingDiagnosticsProvider()
+        val delegate = object :
+            LeaderElector by StubLeaderElector(elected = true),
+            LeaderBackendDiagnosticsProvider by provider {}
+        val inner = InstrumentedLeaderElector(delegate, registry)
+        val outer = InstrumentedLeaderElector(inner, registry)
+
+        (outer as LeaderBackendDiagnosticsAware).backendDiagnosticsProvider
+            .shouldNotBeNull()
+            .checkConnectivity(100.milliseconds)
+
+        registry.find(MicrometerNames.METER_BACKEND_CONNECTIVITY)
+            .tag(MicrometerNames.TAG_BACKEND_REASON, LeaderBackendConnectivityReason.CONNECTED.name)
+            .counter()
+            .shouldNotBeNull()
+            .count() shouldBeEqualTo 1.0
+    }
+
+    @Test
+    fun `cancellation is rethrown without synthetic provider exception metric`() {
+        val cancellation = CancellationException("cancelled")
+        val provider = RecordingDiagnosticsProvider(failure = cancellation)
+        val delegate = object :
+            LeaderElector by StubLeaderElector(elected = true),
+            LeaderBackendDiagnosticsProvider by provider {}
+        val decorated = (InstrumentedLeaderElector(delegate, registry) as LeaderBackendDiagnosticsAware)
+            .backendDiagnosticsProvider
+            .shouldNotBeNull()
+
+        val thrown = assertFailsWith<CancellationException> {
+            decorated.checkConnectivity(100.milliseconds)
+        }
+
+        thrown shouldBeSameInstanceAs cancellation
+        registry.find(MicrometerNames.METER_BACKEND_CONNECTIVITY)
+            .tag(MicrometerNames.TAG_BACKEND_REASON, LeaderBackendConnectivityReason.PROVIDER_EXCEPTION.name)
+            .counter()
             .shouldBeNull()
     }
 
@@ -304,6 +536,20 @@ class InstrumentedLeaderElectorsTest {
             ?.value() ?: 0.0
 
     private val sameThreadExecutor = Executor { command -> command.run() }
+
+    private class RecordingDiagnosticsProvider(
+        private val connectivity: LeaderBackendConnectivity = LeaderBackendConnectivity.up(Instant.EPOCH),
+        backendName: String = "test-backend",
+        private val failure: Throwable? = null,
+    ) : LeaderBackendDiagnosticsProvider {
+
+        override val backendDescriptor = LocalLeaderBackendDiagnostics.backendDescriptor.copy(backendId = backendName)
+
+        override fun checkConnectivity(timeout: kotlin.time.Duration): LeaderBackendConnectivity {
+            failure?.let { throw it }
+            return connectivity
+        }
+    }
 
     private class StubLeaderElector(
         private val elected: Boolean,

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/observability/LeaderBackendHealthIndicator.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/observability/LeaderBackendHealthIndicator.kt
@@ -44,6 +44,7 @@ class LeaderBackendHealthIndicator(
             builder
                 .withDetail(DETAIL_BACKEND, diagnostics.descriptor.backendId)
                 .withDetail(DETAIL_CONNECTIVITY, connectivity.status.name)
+                .withDetail(DETAIL_REASON, connectivity.reason.name)
             connectivity.checkedAt?.let { builder.withDetail(DETAIL_CHECKED_AT, it) }
             connectivity.latencyMillis?.let { builder.withDetail(DETAIL_LATENCY_MILLIS, it) }
         }
@@ -52,6 +53,7 @@ class LeaderBackendHealthIndicator(
     private companion object : KLogging() {
         const val DETAIL_BACKEND = "backend"
         const val DETAIL_CONNECTIVITY = "connectivity"
+        const val DETAIL_REASON = "reason"
         const val DETAIL_CHECKED_AT = "checkedAt"
         const val DETAIL_LATENCY_MILLIS = "latencyMillis"
     }

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/observability/LeaderBackendHealthIndicatorTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/observability/LeaderBackendHealthIndicatorTest.kt
@@ -11,6 +11,7 @@ import io.bluetape4k.leader.LeaderElector
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsAware
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivity
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityStatus
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityReason
 import io.bluetape4k.leader.diagnostics.LeaderBackendDescriptor
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnostics
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProbe
@@ -125,6 +126,17 @@ class LeaderBackendHealthIndicatorTest {
             health.status shouldBeEqualTo expectedHealthStatus
             provider.probeCalls.get() shouldBeEqualTo 1
         }
+    }
+
+    @Test
+    fun `성공한 connectivity health detail에는 bounded reason만 포함한다`() {
+        val health = LeaderBackendHealthIndicator(
+            RecordingDiagnosticsElector(LeaderBackendConnectivityStatus.UNKNOWN),
+            100.milliseconds,
+        ).health()
+
+        health.details["reason"] shouldBeEqualTo LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED.name
+        health.details.values.none { it.toString().contains(RAW_PROBE_MESSAGE) }.shouldBeTrue()
     }
 
     @Test


### PR DESCRIPTION
## 요약

Issue #774의 두 번째 child입니다. OBS-01의 bounded connectivity reason을 Micrometer active probe metric과 Spring health detail에 연결합니다.

## 변경 내용

- `leader.backend.connectivity` counter를 추가하고 `backend.name`, `status`, `reason` 세 low-cardinality tag만 기록합니다.
- passive `diagnostics()`는 계측하지 않고, `checkConnectivity`/`diagnostics(probe = true)`만 정확히 한 번 기록합니다.
- backend name은 기존 `LeaderMetricTagSanitizer`를 통과시키며 exception 원문·endpoint·credential·lock name을 tag에 넣지 않습니다.
- blocking/group/suspend wrapper의 provider decorator를 통일하고 중복 계측을 방지합니다.
- 일반 `Exception`은 `PROVIDER_EXCEPTION` fallback을 기록한 뒤 원래 인스턴스를 전파하고, cancellation/interruption/Error 경계를 보존합니다.
- Spring health detail에 bounded `reason` enum name을 additive하게 추가하고 기존 status/warning을 보존합니다.

## 검증

- RED: 새 metric 상수 부재로 `InstrumentedLeaderElectorsTest` compile 실패를 확인함
- GREEN: Micrometer targeted 26개, Spring health targeted 17개 통과
- 전체 모듈: Micrometer 127개, Spring Boot 616개 통과
- blocking/group/suspend, passive/active, sanitization, concurrent first-use, duplicate decorator, exception/cancellation/interruption/Error 경계를 검증함
- detekt, `checkBinaryCompatibility`, jar packaging, `git diff --check`, forbidden assertion scan 통과

설계: `docs/superpowers/specs/2026-08-28-issue-774-observability-design.md`
계획: `docs/superpowers/plans/2026-08-28-issue-774-observability-plan.md`

Refs #774

## DoD Status

- [x] active-only bounded connectivity counter와 세 tag
- [x] provider decorator blocking/group/suspend parity 및 중복 방지
- [x] exception/cancellation/interruption/Error 전파 경계
- [x] Spring health bounded reason detail
- [x] Micrometer 127 / Spring Boot 616 full module tests
- [x] detekt/ABI/packaging/policy scan
- [x] 1인 개발자 self-review (independent review: N/A)
- [x] hosted exact-head CI
- [ ] OBS-03~OBS-04 후속 child

상태: OBS-02 구현·로컬 검증·hosted exact-head CI 완료, rebase merge 승인 및 후속 child 대기