### PR TITLE
[OBS-04] observability 문서·Prometheus 운영 런북 고정

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -123,6 +123,28 @@ Spring Boot의 정적 `leaderBackendDiagnostics` Actuator endpoint는 명시적�
 Diagnostics 응답에는 backend 종류, capability 제한, connectivity 상태, 검사 시각과 지연 시간이 포함될 수 있습니다. Spring Actuator와 Ktor management route를 인증과 network policy로 보호하세요. 애플리케이션별 정책 없이 diagnostics를 소유권 판단이나 readiness 근거로 사용하면 안 됩니다.
 
 내장 provider는 공개 `LeaderBackendDiagnosticsProbe.check` helper를 사용합니다. 이 helper는 양수이면서 유한한 provider-native timeout을 검증하고, callback 전에 clock을 한 번 읽으며, 일반 `Exception`을 `UNKNOWN`으로 정규화합니다. `CancellationException`, interrupt flag를 복원한 `InterruptedException`, 치명적인 `Error`는 재전파하고 `NOT_CHECKED` callback 결과는 잘못된 결과로 거부합니다. 기존 `checkConnectivity` 또는 `diagnostics` custom override는 호환성을 위한 escape hatch로 유지되며 예외 동작은 해당 provider가 소유합니다.
+
+Connectivity 결과에는 제한된 `LeaderBackendConnectivityReason` 값도 포함됩니다.
+
+| 상태 | Reason | 의미 |
+|---|---|---|
+| `UP` | `CONNECTED` | 기존 client가 probe 시점에 backend 연결 가능 상태를 확인했습니다. |
+| `DOWN` | `DISCONNECTED` | 기존 client가 backend를 사용할 수 없는 상태를 확인했습니다. |
+| `UNKNOWN` | `CLIENT_STATE_UNCONFIRMED` | bounded read-only 검사만으로 연결을 증명하지 못했습니다. |
+| `UNKNOWN` | `PROVIDER_UNSUPPORTED` | provider가 지원하는 active probe를 제공하지 않습니다. |
+| `UNKNOWN` | `PROVIDER_EXCEPTION` | 일반 provider 예외를 원문 없이 정규화했습니다. |
+| `NOT_CHECKED` | `NOT_CHECKED` | active probe를 요청하지 않았으며 health 신호가 아닙니다. |
+
+`leader-micrometer`의 instrumented elector가 active
+`checkConnectivity` 또는 `diagnostics(probe = true)`를 실행하면
+`leader.backend.connectivity` counter가 호출마다 한 번 증가합니다. 태그는
+정제된 `backend.name`, `status`, `reason`뿐이며 passive diagnostics는 series를
+만들지 않습니다. 예외 원문, endpoint, credential, lock name은 export하지
+않습니다. `UNKNOWN`은 dashboard와 warning 신호로만 사용하고 자동으로 `DOWN`이나
+page로 승격하지 마세요.
+
+운영 decision table과 timeout/bypass 런북은 [미배포 observability manual
+초안](docs/manual/drafts/2026-08-28-issue-774-observability.ko.md)에서 확인하세요.
 <!-- LEADER_BACKEND_DIAGNOSTICS:END -->
 
 `@LeaderGroupElection`은 scalar, suspend, `Mono` 결과를 지원하지만 slot별 stream lease extension이 정의되지 않아 `Flux`와 Kotlin `Flow`를 거부합니다. 길거나 무한에 가까운 단일 리더 stream에는 `@LeaderElection(autoExtend = true)`를 사용하세요.
@@ -831,7 +853,7 @@ bluetape4k:
         enabled: false
 ```
 
-Metric tag 값은 export 전에 sanitizer를 거칩니다. 기본값은 동적 `lock.name`을 `redacted-lock`으로, opt-in Observation `leader.id` 값을 `redacted-leader`로 접고, custom 또는 future meter path가 `backend.name`을 emit할 때 cardinality가 제한된 backend label만 raw로 유지합니다. 현재 built-in meter path는 `backend.name`을 emit하지 않습니다. `bluetape4k.leader.aop.metrics.tags.lock-name.mode=RAW`는 작고 정적인 job set에만 사용하세요. 동적 이름을 제한적으로 추적해야 한다면 `HASH` 또는 `TRUNCATE`를 사용합니다.
+Metric tag 값은 export 전에 sanitizer를 거칩니다. 기본값은 동적 `lock.name`을 `redacted-lock`으로, opt-in Observation `leader.id` 값을 `redacted-leader`로 접고, active diagnostics meter는 정제된 bounded `backend.name`만 emit합니다. 그 밖의 built-in meter path는 `backend.name`을 emit하지 않습니다. `bluetape4k.leader.aop.metrics.tags.lock-name.mode=RAW`는 작고 정적인 job set에만 사용하세요. 동적 이름을 제한적으로 추적해야 한다면 `HASH` 또는 `TRUNCATE`를 사용합니다.
 
 ### 메터 카탈로그
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,28 @@ Spring Boot keeps the static `leaderBackendDiagnostics` Actuator endpoint disabl
 Diagnostics can disclose backend type, capability limits, connectivity status, and check timing. Protect Spring Actuator and Ktor management routes with authentication and network policy, and do not treat diagnostics as an ownership decision or readiness proof without an application-specific policy.
 
 Built-in providers use the public `LeaderBackendDiagnosticsProbe.check` helper. It validates a positive, finite provider-native timeout, reads the clock once before invoking the callback, maps an ordinary `Exception` to `UNKNOWN`, and rethrows `CancellationException`, `InterruptedException` (after restoring the interrupt flag), and fatal `Error` values. A `NOT_CHECKED` callback result is invalid. Providers with an existing custom `checkConnectivity` or `diagnostics` override remain a compatibility escape hatch and own their exception behavior.
+
+Connectivity results also carry the bounded `LeaderBackendConnectivityReason` value:
+
+| Status | Reason | Meaning |
+|---|---|---|
+| `UP` | `CONNECTED` | The existing client confirmed that the backend is reachable at probe time. |
+| `DOWN` | `DISCONNECTED` | The existing client confirmed that the backend is unavailable. |
+| `UNKNOWN` | `CLIENT_STATE_UNCONFIRMED` | A bounded read-only check could not prove connectivity. |
+| `UNKNOWN` | `PROVIDER_UNSUPPORTED` | The provider does not expose a supported active probe. |
+| `UNKNOWN` | `PROVIDER_EXCEPTION` | An ordinary provider exception was normalized without retaining its details. |
+| `NOT_CHECKED` | `NOT_CHECKED` | No active probe was requested; this is not a health signal. |
+
+When an instrumented elector from `leader-micrometer` performs an active
+`checkConnectivity` or `diagnostics(probe = true)` call, it increments the
+`leader.backend.connectivity` counter once. The only tags are the sanitized
+`backend.name`, `status`, and `reason`; passive diagnostics do not create a
+series, and exception text, endpoints, credentials, and lock names are never
+exported. `UNKNOWN` is a dashboard and warning signal, not an automatic
+`DOWN` or page condition.
+
+For the operational decision table and timeout/bypass runbook, see the
+[unreleased observability manual draft](docs/manual/drafts/2026-08-28-issue-774-observability.en.md).
 <!-- LEADER_BACKEND_DIAGNOSTICS:END -->
 
 `@LeaderGroupElection` supports scalar, suspend, and `Mono` results, but rejects `Flux` and Kotlin `Flow` because per-slot stream lease extension is undefined. For long-running or unbounded single-leader streams, use `@LeaderElection(autoExtend = true)`.
@@ -830,7 +852,7 @@ bluetape4k:
         enabled: false
 ```
 
-Metric tag values are sanitized before export. By default, dynamic `lock.name` values are collapsed to `redacted-lock`, opt-in Observation `leader.id` values are collapsed to `redacted-leader`, and bounded backend labels stay raw when custom or future meter paths emit `backend.name`. Current built-in meter paths do not emit `backend.name`. Use `bluetape4k.leader.aop.metrics.tags.lock-name.mode=RAW` only for small static job sets; use `HASH` or `TRUNCATE` when dashboards need bounded correlation for dynamic names.
+Metric tag values are sanitized before export. By default, dynamic `lock.name` values are collapsed to `redacted-lock`, opt-in Observation `leader.id` values are collapsed to `redacted-leader`, and the active diagnostics meter emits only sanitized, bounded `backend.name` values. Other built-in meter paths do not emit `backend.name`. Use `bluetape4k.leader.aop.metrics.tags.lock-name.mode=RAW` only for small static job sets; use `HASH` or `TRUNCATE` when dashboards need bounded correlation for dynamic names.
 
 ### Meter Catalog
 

--- a/docs/manual/drafts/2026-08-28-issue-774-observability.en.md
+++ b/docs/manual/drafts/2026-08-28-issue-774-observability.en.md
@@ -1,0 +1,176 @@
+---
+title: "Backend connectivity observability and readiness runbook"
+locale: en
+status: unreleased
+sourceReleaseRef: 0.5.0
+sourceReleaseCommit: 721a9a3808f67489d2bdb8177734325981c24977
+---
+
+# Backend connectivity observability and readiness runbook
+
+> Unreleased draft for Issue #774 and the OBS-01–04 stacked train. The current
+> `develop` sources contain this additive observability contract, but the
+> versioned manual remains pinned to `0.5.0` at
+> `721a9a3808f67489d2bdb8177734325981c24977`. Do not promote this draft or
+> change `docs/manual/manifest.yaml` until a release commit contains the full
+> train.
+
+This document describes how to interpret backend connectivity diagnostics. It
+does not replace the atomic ownership decision made by `runIfLeader`, and it
+does not turn a best-effort health signal into a fencing or force-release
+operation.
+
+## Status and reason model
+
+Every connectivity result has one status and one bounded reason. The reason is
+an enum, not an exception message or a provider payload.
+
+| Status | Reason | Meaning |
+|---|---|---|
+| `UP` | `CONNECTED` | The existing client confirmed reachability at probe time. |
+| `DOWN` | `DISCONNECTED` | The existing client confirmed that the backend is unavailable. |
+| `UNKNOWN` | `CLIENT_STATE_UNCONFIRMED` | A bounded read-only check could not prove connectivity. |
+| `UNKNOWN` | `PROVIDER_UNSUPPORTED` | The provider does not expose a supported active probe. |
+| `UNKNOWN` | `PROVIDER_EXCEPTION` | An ordinary provider exception was normalized without retaining its details. |
+| `NOT_CHECKED` | `NOT_CHECKED` | No active probe was requested; this is not a health signal. |
+
+`UP` and `DOWN` describe the result of an active check, not lock ownership.
+`UNKNOWN` must remain distinguishable from both. `NOT_CHECKED` is the expected
+result of passive diagnostics and must not be treated as `UP`.
+
+The public result is additive:
+
+```kotlin
+data class LeaderBackendConnectivity(
+    val status: LeaderBackendConnectivityStatus,
+    val checkedAt: Instant?,
+    val latencyMillis: Long?,
+    val reason: LeaderBackendConnectivityReason,
+)
+```
+
+Existing Kotlin construction and JSON fields remain compatible; consumers that
+strictly deserialize JSON must allow the new `reason` field.
+
+## Source and adapter mapping
+
+| Source or adapter | Contract |
+|---|---|
+| Direct/core diagnostics | `diagnostics()` is passive and returns `NOT_CHECKED`; an active `checkConnectivity` returns the provider result and bounded reason. |
+| Ktor `/management/leaderElection/diagnostics` | Returns HTTP 200 with the diagnostics payload when the pipeline produced a result. The payload's `connectivity.status` and `connectivity.reason` carry backend meaning. |
+| Spring `leaderBackendDiagnostics` | Static diagnostics remain opt-in and passive. Backend health adds bounded `reason` detail; `UP`/`DOWN`/`UNKNOWN` retain their existing health mapping. |
+| Spring readiness | The readiness indicator evaluates local lock state and lease expiry. It is a separate signal and does not automatically merge backend `DOWN` or `UNKNOWN`. |
+| Application pipeline | A custom provider exception that escapes the route is owned by Ktor `StatusPages` or the application's Spring/web pipeline. The library does not rewrite that HTTP status. |
+
+Ktor returning HTTP 200 means that a diagnostics result was serialized; it does
+not mean that the backend is healthy. A pipeline exception is different from a
+payload containing `status = UNKNOWN`.
+
+## Micrometer and Prometheus
+
+An instrumented elector records one `leader.backend.connectivity` counter event
+for each active `checkConnectivity` or `diagnostics(probe = true)` call. The
+counter is not a background poller. Passive `diagnostics()` calls do not create
+a series.
+
+| Tag | Allowed values and protection |
+|---|---|
+| `backend.name` | The sanitized descriptor backend ID; never an endpoint, credential, tenant, or lock name. |
+| `status` | `UP`, `DOWN`, `UNKNOWN`, or `NOT_CHECKED`. |
+| `reason` | The six `LeaderBackendConnectivityReason` enum names. |
+
+Registry naming converts the source meter to
+`leader_backend_connectivity_total` in Prometheus. No exception class,
+message, endpoint, credential, raw provider payload, or lock name is exported.
+Keep active probe frequency bounded in the caller's scheduler. A counter event
+is an observation, not a retry instruction.
+
+For the bundled dashboard, the following queries are intentionally
+warning-oriented and low-cardinality:
+
+```promql
+sum by (backend_name, status, reason) (rate(leader_backend_connectivity_total[5m]))
+sum by (backend_name) (
+  rate(leader_backend_connectivity_total{status="DOWN",reason="DISCONNECTED"}[5m])
+)
+sum by (backend_name, reason) (
+  rate(leader_backend_connectivity_total{status="UNKNOWN"}[5m])
+)
+```
+
+The example's `LeaderBackendConnectivityDown` rule requires five minutes and
+is `notification: no-page`. The `UNKNOWN` and
+`PROVIDER_EXCEPTION` rules also require sustained observations and never
+promote `UNKNOWN` to `DOWN` automatically.
+
+## Provider and #766 compatibility boundary
+
+Built-in providers use the public `LeaderBackendDiagnosticsProbe.check` helper.
+It validates a positive, finite provider-native timeout, reads the clock once
+before the callback, maps an ordinary `Exception` to
+`UNKNOWN + PROVIDER_EXCEPTION`, and rethrows cancellation, restored
+interruption, and fatal `Error` values. A callback returning `NOT_CHECKED` is
+invalid for an active probe.
+
+The helper's `unknownReason` distinguishes a provider that is unsupported from
+one whose client state cannot be confirmed. Existing custom
+`checkConnectivity` or `diagnostics` overrides remain an escape hatch: they own
+their provider exception behavior, while Micrometer observes the result without
+changing it. Legacy providers that still use their manual diagnostics boundary
+keep the compatible default reason until a separate provider-migration issue
+updates them. This draft records that boundary; it does not silently expand
+#766's implementation scope.
+
+## Timeout and wall-clock runbook
+
+The `timeout` passed to `LeaderBackendDiagnosticsProbe.check` is a
+provider-native budget. It is validated and passed to the callback, but it is
+not a caller-thread wall-clock deadline. A client that ignores the budget or
+does not support cancellation can keep the calling thread waiting.
+
+When a probe is slow or uncertain:
+
+1. For repeated `UNKNOWN + CLIENT_STATE_UNCONFIRMED`, inspect the existing
+   client lifecycle and its native timeout settings first.
+2. For increasing `UNKNOWN + PROVIDER_EXCEPTION`, inspect protected structured
+   application logs and provider-native diagnostics. Do not copy exception text
+   into metrics or route details.
+3. If a hard request deadline is required, own an executor/future timeout or a
+   backend cancellation API in the application. Do not add an interrupt or
+   forced `Future.cancel` to the library helper.
+4. If active probing exceeds the request budget, disable the active probe and
+   use passive diagnostics plus the existing state/readiness signal until the
+   provider is corrected.
+
+### Bypass and rollback
+
+Disable `bluetape4k.leader.observability.backend-health` or
+`backendConnectivityCheckEnabled` to stop active calls. Remove or protect the
+Ktor/Spring management route as appropriate. A missing counter series means
+that no active probe ran; it is not a synthetic `NOT_CHECKED` health sample.
+
+Before rolling back one train child, verify that JSON consumers ignore an
+additive `reason` field and that dashboards tolerate the counter disappearing.
+Revert one child at a time; do not delete a public field or meter name without
+a deprecation and consumer-migration window. Never force-release a lease from a
+connectivity result. Re-check ownership through the backend's conditional
+semantics and continue using `runIfLeader` for execution.
+
+## Operational checklist
+
+- [ ] The route is authenticated and restricted by network policy.
+- [ ] Passive diagnostics is not used as readiness proof.
+- [ ] Active probe frequency and caller wall-clock deadline are explicit.
+- [ ] `backend.name`, `status`, and `reason` are the only exported tags.
+- [ ] `UNKNOWN` is warning/no-page unless an application policy says otherwise.
+- [ ] Provider-native timeout and cancellation behavior are documented for the
+      selected backend.
+- [ ] Built-in and custom providers are tested at the direct, Ktor, and Spring
+      boundaries.
+- [ ] The versioned manual is promoted only after `releaseRef` and
+      `releaseCommit` point at a commit containing this contract.
+
+See the development-line source descriptions in the [root diagnostics
+section](../../../README.md#runtime-backend-diagnostics), the
+[Prometheus dashboard runbook](../../../examples/prometheus-dashboard/README.md#alert-runbooks),
+and the [backend selection guide](../en/guides/backend-selection.md).

--- a/docs/manual/drafts/2026-08-28-issue-774-observability.ko.md
+++ b/docs/manual/drafts/2026-08-28-issue-774-observability.ko.md
@@ -1,0 +1,169 @@
+---
+title: "백엔드 connectivity observability와 readiness 운영 런북"
+locale: ko
+status: unreleased
+sourceReleaseRef: 0.5.0
+sourceReleaseCommit: 721a9a3808f67489d2bdb8177734325981c24977
+---
+
+# 백엔드 connectivity observability와 readiness 운영 런북
+
+> Issue #774와 OBS-01–04 stacked train을 위한 unreleased 초안입니다. 현재
+> `develop` source에는 이 additive observability 계약이 포함되어 있지만,
+> versioned manual은 `721a9a3808f67489d2bdb8177734325981c24977`의 pinned
+> `0.5.0`에 고정되어 있습니다. 전체 train을 포함한 release commit이 나올
+> 때까지 이 초안을 승격하거나 `docs/manual/manifest.yaml`을 변경하지 마세요.
+
+이 문서는 backend connectivity diagnostics를 해석하는 방법을 설명합니다.
+`runIfLeader`가 수행하는 원자적 ownership 결정을 대체하지 않으며, best-effort
+health signal을 fencing이나 force-release 연산으로 바꾸지도 않습니다.
+
+## 상태와 reason 모델
+
+모든 connectivity 결과는 하나의 status와 제한된 하나의 reason을 가집니다.
+reason은 enum이며 exception message나 provider payload가 아닙니다.
+
+| 상태 | Reason | 의미 |
+|---|---|---|
+| `UP` | `CONNECTED` | 기존 client가 probe 시점에 연결 가능 상태를 확인했습니다. |
+| `DOWN` | `DISCONNECTED` | 기존 client가 backend를 사용할 수 없는 상태를 확인했습니다. |
+| `UNKNOWN` | `CLIENT_STATE_UNCONFIRMED` | bounded read-only 검사만으로 connectivity를 증명하지 못했습니다. |
+| `UNKNOWN` | `PROVIDER_UNSUPPORTED` | provider가 지원하는 active probe를 제공하지 않습니다. |
+| `UNKNOWN` | `PROVIDER_EXCEPTION` | 일반 provider 예외를 원문 없이 정규화했습니다. |
+| `NOT_CHECKED` | `NOT_CHECKED` | active probe를 요청하지 않았으며 health signal이 아닙니다. |
+
+`UP`과 `DOWN`은 active check의 결과이며 lock ownership을 뜻하지 않습니다.
+`UNKNOWN`은 둘과 구분해야 합니다. `NOT_CHECKED`는 passive diagnostics의
+정상적인 결과이며 `UP`으로 해석하면 안 됩니다.
+
+공개 결과는 다음처럼 additive로 확장되었습니다.
+
+```kotlin
+data class LeaderBackendConnectivity(
+    val status: LeaderBackendConnectivityStatus,
+    val checkedAt: Instant?,
+    val latencyMillis: Long?,
+    val reason: LeaderBackendConnectivityReason,
+)
+```
+
+기존 Kotlin 생성 방식과 JSON field는 유지됩니다. strict JSON deserializer를
+사용하는 소비자는 새 `reason` field를 허용하도록 설정하세요.
+
+## source와 adapter 매핑
+
+| Source 또는 adapter | 계약 |
+|---|---|
+| Direct/core diagnostics | `diagnostics()`는 passive이며 `NOT_CHECKED`를 반환합니다. active `checkConnectivity`는 provider 결과와 제한된 reason을 반환합니다. |
+| Ktor `/management/leaderElection/diagnostics` | pipeline이 결과를 만들면 diagnostics payload와 함께 HTTP 200을 반환합니다. `connectivity.status`와 `connectivity.reason`이 backend 의미를 전달합니다. |
+| Spring `leaderBackendDiagnostics` | 정적 diagnostics는 계속 opt-in passive입니다. backend health에 제한된 `reason` detail을 추가하고 기존 `UP`/`DOWN`/`UNKNOWN` mapping을 유지합니다. |
+| Spring readiness | readiness indicator는 local lock state와 lease expiry를 평가합니다. 별도 signal이며 backend `DOWN`이나 `UNKNOWN`을 자동으로 합치지 않습니다. |
+| Application pipeline | route 밖으로 전파된 custom provider 예외의 HTTP status는 Ktor `StatusPages` 또는 application의 Spring/web pipeline이 소유합니다. library가 강제로 바꾸지 않습니다. |
+
+Ktor의 HTTP 200은 diagnostics 결과를 직렬화했다는 transport 결과일 뿐 backend가
+정상이라는 뜻이 아닙니다. `status = UNKNOWN` payload와 pipeline exception은
+서로 다른 경우입니다.
+
+## Micrometer와 Prometheus
+
+instrumented elector는 active `checkConnectivity` 또는
+`diagnostics(probe = true)` 호출마다 `leader.backend.connectivity` counter를
+정확히 한 번 기록합니다. background poller를 추가하지 않으며 passive
+`diagnostics()` 호출은 series를 만들지 않습니다.
+
+| Tag | 허용 값과 보호 규칙 |
+|---|---|
+| `backend.name` | 정제된 descriptor backend ID입니다. endpoint, credential, tenant, lock name은 금지합니다. |
+| `status` | `UP`, `DOWN`, `UNKNOWN`, `NOT_CHECKED`만 허용합니다. |
+| `reason` | `LeaderBackendConnectivityReason`의 6개 enum 이름만 허용합니다. |
+
+Registry naming은 source meter를 Prometheus에서
+`leader_backend_connectivity_total`로 변환합니다. exception class, message,
+endpoint, credential, raw provider payload, lock name을 export하지 않습니다.
+Active probe 주기는 caller의 scheduler에서 제한하세요. counter event는
+관측이며 retry 지시가 아닙니다.
+
+번들 dashboard의 query도 warning 목적과 낮은 cardinality를 유지합니다.
+
+```promql
+sum by (backend_name, status, reason) (rate(leader_backend_connectivity_total[5m]))
+sum by (backend_name) (
+  rate(leader_backend_connectivity_total{status="DOWN",reason="DISCONNECTED"}[5m])
+)
+sum by (backend_name, reason) (
+  rate(leader_backend_connectivity_total{status="UNKNOWN"}[5m])
+)
+```
+
+예제의 `LeaderBackendConnectivityDown` rule은 5분 지속을 요구하고
+`notification: no-page`입니다. `UNKNOWN`과 `PROVIDER_EXCEPTION` rule도
+지속 관측을 요구하며 `UNKNOWN`을 자동으로 `DOWN`으로 승격하지 않습니다.
+
+## Provider와 #766 호환성 경계
+
+내장 provider는 공개 `LeaderBackendDiagnosticsProbe.check` helper를 사용합니다.
+helper는 양수이면서 유한한 provider-native timeout을 검증하고 callback 전에
+clock을 한 번 읽습니다. 일반 `Exception`은
+`UNKNOWN + PROVIDER_EXCEPTION`으로 매핑하며 cancellation, interrupt 복원,
+치명적인 `Error`는 다시 전파합니다. active probe callback이 `NOT_CHECKED`를
+반환하면 잘못된 결과입니다.
+
+helper의 `unknownReason`으로 unsupported provider와 client 상태 미확정을
+구분합니다. 기존 `checkConnectivity` 또는 `diagnostics` custom override는
+escape hatch로 유지되고 provider 예외 동작을 계속 소유합니다. Micrometer는
+그 결과를 바꾸지 않고 관측만 추가합니다. 아직 manual diagnostics 경계를
+사용하는 legacy provider는 호환 가능한 기본 reason을 유지하고 별도 provider
+migration issue에서 갱신합니다. 이 초안은 그 경계를 기록할 뿐 #766 구현
+범위를 조용히 넓히지 않습니다.
+
+## Timeout과 wall-clock 운영 런북
+
+`LeaderBackendDiagnosticsProbe.check`의 `timeout`은 provider-native budget입니다.
+helper가 값을 검증해 callback에 전달하지만 caller thread의 wall-clock deadline은
+보장하지 않습니다. Budget을 무시하거나 cancellation을 지원하지 않는 client는
+호출 thread를 계속 대기시킬 수 있습니다.
+
+Probe가 느리거나 상태가 불확실하면 다음 순서를 따르세요.
+
+1. `UNKNOWN + CLIENT_STATE_UNCONFIRMED`가 반복되면 기존 client lifecycle과
+   native timeout 설정을 먼저 확인합니다.
+2. `UNKNOWN + PROVIDER_EXCEPTION`이 증가하면 보호된 structured application
+   log와 provider-native diagnostics를 확인합니다. exception 원문을 metric이나
+   route detail에 복사하지 마세요.
+3. hard request deadline이 필요하면 application이 executor/future timeout 또는
+   backend cancellation API를 소유합니다. library helper에 interrupt나 강제
+   `Future.cancel`을 추가하지 않습니다.
+4. active probe가 request budget을 넘으면 active probe를 끄고 passive
+   diagnostics와 기존 state/readiness signal로 우회합니다.
+
+### Bypass와 rollback
+
+`bluetape4k.leader.observability.backend-health` 또는
+`backendConnectivityCheckEnabled`를 비활성화하면 active 호출을 중지할 수
+있습니다. 필요하면 Ktor/Spring management route를 제거하거나 인증된 내부
+네트워크로 제한하세요. Counter series가 사라지는 것은 active probe가 실행되지
+않았다는 뜻이며 synthetic `NOT_CHECKED` health sample이 아닙니다.
+
+Train child 하나를 rollback하기 전 JSON consumer가 additive `reason` field를
+무시하는지, dashboard가 counter 부재를 견디는지 확인하세요. 한 번에 한 child씩
+되돌리며 public field나 meter name을 deprecation과 consumer migration 기간
+없이 삭제하지 않습니다. Connectivity 결과만으로 lease를 force-release하지
+마세요. backend의 conditional semantics로 ownership을 다시 확인하고 실행은
+계속 `runIfLeader`로 수행하세요.
+
+## 운영 체크리스트
+
+- [ ] route가 인증되고 network policy로 제한되어 있습니다.
+- [ ] passive diagnostics를 readiness 증거로 사용하지 않습니다.
+- [ ] active probe 주기와 caller wall-clock deadline이 명시되어 있습니다.
+- [ ] export tag가 `backend.name`, `status`, `reason`으로만 제한되어 있습니다.
+- [ ] `UNKNOWN`은 application policy가 없는 한 warning/no-page로 처리합니다.
+- [ ] 선택한 backend의 provider-native timeout과 cancellation 동작을 문서화했습니다.
+- [ ] built-in과 custom provider를 direct, Ktor, Spring 경계에서 테스트했습니다.
+- [ ] `releaseRef`와 `releaseCommit`이 이 계약을 포함한 commit을 가리킨 뒤
+      versioned manual을 승격합니다.
+
+개발 line source 설명은 [root diagnostics
+section](../../../README.ko.md#runtime-backend-diagnostics),
+[Prometheus dashboard 런북](../../../examples/prometheus-dashboard/README.ko.md#alert-runbooks),
+[backend 선택 가이드](../ko/guides/backend-selection.md)에서 확인할 수 있습니다.

--- a/examples/prometheus-dashboard/README.ko.md
+++ b/examples/prometheus-dashboard/README.ko.md
@@ -128,6 +128,9 @@ notification route를 서비스 상황에 맞게 조정하세요.
 |---|---|---|
 | `LeaderElectionNoAcquisitions` | 작업은 계속 시도하지만 어느 instance도 `leader_aop_acquired_total` 증가를 보고하지 않습니다. | Redis 접근성, lock key contention, scheduler 주기, 모든 instance가 같은 backend를 쓰는지 확인합니다. |
 | `LeaderElectionBackendErrors` | AOP 경로가 lock 획득에서 `reason="BACKEND_ERROR"`를 보고합니다. | worker 재시작 전에 `leader backend error` 주변 로그, Redis 상태, network 오류, failure-mode 설정을 확인합니다. |
+| `LeaderBackendConnectivityDown` | active backend probe가 5분 동안 `status="DOWN",reason="DISCONNECTED"`를 보고합니다. 예제 rule은 warning 전용이고 `notification: no-page`입니다. | 기존 client, backend 접근성, provider timeout을 확인합니다. 이 결과를 orphan lock의 증거나 강제 lease 해제 근거로 사용하지 마세요. |
+| `LeaderBackendConnectivityUnknown` | active probe가 10분 동안 `CLIENT_STATE_UNCONFIRMED` 또는 `PROVIDER_UNSUPPORTED` reason의 `UNKNOWN`을 보고합니다. info/no-page 신호이며 `DOWN`이 아닙니다. | Provider capability와 native timeout 설정을 확인하세요. Passive diagnostics는 counter를 만들지 않으므로 `NOT_CHECKED`를 이 alert에 포함하지 않습니다. |
+| `LeaderBackendConnectivityProbeExceptions` | 일반 provider 예외가 `PROVIDER_EXCEPTION` reason의 `UNKNOWN`으로 정규화된 상태가 10분 지속됩니다. 예제 rule은 warning 전용이고 `notification: no-page`입니다. | 보호된 애플리케이션 로그와 provider-native 진단을 확인하되 예외 원문을 label에 복사하지 마세요. Probe 지연이 request budget을 넘으면 active probe를 우회합니다. |
 | `LeaderElectionTaskFailures` | lock 획득 후 elected task 본문에서 예외가 발생했습니다. | `exception` label로 실패 코드 경로를 찾고, 애플리케이션 로그를 확인하며, 수정 중에도 lock backend는 유지합니다. |
 | `LeaderHistorySinkFailures` | 실제 history/audit sink가 leader history 기록 중 예외를 던졌습니다. Demo는 `NoopLeaderHistorySink`를 제외합니다. | sink credential, schema/index 상태, write capacity, retention job을 확인합니다. Leader 실행은 계속될 수 있지만 audit 내구성은 낮아진 상태입니다. |
 | `LeaderHistoryAcquireMissing` | 실제 history sink가 elected work에 대한 acquire key를 반환하지 않았습니다. Demo는 의도적으로 key를 반환하지 않는 `NoopLeaderHistorySink`를 제외합니다. | 중복 record, storage unavailable, sink별 conditional write conflict를 확인합니다. |
@@ -143,6 +146,12 @@ alert는 문제가 있는 `instance` label을 보존하려고 의도적으로 ra
 `exception`은 예외 클래스 이름 tag입니다. Exception별 alert/dashboard view는
 내부용으로 유지하세요. Cardinality나 구현 상세 노출이 문제라면
 `sum by (lock_name)`으로 접으세요.
+
+Backend connectivity counter는 Prometheus 이름 변환 후
+`leader_backend_connectivity_total`입니다. label은 정제된 `backend_name`,
+네 가지 status, 여섯 가지 bounded reason뿐입니다. 위 rule은 `for` 지속 시간과
+`notification: no-page`를 사용합니다. `UNKNOWN`을 `DOWN`으로 다시 쓰지 않으며,
+passive `NOT_CHECKED` diagnostics는 series를 만들지 않습니다.
 
 이 demo는 `MicrometerSafeLeaderHistoryRecorder`를 `NoopLeaderHistorySink`와
 함께 등록해 `leader_history_*` meter가 보이게 합니다. Alert rule은 no-op sink가
@@ -172,6 +181,9 @@ sum by (sink) (rate(leader_history_acquire_missing_total[5m]))
 sum by (lock_name) (rate(leader_aop_execution_duration_seconds_sum[1m]))
   / sum by (lock_name) (rate(leader_aop_execution_duration_seconds_count[1m]))
 max by (lock_name) (leader_aop_active)
+sum by (backend_name, status, reason) (rate(leader_backend_connectivity_total[5m]))
+sum by (backend_name) (rate(leader_backend_connectivity_total{status="DOWN",reason="DISCONNECTED"}[5m]))
+sum by (backend_name, reason) (rate(leader_backend_connectivity_total{status="UNKNOWN"}[5m]))
 ```
 
 `leader_aop_active`는 JVM-local gauge이므로 멀티 인스턴스에서는 `sum` 대신

--- a/examples/prometheus-dashboard/README.md
+++ b/examples/prometheus-dashboard/README.md
@@ -129,6 +129,9 @@ your production monitoring stack.
 |---|---|---|
 | `LeaderElectionNoAcquisitions` | The job keeps attempting but no instance reports `leader_aop_acquired_total` growth. | Check Redis reachability, lock key contention, scheduler cadence, and whether all instances share the same backend. |
 | `LeaderElectionBackendErrors` | The AOP path reports `reason="BACKEND_ERROR"` for lock acquisition. | Inspect app logs around `leader backend error`, Redis health, network errors, and failure-mode settings before restarting workers. |
+| `LeaderBackendConnectivityDown` | An active backend probe has reported `status="DOWN",reason="DISCONNECTED"` for 5 minutes. The example rule is warning-only and `notification: no-page`. | Check the existing client, backend reachability, and provider timeout. Do not treat this as proof that a lock is orphaned or force-release a lease. |
+| `LeaderBackendConnectivityUnknown` | An active probe has remained `UNKNOWN` with `CLIENT_STATE_UNCONFIRMED` or `PROVIDER_UNSUPPORTED` for 10 minutes. This is an info, no-page signal, not `DOWN`. | Confirm provider capability and native timeout settings. Keep passive `NOT_CHECKED` out of this alert because passive diagnostics emit no counter. |
+| `LeaderBackendConnectivityProbeExceptions` | Ordinary provider exceptions were normalized to `UNKNOWN` with `PROVIDER_EXCEPTION` for 10 minutes. The rule is warning-only and `notification: no-page`. | Inspect protected application logs and provider-native diagnostics without copying exception text into labels. Bypass active probes when their latency exceeds the request budget. |
 | `LeaderElectionTaskFailures` | An elected task body throws after the lock is acquired. | Use the `exception` label to find the failing code path, inspect application logs, and keep the lock backend running while fixing the task. |
 | `LeaderHistorySinkFailures` | A real history/audit sink throws while recording leader history. The demo excludes `NoopLeaderHistorySink`. | Verify sink credentials, schema/index state, write capacity, and retention jobs. Leader execution may still proceed while audit durability is degraded. |
 | `LeaderHistoryAcquireMissing` | A real history sink returned no acquire key for elected work. The demo excludes `NoopLeaderHistorySink`, which intentionally returns no key. | Look for duplicate records, storage unavailability, or sink-specific conditional write conflicts. |
@@ -144,6 +147,12 @@ the firing alert keeps the offending `instance` label.
 `exception` is the exception class name tag. Keep exception-grouped alert and
 dashboard views internal, or collapse them to `sum by (lock_name)` when
 cardinality or implementation-detail exposure matters.
+
+The backend connectivity counter is `leader_backend_connectivity_total` after
+Prometheus naming conversion. Its only labels are the sanitized `backend_name`,
+the four status values, and the six bounded reason values. The rules above use
+`for` windows and `notification: no-page`; `UNKNOWN` is never rewritten as
+`DOWN`, and passive `NOT_CHECKED` diagnostics do not produce a series.
 
 This demo registers `MicrometerSafeLeaderHistoryRecorder` with
 `NoopLeaderHistorySink` so `leader_history_*` meters are visible. The alert
@@ -174,6 +183,9 @@ sum by (sink) (rate(leader_history_acquire_missing_total[5m]))
 sum by (lock_name) (rate(leader_aop_execution_duration_seconds_sum[1m]))
   / sum by (lock_name) (rate(leader_aop_execution_duration_seconds_count[1m]))
 max by (lock_name) (leader_aop_active)
+sum by (backend_name, status, reason) (rate(leader_backend_connectivity_total[5m]))
+sum by (backend_name) (rate(leader_backend_connectivity_total{status="DOWN",reason="DISCONNECTED"}[5m]))
+sum by (backend_name, reason) (rate(leader_backend_connectivity_total{status="UNKNOWN"}[5m]))
 ```
 
 Use `max by (lock_name) (leader_aop_active)` for the active gauge in

--- a/examples/prometheus-dashboard/provisioning/prometheus/rules/leader-alerts.yml
+++ b/examples/prometheus-dashboard/provisioning/prometheus/rules/leader-alerts.yml
@@ -30,6 +30,51 @@ groups:
           description: "Lock {{ $labels.lock_name }} is reporting BACKEND_ERROR acquisition outcomes."
           runbook_url: "https://github.com/bluetape4k/bluetape4k-leader/blob/develop/examples/prometheus-dashboard/README.md#alert-runbooks"
 
+      - alert: LeaderBackendConnectivityDown
+        expr: |
+          sum by (backend_name) (
+            rate(leader_backend_connectivity_total{status="DOWN",reason="DISCONNECTED"}[5m])
+          ) > 0
+        for: 5m
+        labels:
+          severity: warning
+          notification: no-page
+          component: leader-backend
+        annotations:
+          summary: "A backend connectivity probe is reporting DOWN"
+          description: "Backend {{ $labels.backend_name }} has reported DISCONNECTED for 5 minutes."
+          runbook_url: "https://github.com/bluetape4k/bluetape4k-leader/blob/develop/examples/prometheus-dashboard/README.md#alert-runbooks"
+
+      - alert: LeaderBackendConnectivityUnknown
+        expr: |
+          sum by (backend_name, reason) (
+            rate(leader_backend_connectivity_total{status="UNKNOWN",reason=~"CLIENT_STATE_UNCONFIRMED|PROVIDER_UNSUPPORTED"}[5m])
+          ) > 0
+        for: 10m
+        labels:
+          severity: info
+          notification: no-page
+          component: leader-backend
+        annotations:
+          summary: "A backend connectivity probe remains UNKNOWN"
+          description: "Backend {{ $labels.backend_name }} has reason {{ $labels.reason }}; this is not a DOWN signal."
+          runbook_url: "https://github.com/bluetape4k/bluetape4k-leader/blob/develop/examples/prometheus-dashboard/README.md#alert-runbooks"
+
+      - alert: LeaderBackendConnectivityProbeExceptions
+        expr: |
+          sum by (backend_name) (
+            rate(leader_backend_connectivity_total{status="UNKNOWN",reason="PROVIDER_EXCEPTION"}[5m])
+          ) > 0
+        for: 10m
+        labels:
+          severity: warning
+          notification: no-page
+          component: leader-backend
+        annotations:
+          summary: "Backend connectivity probes are raising provider exceptions"
+          description: "Backend {{ $labels.backend_name }} has normalized PROVIDER_EXCEPTION results for 10 minutes."
+          runbook_url: "https://github.com/bluetape4k/bluetape4k-leader/blob/develop/examples/prometheus-dashboard/README.md#alert-runbooks"
+
       - alert: LeaderElectionTaskFailures
         expr: |
           sum by (lock_name, exception) (rate(leader_aop_task_failed_total[5m])) > 0

--- a/examples/prometheus-dashboard/src/test/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusAssetsTest.kt
+++ b/examples/prometheus-dashboard/src/test/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusAssetsTest.kt
@@ -36,6 +36,14 @@ class PrometheusAssetsTest {
         rules.contains("""leader_history_acquire_missing_total{sink!="NoopLeaderHistorySink"}""").shouldBeTrue()
         rules.contains("""leader_aop_active{lock_name="dashboard-job"} > 1""").shouldBeTrue()
         rules.contains("leader_aop_execution_duration_seconds_sum").shouldBeTrue()
+        rules.contains("leader_backend_connectivity_total").shouldBeTrue()
+        rules.contains("""leader_backend_connectivity_total{status="DOWN",reason="DISCONNECTED"}""").shouldBeTrue()
+        rules.contains(
+            """leader_backend_connectivity_total{status="UNKNOWN",reason="PROVIDER_EXCEPTION"}""",
+        ).shouldBeTrue()
+        rules.contains("notification: no-page").shouldBeTrue()
+        rules.contains("for: 5m").shouldBeTrue()
+        rules.contains("for: 10m").shouldBeTrue()
         rules.contains("""absent(up{job="bluetape4k-leader"}) or up{job="bluetape4k-leader"} == 0""")
             .shouldBeTrue()
         rules.contains(
@@ -86,6 +94,11 @@ class PrometheusAssetsTest {
             readme.contains("examples-prometheus-dashboard-alert-runbook-01.png").shouldBeTrue()
             readme.contains("leader-alerts.yml").shouldBeTrue()
             readme.contains("LeaderElectionBackendErrors").shouldBeTrue()
+            readme.contains("LeaderBackendConnectivityDown").shouldBeTrue()
+            readme.contains("LeaderBackendConnectivityUnknown").shouldBeTrue()
+            readme.contains("LeaderBackendConnectivityProbeExceptions").shouldBeTrue()
+            readme.contains("leader_backend_connectivity_total").shouldBeTrue()
+            readme.contains("PROVIDER_EXCEPTION").shouldBeTrue()
             readme.contains("LeaderHistorySinkFailures").shouldBeTrue()
             readme.contains("max by (lock_name) (leader_aop_active)").shouldBeTrue()
         }
@@ -120,6 +133,9 @@ class PrometheusAssetsTest {
             "LeaderActiveGaugeAnomaly",
             "LeaderLeaseRiskHighExecutionTime",
             "LeaderPrometheusScrapeMissing",
+            "LeaderBackendConnectivityDown",
+            "LeaderBackendConnectivityUnknown",
+            "LeaderBackendConnectivityProbeExceptions",
         )
 
         private fun findProjectRoot(start: Path): Path =

--- a/leader-core/README.ko.md
+++ b/leader-core/README.ko.md
@@ -368,6 +368,24 @@ Spring 및 Ktor 모듈의 HTTP adapter는 다음 공통 mapping을 사용합니�
 
 `LeaderBackendDiagnosticsProbe.check(timeout, clock, probe)`는 내장 backend connectivity 검사를 위한 공통 동기 경계입니다. 양수이면서 유한한 provider-native timeout만 받고 callback 전에 전달된 clock을 한 번 읽으며, I/O, lock, client, retry, thread, executor, wall-clock deadline을 만들거나 관리하지 않습니다. callback의 일반 `Exception`은 `UNKNOWN`이 되고, `CancellationException`, interrupt flag를 복원하는 `InterruptedException`, 치명적인 `Error`는 동일 인스턴스로 재전파됩니다. callback이 `NOT_CHECKED`를 반환하면 잘못된 결과로 거부합니다. 기존 custom `checkConnectivity` 또는 `diagnostics` override는 source 호환성을 위해 유지되며 의도적으로 이 정규화를 우회합니다.
 
+`LeaderBackendConnectivityReason` field는 예외 원문, credential, endpoint,
+lock name을 저장하지 않고 제한된 원인을 설명합니다.
+
+| 상태 | Reason | 해석 |
+|---|---|---|
+| `UP` | `CONNECTED` | probe 시점에 client가 연결 가능 상태를 확인했습니다. |
+| `DOWN` | `DISCONNECTED` | client가 backend를 사용할 수 없는 상태를 확인했습니다. |
+| `UNKNOWN` | `CLIENT_STATE_UNCONFIRMED` | bounded 검사만으로 client 상태를 확정하지 못했습니다. |
+| `UNKNOWN` | `PROVIDER_UNSUPPORTED` | provider가 의도적으로 active probe를 제공하지 않습니다. |
+| `UNKNOWN` | `PROVIDER_EXCEPTION` | callback의 일반 예외를 정규화했습니다. |
+| `NOT_CHECKED` | `NOT_CHECKED` | probe를 실행하지 않았으며 health나 소유권의 증거가 아닙니다. |
+
+기본 provider는 active probe를 제공할 수 없을 때 `PROVIDER_UNSUPPORTED`를
+사용합니다. Helper-backed provider가 client 상태를 읽었지만 backend 연결을
+증명하지 못하면 `CLIENT_STATE_UNCONFIRMED`를 사용합니다. Reason은 설명용
+metadata이며 소유권 판단은 계속 `runIfLeader`의 원자적 lease 획득이 맡고,
+readiness 정책은 애플리케이션이 소유합니다.
+
 ## 테넌트 네임스페이스
 
 같은 논리 작업을 테넌트별 독립 락으로 실행해야 한다면 backend 설정을 바꾸지

--- a/leader-core/README.md
+++ b/leader-core/README.md
@@ -371,6 +371,24 @@ The HTTP adapters in the Spring and Ktor modules share this mapping:
 
 `LeaderBackendDiagnosticsProbe.check(timeout, clock, probe)` is the shared synchronous boundary for built-in backend connectivity checks. It accepts only a positive, finite provider-native timeout, reads the supplied clock once before the callback, and never creates I/O, locks, clients, retries, threads, executors, or wall-clock deadlines. Ordinary callback `Exception` values become `UNKNOWN`; `CancellationException`, `InterruptedException` (with the interrupt flag restored), and fatal `Error` values retain identity and propagate. Returning `NOT_CHECKED` from the callback is invalid. Existing custom `checkConnectivity` or `diagnostics` overrides remain source-compatible and bypass this normalization by design.
 
+The `LeaderBackendConnectivityReason` field explains the bounded cause without
+storing exception text, credentials, endpoints, or lock names:
+
+| Status | Reason | Interpretation |
+|---|---|---|
+| `UP` | `CONNECTED` | The client confirmed connectivity at the time of the probe. |
+| `DOWN` | `DISCONNECTED` | The client confirmed that the backend is unavailable. |
+| `UNKNOWN` | `CLIENT_STATE_UNCONFIRMED` | A bounded check could not confirm the client state. |
+| `UNKNOWN` | `PROVIDER_UNSUPPORTED` | The provider intentionally has no active probe. |
+| `UNKNOWN` | `PROVIDER_EXCEPTION` | An ordinary callback exception was normalized. |
+| `NOT_CHECKED` | `NOT_CHECKED` | No probe ran; this is not proof of health or ownership. |
+
+The default provider uses `PROVIDER_UNSUPPORTED` when it cannot offer an active
+probe. Helper-backed providers use `CLIENT_STATE_UNCONFIRMED` when they read
+client state without proving backend connectivity. The reason is descriptive
+metadata: acquiring a lease through `runIfLeader` remains the ownership
+decision, and readiness policy remains application-owned.
+
 ## Tenant Namespacing
 
 Use `TenantLockNamespace` and `forTenant()` when the same logical job must run

--- a/leader-ktor/README.ko.md
+++ b/leader-ktor/README.ko.md
@@ -398,6 +398,23 @@ install(LeaderElectionPlugin) {
 
 Route는 설정된 제한 시간으로 `Dispatchers.IO`에서 `LeaderBackendDiagnosticsProvider.checkConnectivity()`를 한 번 호출합니다. 지원하지 않거나 판정할 수 없는 검사는 `UNKNOWN`을 반환합니다. Elector는 provider를 직접 노출하거나 `LeaderBackendDiagnosticsAware`를 통해 제공할 수 있습니다. Diagnostics가 활성화됐지만 provider를 찾지 못하면 플러그인 설치 단계에서 명확한 오류와 함께 실패합니다.
 
+JSON payload는 기존 `descriptor`와 connectivity field를 유지하면서 제한된
+`connectivity.reason` field를 추가합니다.
+
+| 상태 | Reason | Route 의미 |
+|---|---|---|
+| `UP` | `CONNECTED` | active probe 시점에 backend 연결 가능 상태를 확인했습니다. |
+| `DOWN` | `DISCONNECTED` | active probe가 backend를 사용할 수 없음을 확인했습니다. |
+| `UNKNOWN` | `CLIENT_STATE_UNCONFIRMED`, `PROVIDER_UNSUPPORTED`, `PROVIDER_EXCEPTION` | 연결을 확정하지 못했으며 자동으로 `DOWN`으로 승격하지 않습니다. |
+| `NOT_CHECKED` | `NOT_CHECKED` | probe 없는 passive diagnostics이며 readiness의 증거가 아닙니다. |
+
+Active diagnostics 결과가 정상적으로 직렬화되면 route는 HTTP 200을 유지하고
+backend 의미를 JSON의 `status`와 `reason`에 담습니다. Custom provider 예외나
+cancellation, interruption, 치명적인 `Error`, 잘못된 `NOT_CHECKED` 결과가 내장
+probe 밖으로 전파되면 HTTP status는 애플리케이션 Ktor pipeline과
+`StatusPages` 정책이 소유합니다. Route가 임의의 synthetic JSON 오류로 바꾸지
+않습니다.
+
 내장 provider는 `LeaderBackendDiagnosticsProbe.check`를 사용합니다. callback의 일반 예외는 `UNKNOWN`인 HTTP 200 응답이 되지만 cancellation, interruption, 치명적인 `Error`, 잘못된 `NOT_CHECKED` 결과는 caller-owned pipeline 실패로 남습니다. Custom provider override는 route가 다시 작성하지 않으며 기존 예외 정책을 유지합니다.
 
 신뢰된 management boundary 밖으로 노출하기 전에 route를 보호하세요. 연결 진단 결과는 현재 프로세스가 leader lease를 보유한다는 증거가 아닙니다.

--- a/leader-ktor/README.md
+++ b/leader-ktor/README.md
@@ -402,6 +402,23 @@ install(LeaderElectionPlugin) {
 
 The route calls `LeaderBackendDiagnosticsProvider.checkConnectivity()` once on `Dispatchers.IO` with the configured timeout. Unsupported or indeterminate checks return `UNKNOWN`. Electors may expose the provider directly or through `LeaderBackendDiagnosticsAware`; plugin installation fails with a clear error when diagnostics are enabled but no provider is available.
 
+The JSON payload keeps the existing `descriptor` and connectivity fields and adds
+the bounded `connectivity.reason` field:
+
+| Status | Reason | Route meaning |
+|---|---|---|
+| `UP` | `CONNECTED` | The backend was reachable when the active probe ran. |
+| `DOWN` | `DISCONNECTED` | The active probe confirmed that the backend is unavailable. |
+| `UNKNOWN` | `CLIENT_STATE_UNCONFIRMED`, `PROVIDER_UNSUPPORTED`, or `PROVIDER_EXCEPTION` | Connectivity was not confirmed; do not promote this to `DOWN`. |
+| `NOT_CHECKED` | `NOT_CHECKED` | Passive diagnostics ran without a probe and are not readiness proof. |
+
+An active diagnostics result is a successful diagnostics serialization, so the
+route keeps HTTP 200 and puts the backend meaning in the JSON `status` and
+`reason`. If a custom provider throws, or if cancellation, interruption, fatal
+`Error`, or invalid `NOT_CHECKED` output escapes the built-in probe, the
+application's Ktor pipeline and `StatusPages` policy own the HTTP status. The
+route does not turn those failures into a synthetic JSON response.
+
 Built-in providers use `LeaderBackendDiagnosticsProbe.check`: ordinary callback exceptions become an HTTP 200 response with `UNKNOWN`, while cancellation, interruption, fatal `Error`, and invalid `NOT_CHECKED` results remain caller-owned pipeline failures. A custom provider override is not rewritten by the route and keeps its existing exception policy.
 
 Protect the route before exposing it outside a trusted management boundary. Connectivity diagnostics are not proof that this process currently owns a leader lease.

--- a/leader-micrometer/README.ko.md
+++ b/leader-micrometer/README.ko.md
@@ -74,7 +74,7 @@ class ReportJobs {
 
 ### 태그 Cardinality 제어
 
-메트릭은 tag 값을 export하기 전에 `LeaderMetricTagOptions`를 적용합니다. 운영 기본값은 동적 `lock.name`을 `redacted-lock`으로, opt-in `leader.id` Observation 값을 `redacted-leader`로 redaction합니다. future/custom meter path가 `backend.name` tag를 emit할 때는 cardinality가 제한된 backend 값만 raw로 유지합니다. 현재 built-in meter path는 `backend.name`을 emit하지 않습니다. 이렇게 하면 Prometheus, Datadog, OTLP backend에 tenant, request, job id마다 새로운 time series가 생기는 일을 막을 수 있습니다.
+메트릭은 tag 값을 export하기 전에 `LeaderMetricTagOptions`를 적용합니다. 운영 기본값은 동적 `lock.name`을 `redacted-lock`으로, opt-in `leader.id` Observation 값을 `redacted-leader`로 redaction합니다. active diagnostics meter는 정제된 제한 범위의 `backend.name`만 emit합니다. 다른 built-in meter path는 `backend.name`을 emit하지 않습니다. 이렇게 하면 Prometheus, Datadog, OTLP backend에 tenant, request, job id마다 새로운 time series가 생기는 일을 막을 수 있습니다.
 
 애플리케이션 정책은 Spring property로 설정합니다.
 
@@ -234,6 +234,14 @@ val election = InstrumentedLeaderElector(
 )
 ```
 
+세 instrumented elector decorator는 delegate의
+`LeaderBackendDiagnosticsProvider`도 노출합니다. Active
+`checkConnectivity`와 `diagnostics(probe = true)` 호출은
+`backend.name`, `status`, `reason` tag와 함께 `leader.backend.connectivity`를
+호출마다 한 번 증가시킵니다. Passive `diagnostics()`는 meter를 만들지
+않습니다. Decorator는 제한된 enum 값만 기록하고 provider의 원래 예외를
+재전파하며, 예외 원문·endpoint·credential·lock name을 export하지 않습니다.
+
 ## Listener 이벤트 메트릭
 
 elector를 instrumented decorator로 감싸지 않고 생명주기 counter만 기록하려면 `MicrometerLeaderElectionListener`를 사용합니다.
@@ -270,6 +278,7 @@ election.runIfLeader("daily-report") {
 | `shedlock.leader.not_acquired` | Counter | `lock.name` | 데코레이터 skip |
 | `shedlock.leader.duration` | Timer | `lock.name` | 데코레이터 본문 실행 시간 |
 | `shedlock.leader.active` | Gauge | `lock.name` | 현재 JVM에서 실행 중인 데코레이터 본문 수 |
+| `leader.backend.connectivity` | Counter | `backend.name`, `status`, `reason` | active backend connectivity probe마다 한 번 기록 |
 
 ### Listener 이벤트 Meter
 

--- a/leader-micrometer/README.md
+++ b/leader-micrometer/README.md
@@ -74,7 +74,7 @@ class ReportJobs {
 
 ### Tag Cardinality Controls
 
-Metrics use `LeaderMetricTagOptions` before exporting tag values. The production default redacts dynamic `lock.name` values to `redacted-lock` and opt-in `leader.id` Observation values to `redacted-leader`; bounded `backend.name` values stay raw when a future or custom meter path emits that tag. Current built-in meter paths do not emit `backend.name`. This keeps Prometheus, Datadog, and OTLP backends from receiving one time series per tenant, request, or job id.
+Metrics use `LeaderMetricTagOptions` before exporting tag values. The production default redacts dynamic `lock.name` values to `redacted-lock` and opt-in `leader.id` Observation values to `redacted-leader`; the active diagnostics meter emits only sanitized, bounded `backend.name` values. Other built-in meter paths do not emit `backend.name`. This keeps Prometheus, Datadog, and OTLP backends from receiving one time series per tenant, request, or job id.
 
 Use Spring properties for application-level policy:
 
@@ -235,6 +235,14 @@ val election = InstrumentedLeaderElector(
 )
 ```
 
+The three instrumented elector decorators also expose the delegate's
+`LeaderBackendDiagnosticsProvider`. Active `checkConnectivity` and
+`diagnostics(probe = true)` calls increment `leader.backend.connectivity` once
+with `backend.name`, `status`, and `reason` tags. Passive `diagnostics()` does
+not create a meter. The decorator records only the bounded enum values and
+rethrows the provider's original exception; it never exports exception text,
+endpoints, credentials, or lock names.
+
 ## Listener Event Metrics
 
 Use `MicrometerLeaderElectionListener` when you need lifecycle counters without wrapping the elector in an instrumented decorator.
@@ -271,6 +279,7 @@ election.runIfLeader("daily-report") {
 | `shedlock.leader.not_acquired` | Counter | `lock.name` | Decorator skips |
 | `shedlock.leader.duration` | Timer | `lock.name` | Decorator body duration |
 | `shedlock.leader.active` | Gauge | `lock.name` | Currently running decorator bodies in this JVM |
+| `leader.backend.connectivity` | Counter | `backend.name`, `status`, `reason` | One sample for each active backend connectivity probe |
 
 ### Listener Event Meters
 

--- a/leader-spring-boot/README.ko.md
+++ b/leader-spring-boot/README.ko.md
@@ -378,7 +378,7 @@ Metrics와 Observation은 별도 스위치를 가집니다.
 | `bluetape4k.leader.aop.metrics.tags.lock-name.mode` | `REDACT` | meter `lock.name` tag export 정책 |
 | `bluetape4k.leader.aop.metrics.tags.lock-name.redacted-value` | `redacted-lock` | redaction된 lock name sentinel |
 | `bluetape4k.leader.aop.metrics.tags.leader-id.mode` | `REDACT` | opt-in Observation `leader.id` 값 export 정책 |
-| `bluetape4k.leader.aop.metrics.tags.backend-name.mode` | `RAW` | custom 또는 future meter path가 `backend.name`을 emit할 때 cardinality가 제한된 backend label export 정책; 현재 built-in meter는 emit하지 않음 |
+| `bluetape4k.leader.aop.metrics.tags.backend-name.mode` | `RAW` | bounded backend label의 export 정책; active diagnostics meter는 정제된 `backend.name`을 emit하고 그 밖의 built-in meter는 emit하지 않음 |
 | `bluetape4k.leader.observability.enabled` | `true` | leader observability와 tracing의 parent switch |
 | `bluetape4k.leader.observability.health.acquisition-failure-window` | `5m` | AOP backend 획득 실패 aggregate의 bounded window |
 | `bluetape4k.leader.observability.tracing.enabled` | `true` | Observation recorder/listener |
@@ -786,6 +786,14 @@ bluetape4k:
 ```
 
 `UP`과 `DOWN`은 같은 이름의 Spring health status로 매핑됩니다. `UNKNOWN`과 `NOT_CHECKED`는 Spring `UNKNOWN`으로 매핑됩니다. 두 surface는 `bluetape4k.leader.observability.state-provider-bean`과 같은 elector 선택 규칙을 사용합니다. 선택된 elector가 `LeaderBackendDiagnosticsProvider`를 노출하지 않으면 typed endpoint와 health indicator를 등록하지 않습니다.
+
+Diagnostics 결과가 정상적으로 반환되면 health indicator는 allow-list detail에
+제한된 `reason` enum name을 추가합니다. `CONNECTED`는 `UP`을,
+`DISCONNECTED`는 `DOWN`을 설명하며 `CLIENT_STATE_UNCONFIRMED`,
+`PROVIDER_UNSUPPORTED`, `PROVIDER_EXCEPTION`은 `UNKNOWN`의 원인을
+구분합니다. 정적 endpoint는 `NOT_CHECKED` 상태와 같은 reason을 반환합니다.
+이 detail은 readiness 판단이 아닙니다. 별도의 JVM-local lock·lease 신호는
+계속 `LeaderElectionReadinessHealthIndicator`가 소유합니다.
 
 활성 backend probe가 일반 provider 예외를 던지면 health indicator는 이를 `UNKNOWN`으로 정규화하고 `error` 키, 예외 class/message/cause, endpoint, token, credential을 Actuator detail에 복사하지 않습니다. `management.endpoint.health.show-details=always`여도 이 계약을 유지하며 indicator의 allow-list detail만 반환합니다. 치명적인 JVM `Error`는 정규화하지 않고 재전파합니다. Probe는 실제 backend I/O를 수행하므로 실패 내용을 정제하더라도 endpoint 접근은 계속 보호해야 합니다.
 

--- a/leader-spring-boot/README.md
+++ b/leader-spring-boot/README.md
@@ -397,7 +397,7 @@ Metrics and Observations are independent:
 | `bluetape4k.leader.aop.metrics.tags.lock-name.mode` | `REDACT` | Export policy for meter `lock.name` tags |
 | `bluetape4k.leader.aop.metrics.tags.lock-name.redacted-value` | `redacted-lock` | Sentinel for redacted lock names |
 | `bluetape4k.leader.aop.metrics.tags.leader-id.mode` | `REDACT` | Export policy for opt-in Observation `leader.id` values |
-| `bluetape4k.leader.aop.metrics.tags.backend-name.mode` | `RAW` | Export policy for bounded backend labels when custom or future meter paths emit `backend.name`; current built-in meters do not emit it |
+| `bluetape4k.leader.aop.metrics.tags.backend-name.mode` | `RAW` | Export policy for bounded backend labels; the active diagnostics meter emits sanitized `backend.name`, while other built-in meters do not |
 | `bluetape4k.leader.observability.enabled` | `true` | Parent switch for leader observability and tracing |
 | `bluetape4k.leader.observability.health.acquisition-failure-window` | `5m` | Bounded window for aggregate AOP backend acquisition failures |
 | `bluetape4k.leader.observability.tracing.enabled` | `true` | Observation recorder and listener |
@@ -814,6 +814,14 @@ bluetape4k:
 ```
 
 `UP` and `DOWN` map directly to Spring health statuses. `UNKNOWN` and `NOT_CHECKED` map to Spring `UNKNOWN`. Both surfaces use the same elector selection as `bluetape4k.leader.observability.state-provider-bean`; when the selected elector does not expose a `LeaderBackendDiagnosticsProvider`, the typed endpoint and health indicator are not registered.
+
+For a successful diagnostics result, the health indicator adds the bounded
+`reason` enum name to its allow-listed details. `CONNECTED` explains `UP`,
+`DISCONNECTED` explains `DOWN`, and `CLIENT_STATE_UNCONFIRMED`,
+`PROVIDER_UNSUPPORTED`, or `PROVIDER_EXCEPTION` explain an `UNKNOWN` result.
+The static endpoint reports `NOT_CHECKED` with the matching reason. This detail
+is not a readiness decision: `LeaderElectionReadinessHealthIndicator` continues
+to own the separate JVM-local lock and lease signal.
 
 If the active backend probe throws an ordinary provider exception, the health indicator reports `UNKNOWN` without copying the `error` key, exception class/message/cause, endpoint, token, or credential into Actuator details. This remains true when `management.endpoint.health.show-details=always`; only the indicator's allow-listed details are returned. Fatal JVM `Error` values are not normalized and are rethrown. Keep the endpoint protected even with sanitized failures because the probe still performs live backend I/O.
 


### PR DESCRIPTION
## 요약

Issue #774의 네 번째 child입니다. OBS-01~03에서 확정한 bounded connectivity reason과 active probe metric을 EN/KO README, unreleased manual draft, Prometheus 운영 예제로 연결합니다.

## 변경 내용

- root와 `leader-core`, `leader-micrometer`, `leader-spring-boot`, `leader-ktor` README에 `UP`/`DOWN`/`UNKNOWN`/`NOT_CHECKED`와 6개 bounded reason의 의미를 EN/KO로 정리했습니다.
- `leader.backend.connectivity` counter와 Prometheus 이름 `leader_backend_connectivity_total`의 active-only, `backend.name`/`status`/`reason` tag, sanitizer 및 민감정보 비노출 규칙을 문서화했습니다.
- Spring health의 bounded `reason` detail과 readiness 분리, Ktor의 additive `connectivity.reason`·HTTP 200 payload·application-owned pipeline 예외 경계를 명시했습니다.
- provider-native timeout이 caller wall-clock deadline을 보장하지 않는다는 점, active probe bypass와 rollback 절차, #766 built-in/custom 및 legacy provider 경계를 manual draft에 기록했습니다.
- Prometheus 예제에 `LeaderBackendConnectivityDown`, `LeaderBackendConnectivityUnknown`, `LeaderBackendConnectivityProbeExceptions` 경보와 no-page 지속 조건·runbook을 추가하고 자산 테스트로 고정했습니다.
- `docs/manual/manifest.yaml`과 generated manifest는 release pin 보호를 위해 변경하지 않았습니다.

## 검증

- `PrometheusAssetsTest`: 5개 통과
- Gradle: `:examples:prometheus-dashboard:test --tests '*PrometheusAssetsTest' --no-configuration-cache --console=plain` → `BUILD SUCCESSFUL` (39초)
- `audit-korean-terms.mjs`: 7개 파일, findings 0
- Prometheus YAML parse: 신규 3개 rule의 `for`/`notification` 확인
- EN/KO draft frontmatter·핵심 계약 parity, placeholder/reference scan, `git diff --check` 통과
- release `releaseRef`/`releaseCommit` manifest diff 없음

## 7-Tier self-review

1. 범위/입력: OBS-01~03 source claim과 Issue #774 완료 조건만 문서·예제에 반영하고 release-pinned manual은 보존
2. API/계약: reason과 counter를 additive로 설명하고 기존 JSON/status/metric 의미를 제거하지 않음
3. 불변식: `NOT_CHECKED`를 `UP`/readiness로 승격하지 않고 `UNKNOWN`을 자동 `DOWN`/page로 승격하지 않음
4. 예외/취소: `PROVIDER_EXCEPTION`은 bounded reason으로만 노출하고 cancellation/interruption/`Error`와 pipeline 예외의 소유권을 보존
5. 동시성/성능: background polling을 발명하지 않고 active probe caller 주기와 wall-clock deadline을 분리
6. 보안/카디널리티: backend ID sanitizer와 세 개 tag만 허용하며 raw exception/endpoint/credential/lock name을 배제
7. 운영/호환성: built-in/custom/legacy provider 경계, no-page 지속 경보, bypass/rollback 및 release promotion gate를 EN/KO로 대칭 기록

1인 개발자 환경으로 independent review는 N/A이며, source-to-claim read-back·targeted test·문서 audit·hosted exact-head CI로 대체합니다.

Refs #774
Depends on #822

## DoD Status

- [x] EN/KO root·module README와 unreleased manual draft
- [x] bounded status/reason·Micrometer·Spring/Ktor·readiness 계약
- [x] provider-native timeout, bypass/rollback, #766 compatibility runbook
- [x] Prometheus 신규 3개 alert와 runbook/PromQL
- [x] `PrometheusAssetsTest` 및 문서/용어/manifest 검증
- [x] 7-Tier self-review (independent review: N/A)
- [x] hosted exact-head CI
- [x] 승인된 rebase merge: `19e12456ac39d49008098d5ca5df82584d84103b`
- [x] canonical `develop` exact sync: `19e12456ac39d49008098d5ca5df82584d84103b`
- [ ] Issue #774 최종 closeout — 1.0.0 versioned manual release pin 갱신 후 수행

상태: OBS-04 구현·검증·hosted exact-head CI·승인된 rebase merge·canonical sync 완료; Issue #774는 release pin gate 대기
