### PR TITLE
feat: Spring Boot Exposed 그룹 설정에서 useDbTime 전달 지원

### DIFF
--- a/docs/manual/en/frameworks/spring-boot.md
+++ b/docs/manual/en/frameworks/spring-boot.md
@@ -29,6 +29,34 @@ Release 0.5.0 uses Freefair post-compile AspectJ weaving. Do not add `@EnableAsp
 
 Use valid SpEL such as `"'prefix-' + #param"`. Invalid expressions and impossible group settings fail validation. Auto-configuration orders elector creation, AOP factories, Micrometer, then aspects so instrumentation sees the same execution boundary.
 
+## Group database server time (0.6.0+ develop)
+
+The current `develop` Spring integration exposes the Exposed group
+`LeaderGroupElectionOptions.useDbTime` policy through the common property and
+the group annotation:
+
+```yaml
+bluetape4k:
+  leader:
+    group:
+      use-db-time: true
+```
+
+The common property defaults to `false`. A method may opt in with
+`@LeaderGroupElection(..., useDbTime = true)`. The effective value is
+`commonProperty || annotationValue`; therefore a common `true` enables every
+group annotation, while the Boolean annotation does not provide a per-method
+`false` override. Only Exposed JDBC and Exposed R2DBC group electors consume
+the flag; other group backends ignore it.
+
+With the flag enabled, Exposed evaluates ownership and active-slot expiry using
+the database server clock. If the timestamp query is unavailable, the Exposed
+path remains fail-closed and does not claim a slot. For AOP calls,
+`failure-mode` still controls backend-error handling (`RETHROW`, `SKIP`, or
+`FAIL_OPEN_RUN`). Route all participants to one authoritative database clock,
+and account for provider-specific timestamp precision plus the extra timestamp
+query in the JDBC/R2DBC pool budget.
+
 ## Readiness and recent acquisition failures
 
 The opt-in `leaderElectionReadiness` contributor reads only the JVM-local lock-name registry. Configure the bounded observation window for backend acquisition failures with:

--- a/docs/manual/ko/frameworks/spring-boot.md
+++ b/docs/manual/ko/frameworks/spring-boot.md
@@ -29,6 +29,32 @@ elector를 자동 구성하고 AspectJ compile-time weaving으로 메서드 호�
 
 SpEL은 `"'prefix-' + #param"`처럼 유효한 식으로 작성합니다. 잘못된 식과 성립하지 않는 group 설정은 validation에서 실패합니다. 자동 구성은 elector, AOP factory, Micrometer, aspect 순으로 적용되어 계측과 실행 경계가 일치합니다.
 
+## Group DB server time (0.6.0+ develop)
+
+현재 `develop` Spring 연동은 공통 속성과 그룹 annotation을 통해 Exposed
+그룹의 `LeaderGroupElectionOptions.useDbTime` 정책을 노출합니다.
+
+```yaml
+bluetape4k:
+  leader:
+    group:
+      use-db-time: true
+```
+
+공통 속성의 기본값은 `false`입니다. 메서드별 opt-in은
+`@LeaderGroupElection(..., useDbTime = true)`로 지정합니다. 실제 적용값은
+`commonProperty || annotationValue`이므로 공통 속성이 `true`이면 모든 그룹
+annotation이 활성화되고 Boolean annotation으로 메서드별 `false` 재정의를
+할 수는 없습니다. 이 flag는 Exposed JDBC와 Exposed R2DBC 그룹 elector만
+사용하며 다른 그룹 backend는 무시합니다.
+
+flag를 켜면 Exposed가 소유권과 활성 슬롯 만료를 database server clock으로
+판정합니다. timestamp query를 사용할 수 없으면 Exposed 경로는 fail-closed로
+유지되어 슬롯을 차지하지 않습니다. AOP 호출에서는 `failure-mode`가 backend
+오류 처리(`RETHROW`, `SKIP`, `FAIL_OPEN_RUN`)를 계속 결정합니다. 모든 참여자를
+하나의 권위 DB clock으로 라우팅하고 provider별 timestamp 정밀도와 JDBC/R2DBC
+pool에 추가되는 timestamp query 비용을 고려하세요.
+
 ## Readiness와 최근 획득 실패
 
 opt-in `leaderElectionReadiness` contributor는 JVM-local lock-name registry만 조회합니다. backend 획득 실패를 bounded하게 관찰하려면 다음과 같이 window를 설정합니다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/annotation/LeaderGroupElection.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/annotation/LeaderGroupElection.kt
@@ -11,6 +11,7 @@ package io.bluetape4k.leader.annotation
  * @property minLeaseTime 작업이 빨리 끝나더라도 lease를 최소로 유지할 시간입니다.
  * @property bean `bean` 호출 또는 상태 계산에 필요한 값입니다.
  * @property failureMode `failureMode` 호출 또는 상태 계산에 필요한 값입니다.
+ * @property useDbTime Exposed JDBC/R2DBC group ownership에 DB server time을 사용할지 여부입니다.
  */
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 @Retention(AnnotationRetention.RUNTIME)
@@ -23,4 +24,5 @@ annotation class LeaderGroupElection(
     val minLeaseTime: String = "PT0S",
     val bean: String = "",
     val failureMode: LeaderAspectFailureMode = LeaderAspectFailureMode.INHERIT,
+    val useDbTime: Boolean = false,
 )

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/annotation/LeaderGroupElectionAnnotationTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/annotation/LeaderGroupElectionAnnotationTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.annotation
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -24,6 +25,7 @@ class LeaderGroupElectionAnnotationTest {
         minLeaseTime = "PT10S",
         bean = "redissonLeaderGroupElectionFactory",
         failureMode = LeaderAspectFailureMode.RETHROW,
+        useDbTime = true,
     )
     fun fullyAnnotatedMethod() {}
 
@@ -37,6 +39,7 @@ class LeaderGroupElectionAnnotationTest {
         annotation.minLeaseTime shouldBeEqualTo "PT0S"
         annotation.bean shouldBeEqualTo ""
         annotation.failureMode shouldBeEqualTo LeaderAspectFailureMode.INHERIT
+        annotation.useDbTime.shouldBeFalse()
     }
 
     @Test
@@ -49,6 +52,7 @@ class LeaderGroupElectionAnnotationTest {
         annotation.minLeaseTime shouldBeEqualTo "PT10S"
         annotation.bean shouldBeEqualTo "redissonLeaderGroupElectionFactory"
         annotation.failureMode shouldBeEqualTo LeaderAspectFailureMode.RETHROW
+        annotation.useDbTime.shouldBeTrue()
     }
 
     @Test

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElectorFactoryTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElectorFactoryTest.kt
@@ -1,0 +1,25 @@
+package io.bluetape4k.leader.exposed.jdbc
+
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.exposed.tests.TestDB
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+/**
+ * [ExposedJdbcLeaderGroupElectorFactory]의 group 옵션 전달 계약을 검증합니다.
+ */
+class ExposedJdbcLeaderGroupElectorFactoryTest : AbstractExposedJdbcLeaderTest() {
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `create - useDbTime 옵션을 Exposed JDBC elector에 전달`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        val elector = ExposedJdbcLeaderGroupElectorFactory(db)
+            .create(LeaderGroupElectionOptions(maxLeaders = 3, useDbTime = true))
+            .shouldBeInstanceOf<ExposedJdbcLeaderGroupElector>()
+
+        elector.options.leaderGroupOptions.useDbTime.shouldBeTrue()
+    }
+}

--- a/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElectorFactoryTest.kt
+++ b/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/ExposedR2DbcSuspendLeaderGroupElectorFactoryTest.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -44,6 +45,16 @@ class ExposedR2DbcSuspendLeaderGroupElectorFactoryTest : AbstractExposedR2dbcLea
         val elector = factory.create(opts)
         elector.shouldNotBeNull()
         elector.maxLeaders shouldBeEqualTo 5
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `create - useDbTime 옵션을 Exposed R2DBC elector에 전달`(testDB: TestR2dbcDB) = runSuspendIO {
+        val factory = makeFactory(testDB)
+        val elector = factory.create(LeaderGroupElectionOptions(maxLeaders = 3, useDbTime = true))
+            .shouldBeInstanceOf<ExposedR2DbcSuspendLeaderGroupElector>()
+
+        elector.options.leaderGroupOptions.useDbTime.shouldBeTrue()
     }
 
     @ParameterizedTest

--- a/leader-spring-boot/README.ko.md
+++ b/leader-spring-boot/README.ko.md
@@ -57,6 +57,7 @@ bluetape4k:
       max-leaders: 3
       wait-time: 5s
       lease-time: 60s
+      use-db-time: false
     aop:
       enabled: true
       strict: false
@@ -115,6 +116,33 @@ bluetape4k:
 ```
 
 Spring 설정 속성은 Spring Boot duration binding을 사용하므로 `5s`, `60s`, `PT1M`을 그대로 쓸 수 있습니다. Kotlin 코드의 core `LeaderElectionOptions`, `LeaderGroupElectionOptions`는 `kotlin.time.Duration`을 사용합니다.
+
+### Group DB server time 정책 (0.6.0+ develop)
+
+Spring에서는 공통 설정과 `@LeaderGroupElection` 양쪽으로 Exposed 그룹의
+`useDbTime` 정책을 설정할 수 있습니다.
+
+```yaml
+bluetape4k:
+  leader:
+    group:
+      use-db-time: true
+```
+
+공통 속성의 기본값은 `false`입니다. 특정 메서드만 켜려면
+`@LeaderGroupElection(..., useDbTime = true)`를 사용합니다. 실제 적용값은
+공통 속성과 annotation 값의 논리 OR입니다. 따라서 공통 속성을 켜면 모든
+그룹 annotation이 활성화되고, Boolean annotation만으로 메서드별 `false`
+재정의는 할 수 없습니다. 이 정책은 Exposed JDBC와 Exposed R2DBC 그룹
+elector만 소비하며 다른 그룹 backend는 무시합니다.
+
+활성화하면 Exposed 소유권과 활성 슬롯 만료가 database server clock을
+사용합니다. DB timestamp를 읽지 못하면 Exposed는 계속 fail-closed로
+동작하여 슬롯을 차지하지 않습니다. AOP 호출에서는 annotation의
+`failure-mode`가 backend 오류를 재전파(`RETHROW`), 건너뛰기(`SKIP`) 또는
+`FAIL_OPEN_RUN`으로 처리할지를 결정합니다. 모든 참여자가 동일한 권위 DB
+clock을 사용하도록 라우팅하고, provider별 timestamp 정밀도와 JDBC/R2DBC
+pool에 추가되는 timestamp query 비용을 반영하세요.
 
 ## 리더 전용 Route (0.5.0)
 

--- a/leader-spring-boot/README.md
+++ b/leader-spring-boot/README.md
@@ -57,6 +57,7 @@ bluetape4k:
       max-leaders: 3
       wait-time: 5s
       lease-time: 60s
+      use-db-time: false
     aop:
       enabled: true
       strict: false
@@ -115,6 +116,33 @@ bluetape4k:
 ```
 
 Spring configuration properties use Spring Boot duration binding (`5s`, `60s`, `PT1M`). Core `LeaderElectionOptions` and `LeaderGroupElectionOptions` use `kotlin.time.Duration` in Kotlin code.
+
+### Group database server time policy (0.6.0+ develop)
+
+Spring exposes the Exposed group `useDbTime` policy through both the common
+configuration and `@LeaderGroupElection`:
+
+```yaml
+bluetape4k:
+  leader:
+    group:
+      use-db-time: true
+```
+
+The common property defaults to `false`. An annotation can opt in for one
+method with `@LeaderGroupElection(..., useDbTime = true)`. The effective value
+is the logical OR of the common property and the annotation value: enabling the
+common property enables every group annotation, and the Boolean annotation has
+no per-method `false` override. This policy is consumed by Exposed JDBC and
+Exposed R2DBC group electors only; other group backends ignore it.
+
+When enabled, Exposed ownership and active-slot expiry use the database server
+clock. If the database timestamp cannot be read, Exposed remains fail-closed
+and the group does not claim a slot. For an AOP invocation, the annotation
+`failure-mode` still determines whether a backend error is rethrown, skipped,
+or handled by `FAIL_OPEN_RUN`. Keep all participants on the same authoritative
+database clock and account for provider-specific timestamp precision and the
+additional timestamp query in the JDBC/R2DBC pool budget.
 
 ## Leader-Gated Routes (0.5.0)
 

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/adapter/PropertiesAdapter.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/adapter/PropertiesAdapter.kt
@@ -33,5 +33,6 @@ internal object PropertiesAdapter {
             maxLeaders = props.group.maxLeaders,
             waitTime = props.group.waitTime.toKotlinDuration(),
             leaseTime = props.group.leaseTime.toKotlinDuration(),
+            useDbTime = props.group.useDbTime,
         )
 }

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -24,6 +24,7 @@ import io.bluetape4k.leader.spring.aop.spel.SpelExpressionEvaluator
 import io.bluetape4k.leader.spring.aop.util.AnnotationLookup
 import io.bluetape4k.leader.spring.aop.util.DurationParser
 import io.bluetape4k.leader.spring.aop.util.LockNameValidator
+import io.bluetape4k.leader.spring.properties.LeaderGroupProperties
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
@@ -57,6 +58,7 @@ import kotlin.time.toKotlinDuration
  * @property spel Spring Boot integration 계약에서 사용하는 속성입니다.
  * @property lockNameValidator Spring Boot integration 계약에서 사용하는 속성입니다.
  * @property recorders Spring Boot integration 계약에서 사용하는 속성입니다.
+ * @property groupProperties 공통 Spring group 정책과 annotation 정책을 결합하는 설정입니다.
  */
 @Suppress("ReactiveStreamsUnusedPublisher")
 @Aspect
@@ -66,7 +68,17 @@ class LeaderGroupElectionAspect(
     private val spel: SpelExpressionEvaluator,
     private val lockNameValidator: LockNameValidator,
     private val recorders: List<LeaderAopMetricsRecorder>,
+    private val groupProperties: LeaderGroupProperties = LeaderGroupProperties(),
 ): SmartInitializingSingleton {
+
+    /** `useDbTime` 정책 추가 전에 공개된 다섯 인자 생성자 descriptor를 보존합니다. */
+    constructor(
+        beanSelector: LeaderBeanSelector,
+        props: LeaderAopProperties,
+        spel: SpelExpressionEvaluator,
+        lockNameValidator: LockNameValidator,
+        recorders: List<LeaderAopMetricsRecorder>,
+    ) : this(beanSelector, props, spel, lockNameValidator, recorders, LeaderGroupProperties())
 
     private val metadataCache = ConcurrentHashMap<Method, GroupAdviceMetadata>()
     private val factoryCache = ConcurrentHashMap<GroupFactoryCacheKey, LeaderGroupElector>()
@@ -590,6 +602,7 @@ class LeaderGroupElectionAspect(
             waitTime = waitTime,
             leaseTime = leaseTime,
             minLeaseTime = minLeaseTime,
+            useDbTime = groupProperties.useDbTime || ann.useDbTime,
         )
         val selected = beanSelector.selectGroupElectionFactory(ann.bean, method)
         val literal = if (LITERAL_PATTERN.matches(ann.name)) ann.name else null

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/autoconfigure/LeaderAopAutoConfiguration.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/autoconfigure/LeaderAopAutoConfiguration.kt
@@ -10,6 +10,8 @@ import io.bluetape4k.leader.spring.aop.properties.LeaderAopProperties
 import io.bluetape4k.leader.spring.aop.spel.SpelExpressionEvaluator
 import io.bluetape4k.leader.spring.aop.util.LockNameValidator
 import io.bluetape4k.leader.spring.aop.validator.LeaderAnnotationValidatorBeanPostProcessor
+import io.bluetape4k.leader.spring.LeaderProperties
+import io.bluetape4k.leader.spring.properties.LeaderGroupProperties
 import io.bluetape4k.leader.spring.scheduling.LeaderScheduledPolicyRegistry
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.beans.factory.ObjectProvider
@@ -34,7 +36,7 @@ import org.springframework.core.annotation.Order
 @ConditionalOnClass(name = ["org.aspectj.lang.annotation.Aspect"])
 @ConditionalOnBean(LeaderElectorFactory::class)
 @ConditionalOnProperty(prefix = "bluetape4k.leader.aop", name = ["enabled"], havingValue = "true", matchIfMissing = true)
-@EnableConfigurationProperties(LeaderAopProperties::class)
+@EnableConfigurationProperties(LeaderAopProperties::class, LeaderProperties::class)
 class LeaderAopAutoConfiguration {
 
     @Bean
@@ -122,12 +124,30 @@ class LeaderAopAutoConfiguration {
         spel: SpelExpressionEvaluator,
         lockNameValidator: LockNameValidator,
         recordersProvider: ObjectProvider<LeaderAopMetricsRecorder>,
+        leaderProperties: LeaderProperties,
     ): LeaderGroupElectionAspect = LeaderGroupElectionAspect(
         beanSelector = beanSelector,
         props = props,
         spel = spel,
         lockNameValidator = lockNameValidator,
         recorders = recordersProvider.orderedStream().toList(),
+        groupProperties = leaderProperties.group,
+    )
+
+    /** `useDbTime` 정책 추가 전에 공개된 다섯 인자 factory 메서드 descriptor를 보존합니다. */
+    fun leaderGroupElectionAspect(
+        beanSelector: LeaderBeanSelector,
+        props: LeaderAopProperties,
+        spel: SpelExpressionEvaluator,
+        lockNameValidator: LockNameValidator,
+        recordersProvider: ObjectProvider<LeaderAopMetricsRecorder>,
+    ): LeaderGroupElectionAspect = LeaderGroupElectionAspect(
+        beanSelector = beanSelector,
+        props = props,
+        spel = spel,
+        lockNameValidator = lockNameValidator,
+        recorders = recordersProvider.orderedStream().toList(),
+        groupProperties = LeaderGroupProperties(),
     )
 
     @Bean

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/properties/LeaderGroupProperties.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/properties/LeaderGroupProperties.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.spring.properties
 
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import java.time.Duration
+import kotlin.jvm.internal.DefaultConstructorMarker
 import kotlin.time.toKotlinDuration
 
 /**
@@ -10,16 +11,68 @@ import kotlin.time.toKotlinDuration
  * @property maxLeaders Spring Boot integration 계약에서 `maxLeaders` 값을 계산하거나 전달할 때 사용하는 속성입니다.
  * @property waitTime Spring Boot integration 계약에서 `waitTime` 값을 계산하거나 전달할 때 사용하는 속성입니다.
  * @property leaseTime Spring Boot integration 계약에서 `leaseTime` 값을 계산하거나 전달할 때 사용하는 속성입니다.
+ * @property useDbTime Exposed JDBC/R2DBC group ownership에 DB server time을 사용할지 여부입니다.
  */
 data class LeaderGroupProperties(
     val maxLeaders: Int = DefaultMaxLeaders,
     val waitTime: Duration = DefaultWaitTime,
     val leaseTime: Duration = DefaultLeaseTime,
+    val useDbTime: Boolean = false,
 ) {
+    /** `useDbTime` 추가 전에 공개된 세 인자 생성자 descriptor를 보존합니다. */
+    constructor(
+        maxLeaders: Int,
+        waitTime: Duration,
+        leaseTime: Duration,
+    ) : this(maxLeaders, waitTime, leaseTime, false)
+
+    /** Kotlin이 `useDbTime` 추가 전에 공개한 세 인자 기본 생성자 descriptor를 보존합니다. */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(
+        maxLeaders: Int,
+        waitTime: Duration,
+        leaseTime: Duration,
+        mask: Int,
+        marker: DefaultConstructorMarker?,
+    ) : this(
+        maxLeaders = if (mask and 0x001 != 0) DefaultMaxLeaders else maxLeaders,
+        waitTime = if (mask and 0x002 != 0) DefaultWaitTime else waitTime,
+        leaseTime = if (mask and 0x004 != 0) DefaultLeaseTime else leaseTime,
+        useDbTime = false,
+    )
+
+    /** `useDbTime` 추가 전에 공개된 세 인자 data-class `copy` 진입점을 보존합니다. */
+    fun copy(
+        maxLeaders: Int,
+        waitTime: Duration,
+        leaseTime: Duration,
+    ): LeaderGroupProperties = copy(
+        maxLeaders = maxLeaders,
+        waitTime = waitTime,
+        leaseTime = leaseTime,
+        useDbTime = useDbTime,
+    )
     companion object {
         const val DefaultMaxLeaders: Int = 2
         val DefaultWaitTime: Duration = Duration.ofSeconds(5)
         val DefaultLeaseTime: Duration = Duration.ofSeconds(60)
+
+        /** `useDbTime` 추가 전에 공개된 세 인자 `copy$default` descriptor를 보존합니다. */
+        @JvmStatic
+        @Suppress("UNUSED_PARAMETER", "FunctionNaming")
+        fun `copy$default`(
+            self: LeaderGroupProperties,
+            maxLeaders: Int,
+            waitTime: Duration?,
+            leaseTime: Duration?,
+            mask: Int,
+            marker: Any?,
+        ): LeaderGroupProperties = self.copy(
+            maxLeaders = if (mask and 0x001 != 0) self.maxLeaders else maxLeaders,
+            waitTime = if (mask and 0x002 != 0) self.waitTime else requireNotNull(waitTime),
+            leaseTime = if (mask and 0x004 != 0) self.leaseTime else requireNotNull(leaseTime),
+            useDbTime = self.useDbTime,
+        )
     }
 
     fun toOptions(): LeaderGroupElectionOptions =
@@ -27,5 +80,6 @@ data class LeaderGroupProperties(
             maxLeaders = maxLeaders,
             waitTime = waitTime.toKotlinDuration(),
             leaseTime = leaseTime.toKotlinDuration(),
+            useDbTime = useDbTime,
         )
 }

--- a/leader-spring-boot/src/main/resources/META-INF/spring/additional-spring-configuration-metadata.json
+++ b/leader-spring-boot/src/main/resources/META-INF/spring/additional-spring-configuration-metadata.json
@@ -215,6 +215,12 @@
       "defaultValue": "PT1M"
     },
     {
+      "name": "bluetape4k.leader.group.use-db-time",
+      "type": "java.lang.Boolean",
+      "description": "Use database server time for Exposed JDBC/R2DBC group ownership.",
+      "defaultValue": false
+    },
+    {
       "name": "bluetape4k.leader.diagnostics.enabled",
       "type": "java.lang.Boolean",
       "description": "Run leader startup diagnostics after auto-configuration creates leader beans.",

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/LeaderPropertiesBindingTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/LeaderPropertiesBindingTest.kt
@@ -38,6 +38,7 @@ class LeaderPropertiesBindingTest {
                 "bluetape4k.leader.group.max-leaders" to "5",
                 "bluetape4k.leader.group.wait-time" to "3s",
                 "bluetape4k.leader.group.lease-time" to "45s",
+                "bluetape4k.leader.group.use-db-time" to "true",
                 "bluetape4k.leader.mongo.single-collection" to "single_election",
                 "bluetape4k.leader.mongo.group-collection" to "group_election",
                 "bluetape4k.leader.etcd.key-prefix" to "/apps/orders/leader",
@@ -68,6 +69,7 @@ class LeaderPropertiesBindingTest {
         props.group.maxLeaders shouldBeEqualTo 5
         props.group.waitTime shouldBeEqualTo Duration.ofSeconds(3)
         props.group.leaseTime shouldBeEqualTo Duration.ofSeconds(45)
+        props.group.useDbTime.shouldBeTrue()
         props.mongo.singleCollection shouldBeEqualTo "single_election"
         props.mongo.groupCollection shouldBeEqualTo "group_election"
         props.etcd.keyPrefix shouldBeEqualTo "/apps/orders/leader"
@@ -101,6 +103,7 @@ class LeaderPropertiesBindingTest {
         props.waitTime shouldBeEqualTo Duration.ofSeconds(5)
         props.leaseTime shouldBeEqualTo Duration.ofSeconds(60)
         props.group.maxLeaders shouldBeEqualTo 2
+        props.group.useDbTime.shouldBeFalse()
         props.mongo.singleCollection shouldBeEqualTo "leader_election"
         props.mongo.groupCollection shouldBeEqualTo "leader_group_election"
         props.etcd.keyPrefix shouldBeEqualTo "/bluetape4k/leader"
@@ -178,6 +181,7 @@ class LeaderPropertiesBindingTest {
 
         opts.waitTime shouldBeEqualTo 5.seconds
         opts.leaseTime shouldBeEqualTo 60.seconds
+        opts.useDbTime.shouldBeFalse()
     }
 
     @Test
@@ -202,6 +206,7 @@ class LeaderPropertiesBindingTest {
         opts.maxLeaders shouldBeEqualTo 2
         opts.waitTime shouldBeEqualTo 5.seconds
         opts.leaseTime shouldBeEqualTo 60.seconds
+        opts.useDbTime.shouldBeFalse()
     }
 
     @Test
@@ -210,12 +215,14 @@ class LeaderPropertiesBindingTest {
             maxLeaders = 5,
             waitTime = Duration.ofSeconds(3),
             leaseTime = Duration.ofMinutes(1),
+            useDbTime = true,
         )
         val opts = props.toOptions()
 
         opts.maxLeaders shouldBeEqualTo 5
         opts.waitTime shouldBeEqualTo 3.seconds
         opts.leaseTime shouldBeEqualTo 60.seconds
+        opts.useDbTime.shouldBeTrue()
     }
 
     @EnableConfigurationProperties(LeaderProperties::class)

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/adapter/PropertiesAdapterTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/adapter/PropertiesAdapterTest.kt
@@ -30,12 +30,14 @@ class PropertiesAdapterTest {
                 maxLeaders = 4,
                 waitTime = Duration.ofSeconds(2),
                 leaseTime = Duration.ofSeconds(30),
+                useDbTime = true,
             ),
         )
         val options = PropertiesAdapter.toCommonGroup(props)
         options.maxLeaders shouldBeEqualTo 4
         options.waitTime shouldBeEqualTo 2.seconds
         options.leaseTime shouldBeEqualTo 30.seconds
+        options.useDbTime shouldBeEqualTo true
     }
 
     @Test
@@ -49,5 +51,6 @@ class PropertiesAdapterTest {
     fun `default group 옵션은 maxLeaders 2`() {
         val options = PropertiesAdapter.toCommonGroup(LeaderProperties())
         options.maxLeaders shouldBeEqualTo 2
+        options.useDbTime shouldBeEqualTo false
     }
 }

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectSuspendMonoTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectSuspendMonoTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.spring.aop
 
 import io.bluetape4k.leader.LeaderGroupElectionException
+import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderGroupElectorFactory
 import io.bluetape4k.leader.LeaderGroupState
 import io.bluetape4k.leader.annotation.LeaderAspectFailureMode
@@ -18,6 +19,8 @@ import io.mockk.verify
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.assertions.assertFailsWith
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -55,6 +58,7 @@ class LeaderGroupElectionAspectSuspendMonoTest {
         suspend fun runSuspendFailOpen(): String?
         suspend fun runSuspendSkip(): String?
         suspend fun runSuspendInvalidName(): String?
+        suspend fun runSuspendDbTime(): String?
     }
 
     private class SuspendGroupServiceImpl : SuspendGroupService {
@@ -69,6 +73,9 @@ class LeaderGroupElectionAspectSuspendMonoTest {
 
         @LeaderGroupElection(name = "ns.subns.group-suspend", maxLeaders = 3)
         override suspend fun runSuspendInvalidName(): String? = SAMPLE_RESULT
+
+        @LeaderGroupElection(name = "g-suspend-db-time", maxLeaders = 3, useDbTime = true)
+        override suspend fun runSuspendDbTime(): String? = SAMPLE_RESULT
     }
 
     // ── Mono 서비스 정의 ────────────────────────────────────────────────────
@@ -77,6 +84,7 @@ class LeaderGroupElectionAspectSuspendMonoTest {
         fun runMono(): Mono<String>
         fun runMonoFailOpen(): Mono<String>
         fun runMonoInvalidName(): Mono<String>
+        fun runMonoDbTime(): Mono<String>
     }
 
     private class MonoGroupServiceImpl : MonoGroupService {
@@ -88,6 +96,9 @@ class LeaderGroupElectionAspectSuspendMonoTest {
 
         @LeaderGroupElection(name = "ns.subns.group-mono", maxLeaders = 3)
         override fun runMonoInvalidName(): Mono<String> = Mono.just(SAMPLE_RESULT)
+
+        @LeaderGroupElection(name = "g-mono-db-time", maxLeaders = 3, useDbTime = true)
+        override fun runMonoDbTime(): Mono<String> = Mono.just(SAMPLE_RESULT)
     }
 
     private interface StreamGroupService {
@@ -127,6 +138,17 @@ class LeaderGroupElectionAspectSuspendMonoTest {
 
     private fun fakeGroupFactory(elector: SuspendLeaderGroupElector): SuspendLeaderGroupElectorFactory =
         SuspendLeaderGroupElectorFactory { _ -> elector }
+
+    private class CapturingGroupFactory(
+        private val elector: SuspendLeaderGroupElector,
+    ) : SuspendLeaderGroupElectorFactory {
+        var options: LeaderGroupElectionOptions? = null
+
+        override suspend fun create(options: LeaderGroupElectionOptions): SuspendLeaderGroupElector {
+            this.options = options
+            return elector
+        }
+    }
 
     // ── MockK mocks ─────────────────────────────────────────────────────────
 
@@ -210,6 +232,18 @@ class LeaderGroupElectionAspectSuspendMonoTest {
         val result = runSuspendAspect(aspect)
 
         result.shouldBeNull()
+    }
+
+    @Test
+    fun `group suspend useDbTime - annotation 옵션이 factory에 전달`() = runTest {
+        configureSuspendPjp("runSuspendDbTime", SuspendGroupServiceImpl())
+        every { pjp.proceed(any<Array<Any?>>()) } returns SAMPLE_RESULT
+        val factory = CapturingGroupFactory(ElectedGroupElector())
+
+        val result = runSuspendAspect(newAspect(factory))
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        factory.options.shouldNotBeNull().useDbTime.shouldBeTrue()
     }
 
     @Test
@@ -302,6 +336,18 @@ class LeaderGroupElectionAspectSuspendMonoTest {
         val result = (aspect.aroundLeader(pjp) as Mono<*>).block()
 
         result.shouldBeNull()
+    }
+
+    @Test
+    fun `group mono useDbTime - annotation 옵션이 factory에 전달`() {
+        configureMonoJoinPoint("runMonoDbTime", MonoGroupServiceImpl())
+        every { pjp.proceed() } returns Mono.just(SAMPLE_RESULT)
+        val factory = CapturingGroupFactory(ElectedGroupElector())
+
+        val result = (newAspect(factory).aroundLeader(pjp) as Mono<*>).block()
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        factory.options.shouldNotBeNull().useDbTime.shouldBeTrue()
     }
 
     @Test

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspectTest.kt
@@ -14,6 +14,7 @@ import io.bluetape4k.leader.metrics.SkipReason
 import io.bluetape4k.leader.spring.aop.properties.LeaderAopProperties
 import io.bluetape4k.leader.spring.aop.spel.SpelExpressionEvaluator
 import io.bluetape4k.leader.spring.aop.util.LockNameValidator
+import io.bluetape4k.leader.spring.properties.LeaderGroupProperties
 import io.bluetape4k.logging.KLogging
 import io.mockk.clearMocks
 import io.mockk.every
@@ -33,6 +34,7 @@ import io.bluetape4k.assertions.assertFailsWith
 import java.util.concurrent.CancellationException
 import kotlin.time.Duration.Companion.seconds
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
 
 /**
@@ -60,6 +62,7 @@ class LeaderGroupElectionAspectTest {
         fun runWithArg(region: String): String?
         fun runWithMinLease(): String?
         fun runWithDotName(): String?
+        fun runWithDbTime(): String?
     }
 
     private class SampleServiceImpl: SampleService {
@@ -74,6 +77,9 @@ class LeaderGroupElectionAspectTest {
 
         @LeaderGroupElection(name = "ns.subns.group", maxLeaders = 2)
         override fun runWithDotName(): String? = SAMPLE_RESULT
+
+        @LeaderGroupElection(name = "db-time-group-job", maxLeaders = 2, useDbTime = true)
+        override fun runWithDbTime(): String? = SAMPLE_RESULT
     }
 
     // Class-level mocks — reused across all tests, cleared in @BeforeEach
@@ -99,6 +105,7 @@ class LeaderGroupElectionAspectTest {
     private fun newAspect(
         recorders: List<LeaderAopMetricsRecorder> = emptyList(),
         props: LeaderAopProperties = LeaderAopProperties(),
+        groupProperties: LeaderGroupProperties = LeaderGroupProperties(),
     ): LeaderGroupElectionAspect {
         every { factoryMock.create(any()) } returns election
         every { beanSelector.selectGroupElectionFactory(any(), any()) } returns
@@ -110,6 +117,7 @@ class LeaderGroupElectionAspectTest {
             spel = SpelExpressionEvaluator(embeddedValueResolver = { it }, allowMethodInvocation = false),
             lockNameValidator = LockNameValidator(prefix = ""),
             recorders = recorders,
+            groupProperties = groupProperties,
         )
     }
 
@@ -155,6 +163,50 @@ class LeaderGroupElectionAspectTest {
         result shouldBeEqualTo SAMPLE_RESULT
         optionsSlot.captured.leaseTime shouldBeEqualTo 30.seconds
         optionsSlot.captured.minLeaseTime shouldBeEqualTo 10.seconds
+    }
+
+    @Test
+    fun `useDbTime - 어노테이션 opt-in을 group options 로 전달한다`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("runWithDbTime")
+        configureJoinPoint(method, target, emptyArray())
+        every { pjp.proceed() } returns SAMPLE_RESULT
+
+        val actionSlot = slot<() -> Any?>()
+        every { election.runIfLeaderResult(any<String>(), capture(actionSlot)) } answers {
+            LeaderRunResult.Elected(actionSlot.captured.invoke())
+        }
+        val aspect = newAspect()
+        val optionsSlot = slot<LeaderGroupElectionOptions>()
+        every { factoryMock.create(capture(optionsSlot)) } returns election
+
+        val result = aspect.aroundLeader(pjp)
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        optionsSlot.captured.useDbTime.shouldBeTrue()
+    }
+
+    @Test
+    fun `useDbTime - 공통 Spring group 속성을 annotation 기본값에 반영한다`() {
+        val target = SampleServiceImpl()
+        val method = SampleService::class.java.getDeclaredMethod("runSync")
+        configureJoinPoint(method, target, emptyArray())
+        every { pjp.proceed() } returns SAMPLE_RESULT
+
+        val actionSlot = slot<() -> Any?>()
+        every { election.runIfLeaderResult(any<String>(), capture(actionSlot)) } answers {
+            LeaderRunResult.Elected(actionSlot.captured.invoke())
+        }
+        val aspect = newAspect(
+            groupProperties = LeaderGroupProperties(useDbTime = true),
+        )
+        val optionsSlot = slot<LeaderGroupElectionOptions>()
+        every { factoryMock.create(capture(optionsSlot)) } returns election
+
+        val result = aspect.aroundLeader(pjp)
+
+        result shouldBeEqualTo SAMPLE_RESULT
+        optionsSlot.captured.useDbTime.shouldBeTrue()
     }
 
     @Test

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/compatibility/PublicJvmAbiCompatibilityTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/compatibility/PublicJvmAbiCompatibilityTest.kt
@@ -15,6 +15,7 @@ import io.bluetape4k.leader.spring.observability.LeaderElectionReadinessHealthIn
 import io.bluetape4k.leader.spring.observability.LeaderElectionStatusRegistry
 import io.bluetape4k.leader.spring.observability.LeaderElectionStatusResponse
 import io.bluetape4k.leader.spring.observability.LeaderElectionStatusEndpoint
+import io.bluetape4k.leader.spring.properties.LeaderGroupProperties
 import io.bluetape4k.leader.spring.properties.LeaderObservabilityHealthProperties
 import io.bluetape4k.leader.spring.route.LeaderRouteGuardConfigurationException
 import java.io.ObjectStreamClass
@@ -38,6 +39,15 @@ class PublicJvmAbiCompatibilityTest {
             LockNameValidator::class.java,
             ObjectProvider::class.java,
         ).returnType shouldBeEqualTo LeaderElectionAspect::class.java
+
+        LeaderAopAutoConfiguration::class.java.getMethod(
+            "leaderGroupElectionAspect",
+            LeaderBeanSelector::class.java,
+            LeaderAopProperties::class.java,
+            SpelExpressionEvaluator::class.java,
+            LockNameValidator::class.java,
+            ObjectProvider::class.java,
+        ).returnType shouldBeEqualTo io.bluetape4k.leader.spring.aop.LeaderGroupElectionAspect::class.java
 
         LeaderElectionActuatorAutoConfiguration::class.java.getMethod(
             "leaderElectionStatusEndpoint",
@@ -100,6 +110,68 @@ class PublicJvmAbiCompatibilityTest {
             as LeaderObservabilityHealthProperties
         health.enabled shouldBeEqualTo false
         health.leaseWarningThreshold shouldBeEqualTo Duration.ofSeconds(10)
+    }
+
+    @Test
+    fun `0_5_0 LeaderGroupProperties의 생성자와 copy descriptor를 유지한다`() {
+        val legacyConstructor = LeaderGroupProperties::class.java.getConstructor(
+            intType,
+            Duration::class.java,
+            Duration::class.java,
+        )
+        val legacy = legacyConstructor.newInstance(
+            4,
+            Duration.ofSeconds(2),
+            Duration.ofSeconds(8),
+        ) as LeaderGroupProperties
+        legacy.useDbTime shouldBeEqualTo false
+
+        val legacySyntheticConstructor = LeaderGroupProperties::class.java.getConstructor(
+            intType,
+            Duration::class.java,
+            Duration::class.java,
+            intType,
+            DefaultConstructorMarker::class.java,
+        )
+        legacySyntheticConstructor.isSynthetic shouldBeEqualTo false
+        val defaults = legacySyntheticConstructor.newInstance(
+            *arrayOf<Any?>(0, Duration.ZERO, Duration.ZERO, 0b111, null),
+        ) as LeaderGroupProperties
+        defaults.maxLeaders shouldBeEqualTo LeaderGroupProperties.DefaultMaxLeaders
+        defaults.waitTime shouldBeEqualTo LeaderGroupProperties.DefaultWaitTime
+        defaults.leaseTime shouldBeEqualTo LeaderGroupProperties.DefaultLeaseTime
+        defaults.useDbTime shouldBeEqualTo false
+
+        val legacyCopy = LeaderGroupProperties::class.java.getMethod(
+            "copy",
+            intType,
+            Duration::class.java,
+            Duration::class.java,
+        )
+        val copied = legacyCopy.invoke(
+            LeaderGroupProperties(useDbTime = true),
+            5,
+            Duration.ofSeconds(3),
+            Duration.ofSeconds(9),
+        ) as LeaderGroupProperties
+        copied.maxLeaders shouldBeEqualTo 5
+        copied.useDbTime shouldBeEqualTo true
+
+        val legacyCopyDefault = LeaderGroupProperties::class.java.getMethod(
+            "copy\$default",
+            LeaderGroupProperties::class.java,
+            intType,
+            Duration::class.java,
+            Duration::class.java,
+            intType,
+            Any::class.java,
+        )
+        val copiedWithDefaults = legacyCopyDefault.invoke(
+            null,
+            *arrayOf<Any?>(LeaderGroupProperties(useDbTime = true), 7, null, null, 0b110, null),
+        ) as LeaderGroupProperties
+        copiedWithDefaults.maxLeaders shouldBeEqualTo 7
+        copiedWithDefaults.useDbTime shouldBeEqualTo true
     }
 
     @Test

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/metadata/LeaderConfigurationMetadataTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/metadata/LeaderConfigurationMetadataTest.kt
@@ -76,6 +76,7 @@ class LeaderConfigurationMetadataTest {
     fun `configuration metadata defaults match property classes`() {
         mapOf(
             "bluetape4k.leader.group.max-leaders" to "2",
+            "bluetape4k.leader.group.use-db-time" to "false",
             "bluetape4k.leader.mongo.single-collection" to "leader_election",
             "bluetape4k.leader.mongo.group-collection" to "leader_group_election",
             "bluetape4k.leader.dynamodb.retry-delay" to "PT0.05S",


### PR DESCRIPTION
## 요약

Spring Boot의 `bluetape4k.leader.group.use-db-time`와 `@LeaderGroupElection(useDbTime = true)`를 Exposed JDBC/R2DBC 그룹 elector factory까지 전달합니다. 기존 기본값과 공개 JVM descriptor는 유지합니다.

## 배경

직접 Exposed 경로에는 `LeaderGroupElectionOptions.useDbTime`가 이미 있었지만 Spring Boot properties, adapter, AOP 경로에서 값이 소실됐습니다. 그 결과 Spring 애플리케이션이 DB server time ownership 정책을 선택할 수 없었습니다.

## 변경 내용

- `LeaderGroupProperties`와 configuration metadata에 `useDbTime=false`를 추가했습니다.
- `PropertiesAdapter`, group AOP sync/suspend/Mono 경로, JDBC/R2DBC factory 전달을 연결했습니다.
- 공통 property와 annotation은 `commonProperty || annotation`으로 결합하며 annotation에는 per-method false opt-out이 없습니다.
- Exposed JDBC/R2DBC만 이 옵션을 소비하고, DB timestamp 실패는 직접 경로에서 fail-closed로 유지합니다. AOP `failureMode` 경계도 문서화했습니다.
- 기존 `LeaderGroupProperties` 생성자/copy/copy$default 및 group AOP factory descriptor를 호환 overload와 reflection 회귀로 보존했습니다.
- 영문/한국어 README와 Spring Boot manual에 기본값·지원 backend·실패 정책·정밀도/connection pool 주의를 반영했습니다.

## 검증

- RED: 구현 전 useDbTime annotation/properties/adapter/aspect/factory 회귀가 compile 오류로 실패함
- GREEN: Spring Boot 620개, core 957개, Exposed JDBC group 54개, R2DBC group 57개 통과
- factory 전달: JDBC 3개 및 R2DBC 15개 DB matrix 테스트 통과
- ABI: `PublicJvmAbiCompatibilityTest` 4개 및 `javap` descriptor 확인 통과
- 문서/정적: manual 442개 누락 0, Ruby 392 assertions, metadata JSON parse, detekt, `git diff --check` 통과
- 독립 read-only code review 2건: P0/P1/P2 0, APPROVE

Closes #719

## DoD Status

- [x] Spring property/metadata와 annotation 기본값
- [x] adapter/AOP/factory useDbTime 전달 및 OR precedence
- [x] Exposed JDBC/R2DBC 회귀와 DB-time fail-closed 경계
- [x] 공개 JVM descriptor 호환성 회귀
- [x] EN/KO README 및 manual 문서
- [x] local workflow required checks 7/7, component/main verification
- [x] independent review P0/P1/P2 = 0
- [x] hosted exact-head CI 48/48 (`33099085922`, `33099085745`)
- [x] GitHub review/thread read-back: reviews/comments/review-comments 0

상태: 구현·로컬/hosted exact-head 검증·독립 리뷰 완료, merge-ready; 별도 병합 승인 대기
