### PR TITLE
fix(spring): 0.5.0 직렬화 설정의 health 기본값 복구

### DIFF
--- a/docs/lessons/2026-08-28-issue-739-serializable-defaults.md
+++ b/docs/lessons/2026-08-28-issue-739-serializable-defaults.md
@@ -1,0 +1,61 @@
+# Issue #739 lesson — Kotlin 기본 인자를 우회하는 Java serialization
+
+## 맥락
+
+`leader-spring-boot`의 `LeaderObservabilityProperties`에
+`backendHealth`를, `LeaderObservabilityHealthProperties`에
+`acquisitionFailureWindow`를 추가한 뒤 `0.5.0`에서 저장한 Java serialized
+payload를 `1.0.0` release line에서 읽는 경계를 확인했다. `0.5.0` tag 커밋
+`721a9a3808f67489d2bdb8177734325981c24977`의 실제 source로 만든 fixture를
+사용했다.
+
+## 발견
+
+Java serialization은 Kotlin 생성자를 호출하지 않으므로 생성자 기본 인자가
+적용되지 않는다. 구형 stream에는 새 필드가 없어서 현재 객체의
+`backendHealth`와 `acquisitionFailureWindow`가 모두 `null`로 남았고, health
+auto-configuration이 이 값을 읽는 순간 실패할 수 있었다.
+
+## 결정
+
+- 두 클래스의 `serialVersionUID=1L`을 유지해 기존 payload를 계속 읽는다.
+- 각 클래스의 private `readResolve()`에서 누락 필드를 현재 기본값으로
+  보정한다.
+- outer property와 nested health property를 함께 보정한다. 한 필드만
+  복구하면 같은 `0.5.0` stream의 다른 새 필드가 다시 null 경계를 만든다.
+- 새 field가 있는 현재 payload의 round-trip과 실제 `0.5.0` fixture를 모두
+  회귀 테스트하고, 두 health auto-configuration factory가 복원 객체를
+  사용할 수 있는지 직접 확인한다.
+
+## 결과
+
+기존 payload를 먼저 재저장할 필요 없이 `LeaderBackendHealthAutoConfiguration`
+과 `LeaderAcquisitionFailureWindowAutoConfiguration`이 각각
+`LeaderBackendHealthProperties()`와 5분 window를 사용한다. 새 의존성이나
+public JVM descriptor 변경은 추가하지 않았다.
+
+## 검증
+
+- RED: `LeaderObservabilityPropertiesSerializationTest`에서 구형 fixture를
+  읽은 두 필드가 `null`이라 각각 기본값 비교가 실패했다.
+- GREEN: 같은 회귀 테스트 4개 통과.
+- 영향 모듈: `./gradlew :bluetape4k-leader-spring-boot:test` — 625개 통과.
+- 정적/ABI: `:bluetape4k-leader-spring-boot:detekt` 통과,
+  `PublicJvmAbiCompatibilityTest` 4개 통과,
+  `checkBinaryCompatibility` — `artifacts=16, ignored=10, unknown=0` 및
+  `Binary API compatibility gate passed`.
+- 문서: 한국어 용어 감사 4개 파일, findings=0.
+
+## 향후 지침
+
+Kotlin `Serializable` data class에 non-null field를 추가할 때는 생성자 기본값이
+구형 stream에 적용된다고 가정하지 않는다. 변경 전에 이전 release source 또는
+published artifact로 실제 serialized fixture를 만들고, 다음 중 하나를 명시한다.
+
+1. 호환성을 유지하면 `serialVersionUID`를 고정하고 `readResolve()` 또는
+   명시적인 read migration으로 누락 필드를 보정한다.
+2. 호환성을 중단하면 UID 변경, `InvalidClassException` 계약, migration 문서와
+   fail-fast 테스트를 함께 제공한다.
+
+어느 경로든 property 자체의 값 비교만으로 끝내지 말고, 해당 값을 소비하는
+auto-configuration/read path를 복원 객체로 직접 실행해 null 경계를 닫는다.

--- a/docs/migration/0.5.0-binary-compatibility.md
+++ b/docs/migration/0.5.0-binary-compatibility.md
@@ -155,3 +155,30 @@ ABI_BASE_VERSION=0.5.0 ABI_CURRENT_VERSION=1.0.0 \
 
 현재 실행 결과는 `artifacts=16, ignored=10, unknown=0`이며,
 `Binary API compatibility gate passed`를 반환했다.
+
+### `LeaderObservabilityProperties` Java serialization 경계
+
+Issue [#739](https://github.com/bluetape4k/bluetape4k-leader/issues/739)는
+`0.5.0`에서 저장한 `LeaderObservabilityProperties`를 `1.0.0` release line이
+읽을 때 새 관찰 설정이 `null`로 남는 문제를 다룬다. Java serialization은
+Kotlin 생성자와 기본 인자를 호출하지 않으므로, 다음 두 필드가 추가된 뒤에도
+구형 스트림에서는 기본값이 자동으로 채워지지 않는다.
+
+- `LeaderObservabilityProperties.backendHealth`는
+  `LeaderBackendHealthProperties()`로 복구한다.
+- `LeaderObservabilityHealthProperties.acquisitionFailureWindow`는
+  `Duration.ofMinutes(5)`로 복구한다.
+
+두 클래스의 `serialVersionUID`는 계속 `1L`로 유지하고, private
+`readResolve()`에서 누락 필드를 기본값으로 보정한다. 따라서 기존
+`0.5.0` payload를 먼저 재저장할 필요가 없으며, 복구된 객체를 backend health와
+acquisition-failure window auto-configuration이 그대로 사용할 수 있다. 새
+필드가 있는 현재 payload의 round-trip과 `0.5.0`에서 생성한 실제 serialized
+fixture를 함께 회귀 테스트한다.
+
+릴리스 전에 다음 호환성 gate를 실행한다.
+
+```bash
+./gradlew :bluetape4k-leader-spring-boot:test \
+  --tests 'io.bluetape4k.leader.spring.properties.LeaderObservabilityPropertiesSerializationTest'
+```

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/properties/LeaderObservabilityProperties.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/properties/LeaderObservabilityProperties.kt
@@ -148,6 +148,25 @@ data class LeaderObservabilityProperties(
 
         private const val serialVersionUID = 1L
     }
+
+    /**
+     * `backendHealth` 추가 전 직렬화 스트림을 읽을 때 Java serialization이 Kotlin 기본값을
+     * 호출하지 않는 경계를 복구합니다.
+     */
+    @Suppress("SENSELESS_COMPARISON", "UNNECESSARY_SAFE_CALL")
+    private fun readResolve(): Any =
+        if (backendHealth == null) {
+            LeaderObservabilityProperties(
+                enabled = enabled,
+                lockNames = lockNames,
+                tracing = tracing,
+                health = health,
+                stateProviderBean = stateProviderBean,
+                backendHealth = backendHealth ?: LeaderBackendHealthProperties(),
+            )
+        } else {
+            this
+        }
 }
 
 /**
@@ -250,6 +269,22 @@ data class LeaderObservabilityHealthProperties(
 
         private const val serialVersionUID = 1L
     }
+
+    /**
+     * `acquisitionFailureWindow` 추가 전 직렬화 스트림을 읽을 때 Java serialization이 Kotlin
+     * 기본값을 호출하지 않는 경계를 복구합니다.
+     */
+    @Suppress("SENSELESS_COMPARISON", "UNNECESSARY_SAFE_CALL")
+    private fun readResolve(): Any =
+        if (acquisitionFailureWindow == null) {
+            LeaderObservabilityHealthProperties(
+                enabled = enabled,
+                leaseWarningThreshold = leaseWarningThreshold,
+                acquisitionFailureWindow = Duration.ofMinutes(DefaultAcquisitionFailureWindowMinutes),
+            )
+        } else {
+            this
+        }
 
     init {
         require(!leaseWarningThreshold.isNegative) {

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/properties/LeaderObservabilityPropertiesSerializationTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/properties/LeaderObservabilityPropertiesSerializationTest.kt
@@ -1,0 +1,106 @@
+package io.bluetape4k.leader.spring.properties
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.leader.LeaderElectionState
+import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
+import io.bluetape4k.leader.diagnostics.LocalLeaderBackendDiagnostics
+import io.bluetape4k.leader.spring.LeaderProperties
+import io.bluetape4k.leader.spring.observability.LeaderAcquisitionFailureWindowAutoConfiguration
+import io.bluetape4k.leader.spring.observability.LeaderBackendHealthAutoConfiguration
+import io.bluetape4k.leader.spring.observability.LeaderBackendHealthIndicator
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.support.DefaultListableBeanFactory
+import org.springframework.boot.health.contributor.Status
+import java.io.ByteArrayInputStream
+import java.io.ObjectInputStream
+import java.io.ObjectStreamClass
+import java.time.Duration
+import java.util.Base64
+
+class LeaderObservabilityPropertiesSerializationTest {
+
+    @Test
+    fun `0_5_0 serialized properties restore backend health defaults`() {
+        val restored = deserializeLegacyProperties()
+
+        restored.backendHealth shouldBeEqualTo LeaderBackendHealthProperties()
+    }
+
+    @Test
+    fun `0_5_0 serialized health restores acquisition failure window default`() {
+        val restored = deserializeLegacyProperties()
+
+        restored.health.acquisitionFailureWindow shouldBeEqualTo Duration.ofMinutes(5)
+    }
+
+    @Test
+    fun `0_5_0 serialized properties configure health auto configurations without null fields`() {
+        val restored = deserializeLegacyProperties()
+        val properties = LeaderProperties(observability = restored)
+
+        val acquisitionFailureWindow = LeaderAcquisitionFailureWindowAutoConfiguration()
+            .leaderAcquisitionFailureWindow(properties)
+        acquisitionFailureWindow.view().window shouldBeEqualTo Duration.ofMinutes(5)
+
+        val beanFactory = DefaultListableBeanFactory().apply {
+            registerSingleton("legacyStateProvider", LegacyDiagnosticsState())
+        }
+        val backendHealthIndicator = LeaderBackendHealthAutoConfiguration()
+            .leaderBackendHealthIndicator(beanFactory, properties)
+            .shouldBeInstanceOf<LeaderBackendHealthIndicator>()
+
+        backendHealthIndicator.health().status shouldBeEqualTo Status.UNKNOWN
+    }
+
+    @Test
+    fun `current serialized properties keep serial uid and custom values`() {
+        val original = LeaderObservabilityProperties(
+            enabled = false,
+            lockNames = setOf("orders"),
+            health = LeaderObservabilityHealthProperties(
+                enabled = true,
+                leaseWarningThreshold = Duration.ofSeconds(17),
+                acquisitionFailureWindow = Duration.ofSeconds(45),
+            ),
+            backendHealth = LeaderBackendHealthProperties(
+                enabled = true,
+                timeout = Duration.ofMillis(275),
+            ),
+        )
+
+        val restored = roundTrip(original)
+
+        restored shouldBeEqualTo original
+        ObjectStreamClass.lookup(LeaderObservabilityProperties::class.java).serialVersionUID shouldBeEqualTo 1L
+        ObjectStreamClass.lookup(LeaderObservabilityHealthProperties::class.java).serialVersionUID shouldBeEqualTo 1L
+    }
+
+    private fun deserializeLegacyProperties(): LeaderObservabilityProperties =
+        ObjectInputStream(
+            ByteArrayInputStream(
+                Base64.getDecoder().decode(LEGACY_0_5_0_SERIALIZED_PROPERTIES),
+            ),
+        ).use { input ->
+            input.readObject().shouldBeInstanceOf<LeaderObservabilityProperties>()
+        }
+
+    private fun <T> roundTrip(value: T): T {
+        val bytes = java.io.ByteArrayOutputStream()
+        java.io.ObjectOutputStream(bytes).use { it.writeObject(value) }
+        return ObjectInputStream(ByteArrayInputStream(bytes.toByteArray())).use {
+            @Suppress("UNCHECKED_CAST")
+            it.readObject() as T
+        }
+    }
+
+    private companion object {
+        val LEGACY_0_5_0_SERIALIZED_PROPERTIES = """
+            rO0ABXNyAERpby5ibHVldGFwZTRrLmxlYWRlci5zcHJpbmcucHJvcGVydGllcy5MZWFkZXJPYnNlcnZhYmlsaXR5UHJvcGVydGllcwAAAAAAAAABAgAFWgAHZW5hYmxlZEwABmhlYWx0aHQATExpby9ibHVldGFwZTRrL2xlYWRlci9zcHJpbmcvcHJvcGVydGllcy9MZWFkZXJPYnNlcnZhYmlsaXR5SGVhbHRoUHJvcGVydGllcztMAAlsb2NrTmFtZXN0AA9MamF2YS91dGlsL1NldDtMABFzdGF0ZVByb3ZpZGVyQmVhbnQAEkxqYXZhL2xhbmcvU3RyaW5nO0wAB3RyYWNpbmd0AEBMaW8vYmx1ZXRhcGU0ay9sZWFkZXIvc3ByaW5nL3Byb3BlcnRpZXMvTGVhZGVyVHJhY2luZ1Byb3BlcnRpZXM7eHABc3IASmlvLmJsdWV0YXBlNGsubGVhZGVyLnNwcmluZy5wcm9wZXJ0aWVzLkxlYWRlck9ic2VydmFiaWxpdHlIZWFsdGhQcm9wZXJ0aWVzAAAAAAAAAAECAAJaAAdlbmFibGVkTAAVbGVhc2VXYXJuaW5nVGhyZXNob2xkdAAUTGphdmEvdGltZS9EdXJhdGlvbjt4cAFzcgANamF2YS50aW1lLlNlcpVdhLobIkiyDAAAeHB3DQEAAAAAAAAAEQAAAAB4c3IAF2phdmEudXRpbC5MaW5rZWRIYXNoU2V02GzXWpXdKh4CAAB4cgARamF2YS51dGlsLkhhc2hTZXS6RIWVlri3NAMAAHhwdwwAAAAEP0AAAAAAAAJ0AAZvcmRlcnN0AAhwYXltZW50c3h0ABNsZWdhY3lTdGF0ZVByb3ZpZGVyc3IAPmlvLmJsdWV0YXBlNGsubGVhZGVyLnNwcmluZy5wcm9wZXJ0aWVzLkxlYWRlclRyYWNpbmdQcm9wZXJ0aWVzAAAAAAAAAAECAARaAAdlbmFibGVkWgAXaW5jbHVkZUV4Y2VwdGlvbkRldGFpbHNaAA9pbmNsdWRlTGVhZGVySWRaAA9pbmNsdWRlTG9ja05hbWV4cAEBAQE=
+        """.trimIndent()
+    }
+
+    private class LegacyDiagnosticsState : LeaderElectionState, LeaderBackendDiagnosticsProvider {
+        override val backendDescriptor = LocalLeaderBackendDiagnostics.backendDescriptor
+    }
+}


### PR DESCRIPTION
## Summary

Closes #739

`0.5.0`에서 저장한 `LeaderObservabilityProperties`를 현재 release line이 읽을 때 Java serialization이 Kotlin 생성자 기본값을 우회해 새 health 필드를 `null`로 복원하던 결함을 수정합니다.

## Background

`LeaderObservabilityProperties`와 중첩 `LeaderObservabilityHealthProperties`는 `Serializable`과 `serialVersionUID = 1L`을 유지하면서 새 필드를 추가했습니다. 실제 `0.5.0` source로 만든 serialized fixture를 현재 class로 읽으면 `backendHealth`와 `acquisitionFailureWindow`가 모두 `null`이 되어 Spring health auto-configuration의 read path가 깨질 수 있었습니다.

## What This Solves

- 이전 `0.5.0` serialized payload를 재저장하지 않고 현재 기본값으로 안전하게 복구합니다.
- backend health와 acquisition-failure window auto-configuration이 복구된 non-null 설정을 소비하도록 보장합니다.

## Work Done

- `LeaderObservabilityProperties`와 `LeaderObservabilityHealthProperties`에 기존 `serialVersionUID = 1L`을 보존하는 private `readResolve()` migration을 추가했습니다.
- 실제 `0.5.0` serialized fixture 및 현재 payload round-trip 회귀 테스트를 추가하고, 두 Spring auto-configuration factory 소비 경로를 직접 검증했습니다.
- `docs/migration/0.5.0-binary-compatibility.md`에 compatibility 결정/release gate를, `docs/lessons/2026-08-28-issue-739-serializable-defaults.md`에 재발 방지 규칙을 기록했습니다.

## Validation

- `./gradlew :bluetape4k-leader-spring-boot:test --tests "io.bluetape4k.leader.spring.properties.LeaderObservabilityPropertiesSerializationTest"`: PASS (4 tests)
- `./gradlew :bluetape4k-leader-spring-boot:test`: PASS (625 tests)
- `./gradlew :bluetape4k-leader-spring-boot:detekt`: PASS
- `./gradlew :bluetape4k-leader-spring-boot:test --tests "io.bluetape4k.leader.spring.compatibility.PublicJvmAbiCompatibilityTest"`: PASS (4 tests)
- `./gradlew checkBinaryCompatibility`: PASS (`artifacts=16, ignored=10, unknown=0`)
- 한국어 용어 감사: PASS (4 files, findings=0)
- `git diff --check`: PASS

## Review Notes

- 7-Tier self-review: P0=0, P1=0, P2=0, P3=0.
- 독립 리뷰: N/A (1인 개발자 lane이며 추가 maintainer/reviewer는 범위에 없음).
- lifecycle/concurrency: N/A (직렬화 read path와 Spring 설정 소비 경계만 변경하며 lock/watchdog/비동기 lifecycle은 변경하지 않음).
- heavy shared-state checks: hosted CI의 `leader-spring-boot (Testcontainers)` job이 PASS했으며 별도 native/emulator/benchmark lane은 해당하지 않습니다.

## Metadata

- Issue: #739, milestone `1.0.0`, assignee `debop`, labels `bug`, `integration`, `test`, `maintenance`
- PR: #825, milestone `1.0.0`, assignee `debop`, labels `bug`, `integration`, `test`, `maintenance` (live read-back 확인).
- Head: `c85003baef4546432f12bf8cd8b71ee3619dc2ce`
- Base: `develop`
- CI: [run 33112724617](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33112724617) exact-head checks PASS (12개 통과, 35개 intended skip; `CI Status` PASS).

## DoD Status

Required checks: 18/18; N/A: 0; Blocked: 0

Type C rows: 9/9 PASS

| Check | Status | Evidence |
|------|--------|----------|
| C-09 - merge·sync·cleanup | PASS | PR #825 rebase merge, Issue #739 CLOSED, canonical develop 동기화, 대상 worktree/local branch 제거, remote feature ref 복원 |
| CG-16 - fresh merge approval | PASS | 현재 exact head c85003baef4546432f12bf8cd8b71ee3619dc2ce에 대한 사용자 승인 확인 |
| CG-17 - rebase merge | PASS | merge SHA 6b2c24bb9045b9f0c3980006290f0e1bc246abbf, PR state MERGED |
| CG-18 - canonical sync/cleanup | PASS | local/origin develop 826b463c03c32a5b1d105cb486eeede286685cd5 일치, 대상만 정리, 15 worktree 유지 |

Final status: DONE

Unchecked required items: 없음