### PR TITLE
[OBS-03] Ktor diagnostics JSON에 bounded reason 추가

### DIFF
--- a/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderBackendDiagnosticsRoute.kt
+++ b/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderBackendDiagnosticsRoute.kt
@@ -21,6 +21,8 @@ import kotlin.time.Duration
  * Leader backend의 정적 capability와 선택적인 connectivity 결과를 JSON route로 노출합니다.
  *
  * [connectivityCheckEnabled]가 `false`이면 외부 backend I/O를 실행하지 않습니다.
+ * connectivity payload에는 상태와 함께 bounded [LeaderBackendConnectivity.reason]을
+ * 포함하며, provider 예외의 HTTP status 처리는 application pipeline이 소유합니다.
  */
 fun Application.leaderBackendDiagnosticsRoute(
     path: String = LeaderElectionPluginConfig.DefaultBackendDiagnosticsRoutePath,
@@ -103,5 +105,6 @@ private fun StringBuilder.appendConnectivity(connectivity: LeaderBackendConnecti
     append("{\"status\":").append(connectivity.status.name.jsonValue())
     append(",\"checkedAt\":").append(connectivity.checkedAt?.toString()?.jsonValue() ?: "null")
     append(",\"latencyMillis\":").append(connectivity.latencyMillis ?: "null")
+    append(",\"reason\":").append(connectivity.reason.name.jsonValue())
     append('}')
 }

--- a/leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/LeaderBackendDiagnosticsRouteTest.kt
+++ b/leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/LeaderBackendDiagnosticsRouteTest.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.ktor.testing.shouldHaveStatus
 import io.bluetape4k.leader.coroutines.LocalSuspendLeaderElector
 import io.bluetape4k.leader.coroutines.SuspendLeaderElector
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivity
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityReason
 import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityStatus
 import io.bluetape4k.leader.diagnostics.LeaderBackendDescriptor
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnostics
@@ -107,7 +108,55 @@ class LeaderBackendDiagnosticsRouteTest {
             val response = client.get(LeaderElectionPluginConfig.DefaultBackendDiagnosticsRoutePath)
 
             response shouldHaveStatus HttpStatusCode.OK
+            val body = response.bodyAsText()
+            body.contains("\"status\":\"UNKNOWN\"") shouldBeEqualTo true
+            body.contains("\"reason\":\"PROVIDER_EXCEPTION\"") shouldBeEqualTo true
+            body.contains("backend endpoint and credential must not escape") shouldBeEqualTo false
+        }
+    }
+
+    @Test
+    fun `active diagnostics route는 DOWN 상태와 bounded reason을 함께 반환한다`() = runSuspendIO {
+        testApplication {
+            application {
+                install(LeaderElectionPlugin) {
+                    leaderElection = ProbeBackedDiagnosticsElector {
+                        LeaderBackendConnectivityStatus.DOWN
+                    }
+                    backendDiagnosticsRouteEnabled = true
+                    backendConnectivityCheckEnabled = true
+                }
+            }
+            startApplication()
+
+            val response = client.get(LeaderElectionPluginConfig.DefaultBackendDiagnosticsRoutePath)
+
+            response shouldHaveStatus HttpStatusCode.OK
+            response.bodyAsText().contains("\"status\":\"DOWN\"") shouldBeEqualTo true
+            response.bodyAsText().contains("\"reason\":\"DISCONNECTED\"") shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `active diagnostics route는 명시한 UNKNOWN reason을 보존한다`() = runSuspendIO {
+        testApplication {
+            application {
+                install(LeaderElectionPlugin) {
+                    leaderElection = ProbeBackedDiagnosticsElector(
+                        probe = { LeaderBackendConnectivityStatus.UNKNOWN },
+                        unknownReason = LeaderBackendConnectivityReason.PROVIDER_UNSUPPORTED,
+                    )
+                    backendDiagnosticsRouteEnabled = true
+                    backendConnectivityCheckEnabled = true
+                }
+            }
+            startApplication()
+
+            val response = client.get(LeaderElectionPluginConfig.DefaultBackendDiagnosticsRoutePath)
+
+            response shouldHaveStatus HttpStatusCode.OK
             response.bodyAsText().contains("\"status\":\"UNKNOWN\"") shouldBeEqualTo true
+            response.bodyAsText().contains("\"reason\":\"PROVIDER_UNSUPPORTED\"") shouldBeEqualTo true
         }
     }
 
@@ -283,6 +332,8 @@ class LeaderBackendDiagnosticsRouteTest {
     }
 
     private class ProbeBackedDiagnosticsElector(
+        private val unknownReason: LeaderBackendConnectivityReason =
+            LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED,
         private val probe: (Duration) -> LeaderBackendConnectivityStatus,
     ) : SuspendLeaderElector by LocalSuspendLeaderElector(), LeaderBackendDiagnosticsProvider {
 
@@ -292,6 +343,7 @@ class LeaderBackendDiagnosticsRouteTest {
             LeaderBackendDiagnosticsProbe.check(
                 timeout = timeout,
                 clock = Clock.fixed(CheckedAt, java.time.ZoneOffset.UTC),
+                unknownReason = unknownReason,
                 probe = probe,
             )
     }
@@ -330,7 +382,7 @@ class LeaderBackendDiagnosticsRouteTest {
                     "\"leaseExtension\":{\"single\":\"SUPPORTED\",\"group\":\"SUPPORTED\"}," +
                     "\"auditState\":{\"single\":\"SUPPORTED\",\"group\":\"UNSUPPORTED\"}," +
                     "\"clockSource\":\"PROCESS\",\"ttlMode\":\"CLIENT_LEASE\",\"limitations\":[]}}," +
-                    "\"connectivity\":{\"status\":\"NOT_CHECKED\",\"checkedAt\":null,\"latencyMillis\":null}}"
+                    "\"connectivity\":{\"status\":\"NOT_CHECKED\",\"checkedAt\":null,\"latencyMillis\":null,\"reason\":\"NOT_CHECKED\"}}"
 
         const val LocalConnectivityJson: String =
             "{\"descriptor\":{\"backendId\":\"local\",\"displayName\":\"Local\",\"capabilities\":" +
@@ -340,6 +392,6 @@ class LeaderBackendDiagnosticsRouteTest {
                     "\"auditState\":{\"single\":\"SUPPORTED\",\"group\":\"UNSUPPORTED\"}," +
                     "\"clockSource\":\"PROCESS\",\"ttlMode\":\"CLIENT_LEASE\",\"limitations\":[]}}," +
                     "\"connectivity\":{\"status\":\"UP\",\"checkedAt\":\"2026-08-16T00:00:00Z\"," +
-                    "\"latencyMillis\":7}}"
+                    "\"latencyMillis\":7,\"reason\":\"CONNECTED\"}}"
     }
 }


### PR DESCRIPTION
## 요약

Issue #774의 세 번째 child입니다. OBS-01의 bounded connectivity reason을 Ktor diagnostics JSON에 additive하게 노출하고, HTTP transport와 application pipeline 예외 경계를 회귀 테스트로 고정합니다.

## 변경 내용

- `connectivity.reason`을 기존 `status`, `checkedAt`, `latencyMillis` 뒤에 additive하게 직렬화합니다.
- passive payload는 `NOT_CHECKED` reason을 포함하고, active `UP`/`DOWN`/`UNKNOWN` 결과는 core가 계산한 bounded reason을 그대로 보존합니다.
- 일반 `Exception`의 `PROVIDER_EXCEPTION`은 payload에 노출하고 raw exception message는 JSON에 넣지 않습니다.
- active diagnostics 결과의 HTTP 200 transport 의미와 cancellation/`Error`/custom provider 예외의 application-owned pipeline 경계를 유지합니다.
- 기존 descriptor/capability/status/time/latency field, path validation, `Dispatchers.IO` 경계를 변경하지 않습니다.

## 검증

- RED: reason을 기대하는 Ktor route 테스트가 기존 serializer에서 실패함을 확인
- GREEN: `LeaderBackendDiagnosticsRouteTest` 14개 통과
- 전체 `leader-ktor` 테스트: 120개 통과, 실패/오류/skip 0
- detekt, jar packaging, root `checkBinaryCompatibility`, `javap`, `git diff --check` 통과
- `assertThrows`, `kotlin.test.assertFailsWith`, `shouldThrow` 금지 assertion scan 통과

## 7-Tier self-review

1. 입력/경계: path와 기존 timeout 검증을 유지하고 serializer는 core 결과만 소비
2. API/ABI: JSON field additive, 기존 field·HTTP contract 유지
3. 불변식: 상태와 reason 조합을 core에서 보장하며 route에서 재계산하지 않음
4. 예외/취소: 일반 예외의 bounded reason만 payload에 남기고 cancellation/`Error`/custom 예외는 pipeline에 위임
5. 동시성: 기존 `Dispatchers.IO` route 경계 유지, 새 shared state 없음
6. 성능/보안: 문자열 field 하나만 추가하고 raw exception/endpoint/credential/lock name 비노출
7. 운영 호환성: `NOT_CHECKED`를 readiness/UP로 승격하지 않고 transport status와 backend status를 분리

1인 개발자 환경으로 independent review는 N/A이며, source/test read-back과 exact-head CI로 대체합니다.

Refs #774
Depends on #820

## DoD Status

- [x] passive/active Ktor JSON에 bounded `reason` additive field
- [x] `UP`/`DOWN`/`UNKNOWN`/`NOT_CHECKED` reason parity
- [x] HTTP 200 payload 및 application-owned pipeline exception 경계
- [x] raw exception message/endpoint/credential/lock name 비노출
- [x] Ktor targeted 14 / full module 120 tests
- [x] detekt/ABI/packaging/policy scan
- [x] 7-Tier self-review (independent review: N/A)
- [x] hosted exact-head CI
- [ ] OBS-04 후속 child

상태: OBS-03 구현·로컬 검증·hosted exact-head CI 완료, rebase merge 승인 및 OBS-04 대기