### PR TITLE
build: Exposed provider 테스트와 Kover 증거의 캐시 격리를 보장한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,8 @@ jobs:
           python3 scripts/ci/validate_timing_contract_test.py
           python3 scripts/ci/validate_detekt_configuration_cache.py
           python3 scripts/ci/validate_detekt_configuration_cache_test.py
+          python3 scripts/ci/validate_provider_artifacts.py --workflow-contract .github/workflows/ci.yml .github/workflows/nightly-tests.yml
+          python3 scripts/ci/validate_provider_artifacts.py --self-test
           python3 scripts/compatibility/check_binary_api_test.py
 
   # ── 2-B. 매뉴얼/릴리스 provenance 계약 검증 ─────────────────────────────
@@ -676,14 +678,22 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-configuration-cache --no-daemon
+        env:
+          LEADER_TEST_DB: "H2"
         continue-on-error: true
+
+      - name: Verify provider artifact provenance
+        if: always()
+        run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-jdbc --provider H2
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results-exposed-jdbc-h2
-          path: '**/build/test-results/test/*.xml'
+          path: |
+            **/build/test-results/test/*.xml
+            **/build/test-results/test/leader-test-db.txt
           retention-days: 7
 
       - name: Upload coverage report
@@ -691,7 +701,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: coverage-exposed-jdbc-h2
-          path: '**/build/reports/kover/'
+          path: |
+            **/build/reports/kover/
+            **/build/reports/kover/leader-test-db.txt
           retention-days: 7
 
   # ── 8. leader-exposed-jdbc 테스트 (PostgreSQL, Testcontainers) ────────────
@@ -730,14 +742,22 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-configuration-cache --no-daemon
+        env:
+          LEADER_TEST_DB: "POSTGRESQL"
         continue-on-error: true
+
+      - name: Verify provider artifact provenance
+        if: always()
+        run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-jdbc --provider POSTGRESQL
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results-exposed-jdbc-postgresql
-          path: '**/build/test-results/test/*.xml'
+          path: |
+            **/build/test-results/test/*.xml
+            **/build/test-results/test/leader-test-db.txt
           retention-days: 7
 
       - name: Upload coverage report
@@ -745,7 +765,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: coverage-exposed-jdbc-postgresql
-          path: '**/build/reports/kover/'
+          path: |
+            **/build/reports/kover/
+            **/build/reports/kover/leader-test-db.txt
           retention-days: 7
 
   # ── 9. leader-exposed-jdbc 테스트 (MySQL 8, Testcontainers) ──────────────
@@ -784,14 +806,22 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-configuration-cache --no-daemon
+        env:
+          LEADER_TEST_DB: "MYSQL_V8"
         continue-on-error: true
+
+      - name: Verify provider artifact provenance
+        if: always()
+        run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-jdbc --provider MYSQL_V8
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results-exposed-jdbc-mysql
-          path: '**/build/test-results/test/*.xml'
+          path: |
+            **/build/test-results/test/*.xml
+            **/build/test-results/test/leader-test-db.txt
           retention-days: 7
 
       - name: Upload coverage report
@@ -799,7 +829,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: coverage-exposed-jdbc-mysql
-          path: '**/build/reports/kover/'
+          path: |
+            **/build/reports/kover/
+            **/build/reports/kover/leader-test-db.txt
           retention-days: 7
 
 
@@ -833,20 +865,29 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-configuration-cache --no-daemon
+        env:
+          LEADER_TEST_DB: "H2"
         continue-on-error: true
+      - name: Verify provider artifact provenance
+        if: always()
+        run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-r2dbc --provider H2
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results-exposed-r2dbc-h2
-          path: '**/build/test-results/test/*.xml'
+          path: |
+            **/build/test-results/test/*.xml
+            **/build/test-results/test/leader-test-db.txt
           retention-days: 7
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: coverage-exposed-r2dbc-h2
-          path: '**/build/reports/kover/'
+          path: |
+            **/build/reports/kover/
+            **/build/reports/kover/leader-test-db.txt
           retention-days: 7
 
   # ── 11. leader-exposed-r2dbc 테스트 (PostgreSQL, Testcontainers) ──────────
@@ -881,20 +922,29 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-configuration-cache --no-daemon
+        env:
+          LEADER_TEST_DB: "POSTGRESQL"
         continue-on-error: true
+      - name: Verify provider artifact provenance
+        if: always()
+        run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-r2dbc --provider POSTGRESQL
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results-exposed-r2dbc-postgresql
-          path: '**/build/test-results/test/*.xml'
+          path: |
+            **/build/test-results/test/*.xml
+            **/build/test-results/test/leader-test-db.txt
           retention-days: 7
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: coverage-exposed-r2dbc-postgresql
-          path: '**/build/reports/kover/'
+          path: |
+            **/build/reports/kover/
+            **/build/reports/kover/leader-test-db.txt
           retention-days: 7
 
   # ── 12. leader-exposed-r2dbc 테스트 (MySQL 8, Testcontainers) ─────────────
@@ -929,20 +979,29 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-configuration-cache --no-daemon
+        env:
+          LEADER_TEST_DB: "MYSQL_V8"
         continue-on-error: true
+      - name: Verify provider artifact provenance
+        if: always()
+        run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-r2dbc --provider MYSQL_V8
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results-exposed-r2dbc-mysql
-          path: '**/build/test-results/test/*.xml'
+          path: |
+            **/build/test-results/test/*.xml
+            **/build/test-results/test/leader-test-db.txt
           retention-days: 7
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: coverage-exposed-r2dbc-mysql
-          path: '**/build/reports/kover/'
+          path: |
+            **/build/reports/kover/
+            **/build/reports/kover/leader-test-db.txt
           retention-days: 7
 
   # ── examples-migration-gate (Testcontainers PostgreSQL + H2) ────────────────

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -425,20 +425,29 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon --no-configuration-cache
+        env:
+          LEADER_TEST_DB: "H2"
         continue-on-error: true
+      - name: Verify provider artifact provenance
+        if: always()
+        run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-jdbc --provider H2
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results-exposed-jdbc-h2
-          path: '**/build/test-results/test/*.xml'
+          path: |
+            **/build/test-results/test/*.xml
+            **/build/test-results/test/leader-test-db.txt
           retention-days: 14
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: coverage-exposed-jdbc-h2
-          path: '**/build/reports/kover/'
+          path: |
+            **/build/reports/kover/
+            **/build/reports/kover/leader-test-db.txt
           retention-days: 14
 
   # ── leader-exposed-jdbc (PostgreSQL, Testcontainers) ───────────────────────
@@ -474,20 +483,29 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon --no-configuration-cache
+        env:
+          LEADER_TEST_DB: "POSTGRESQL"
         continue-on-error: true
+      - name: Verify provider artifact provenance
+        if: always()
+        run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-jdbc --provider POSTGRESQL
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results-exposed-jdbc-postgresql
-          path: '**/build/test-results/test/*.xml'
+          path: |
+            **/build/test-results/test/*.xml
+            **/build/test-results/test/leader-test-db.txt
           retention-days: 14
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: coverage-exposed-jdbc-postgresql
-          path: '**/build/reports/kover/'
+          path: |
+            **/build/reports/kover/
+            **/build/reports/kover/leader-test-db.txt
           retention-days: 14
 
   # ── leader-exposed-jdbc (MySQL 8, Testcontainers) ──────────────────────────
@@ -523,20 +541,29 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon --no-configuration-cache
+        env:
+          LEADER_TEST_DB: "MYSQL_V8"
         continue-on-error: true
+      - name: Verify provider artifact provenance
+        if: always()
+        run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-jdbc --provider MYSQL_V8
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results-exposed-jdbc-mysql
-          path: '**/build/test-results/test/*.xml'
+          path: |
+            **/build/test-results/test/*.xml
+            **/build/test-results/test/leader-test-db.txt
           retention-days: 14
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: coverage-exposed-jdbc-mysql
-          path: '**/build/reports/kover/'
+          path: |
+            **/build/reports/kover/
+            **/build/reports/kover/leader-test-db.txt
           retention-days: 14
 
   # ── leader-exposed-r2dbc (H2) ─────────────────────────────────────────────
@@ -568,20 +595,29 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon --no-configuration-cache
+        env:
+          LEADER_TEST_DB: "H2"
         continue-on-error: true
+      - name: Verify provider artifact provenance
+        if: always()
+        run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-r2dbc --provider H2
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results-exposed-r2dbc-h2
-          path: '**/build/test-results/test/*.xml'
+          path: |
+            **/build/test-results/test/*.xml
+            **/build/test-results/test/leader-test-db.txt
           retention-days: 14
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: coverage-exposed-r2dbc-h2
-          path: '**/build/reports/kover/'
+          path: |
+            **/build/reports/kover/
+            **/build/reports/kover/leader-test-db.txt
           retention-days: 14
 
   # ── leader-exposed-r2dbc (PostgreSQL) ─────────────────────────────────────
@@ -616,20 +652,29 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon --no-configuration-cache
+        env:
+          LEADER_TEST_DB: "POSTGRESQL"
         continue-on-error: true
+      - name: Verify provider artifact provenance
+        if: always()
+        run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-r2dbc --provider POSTGRESQL
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results-exposed-r2dbc-postgresql
-          path: '**/build/test-results/test/*.xml'
+          path: |
+            **/build/test-results/test/*.xml
+            **/build/test-results/test/leader-test-db.txt
           retention-days: 14
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: coverage-exposed-r2dbc-postgresql
-          path: '**/build/reports/kover/'
+          path: |
+            **/build/reports/kover/
+            **/build/reports/kover/leader-test-db.txt
           retention-days: 14
 
   # ── leader-exposed-r2dbc (MySQL 8) ────────────────────────────────────────
@@ -664,20 +709,29 @@ jobs:
       - name: Generate Kover XML report
         if: always()
         run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon --no-configuration-cache
+        env:
+          LEADER_TEST_DB: "MYSQL_V8"
         continue-on-error: true
+      - name: Verify provider artifact provenance
+        if: always()
+        run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-r2dbc --provider MYSQL_V8
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results-exposed-r2dbc-mysql
-          path: '**/build/test-results/test/*.xml'
+          path: |
+            **/build/test-results/test/*.xml
+            **/build/test-results/test/leader-test-db.txt
           retention-days: 14
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: coverage-exposed-r2dbc-mysql
-          path: '**/build/reports/kover/'
+          path: |
+            **/build/reports/kover/
+            **/build/reports/kover/leader-test-db.txt
           retention-days: 14
 
   # ── leader-mongodb (Testcontainers: MongoDB) ────────────────────────────────

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -267,6 +267,43 @@ subprojects {
             }
         }
 
+        if (path == ":bluetape4k-leader-exposed-jdbc" || path == ":bluetape4k-leader-exposed-r2dbc") {
+            val leaderTestDb = providers
+                .environmentVariable("LEADER_TEST_DB")
+                .map { value ->
+                    when (val normalized = value.trim().uppercase()) {
+                        "POSTGRES" -> "POSTGRESQL"
+                        "MYSQL" -> "MYSQL_V8"
+                        else -> normalized
+                    }
+                }
+                .orElse("ALL")
+
+            named("test") {
+                val providerMarker = layout.buildDirectory.file("test-results/test/leader-test-db.txt")
+                inputs.property("leaderTestDb", leaderTestDb)
+                outputs.file(providerMarker)
+                doFirst { providerMarker.get().asFile.delete() }
+                doLast {
+                    val markerFile = providerMarker.get().asFile
+                    markerFile.parentFile.mkdirs()
+                    markerFile.writeText("LEADER_TEST_DB=${leaderTestDb.get()}\n")
+                }
+            }
+
+            matching { it.name == "koverXmlReport" }.configureEach {
+                val providerMarker = layout.buildDirectory.file("reports/kover/leader-test-db.txt")
+                inputs.property("leaderTestDb", leaderTestDb)
+                outputs.file(providerMarker)
+                doFirst { providerMarker.get().asFile.delete() }
+                doLast {
+                    val markerFile = providerMarker.get().asFile
+                    markerFile.parentFile.mkdirs()
+                    markerFile.writeText("LEADER_TEST_DB=${leaderTestDb.get()}\n")
+                }
+            }
+        }
+
         withType<Sign>().configureEach {
             usesService(signingMutex)
         }

--- a/docs/lessons/2026-08-28-issue-720-test-cache-isolation.md
+++ b/docs/lessons/2026-08-28-issue-720-test-cache-isolation.md
@@ -1,0 +1,50 @@
+# Issue #720: Exposed provider별 테스트 증거 캐시 격리 교훈
+
+## 문제
+
+`leader-exposed-jdbc`와 `leader-exposed-r2dbc` 테스트 fixture는
+`LEADER_TEST_DB`로 실행 provider를 선택하지만, Gradle `Test` task가 이 환경
+값을 입력으로 선언하지 않았다. H2를 실행한 뒤 provider만 바꿔 같은 task를
+호출하면 Gradle이 task를 `UP-TO-DATE`로 판단해 H2 결과와 Kover 증거가 남을 수
+있었다. CI와 Nightly의 Kover 단계도 provider 환경값을 받지 않아, artifact가
+어떤 provider를 검증했는지 확인할 수 없었다.
+
+## 결정
+
+1. Exposed JDBC/R2DBC의 `test`와 `koverXmlReport` task에 정규화한
+   `LEADER_TEST_DB`를 입력으로 선언한다. 값이 없으면 `ALL`을 사용해 로컬의
+   기존 다중-provider 동작을 유지한다.
+2. 각 task가 실행한 provider를 `test-results/test/leader-test-db.txt`와
+   `reports/kover/leader-test-db.txt`에 기록한다. marker가 없거나 기대값과
+   다르면 CI 검증 단계가 실패한다.
+3. CI와 Nightly는 test와 Kover 단계에 같은 provider를 전달하고, 테스트 XML과
+   marker를 함께 업로드한다. 여섯 provider fan-out은 정적 계약 validator와
+   validator 자체 회귀 테스트로 고정한다.
+4. 버전 고정 매뉴얼의 release pin을 유지하기 위해, JDBC/R2DBC의 H2·PostgreSQL·
+   MySQL_V8 순차 실행과 두 marker 비교는
+   `docs/release/issue-720-exposed-provider-evidence.md`에 release 증거 runbook으로
+   기록한다. marker는 provenance 증거이며 backend assertion을 대체하지 않는다.
+
+## 검증
+
+- 구현 전 H2 실행 뒤 `LEADER_TEST_DB=POSTGRESQL`로 같은 JDBC `test` task를
+  다시 호출했을 때 `UP-TO-DATE`가 재현됐다.
+- 구현 후 JDBC H2와 PostgreSQL 실행에서 task가 다시 실행되고 marker가 각각
+  `LEADER_TEST_DB=H2`, `LEADER_TEST_DB=POSTGRESQL`로 갱신됐다.
+- 최종 여섯 조합을 `--rerun-tasks`로 실행했다. JDBC는 H2/PostgreSQL/MySQL_V8
+  각각 148개, R2DBC는 각각 153개 테스트가 성공했고, 모든 test/Kover marker가
+  해당 provider와 일치했다.
+- 환경 변수가 없을 때 JDBC 304개와 R2DBC 323개 전체 테스트가 성공했고, 두
+  marker가 `LEADER_TEST_DB=ALL`로 기록됐다.
+- `scripts/ci/validate_provider_artifacts_test.py`의 positive/mismatch/
+  workflow/self-test 계약이 통과했다.
+- CI/Nightly workflow contract, `actionlint`, Detekt, 매뉴얼 release contract,
+  `git diff --check`도 통과했다.
+
+## 재발 방지
+
+provider를 선택하는 환경 변수, system property, 파일 입력은 실행 task의
+Gradle input으로 선언하고, 결과 artifact에는 선택값을 검증 가능한 marker로
+남긴다. CI가 생성한 결과를 업로드할 때는 marker를 XML과 함께 보존하며,
+provider별 job은 test·report 단계의 환경 전파와 marker 일치를 계약 검사로
+확인한다.

--- a/docs/release/issue-720-exposed-provider-evidence.md
+++ b/docs/release/issue-720-exposed-provider-evidence.md
@@ -1,0 +1,46 @@
+# #720 Exposed provider 증거 검증
+
+이 문서는 `develop`에서 #720 구현 이후 실행하는 릴리스 증거 runbook입니다.
+`docs/manual/`은 `0.5.0` release commit에 고정된 버전 문서이므로, 해당 릴리스에
+아직 없는 provider marker와 Gradle 입력 계약을 버전 매뉴얼에 소급해 기록하지
+않습니다.
+
+## 여섯 provider 순차 검증
+
+`--rerun-tasks`로 각 provider 실행을 강제하고, `set -euo pipefail`로 테스트나
+검증 명령이 실패하면 다음 provider로 진행하지 않게 합니다.
+
+```bash
+set -euo pipefail
+
+for module in leader-exposed-jdbc leader-exposed-r2dbc; do
+  for provider in H2 POSTGRESQL MYSQL_V8; do
+    LEADER_TEST_DB="$provider" ./gradlew \
+      ":bluetape4k-${module}:test" \
+      ":bluetape4k-${module}:koverXmlReport" \
+      --no-configuration-cache --no-daemon --rerun-tasks --console=plain
+
+    python3 scripts/ci/validate_provider_artifacts.py \
+      --root . --module "$module" --provider "$provider"
+    printf 'LEADER_TEST_DB=%s\n' "$provider" | diff -u - \
+      "$module/build/test-results/test/leader-test-db.txt"
+    printf 'LEADER_TEST_DB=%s\n' "$provider" | diff -u - \
+      "$module/build/reports/kover/leader-test-db.txt"
+  done
+done
+```
+
+검증기는 테스트 XML, Kover XML, 두 provenance marker의 존재와 provider 일치를
+확인합니다. marker는 선택값과 artifact provenance를 증명하지만 backend assertion을
+대신하지 않습니다.
+
+## CI 계약 검증
+
+```bash
+python3 scripts/ci/validate_provider_artifacts.py \
+  --workflow-contract .github/workflows/ci.yml .github/workflows/nightly-tests.yml
+python3 scripts/ci/validate_provider_artifacts.py --self-test
+```
+
+CI와 Nightly의 각 provider job은 test와 Kover 단계에 같은 canonical provider를
+전달하고, provider별 artifact 이름과 marker를 업로드합니다.

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/AbstractExposedJdbcLeaderTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/AbstractExposedJdbcLeaderTest.kt
@@ -29,7 +29,7 @@ abstract class AbstractExposedJdbcLeaderTest {
          */
         @JvmStatic
         fun enableDialects(): List<TestDB> {
-            val filter = System.getenv("LEADER_TEST_DB")?.uppercase()
+            val filter = System.getenv("LEADER_TEST_DB")?.trim()?.uppercase()
                 ?: return listOf(TestDB.H2, TestDB.POSTGRESQL, TestDB.MYSQL_V8)
 
             return when (filter) {

--- a/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/AbstractExposedR2dbcLeaderTest.kt
+++ b/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/AbstractExposedR2dbcLeaderTest.kt
@@ -48,7 +48,7 @@ abstract class AbstractExposedR2dbcLeaderTest {
          */
         @JvmStatic
         fun enableDialects(): List<TestR2dbcDB> {
-            val filter = System.getenv("LEADER_TEST_DB")?.uppercase()
+            val filter = System.getenv("LEADER_TEST_DB")?.trim()?.uppercase()
                 ?: return listOf(TestR2dbcDB.H2, TestR2dbcDB.POSTGRESQL, TestR2dbcDB.MYSQL_V8)
             return when (filter) {
                 "H2"                -> listOf(TestR2dbcDB.H2)

--- a/scripts/ci/validate_provider_artifacts.py
+++ b/scripts/ci/validate_provider_artifacts.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Exposed provider별 테스트·Kover artifact provenance 계약을 검증한다."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+EXPECTED_JOBS: dict[str, tuple[str, str]] = {
+    "test-exposed-jdbc-h2": ("leader-exposed-jdbc", "H2"),
+    "test-exposed-jdbc-postgresql": ("leader-exposed-jdbc", "POSTGRESQL"),
+    "test-exposed-jdbc-mysql": ("leader-exposed-jdbc", "MYSQL_V8"),
+    "test-exposed-r2dbc-h2": ("leader-exposed-r2dbc", "H2"),
+    "test-exposed-r2dbc-postgresql": ("leader-exposed-r2dbc", "POSTGRESQL"),
+    "test-exposed-r2dbc-mysql": ("leader-exposed-r2dbc", "MYSQL_V8"),
+}
+EXPECTED_MODULES = frozenset(module for module, _ in EXPECTED_JOBS.values())
+EXPECTED_PROVIDERS = frozenset(provider for _, provider in EXPECTED_JOBS.values())
+MARKER_NAME = "leader-test-db.txt"
+PROVIDER_ARTIFACT_SUFFIX = {
+    "H2": "h2",
+    "POSTGRESQL": "postgresql",
+    "MYSQL_V8": "mysql",
+}
+
+
+def _job_block(source: str, job_id: str) -> str | None:
+    marker = f"  {job_id}:"
+    start = source.find(marker)
+    if start < 0 or (start and source[start - 1] != "\n"):
+        return None
+    next_job_match = re.search(
+        r"^  [A-Za-z0-9][A-Za-z0-9_-]*:\s*$",
+        source[start + len(marker) :],
+        flags=re.MULTILINE,
+    )
+    if next_job_match is None:
+        return source[start:]
+    next_job = start + len(marker) + next_job_match.start()
+    return source[start:next_job]
+
+
+def _step_block(block: str, step_name: str) -> str | None:
+    marker = f"- name: {step_name}"
+    start = block.find(marker)
+    if start < 0:
+        return None
+    step_start = block.rfind("\n", 0, start) + 1
+    next_step = block.find("\n      - name:", start + len(marker))
+    return block[step_start:] if next_step < 0 else block[step_start : next_step + 1]
+
+
+def _step_block_with_name_prefix(block: str, step_name_prefix: str) -> str | None:
+    match = re.search(
+        rf"^      - name: {re.escape(step_name_prefix)}[^\n]*$",
+        block,
+        flags=re.MULTILINE,
+    )
+    if match is None:
+        return None
+    step_start = match.start()
+    next_step = re.search(r"^      - name:", block[match.end() :], flags=re.MULTILINE)
+    if next_step is None:
+        return block[step_start:]
+    return block[step_start : match.end() + next_step.start()]
+
+
+def _step_field_block(step: str, field_name: str) -> str:
+    marker = f"        {field_name}:"
+    start = step.find(marker)
+    if start < 0 or (start and step[start - 1] != "\n"):
+        return ""
+    next_field = re.search(
+        r"^        [A-Za-z0-9_-]+:",
+        step[start + len(marker) :],
+        flags=re.MULTILINE,
+    )
+    return step[start:] if next_field is None else step[start : start + len(marker) + next_field.start()]
+
+
+def _has_env_provider(step: str, provider: str) -> bool:
+    env = _step_field_block(step, "env")
+    return re.search(
+        rf'^          LEADER_TEST_DB:\s*"{re.escape(provider)}"\s*$',
+        env,
+        flags=re.MULTILINE,
+    ) is not None
+
+
+def _has_with_name(step: str, expected_name: str) -> bool:
+    with_block = _step_field_block(step, "with")
+    return re.search(
+        rf"^          name:\s*{re.escape(expected_name)}\s*$",
+        with_block,
+        flags=re.MULTILINE,
+    ) is not None
+
+
+def _with_contains(step: str, value: str) -> bool:
+    return value in _step_field_block(step, "with")
+
+
+def _normalise_provider(provider: str) -> str:
+    value = provider.strip().upper()
+    aliases = {"POSTGRES": "POSTGRESQL", "MYSQL": "MYSQL_V8"}
+    return aliases.get(value, value)
+
+
+def validate_build_source(root: Path) -> list[str]:
+    path = root.resolve() / "build.gradle.kts"
+    if path.is_symlink() or not path.is_file():
+        return [f"{path}: build.gradle.kts가 없습니다"]
+
+    source = path.read_text(encoding="utf-8")
+    violations: list[str] = []
+    required_patterns = {
+        r"providers\s*\.\s*environmentVariable\(\"LEADER_TEST_DB\"\)": "LEADER_TEST_DB Provider 입력",
+        r"map\s*\{[\s\S]*?trim\(\)\.uppercase\(\)[\s\S]*?\}": "provider 정규화",
+        r'orElse\("ALL"\)': "provider 기본값",
+        r"test-results/test/leader-test-db\.txt": "테스트 marker 출력",
+        r"reports/kover/leader-test-db\.txt": "Kover marker 출력",
+        r'matching\s*\{\s*it\.name\s*==\s*"koverXmlReport"\s*\}': "Kover report task 구성",
+    }
+    for pattern, description in required_patterns.items():
+        if re.search(pattern, source) is None:
+            violations.append(f"{path}: {description}이 없습니다 ({pattern})")
+
+    input_count = source.count('inputs.property("leaderTestDb"')
+    if input_count < 2:
+        violations.append(
+            f"{path}: test와 Kover report 모두에 leaderTestDb 입력을 선언해야 합니다 (현재 {input_count}개)"
+        )
+    if source.count("LEADER_TEST_DB=") < 2:
+        violations.append(f"{path}: test와 Kover marker에 provider 값을 기록해야 합니다")
+    if source.count("providerMarker.get().asFile.delete()") < 2:
+        violations.append(f"{path}: test와 Kover 실행 전에 이전 provider marker를 삭제해야 합니다")
+    return violations
+
+
+def validate_workflow(path: Path) -> list[str]:
+    if path.is_symlink() or not path.is_file():
+        return [f"{path}: workflow 파일이 없습니다"]
+
+    source = path.read_text(encoding="utf-8")
+    violations: list[str] = []
+    for job_id, (module, provider) in EXPECTED_JOBS.items():
+        block = _job_block(source, job_id)
+        if block is None:
+            violations.append(f"{path}: {job_id} job이 없습니다")
+            continue
+
+        gradle_task = f":bluetape4k-{module}:test"
+        if gradle_task not in block:
+            violations.append(f"{path}: {job_id}에 {gradle_task} 실행이 없습니다")
+
+        test_step = _step_block_with_name_prefix(block, f"Test {module}")
+        if test_step is None or not _has_env_provider(test_step, provider):
+            violations.append(f"{path}: {job_id} test env에 LEADER_TEST_DB={provider}가 없습니다")
+
+        kover = _step_block(block, "Generate Kover XML report")
+        if kover is None:
+            violations.append(f"{path}: {job_id}에 Kover report step이 없습니다")
+        elif not _has_env_provider(kover, provider):
+            violations.append(
+                f"{path}: {job_id} Kover report env에 LEADER_TEST_DB={provider}가 없습니다"
+            )
+
+        test_upload = _step_block(block, "Upload test results")
+        artifact_suffix = PROVIDER_ARTIFACT_SUFFIX[provider]
+        artifact_module = module.removeprefix("leader-")
+        expected_test_artifact = f"test-results-{artifact_module}-{artifact_suffix}"
+        if (
+            test_upload is None
+            or not _has_with_name(test_upload, expected_test_artifact)
+            or not _with_contains(test_upload, "**/build/test-results/test/*.xml")
+            or not _with_contains(test_upload, MARKER_NAME)
+        ):
+            violations.append(
+                f"{path}: {job_id} test artifact 이름/내용이 {expected_test_artifact}/{MARKER_NAME}이어야 합니다"
+            )
+
+        coverage_upload = _step_block(block, "Upload coverage report")
+        expected_coverage_artifact = f"coverage-{artifact_module}-{artifact_suffix}"
+        if (
+            coverage_upload is None
+            or not _has_with_name(coverage_upload, expected_coverage_artifact)
+            or not _with_contains(coverage_upload, "**/build/reports/kover/")
+            or not _with_contains(coverage_upload, MARKER_NAME)
+        ):
+            violations.append(
+                f"{path}: {job_id} coverage artifact 이름/경로/marker가 올바르지 않습니다"
+            )
+
+        verify = _step_block(block, "Verify provider artifact provenance")
+        expected_args = (
+            "validate_provider_artifacts.py",
+            f"--module {module}",
+            f"--provider {provider}",
+        )
+        if verify is None or any(argument not in verify for argument in expected_args):
+            violations.append(
+                f"{path}: {job_id}에 {module}/{provider} provenance 검증 step이 없습니다"
+            )
+    return violations
+
+
+def validate_workflow_contract(workflows: tuple[Path, ...]) -> list[str]:
+    if not workflows:
+        return ["검증할 workflow가 없습니다"]
+    violations = []
+    for workflow in workflows:
+        violations.extend(validate_workflow(workflow))
+    root = workflows[0].resolve().parents[2]
+    violations.extend(validate_build_source(root))
+    return violations
+
+
+def _read_marker(path: Path, expected: str, label: str) -> list[str]:
+    if path.is_symlink() or not path.is_file():
+        return [f"{label}: {path}가 없습니다"]
+    try:
+        lines = [line.strip() for line in path.read_text(encoding="utf-8").splitlines()]
+    except OSError as error:
+        return [f"{label}: {path}를 읽을 수 없습니다 ({error})"]
+    actual = f"LEADER_TEST_DB={expected}"
+    if lines != [actual]:
+        return [f"{label}: {path} 내용이 {actual!r}와 다릅니다"]
+    return []
+
+
+def validate_artifacts(root: Path, module: str, provider: str) -> list[str]:
+    module = module.strip()
+    provider = _normalise_provider(provider)
+    if module not in EXPECTED_MODULES:
+        return [f"지원하지 않는 module: {module}"]
+    if provider not in EXPECTED_PROVIDERS:
+        return [f"지원하지 않는 provider: {provider}"]
+
+    module_root = root.resolve() / module / "build"
+    test_root = module_root / "test-results" / "test"
+    kover_root = module_root / "reports" / "kover"
+    violations = []
+    test_xml = sorted(test_root.rglob("*.xml")) if test_root.is_dir() else []
+    if not test_xml:
+        violations.append(f"{module}: test result XML이 없습니다 ({test_root})")
+    kover_xml = sorted(kover_root.rglob("*.xml")) if kover_root.is_dir() else []
+    if not kover_xml:
+        violations.append(f"{module}: Kover XML이 없습니다 ({kover_root})")
+    violations.extend(
+        _read_marker(test_root / MARKER_NAME, provider, "test provider marker")
+    )
+    violations.extend(
+        _read_marker(kover_root / MARKER_NAME, provider, "Kover provider marker")
+    )
+    return violations
+
+
+def _self_test() -> list[str]:
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        test_root = root / "leader-exposed-jdbc/build/test-results/test"
+        kover_root = root / "leader-exposed-jdbc/build/reports/kover"
+        test_root.mkdir(parents=True)
+        kover_root.mkdir(parents=True)
+        (test_root / "TEST-self.xml").write_text("<testsuite/>", encoding="utf-8")
+        (kover_root / "report.xml").write_text("<report/>", encoding="utf-8")
+        (test_root / MARKER_NAME).write_text("LEADER_TEST_DB=H2\n", encoding="utf-8")
+        (kover_root / MARKER_NAME).write_text("LEADER_TEST_DB=H2\n", encoding="utf-8")
+        violations = validate_artifacts(root, "leader-exposed-jdbc", "H2")
+        if violations:
+            return violations
+        (kover_root / MARKER_NAME).write_text("LEADER_TEST_DB=MYSQL_V8\n", encoding="utf-8")
+        if not validate_artifacts(root, "leader-exposed-jdbc", "H2"):
+            return ["불일치 provider marker를 거부하지 못했습니다"]
+    return []
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--workflow-contract",
+        nargs="+",
+        type=Path,
+        metavar="WORKFLOW",
+        help="CI/Nightly workflow의 provider fan-out 계약을 검증한다",
+    )
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--module")
+    parser.add_argument("--provider")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        violations = _self_test()
+    elif args.workflow_contract:
+        violations = validate_workflow_contract(tuple(path.resolve() for path in args.workflow_contract))
+    elif args.module and args.provider:
+        violations = validate_artifacts(args.root, args.module, args.provider)
+    else:
+        parser.error("--workflow-contract, --self-test, 또는 --module과 --provider가 필요합니다")
+
+    if violations:
+        for violation in violations:
+            print(f"::error::{violation}")
+        return 1
+    print("Exposed provider artifact contract OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/validate_provider_artifacts_test.py
+++ b/scripts/ci/validate_provider_artifacts_test.py
@@ -121,11 +121,21 @@ class ProviderArtifactContractTest(unittest.TestCase):
 
     def test_rejects_provider_mentioned_only_in_test_script(self) -> None:
         source = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
-        source = source.replace(
-            '          LEADER_TEST_DB: "H2"\n\n      - name: Generate Kover XML report',
-            '          echo \'LEADER_TEST_DB: "H2"\'\n\n      - name: Generate Kover XML report',
+        job_start = source.index("  test-exposed-jdbc-h2:")
+        job_end = source.index("  test-exposed-jdbc-postgresql:", job_start)
+        job = source[job_start:job_end]
+        job = job.replace(
+            "          for attempt in 1 2 3 4 5; do",
+            "          echo 'LEADER_TEST_DB: \"H2\"'\n"
+            "          for attempt in 1 2 3 4 5; do",
             1,
         )
+        job = job.replace(
+            '          LEADER_TEST_DB: "H2"\n\n      - name: Generate Kover XML report',
+            '\n      - name: Generate Kover XML report',
+            1,
+        )
+        source = source[:job_start] + job + source[job_end:]
 
         with tempfile.TemporaryDirectory() as directory:
             workflow = Path(directory) / "ci.yml"

--- a/scripts/ci/validate_provider_artifacts_test.py
+++ b/scripts/ci/validate_provider_artifacts_test.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Exposed provider artifact 계약 테스트."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/ci/validate_provider_artifacts.py"
+WORKFLOWS = (
+    ROOT / ".github/workflows/ci.yml",
+    ROOT / ".github/workflows/nightly-tests.yml",
+)
+SPEC = importlib.util.spec_from_file_location("provider_artifact_validator", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(VALIDATOR)
+
+
+def run_validator(*arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *arguments],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+class ProviderArtifactContractTest(unittest.TestCase):
+    def test_current_workflows_propagate_provider_and_upload_markers(self) -> None:
+        result = run_validator(
+            "--workflow-contract",
+            *(str(workflow) for workflow in WORKFLOWS),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_accepts_matching_test_and_kover_markers(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            test_dir = root / "leader-exposed-jdbc/build/test-results/test"
+            kover_dir = root / "leader-exposed-jdbc/build/reports/kover"
+            test_dir.mkdir(parents=True)
+            kover_dir.mkdir(parents=True)
+            (test_dir / "TEST-provider.xml").write_text("<testsuite/>", encoding="utf-8")
+            (kover_dir / "report.xml").write_text("<report/>", encoding="utf-8")
+            (test_dir / "leader-test-db.txt").write_text(
+                "LEADER_TEST_DB=POSTGRESQL\n", encoding="utf-8"
+            )
+            (kover_dir / "leader-test-db.txt").write_text(
+                "LEADER_TEST_DB=POSTGRESQL\n", encoding="utf-8"
+            )
+
+            result = run_validator(
+                "--root",
+                str(root),
+                "--module",
+                "leader-exposed-jdbc",
+                "--provider",
+                "POSTGRESQL",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_rejects_mismatched_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            test_dir = root / "leader-exposed-r2dbc/build/test-results/test"
+            kover_dir = root / "leader-exposed-r2dbc/build/reports/kover"
+            test_dir.mkdir(parents=True)
+            kover_dir.mkdir(parents=True)
+            (test_dir / "TEST-provider.xml").write_text("<testsuite/>", encoding="utf-8")
+            (kover_dir / "reportJvm.xml").write_text("<report/>", encoding="utf-8")
+            (test_dir / "leader-test-db.txt").write_text(
+                "LEADER_TEST_DB=H2\n", encoding="utf-8"
+            )
+            (kover_dir / "leader-test-db.txt").write_text(
+                "LEADER_TEST_DB=H2\n", encoding="utf-8"
+            )
+
+            result = run_validator(
+                "--root",
+                str(root),
+                "--module",
+                "leader-exposed-r2dbc",
+                "--provider",
+                "MYSQL_V8",
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("leader-test-db.txt", result.stdout + result.stderr)
+
+    def test_self_test_passes(self) -> None:
+        result = run_validator("--self-test")
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_rejects_provider_removed_from_test_step(self) -> None:
+        source = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        source = source.replace(
+            '          LEADER_TEST_DB: "H2"\n\n      - name: Generate Kover XML report',
+            '          LEADER_TEST_DB: "BROKEN"\n\n      - name: Generate Kover XML report',
+            1,
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            workflow = Path(directory) / "ci.yml"
+            workflow.write_text(source, encoding="utf-8")
+            violations = VALIDATOR.validate_workflow(workflow)
+
+        self.assertTrue(
+            any("test-exposed-jdbc-h2" in violation and "LEADER_TEST_DB" in violation for violation in violations),
+            violations,
+        )
+
+    def test_rejects_provider_mentioned_only_in_test_script(self) -> None:
+        source = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        source = source.replace(
+            '          LEADER_TEST_DB: "H2"\n\n      - name: Generate Kover XML report',
+            '          echo \'LEADER_TEST_DB: "H2"\'\n\n      - name: Generate Kover XML report',
+            1,
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            workflow = Path(directory) / "ci.yml"
+            workflow.write_text(source, encoding="utf-8")
+            violations = VALIDATOR.validate_workflow(workflow)
+
+        self.assertTrue(
+            any("test-exposed-jdbc-h2" in violation and "test env" in violation for violation in violations),
+            violations,
+        )
+
+    def test_rejects_provider_artifact_name_mismatch(self) -> None:
+        source = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        source = source.replace(
+            "          name: test-results-exposed-jdbc-h2",
+            "          name: test-results-exposed-jdbc-postgresql",
+            1,
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            workflow = Path(directory) / "ci.yml"
+            workflow.write_text(source, encoding="utf-8")
+            violations = VALIDATOR.validate_workflow(workflow)
+
+        self.assertTrue(
+            any("test-exposed-jdbc-h2" in violation and "artifact" in violation for violation in violations),
+            violations,
+        )
+
+    def test_rejects_test_artifact_without_xml_results(self) -> None:
+        source = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+        source = source.replace(
+            "            **/build/test-results/test/*.xml\n            **/build/test-results/test/leader-test-db.txt",
+            "            **/build/test-results/test/leader-test-db.txt",
+            1,
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            workflow = Path(directory) / "ci.yml"
+            workflow.write_text(source, encoding="utf-8")
+            violations = VALIDATOR.validate_workflow(workflow)
+
+        self.assertTrue(
+            any("test-exposed-jdbc-h2" in violation and "artifact" in violation for violation in violations),
+            violations,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #720

Exposed JDBC/R2DBC provider 선택값이 Gradle 캐시와 CI/Nightly 증거에 섞이지 않도록
Test·Kover 입력과 provenance marker를 고정합니다.

## Background

`LEADER_TEST_DB`가 fixture에서만 읽혀 H2 실행 뒤 PostgreSQL/MySQL task가
`UP-TO-DATE`로 건너뛰는 문제가 #720에서 재현됐습니다. Kover 단계에는 provider
환경값이 없었고, provider 이름의 artifact가 실제 결과와 일치하는지 확인할 계약도
없었습니다.

## What This Solves

- provider 변경이 `test`와 `koverXmlReport`의 Gradle cache key에 반영됩니다.
- 테스트/Kover 결과가 선택 provider의 marker와 artifact 이름을 함께 갖고, CI/Nightly
  provenance 검증이 불일치를 실패로 처리합니다.
- `POSTGRES`/`MYSQL` alias와 공백 입력을 canonical provider로 정규화하면서 기본
  `LEADER_TEST_DB` 미설정 시 기존 `ALL` 동작을 유지합니다.

## Work Done

- `build.gradle.kts`: Exposed JDBC/R2DBC Test·Kover task에 canonical
  `LEADER_TEST_DB` input, stale marker 삭제, 성공 marker output을 선언했습니다.
- `AbstractExposed*LeaderTest.kt`: fixture provider 입력을 trim/uppercase로 읽도록
  정렬했습니다.
- `.github/workflows/ci.yml`, `.github/workflows/nightly-tests.yml`: 여섯 provider
  job의 Test/Kover 환경 전파, marker/XML 업로드, provider별 artifact 검증을 고정했습니다.
- `scripts/ci/validate_provider_artifacts*.py`: workflow/artifact 계약과 positive 및
  negative 회귀 테스트를 추가했습니다.
- `docs/release/issue-720-exposed-provider-evidence.md`,
  `docs/lessons/2026-08-28-issue-720-test-cache-isolation.md`: release pin을
  침범하지 않는 develop 전용 runbook과 교훈을 기록했습니다.

## Validation

- `LEADER_TEST_DB=$provider ./gradlew ...:test ...:koverXmlReport --rerun-tasks`: PASS
  (JDBC 148개·R2DBC 153개, H2/PostgreSQL/MySQL_V8 모두 marker 일치)
- `./gradlew ...:test` (환경 변수 없음): PASS (JDBC 304개·R2DBC 323개, `ALL` marker)
- `python3 scripts/ci/validate_provider_artifacts_test.py`: PASS (8 tests)
- `python3 scripts/ci/validate_provider_artifacts.py --workflow-contract ...`: PASS
- `actionlint .github/workflows/ci.yml .github/workflows/nightly-tests.yml`: PASS
- `./gradlew detekt --no-daemon`: PASS
- manual release-contract suite, Ruff, Python compile, `git diff --check`: PASS

## Review Notes

- P0/P1/P2: 0
- P3: 0
- Review evidence: 독립 `code-reviewer` 및 `architect` 최종 검토 결과 코드 `APPROVE`, architecture `CLEAR`, P0/P1/P2/P3 모두 0입니다.

## Metadata

- Issue: #720, milestone `1.0.0`, assignee `debop`
- PR: #824, exact head `0babfab6428156593a6bf4f3116e9926b9fe6b07`
- 병합 커밋: `826b463c03c32a5b1d105cb486eeede286685cd5` (squash merge, `develop`)
- CI: exact-head run [33112511123](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33112511123) 성공.
- Nightly: full exact-head dispatch [33112575928](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33112575928) 성공.
- Post-merge develop CI: [33133738984](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33133738984) 47/47 성공.
- Post-merge Dependency Submission: [33133738986](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33133738986) 성공.

## DoD Status

Required checks: 8/8 local; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| red-green - 캐시 오염 재현/해소 | H2→PostgreSQL cache 전환과 marker 비교 | PASS | pre-fix UP-TO-DATE 재현, post-fix provider marker | none |
| gradle-isolation - Test/Kover 입력 | canonical env input, stale marker 삭제, marker output | PASS | `build.gradle.kts`, six-provider matrix | none |
| ci-contract - CI fan-out/artifact | workflow validator와 8개 회귀 테스트 | PASS | CI/Nightly contract, Python tests | none |
| nightly-contract - Nightly fan-out | Nightly 동일 provider 전파/검증 | PASS | exact-head full dispatch 33112575928, 여섯 Exposed provider job과 aggregate 성공 | none |
| docs - release pin/runbook | pinned manual 보존, develop runbook 기록 | PASS | manual release contract, writer audit | none |
| tests - runtime/quality | provider matrix, default ALL, Detekt | PASS | fresh local Gradle/Kover evidence | none |
| independent-review - 독립 검토 | code review와 architecture review | PASS | P0/P1/P2/P3 clear | none |
| diff-check - 변경 위생 | actionlint, Ruff, compile, diff check | PASS | commands above | none |

Final status: PASS (PR 병합 및 post-merge 검증 완료)

Unchecked required items: none
