### PR TITLE
fix: 전략 후보 heartbeat·취소·interrupt 상태를 보존한다

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -568,6 +568,15 @@ val result = election.runIfLeader(
 ) { processShard() }
 ```
 
+`registerCandidate`는 `CandidateInfo` 전체를 교체하므로 `updateResult` 뒤에 오래된
+후보 정보로 heartbeat를 보내는 용도로 사용하면 결과 카운터와 실행 시각이 되돌아갈 수
+있습니다. 기존 후보의 heartbeat에는 `refreshCandidate`를 사용하세요. 이 메서드는
+`registeredAt`, `lastStartTime`, `lastCompletionTime`, `successCount`, `failureCount`를
+보존하고 `metadata`와 요청한 TTL만 갱신합니다. Redis 구현은 이 병합을 원자적으로
+처리하며, 이미 만료되었거나 없는 Redis 후보를 refresh하면 새 후보를 만들지 않습니다.
+최초 등록에는 `registerCandidate`를 사용하세요. `updateResult`는 현재 TTL을 보존하고,
+`refreshCandidate(..., Duration.ZERO)`는 후보를 영구 저장으로 전환합니다.
+
 `maxLeaders`는 해당 호출이 읽은 후보 기준 목록에 대한 자문형 top-N 한도이며, 전역 분산 동시 실행 상한이 아닙니다. 노드마다 서로 다른 후보 기준 목록을 볼 수 있으므로 합집합은 N을 초과할 수 있습니다. 전역 슬롯 상한이 필요하면 `LeaderGroupElector`를 사용하세요. Redis 전략적 그룹 레지스트리는 전략적 단일 리더와 분리하고, 저장 schema 충돌을 막기 위해 Lettuce는 `leader:strategy:group-candidates:lettuce:v1`, Redisson은 `leader:strategy:group-candidates:redisson:v1` namespace를 사용합니다. 0이 아닌 후보 TTL은 만료 전에 재등록 또는 heartbeat가 필요하고, `Duration.ZERO`는 영구 등록입니다. Local 구현은 프로세스 메모리 수명 동안 후보를 유지하며 TTL을 무시합니다. Lettuce는 후보별 TTL과 index set을 분리하므로, 같은 lockName의 유한 TTL 후보가 만료되어도 영구 후보가 가려지지 않습니다. Custom strategy는 같은 후보 기준 목록의 모든 후보를 winner/elimination으로 중복 없이 완전히 분할해 반환해야 하며, 위반 시 elector가 `IllegalArgumentException`을 즉시 던집니다.
 
 ### 전략적 선출 vs 락 기반 선출

--- a/README.md
+++ b/README.md
@@ -567,6 +567,15 @@ val result = election.runIfLeader(
 ) { processShard() }
 ```
 
+`registerCandidate` replaces the complete `CandidateInfo` record, so do not use it as a
+heartbeat after `updateResult`: a stale candidate record can roll back the result counters and
+timestamps. Use `refreshCandidate` for an existing candidate instead. It preserves
+`registeredAt`, `lastStartTime`, `lastCompletionTime`, `successCount`, and `failureCount`,
+while replacing `metadata` and applying the requested TTL. Redis implementations perform
+this merge atomically; a refresh for an expired or missing Redis candidate is a no-op, so
+call `registerCandidate` for initial enrollment. `updateResult` keeps the current TTL,
+whereas `refreshCandidate(..., Duration.ZERO)` makes the candidate persistent.
+
 `maxLeaders` is an advisory top-N limit for the candidate list read by that invocation; it is not a global distributed concurrency cap. Different nodes can observe different candidate lists and their union can exceed N. Use `LeaderGroupElector` when a hard global slot limit is required. Redis strategic group registries use separate backend-qualified namespaces (`leader:strategy:group-candidates:lettuce:v1` and `leader:strategy:group-candidates:redisson:v1`) from strategic single-leader registries. A non-zero candidate TTL requires re-registration or heartbeat before expiry; `Duration.ZERO` is persistent, while the Local implementation keeps candidates for the process lifetime and ignores TTL. Lettuce keeps the candidate index independent from per-candidate TTLs, so an expiring candidate cannot hide a persistent candidate with the same lock name. Custom strategies must return a complete, non-overlapping winner/elimination partition of the same candidate list, or the elector fails fast with `IllegalArgumentException`.
 
 ### Strategic election vs lock-based election

--- a/docs/lessons/2026-08-28-issue-804-strategic-heartbeat-counters.md
+++ b/docs/lessons/2026-08-28-issue-804-strategic-heartbeat-counters.md
@@ -14,7 +14,8 @@
 - `refreshCandidate`는 등록·실행·결과 필드를 보존하고 `metadata`와 요청한 TTL만
   갱신한다.
 - Lettuce는 GET과 갱신을 하나의 Redis script로 묶고, Redisson은 후보별 entry lock을
-  `refreshCandidate`와 `updateResult`가 함께 사용하게 한다.
+  `refreshCandidate`와 `updateResult`가 함께 사용하게 한다. Local 네 구현은
+  `ConcurrentHashMap.computeIfPresent`로 같은 키의 갱신을 원자화한다.
 - 이미 만료된 Redis 후보를 refresh해서 새 후보가 생기지 않도록 한다. 최초 등록은
   `registerCandidate`가 담당한다.
 - `updateResult`는 기존 TTL을 유지하고, heartbeat가 명시한 TTL만 후보 생존 시간을
@@ -31,7 +32,9 @@
 Redis backend에서는 결과 필드 보존을 저장소 원자 경계로 강제했다.
 
 향후 예방 확인: 새 후보 생존 갱신 API를 추가할 때는 blocking·suspend single/group의
-두 호출 순서, TTL 보존·재설정, 만료 후보 no-op, 점수 순서를 함께 검증한다.
+두 호출 순서, TTL 보존·재설정, 만료 후보 no-op, 점수 순서, update/unregister와의
+동시 실행을 함께 검증한다. Local 구현에서 `listCandidates` 후 `registerCandidate`를
+다시 조합하지 말고 후보 키의 `computeIfPresent` 경계를 유지한다.
 
 ## 검증
 

--- a/docs/lessons/2026-08-28-issue-804-strategic-heartbeat-counters.md
+++ b/docs/lessons/2026-08-28-issue-804-strategic-heartbeat-counters.md
@@ -1,0 +1,42 @@
+# #804 전략적 후보 heartbeat가 결과 카운터를 되돌린 문제
+
+## 문제
+
+`CandidateInfo` 전체를 저장하는 `registerCandidate`를 heartbeat처럼 호출하면,
+호출자가 들고 있던 오래된 후보 정보가 Redis의 최신 후보를 덮어쓴다. 그 결과
+`successCount`, `failureCount`, `lastCompletionTime`이 최근 실행 전 상태로
+되돌아가고, 점수 기반 선출 순서도 달라질 수 있다.
+
+## 수정
+
+- `registerCandidate`의 전체 교체 의미는 호환성을 위해 유지한다.
+- 네 가지 strategic 인터페이스에 `refreshCandidate`를 추가한다.
+- `refreshCandidate`는 등록·실행·결과 필드를 보존하고 `metadata`와 요청한 TTL만
+  갱신한다.
+- Lettuce는 GET과 갱신을 하나의 Redis script로 묶고, Redisson은 후보별 entry lock을
+  `refreshCandidate`와 `updateResult`가 함께 사용하게 한다.
+- 이미 만료된 Redis 후보를 refresh해서 새 후보가 생기지 않도록 한다. 최초 등록은
+  `registerCandidate`가 담당한다.
+- `updateResult`는 기존 TTL을 유지하고, heartbeat가 명시한 TTL만 후보 생존 시간을
+  다시 설정한다.
+
+## 예방 규칙
+
+실패한 가정: 후보 등록을 반복하면 최신 `CandidateInfo`가 자동으로 병합된다.
+
+발견 증거 또는 교정: 등록은 전체 교체이고, 결과 갱신은 카운터를 원자적으로
+증가시키므로 오래된 등록 정보가 최신 결과를 덮어쓸 수 있었다.
+
+수정 결정: 초기 등록과 heartbeat를 `registerCandidate`/`refreshCandidate`로 분리하고,
+Redis backend에서는 결과 필드 보존을 저장소 원자 경계로 강제했다.
+
+향후 예방 확인: 새 후보 생존 갱신 API를 추가할 때는 blocking·suspend single/group의
+두 호출 순서, TTL 보존·재설정, 만료 후보 no-op, 점수 순서를 함께 검증한다.
+
+## 검증
+
+- Lettuce strategic heartbeat: 5 passing
+- Redisson strategic heartbeat: 5 passing
+- 각 테스트는 blocking/suspend single/group과 refresh 전후 결과 갱신 순서를 포함한다.
+- `updateResult` 후 TTL 보존과 `refreshCandidate` 후 TTL 재설정은 Lettuce `PTTL`과
+  Redisson `remainTimeToLive`로 확인한다.

--- a/docs/lessons/2026-08-28-issue-826-redisson-entry-lock-cancellation.md
+++ b/docs/lessons/2026-08-28-issue-826-redisson-entry-lock-cancellation.md
@@ -15,30 +15,37 @@ Redisson suspend 후보 registry가 entry lock을 `lockAsync(threadId)`로 기�
 - 성공한 attempt는 `leaseTime=-1`을 사용해 Redisson watchdog 갱신을 유지한다. source
   future가 2초 deadline을 넘기면 원본 future를 취소해 backend 지연이 coroutine waiter를
   붙잡지 않게 한다.
+- suspend entry lock의 logical owner ID는 음수 namespace에서 할당해 같은 RedissonClient의
+  blocking JVM thread ID(양수)와 reentrant owner로 오인되지 않게 한다.
 - 취소와 실제 획득이 경합하면 기존 상태 기계가 late acquisition을 관찰해 bounded
   `unlockAsync` cleanup을 예약한다.
-- Toxiproxy 회귀 시험은 취소 후 500ms attempt window 안에 owner를 해제해 실제 late
-  acquisition 경합을 만들고, 취소된 waiter의 정리 뒤 새 logical thread가 bounded 시간에
-  재획득하는지 확인한다.
+- Toxiproxy 회귀 시험은 upstream 500ms 지연으로 취소된 acquire 명령을 Redis에 남겨 두고,
+  owner를 해제한 뒤 늦은 owner가 실제로 생성되는지와 cleanup으로 사라지는지를 각각
+  확인한다. 이후 새 logical thread가 bounded 시간에 재획득하는지도 검증한다.
 
 ## 예방 규칙
 
 실패한 가정: coroutine 취소가 caller를 반환시키면 backend lock waiter도 곧 끝난다.
 
 발견 증거 또는 교정: Redisson `lockAsync`는 owner가 유지되는 동안 pub/sub waiter를
-계속 보유하며, future cancellation과 서버의 실제 lock 획득 시점은 어긋날 수 있다.
+계속 보유하며, `CompletableFutureWrapper.cancel()`은 노출된 future만 취소하므로 내부
+Redis 명령과 서버의 실제 lock 획득 시점은 어긋날 수 있다. JVM thread ID와 coroutine
+logical ID를 섞으면 같은 owner로 취급되어 대기를 우회할 수도 있다.
 
 수정 결정: 무기한 `lockAsync` 대신 watchdog을 유지하는 bounded `tryLockAsync` 시도와
 source future 취소, late-acquisition cleanup을 함께 사용한다. P1 review 지적은 기존
 green CI보다 우선하는 blocker로 취급하고, non-completing source와 owner-held 실제
-late-acquisition integration 경계를 추가한다.
+late-acquisition integration 경계를 추가한다. 내부 명령의 server-side 취소를 가정하지
+않고 늦은 획득 관찰과 owner-specific cleanup을 증명한다.
 
 향후 예방 확인: suspend distributed lock 대기 경로를 추가하거나 바꿀 때는 bounded
-wait, watchdog lease, source cancellation deadline, logical thread ownership, cancellation
-race, owner-held cleanup, unlock 응답 timeout을 mock과 실제 Redis/Toxiproxy에서 각각
-검증한다.
+wait, watchdog lease, source cancellation deadline, blocking/suspend logical owner namespace,
+cancellation race, owner-held cleanup, unlock 응답 timeout을 mock과 실제 Redis/Toxiproxy에서
+각각 검증한다. future 취소를 server-side 명령 취소로 표현하지 말고, 실제 늦은 획득과
+정리 결과를 별도로 관찰한다.
 
 ## 검증
 
 - `RedissonCandidateRegistryCancellationTest`: 3개 통과
+- `RedissonCandidateRegistryContentionTest`: 1개 통과
 - `RedissonStrategicGroupToxiproxyCancellationTest`: 3개 통과

--- a/docs/lessons/2026-08-28-issue-826-redisson-entry-lock-cancellation.md
+++ b/docs/lessons/2026-08-28-issue-826-redisson-entry-lock-cancellation.md
@@ -1,0 +1,40 @@
+# #826 Redisson entry lock 취소 waiter가 남은 문제
+
+## 문제
+
+Redisson suspend 후보 registry가 entry lock을 `lockAsync(threadId)`로 기다리면,
+호출 coroutine이 취소되어도 Redis의 pub/sub waiter가 owner 해제 또는 연결 복구까지
+남을 수 있다. 취소된 caller만 빠르게 반환하고 원본 lock future를 계속 보존하는 방식은
+늦은 획득을 정리할 수 있지만, owner가 오래 유지되는 동안 waiter lifecycle을 끝내지
+못한다.
+
+## 수정
+
+- `tryLockAsync(wait, lease, unit, threadId)`를 500ms bounded attempt로 사용하고,
+  실패하면 취소 여부를 확인하며 다음 attempt를 시작한다.
+- 각 attempt의 lease는 30초로 제한해 짧은 registry 작업이 watchdog 없이도 소유권을
+  유지하게 하고, caller 취소 시 원본 bounded future는 취소하지 않는다.
+- 취소와 실제 획득이 경합하면 기존 상태 기계가 late acquisition을 관찰해 bounded
+  `unlockAsync` cleanup을 예약한다.
+- Toxiproxy 회귀 시험은 owner를 attempt window보다 오래 유지한 뒤 해제하고, 잔여
+  waiter 없이 새 logical thread가 즉시 재획득하는지 확인한다.
+
+## 예방 규칙
+
+실패한 가정: coroutine 취소가 caller를 반환시키면 backend lock waiter도 곧 끝난다.
+
+발견 증거 또는 교정: Redisson `lockAsync`는 owner가 유지되는 동안 pub/sub waiter를
+계속 보유하며, future cancellation과 서버의 실제 lock 획득 시점은 어긋날 수 있다.
+
+수정 결정: 무기한 `lockAsync` 대신 bounded `tryLockAsync` 시도와 late-acquisition
+cleanup을 함께 사용한다. P1 review 지적은 기존 green CI보다 우선하는 blocker로
+취급하고, owner-held integration 경계를 추가한다.
+
+향후 예방 확인: suspend distributed lock 대기 경로를 추가하거나 바꿀 때는 bounded
+wait, logical thread ownership, cancellation race, owner-held cleanup, unlock 응답
+timeout을 mock과 실제 Redis/Toxiproxy에서 각각 검증한다.
+
+## 검증
+
+- `RedissonCandidateRegistryCancellationTest`: 2개 통과
+- `RedissonStrategicGroupToxiproxyCancellationTest`: 3개 통과

--- a/docs/lessons/2026-08-28-issue-826-redisson-entry-lock-cancellation.md
+++ b/docs/lessons/2026-08-28-issue-826-redisson-entry-lock-cancellation.md
@@ -12,12 +12,14 @@ Redisson suspend 후보 registry가 entry lock을 `lockAsync(threadId)`로 기�
 
 - `tryLockAsync(wait, lease, unit, threadId)`를 500ms bounded attempt로 사용하고,
   실패하면 취소 여부를 확인하며 다음 attempt를 시작한다.
-- 각 attempt의 lease는 30초로 제한해 짧은 registry 작업이 watchdog 없이도 소유권을
-  유지하게 하고, caller 취소 시 원본 bounded future는 취소하지 않는다.
+- 성공한 attempt는 `leaseTime=-1`을 사용해 Redisson watchdog 갱신을 유지한다. source
+  future가 2초 deadline을 넘기면 원본 future를 취소해 backend 지연이 coroutine waiter를
+  붙잡지 않게 한다.
 - 취소와 실제 획득이 경합하면 기존 상태 기계가 late acquisition을 관찰해 bounded
   `unlockAsync` cleanup을 예약한다.
-- Toxiproxy 회귀 시험은 owner를 attempt window보다 오래 유지한 뒤 해제하고, 잔여
-  waiter 없이 새 logical thread가 즉시 재획득하는지 확인한다.
+- Toxiproxy 회귀 시험은 취소 후 500ms attempt window 안에 owner를 해제해 실제 late
+  acquisition 경합을 만들고, 취소된 waiter의 정리 뒤 새 logical thread가 bounded 시간에
+  재획득하는지 확인한다.
 
 ## 예방 규칙
 
@@ -26,15 +28,17 @@ Redisson suspend 후보 registry가 entry lock을 `lockAsync(threadId)`로 기�
 발견 증거 또는 교정: Redisson `lockAsync`는 owner가 유지되는 동안 pub/sub waiter를
 계속 보유하며, future cancellation과 서버의 실제 lock 획득 시점은 어긋날 수 있다.
 
-수정 결정: 무기한 `lockAsync` 대신 bounded `tryLockAsync` 시도와 late-acquisition
-cleanup을 함께 사용한다. P1 review 지적은 기존 green CI보다 우선하는 blocker로
-취급하고, owner-held integration 경계를 추가한다.
+수정 결정: 무기한 `lockAsync` 대신 watchdog을 유지하는 bounded `tryLockAsync` 시도와
+source future 취소, late-acquisition cleanup을 함께 사용한다. P1 review 지적은 기존
+green CI보다 우선하는 blocker로 취급하고, non-completing source와 owner-held 실제
+late-acquisition integration 경계를 추가한다.
 
 향후 예방 확인: suspend distributed lock 대기 경로를 추가하거나 바꿀 때는 bounded
-wait, logical thread ownership, cancellation race, owner-held cleanup, unlock 응답
-timeout을 mock과 실제 Redis/Toxiproxy에서 각각 검증한다.
+wait, watchdog lease, source cancellation deadline, logical thread ownership, cancellation
+race, owner-held cleanup, unlock 응답 timeout을 mock과 실제 Redis/Toxiproxy에서 각각
+검증한다.
 
 ## 검증
 
-- `RedissonCandidateRegistryCancellationTest`: 2개 통과
+- `RedissonCandidateRegistryCancellationTest`: 3개 통과
 - `RedissonStrategicGroupToxiproxyCancellationTest`: 3개 통과

--- a/docs/lessons/2026-08-28-issue-828-micrometer-interrupt-flag.md
+++ b/docs/lessons/2026-08-28-issue-828-micrometer-interrupt-flag.md
@@ -1,0 +1,28 @@
+# #828 Micrometer diagnostics probe의 interrupt flag 보존
+
+## 문제
+
+Micrometer가 backend diagnostics probe를 감싸면서 `InterruptedException`을 같은
+인스턴스로 재전파했지만, 인터럽트로 지워진 현재 스레드의 interrupt flag를 복원하지
+않았다. 호출자는 예외를 받더라도 상위 취소·종료 경로가 인터럽트 상태를 확인할 수
+없었다.
+
+## 수정과 예방 규칙
+
+실패한 가정: 예외 인스턴스를 그대로 던지면 blocking interrupt 계약이 충분하다.
+
+발견 증거 또는 교정: `recordActiveProbe`는 예외 identity만 보존했고
+`Thread.currentThread().isInterrupted`는 `false`로 남았다.
+
+수정 결정: `InterruptedException`을 잡는 즉시 `Thread.currentThread().interrupt()`를
+호출한 뒤 같은 예외를 다시 던진다. `CancellationException`, 일반 예외의 메트릭
+fallback, `Error` 재전파 경계는 기존 동작을 유지한다.
+
+향후 예방 확인: 동기 probe를 장식하거나 로깅하는 새 경계마다
+`checkConnectivity`와 `diagnostics(probe=true)` 각각에 대해 동일 인스턴스 재전파와
+interrupt flag 복원을 함께 검증한다.
+
+## 검증
+
+- `InstrumentedLeaderElectorsTest.active connectivity probes restore interrupt flag and preserve exception identity`: passing
+- 기존 Micrometer decorator 테스트와 `Error`/`CancellationException` 예외 경계: 회귀 테스트에서 확인

--- a/docs/superpowers/specs/2026-08-25-strategic-group-election-design.md
+++ b/docs/superpowers/specs/2026-08-25-strategic-group-election-design.md
@@ -104,6 +104,15 @@ coroutine variant는 같은 인자와 `suspend () -> T` action을 사용한다.
 
 - `registerCandidate`, `unregisterCandidate`, `listCandidates`, `updateResult`는
   기존 `StrategicLeaderElector`와 같은 시그니처와 TTL 전달 규칙을 따른다.
+- `registerCandidate`는 `CandidateInfo` 전체를 교체한다. 실행 중인 후보가 오래된
+  후보 정보로 heartbeat를 보내면 결과 통계가 되돌아갈 수 있으므로, 네 인터페이스는
+  기존 후보의 `metadata`와 TTL만 갱신하는 `refreshCandidate`를 제공한다.
+- `refreshCandidate`는 `registeredAt`, `lastStartTime`, `lastCompletionTime`,
+  `successCount`, `failureCount`를 보존한다. Redis Lettuce와 Redisson은 이 병합을
+  backend 원자 경계에서 수행하며, 이미 만료되었거나 없는 후보를 refresh해 새 후보를
+  만들지 않는다. 최초 등록은 `registerCandidate`로 수행한다.
+- `updateResult`는 현재 TTL을 보존하고, `refreshCandidate(..., Duration.ZERO)`는
+  `Duration.ZERO` 등록 규칙과 같이 만료되지 않는 후보로 저장한다.
 - 현재 `nodeId`가 관찰된 후보 기준 목록의 winner 목록에 없으면 action을 호출하지 않고
   `null`을 반환한다.
 - 현재 `nodeId`가 관찰된 후보 기준 목록의 winner 목록에 있으면 해당 호출에서 action을
@@ -152,7 +161,8 @@ coroutine variant는 같은 인자와 `suspend () -> T` action을 사용한다.
   index set은 후보별 TTL과 독립적으로 유지해 영구 후보와 유한 TTL 후보가 같은
   `lockName`에 함께 등록되어도 유한 후보 만료가 영구 후보를 가리지 않게 한다.
 - `Duration.ZERO`는 만료되지 않는 후보 등록이다. 유한 TTL 후보는 호출자가
-  재등록/heartbeat해야 하며 권장 cadence는 TTL보다 짧게 잡는다. Local은
+  재등록/heartbeat해야 하며 권장 cadence는 TTL보다 짧게 잡는다. heartbeat에는
+  `refreshCandidate`를 사용해야 결과 카운터와 실행 시각을 보존할 수 있다. Local은
   기존 구현과 같이 TTL을 저장하지 않고 프로세스 메모리 수명으로 유지한다.
 - 지원하지 않는 backend에 전략적 group adapter를 추가하는 작업은 별도
   issue로 분리한다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderElector.kt
@@ -31,6 +31,18 @@ interface StrategicLeaderElector {
     fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO)
 
     /**
+     * heartbeat용 후보 갱신입니다. 기존 결과 카운터와 실행 시각은 보존하고
+     * `info.metadata`와 TTL만 갱신합니다.
+     *
+     * Redis 구현은 이 연산을 backend 원자 경계로 처리합니다. 다른 구현은
+     * `listCandidates`와 `registerCandidate` 조합을 기본 동작으로 사용합니다.
+     */
+    fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO) {
+        val current = listCandidates(lockName).firstOrNull { it.nodeId == info.nodeId }
+        registerCandidate(lockName, current?.copy(metadata = info.metadata) ?: info, ttl)
+    }
+
+    /**
      * `unregisterCandidate` 호출은 leader election 계약의 일부 동작을 수행합니다.
      *
      * 정상 contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderElector.kt
@@ -34,8 +34,9 @@ interface StrategicLeaderElector {
      * heartbeat용 후보 갱신입니다. 기존 결과 카운터와 실행 시각은 보존하고
      * `info.metadata`와 TTL만 갱신합니다.
      *
-     * Redis 구현은 이 연산을 backend 원자 경계로 처리합니다. 다른 구현은
-     * `listCandidates`와 `registerCandidate` 조합을 기본 동작으로 사용합니다.
+     * Redis와 Local 구현은 이 연산을 backend 원자 경계로 처리합니다. 다른 구현은
+     * 호환성을 위해 `listCandidates`와 `registerCandidate` 조합을 기본 동작으로
+     * 사용할 수 있으므로, 동시 결과 갱신이 필요하면 backend 원자 구현을 제공해야 합니다.
      */
     fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO) {
         val current = listCandidates(lockName).firstOrNull { it.nodeId == info.nodeId }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderGroupElector.kt
@@ -25,6 +25,9 @@ interface StrategicLeaderGroupElector {
     /**
      * heartbeat용 후보 갱신입니다. 기존 결과 카운터와 실행 시각은 보존하고
      * `info.metadata`와 TTL만 갱신합니다.
+     * Redis와 Local 구현은 이 연산을 backend 원자 경계로 처리합니다. 다른 구현은
+     * 호환성을 위해 `listCandidates`와 `registerCandidate` 조합을 기본 동작으로
+     * 사용할 수 있으므로, 동시 결과 갱신이 필요하면 backend 원자 구현을 제공해야 합니다.
      */
     fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO) {
         val current = listCandidates(lockName).firstOrNull { it.nodeId == info.nodeId }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderGroupElector.kt
@@ -22,6 +22,15 @@ interface StrategicLeaderGroupElector {
     /** 후보를 등록하고 backend가 지원하는 경우 TTL을 적용합니다. */
     fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO)
 
+    /**
+     * heartbeat용 후보 갱신입니다. 기존 결과 카운터와 실행 시각은 보존하고
+     * `info.metadata`와 TTL만 갱신합니다.
+     */
+    fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO) {
+        val current = listCandidates(lockName).firstOrNull { it.nodeId == info.nodeId }
+        registerCandidate(lockName, current?.copy(metadata = info.metadata) ?: info, ttl)
+    }
+
     /** 후보를 등록 해제합니다. */
     fun unregisterCandidate(lockName: String, nodeId: String)
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderElector.kt
@@ -32,6 +32,18 @@ interface StrategicSuspendLeaderElector {
     suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO)
 
     /**
+     * heartbeat용 후보 갱신입니다. 기존 결과 카운터와 실행 시각은 보존하고
+     * `info.metadata`와 TTL만 갱신합니다.
+     *
+     * Redis 구현은 이 연산을 backend 원자 경계로 처리합니다. 다른 구현은
+     * `listCandidates`와 `registerCandidate` 조합을 기본 동작으로 사용합니다.
+     */
+    suspend fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO) {
+        val current = listCandidates(lockName).firstOrNull { it.nodeId == info.nodeId }
+        registerCandidate(lockName, current?.copy(metadata = info.metadata) ?: info, ttl)
+    }
+
+    /**
      * `unregisterCandidate` 호출은 leader election 계약의 일부 동작을 수행합니다.
      *
      * 정상 contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderElector.kt
@@ -35,8 +35,9 @@ interface StrategicSuspendLeaderElector {
      * heartbeat용 후보 갱신입니다. 기존 결과 카운터와 실행 시각은 보존하고
      * `info.metadata`와 TTL만 갱신합니다.
      *
-     * Redis 구현은 이 연산을 backend 원자 경계로 처리합니다. 다른 구현은
-     * `listCandidates`와 `registerCandidate` 조합을 기본 동작으로 사용합니다.
+     * Redis와 Local 구현은 이 연산을 backend 원자 경계로 처리합니다. 다른 구현은
+     * 호환성을 위해 `listCandidates`와 `registerCandidate` 조합을 기본 동작으로
+     * 사용할 수 있으므로, 동시 결과 갱신이 필요하면 backend 원자 구현을 제공해야 합니다.
      */
     suspend fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO) {
         val current = listCandidates(lockName).firstOrNull { it.nodeId == info.nodeId }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderGroupElector.kt
@@ -25,6 +25,9 @@ interface StrategicSuspendLeaderGroupElector {
     /**
      * heartbeat용 후보 갱신입니다. 기존 결과 카운터와 실행 시각은 보존하고
      * `info.metadata`와 TTL만 갱신합니다.
+     * Redis와 Local 구현은 이 연산을 backend 원자 경계로 처리합니다. 다른 구현은
+     * 호환성을 위해 `listCandidates`와 `registerCandidate` 조합을 기본 동작으로
+     * 사용할 수 있으므로, 동시 결과 갱신이 필요하면 backend 원자 구현을 제공해야 합니다.
      */
     suspend fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO) {
         val current = listCandidates(lockName).firstOrNull { it.nodeId == info.nodeId }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderGroupElector.kt
@@ -22,6 +22,15 @@ interface StrategicSuspendLeaderGroupElector {
     /** 후보를 등록하고 backend가 지원하는 경우 TTL을 적용합니다. */
     suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO)
 
+    /**
+     * heartbeat용 후보 갱신입니다. 기존 결과 카운터와 실행 시각은 보존하고
+     * `info.metadata`와 TTL만 갱신합니다.
+     */
+    suspend fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO) {
+        val current = listCandidates(lockName).firstOrNull { it.nodeId == info.nodeId }
+        registerCandidate(lockName, current?.copy(metadata = info.metadata) ?: info, ttl)
+    }
+
     /** 후보를 등록 해제합니다. */
     suspend fun unregisterCandidate(lockName: String, nodeId: String)
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElector.kt
@@ -46,6 +46,12 @@ class LocalStrategicLeaderElector(
         candidatesFor(lockName)[info.nodeId] = info
     }
 
+    override fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+        candidatesFor(lockName).computeIfPresent(info.nodeId) { _, current ->
+            current.copy(metadata = info.metadata)
+        }
+    }
+
     override fun unregisterCandidate(lockName: String, nodeId: String) {
         candidatesFor(lockName).remove(nodeId)
     }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElector.kt
@@ -42,6 +42,12 @@ class LocalStrategicLeaderGroupElector(
         candidatesFor(lockName)[info.nodeId] = info
     }
 
+    override fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+        candidatesFor(lockName).computeIfPresent(info.nodeId) { _, current ->
+            current.copy(metadata = info.metadata)
+        }
+    }
+
     override fun unregisterCandidate(lockName: String, nodeId: String) {
         candidatesFor(lockName).remove(nodeId)
     }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElector.kt
@@ -46,6 +46,12 @@ class LocalStrategicSuspendLeaderElector(
         candidatesFor(lockName)[info.nodeId] = info
     }
 
+    override suspend fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+        candidatesFor(lockName).computeIfPresent(info.nodeId) { _, current ->
+            current.copy(metadata = info.metadata)
+        }
+    }
+
     override suspend fun unregisterCandidate(lockName: String, nodeId: String) {
         candidatesFor(lockName).remove(nodeId)
     }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderGroupElector.kt
@@ -42,6 +42,12 @@ class LocalStrategicSuspendLeaderGroupElector(
         candidatesFor(lockName)[info.nodeId] = info
     }
 
+    override suspend fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+        candidatesFor(lockName).computeIfPresent(info.nodeId) { _, current ->
+            current.copy(metadata = info.metadata)
+        }
+    }
+
     override suspend fun unregisterCandidate(lockName: String, nodeId: String) {
         candidatesFor(lockName).remove(nodeId)
     }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElectorTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElectorTest.kt
@@ -2,8 +2,8 @@ package io.bluetape4k.leader.local
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeNull
-import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.codec.Base58
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
@@ -98,7 +98,7 @@ class LocalStrategicLeaderElectorTest {
             CandidateInfo("ghost", metadata = mapOf("heartbeat" to "missing")),
         )
 
-        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+        node1.listCandidates(lockName).shouldBeEmpty()
     }
 
     @Test
@@ -160,7 +160,7 @@ class LocalStrategicLeaderElectorTest {
             )
             .run()
 
-        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+        node1.listCandidates(lockName).shouldBeEmpty()
     }
 
     @Test
@@ -220,7 +220,7 @@ class LocalStrategicLeaderElectorTest {
         node1.registerCandidate(lockName, CandidateInfo("node-1"))
         node1.unregisterCandidate(lockName, "node-1")
 
-        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+        node1.listCandidates(lockName).shouldBeEmpty()
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElectorTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderElectorTest.kt
@@ -1,7 +1,12 @@
 package io.bluetape4k.leader.local
 
 import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.scorers.IdleTimeScorer
@@ -10,10 +15,6 @@ import io.bluetape4k.leader.strategy.scorers.WeightedScorer
 import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
 import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
 import kotlinx.coroutines.CancellationException
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeNull
-import io.bluetape4k.assertions.shouldBeTrue
-import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -88,6 +89,78 @@ class LocalStrategicLeaderElectorTest {
         val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
         updated.successCount shouldBeEqualTo 0L
         updated.failureCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `refreshCandidate - 없는 후보는 새로 등록하지 않는다`() {
+        node1.refreshCandidate(
+            lockName,
+            CandidateInfo("ghost", metadata = mapOf("heartbeat" to "missing")),
+        )
+
+        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun `refreshCandidate - 결과 통계와 완료 시각을 보존하고 metadata만 갱신한다`() {
+        node1.registerCandidate(
+            lockName,
+            CandidateInfo(
+                nodeId = node1.nodeId,
+                registeredAt = Instant.parse("2026-01-01T00:00:00Z"),
+                successCount = 3,
+                failureCount = 2,
+                metadata = mapOf("version" to "old"),
+            ),
+        )
+        node1.updateResult(lockName, node1.nodeId, CandidateResult.SUCCESS)
+        val beforeRefresh = node1.listCandidates(lockName).single()
+
+        node1.refreshCandidate(
+            lockName,
+            CandidateInfo(node1.nodeId, metadata = mapOf("version" to "new")),
+        )
+
+        val refreshed = node1.listCandidates(lockName).single()
+        refreshed.registeredAt shouldBeEqualTo beforeRefresh.registeredAt
+        refreshed.lastCompletionTime shouldBeEqualTo beforeRefresh.lastCompletionTime
+        refreshed.successCount shouldBeEqualTo beforeRefresh.successCount
+        refreshed.failureCount shouldBeEqualTo beforeRefresh.failureCount
+        refreshed.metadata shouldBeEqualTo mapOf("version" to "new")
+    }
+
+    @Test
+    fun `refreshCandidate와 updateResult 동시 호출에서도 결과 카운터를 잃지 않는다`() {
+        val workers = 8
+        val rounds = 100
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        MultithreadingTester()
+            .workers(workers)
+            .rounds(rounds)
+            .add {
+                node1.updateResult(lockName, node1.nodeId, CandidateResult.SUCCESS)
+                node1.refreshCandidate(lockName, CandidateInfo(node1.nodeId, metadata = mapOf("heartbeat" to "ok")))
+            }
+            .run()
+
+        node1.listCandidates(lockName).single().successCount shouldBeEqualTo (workers * rounds).toLong()
+    }
+
+    @Test
+    fun `refreshCandidate와 unregisterCandidate 동시 호출에서도 후보를 되살리지 않는다`() {
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        MultithreadingTester()
+            .workers(2)
+            .rounds(100)
+            .addAll(
+                { node1.refreshCandidate(lockName, CandidateInfo(node1.nodeId, metadata = mapOf("heartbeat" to "ok"))) },
+                { node1.unregisterCandidate(lockName, node1.nodeId) },
+            )
+            .run()
+
+        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElectorTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElectorTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.local
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.codec.Base58
@@ -91,7 +92,7 @@ class LocalStrategicLeaderGroupElectorTest {
             CandidateInfo("ghost", metadata = mapOf("heartbeat" to "missing")),
         )
 
-        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+        node1.listCandidates(lockName).shouldBeEmpty()
     }
 
     @Test
@@ -153,7 +154,7 @@ class LocalStrategicLeaderGroupElectorTest {
             )
             .run()
 
-        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+        node1.listCandidates(lockName).shouldBeEmpty()
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElectorTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElectorTest.kt
@@ -4,7 +4,6 @@ import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeNull
-import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.codec.Base58
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.leader.strategy.CandidateInfo
@@ -170,7 +169,7 @@ class LocalStrategicLeaderGroupElectorTest {
         val candidate = node1.listCandidates(lockName).single()
         candidate.successCount shouldBeEqualTo 0L
         candidate.failureCount shouldBeEqualTo 0L
-        (candidate.lastCompletionTime == null).shouldBeTrue()
+        candidate.lastCompletionTime.shouldBeNull()
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElectorTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicLeaderGroupElectorTest.kt
@@ -5,7 +5,9 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.codec.Base58
+import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.strategy.GroupElectionStrategy
 import io.bluetape4k.leader.strategy.StrategicGroupElectionResult
 import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
@@ -80,6 +82,78 @@ class LocalStrategicLeaderGroupElectorTest {
         node1.listCandidates(lockName)
             .first { it.nodeId == node1.nodeId }
             .failureCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `refreshCandidate - 없는 후보는 새로 등록하지 않는다`() {
+        node1.refreshCandidate(
+            lockName,
+            CandidateInfo("ghost", metadata = mapOf("heartbeat" to "missing")),
+        )
+
+        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun `refreshCandidate - 결과 통계와 등록 시각을 보존하고 metadata만 갱신한다`() {
+        node1.registerCandidate(
+            lockName,
+            CandidateInfo(
+                nodeId = node1.nodeId,
+                registeredAt = Instant.parse("2026-01-01T00:00:00Z"),
+                successCount = 3,
+                failureCount = 2,
+                metadata = mapOf("version" to "old"),
+            ),
+        )
+        node1.updateResult(lockName, node1.nodeId, io.bluetape4k.leader.strategy.CandidateResult.SUCCESS)
+        val beforeRefresh = node1.listCandidates(lockName).single()
+
+        node1.refreshCandidate(
+            lockName,
+            CandidateInfo(node1.nodeId, metadata = mapOf("version" to "new")),
+        )
+
+        val refreshed = node1.listCandidates(lockName).single()
+        refreshed.registeredAt shouldBeEqualTo beforeRefresh.registeredAt
+        refreshed.lastCompletionTime shouldBeEqualTo beforeRefresh.lastCompletionTime
+        refreshed.successCount shouldBeEqualTo beforeRefresh.successCount
+        refreshed.failureCount shouldBeEqualTo beforeRefresh.failureCount
+        refreshed.metadata shouldBeEqualTo mapOf("version" to "new")
+    }
+
+    @Test
+    fun `refreshCandidate와 updateResult 동시 호출에서도 결과 카운터를 잃지 않는다`() {
+        val workers = 8
+        val rounds = 100
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        MultithreadingTester()
+            .workers(workers)
+            .rounds(rounds)
+            .add {
+                node1.updateResult(lockName, node1.nodeId, CandidateResult.SUCCESS)
+                node1.refreshCandidate(lockName, CandidateInfo(node1.nodeId, metadata = mapOf("heartbeat" to "ok")))
+            }
+            .run()
+
+        node1.listCandidates(lockName).single().successCount shouldBeEqualTo (workers * rounds).toLong()
+    }
+
+    @Test
+    fun `refreshCandidate와 unregisterCandidate 동시 호출에서도 후보를 되살리지 않는다`() {
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        MultithreadingTester()
+            .workers(2)
+            .rounds(100)
+            .addAll(
+                { node1.refreshCandidate(lockName, CandidateInfo(node1.nodeId, metadata = mapOf("heartbeat" to "ok"))) },
+                { node1.unregisterCandidate(lockName, node1.nodeId) },
+            )
+            .run()
+
+        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElectorTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElectorTest.kt
@@ -1,7 +1,11 @@
 package io.bluetape4k.leader.local
 
-import io.bluetape4k.codec.Base58
 import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.codec.Base58
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.LeaderElectionException
 import io.bluetape4k.leader.strategy.CandidateInfo
@@ -10,17 +14,16 @@ import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
 import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
 import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
-import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeNull
-import io.bluetape4k.assertions.shouldBeTrue
-import io.bluetape4k.assertions.shouldNotBeNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.Instant
@@ -66,6 +69,89 @@ class LocalStrategicSuspendLeaderElectorTest {
 
         val updated = node1.listCandidates(lockName).first { it.nodeId == "node-1" }
         updated.successCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `refreshCandidate - 없는 후보는 새로 등록하지 않는다`() = runTest {
+        node1.refreshCandidate(
+            lockName,
+            CandidateInfo("ghost", metadata = mapOf("heartbeat" to "missing")),
+        )
+
+        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun `refreshCandidate - 결과 통계와 완료 시각을 보존하고 metadata만 갱신한다`() = runTest {
+        node1.registerCandidate(
+            lockName,
+            CandidateInfo(
+                nodeId = node1.nodeId,
+                registeredAt = Instant.parse("2026-01-01T00:00:00Z"),
+                successCount = 3,
+                failureCount = 2,
+                metadata = mapOf("version" to "old"),
+            ),
+        )
+        node1.updateResult(lockName, node1.nodeId, CandidateResult.SUCCESS)
+        val beforeRefresh = node1.listCandidates(lockName).single()
+
+        node1.refreshCandidate(
+            lockName,
+            CandidateInfo(node1.nodeId, metadata = mapOf("version" to "new")),
+        )
+
+        val refreshed = node1.listCandidates(lockName).single()
+        refreshed.registeredAt shouldBeEqualTo beforeRefresh.registeredAt
+        refreshed.lastCompletionTime shouldBeEqualTo beforeRefresh.lastCompletionTime
+        refreshed.successCount shouldBeEqualTo beforeRefresh.successCount
+        refreshed.failureCount shouldBeEqualTo beforeRefresh.failureCount
+        refreshed.metadata shouldBeEqualTo mapOf("version" to "new")
+    }
+
+    @Test
+    fun `refreshCandidate와 updateResult 동시 호출에서도 결과 카운터를 잃지 않는다`() = runSuspendIO {
+        val workers = 8
+        val rounds = 100
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        coroutineScope {
+            List(workers) {
+                launch(Dispatchers.Default) {
+                    repeat(rounds) {
+                        node1.updateResult(lockName, node1.nodeId, CandidateResult.SUCCESS)
+                        node1.refreshCandidate(lockName, CandidateInfo(node1.nodeId, metadata = mapOf("heartbeat" to "ok")))
+                    }
+                }
+            }.joinAll()
+        }
+
+        node1.listCandidates(lockName).single().successCount shouldBeEqualTo (workers * rounds).toLong()
+    }
+
+    @Test
+    fun `refreshCandidate와 unregisterCandidate 동시 호출에서도 후보를 되살리지 않는다`() = runSuspendIO {
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        coroutineScope {
+            listOf(
+                launch(Dispatchers.Default) {
+                    repeat(100) {
+                        node1.refreshCandidate(
+                            lockName,
+                            CandidateInfo(node1.nodeId, metadata = mapOf("heartbeat" to "ok")),
+                        )
+                    }
+                },
+                launch(Dispatchers.Default) {
+                    repeat(100) {
+                        node1.unregisterCandidate(lockName, node1.nodeId)
+                    }
+                },
+            ).joinAll()
+        }
+
+        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElectorTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderElectorTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.local
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
@@ -78,7 +79,7 @@ class LocalStrategicSuspendLeaderElectorTest {
             CandidateInfo("ghost", metadata = mapOf("heartbeat" to "missing")),
         )
 
-        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+        node1.listCandidates(lockName).shouldBeEmpty()
     }
 
     @Test
@@ -151,7 +152,7 @@ class LocalStrategicSuspendLeaderElectorTest {
             ).joinAll()
         }
 
-        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+        node1.listCandidates(lockName).shouldBeEmpty()
     }
 
     @Test
@@ -164,7 +165,7 @@ class LocalStrategicSuspendLeaderElectorTest {
     fun `unregisterCandidate - 등록 해제 후 목록에서 제거`() = runTest {
         node1.registerCandidate(lockName, CandidateInfo("node-1"))
         node1.unregisterCandidate(lockName, "node-1")
-        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+        node1.listCandidates(lockName).shouldBeEmpty()
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderGroupElectorTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderGroupElectorTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.local
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.codec.Base58
@@ -84,7 +85,7 @@ class LocalStrategicSuspendLeaderGroupElectorTest {
             CandidateInfo("ghost", metadata = mapOf("heartbeat" to "missing")),
         )
 
-        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+        node1.listCandidates(lockName).shouldBeEmpty()
     }
 
     @Test
@@ -164,7 +165,7 @@ class LocalStrategicSuspendLeaderGroupElectorTest {
             ).joinAll()
         }
 
-        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+        node1.listCandidates(lockName).shouldBeEmpty()
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderGroupElectorTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/local/LocalStrategicSuspendLeaderGroupElectorTest.kt
@@ -3,14 +3,18 @@ package io.bluetape4k.leader.local
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.codec.Base58
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -71,6 +75,96 @@ class LocalStrategicSuspendLeaderGroupElectorTest {
         }
 
         node1.listCandidates(lockName).single().failureCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `refreshCandidate - 없는 후보는 새로 등록하지 않는다`() = runTest {
+        node1.refreshCandidate(
+            lockName,
+            CandidateInfo("ghost", metadata = mapOf("heartbeat" to "missing")),
+        )
+
+        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
+    }
+
+    @Test
+    fun `refreshCandidate - 결과 통계와 등록 시각을 보존하고 metadata만 갱신한다`() = runTest {
+        node1.registerCandidate(
+            lockName,
+            CandidateInfo(
+                nodeId = node1.nodeId,
+                registeredAt = Instant.parse("2026-01-01T00:00:00Z"),
+                successCount = 3,
+                failureCount = 2,
+                metadata = mapOf("version" to "old"),
+            ),
+        )
+        node1.updateResult(lockName, node1.nodeId, io.bluetape4k.leader.strategy.CandidateResult.SUCCESS)
+        val beforeRefresh = node1.listCandidates(lockName).single()
+
+        node1.refreshCandidate(
+            lockName,
+            CandidateInfo(node1.nodeId, metadata = mapOf("version" to "new")),
+        )
+
+        val refreshed = node1.listCandidates(lockName).single()
+        refreshed.registeredAt shouldBeEqualTo beforeRefresh.registeredAt
+        refreshed.lastCompletionTime shouldBeEqualTo beforeRefresh.lastCompletionTime
+        refreshed.successCount shouldBeEqualTo beforeRefresh.successCount
+        refreshed.failureCount shouldBeEqualTo beforeRefresh.failureCount
+        refreshed.metadata shouldBeEqualTo mapOf("version" to "new")
+    }
+
+    @Test
+    fun `refreshCandidate와 updateResult 동시 호출에서도 결과 카운터를 잃지 않는다`() = runSuspendIO {
+        val workers = 8
+        val rounds = 100
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        coroutineScope {
+            List(workers) {
+                launch(Dispatchers.Default) {
+                    repeat(rounds) {
+                        node1.updateResult(
+                            lockName,
+                            node1.nodeId,
+                            io.bluetape4k.leader.strategy.CandidateResult.SUCCESS,
+                        )
+                        node1.refreshCandidate(
+                            lockName,
+                            CandidateInfo(node1.nodeId, metadata = mapOf("heartbeat" to "ok")),
+                        )
+                    }
+                }
+            }.joinAll()
+        }
+
+        node1.listCandidates(lockName).single().successCount shouldBeEqualTo (workers * rounds).toLong()
+    }
+
+    @Test
+    fun `refreshCandidate와 unregisterCandidate 동시 호출에서도 후보를 되살리지 않는다`() = runSuspendIO {
+        node1.registerCandidate(lockName, CandidateInfo(node1.nodeId))
+
+        coroutineScope {
+            listOf(
+                launch(Dispatchers.Default) {
+                    repeat(100) {
+                        node1.refreshCandidate(
+                            lockName,
+                            CandidateInfo(node1.nodeId, metadata = mapOf("heartbeat" to "ok")),
+                        )
+                    }
+                },
+                launch(Dispatchers.Default) {
+                    repeat(100) {
+                        node1.unregisterCandidate(lockName, node1.nodeId)
+                    }
+                },
+            ).joinAll()
+        }
+
+        node1.listCandidates(lockName).isEmpty().shouldBeTrue()
     }
 
     @Test

--- a/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/InstrumentedLeaderElectors.kt
+++ b/leader-micrometer/src/main/kotlin/io/bluetape4k/leader/micrometer/InstrumentedLeaderElectors.kt
@@ -332,6 +332,7 @@ private class InstrumentedLeaderBackendDiagnosticsProvider(
     } catch (e: CancellationException) {
         throw e
     } catch (e: InterruptedException) {
+        Thread.currentThread().interrupt()
         throw e
     } catch (e: Exception) {
         metrics.record(

--- a/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/InstrumentedLeaderElectorsTest.kt
+++ b/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/InstrumentedLeaderElectorsTest.kt
@@ -9,6 +9,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBe
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeSameInstanceAs
@@ -143,7 +144,7 @@ class InstrumentedLeaderElectorsTest {
             .shouldNotBeNull()
             .diagnostics()
 
-        registry.find(MicrometerNames.METER_BACKEND_CONNECTIVITY).meters().isEmpty().shouldBeTrue()
+        registry.find(MicrometerNames.METER_BACKEND_CONNECTIVITY).meters().shouldBeEmpty()
     }
 
     @Test

--- a/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/InstrumentedLeaderElectorsTest.kt
+++ b/leader-micrometer/src/test/kotlin/io/bluetape4k/leader/micrometer/InstrumentedLeaderElectorsTest.kt
@@ -281,6 +281,37 @@ class InstrumentedLeaderElectorsTest {
     }
 
     @Test
+    fun `active connectivity probes restore interrupt flag and preserve exception identity`() {
+        val interrupted = InterruptedException("probe interrupted")
+        val operations: List<(LeaderBackendDiagnosticsProvider) -> Unit> = listOf(
+            { provider -> provider.checkConnectivity(100.milliseconds) },
+            { provider -> provider.diagnostics(probe = true, timeout = 100.milliseconds) },
+        )
+
+        try {
+            operations.forEach { operation ->
+                Thread.interrupted()
+                val provider = RecordingDiagnosticsProvider(failure = interrupted)
+                val delegate = object :
+                    LeaderElector by StubLeaderElector(elected = true),
+                    LeaderBackendDiagnosticsProvider by provider {}
+                val decorated = (InstrumentedLeaderElector(delegate, registry) as LeaderBackendDiagnosticsAware)
+                    .backendDiagnosticsProvider
+                    .shouldNotBeNull()
+
+                val thrown = assertFailsWith<InterruptedException> {
+                    operation(decorated)
+                }
+
+                thrown shouldBeSameInstanceAs interrupted
+                Thread.currentThread().isInterrupted.shouldBeTrue()
+            }
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
     fun `decorating an instrumented provider does not double count`() {
         val provider = RecordingDiagnosticsProvider()
         val delegate = object :

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRefreshScript.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRefreshScript.kt
@@ -1,0 +1,90 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.leader.lettuce.script.RedisScript
+
+/**
+ * Redis 후보 heartbeat를 기존 결과 통계와 같은 원자 경계에서 갱신하는 스크립트입니다.
+ *
+ * 현재 후보의 등록·실행·결과 필드는 보존하고 metadata와 요청한 TTL만 교체합니다.
+ * 후보가 이미 만료되었으면 새 후보를 만들지 않고 `ABSENT`를 반환합니다.
+ */
+internal object LettuceCandidateRefreshScript {
+
+    const val ABSENT = 0L
+    const val UPDATED = 1L
+    const val MALFORMED = -1L
+
+    val REFRESH = RedisScript(
+        """
+        local current = redis.call('GET', KEYS[1])
+        if not current then
+          return { $ABSENT }
+        end
+
+        local function validLong(value)
+          return value and string.match(value, '^[+-]?%d+$') ~= nil
+        end
+
+        local function validOptionalLong(value)
+          return value == '' or validLong(value)
+        end
+
+        local function validMetadata(value)
+          if value == '' then
+            return true
+          end
+          local start = 1
+          while true do
+            local separator = string.find(value, ',', start, true)
+            local item = separator and string.sub(value, start, separator - 1) or string.sub(value, start)
+            if not string.find(item, '=', 1, true) then
+              return false
+            end
+            if not separator then
+              return true
+            end
+            start = separator + 1
+          end
+        end
+
+        local nodeId, registeredAt, lastStartTime, lastCompletionTime, successCount, failureCount, metadata =
+          string.match(current, '^([^|]*)|([^|]*)|([^|]*)|([^|]*)|([^|]*)|([^|]*)|(.*)$')
+        local incomingNodeId, _, _, _, _, _, incomingMetadata =
+          string.match(ARGV[1], '^([^|]*)|([^|]*)|([^|]*)|([^|]*)|([^|]*)|([^|]*)|(.*)$')
+
+        if not nodeId or not incomingNodeId or incomingNodeId ~= nodeId
+          or not validLong(registeredAt)
+          or not validOptionalLong(lastStartTime)
+          or not validOptionalLong(lastCompletionTime)
+          or not validLong(successCount)
+          or not validLong(failureCount)
+          or not validMetadata(metadata)
+          or not incomingMetadata
+          or not validMetadata(incomingMetadata) then
+          return { $MALFORMED, current }
+        end
+
+        local updated = table.concat({
+          nodeId, registeredAt, lastStartTime, lastCompletionTime, successCount,
+          failureCount, incomingMetadata
+        }, '|')
+        local ttl = tonumber(ARGV[2])
+        if ttl and ttl > 0 then
+          redis.call('PSETEX', KEYS[1], ttl, updated)
+        else
+          redis.call('SET', KEYS[1], updated)
+        end
+        redis.call('SADD', KEYS[2], nodeId)
+        redis.call('PERSIST', KEYS[2])
+        return { $UPDATED }
+        """.trimIndent()
+    )
+
+    /** 스크립트가 감지한 기존 codec 오류를 기존 예외 계약으로 다시 표면화합니다. */
+    fun rethrowMalformed(reply: List<Any>) {
+        val status = reply.firstOrNull()?.toString()?.toLongOrNull()
+        if (status == MALFORMED) {
+            LettuceCandidateInfoCodec.decode(reply.getOrNull(1)?.toString().orEmpty())
+        }
+    }
+}

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt
@@ -56,6 +56,20 @@ internal class LettuceCandidateRegistry(
         sync.persist(indexKey)
     }
 
+    /** 기존 후보의 heartbeat를 원자적으로 갱신하고 결과 통계는 보존합니다. */
+    fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+        validateLockName(lockName)
+        val reply = RedisScriptRunner.run<List<Any>>(
+            sync,
+            LettuceCandidateRefreshScript.REFRESH,
+            ScriptOutputType.MULTI,
+            arrayOf(candidateKey(lockName, info.nodeId), indexKey(lockName)),
+            LettuceCandidateInfoCodec.encode(info),
+            ttl.inWholeMilliseconds.toString(),
+        )
+        LettuceCandidateRefreshScript.rethrowMalformed(reply)
+    }
+
     /**
      * `unregisterCandidate` 호출은 Redis Lettuce backend leader election 계약의 일부 동작을 수행합니다.
      *

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElector.kt
@@ -35,6 +35,9 @@ class LettuceStrategicLeaderElector(
     override fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
         registry.registerCandidate(lockName, info, ttl)
 
+    override fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
+        registry.refreshCandidate(lockName, info, ttl)
+
     override fun unregisterCandidate(lockName: String, nodeId: String) =
         registry.unregisterCandidate(lockName, nodeId)
 

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElector.kt
@@ -36,6 +36,9 @@ class LettuceStrategicLeaderGroupElector(
     override fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
         registry.registerCandidate(lockName, info, ttl)
 
+    override fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
+        registry.refreshCandidate(lockName, info, ttl)
+
     override fun unregisterCandidate(lockName: String, nodeId: String) =
         registry.unregisterCandidate(lockName, nodeId)
 

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElector.kt
@@ -38,6 +38,9 @@ class LettuceStrategicSuspendLeaderElector(
     override suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
         registry.registerCandidate(lockName, info, ttl)
 
+    override suspend fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
+        registry.refreshCandidate(lockName, info, ttl)
+
     override suspend fun unregisterCandidate(lockName: String, nodeId: String) =
         registry.unregisterCandidate(lockName, nodeId)
 

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElector.kt
@@ -41,6 +41,9 @@ class LettuceStrategicSuspendLeaderGroupElector(
     override suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
         registry.registerCandidate(lockName, info, ttl)
 
+    override suspend fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
+        registry.refreshCandidate(lockName, info, ttl)
+
     override suspend fun unregisterCandidate(lockName: String, nodeId: String) =
         registry.unregisterCandidate(lockName, nodeId)
 

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt
@@ -63,6 +63,20 @@ internal class LettuceSuspendCandidateRegistry(
         cmds.persist(indexKey)
     }
 
+    /** 기존 후보의 heartbeat를 원자적으로 갱신하고 결과 통계는 보존합니다. */
+    suspend fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+        validateLockName(lockName)
+        val reply = RedisScriptRunner.runSuspending<List<Any>>(
+            asyncCommands,
+            LettuceCandidateRefreshScript.REFRESH,
+            ScriptOutputType.MULTI,
+            arrayOf(candidateKey(lockName, info.nodeId), indexKey(lockName)),
+            LettuceCandidateInfoCodec.encode(info),
+            ttl.inWholeMilliseconds.toString(),
+        )
+        LettuceCandidateRefreshScript.rethrowMalformed(reply)
+    }
+
     /**
      * `unregisterCandidate` 호출은 Redis Lettuce backend leader election 계약의 일부 동작을 수행합니다.
      *

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicHeartbeatTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicHeartbeatTest.kt
@@ -1,0 +1,160 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
+import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
+import io.bluetape4k.leader.strategy.strategies.ScoredGroupElectionStrategy
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class LettuceStrategicHeartbeatTest : AbstractLettuceLeaderTest() {
+
+    private val registeredAt = Instant.parse("2026-01-01T00:00:00Z")
+    private val lastStartTime = Instant.parse("2026-01-01T00:00:30Z")
+    private val staleCompletion = Instant.parse("2026-01-01T00:01:00Z")
+
+    private fun candidate(
+        nodeId: String,
+        successCount: Long,
+        failureCount: Long,
+        metadata: String,
+    ) = CandidateInfo(
+        nodeId = nodeId,
+        registeredAt = registeredAt,
+        lastStartTime = lastStartTime,
+        lastCompletionTime = staleCompletion,
+        successCount = successCount,
+        failureCount = failureCount,
+        metadata = mapOf("source" to metadata),
+    )
+
+    private fun assertHeartbeatResult(
+        candidate: CandidateInfo,
+        expectedSuccessCount: Long,
+        expectedFailureCount: Long,
+        expectedMetadata: String,
+    ) {
+        candidate.registeredAt shouldBeEqualTo registeredAt
+        candidate.lastStartTime shouldBeEqualTo lastStartTime
+        (candidate.lastCompletionTime?.isAfter(staleCompletion) == true).shouldBeTrue()
+        candidate.successCount shouldBeEqualTo expectedSuccessCount
+        candidate.failureCount shouldBeEqualTo expectedFailureCount
+        candidate.metadata shouldBeEqualTo mapOf("source" to expectedMetadata)
+    }
+
+    @Test
+    fun `blocking single heartbeat preserves counters for both operation orderings`() {
+        val lockName = randomName()
+        val elector = LettuceStrategicLeaderElector(connection, "node-1")
+        val node1 = candidate("node-1", successCount = 4, failureCount = 1, metadata = "stale-1")
+        val node2 = candidate("node-2", successCount = 2, failureCount = 3, metadata = "stale-2")
+
+        elector.registerCandidate(lockName, node1, ttl = 5.seconds)
+        elector.registerCandidate(lockName, node2, ttl = 5.seconds)
+        elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+        elector.refreshCandidate(lockName, node1.copy(metadata = mapOf("source" to "fresh-1")), ttl = 5.seconds)
+        elector.refreshCandidate(lockName, node2.copy(metadata = mapOf("source" to "fresh-2")), ttl = 5.seconds)
+        elector.updateResult(lockName, "node-2", CandidateResult.FAILURE)
+
+        val candidates = elector.listCandidates(lockName)
+        assertHeartbeatResult(candidates.first { it.nodeId == "node-1" }, 5L, 1L, "fresh-1")
+        assertHeartbeatResult(candidates.first { it.nodeId == "node-2" }, 2L, 4L, "fresh-2")
+        ScoredElectionStrategy(SuccessRateScorer).elect(candidates).winner?.nodeId shouldBeEqualTo "node-1"
+    }
+
+    @Test
+    fun `blocking group heartbeat preserves counters for both operation orderings`() {
+        val lockName = randomName()
+        val elector = LettuceStrategicLeaderGroupElector(connection, "node-1")
+        val node1 = candidate("node-1", successCount = 4, failureCount = 1, metadata = "stale-1")
+        val node2 = candidate("node-2", successCount = 2, failureCount = 3, metadata = "stale-2")
+
+        elector.registerCandidate(lockName, node1, ttl = 5.seconds)
+        elector.registerCandidate(lockName, node2, ttl = 5.seconds)
+        elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+        elector.refreshCandidate(lockName, node1.copy(metadata = mapOf("source" to "fresh-1")), ttl = 5.seconds)
+        elector.refreshCandidate(lockName, node2.copy(metadata = mapOf("source" to "fresh-2")), ttl = 5.seconds)
+        elector.updateResult(lockName, "node-2", CandidateResult.FAILURE)
+
+        val candidates = elector.listCandidates(lockName)
+        assertHeartbeatResult(candidates.first { it.nodeId == "node-1" }, 5L, 1L, "fresh-1")
+        assertHeartbeatResult(candidates.first { it.nodeId == "node-2" }, 2L, 4L, "fresh-2")
+        ScoredGroupElectionStrategy(SuccessRateScorer)
+            .elect(candidates, maxLeaders = 1)
+            .winners
+            .single()
+            .nodeId shouldBeEqualTo "node-1"
+    }
+
+    @Test
+    fun `suspend single heartbeat preserves counters for both operation orderings`() = runSuspendIO {
+        val lockName = randomName()
+        val elector = LettuceStrategicSuspendLeaderElector(connection, "node-1")
+        val node1 = candidate("node-1", successCount = 4, failureCount = 1, metadata = "stale-1")
+        val node2 = candidate("node-2", successCount = 2, failureCount = 3, metadata = "stale-2")
+
+        elector.registerCandidate(lockName, node1, ttl = 5.seconds)
+        elector.registerCandidate(lockName, node2, ttl = 5.seconds)
+        elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+        elector.refreshCandidate(lockName, node1.copy(metadata = mapOf("source" to "fresh-1")), ttl = 5.seconds)
+        elector.refreshCandidate(lockName, node2.copy(metadata = mapOf("source" to "fresh-2")), ttl = 5.seconds)
+        elector.updateResult(lockName, "node-2", CandidateResult.FAILURE)
+
+        val candidates = elector.listCandidates(lockName)
+        assertHeartbeatResult(candidates.first { it.nodeId == "node-1" }, 5L, 1L, "fresh-1")
+        assertHeartbeatResult(candidates.first { it.nodeId == "node-2" }, 2L, 4L, "fresh-2")
+        ScoredElectionStrategy(SuccessRateScorer).elect(candidates).winner?.nodeId shouldBeEqualTo "node-1"
+    }
+
+    @Test
+    fun `suspend group heartbeat preserves counters for both operation orderings`() = runSuspendIO {
+        val lockName = randomName()
+        val elector = LettuceStrategicSuspendLeaderGroupElector(connection, "node-1")
+        val node1 = candidate("node-1", successCount = 4, failureCount = 1, metadata = "stale-1")
+        val node2 = candidate("node-2", successCount = 2, failureCount = 3, metadata = "stale-2")
+
+        elector.registerCandidate(lockName, node1, ttl = 5.seconds)
+        elector.registerCandidate(lockName, node2, ttl = 5.seconds)
+        elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+        elector.refreshCandidate(lockName, node1.copy(metadata = mapOf("source" to "fresh-1")), ttl = 5.seconds)
+        elector.refreshCandidate(lockName, node2.copy(metadata = mapOf("source" to "fresh-2")), ttl = 5.seconds)
+        elector.updateResult(lockName, "node-2", CandidateResult.FAILURE)
+
+        val candidates = elector.listCandidates(lockName)
+        assertHeartbeatResult(candidates.first { it.nodeId == "node-1" }, 5L, 1L, "fresh-1")
+        assertHeartbeatResult(candidates.first { it.nodeId == "node-2" }, 2L, 4L, "fresh-2")
+        ScoredGroupElectionStrategy(SuccessRateScorer)
+            .elect(candidates, maxLeaders = 1)
+            .winners
+            .single()
+            .nodeId shouldBeEqualTo "node-1"
+    }
+
+    @Test
+    fun `refreshCandidate는 TTL을 재설정하지만 만료된 후보를 되살리지 않는다`() {
+        val lockName = randomName()
+        val elector = LettuceStrategicLeaderElector(connection, "node-1")
+        val stale = candidate("node-1", successCount = 1, failureCount = 0, metadata = "stale")
+        val key = "${LettuceCandidateRegistry.DEFAULT_KEY_PREFIX}:$lockName:node-1"
+
+        elector.registerCandidate(lockName, stale, ttl = 800.milliseconds)
+        val beforeUpdate = connection.sync().pttl(key)
+        elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+        val afterUpdate = connection.sync().pttl(key)
+        (beforeUpdate > 0L && afterUpdate > 0L && afterUpdate <= beforeUpdate + 50L).shouldBeTrue()
+
+        elector.refreshCandidate(lockName, stale.copy(metadata = mapOf("source" to "fresh")), ttl = 2.seconds)
+        val afterRefresh = connection.sync().pttl(key)
+        (afterRefresh > afterUpdate).shouldBeTrue()
+
+        connection.sync().del(key)
+        elector.refreshCandidate(lockName, stale.copy(metadata = mapOf("source" to "late")), ttl = 2.seconds)
+        elector.listCandidates(lockName).isEmpty().shouldBeTrue()
+    }
+}

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicHeartbeatTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicHeartbeatTest.kt
@@ -1,7 +1,11 @@
 package io.bluetape4k.leader.lettuce
 
+import io.bluetape4k.assertions.shouldBeAfter
 import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeLessOrEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
@@ -42,7 +46,7 @@ class LettuceStrategicHeartbeatTest : AbstractLettuceLeaderTest() {
     ) {
         candidate.registeredAt shouldBeEqualTo registeredAt
         candidate.lastStartTime shouldBeEqualTo lastStartTime
-        (candidate.lastCompletionTime?.isAfter(staleCompletion) == true).shouldBeTrue()
+        candidate.lastCompletionTime.shouldNotBeNull() shouldBeAfter staleCompletion
         candidate.successCount shouldBeEqualTo expectedSuccessCount
         candidate.failureCount shouldBeEqualTo expectedFailureCount
         candidate.metadata shouldBeEqualTo mapOf("source" to expectedMetadata)
@@ -147,14 +151,16 @@ class LettuceStrategicHeartbeatTest : AbstractLettuceLeaderTest() {
         val beforeUpdate = connection.sync().pttl(key)
         elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
         val afterUpdate = connection.sync().pttl(key)
-        (beforeUpdate > 0L && afterUpdate > 0L && afterUpdate <= beforeUpdate + 50L).shouldBeTrue()
+        beforeUpdate shouldBeGreaterThan 0L
+        afterUpdate shouldBeGreaterThan 0L
+        afterUpdate shouldBeLessOrEqualTo beforeUpdate + 50L
 
         elector.refreshCandidate(lockName, stale.copy(metadata = mapOf("source" to "fresh")), ttl = 2.seconds)
         val afterRefresh = connection.sync().pttl(key)
-        (afterRefresh > afterUpdate).shouldBeTrue()
+        afterRefresh shouldBeGreaterThan afterUpdate
 
         connection.sync().del(key)
         elector.refreshCandidate(lockName, stale.copy(metadata = mapOf("source" to "late")), ttl = 2.seconds)
-        elector.listCandidates(lockName).isEmpty().shouldBeTrue()
+        elector.listCandidates(lockName).shouldBeEmpty()
     }
 }

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
@@ -124,19 +124,6 @@ internal class RedissonCandidateRegistry(
                 end
             end
 
-            local hasListeners = redis.call('hget', KEYS[5], 'has-listeners')
-            if hasListeners ~= false then
-                local message = struct.pack(
-                    'Lc0Lc0Lc0',
-                    string.len(mapKey),
-                    mapKey,
-                    string.len(ARGV[3]),
-                    ARGV[3],
-                    string.len(oldValue),
-                    oldValue
-                )
-                redis.call('PUBLISH', KEYS[6], message)
-            end
             return 1
         """
     }
@@ -218,6 +205,7 @@ internal class RedissonCandidateRegistry(
         ttl: Duration,
     ): Boolean {
         val result = redissonClient.getScript(refreshScriptCodec(cache)).eval<Long>(
+            cache.name,
             RScript.Mode.READ_WRITE,
             REFRESH_CANDIDATE_SCRIPT,
             RScript.ReturnType.LONG,
@@ -238,6 +226,7 @@ internal class RedissonCandidateRegistry(
     ): Boolean {
         val result = redissonClient.getScript(refreshScriptCodec(cache))
             .evalAsync<Long>(
+                cache.name,
                 RScript.Mode.READ_WRITE,
                 REFRESH_CANDIDATE_SCRIPT,
                 RScript.ReturnType.LONG,
@@ -276,7 +265,6 @@ internal class RedissonCandidateRegistry(
             RedissonObject.prefixName("redisson__idle__set", name),
             RedissonObject.prefixName("redisson__map_cache__last_access__set", name),
             RedissonObject.suffixName(name, "redisson_options"),
-            RedissonObject.prefixName("redisson_map_cache_updated", name),
         ).map { it.toByteArray(StandardCharsets.UTF_8) }
     }
 

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withContext
 import org.redisson.api.RedissonClient
 import org.redisson.api.RLock
@@ -46,7 +47,7 @@ internal class RedissonCandidateRegistry(
         internal const val DEFAULT_KEY_PREFIX = "leader:strategy:candidates"
         internal const val GROUP_KEY_PREFIX = "leader:strategy:group-candidates:redisson:v1"
         private val ENTRY_LOCK_ATTEMPT_TIMEOUT = 500.milliseconds
-        private val ENTRY_LOCK_LEASE_TIMEOUT = 30.seconds
+        private val ENTRY_LOCK_SOURCE_DEADLINE = 2.seconds
         private val ENTRY_LOCK_CLEANUP_TIMEOUT = 1.seconds
         private val suspendLockThreadIds = AtomicLong()
 
@@ -203,8 +204,9 @@ internal class RedissonCandidateRegistry(
 
     /**
      * 무기한 `lockAsync` waiter를 만들지 않도록 finite `tryLockAsync` 시도만 반복합니다.
-     * 각 시도는 bounded wait/lease를 사용하므로 caller가 취소되어도 Redis pub/sub waiter가
-     * 무기한 남지 않습니다. 취소와 실제 획득이 경합하면 late acquisition을 관찰해 해제합니다.
+     * 시도 자체는 500ms로 제한하고, 성공한 entry lock은 `leaseTime=-1`로 Redisson watchdog
+     * 갱신을 유지합니다. source future가 backend 지연으로 deadline을 넘기면 source를 취소하고,
+     * 취소와 실제 획득이 경합하면 late acquisition을 관찰해 해제합니다.
      */
     @Suppress("TooGenericExceptionCaught")
     private suspend fun awaitEntryLock(lock: RLock, threadId: Long) {
@@ -218,48 +220,51 @@ internal class RedissonCandidateRegistry(
 
     @Suppress("TooGenericExceptionCaught")
     private suspend fun awaitEntryLockAttempt(lock: RLock, threadId: Long): Boolean =
-        suspendCancellableCoroutine { continuation ->
-            val state = AtomicInteger(LOCK_WAITING)
-            val lockFuture = try {
-                lock.tryLockAsync(
-                    ENTRY_LOCK_ATTEMPT_TIMEOUT.inWholeMilliseconds,
-                    ENTRY_LOCK_LEASE_TIMEOUT.inWholeMilliseconds,
-                    TimeUnit.MILLISECONDS,
-                    threadId,
-                )
-            } catch (failure: Throwable) {
-                state.compareAndSet(LOCK_WAITING, LOCK_FAILED)
-                continuation.resumeWithException(failure)
-                return@suspendCancellableCoroutine
-            }
-
-            lockFuture.whenComplete { acquired, failure ->
-                if (failure != null) {
-                    if (state.compareAndSet(LOCK_WAITING, LOCK_FAILED)) {
-                        continuation.resumeWithException(failure.unwrapCompletionException())
-                    }
-                } else if (acquired == true) {
-                    when {
-                        state.compareAndSet(LOCK_WAITING, LOCK_ACQUIRED) -> continuation.resume(true)
-                        state.compareAndSet(LOCK_CANCELLED, LOCK_CLEANUP_SCHEDULED) ->
-                            scheduleLateEntryLockCleanup(lock, threadId)
-                    }
-                } else if (state.compareAndSet(LOCK_WAITING, LOCK_COMPLETED)) {
-                    continuation.resume(false)
+        withTimeout(ENTRY_LOCK_SOURCE_DEADLINE) {
+            suspendCancellableCoroutine { continuation ->
+                val state = AtomicInteger(LOCK_WAITING)
+                val lockFuture = try {
+                    lock.tryLockAsync(
+                        ENTRY_LOCK_ATTEMPT_TIMEOUT.inWholeMilliseconds,
+                        -1L,
+                        TimeUnit.MILLISECONDS,
+                        threadId,
+                    )
+                } catch (failure: Throwable) {
+                    state.compareAndSet(LOCK_WAITING, LOCK_FAILED)
+                    continuation.resumeWithException(failure)
+                    return@suspendCancellableCoroutine
                 }
-            }
 
-            continuation.invokeOnCancellation {
-                while (true) {
-                    when (state.get()) {
-                        LOCK_WAITING -> if (state.compareAndSet(LOCK_WAITING, LOCK_CANCELLED)) {
-                            return@invokeOnCancellation
+                lockFuture.whenComplete { acquired, failure ->
+                    if (failure != null) {
+                        if (state.compareAndSet(LOCK_WAITING, LOCK_FAILED)) {
+                            continuation.resumeWithException(failure.unwrapCompletionException())
                         }
-                        LOCK_ACQUIRED -> if (state.compareAndSet(LOCK_ACQUIRED, LOCK_CLEANUP_SCHEDULED)) {
-                            scheduleLateEntryLockCleanup(lock, threadId)
-                            return@invokeOnCancellation
+                    } else if (acquired == true) {
+                        when {
+                            state.compareAndSet(LOCK_WAITING, LOCK_ACQUIRED) -> continuation.resume(true)
+                            state.compareAndSet(LOCK_CANCELLED, LOCK_CLEANUP_SCHEDULED) ->
+                                scheduleLateEntryLockCleanup(lock, threadId)
                         }
-                        else -> return@invokeOnCancellation
+                    } else if (state.compareAndSet(LOCK_WAITING, LOCK_COMPLETED)) {
+                        continuation.resume(false)
+                    }
+                }
+
+                continuation.invokeOnCancellation {
+                    while (true) {
+                        when (state.get()) {
+                            LOCK_WAITING -> if (state.compareAndSet(LOCK_WAITING, LOCK_CANCELLED)) {
+                                lockFuture.cancel(false)
+                                return@invokeOnCancellation
+                            }
+                            LOCK_ACQUIRED -> if (state.compareAndSet(LOCK_ACQUIRED, LOCK_CLEANUP_SCHEDULED)) {
+                                scheduleLateEntryLockCleanup(lock, threadId)
+                                return@invokeOnCancellation
+                            }
+                            else -> return@invokeOnCancellation
+                        }
                     }
                 }
             }
@@ -315,7 +320,7 @@ internal class RedissonCandidateRegistry(
         }
     }
 
-    /** Source future를 취소하지 않는 await입니다. cancellation handler가 원본 명령을 보존해야 합니다. */
+    /** Unlock 응답은 취소하지 않고 관찰하여 backend의 늦은 정리를 보존합니다. */
     private suspend fun <T> org.redisson.api.RFuture<T>.awaitWithoutCancellingSource(): T =
         suspendCancellableCoroutine { continuation ->
             whenComplete { value, failure ->

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
@@ -128,6 +128,12 @@ internal class RedissonCandidateRegistry(
         """
     }
 
+    private class RefreshScriptMapKey(val value: String)
+
+    private class RefreshScriptMapValue(val value: CandidateInfo)
+
+    private class RefreshScriptTtl(val value: Long)
+
     private fun cacheKey(lockName: String): String {
         validateLockName(lockName)
         return "$keyPrefix:$lockName"
@@ -148,6 +154,7 @@ internal class RedissonCandidateRegistry(
     }
 
     fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+        requireRefreshTtl(ttl)
         val cache = mapCacheFor(lockName)
         withEntryLock(cache, info.nodeId) {
             val current = cache.get(info.nodeId) ?: return@withEntryLock
@@ -191,6 +198,7 @@ internal class RedissonCandidateRegistry(
     }
 
     suspend fun refreshCandidateSuspending(lockName: String, info: CandidateInfo, ttl: Duration) {
+        requireRefreshTtl(ttl)
         val cache = mapCacheFor(lockName)
         withEntryLockSuspending(cache, info.nodeId) {
             val current = cache.getAsync(info.nodeId).await() ?: return@withEntryLockSuspending
@@ -210,10 +218,10 @@ internal class RedissonCandidateRegistry(
             REFRESH_CANDIDATE_SCRIPT,
             RScript.ReturnType.LONG,
             mapCacheScriptKeys(cache),
-            current.nodeId,
-            current,
-            refreshed,
-            ttl.inWholeMilliseconds,
+            RefreshScriptMapKey(current.nodeId),
+            RefreshScriptMapValue(current),
+            RefreshScriptMapValue(refreshed),
+            RefreshScriptTtl(ttl.inWholeMilliseconds),
         )
         return result == 1L
     }
@@ -231,30 +239,38 @@ internal class RedissonCandidateRegistry(
                 REFRESH_CANDIDATE_SCRIPT,
                 RScript.ReturnType.LONG,
                 mapCacheScriptKeys(cache),
-                current.nodeId,
-                current,
-                refreshed,
-                ttl.inWholeMilliseconds,
+                RefreshScriptMapKey(current.nodeId),
+                RefreshScriptMapValue(current),
+                RefreshScriptMapValue(refreshed),
+                RefreshScriptTtl(ttl.inWholeMilliseconds),
             )
             .toCompletableFuture()
             .await()
         return result == 1L
     }
 
-    /** RScript는 모든 ARGV를 codec으로 직렬화하므로 Lua가 숫자를 읽도록 TTL만 평문으로 인코딩합니다. */
+    /**
+     * RScript는 모든 ARGV를 value encoder 하나로 직렬화하므로 RMapCache의 map key/value
+     * encoder와 Lua가 읽는 TTL encoder를 인자별 marker로 선택합니다.
+     */
     private fun refreshScriptCodec(cache: RMapCache<String, CandidateInfo>): Codec {
         val delegate = cache.codec
         return object : Codec by delegate {
             private val valueEncoder = Encoder { value ->
-                if (value is Number) {
-                    StringCodec.INSTANCE.valueEncoder.encode(value.toString())
-                } else {
-                    delegate.valueEncoder.encode(value)
+                when (value) {
+                    is RefreshScriptMapKey -> delegate.mapKeyEncoder.encode(value.value)
+                    is RefreshScriptMapValue -> delegate.mapValueEncoder.encode(value.value)
+                    is RefreshScriptTtl -> StringCodec.INSTANCE.valueEncoder.encode(value.value.toString())
+                    else -> error("지원하지 않는 refresh script 인자입니다: ${value::class.qualifiedName}")
                 }
             }
 
             override fun getValueEncoder(): Encoder = valueEncoder
         }
+    }
+
+    private fun requireRefreshTtl(ttl: Duration) {
+        require(!ttl.isNegative()) { "refresh ttl은 음수가 될 수 없습니다: $ttl" }
     }
 
     private fun mapCacheScriptKeys(cache: RMapCache<String, CandidateInfo>): List<Any> {

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
@@ -6,6 +6,8 @@ import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
@@ -18,6 +20,7 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -42,6 +45,8 @@ internal class RedissonCandidateRegistry(
     companion object: KLogging() {
         internal const val DEFAULT_KEY_PREFIX = "leader:strategy:candidates"
         internal const val GROUP_KEY_PREFIX = "leader:strategy:group-candidates:redisson:v1"
+        private val ENTRY_LOCK_ATTEMPT_TIMEOUT = 500.milliseconds
+        private val ENTRY_LOCK_LEASE_TIMEOUT = 30.seconds
         private val ENTRY_LOCK_CLEANUP_TIMEOUT = 1.seconds
         private val suspendLockThreadIds = AtomicLong()
 
@@ -50,6 +55,7 @@ internal class RedissonCandidateRegistry(
         private const val LOCK_CANCELLED = 2
         private const val LOCK_CLEANUP_SCHEDULED = 3
         private const val LOCK_FAILED = 4
+        private const val LOCK_COMPLETED = 5
     }
 
     private fun cacheKey(lockName: String): String {
@@ -196,31 +202,50 @@ internal class RedissonCandidateRegistry(
     }
 
     /**
-     * Redisson의 `RFuture.await`는 coroutine 취소 시 원본 future까지 취소합니다.
-     * lock 명령은 취소 응답과 서버의 실제 획득 시점이 어긋날 수 있으므로, 원본 future를
-     * 취소하지 않고 late acquisition을 관찰해 반드시 해제하도록 별도 상태 기계를 둡니다.
+     * 무기한 `lockAsync` waiter를 만들지 않도록 finite `tryLockAsync` 시도만 반복합니다.
+     * 각 시도는 bounded wait/lease를 사용하므로 caller가 취소되어도 Redis pub/sub waiter가
+     * 무기한 남지 않습니다. 취소와 실제 획득이 경합하면 late acquisition을 관찰해 해제합니다.
      */
     @Suppress("TooGenericExceptionCaught")
     private suspend fun awaitEntryLock(lock: RLock, threadId: Long) {
-        val state = AtomicInteger(LOCK_WAITING)
-        suspendCancellableCoroutine<Unit> { continuation ->
+        while (true) {
+            if (awaitEntryLockAttempt(lock, threadId)) {
+                return
+            }
+            currentCoroutineContext().ensureActive()
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun awaitEntryLockAttempt(lock: RLock, threadId: Long): Boolean =
+        suspendCancellableCoroutine { continuation ->
+            val state = AtomicInteger(LOCK_WAITING)
             val lockFuture = try {
-                lock.lockAsync(threadId)
+                lock.tryLockAsync(
+                    ENTRY_LOCK_ATTEMPT_TIMEOUT.inWholeMilliseconds,
+                    ENTRY_LOCK_LEASE_TIMEOUT.inWholeMilliseconds,
+                    TimeUnit.MILLISECONDS,
+                    threadId,
+                )
             } catch (failure: Throwable) {
                 state.compareAndSet(LOCK_WAITING, LOCK_FAILED)
                 continuation.resumeWithException(failure)
                 return@suspendCancellableCoroutine
             }
 
-            lockFuture.whenComplete { _, failure ->
-                if (failure == null) {
+            lockFuture.whenComplete { acquired, failure ->
+                if (failure != null) {
+                    if (state.compareAndSet(LOCK_WAITING, LOCK_FAILED)) {
+                        continuation.resumeWithException(failure.unwrapCompletionException())
+                    }
+                } else if (acquired == true) {
                     when {
-                        state.compareAndSet(LOCK_WAITING, LOCK_ACQUIRED) -> continuation.resume(Unit)
+                        state.compareAndSet(LOCK_WAITING, LOCK_ACQUIRED) -> continuation.resume(true)
                         state.compareAndSet(LOCK_CANCELLED, LOCK_CLEANUP_SCHEDULED) ->
                             scheduleLateEntryLockCleanup(lock, threadId)
                     }
-                } else if (state.compareAndSet(LOCK_WAITING, LOCK_FAILED)) {
-                    continuation.resumeWithException(failure.unwrapCompletionException())
+                } else if (state.compareAndSet(LOCK_WAITING, LOCK_COMPLETED)) {
+                    continuation.resume(false)
                 }
             }
 
@@ -239,7 +264,6 @@ internal class RedissonCandidateRegistry(
                 }
             }
         }
-    }
 
     /** 취소되지 않은 정상 경로의 unlock도 backend 응답 지연으로 호출자를 붙잡지 않도록 제한합니다. */
     @Suppress("TooGenericExceptionCaught")

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
@@ -12,9 +12,15 @@ import kotlinx.coroutines.future.await
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withContext
+import org.redisson.RedissonObject
 import org.redisson.api.RedissonClient
 import org.redisson.api.RLock
 import org.redisson.api.RMapCache
+import org.redisson.api.RScript
+import org.redisson.client.codec.Codec
+import org.redisson.client.codec.StringCodec
+import org.redisson.client.protocol.Encoder
+import java.nio.charset.StandardCharsets
 import java.util.concurrent.CompletionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
@@ -60,6 +66,79 @@ internal class RedissonCandidateRegistry(
         private const val LOCK_CLEANUP_SCHEDULED = 3
         private const val LOCK_FAILED = 4
         private const val LOCK_COMPLETED = 5
+
+        /**
+         * RMapCache의 live entry 확인과 metadata/TTL 갱신을 하나의 Redis 연산으로 묶습니다.
+         * GET 후 PUT을 분리하면 두 명령 사이에 timeout zset이 만료되어 PUT이 후보를 부활시킬 수 있습니다.
+         */
+        private const val REFRESH_CANDIDATE_SCRIPT = """
+            local mapKey = ARGV[1]
+            local currentTime = redis.call('time')
+            local currentTimeMillis = tonumber(currentTime[1]) * 1000 + math.floor(tonumber(currentTime[2]) / 1000)
+            local packedValue = redis.call('hget', KEYS[1], mapKey)
+            if packedValue == false then
+                return 0
+            end
+
+            local idleDelta, oldValue = struct.unpack('dLc0', packedValue)
+            if oldValue ~= ARGV[2] then
+                return 0
+            end
+            local expireDate = 92233720368547758
+            local expireDateScore = redis.call('zscore', KEYS[2], mapKey)
+            if expireDateScore ~= false then
+                expireDate = tonumber(expireDateScore)
+            end
+            if idleDelta ~= 0 then
+                local expireIdle = redis.call('zscore', KEYS[3], mapKey)
+                if expireIdle ~= false then
+                    expireDate = math.min(expireDate, tonumber(expireIdle))
+                end
+            end
+            if expireDate <= currentTimeMillis then
+                redis.call('hdel', KEYS[1], mapKey)
+                redis.call('zrem', KEYS[2], mapKey)
+                redis.call('zrem', KEYS[3], mapKey)
+                redis.call('zrem', KEYS[4], mapKey)
+                return 0
+            end
+
+            local ttl = tonumber(ARGV[4])
+            if ttl > 0 then
+                redis.call('zadd', KEYS[2], currentTimeMillis + ttl, mapKey)
+            else
+                redis.call('zrem', KEYS[2], mapKey)
+            end
+            redis.call('zrem', KEYS[3], mapKey)
+
+            local refreshedValue = struct.pack('dLc0', 0, string.len(ARGV[3]), ARGV[3])
+            redis.call('hset', KEYS[1], mapKey, refreshedValue)
+
+            local maxSize = tonumber(redis.call('hget', KEYS[5], 'max-size'))
+            if maxSize ~= nil and maxSize ~= 0 then
+                local mode = redis.call('hget', KEYS[5], 'mode')
+                if mode == false or mode == 'LRU' then
+                    redis.call('zadd', KEYS[4], currentTimeMillis, mapKey)
+                else
+                    redis.call('zincrby', KEYS[4], 1, mapKey)
+                end
+            end
+
+            local hasListeners = redis.call('hget', KEYS[5], 'has-listeners')
+            if hasListeners ~= false then
+                local message = struct.pack(
+                    'Lc0Lc0Lc0',
+                    string.len(mapKey),
+                    mapKey,
+                    string.len(ARGV[3]),
+                    ARGV[3],
+                    string.len(oldValue),
+                    oldValue
+                )
+                redis.call('PUBLISH', KEYS[6], message)
+            end
+            return 1
+        """
     }
 
     private fun cacheKey(lockName: String): String {
@@ -85,12 +164,7 @@ internal class RedissonCandidateRegistry(
         val cache = mapCacheFor(lockName)
         withEntryLock(cache, info.nodeId) {
             val current = cache.get(info.nodeId) ?: return@withEntryLock
-            val refreshed = current.copy(metadata = info.metadata)
-            if (ttl == Duration.ZERO) {
-                cache.put(info.nodeId, refreshed)
-            } else {
-                cache.put(info.nodeId, refreshed, ttl.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-            }
+            refreshCandidateAtomically(cache, current, current.copy(metadata = info.metadata), ttl)
         }
     }
 
@@ -133,18 +207,77 @@ internal class RedissonCandidateRegistry(
         val cache = mapCacheFor(lockName)
         withEntryLockSuspending(cache, info.nodeId) {
             val current = cache.getAsync(info.nodeId).await() ?: return@withEntryLockSuspending
-            val refreshed = current.copy(metadata = info.metadata)
-            if (ttl == Duration.ZERO) {
-                cache.putAsync(info.nodeId, refreshed).await()
-            } else {
-                cache.putAsync(
-                    info.nodeId,
-                    refreshed,
-                    ttl.inWholeMilliseconds,
-                    TimeUnit.MILLISECONDS,
-                ).await()
-            }
+            refreshCandidateAtomicallySuspending(cache, current, current.copy(metadata = info.metadata), ttl)
         }
+    }
+
+    private fun refreshCandidateAtomically(
+        cache: RMapCache<String, CandidateInfo>,
+        current: CandidateInfo,
+        refreshed: CandidateInfo,
+        ttl: Duration,
+    ): Boolean {
+        val result = redissonClient.getScript(refreshScriptCodec(cache)).eval<Long>(
+            RScript.Mode.READ_WRITE,
+            REFRESH_CANDIDATE_SCRIPT,
+            RScript.ReturnType.LONG,
+            mapCacheScriptKeys(cache),
+            current.nodeId,
+            current,
+            refreshed,
+            ttl.inWholeMilliseconds,
+        )
+        return result == 1L
+    }
+
+    private suspend fun refreshCandidateAtomicallySuspending(
+        cache: RMapCache<String, CandidateInfo>,
+        current: CandidateInfo,
+        refreshed: CandidateInfo,
+        ttl: Duration,
+    ): Boolean {
+        val result = redissonClient.getScript(refreshScriptCodec(cache))
+            .evalAsync<Long>(
+                RScript.Mode.READ_WRITE,
+                REFRESH_CANDIDATE_SCRIPT,
+                RScript.ReturnType.LONG,
+                mapCacheScriptKeys(cache),
+                current.nodeId,
+                current,
+                refreshed,
+                ttl.inWholeMilliseconds,
+            )
+            .toCompletableFuture()
+            .await()
+        return result == 1L
+    }
+
+    /** RScript는 모든 ARGV를 codec으로 직렬화하므로 Lua가 숫자를 읽도록 TTL만 평문으로 인코딩합니다. */
+    private fun refreshScriptCodec(cache: RMapCache<String, CandidateInfo>): Codec {
+        val delegate = cache.codec
+        return object : Codec by delegate {
+            private val valueEncoder = Encoder { value ->
+                if (value is Number) {
+                    StringCodec.INSTANCE.valueEncoder.encode(value.toString())
+                } else {
+                    delegate.valueEncoder.encode(value)
+                }
+            }
+
+            override fun getValueEncoder(): Encoder = valueEncoder
+        }
+    }
+
+    private fun mapCacheScriptKeys(cache: RMapCache<String, CandidateInfo>): List<Any> {
+        val name = (cache as RedissonObject).rawName
+        return listOf(
+            name,
+            RedissonObject.prefixName("redisson__timeout__set", name),
+            RedissonObject.prefixName("redisson__idle__set", name),
+            RedissonObject.prefixName("redisson__map_cache__last_access__set", name),
+            RedissonObject.suffixName(name, "redisson_options"),
+            RedissonObject.prefixName("redisson_map_cache_updated", name),
+        ).map { it.toByteArray(StandardCharsets.UTF_8) }
     }
 
     /** Redisson `RFuture` 기반 후보 해제입니다. */

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
@@ -49,7 +49,10 @@ internal class RedissonCandidateRegistry(
         private val ENTRY_LOCK_ATTEMPT_TIMEOUT = 500.milliseconds
         private val ENTRY_LOCK_SOURCE_DEADLINE = 2.seconds
         private val ENTRY_LOCK_CLEANUP_TIMEOUT = 1.seconds
-        private val suspendLockThreadIds = AtomicLong()
+        // Redisson은 owner ID를 lock hash의 `clientId:threadId`로 저장한다.
+        // Blocking 경로는 JVM thread ID(양수)를 사용하므로 같은 client에서도
+        // coroutine entry lock은 충돌하지 않는 음수 namespace를 사용한다.
+        private val suspendLockThreadIds = AtomicLong(Long.MIN_VALUE)
 
         private const val LOCK_WAITING = 0
         private const val LOCK_ACQUIRED = 1
@@ -186,10 +189,11 @@ internal class RedissonCandidateRegistry(
         crossinline action: suspend () -> T,
     ): T {
         val lock = cache.getLock(nodeId)
-        // Redisson lock ownership is thread-id based. A dispatcher thread may
-        // host multiple suspended coroutines, so allocate one id per logical
-        // lock hold instead of reusing the physical thread id.
-        val threadId = suspendLockThreadIds.incrementAndGet()
+        // Redisson lock ownership은 thread ID 기반이다. dispatcher thread 하나가 여러
+        // suspend coroutine을 실행할 수 있으므로 physical thread ID를 재사용하지 않고
+        // logical lock hold마다 ID를 할당한다. 음수 namespace는 blocking JVM thread ID와
+        // 충돌하지 않는다.
+        val threadId = suspendLockThreadIds.getAndIncrement()
         var acquired = false
         return try {
             awaitEntryLock(lock, threadId)

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistry.kt
@@ -4,16 +4,23 @@ import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.warn
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.future.await
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import org.redisson.api.RedissonClient
+import org.redisson.api.RLock
 import org.redisson.api.RMapCache
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
+import java.util.concurrent.CompletionException
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * `RedissonCandidateRegistry`는 Redis Redisson backend의 leader election, lock lease, ownership 확인을 담당합니다.
@@ -35,7 +42,14 @@ internal class RedissonCandidateRegistry(
     companion object: KLogging() {
         internal const val DEFAULT_KEY_PREFIX = "leader:strategy:candidates"
         internal const val GROUP_KEY_PREFIX = "leader:strategy:group-candidates:redisson:v1"
+        private val ENTRY_LOCK_CLEANUP_TIMEOUT = 1.seconds
         private val suspendLockThreadIds = AtomicLong()
+
+        private const val LOCK_WAITING = 0
+        private const val LOCK_ACQUIRED = 1
+        private const val LOCK_CANCELLED = 2
+        private const val LOCK_CLEANUP_SCHEDULED = 3
+        private const val LOCK_FAILED = 4
     }
 
     private fun cacheKey(lockName: String): String {
@@ -57,6 +71,19 @@ internal class RedissonCandidateRegistry(
         }
     }
 
+    fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+        val cache = mapCacheFor(lockName)
+        withEntryLock(cache, info.nodeId) {
+            val current = cache.get(info.nodeId) ?: return@withEntryLock
+            val refreshed = current.copy(metadata = info.metadata)
+            if (ttl == Duration.ZERO) {
+                cache.put(info.nodeId, refreshed)
+            } else {
+                cache.put(info.nodeId, refreshed, ttl.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+            }
+        }
+    }
+
     fun unregisterCandidate(lockName: String, nodeId: String) {
         val cache = mapCacheFor(lockName)
         withEntryLock(cache, nodeId) {
@@ -69,9 +96,11 @@ internal class RedissonCandidateRegistry(
 
     fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
         val cache = mapCacheFor(lockName)
-        // Redisson의 per-entry lock과 server-side fastPutIfExists를 사용해
-        // read-modify-write 및 GET/TTL/PUT 사이의 만료 경쟁을 제거한다.
-        cache.computeIfPresent(nodeId) { _, current -> current.withResult(result) }
+        // Redisson의 per-entry lock과 server-side computeIfPresent를 사용해
+        // heartbeat/read-modify-write와의 경합 및 GET/TTL/PUT 사이의 만료 경쟁을 제거한다.
+        withEntryLock(cache, nodeId) {
+            cache.computeIfPresent(nodeId) { _, current -> current.withResult(result) }
+        }
     }
 
     /**
@@ -86,6 +115,24 @@ internal class RedissonCandidateRegistry(
                 cache.putAsync(info.nodeId, info).await()
             } else {
                 cache.putAsync(info.nodeId, info, ttl.inWholeMilliseconds, TimeUnit.MILLISECONDS).await()
+            }
+        }
+    }
+
+    suspend fun refreshCandidateSuspending(lockName: String, info: CandidateInfo, ttl: Duration) {
+        val cache = mapCacheFor(lockName)
+        withEntryLockSuspending(cache, info.nodeId) {
+            val current = cache.getAsync(info.nodeId).await() ?: return@withEntryLockSuspending
+            val refreshed = current.copy(metadata = info.metadata)
+            if (ttl == Duration.ZERO) {
+                cache.putAsync(info.nodeId, refreshed).await()
+            } else {
+                cache.putAsync(
+                    info.nodeId,
+                    refreshed,
+                    ttl.inWholeMilliseconds,
+                    TimeUnit.MILLISECONDS,
+                ).await()
             }
         }
     }
@@ -136,13 +183,129 @@ internal class RedissonCandidateRegistry(
         // host multiple suspended coroutines, so allocate one id per logical
         // lock hold instead of reusing the physical thread id.
         val threadId = suspendLockThreadIds.incrementAndGet()
-        lock.lockAsync(threadId).await()
+        var acquired = false
         return try {
+            awaitEntryLock(lock, threadId)
+            acquired = true
             action()
         } finally {
-            withContext(NonCancellable) {
-                lock.unlockAsync(threadId).await()
+            if (acquired) {
+                unlockEntryLockBounded(lock, threadId)
             }
         }
     }
+
+    /**
+     * Redisson의 `RFuture.await`는 coroutine 취소 시 원본 future까지 취소합니다.
+     * lock 명령은 취소 응답과 서버의 실제 획득 시점이 어긋날 수 있으므로, 원본 future를
+     * 취소하지 않고 late acquisition을 관찰해 반드시 해제하도록 별도 상태 기계를 둡니다.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun awaitEntryLock(lock: RLock, threadId: Long) {
+        val state = AtomicInteger(LOCK_WAITING)
+        suspendCancellableCoroutine<Unit> { continuation ->
+            val lockFuture = try {
+                lock.lockAsync(threadId)
+            } catch (failure: Throwable) {
+                state.compareAndSet(LOCK_WAITING, LOCK_FAILED)
+                continuation.resumeWithException(failure)
+                return@suspendCancellableCoroutine
+            }
+
+            lockFuture.whenComplete { _, failure ->
+                if (failure == null) {
+                    when {
+                        state.compareAndSet(LOCK_WAITING, LOCK_ACQUIRED) -> continuation.resume(Unit)
+                        state.compareAndSet(LOCK_CANCELLED, LOCK_CLEANUP_SCHEDULED) ->
+                            scheduleLateEntryLockCleanup(lock, threadId)
+                    }
+                } else if (state.compareAndSet(LOCK_WAITING, LOCK_FAILED)) {
+                    continuation.resumeWithException(failure.unwrapCompletionException())
+                }
+            }
+
+            continuation.invokeOnCancellation {
+                while (true) {
+                    when (state.get()) {
+                        LOCK_WAITING -> if (state.compareAndSet(LOCK_WAITING, LOCK_CANCELLED)) {
+                            return@invokeOnCancellation
+                        }
+                        LOCK_ACQUIRED -> if (state.compareAndSet(LOCK_ACQUIRED, LOCK_CLEANUP_SCHEDULED)) {
+                            scheduleLateEntryLockCleanup(lock, threadId)
+                            return@invokeOnCancellation
+                        }
+                        else -> return@invokeOnCancellation
+                    }
+                }
+            }
+        }
+    }
+
+    /** 취소되지 않은 정상 경로의 unlock도 backend 응답 지연으로 호출자를 붙잡지 않도록 제한합니다. */
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun unlockEntryLockBounded(lock: RLock, threadId: Long) {
+        withContext(NonCancellable) {
+            try {
+                val released = kotlinx.coroutines.withTimeoutOrNull(ENTRY_LOCK_CLEANUP_TIMEOUT) {
+                    lock.unlockAsync(threadId).awaitWithoutCancellingSource()
+                    true
+                } ?: false
+                if (!released) {
+                    log.warn {
+                        "Redisson entry lock cleanup timed out. threadId=$threadId"
+                    }
+                }
+            } catch (failure: Exception) {
+                log.warn(failure) {
+                    "Redisson entry lock cleanup failed. threadId=$threadId"
+                }
+            }
+        }
+    }
+
+    /** 취소된 caller와 독립적으로 late acquisition의 unlock 명령만 bounded하게 예약합니다. */
+    @Suppress("TooGenericExceptionCaught")
+    private fun scheduleLateEntryLockCleanup(lock: RLock, threadId: Long) {
+        try {
+            lock.unlockAsync(threadId)
+                .toCompletableFuture()
+                .orTimeout(ENTRY_LOCK_CLEANUP_TIMEOUT.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+                .whenComplete { _, failure ->
+                    if (failure != null) {
+                        val cleanupFailure = failure.unwrapCompletionException()
+                        if (cleanupFailure is TimeoutException) {
+                            log.warn {
+                                "Redisson late entry lock cleanup timed out. threadId=$threadId"
+                            }
+                        } else {
+                            log.warn(cleanupFailure) {
+                                "Redisson late entry lock cleanup failed. threadId=$threadId"
+                            }
+                        }
+                    }
+                }
+        } catch (failure: Exception) {
+            log.warn(failure) {
+                "Redisson late entry lock cleanup could not be scheduled. threadId=$threadId"
+            }
+        }
+    }
+
+    /** Source future를 취소하지 않는 await입니다. cancellation handler가 원본 명령을 보존해야 합니다. */
+    private suspend fun <T> org.redisson.api.RFuture<T>.awaitWithoutCancellingSource(): T =
+        suspendCancellableCoroutine { continuation ->
+            whenComplete { value, failure ->
+                if (!continuation.isActive) {
+                    return@whenComplete
+                }
+                if (failure == null) {
+                    continuation.resume(value)
+                } else {
+                    continuation.resumeWithException(failure.unwrapCompletionException())
+                }
+            }
+        }
+
+    private fun Throwable.unwrapCompletionException(): Throwable =
+        (this as? CompletionException)?.cause ?: this
 }

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderElector.kt
@@ -35,6 +35,9 @@ class RedissonStrategicLeaderElector(
     override fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
         registry.registerCandidate(lockName, info, ttl)
 
+    override fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
+        registry.refreshCandidate(lockName, info, ttl)
+
     override fun unregisterCandidate(lockName: String, nodeId: String) =
         registry.unregisterCandidate(lockName, nodeId)
 

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicLeaderGroupElector.kt
@@ -36,6 +36,9 @@ class RedissonStrategicLeaderGroupElector(
     override fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
         registry.registerCandidate(lockName, info, ttl)
 
+    override fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
+        registry.refreshCandidate(lockName, info, ttl)
+
     override fun unregisterCandidate(lockName: String, nodeId: String) =
         registry.unregisterCandidate(lockName, nodeId)
 

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderElector.kt
@@ -37,6 +37,9 @@ class RedissonStrategicSuspendLeaderElector(
     override suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
         withContext(Dispatchers.IO) { registry.registerCandidate(lockName, info, ttl) }
 
+    override suspend fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
+        withContext(Dispatchers.IO) { registry.refreshCandidate(lockName, info, ttl) }
+
     override suspend fun unregisterCandidate(lockName: String, nodeId: String) =
         withContext(Dispatchers.IO) { registry.unregisterCandidate(lockName, nodeId) }
 

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicSuspendLeaderGroupElector.kt
@@ -38,6 +38,9 @@ class RedissonStrategicSuspendLeaderGroupElector(
     override suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
         registry.registerCandidateSuspending(lockName, info, ttl)
 
+    override suspend fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
+        registry.refreshCandidateSuspending(lockName, info, ttl)
+
     override suspend fun unregisterCandidate(lockName: String, nodeId: String) =
         registry.unregisterCandidateSuspending(lockName, nodeId)
 

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistryCancellationTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistryCancellationTest.kt
@@ -27,14 +27,21 @@ class RedissonCandidateRegistryCancellationTest {
         val nodeId = "node-826-late-acquire"
         val lockRequested = CompletableDeferred<Unit>()
         val unlockRequested = CompletableDeferred<Long>()
-        val acquisition = ControlledRFuture<Void>(ignoreCancellation = true)
+        val acquisition = ControlledRFuture<Boolean>(ignoreCancellation = true)
         val lock = mockk<RLock>()
         val cache = mockk<RMapCache<String, CandidateInfo>>()
         val client = mockk<RedissonClient>()
 
         every { client.getMapCache<String, CandidateInfo>(any<String>()) } returns cache
         every { cache.getLock(nodeId) } returns lock
-        every { lock.lockAsync(any<Long>()) } answers {
+        every {
+            lock.tryLockAsync(
+                any<Long>(),
+                any<Long>(),
+                any<java.util.concurrent.TimeUnit>(),
+                any<Long>(),
+            )
+        } answers {
             lockRequested.complete(Unit)
             acquisition
         }
@@ -59,7 +66,7 @@ class RedissonCandidateRegistryCancellationTest {
             job.join()
 
             // The Redis command may complete after the cancelled coroutine has returned.
-            acquisition.complete(null)
+            acquisition.complete(true)
             withTimeout(1.seconds) {
                 unlockRequested.await() > 0L
             } shouldBeEqualTo true
@@ -70,7 +77,7 @@ class RedissonCandidateRegistryCancellationTest {
     fun `entry lock cancellation does not wait indefinitely for unlock response`() = runSuspendIO {
         val nodeId = "node-826-unlock-timeout"
         val actionStarted = CompletableDeferred<Unit>()
-        val acquisition = completedFuture<Void>()
+        val acquisition = completedFuture(true)
         val action = ControlledRFuture<CandidateInfo>(ignoreCancellation = true)
         val unlock = ControlledRFuture<Void>(ignoreCancellation = true)
         val lock = mockk<RLock>()
@@ -79,7 +86,14 @@ class RedissonCandidateRegistryCancellationTest {
 
         every { client.getMapCache<String, CandidateInfo>(any<String>()) } returns cache
         every { cache.getLock(nodeId) } returns lock
-        every { lock.lockAsync(any<Long>()) } returns acquisition
+        every {
+            lock.tryLockAsync(
+                any<Long>(),
+                any<Long>(),
+                any<java.util.concurrent.TimeUnit>(),
+                any<Long>(),
+            )
+        } returns acquisition
         every { lock.unlockAsync(any<Long>()) } returns unlock
         every { cache.putAsync(nodeId, any<CandidateInfo>()) } answers {
             actionStarted.complete(Unit)

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistryCancellationTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistryCancellationTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.leader.redisson
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.strategy.CandidateInfo
@@ -8,6 +9,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
@@ -26,8 +28,12 @@ class RedissonCandidateRegistryCancellationTest {
     fun `entry lock cancellation unlocks a late server-side acquisition`() = runSuspendIO {
         val nodeId = "node-826-late-acquire"
         val lockRequested = CompletableDeferred<Unit>()
+        val lockLease = CompletableDeferred<Long>()
+        val sourceCancellationRequested = CompletableDeferred<Unit>()
         val unlockRequested = CompletableDeferred<Long>()
-        val acquisition = ControlledRFuture<Boolean>(ignoreCancellation = true)
+        val acquisition = ControlledRFuture<Boolean>(ignoreCancellation = true) {
+            sourceCancellationRequested.complete(Unit)
+        }
         val lock = mockk<RLock>()
         val cache = mockk<RMapCache<String, CandidateInfo>>()
         val client = mockk<RedissonClient>()
@@ -43,6 +49,7 @@ class RedissonCandidateRegistryCancellationTest {
             )
         } answers {
             lockRequested.complete(Unit)
+            lockLease.complete(secondArg())
             acquisition
         }
         every { lock.unlockAsync(any<Long>()) } answers {
@@ -62,14 +69,66 @@ class RedissonCandidateRegistryCancellationTest {
             }
 
             lockRequested.await()
-            job.cancel(CancellationException("caller cancelled while waiting for entry lock"))
-            job.join()
+            lockLease.await() shouldBeEqualTo -1L
+            val cancellation = CancellationException("caller cancelled while waiting for entry lock")
+            job.cancel(cancellation)
+            val thrown = assertFailsWith<CancellationException> { job.await() }
+            thrown.message shouldBeEqualTo cancellation.message
+            withTimeout(1.seconds) { sourceCancellationRequested.await() }
 
             // The Redis command may complete after the cancelled coroutine has returned.
             acquisition.complete(true)
             withTimeout(1.seconds) {
                 unlockRequested.await() > 0L
             } shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `non completing entry lock source is cancelled by the bounded attempt deadline`() = runSuspendIO {
+        val nodeId = "node-826-source-timeout"
+        val lockRequested = CompletableDeferred<Unit>()
+        val sourceCancellationRequested = CompletableDeferred<Unit>()
+        val acquisition = ControlledRFuture<Boolean>(ignoreCancellation = true) {
+            lockRequested.complete(Unit)
+            sourceCancellationRequested.complete(Unit)
+        }
+        val lock = mockk<RLock>()
+        val cache = mockk<RMapCache<String, CandidateInfo>>()
+        val client = mockk<RedissonClient>()
+
+        every { client.getMapCache<String, CandidateInfo>(any<String>()) } returns cache
+        every { cache.getLock(nodeId) } returns lock
+        every {
+            lock.tryLockAsync(
+                any<Long>(),
+                any<Long>(),
+                any<java.util.concurrent.TimeUnit>(),
+                any<Long>(),
+            )
+        } answers {
+            lockRequested.complete(Unit)
+            acquisition
+        }
+
+        val registry = RedissonCandidateRegistry(client)
+        coroutineScope {
+            val job = async(start = CoroutineStart.UNDISPATCHED) {
+                registry.registerCandidateSuspending(
+                    lockName = "issue-826-source-timeout",
+                    info = CandidateInfo(nodeId),
+                    ttl = kotlin.time.Duration.ZERO,
+                )
+            }
+
+            lockRequested.await()
+            withTimeout(3.seconds) {
+                sourceCancellationRequested.await()
+            }
+            assertFailsWith<TimeoutCancellationException> {
+                withTimeout(1.seconds) { job.await() }
+            }
+            job.cancelAndJoin()
         }
     }
 
@@ -130,9 +189,16 @@ class RedissonCandidateRegistryCancellationTest {
 
     private class ControlledRFuture<T>(
         private val ignoreCancellation: Boolean = false,
+        private val onCancellation: () -> Unit = {},
     ) : CompletableFuture<T>(), RFuture<T> {
         override fun cancel(mayInterruptIfRunning: Boolean): Boolean =
-            if (ignoreCancellation) true else super.cancel(mayInterruptIfRunning)
+            if (ignoreCancellation) {
+                onCancellation()
+                true
+            } else {
+                onCancellation()
+                super.cancel(mayInterruptIfRunning)
+            }
     }
 
     private fun <T> completedFuture(value: T? = null): RFuture<T> =

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistryCancellationTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistryCancellationTest.kt
@@ -1,0 +1,126 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Test
+import org.redisson.api.RFuture
+import org.redisson.api.RLock
+import org.redisson.api.RMapCache
+import org.redisson.api.RedissonClient
+import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration.Companion.seconds
+
+class RedissonCandidateRegistryCancellationTest {
+
+    @Test
+    fun `entry lock cancellation unlocks a late server-side acquisition`() = runSuspendIO {
+        val nodeId = "node-826-late-acquire"
+        val lockRequested = CompletableDeferred<Unit>()
+        val unlockRequested = CompletableDeferred<Long>()
+        val acquisition = ControlledRFuture<Void>(ignoreCancellation = true)
+        val lock = mockk<RLock>()
+        val cache = mockk<RMapCache<String, CandidateInfo>>()
+        val client = mockk<RedissonClient>()
+
+        every { client.getMapCache<String, CandidateInfo>(any<String>()) } returns cache
+        every { cache.getLock(nodeId) } returns lock
+        every { lock.lockAsync(any<Long>()) } answers {
+            lockRequested.complete(Unit)
+            acquisition
+        }
+        every { lock.unlockAsync(any<Long>()) } answers {
+            unlockRequested.complete(firstArg())
+            completedFuture()
+        }
+        every { cache.putAsync(nodeId, any<CandidateInfo>()) } returns completedFuture()
+
+        val registry = RedissonCandidateRegistry(client)
+        coroutineScope {
+            val job = async(start = CoroutineStart.UNDISPATCHED) {
+                registry.registerCandidateSuspending(
+                    lockName = "issue-826-late-acquire",
+                    info = CandidateInfo(nodeId),
+                    ttl = kotlin.time.Duration.ZERO,
+                )
+            }
+
+            lockRequested.await()
+            job.cancel(CancellationException("caller cancelled while waiting for entry lock"))
+            job.join()
+
+            // The Redis command may complete after the cancelled coroutine has returned.
+            acquisition.complete(null)
+            withTimeout(1.seconds) {
+                unlockRequested.await() > 0L
+            } shouldBeEqualTo true
+        }
+    }
+
+    @Test
+    fun `entry lock cancellation does not wait indefinitely for unlock response`() = runSuspendIO {
+        val nodeId = "node-826-unlock-timeout"
+        val actionStarted = CompletableDeferred<Unit>()
+        val acquisition = completedFuture<Void>()
+        val action = ControlledRFuture<CandidateInfo>(ignoreCancellation = true)
+        val unlock = ControlledRFuture<Void>(ignoreCancellation = true)
+        val lock = mockk<RLock>()
+        val cache = mockk<RMapCache<String, CandidateInfo>>()
+        val client = mockk<RedissonClient>()
+
+        every { client.getMapCache<String, CandidateInfo>(any<String>()) } returns cache
+        every { cache.getLock(nodeId) } returns lock
+        every { lock.lockAsync(any<Long>()) } returns acquisition
+        every { lock.unlockAsync(any<Long>()) } returns unlock
+        every { cache.putAsync(nodeId, any<CandidateInfo>()) } answers {
+            actionStarted.complete(Unit)
+            action
+        }
+
+        val registry = RedissonCandidateRegistry(client)
+        coroutineScope {
+            val job = async(start = CoroutineStart.UNDISPATCHED) {
+                registry.registerCandidateSuspending(
+                    lockName = "issue-826-unlock-timeout",
+                    info = CandidateInfo(nodeId),
+                    ttl = kotlin.time.Duration.ZERO,
+                )
+            }
+
+            actionStarted.await()
+            val cancellation = CancellationException("caller cancelled while action was in flight")
+            job.cancel(cancellation)
+            try {
+                withTimeout(2.seconds) {
+                    val thrown = io.bluetape4k.assertions.assertFailsWith<CancellationException> {
+                        job.await()
+                    }
+                    thrown.message shouldBeEqualTo cancellation.message
+                }
+            } finally {
+                action.complete(CandidateInfo(nodeId))
+                unlock.complete(null)
+                job.cancelAndJoin()
+            }
+        }
+    }
+
+    private class ControlledRFuture<T>(
+        private val ignoreCancellation: Boolean = false,
+    ) : CompletableFuture<T>(), RFuture<T> {
+        override fun cancel(mayInterruptIfRunning: Boolean): Boolean =
+            if (ignoreCancellation) true else super.cancel(mayInterruptIfRunning)
+    }
+
+    private fun <T> completedFuture(value: T? = null): RFuture<T> =
+        ControlledRFuture<T>().also { it.complete(value) }
+}

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistryCancellationTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistryCancellationTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.redisson
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeLessThan
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.mockk.every
@@ -29,6 +30,7 @@ class RedissonCandidateRegistryCancellationTest {
         val nodeId = "node-826-late-acquire"
         val lockRequested = CompletableDeferred<Unit>()
         val lockLease = CompletableDeferred<Long>()
+        val lockOwnerId = CompletableDeferred<Long>()
         val sourceCancellationRequested = CompletableDeferred<Unit>()
         val unlockRequested = CompletableDeferred<Long>()
         val acquisition = ControlledRFuture<Boolean>(ignoreCancellation = true) {
@@ -50,6 +52,7 @@ class RedissonCandidateRegistryCancellationTest {
         } answers {
             lockRequested.complete(Unit)
             lockLease.complete(secondArg())
+            lockOwnerId.complete(invocation.args[3] as Long)
             acquisition
         }
         every { lock.unlockAsync(any<Long>()) } answers {
@@ -70,17 +73,16 @@ class RedissonCandidateRegistryCancellationTest {
 
             lockRequested.await()
             lockLease.await() shouldBeEqualTo -1L
+            lockOwnerId.await() shouldBeLessThan 0L
             val cancellation = CancellationException("caller cancelled while waiting for entry lock")
             job.cancel(cancellation)
             val thrown = assertFailsWith<CancellationException> { job.await() }
             thrown.message shouldBeEqualTo cancellation.message
             withTimeout(1.seconds) { sourceCancellationRequested.await() }
 
-            // The Redis command may complete after the cancelled coroutine has returned.
+            // Redis 명령은 취소된 coroutine이 반환된 뒤 완료될 수 있다.
             acquisition.complete(true)
-            withTimeout(1.seconds) {
-                unlockRequested.await() > 0L
-            } shouldBeEqualTo true
+            withTimeout(1.seconds) { unlockRequested.await() } shouldBeLessThan 0L
         }
     }
 

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistryContentionTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistryContentionTest.kt
@@ -23,8 +23,8 @@ class RedissonCandidateRegistryContentionTest : AbstractRedissonLeaderTest() {
             "${RedissonCandidateRegistry.DEFAULT_KEY_PREFIX}:$lockName",
         )
         val entryLock = cache.getLock(nodeId)
-        val blockingThreadId = Thread.currentThread().threadId()
-        entryLock.lockAsync(blockingThreadId).await()
+        val blockingOwnerId = 1L
+        entryLock.lockAsync(blockingOwnerId).await()
 
         val registry = RedissonCandidateRegistry(redissonClient)
         val waiting = async(start = CoroutineStart.UNDISPATCHED) {
@@ -39,11 +39,11 @@ class RedissonCandidateRegistryContentionTest : AbstractRedissonLeaderTest() {
             delay(100)
             waiting.isCompleted.shouldBeFalse()
 
-            entryLock.unlockAsync(blockingThreadId).await()
+            entryLock.unlockAsync(blockingOwnerId).await()
             withTimeout(5.seconds) { waiting.await() }
         } finally {
             waiting.cancelAndJoin()
-            if (entryLock.isHeldByThread(blockingThreadId)) {
+            if (entryLock.isHeldByThread(blockingOwnerId)) {
                 entryLock.forceUnlock()
             }
             cache.removeAsync(nodeId).await()

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistryContentionTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonCandidateRegistryContentionTest.kt
@@ -1,0 +1,52 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.strategy.CandidateInfo
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class RedissonCandidateRegistryContentionTest : AbstractRedissonLeaderTest() {
+
+    @Test
+    fun `blocking and suspend entry lock owners remain mutually exclusive`() = runSuspendIO {
+        val lockName = "issue-826-mixed-contention-${System.nanoTime()}"
+        val nodeId = "node-826-mixed-contention"
+        val cache = redissonClient.getMapCache<String, CandidateInfo>(
+            "${RedissonCandidateRegistry.DEFAULT_KEY_PREFIX}:$lockName",
+        )
+        val entryLock = cache.getLock(nodeId)
+        val blockingThreadId = Thread.currentThread().threadId()
+        entryLock.lockAsync(blockingThreadId).await()
+
+        val registry = RedissonCandidateRegistry(redissonClient)
+        val waiting = async(start = CoroutineStart.UNDISPATCHED) {
+            registry.registerCandidateSuspending(
+                lockName = lockName,
+                info = CandidateInfo(nodeId),
+                ttl = Duration.ZERO,
+            )
+        }
+
+        try {
+            delay(100)
+            waiting.isCompleted.shouldBeFalse()
+
+            entryLock.unlockAsync(blockingThreadId).await()
+            withTimeout(5.seconds) { waiting.await() }
+        } finally {
+            waiting.cancelAndJoin()
+            if (entryLock.isHeldByThread(blockingThreadId)) {
+                entryLock.forceUnlock()
+            }
+            cache.removeAsync(nodeId).await()
+        }
+    }
+}

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicGroupToxiproxyCancellationTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicGroupToxiproxyCancellationTest.kt
@@ -64,14 +64,17 @@ class RedissonStrategicGroupToxiproxyCancellationTest {
                         thrown.message shouldBeEqualTo cancellation.message
                     }
 
+                    // owner를 bounded attempt window보다 오래 유지하므로, 취소된 waiter가
+                    // owner 해제 시점에 서버 측 대기 요청을 남기지 않았는지 확인한다.
+                    delay(ENTRY_LOCK_ATTEMPT_SETTLE_MILLIS)
                     entryLock.unlockAsync(OWNER_THREAD_ID).await()
-                    val reacquired = kotlinx.coroutines.withTimeout(5.seconds) {
-                        while (true) {
-                            if (entryLock.tryLockAsync(REACQUIRE_THREAD_ID).await()) {
-                                return@withTimeout true
-                            }
-                            delay(50)
-                        }
+                    val reacquired = kotlinx.coroutines.withTimeout(1.seconds) {
+                        entryLock.tryLockAsync(
+                            REACQUIRE_WAIT_MILLIS,
+                            REACQUIRE_LEASE_MILLIS,
+                            TimeUnit.MILLISECONDS,
+                            REACQUIRE_THREAD_ID,
+                        ).await()
                     }
                     reacquired shouldBeEqualTo true
                     entryLock.unlockAsync(REACQUIRE_THREAD_ID).await()
@@ -247,6 +250,9 @@ class RedissonStrategicGroupToxiproxyCancellationTest {
         const val REDISSON_SHUTDOWN_TIMEOUT_SECONDS = 1L
         const val CANCEL_SETTLE_MILLIS = 250L
         const val CANCEL_SETTLE_ROUNDS = 5
+        const val ENTRY_LOCK_ATTEMPT_SETTLE_MILLIS = 1_000L
+        const val REACQUIRE_WAIT_MILLIS = 100L
+        const val REACQUIRE_LEASE_MILLIS = 30_000L
         const val OWNER_THREAD_ID = 826_001L
         const val REACQUIRE_THREAD_ID = 826_002L
     }

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicGroupToxiproxyCancellationTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicGroupToxiproxyCancellationTest.kt
@@ -64,9 +64,9 @@ class RedissonStrategicGroupToxiproxyCancellationTest {
                         thrown.message shouldBeEqualTo cancellation.message
                     }
 
-                    // owner를 bounded attempt window보다 오래 유지하므로, 취소된 waiter가
-                    // owner 해제 시점에 서버 측 대기 요청을 남기지 않았는지 확인한다.
-                    delay(ENTRY_LOCK_ATTEMPT_SETTLE_MILLIS)
+                    // bounded attempt window 안에 owner를 해제해 실제 late acquisition 경합을 만든다.
+                    // 취소된 Redisson waiter가 늦게 획득하더라도 반드시 자체 unlock되어야 한다.
+                    delay(LATE_ACQUISITION_RACE_DELAY_MILLIS)
                     entryLock.unlockAsync(OWNER_THREAD_ID).await()
                     val reacquired = kotlinx.coroutines.withTimeout(1.seconds) {
                         entryLock.tryLockAsync(
@@ -250,7 +250,7 @@ class RedissonStrategicGroupToxiproxyCancellationTest {
         const val REDISSON_SHUTDOWN_TIMEOUT_SECONDS = 1L
         const val CANCEL_SETTLE_MILLIS = 250L
         const val CANCEL_SETTLE_ROUNDS = 5
-        const val ENTRY_LOCK_ATTEMPT_SETTLE_MILLIS = 1_000L
+        const val LATE_ACQUISITION_RACE_DELAY_MILLIS = 50L
         const val REACQUIRE_WAIT_MILLIS = 100L
         const val REACQUIRE_LEASE_MILLIS = 30_000L
         const val OWNER_THREAD_ID = 826_001L

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicGroupToxiproxyCancellationTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicGroupToxiproxyCancellationTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.future.await
 import kotlinx.coroutines.yield
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
@@ -27,6 +28,7 @@ import org.testcontainers.containers.Network
 import org.testcontainers.toxiproxy.ToxiproxyContainer
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Redisson strategic group의 Redis 후보 조회·결과 갱신 I/O 대기 중 취소 회귀입니다.
@@ -36,6 +38,54 @@ import java.util.concurrent.TimeUnit
  */
 @Execution(ExecutionMode.SAME_THREAD)
 class RedissonStrategicGroupToxiproxyCancellationTest {
+
+    @Test
+    fun `entry lock waiter cancellation cleans up late acquisition and allows reacquisition`() = runSuspendIO {
+        withRedisProxy { redis, toxiproxy, proxy ->
+            withClients(redis, toxiproxy) { redisson, observerRedisson ->
+                val lockName = randomLockName()
+                val candidateNode = "toxiproxy-entry-lock-node"
+                val elector = RedissonStrategicSuspendLeaderGroupElector(redisson, candidateNode)
+                val cache = observerRedisson.getMapCache<String, CandidateInfo>(
+                    "${RedissonCandidateRegistry.GROUP_KEY_PREFIX}:$lockName",
+                )
+                val entryLock = cache.getLock(candidateNode)
+                entryLock.lockAsync(OWNER_THREAD_ID).await()
+
+                try {
+                    coroutineScope {
+                        val deferred = async(start = CoroutineStart.UNDISPATCHED) {
+                            elector.registerCandidate(lockName, CandidateInfo(candidateNode))
+                        }
+                        delay(CANCEL_SETTLE_MILLIS)
+                        val cancellation = CancellationException("cancel while waiting for entry lock")
+                        deferred.cancel(cancellation)
+                        val thrown = assertFailsWith<CancellationException> { deferred.await() }
+                        thrown.message shouldBeEqualTo cancellation.message
+                    }
+
+                    entryLock.unlockAsync(OWNER_THREAD_ID).await()
+                    val reacquired = kotlinx.coroutines.withTimeout(5.seconds) {
+                        while (true) {
+                            if (entryLock.tryLockAsync(REACQUIRE_THREAD_ID).await()) {
+                                return@withTimeout true
+                            }
+                            delay(50)
+                        }
+                    }
+                    reacquired shouldBeEqualTo true
+                    entryLock.unlockAsync(REACQUIRE_THREAD_ID).await()
+                } finally {
+                    if (entryLock.isHeldByThread(OWNER_THREAD_ID)) {
+                        entryLock.forceUnlock()
+                    }
+                    if (entryLock.isHeldByThread(REACQUIRE_THREAD_ID)) {
+                        entryLock.forceUnlock()
+                    }
+                }
+            }
+        }
+    }
 
     @Test
     fun `후보 조회 응답이 보류된 동안 Job 취소는 action 전에 재전파된다`() = runSuspendIO {
@@ -197,5 +247,7 @@ class RedissonStrategicGroupToxiproxyCancellationTest {
         const val REDISSON_SHUTDOWN_TIMEOUT_SECONDS = 1L
         const val CANCEL_SETTLE_MILLIS = 250L
         const val CANCEL_SETTLE_ROUNDS = 5
+        const val OWNER_THREAD_ID = 826_001L
+        const val REACQUIRE_THREAD_ID = 826_002L
     }
 }

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicGroupToxiproxyCancellationTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicGroupToxiproxyCancellationTest.kt
@@ -6,6 +6,8 @@ import eu.rekawek.toxiproxy.model.Toxic
 import eu.rekawek.toxiproxy.model.ToxicDirection
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
@@ -19,6 +21,10 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.yield
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.awaitility.kotlin.withPollInterval
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
@@ -28,6 +34,7 @@ import org.testcontainers.containers.Network
 import org.testcontainers.toxiproxy.ToxiproxyContainer
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -51,6 +58,11 @@ class RedissonStrategicGroupToxiproxyCancellationTest {
                 )
                 val entryLock = cache.getLock(candidateNode)
                 entryLock.lockAsync(OWNER_THREAD_ID).await()
+                val toxic = proxy.toxics().latency(
+                    "delay-entry-lock-owner-command",
+                    ToxicDirection.UPSTREAM,
+                    LATE_ACQUISITION_COMMAND_DELAY_MILLIS,
+                )
 
                 try {
                     coroutineScope {
@@ -68,6 +80,17 @@ class RedissonStrategicGroupToxiproxyCancellationTest {
                     // 취소된 Redisson waiter가 늦게 획득하더라도 반드시 자체 unlock되어야 한다.
                     delay(LATE_ACQUISITION_RACE_DELAY_MILLIS)
                     entryLock.unlockAsync(OWNER_THREAD_ID).await()
+                    // Upstream latency로 취소된 acquire 명령이 owner 해제 뒤 Redis에 도착하게
+                    // 한다. 지연된 cleanup이 늦은 owner를 충분히 관찰 가능하게 만든다.
+                    await.atMost(2.seconds).withPollInterval(20.milliseconds).untilAsserted {
+                        entryLock.isLocked().shouldBeTrue()
+                    }
+
+                    removeToxic(toxic)
+                    await.atMost(2.seconds).withPollInterval(20.milliseconds).untilAsserted {
+                        entryLock.isLocked().shouldBeFalse()
+                    }
+
                     val reacquired = kotlinx.coroutines.withTimeout(1.seconds) {
                         entryLock.tryLockAsync(
                             REACQUIRE_WAIT_MILLIS,
@@ -76,9 +99,10 @@ class RedissonStrategicGroupToxiproxyCancellationTest {
                             REACQUIRE_THREAD_ID,
                         ).await()
                     }
-                    reacquired shouldBeEqualTo true
+                    reacquired.shouldBeTrue()
                     entryLock.unlockAsync(REACQUIRE_THREAD_ID).await()
                 } finally {
+                    removeToxic(toxic)
                     if (entryLock.isHeldByThread(OWNER_THREAD_ID)) {
                         entryLock.forceUnlock()
                     }
@@ -118,7 +142,7 @@ class RedissonStrategicGroupToxiproxyCancellationTest {
                         assertFailsWith<CancellationException> { deferred.await() }
                     }
 
-                    actionInvoked.isCompleted shouldBeEqualTo false
+                    actionInvoked.isCompleted.shouldBeFalse()
                 } finally {
                     removeToxic(toxic)
                 }
@@ -250,6 +274,7 @@ class RedissonStrategicGroupToxiproxyCancellationTest {
         const val REDISSON_SHUTDOWN_TIMEOUT_SECONDS = 1L
         const val CANCEL_SETTLE_MILLIS = 250L
         const val CANCEL_SETTLE_ROUNDS = 5
+        const val LATE_ACQUISITION_COMMAND_DELAY_MILLIS = 500L
         const val LATE_ACQUISITION_RACE_DELAY_MILLIS = 50L
         const val REACQUIRE_WAIT_MILLIS = 100L
         const val REACQUIRE_LEASE_MILLIS = 30_000L

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicHeartbeatCodecTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicHeartbeatCodecTest.kt
@@ -1,0 +1,59 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.strategy.CandidateInfo
+import org.junit.jupiter.api.Test
+import org.redisson.Redisson
+import org.redisson.api.RedissonClient
+import org.redisson.client.codec.StringCodec
+import org.redisson.codec.CompositeCodec
+import org.redisson.codec.Kryo5Codec
+import org.redisson.config.Config
+import kotlin.time.Duration.Companion.seconds
+
+class RedissonStrategicHeartbeatCodecTest : AbstractRedissonLeaderTest() {
+
+    @Test
+    fun `composite codec는 blocking과 suspend refresh에서 map key와 value encoder를 각각 사용한다`() = runSuspendIO {
+        val client = createAsymmetricCodecClient()
+        try {
+            val blockingLockName = randomName()
+            val blocking = RedissonStrategicLeaderElector(client, "blocking-node")
+            val blockingCandidate = CandidateInfo("blocking-node", metadata = mapOf("source" to "stale"))
+
+            blocking.registerCandidate(blockingLockName, blockingCandidate, ttl = 5.seconds)
+            blocking.refreshCandidate(
+                blockingLockName,
+                blockingCandidate.copy(metadata = mapOf("source" to "fresh")),
+                ttl = 5.seconds,
+            )
+            blocking.listCandidates(blockingLockName).single().metadata shouldBeEqualTo mapOf("source" to "fresh")
+
+            val suspendLockName = randomName()
+            val suspending = RedissonStrategicSuspendLeaderElector(client, "suspend-node")
+            val suspendCandidate = CandidateInfo("suspend-node", metadata = mapOf("source" to "stale"))
+
+            suspending.registerCandidate(suspendLockName, suspendCandidate, ttl = 5.seconds)
+            suspending.refreshCandidate(
+                suspendLockName,
+                suspendCandidate.copy(metadata = mapOf("source" to "fresh")),
+                ttl = 5.seconds,
+            )
+            suspending.listCandidates(suspendLockName).single().metadata shouldBeEqualTo mapOf("source" to "fresh")
+        } finally {
+            client.shutdown()
+        }
+    }
+
+    private fun createAsymmetricCodecClient(): RedissonClient {
+        val config = Config().apply {
+            setCodec(CompositeCodec(StringCodec.INSTANCE, Kryo5Codec()))
+            useSingleServer()
+                .setAddress(redisUrl)
+                .setConnectionPoolSize(8)
+                .setConnectionMinimumIdleSize(2)
+        }
+        return Redisson.create(config)
+    }
+}

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicHeartbeatExpirationRaceTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicHeartbeatExpirationRaceTest.kt
@@ -1,0 +1,140 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Test
+import org.redisson.api.RedissonClient
+import org.redisson.client.codec.Codec
+import org.redisson.misc.CompletableFutureWrapper
+import kotlin.time.Duration.Companion.seconds
+
+class RedissonStrategicHeartbeatExpirationRaceTest : AbstractRedissonLeaderTest() {
+
+    @Test
+    fun `blocking single refresh does not resurrect candidate after read expires`() = runSuspendIO {
+        assertRefreshDoesNotResurrectExpiredCandidate(gateAsyncRead = false) { client, lockName, stale, fresh ->
+            withContext(Dispatchers.IO) {
+                RedissonStrategicLeaderElector(client, stale.nodeId)
+                    .refreshCandidate(lockName, fresh, ttl = 2.seconds)
+            }
+        }
+    }
+
+    @Test
+    fun `blocking group refresh does not resurrect candidate after read expires`() = runSuspendIO {
+        assertRefreshDoesNotResurrectExpiredCandidate(
+            keyPrefix = RedissonCandidateRegistry.GROUP_KEY_PREFIX,
+            gateAsyncRead = false,
+        ) { client, lockName, stale, fresh ->
+            withContext(Dispatchers.IO) {
+                RedissonStrategicLeaderGroupElector(client, stale.nodeId)
+                    .refreshCandidate(lockName, fresh, ttl = 2.seconds)
+            }
+        }
+    }
+
+    @Test
+    fun `suspend single refresh does not resurrect candidate after read expires`() = runSuspendIO {
+        assertRefreshDoesNotResurrectExpiredCandidate(gateAsyncRead = false) { client, lockName, stale, fresh ->
+            RedissonStrategicSuspendLeaderElector(client, stale.nodeId)
+                .refreshCandidate(lockName, fresh, ttl = 2.seconds)
+        }
+    }
+
+    @Test
+    fun `suspend group refresh does not resurrect candidate after read expires`() = runSuspendIO {
+        assertRefreshDoesNotResurrectExpiredCandidate(
+            keyPrefix = RedissonCandidateRegistry.GROUP_KEY_PREFIX,
+            gateAsyncRead = true,
+        ) { client, lockName, stale, fresh ->
+            RedissonStrategicSuspendLeaderGroupElector(client, stale.nodeId)
+                .refreshCandidate(lockName, fresh, ttl = 2.seconds)
+        }
+    }
+
+    private suspend fun assertRefreshDoesNotResurrectExpiredCandidate(
+        keyPrefix: String = RedissonCandidateRegistry.DEFAULT_KEY_PREFIX,
+        gateAsyncRead: Boolean,
+        refresh: suspend (
+            client: RedissonClient,
+            lockName: String,
+            stale: CandidateInfo,
+            fresh: CandidateInfo,
+        ) -> Unit,
+    ) {
+        val lockName = randomName()
+        val nodeId = "node-expiration-race"
+        val stale = CandidateInfo(nodeId = nodeId, metadata = mapOf("source" to "stale"))
+        val fresh = stale.copy(metadata = mapOf("source" to "fresh"))
+        val cacheName = "$keyPrefix:$lockName"
+        val realCache = redissonClient.getMapCache<String, CandidateInfo>(cacheName)
+        val cache = spyk(realCache)
+        val client = mockk<RedissonClient>()
+        val operationEntered = CompletableDeferred<Unit>()
+        val releaseOperation = CompletableDeferred<Unit>()
+
+        realCache.put(nodeId, stale, 2.seconds.inWholeMilliseconds, java.util.concurrent.TimeUnit.MILLISECONDS)
+        every { client.getMapCache<String, CandidateInfo>(cacheName) } returns cache
+        every { client.getScript(any<Codec>()) } answers {
+            redissonClient.getScript(firstArg<Codec>())
+        }
+        if (gateAsyncRead) {
+            every { cache.getAsync(nodeId) } answers {
+                val source = callOriginal()
+                val gated = java.util.concurrent.CompletableFuture<CandidateInfo>()
+                source.whenComplete { value, failure ->
+                    if (failure != null) {
+                        gated.completeExceptionally(failure)
+                    } else {
+                        operationEntered.complete(Unit)
+                        releaseOperation.invokeOnCompletion { gated.complete(value) }
+                    }
+                }
+                CompletableFutureWrapper(gated)
+            }
+        } else {
+            every { cache.get(nodeId) } answers {
+                val value = callOriginal()
+                operationEntered.complete(Unit)
+                runBlocking { releaseOperation.await() }
+                value
+            }
+        }
+
+        try {
+            coroutineScope {
+                val refreshJob = async(Dispatchers.IO) {
+                    refresh(client, lockName, stale, fresh)
+                }
+
+                withTimeout(2.seconds) { operationEntered.await() }
+                withTimeout(5.seconds) {
+                    while (realCache.remainTimeToLive(nodeId) > 0L) {
+                        delay(10)
+                    }
+                }
+                releaseOperation.complete(Unit)
+                refreshJob.await()
+
+                realCache.get(nodeId).shouldBeNull()
+                realCache.readAllValues().shouldBeEmpty()
+            }
+        } finally {
+            releaseOperation.complete(Unit)
+            realCache.removeAsync(nodeId).toCompletableFuture().join()
+        }
+    }
+}

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicHeartbeatTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicHeartbeatTest.kt
@@ -1,0 +1,162 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.scorers.SuccessRateScorer
+import io.bluetape4k.leader.strategy.strategies.ScoredElectionStrategy
+import io.bluetape4k.leader.strategy.strategies.ScoredGroupElectionStrategy
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class RedissonStrategicHeartbeatTest : AbstractRedissonLeaderTest() {
+
+    private val registeredAt = Instant.parse("2026-01-01T00:00:00Z")
+    private val lastStartTime = Instant.parse("2026-01-01T00:00:30Z")
+    private val staleCompletion = Instant.parse("2026-01-01T00:01:00Z")
+
+    private fun candidate(
+        nodeId: String,
+        successCount: Long,
+        failureCount: Long,
+        metadata: String,
+    ) = CandidateInfo(
+        nodeId = nodeId,
+        registeredAt = registeredAt,
+        lastStartTime = lastStartTime,
+        lastCompletionTime = staleCompletion,
+        successCount = successCount,
+        failureCount = failureCount,
+        metadata = mapOf("source" to metadata),
+    )
+
+    private fun assertHeartbeatResult(
+        candidate: CandidateInfo,
+        expectedSuccessCount: Long,
+        expectedFailureCount: Long,
+        expectedMetadata: String,
+    ) {
+        candidate.registeredAt shouldBeEqualTo registeredAt
+        candidate.lastStartTime shouldBeEqualTo lastStartTime
+        (candidate.lastCompletionTime?.isAfter(staleCompletion) == true).shouldBeTrue()
+        candidate.successCount shouldBeEqualTo expectedSuccessCount
+        candidate.failureCount shouldBeEqualTo expectedFailureCount
+        candidate.metadata shouldBeEqualTo mapOf("source" to expectedMetadata)
+    }
+
+    @Test
+    fun `blocking single heartbeat preserves counters for both operation orderings`() {
+        val lockName = randomName()
+        val elector = RedissonStrategicLeaderElector(redissonClient, "node-1")
+        val node1 = candidate("node-1", successCount = 4, failureCount = 1, metadata = "stale-1")
+        val node2 = candidate("node-2", successCount = 2, failureCount = 3, metadata = "stale-2")
+
+        elector.registerCandidate(lockName, node1, ttl = 5.seconds)
+        elector.registerCandidate(lockName, node2, ttl = 5.seconds)
+        elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+        elector.refreshCandidate(lockName, node1.copy(metadata = mapOf("source" to "fresh-1")), ttl = 5.seconds)
+        elector.refreshCandidate(lockName, node2.copy(metadata = mapOf("source" to "fresh-2")), ttl = 5.seconds)
+        elector.updateResult(lockName, "node-2", CandidateResult.FAILURE)
+
+        val candidates = elector.listCandidates(lockName)
+        assertHeartbeatResult(candidates.first { it.nodeId == "node-1" }, 5L, 1L, "fresh-1")
+        assertHeartbeatResult(candidates.first { it.nodeId == "node-2" }, 2L, 4L, "fresh-2")
+        ScoredElectionStrategy(SuccessRateScorer).elect(candidates).winner?.nodeId shouldBeEqualTo "node-1"
+    }
+
+    @Test
+    fun `blocking group heartbeat preserves counters for both operation orderings`() {
+        val lockName = randomName()
+        val elector = RedissonStrategicLeaderGroupElector(redissonClient, "node-1")
+        val node1 = candidate("node-1", successCount = 4, failureCount = 1, metadata = "stale-1")
+        val node2 = candidate("node-2", successCount = 2, failureCount = 3, metadata = "stale-2")
+
+        elector.registerCandidate(lockName, node1, ttl = 5.seconds)
+        elector.registerCandidate(lockName, node2, ttl = 5.seconds)
+        elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+        elector.refreshCandidate(lockName, node1.copy(metadata = mapOf("source" to "fresh-1")), ttl = 5.seconds)
+        elector.refreshCandidate(lockName, node2.copy(metadata = mapOf("source" to "fresh-2")), ttl = 5.seconds)
+        elector.updateResult(lockName, "node-2", CandidateResult.FAILURE)
+
+        val candidates = elector.listCandidates(lockName)
+        assertHeartbeatResult(candidates.first { it.nodeId == "node-1" }, 5L, 1L, "fresh-1")
+        assertHeartbeatResult(candidates.first { it.nodeId == "node-2" }, 2L, 4L, "fresh-2")
+        ScoredGroupElectionStrategy(SuccessRateScorer)
+            .elect(candidates, maxLeaders = 1)
+            .winners
+            .single()
+            .nodeId shouldBeEqualTo "node-1"
+    }
+
+    @Test
+    fun `suspend single heartbeat preserves counters for both operation orderings`() = runSuspendIO {
+        val lockName = randomName()
+        val elector = RedissonStrategicSuspendLeaderElector(redissonClient, "node-1")
+        val node1 = candidate("node-1", successCount = 4, failureCount = 1, metadata = "stale-1")
+        val node2 = candidate("node-2", successCount = 2, failureCount = 3, metadata = "stale-2")
+
+        elector.registerCandidate(lockName, node1, ttl = 5.seconds)
+        elector.registerCandidate(lockName, node2, ttl = 5.seconds)
+        elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+        elector.refreshCandidate(lockName, node1.copy(metadata = mapOf("source" to "fresh-1")), ttl = 5.seconds)
+        elector.refreshCandidate(lockName, node2.copy(metadata = mapOf("source" to "fresh-2")), ttl = 5.seconds)
+        elector.updateResult(lockName, "node-2", CandidateResult.FAILURE)
+
+        val candidates = elector.listCandidates(lockName)
+        assertHeartbeatResult(candidates.first { it.nodeId == "node-1" }, 5L, 1L, "fresh-1")
+        assertHeartbeatResult(candidates.first { it.nodeId == "node-2" }, 2L, 4L, "fresh-2")
+        ScoredElectionStrategy(SuccessRateScorer).elect(candidates).winner?.nodeId shouldBeEqualTo "node-1"
+    }
+
+    @Test
+    fun `suspend group heartbeat preserves counters for both operation orderings`() = runSuspendIO {
+        val lockName = randomName()
+        val elector = RedissonStrategicSuspendLeaderGroupElector(redissonClient, "node-1")
+        val node1 = candidate("node-1", successCount = 4, failureCount = 1, metadata = "stale-1")
+        val node2 = candidate("node-2", successCount = 2, failureCount = 3, metadata = "stale-2")
+
+        elector.registerCandidate(lockName, node1, ttl = 5.seconds)
+        elector.registerCandidate(lockName, node2, ttl = 5.seconds)
+        elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+        elector.refreshCandidate(lockName, node1.copy(metadata = mapOf("source" to "fresh-1")), ttl = 5.seconds)
+        elector.refreshCandidate(lockName, node2.copy(metadata = mapOf("source" to "fresh-2")), ttl = 5.seconds)
+        elector.updateResult(lockName, "node-2", CandidateResult.FAILURE)
+
+        val candidates = elector.listCandidates(lockName)
+        assertHeartbeatResult(candidates.first { it.nodeId == "node-1" }, 5L, 1L, "fresh-1")
+        assertHeartbeatResult(candidates.first { it.nodeId == "node-2" }, 2L, 4L, "fresh-2")
+        ScoredGroupElectionStrategy(SuccessRateScorer)
+            .elect(candidates, maxLeaders = 1)
+            .winners
+            .single()
+            .nodeId shouldBeEqualTo "node-1"
+    }
+
+    @Test
+    fun `refreshCandidate는 TTL을 재설정하지만 만료된 후보를 되살리지 않는다`() {
+        val lockName = randomName()
+        val elector = RedissonStrategicLeaderElector(redissonClient, "node-1")
+        val stale = candidate("node-1", successCount = 1, failureCount = 0, metadata = "stale")
+        val cache = redissonClient.getMapCache<String, CandidateInfo>(
+            "${RedissonCandidateRegistry.DEFAULT_KEY_PREFIX}:$lockName",
+        )
+
+        elector.registerCandidate(lockName, stale, ttl = 800.milliseconds)
+        val beforeUpdate = cache.remainTimeToLive("node-1")
+        elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
+        val afterUpdate = cache.remainTimeToLive("node-1")
+        (beforeUpdate > 0L && afterUpdate > 0L && afterUpdate <= beforeUpdate + 50L).shouldBeTrue()
+
+        elector.refreshCandidate(lockName, stale.copy(metadata = mapOf("source" to "fresh")), ttl = 2.seconds)
+        val afterRefresh = cache.remainTimeToLive("node-1")
+        (afterRefresh > afterUpdate).shouldBeTrue()
+
+        cache.remove("node-1")
+        elector.refreshCandidate(lockName, stale.copy(metadata = mapOf("source" to "late")), ttl = 2.seconds)
+        elector.listCandidates(lockName).isEmpty().shouldBeTrue()
+    }
+}

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicHeartbeatTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicHeartbeatTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.leader.redisson
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeAfter
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeEmpty
@@ -164,5 +165,23 @@ class RedissonStrategicHeartbeatTest : AbstractRedissonLeaderTest() {
         cache.remove("node-1")
         elector.refreshCandidate(lockName, stale.copy(metadata = mapOf("source" to "late")), ttl = 2.seconds)
         elector.listCandidates(lockName).shouldBeEmpty()
+    }
+
+    @Test
+    fun `blocking refreshCandidate는 음수 TTL을 거부한다`() {
+        val elector = RedissonStrategicLeaderElector(redissonClient, "node-1")
+
+        assertFailsWith<IllegalArgumentException> {
+            elector.refreshCandidate(randomName(), candidate("node-1", 0L, 0L, "stale"), (-1).milliseconds)
+        }
+    }
+
+    @Test
+    fun `suspend refreshCandidate는 음수 TTL을 거부한다`() = runSuspendIO {
+        val elector = RedissonStrategicSuspendLeaderElector(redissonClient, "node-1")
+
+        assertFailsWith<IllegalArgumentException> {
+            elector.refreshCandidate(randomName(), candidate("node-1", 0L, 0L, "stale"), (-1).milliseconds)
+        }
     }
 }

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicHeartbeatTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonStrategicHeartbeatTest.kt
@@ -1,7 +1,11 @@
 package io.bluetape4k.leader.redisson
 
+import io.bluetape4k.assertions.shouldBeAfter
 import io.bluetape4k.assertions.shouldBeEqualTo
-import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeLessOrEqualTo
+import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
@@ -42,7 +46,7 @@ class RedissonStrategicHeartbeatTest : AbstractRedissonLeaderTest() {
     ) {
         candidate.registeredAt shouldBeEqualTo registeredAt
         candidate.lastStartTime shouldBeEqualTo lastStartTime
-        (candidate.lastCompletionTime?.isAfter(staleCompletion) == true).shouldBeTrue()
+        candidate.lastCompletionTime.shouldNotBeNull() shouldBeAfter staleCompletion
         candidate.successCount shouldBeEqualTo expectedSuccessCount
         candidate.failureCount shouldBeEqualTo expectedFailureCount
         candidate.metadata shouldBeEqualTo mapOf("source" to expectedMetadata)
@@ -149,14 +153,16 @@ class RedissonStrategicHeartbeatTest : AbstractRedissonLeaderTest() {
         val beforeUpdate = cache.remainTimeToLive("node-1")
         elector.updateResult(lockName, "node-1", CandidateResult.SUCCESS)
         val afterUpdate = cache.remainTimeToLive("node-1")
-        (beforeUpdate > 0L && afterUpdate > 0L && afterUpdate <= beforeUpdate + 50L).shouldBeTrue()
+        beforeUpdate shouldBeGreaterThan 0L
+        afterUpdate shouldBeGreaterThan 0L
+        afterUpdate shouldBeLessOrEqualTo beforeUpdate + 50L
 
         elector.refreshCandidate(lockName, stale.copy(metadata = mapOf("source" to "fresh")), ttl = 2.seconds)
         val afterRefresh = cache.remainTimeToLive("node-1")
-        (afterRefresh > afterUpdate).shouldBeTrue()
+        afterRefresh shouldBeGreaterThan afterUpdate
 
         cache.remove("node-1")
         elector.refreshCandidate(lockName, stale.copy(metadata = mapOf("source" to "late")), ttl = 2.seconds)
-        elector.listCandidates(lockName).isEmpty().shouldBeTrue()
+        elector.listCandidates(lockName).shouldBeEmpty()
     }
 }


### PR DESCRIPTION
## 요약

Closes #826
Closes #804
Closes #828

전략적 후보 heartbeat가 최신 실행 결과를 덮어쓰지 않도록 갱신 경계를 분리하고, Redisson coroutine entry-lock 취소와 Micrometer blocking probe의 interrupt 상태를 보존합니다. 만료 경합에서는 후보를 부활시키지 않도록 Redisson refresh를 원자화하고, `bluetape-kotlin-patterns`에 맞춰 테스트 assertion을 의도별 matcher로 정리했습니다.

## 배경

오래된 `CandidateInfo`를 heartbeat에 재사용하면 `successCount`, `failureCount`, `lastCompletionTime`이 되돌아갈 수 있습니다. Redisson entry-lock 대기 취소는 서버의 늦은 lock 획득 뒤 고아 lock을 남길 수 있고, Micrometer diagnostics probe는 `InterruptedException` 발생 시 현재 스레드의 interrupt flag를 잃을 수 있습니다. 독립 P1 검토에서 watchdog lease, source future lifecycle, logical owner 충돌, 실제 late-acquisition race, 만료 중 GET→PUT 부활 경계가 부족한 것을 확인하고 보강했습니다.

## 변경 내용

- #826: Redisson coroutine entry-lock을 시도별 500ms bounded `tryLockAsync(wait, -1L, unit, threadId)`로 실행해 watchdog lease를 유지합니다. suspend logical owner ID를 음수 namespace로 분리하고, source future에 2초 deadline과 `cancel(false)`를 연결하며, 취소 뒤 늦은 획득은 bounded unlock cleanup으로 보상합니다. upstream 500ms Toxiproxy 지연으로 실제 late-acquisition과 owner-specific cleanup을 관찰하고, non-completing source·mixed blocking/suspend contention 회귀를 추가했습니다.
- #804: 네 strategic 인터페이스의 heartbeat 갱신 경계를 유지하고 Lettuce Redis script와 Redisson entry lock에서 등록·실행·결과 필드를 보존한 metadata/TTL 갱신을 원자화했습니다. Local blocking/suspend single/group 구현은 `ConcurrentHashMap.computeIfPresent`로 refresh를 원자화해 missing/unregistered 후보를 재등록하지 않습니다. Redisson은 live packed value와 timeout/idle zset을 한 Lua 연산에서 확인·갱신하며, 현재 카운터와 completion time을 덮어쓰지 않습니다.
- #804 P1 보강: Redisson `RScript`의 단일 value encoder 경계를 map key, map value, TTL marker별 encoder로 분리해 비대칭 `CompositeCodec`에서도 blocking/suspend refresh가 동일하게 동작하도록 했습니다. Redis 접근 전에 음수 refresh TTL을 `IllegalArgumentException`으로 거부합니다.
- #828: active `checkConnectivity`와 `diagnostics(probe=true)`에서 `InterruptedException` 발생 즉시 interrupt flag를 복원한 뒤 같은 예외를 재전파합니다.
- 테스트 assertion은 컬렉션에 `shouldBeEmpty()`, nullable 값에 `shouldBeNull()`/`shouldNotBeNull()`, 숫자 비교에 직접 matcher를 사용하도록 정리했습니다. 조건식을 `(...).shouldBeTrue()` 또는 `(...).shouldBeFalse()`로 감싸지 않았습니다.

## 검증

- TDD RED: 기존 양수 owner allocator는 `Expected <1> to be less than <0>, but was not.`으로 실패했고, GET-held-until-expiry Redisson race 4개도 기존 GET→PUT 구현에서 실패했습니다.
- 추가 RED: 비대칭 `CompositeCodec` refresh는 `CompositeCodec.valueCodec == null` NPE로, 음수 TTL blocking/suspend 테스트는 예외 미발생으로 각각 실패했습니다.
- GREEN targeted: codec/negative-TTL 및 기존 heartbeat·만료 경합·contention 회귀 8개가 통과했습니다.
- Fresh full affected command: `:bluetape4k-leader-redis-redisson:test` 312개 통과, `:bluetape4k-leader-core:test`, `:bluetape4k-leader-micrometer:test`, `detekt`, `checkBinaryCompatibility` 성공. ABI 결과는 `artifacts=16`, `ignored=10`, `unknown=0`입니다.
- assertion contract, configuration-cache guard, leader contract matrix, timing contract, CI fan-out contract, `git diff --check` 통과; 관계식·널·컬렉션 조건을 `shouldBeTrue()`/`shouldBeFalse()`로 감싼 추가 assertion은 0개이며 Boolean 결과 자체에는 직접 boolean matcher를 사용했습니다.
- workflow receipt `20260828T184028Z-eccec461` terminal `completed`, final checksum `a5274840a8fcf23554c41df446190355e30f734428691d71f3a98e4e0775ce47`.
- hosted exact-head CI `33200146326` (`64e88c31f1588d32714a3e03085eab639d7c957d`) 47개 job 전체 성공: [CI run](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33200146326)

## 검토 메모

- 독립 최종 code review를 exact head `64e88c31f1588d32714a3e03085eab639d7c957d`에서 완료했으며 P0/P1/P2/P3 모두 0, verdict는 `APPROVE`입니다.
- Redisson 4.7.0 기준 sharded Pub/Sub command를 고정하지 않도록 refresh Lua의 불필요한 listener publish 분기를 제거하고, script routing에는 logical `cache.name`, Redis KEYS에는 mapped raw key를 사용했습니다.
- `bluetape-kotlin-patterns` 재감사에서 직접 의도 matcher, Bluetape `assertFailsWith`, nullable/collection matcher 규칙을 확인했습니다. LSP는 사용할 수 없어 Gradle compile/test, detekt, contract 검사로 대체 검증했습니다.
- Maintainer의 exact-head merge approval을 받은 뒤 rebase merge를 완료했습니다. 생성된 merge SHA는 `4c0d1156c268cde6191f6901c933b60ae6b92cff`입니다.
- 원격 feature branch는 merge 후 GitHub 정책에 따라 삭제되었고, 사용자 cleanup 승인 후 clean·patch-equivalent 증거를 확인한 뒤 local feature worktree와 branch도 제거했습니다.

## 메타데이터

- Issues: #826, #804, #828; milestone `1.0.0`; assignee `debop`; labels `bug`, `integration`, `test`, `maintenance`
- Base: `develop`
- Head: `fix/issue-826-redisson-entry-lock-cancellation` @ `64e88c31f1588d32714a3e03085eab639d7c957d`
- Merge: rebase @ `4c0d1156c268cde6191f6901c933b60ae6b92cff`

## DoD Status

Required checks: 완료된 로컬/호스티드 검증 전체 성공; N/A: 0; Blocked: 0

- [x] #826 Redisson cancellation/cleanup 구현 및 owner namespace·late-acquisition 회귀 검증
- [x] #804 Redis/Local strategic heartbeat counter·metadata·TTL 보존 및 만료 부활 방지 구현·회귀 검증
- [x] #828 Micrometer interrupt flag 보존 구현 및 회귀 검증
- [x] P1 리뷰 차단 조건과 Redisson refresh script 호환성 경계 수정 및 TDD RED/GREEN 증거 확보
- [x] 비대칭 `CompositeCodec` 및 음수 TTL 입력 계약 회귀 검증
- [x] `bluetape-kotlin-patterns` assertion 규칙 재감사 및 계약 검증
- [x] detekt, ABI, assertion/configuration/timing/CI contracts, `git diff --check`
- [x] 현재 HEAD workflow receipt 완료
- [x] 독립 최종 code review (`APPROVE`, P0/P1/P2/P3=0)
- [x] hosted exact-head CI 재실행 (`33200146326`, success)
- [x] maintainer exact-head review/merge approval 및 PR #830 rebase merge (`4c0d1156c268cde6191f6901c933b60ae6b92cff`)
- [x] canonical `develop` sync (`HEAD == origin/develop`)
- [x] local feature worktree/branch cleanup (non-force worktree 제거, patch-equivalent 확인 후 local branch 삭제, `git worktree prune`)

Final status: DONE (merge, canonical sync, post-merge 검증, PR/이슈 상태 확인, feature worktree/branch cleanup 완료)

Unchecked required items: none
