### PR TITLE
fix: R2DBC group callback과 JDBC 취소 전파를 보장한다

### DIFF
--- a/docs/lessons/2026-08-28-issue-721-cancellation-parity.md
+++ b/docs/lessons/2026-08-28-issue-721-cancellation-parity.md
@@ -1,0 +1,97 @@
+# 배운 교훈 - 그룹 선출의 취소·가용성·해제 결과 경계
+
+## 맥락
+
+Issue #721은 Exposed JDBC 그룹 선출과 R2DBC 그룹 lock의 오류·취소 경계를
+같은 계약으로 맞추는 작업이다. 가용성 callback은 DB-time fail-closed 상태
+전이의 일부이고, 해제 결과는 작업 이력의 성공 여부와 별개의 신호다.
+
+## 발견
+
+- R2DBC `markUnavailable`/`markAvailable`이 `runCatching`으로 callback 예외와
+  `CancellationException`을 삼켜 호출자가 DB-time 상태 전이를 관측할 수 없었다.
+- JDBC 그룹 비동기 경로는 action `CompletableFuture` 취소를 terminal `FAILED`
+  이력으로 남기지 않아 동기·suspend 경로와 감사 결과가 달랐다.
+- JDBC 그룹 비동기 경로가 반환한 외부 `CompletableFuture`의 취소는 내부 action에
+  전파되지 않아 slot과 audit이 terminal 상태로 수렴하지 않았다.
+- 외부 future를 slot 획득 대기 중 취소해도 acquisition retry loop는 기존 wait
+  budget이 끝날 때까지 executor를 점유했다.
+- JDBC 그룹 비동기 경로가 cleanup stage가 아닌 원래 action future를 반환해,
+  호출자가 history 기록과 slot 반납보다 먼저 결과 완료를 관측할 수 있었다.
+- JDBC 해제의 `Unit` 계약만으로는 `RELEASED`, `NOT_HELD`, DB 오류를 로그에서
+  구분할 수 없었다.
+
+## 결정
+
+R2DBC availability callback은 예외를 허용 범위에서 삼키지 않고 그대로 전파해
+fail-closed 신호를 보존한다. JDBC 그룹 비동기 취소도 다른 action 실패와 같이
+`FAILED`와 종료 시각을 기록한다. 외부 future 취소는 내부 action future에
+전파하고, action 종료·watchdog 종료·history 기록·slot 반납을 단일 terminal
+cleanup으로 묶고 public result는 그 cleanup stage 완료 뒤에만 종료한다. JDBC
+async slot 획득은 public cancellation predicate를 retry loop에 전달하되 기존
+2-인자 `tryLock` ABI는 보존한다. JDBC lock은 기존 `unlock(): Unit` API를 유지하면서 내부
+결과를 `RELEASED`/`NOT_HELD`/`FAILED`로 분류하고, elector는 작업 history와
+해제 결과를 별도로 로깅한다. R2DBC callback 실패는 원래 DB 오류를 suppressed로
+보존하고, 획득 뒤 보상 해제는 5초 budget과 명시적 실패 outcome으로 제한한다.
+
+## 결과
+
+callback·DB 오류·내부/외부 취소가 호출자와 history recorder에 도달하고, 해제
+실패가 정상 반납으로 표시되지 않는다. DB-time 연산이 실패한 뒤에는 기존
+fail-closed availability 상태를 유지하며 callback 오류와 DB 원인을 함께 남긴다.
+
+## 검증
+
+- R2DBC callback 예외·취소 회귀 테스트와 `ExposedR2dbcGroupLockTest` 전체:
+  347 tests, failures/errors/skipped 0
+- JDBC 비동기 취소 이력·해제 결과 테스트와 `ExposedJdbcGroupLockTest`,
+  `ExposedJdbcLeaderGroupElectionTest` 전체:
+  319 tests, failures/errors/skipped 0
+- 변경 모듈 Kotlin compile/test compile, `detekt`, `checkBinaryCompatibility`,
+  `git diff --check` 통과
+
+## 향후 지침
+
+분산 lock의 callback은 상태 전이의 관측 경계이므로 일반 예외와 취소를
+무조건 `runCatching`으로 감싸지 않는다. 모든 실행 모델은 action 취소의
+terminal audit와 unlock 결과 분류를 같은 표로 검토하고, 작업 history의
+성공 상태와 리소스 해제 상태를 하나의 결과로 합치지 않는다.
+
+## 재발 방지 규칙
+
+- 실패한 가정/판단: availability callback은 부가 알림이므로 `runCatching`으로
+  감싸도 안전하다. → 발견 증거 또는 교정: baseline에 callback 회귀 테스트만
+  적용하자 69건 중 21건이 예외 미전파로 실패했다. → 수정 결정: DB 연산 경계와
+  callback 경계를 분리하고, 획득 뒤 callback 실패는 `NonCancellable` 보상 해제
+  후 원래 예외를 전파한다. → 향후 예방 확인: 가용성 callback 변경 시 일반 예외,
+  `CancellationException`, 획득 row 정리를 RED/GREEN으로 함께 검증한다.
+- 실패한 가정/판단: `CompletableFuture` 취소는 별도 상태이므로 terminal audit을
+  생략해도 된다. → 발견 증거 또는 교정: JDBC async baseline은 취소 뒤 history를
+  `FAILED`가 아니라 `ACQUIRED`로 남겼고, 반환 future 취소 테스트도 3개 provider
+  모두 실패했다. → 수정 결정: sync/async/suspend 모두 action 취소를 terminal
+  `FAILED`로 기록하고 외부 취소를 내부 action과 단일 cleanup으로 연결한다. → 향후
+  예방 확인: 실행 모델별 취소 matrix에서 내부/외부 취소, status, `finishedAt`,
+  `durationMs`, 재선출 가능성을 같은 표로 확인한다.
+- 실패한 가정/판단: `unlock(): Unit`과 예외 로그만으로 해제 결과를 충분히
+  구분할 수 있다. → 발견 증거 또는 교정: DB 오류를 내부에서 흡수한 뒤 elector가
+  정상 반납 로그를 남길 수 있었다. → 수정 결정: 공개 `Unit` 계약은 유지하면서
+  내부 결과를 `RELEASED`/`NOT_HELD`/`FAILED`로 분리한다. → 향후 예방 확인:
+  history 결과와 resource release 결과를 별도 assertion과 로그 경로로 검증한다.
+- 실패한 가정/판단: callback 예외만 전파하면 DB 오류의 관측 계약도 충분히
+  보존된다. → 발견 증거 또는 교정: 독립 리뷰에서 callback이 원래 DB 예외와
+  무제한 `NonCancellable` 보상 결과를 가릴 수 있음을 확인했다. → 수정 결정: DB
+  오류를 먼저 로깅하고 callback 예외의 suppressed 원인으로 보존하며, 보상 해제에
+  5초 budget과 `FAILED` marker를 둔다. → 향후 예방 확인: callback failure 테스트는
+  전파 예외뿐 아니라 suppressed DB 원인과 보상 실패 outcome도 함께 검증한다.
+- 실패한 가정/판단: action future에 `whenComplete` cleanup을 등록하면 public
+  result도 cleanup 뒤에 완료된다. → 발견 증거 또는 교정: 독립 아키텍처 검토와
+  세 dialect 회귀 테스트에서 cleanup이 멈춘 동안 public result가 이미 완료됐다.
+  → 수정 결정: 취소 참조는 원래 action future에 유지하고 pipeline은 cleanup을
+  포함한 terminal future를 반환한다. → 향후 예방 확인: 비동기 terminal 테스트는
+  cleanup을 latch로 지연해 result, history, unlock의 완료 순서를 검증한다.
+- 실패한 가정/판단: public future 취소를 action future에만 연결해도 비동기 작업이
+  즉시 멈춘다. → 발견 증거 또는 교정: 점유된 slot을 기다리는 세 dialect 테스트에서
+  취소 뒤 single-thread executor의 후속 작업이 3초 안에 실행되지 않았다. → 수정
+  결정: async group 경로가 retry loop에 cancellation predicate를 전달하고, 기존
+  2-인자 `tryLock`은 그대로 위임해 ABI를 보존한다. → 향후 예방 확인: 취소 matrix에
+  action 전 acquisition 대기와 executor 반환 시간을 포함한다.

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElector.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElector.kt
@@ -11,6 +11,7 @@ import io.bluetape4k.leader.exposed.jdbc.internal.ExposedJdbcBackendErrorClassif
 import io.bluetape4k.leader.exposed.jdbc.internal.ExposedJdbcSlotExtendDelegate
 import io.bluetape4k.leader.exposed.jdbc.lock.ExposedJdbcGroupLock
 import io.bluetape4k.leader.exposed.jdbc.lock.ExposedJdbcSchemaInitializer
+import io.bluetape4k.leader.exposed.jdbc.lock.ExposedJdbcUnlockOutcome
 import io.bluetape4k.leader.exposed.jdbc.lock.currentTime
 import io.bluetape4k.leader.exposed.jdbc.lock.validateExposedLockName
 import io.bluetape4k.leader.exposed.tables.LeaderGroupLockTable
@@ -34,6 +35,8 @@ import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.random.Random
 
 /**
@@ -218,13 +221,13 @@ class ExposedJdbcLeaderGroupElector private constructor(
                     actionSucceeded -> effectiveKey?.let { historyRecorder?.recordCompleted(it, finishedAt, durationMs) }
                     capturedError != null -> effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, capturedError) }
                 }
-                try {
-                    lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos)
-                    log.debug { "그룹 슬롯을 반납했습니다. lockName=$lockName, slot=$slot" }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    log.warn(e) { "그룹 슬롯 해제 실패. lockName=$lockName, slot=$slot" }
+                when (lock.unlockAndReport(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos)) {
+                    ExposedJdbcUnlockOutcome.RELEASED ->
+                        log.debug { "그룹 슬롯을 반납했습니다. lockName=$lockName, slot=$slot" }
+                    ExposedJdbcUnlockOutcome.NOT_HELD ->
+                        log.warn { "그룹 슬롯 반납 대상이 없습니다. lockName=$lockName, slot=$slot" }
+                    ExposedJdbcUnlockOutcome.FAILED ->
+                        log.warn { "그룹 슬롯 해제 실패(DB 오류). lockName=$lockName, slot=$slot" }
                 }
             }
         }
@@ -249,9 +252,12 @@ class ExposedJdbcLeaderGroupElector private constructor(
         val perSlotWait = (options.leaderGroupOptions.waitTime / maxLeaders).coerceAtLeast(1.milliseconds)
         val start = Random.nextInt(maxLeaders)
 
-        return CompletableFuture.supplyAsync({
+        val resultFuture = CompletableFuture<T?>()
+        val actionFutureRef = AtomicReference<CompletableFuture<*>?>()
+        val pipelineFuture = CompletableFuture.supplyAsync({
             var acquired: Pair<ExposedJdbcGroupLock, Int>? = null
             for (i in 0 until maxLeaders) {
+                if (resultFuture.isCancelled) return@supplyAsync null
                 val slot = (start + i) % maxLeaders
                 val lock = ExposedJdbcGroupLock(
                     db,
@@ -261,7 +267,7 @@ class ExposedJdbcLeaderGroupElector private constructor(
                     options.lockOwner,
                     options.leaderGroupOptions.useDbTime,
                 )
-                when (lock.tryLock(perSlotWait, leaseTime)) {
+                when (lock.tryLock(perSlotWait, leaseTime) { resultFuture.isCancelled }) {
                     true -> { acquired = lock to slot; break }
                     false -> continue
                     null -> {
@@ -277,6 +283,19 @@ class ExposedJdbcLeaderGroupElector private constructor(
                 CompletableFuture.completedFuture(null)
             } else {
                 val (lock, slot) = acquired
+                if (resultFuture.isCancelled) {
+                    when (lock.unlockAndReport()) {
+                        ExposedJdbcUnlockOutcome.RELEASED ->
+                            log.debug { "외부 취소 후 획득한 슬롯을 즉시 반납했습니다. lockName=$lockName, slot=$slot" }
+                        ExposedJdbcUnlockOutcome.NOT_HELD ->
+                            log.warn { "외부 취소 후 반납할 슬롯이 없습니다. lockName=$lockName, slot=$slot" }
+                        ExposedJdbcUnlockOutcome.FAILED ->
+                            log.warn { "외부 취소 후 슬롯 해제에 실패했습니다(DB 오류). lockName=$lockName, slot=$slot" }
+                    }
+                    return@thenComposeAsync CompletableFuture.failedFuture<T?>(
+                        java.util.concurrent.CancellationException("runAsyncIfLeader result was cancelled"),
+                    )
+                }
                 log.debug { "그룹 슬롯 비동기 작업 수행. lockName=$lockName, slot=$slot" }
 
                 val startedAt = Instant.now()
@@ -305,45 +324,57 @@ class ExposedJdbcLeaderGroupElector private constructor(
                     delegate,
                     ERROR_CLASSIFIER,
                 )
-
-                val actionFuture = runCatching { action() }
-                    .getOrElse { e ->
+                val terminal = AtomicBoolean()
+                val finishAction: (Throwable?) -> Unit = { throwable ->
+                    if (terminal.compareAndSet(false, true)) {
                         watchdog.close()
                         val finishedAt = Instant.now()
                         val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
-                        effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, e) }
-                        try {
-                            lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos)
-                        } catch (ex: CancellationException) {
-                            throw ex
-                        } catch (ex: Exception) {
-                            log.warn(ex) { "슬롯 해제 실패 (action 오류 경로). slot=$slot" }
+                        when {
+                            throwable == null -> effectiveKey?.let {
+                                historyRecorder?.recordCompleted(it, finishedAt, durationMs)
+                            }
+                            else -> effectiveKey?.let {
+                                historyRecorder?.recordFailed(it, finishedAt, durationMs, throwable)
+                            }
                         }
+                        when (lock.unlockAndReport(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos)) {
+                            ExposedJdbcUnlockOutcome.RELEASED ->
+                                log.debug { "비동기 그룹 슬롯 반납. lockName=$lockName, slot=$slot" }
+                            ExposedJdbcUnlockOutcome.NOT_HELD ->
+                                log.warn { "비동기 그룹 슬롯 반납 대상이 없습니다. lockName=$lockName, slot=$slot" }
+                            ExposedJdbcUnlockOutcome.FAILED ->
+                                log.warn { "비동기 그룹 슬롯 해제 실패(DB 오류). lockName=$lockName, slot=$slot" }
+                        }
+                    }
+                }
+
+                val actionFuture = runCatching { action() }
+                    .getOrElse { e ->
+                        finishAction(e)
                         return@thenComposeAsync CompletableFuture.failedFuture(e)
                     }
 
-                actionFuture.whenComplete { _, throwable ->
-                    watchdog.close()
-                    val finishedAt = Instant.now()
-                    val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
-                    when {
-                        throwable == null -> effectiveKey?.let { historyRecorder?.recordCompleted(it, finishedAt, durationMs) }
-                        // 취소(코루틴/CompletableFuture)는 FAILED로 기록하지 않음
-                        throwable is java.util.concurrent.CancellationException -> { /* skip */ }
-                        throwable is CancellationException -> { /* skip */ }
-                        else -> effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, throwable) }
-                    }
-                    try {
-                        lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos)
-                        log.debug { "비동기 그룹 슬롯 반납. lockName=$lockName, slot=$slot" }
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        log.warn(e) { "비동기 슬롯 해제 실패. lockName=$lockName, slot=$slot" }
-                    }
+                val terminalFuture = actionFuture.whenComplete { _, throwable ->
+                    finishAction(throwable)
                 }
+                actionFutureRef.set(actionFuture)
+                if (resultFuture.isCancelled) actionFuture.cancel(false)
+                terminalFuture
             }
         }, executor)
+
+        resultFuture.whenComplete { _, _ ->
+            if (resultFuture.isCancelled) actionFutureRef.get()?.cancel(false)
+        }
+        pipelineFuture.whenComplete { value, throwable ->
+            if (throwable == null) {
+                resultFuture.complete(value)
+            } else {
+                resultFuture.completeExceptionally(throwable)
+            }
+        }
+        return resultFuture
     }
 
 }

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLock.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLock.kt
@@ -27,6 +27,13 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import java.time.Clock
 
+/** 해제 결과를 DB 반영 성공, 미소유, DB 오류로 구분합니다. */
+internal enum class ExposedJdbcUnlockOutcome {
+    RELEASED,
+    NOT_HELD,
+    FAILED,
+}
+
 /**
  * `ExposedJdbcGroupLock`는 Exposed database backend의 leader election, lock lease, ownership 확인을 담당합니다.
  *
@@ -77,12 +84,23 @@ internal class ExposedJdbcGroupLock internal constructor(
      */
     // The retry loop must distinguish cancellation, interruption, transient database errors,
     // and the sleep interruption path to preserve the blocking API contract.
+    fun tryLock(waitTime: Duration, leaseTime: Duration): Boolean? =
+        tryLock(waitTime, leaseTime) { false }
+
     @Suppress("ThrowsCount", "ReturnCount")
-    fun tryLock(waitTime: Duration, leaseTime: Duration): Boolean? {
+    internal fun tryLock(
+        waitTime: Duration,
+        leaseTime: Duration,
+        isCancelled: () -> Boolean,
+    ): Boolean? {
         val deadline = MonotonicDeadline.fromNow(waitTime)
         var attempt = 0
 
         do {
+            if (isCancelled()) {
+                log.debug { "그룹 슬롯 락 획득 취소: lockName=$lockName, slot=$slot" }
+                return false
+            }
             val acquired = try {
                 tryAcquireOnce(leaseTime)
             } catch (e: CancellationException) {
@@ -98,6 +116,10 @@ internal class ExposedJdbcGroupLock internal constructor(
             if (acquired) {
                 log.debug { "그룹 슬롯 락 획득 성공: lockName=$lockName, slot=$slot, token=${token.take(8)}" }
                 return true
+            }
+            if (isCancelled()) {
+                log.debug { "그룹 슬롯 락 재시도 취소: lockName=$lockName, slot=$slot" }
+                return false
             }
 
             val remaining = deadline.remainingMillisForSleep()
@@ -212,12 +234,25 @@ internal class ExposedJdbcGroupLock internal constructor(
         minLeaseTime: Duration = Duration.ZERO,
         acquiredAtNanos: Long = System.nanoTime(),
     ) {
+        unlockAndReport(minLeaseTime, acquiredAtNanos)
+    }
+
+    /**
+     * 해제 결과를 DB 성공, 미소유, DB 오류로 구분합니다.
+     *
+     * 기존 `unlock`의 Unit 반환 계약은 유지하되, 그룹 선출기는 DB 오류를
+     * 정상 해제와 혼동하지 않도록 이 결과를 사용합니다.
+     */
+    internal fun unlockAndReport(
+        minLeaseTime: Duration = Duration.ZERO,
+        acquiredAtNanos: Long = System.nanoTime(),
+    ): ExposedJdbcUnlockOutcome {
         val lockNameVal = this@ExposedJdbcGroupLock.lockName
         val slotVal = this@ExposedJdbcGroupLock.slot
         val tokenVal = this@ExposedJdbcGroupLock.token
         val remaining = remainingMinLeaseTime(acquiredAtNanos, minLeaseTime)
 
-        try {
+        return try {
             val matched = transaction(db) {
                 if (remaining > Duration.ZERO) {
                     val now = currentTime(useDbTime, clock)
@@ -241,13 +276,16 @@ internal class ExposedJdbcGroupLock internal constructor(
             }
             if (matched == 0) {
                 log.warn { "그룹 슬롯 해제 실패 — 토큰 불일치 또는 이미 만료됨: lockName=$lockName, slot=$slot" }
+                ExposedJdbcUnlockOutcome.NOT_HELD
             } else {
                 log.debug { "그룹 슬롯 해제 성공: lockName=$lockName, slot=$slot" }
+                ExposedJdbcUnlockOutcome.RELEASED
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             log.warn(e) { "그룹 슬롯 해제 중 DB 오류: lockName=$lockName, slot=$slot" }
+            ExposedJdbcUnlockOutcome.FAILED
         }
     }
 

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElectionTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElectionTest.kt
@@ -13,6 +13,7 @@ import io.bluetape4k.leader.exposed.ExposedLeaderConstants.GROUP_LOCK_TABLE_NAME
 import io.bluetape4k.leader.exposed.jdbc.history.ExposedLeaderHistorySink
 import io.bluetape4k.leader.history.LeaderHistoryStatus
 import io.bluetape4k.leader.exposed.tables.LeaderLockHistoryTable
+import io.bluetape4k.leader.history.LeaderHistoryKey
 import io.bluetape4k.leader.history.SafeLeaderHistoryRecorder
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
@@ -33,8 +34,10 @@ import org.junit.jupiter.params.provider.MethodSource
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import java.time.Instant
 import java.util.concurrent.CompletionException
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CancellationException as FutureCancellationException
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -350,6 +353,44 @@ class ExposedJdbcLeaderGroupElectionTest: AbstractExposedJdbcLeaderTest() {
 
     @ParameterizedTest
     @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - terminal cleanup 완료 후 결과를 반환한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val cleanupStarted = CountDownLatch(1)
+        val cleanupAllowed = CountDownLatch(1)
+        val recorder = object: SafeLeaderHistoryRecorder(ExposedLeaderHistorySink(db)) {
+            override fun recordCompleted(key: LeaderHistoryKey, finishedAt: Instant, durationMs: Long) {
+                cleanupStarted.countDown()
+                check(cleanupAllowed.await(5, TimeUnit.SECONDS)) { "terminal cleanup 대기 시간이 초과되었습니다." }
+                super.recordCompleted(key, finishedAt, durationMs)
+            }
+        }
+        val election = ExposedJdbcLeaderGroupElector(db, makeOptions(maxLeaders = 1), recorder)
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = java.util.concurrent.CompletableFuture<String>()
+        val completionExecutor = Executors.newSingleThreadExecutor()
+
+        try {
+            val resultFuture = election.runAsyncIfLeader(randomName(), VirtualThreadExecutor) {
+                actionStarted.countDown()
+                actionFuture
+            }
+
+            actionStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            completionExecutor.submit { actionFuture.complete("async cleanup 완료") }
+            cleanupStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            resultFuture.isDone.shouldBeFalse()
+
+            cleanupAllowed.countDown()
+            resultFuture.get(5, TimeUnit.SECONDS) shouldBeEqualTo "async cleanup 완료"
+        } finally {
+            cleanupAllowed.countDown()
+            completionExecutor.shutdownNow()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
     fun `runAsyncIfLeader - action 동기 throw 후 슬롯이 반환되어 다음 호출이 성공한다`(testDB: TestDB) {
         val db = connectDb(testDB)
         cleanTables(db)
@@ -384,6 +425,108 @@ class ExposedJdbcLeaderGroupElectionTest: AbstractExposedJdbcLeaderTest() {
 
         val result = election.runIfLeader(lockName) { "복구 성공" }
         result shouldBeEqualTo "복구 성공"
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - action future 취소 후 FAILED 이력을 기록하고 슬롯을 반환한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val recorder = SafeLeaderHistoryRecorder(ExposedLeaderHistorySink(db))
+        val election = ExposedJdbcLeaderGroupElector(
+            db,
+            makeOptions(maxLeaders = 1),
+            recorder,
+        )
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = java.util.concurrent.CompletableFuture<String>()
+
+        val resultFuture = election.runAsyncIfLeader(lockName, VirtualThreadExecutor) {
+            actionStarted.countDown()
+            actionFuture
+        }
+
+        actionStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        actionFuture.cancel(false).shouldBeTrue()
+
+        val thrown = assertFailsWith<CompletionException> { resultFuture.join() }
+        thrown.cause.shouldNotBeNull()
+        (thrown.cause is FutureCancellationException).shouldBeTrue()
+        val history = transaction(db) {
+            LeaderLockHistoryTable.selectAll()
+                .where { LeaderLockHistoryTable.lockName eq lockName }
+                .single()
+        }
+        history[LeaderLockHistoryTable.status] shouldBeEqualTo LeaderHistoryStatus.FAILED.name
+        history[LeaderLockHistoryTable.finishedAt].shouldNotBeNull()
+        history[LeaderLockHistoryTable.durationMs].shouldNotBeNull() shouldBeGreaterOrEqualTo 0L
+        election.runIfLeader(lockName) { "async-group-recovered-after-cancel" } shouldBeEqualTo "async-group-recovered-after-cancel"
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - 반환 future 취소를 action에 전파하고 FAILED 이력과 슬롯 반환을 보장한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val recorder = SafeLeaderHistoryRecorder(ExposedLeaderHistorySink(db))
+        val election = ExposedJdbcLeaderGroupElector(
+            db,
+            makeOptions(maxLeaders = 1),
+            recorder,
+        )
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = java.util.concurrent.CompletableFuture<String>()
+
+        val resultFuture = election.runAsyncIfLeader(lockName, VirtualThreadExecutor) {
+            actionStarted.countDown()
+            actionFuture
+        }
+
+        actionStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        resultFuture.cancel(false).shouldBeTrue()
+        assertFailsWith<FutureCancellationException> { resultFuture.join() }
+        actionFuture.isCancelled.shouldBeTrue()
+
+        val history = transaction(db) {
+            LeaderLockHistoryTable.selectAll()
+                .where { LeaderLockHistoryTable.lockName eq lockName }
+                .single()
+        }
+        history[LeaderLockHistoryTable.status] shouldBeEqualTo LeaderHistoryStatus.FAILED.name
+        history[LeaderLockHistoryTable.finishedAt].shouldNotBeNull()
+        history[LeaderLockHistoryTable.durationMs].shouldNotBeNull() shouldBeGreaterOrEqualTo 0L
+        election.runIfLeader(lockName) { "async-group-recovered-after-result-cancel" } shouldBeEqualTo
+            "async-group-recovered-after-result-cancel"
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - 반환 future 취소 시 슬롯 획득 대기를 중단한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val holder = ExposedJdbcGroupLock(db, lockName, slot = 0, RetryStrategy.Fixed(10L))
+        holder.tryLock(Duration.ZERO, 30.seconds).shouldBeTrue()
+        val election = ExposedJdbcLeaderGroupElector(db, makeOptions(maxLeaders = 1, waitSec = 10))
+        val executor = Executors.newSingleThreadExecutor()
+        val actionInvocations = AtomicInteger()
+
+        try {
+            val resultFuture = election.runAsyncIfLeader(lockName, executor) {
+                actionInvocations.incrementAndGet()
+                java.util.concurrent.CompletableFuture.completedFuture("실행되면 안 됨")
+            }
+
+            resultFuture.cancel(false).shouldBeTrue()
+            assertFailsWith<FutureCancellationException> { resultFuture.join() }
+            executor.submit { }.get(3, TimeUnit.SECONDS)
+            actionInvocations.get() shouldBeEqualTo 0
+        } finally {
+            executor.shutdownNow()
+            holder.unlock()
+        }
     }
 
     @ParameterizedTest

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLockTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcGroupLockTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.exposed.jdbc.lock
 
 import io.bluetape4k.exposed.tests.TestDB
+import io.bluetape4k.leader.exposed.ExposedLeaderConstants.GROUP_LOCK_TABLE_NAME
 import io.bluetape4k.leader.exposed.jdbc.AbstractExposedJdbcLeaderTest
 import io.bluetape4k.leader.exposed.tables.LeaderGroupLockTable
 import io.bluetape4k.leader.exposed.retry.RetryStrategy
@@ -215,6 +216,28 @@ class ExposedJdbcGroupLockTest : AbstractExposedJdbcLeaderTest() {
         lock.unlock()
 
         lock.unlock()
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `unlockAndReport - RELEASED NOT_HELD FAILED를 구분한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        try {
+            val lock = ExposedJdbcGroupLock(db, randomName(), slot = 0, RetryStrategy.Jitter())
+            lock.tryLock(1.seconds, 10.seconds).shouldBeTrue()
+
+            lock.unlockAndReport() shouldBeEqualTo ExposedJdbcUnlockOutcome.RELEASED
+            lock.unlockAndReport() shouldBeEqualTo ExposedJdbcUnlockOutcome.NOT_HELD
+
+            transaction(db) { exec("DROP TABLE $GROUP_LOCK_TABLE_NAME") }
+            ExposedJdbcSchemaInitializer.resetFor(db)
+            val failed = ExposedJdbcGroupLock(db, randomName(), slot = 0, RetryStrategy.Jitter())
+            failed.unlockAndReport() shouldBeEqualTo ExposedJdbcUnlockOutcome.FAILED
+        } finally {
+            ExposedJdbcSchemaInitializer.ensureSchema(db)
+            cleanTables(db)
+        }
     }
 
     @ParameterizedTest

--- a/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcGroupLock.kt
+++ b/leader-exposed-r2dbc/src/main/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcGroupLock.kt
@@ -11,10 +11,13 @@ import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.currentCoroutineContext
-import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import org.jetbrains.exposed.v1.exceptions.UnsupportedByDialectException
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.greater
@@ -56,6 +59,12 @@ internal class ExposedR2dbcGroupLock internal constructor(
     private val lockOwner: String? = null,
     private val useDbTime: Boolean = false,
     private val clock: Clock = Clock.systemUTC(),
+    /**
+     * DB-time availability 상태를 갱신하는 동기 callback입니다.
+     *
+     * callback은 fail-closed 상태 전이의 일부이므로 일반 예외와
+     * [CancellationException]을 삼키지 않고 호출자에게 전파합니다.
+     */
     private val onAvailabilityChanged: (Boolean) -> Unit = {},
 ) {
     /**
@@ -73,14 +82,16 @@ internal class ExposedR2dbcGroupLock internal constructor(
         slot.requireZeroOrPositiveNumber("slot")
     }
 
-    companion object: KLoggingChannel()
+    companion object: KLoggingChannel() {
+        private val AVAILABILITY_CALLBACK_CLEANUP_TIMEOUT = 5.seconds
+    }
 
     private fun markUnavailable() {
-        if (useDbTime) runCatching { onAvailabilityChanged(false) }
+        if (useDbTime) onAvailabilityChanged(false)
     }
 
     private fun markAvailable() {
-        if (useDbTime) runCatching { onAvailabilityChanged(true) }
+        if (useDbTime) onAvailabilityChanged(true)
     }
 
     /**
@@ -105,14 +116,19 @@ internal class ExposedR2dbcGroupLock internal constructor(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Throwable) {
-                markUnavailable()
                 log.warn(e) { "DB 오류로 슬롯 순회 중단: lockName=$lockName, slot=$slot, attempt=$attempt" }
+                markUnavailablePreservingFailure(e)
                 return null
             }
 
-            // A completed DB-time operation is a positive health signal even when the
-            // slot was occupied and acquisition returned false.
-            markAvailable()
+            // 슬롯 경합으로 획득에 실패했더라도 완료된 DB-time 연산은 정상 상태 신호입니다.
+            // callback 실패는 DB 오류가 아니므로 호출자에게 그대로 관찰되어야 합니다.
+            try {
+                markAvailable()
+            } catch (e: Throwable) {
+                cleanupAfterAvailabilityCallbackFailure(acquired, e)
+                throw e
+            }
             if (acquired) {
                 log.debug { "그룹 슬롯 락 획득 성공: lockName=$lockName, slot=$slot, token=${token.take(8)}" }
                 return true
@@ -200,15 +216,16 @@ internal class ExposedR2dbcGroupLock internal constructor(
      *
      * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
      */
-    suspend fun isHeldByCurrentInstance(): Boolean =
-        runR2dbcLockOperationPreservingCancellation(
+    @Suppress("TooGenericExceptionCaught")
+    suspend fun isHeldByCurrentInstance(): Boolean {
+        val held = runR2dbcLockOperationPreservingCancellation(
             onFailure = { e ->
-                markUnavailable()
                 log.warn(e) { "isHeldByCurrentInstance DB 오류 (false 반환): lockName=$lockName, slot=$slot" }
-                false
+                markUnavailablePreservingFailure(e)
+                null
             },
         ) {
-            val held = suspendTransaction(db) {
+            suspendTransaction(db) {
                 val now = currentTime(useDbTime, clock)
                 !LeaderGroupLockTable
                     .selectAll()
@@ -220,9 +237,11 @@ internal class ExposedR2dbcGroupLock internal constructor(
                     }
                     .empty()
             }
-            markAvailable()
-            held
-        }
+        } ?: return false
+        // callback 실패가 DB 오류 fallback 경계에 포함되지 않도록 분리합니다.
+        markAvailable()
+        return held
+    }
 
     /**
      * `unlock` 호출은 Exposed database backend leader election 계약의 일부 동작을 수행합니다.
@@ -237,9 +256,10 @@ internal class ExposedR2dbcGroupLock internal constructor(
     }
 
     /**
-     * The elector needs to distinguish a confirmed lost token from a database failure before it
-     * evicts its local active-count entry. The public `unlock` keeps its 0.4.0 Unit contract.
+     * 선출기가 로컬 active-count를 제거하기 전에 토큰 소실과 DB 오류를 구분할 수 있도록 합니다.
+     * 공개 `unlock`의 0.4.0 `Unit` 반환 계약은 유지합니다.
      */
+    @Suppress("TooGenericExceptionCaught")
     internal suspend fun unlockAndReport(
         minLeaseTime: Duration = Duration.ZERO,
         acquiredAtNanos: Long = System.nanoTime(),
@@ -249,14 +269,14 @@ internal class ExposedR2dbcGroupLock internal constructor(
         val tokenVal = this@ExposedR2dbcGroupLock.token
         val remaining = remainingMinLeaseTime(acquiredAtNanos, minLeaseTime)
 
-        return runR2dbcLockOperationPreservingCancellation(
+        val unlockResult = runR2dbcLockOperationPreservingCancellation(
             onFailure = { e ->
-                markUnavailable()
                 log.warn(e) { "그룹 슬롯 해제 중 DB 오류: lockName=$lockName, slot=$slot" }
-                ExposedR2dbcUnlockOutcome.FAILED
+                markUnavailablePreservingFailure(e)
+                null
             },
         ) {
-            val (matched, timeVerified) = suspendTransaction(db) {
+            suspendTransaction(db) {
                 if (remaining > Duration.ZERO) {
                     val now = currentTime(useDbTime, clock)
                     LeaderGroupLockTable.update(
@@ -277,14 +297,17 @@ internal class ExposedR2dbcGroupLock internal constructor(
                     } to false
                 }
             }
-            if (timeVerified) markAvailable()
-            if (matched == 0) {
-                log.warn { "그룹 슬롯 해제 실패 — 토큰 불일치 또는 이미 만료됨: lockName=$lockName, slot=$slot" }
-                ExposedR2dbcUnlockOutcome.NOT_HELD
-            } else {
-                log.debug { "그룹 슬롯 해제 성공: lockName=$lockName, slot=$slot" }
-                ExposedR2dbcUnlockOutcome.RELEASED
-            }
+        } ?: return ExposedR2dbcUnlockOutcome.FAILED
+        val (matched, timeVerified) = unlockResult
+
+        // callback 실패는 transaction 실패와 구분하여 그대로 전파합니다.
+        if (timeVerified) markAvailable()
+        return if (matched == 0) {
+            log.warn { "그룹 슬롯 해제 실패 — 토큰 불일치 또는 이미 만료됨: lockName=$lockName, slot=$slot" }
+            ExposedR2dbcUnlockOutcome.NOT_HELD
+        } else {
+            log.debug { "그룹 슬롯 해제 성공: lockName=$lockName, slot=$slot" }
+            ExposedR2dbcUnlockOutcome.RELEASED
         }
     }
 
@@ -299,8 +322,14 @@ internal class ExposedR2dbcGroupLock internal constructor(
         val slotVal = this@ExposedR2dbcGroupLock.slot
         val tokenVal = this@ExposedR2dbcGroupLock.token
 
-        return try {
-            val outcome = suspendTransaction(db) {
+        val outcome = runR2dbcLockOperationPreservingCancellation(
+            onFailure = { e ->
+                log.warn(e) { "그룹 슬롯 연장 중 DB 오류: lockName=$lockName, slot=$slot" }
+                markUnavailablePreservingFailure(e)
+                throw e
+            },
+        ) {
+            suspendTransaction(db) {
                 val now = currentTime(useDbTime, clock)
                 val newLockedUntil = now.plusMillis(leaseTime.inWholeMilliseconds)
                 val updated = LeaderGroupLockTable.update(
@@ -320,13 +349,60 @@ internal class ExposedR2dbcGroupLock internal constructor(
                     ExtendOutcome.NotHeld
                 }
             }
-            markAvailable()
-            outcome
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            markUnavailable()
-            throw e
         }
+        // callback 실패가 DB 오류 fallback 경계에 포함되지 않도록 분리합니다.
+        markAvailable()
+        return outcome
+    }
+
+    /**
+     * DB-time success callback 실패 뒤에 이미 획득한 row가 남지 않도록 보상 해제합니다.
+     * callback 예외를 원인으로 유지하고 보상 해제 실패는 suppressed 예외로만 남깁니다.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun cleanupAfterAvailabilityCallbackFailure(acquired: Boolean, failure: Throwable) {
+        if (!acquired) return
+
+        val outcome = try {
+            withContext(NonCancellable) {
+                withTimeoutOrNull(AVAILABILITY_CALLBACK_CLEANUP_TIMEOUT) {
+                    unlockAndReport()
+                }
+            }
+        } catch (cleanupFailure: Throwable) {
+            failure.addSuppressedSafely(cleanupFailure)
+            return
+        }
+        when (outcome) {
+            ExposedR2dbcUnlockOutcome.FAILED -> failure.addSuppressedSafely(
+                IllegalStateException(
+                    "availability callback 보상 슬롯 해제 실패: " +
+                            "lockName=$lockName, slot=$slot",
+                ),
+            )
+            null -> failure.addSuppressedSafely(
+                IllegalStateException(
+                    "availability callback 보상 슬롯 해제 시간 초과: " +
+                            "lockName=$lockName, slot=$slot",
+                ),
+            )
+            ExposedR2dbcUnlockOutcome.RELEASED,
+            ExposedR2dbcUnlockOutcome.NOT_HELD,
+            -> Unit
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun markUnavailablePreservingFailure(failure: Throwable) {
+        try {
+            markUnavailable()
+        } catch (callbackFailure: Throwable) {
+            callbackFailure.addSuppressedSafely(failure)
+            throw callbackFailure
+        }
+    }
+
+    private fun Throwable.addSuppressedSafely(cause: Throwable) {
+        if (cause !== this && suppressed.none { it === cause }) addSuppressed(cause)
     }
 }

--- a/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcGroupLockTest.kt
+++ b/leader-exposed-r2dbc/src/test/kotlin/io/bluetape4k/leader/exposed/r2dbc/lock/ExposedR2dbcGroupLockTest.kt
@@ -10,6 +10,8 @@ import io.bluetape4k.leader.exposed.tables.LeaderGroupLockTable
 import io.bluetape4k.leader.exposed.retry.RetryStrategy
 import io.bluetape4k.logging.coroutines.KLoggingChannel
 import io.bluetape4k.logging.debug
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
@@ -34,6 +36,8 @@ import kotlin.time.Duration.Companion.seconds
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class ExposedR2dbcGroupLockTest: AbstractExposedR2dbcLeaderTest() {
 
@@ -158,33 +162,319 @@ class ExposedR2dbcGroupLockTest: AbstractExposedR2dbcLeaderTest() {
             )
         }
 
-        val tryLockSignals = mutableListOf<Boolean>()
-        dropSchema()
-        val failedTryLock = newLock(tryLockSignals)
-        failedTryLock.tryLock(Duration.ZERO, 1.seconds).shouldBeNull()
-        tryLockSignals shouldBeEqualTo listOf(false)
-        restoreSchema()
-        failedTryLock.unlockAndReport() shouldBeEqualTo ExposedR2dbcUnlockOutcome.NOT_HELD
-        // CURRENT_TIMESTAMP 없이 성공한 DELETE는 DB-time admission을 다시 열면 안 됩니다.
-        tryLockSignals shouldBeEqualTo listOf(false)
+        try {
+            val tryLockSignals = mutableListOf<Boolean>()
+            dropSchema()
+            val failedTryLock = newLock(tryLockSignals)
+            failedTryLock.tryLock(Duration.ZERO, 1.seconds).shouldBeNull()
+            tryLockSignals shouldBeEqualTo listOf(false)
+            restoreSchema()
+            failedTryLock.unlockAndReport() shouldBeEqualTo ExposedR2dbcUnlockOutcome.NOT_HELD
+            // CURRENT_TIMESTAMP 없이 성공한 DELETE는 DB-time admission을 다시 열면 안 됩니다.
+            tryLockSignals shouldBeEqualTo listOf(false)
 
-        val heldSignals = mutableListOf<Boolean>()
-        dropSchema()
-        newLock(heldSignals).isHeldByCurrentInstance().shouldBeFalse()
-        heldSignals shouldBeEqualTo listOf(false)
-        restoreSchema()
+            val heldSignals = mutableListOf<Boolean>()
+            dropSchema()
+            newLock(heldSignals).isHeldByCurrentInstance().shouldBeFalse()
+            heldSignals shouldBeEqualTo listOf(false)
+            restoreSchema()
 
-        val unlockSignals = mutableListOf<Boolean>()
-        dropSchema()
-        newLock(unlockSignals).unlockAndReport() shouldBeEqualTo ExposedR2dbcUnlockOutcome.FAILED
-        unlockSignals shouldBeEqualTo listOf(false)
-        restoreSchema()
+            val unlockSignals = mutableListOf<Boolean>()
+            dropSchema()
+            newLock(unlockSignals).unlockAndReport() shouldBeEqualTo ExposedR2dbcUnlockOutcome.FAILED
+            unlockSignals shouldBeEqualTo listOf(false)
+            restoreSchema()
 
-        val extendSignals = mutableListOf<Boolean>()
-        dropSchema()
-        assertFailsWith<Exception> { newLock(extendSignals).extendDetailed(1.seconds) }
-        extendSignals shouldBeEqualTo listOf(false)
-        restoreSchema()
+            val extendSignals = mutableListOf<Boolean>()
+            dropSchema()
+            assertFailsWith<Exception> { newLock(extendSignals).extendDetailed(1.seconds) }
+            extendSignals shouldBeEqualTo listOf(false)
+            restoreSchema()
+        } finally {
+            restoreSchema()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `DB 오류 시 availability callback 예외는 전파되고 unavailable 신호를 보존한다`(testDB: TestR2dbcDB) = runSuspendIO {
+        val db = setupDb(testDB)
+        cleanTables(db)
+        try {
+            suspendTransaction(db) { exec("DROP TABLE $GROUP_LOCK_TABLE_NAME") }
+            ExposedR2dbcSchemaInitializer.resetFor(db)
+
+            val signals = mutableListOf<Boolean>()
+            val callbackFailure = IllegalStateException("availability callback failed")
+            val lock = ExposedR2dbcGroupLock(
+                db,
+                randomName(),
+                slot = 0,
+                retryStrategy = RetryStrategy.Jitter(),
+                useDbTime = true,
+                onAvailabilityChanged = { available ->
+                    signals += available
+                    if (!available) throw callbackFailure
+                },
+            )
+
+            val thrown = assertFailsWith<IllegalStateException> {
+                lock.tryLock(Duration.ZERO, 1.seconds)
+            }
+
+            thrown shouldBeEqualTo callbackFailure
+            signals shouldBeEqualTo listOf(false)
+            thrown.suppressed.size shouldBeEqualTo 1
+            (thrown.suppressed.single() === thrown).shouldBeFalse()
+        } finally {
+            ExposedR2dbcSchemaInitializer.ensureSchema(db)
+            cleanTables(db)
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `DB 오류 시 availability callback CancellationException은 전파되고 unavailable 신호를 보존한다`(testDB: TestR2dbcDB) = runSuspendIO {
+        val db = setupDb(testDB)
+        cleanTables(db)
+        try {
+            suspendTransaction(db) { exec("DROP TABLE $GROUP_LOCK_TABLE_NAME") }
+            ExposedR2dbcSchemaInitializer.resetFor(db)
+
+            val signals = mutableListOf<Boolean>()
+            val cancellation = CancellationException("availability callback cancelled")
+            val lock = ExposedR2dbcGroupLock(
+                db,
+                randomName(),
+                slot = 0,
+                retryStrategy = RetryStrategy.Jitter(),
+                useDbTime = true,
+                onAvailabilityChanged = { available ->
+                    signals += available
+                    if (!available) throw cancellation
+                },
+            )
+
+            val thrown = assertFailsWith<CancellationException> {
+                lock.tryLock(Duration.ZERO, 1.seconds)
+            }
+
+            thrown shouldBeEqualTo cancellation
+            signals shouldBeEqualTo listOf(false)
+            thrown.suppressed.size shouldBeEqualTo 1
+            (thrown.suppressed.single() === thrown).shouldBeFalse()
+        } finally {
+            ExposedR2dbcSchemaInitializer.ensureSchema(db)
+            cleanTables(db)
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `정상 DB 연산 시 availability callback 예외도 전파된다`(testDB: TestR2dbcDB) = runSuspendIO {
+        val db = setupDb(testDB)
+        cleanTables(db)
+
+        val signals = mutableListOf<Boolean>()
+        val callbackFailure = IllegalStateException("availability recovery callback failed")
+        val lock = ExposedR2dbcGroupLock(
+            db,
+            randomName(),
+            slot = 0,
+            retryStrategy = RetryStrategy.Jitter(),
+            useDbTime = true,
+            onAvailabilityChanged = { available ->
+                signals += available
+                if (available) throw callbackFailure
+            },
+        )
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            lock.tryLock(Duration.ZERO, 1.seconds)
+        }
+
+        thrown shouldBeEqualTo callbackFailure
+        signals shouldBeEqualTo listOf(true)
+        lock.unlock()
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `isHeldByCurrentInstance - availability callback 예외는 DB 오류로 변환되지 않는다`(testDB: TestR2dbcDB) = runSuspendIO {
+        val db = setupDb(testDB)
+        cleanTables(db)
+        val callbackFailure = IllegalStateException("availability callback failed while checking ownership")
+        val lock = ExposedR2dbcGroupLock(
+            db,
+            randomName(),
+            slot = 0,
+            retryStrategy = RetryStrategy.Jitter(),
+            useDbTime = true,
+            onAvailabilityChanged = { available ->
+                if (available) throw callbackFailure
+            },
+        )
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            lock.isHeldByCurrentInstance()
+        }
+
+        thrown shouldBeEqualTo callbackFailure
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `unlockAndReport - min lease availability callback 예외는 DB 오류로 변환되지 않는다`(testDB: TestR2dbcDB) = runSuspendIO {
+        val db = setupDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val callbackFailure = IllegalStateException("availability callback failed while unlocking")
+        var failCallback = false
+        val lock = ExposedR2dbcGroupLock(
+            db,
+            lockName,
+            slot = 0,
+            retryStrategy = RetryStrategy.Jitter(),
+            useDbTime = true,
+            onAvailabilityChanged = { available ->
+                if (available && failCallback) throw callbackFailure
+            },
+        )
+        lock.tryLock(Duration.ZERO, 1.seconds).shouldNotBeNull().shouldBeTrue()
+        failCallback = true
+
+        try {
+            val thrown = assertFailsWith<IllegalStateException> {
+                lock.unlockAndReport(1.seconds)
+            }
+
+            thrown shouldBeEqualTo callbackFailure
+        } finally {
+            lock.unlock()
+            cleanTables(db)
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `tryLock - availability callback 예외 시 획득한 row를 정리하고 예외를 전파한다`(testDB: TestR2dbcDB) = runSuspendIO {
+        val db = setupDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val callbackFailure = IllegalStateException("availability callback failed after acquire")
+        val lock = ExposedR2dbcGroupLock(
+            db,
+            lockName,
+            slot = 0,
+            retryStrategy = RetryStrategy.Jitter(),
+            useDbTime = true,
+            onAvailabilityChanged = { available ->
+                if (available) throw callbackFailure
+            },
+        )
+
+        try {
+            val thrown = assertFailsWith<IllegalStateException> {
+                lock.tryLock(Duration.ZERO, 1.seconds)
+            }
+            thrown shouldBeEqualTo callbackFailure
+
+            val recovered = ExposedR2dbcGroupLock(
+                db,
+                lockName,
+                slot = 0,
+                retryStrategy = RetryStrategy.Jitter(),
+                useDbTime = true,
+            )
+            recovered.tryLock(Duration.ZERO, 1.seconds).shouldNotBeNull().shouldBeTrue()
+            recovered.unlock()
+        } finally {
+            cleanTables(db)
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `tryLock - availability callback CancellationException 시 획득한 row를 정리하고 취소를 전파한다`(testDB: TestR2dbcDB) = runSuspendIO {
+        val db = setupDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val cancellation = CancellationException("availability callback cancelled after acquire")
+        val lock = ExposedR2dbcGroupLock(
+            db,
+            lockName,
+            slot = 0,
+            retryStrategy = RetryStrategy.Jitter(),
+            useDbTime = true,
+            onAvailabilityChanged = { available ->
+                if (available) throw cancellation
+            },
+        )
+
+        try {
+            val thrown = assertFailsWith<CancellationException> {
+                lock.tryLock(Duration.ZERO, 1.seconds)
+            }
+            thrown shouldBeEqualTo cancellation
+
+            val recovered = ExposedR2dbcGroupLock(
+                db,
+                lockName,
+                slot = 0,
+                retryStrategy = RetryStrategy.Jitter(),
+                useDbTime = true,
+            )
+            recovered.tryLock(Duration.ZERO, 1.seconds).shouldNotBeNull().shouldBeTrue()
+            recovered.unlock()
+        } finally {
+            cleanTables(db)
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `tryLock - callback 실패 보상 해제의 DB 오류를 suppressed 결과로 보존한다`(testDB: TestR2dbcDB) = runSuspendIO {
+        val db = setupDb(testDB)
+        cleanTables(db)
+        val callbackEntered = CountDownLatch(1)
+        val tableDropped = CountDownLatch(1)
+        val callbackFailure = IllegalStateException("availability callback failed before compensation")
+        val dropper = async(Dispatchers.IO) {
+            callbackEntered.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            suspendTransaction(db) { exec("DROP TABLE $GROUP_LOCK_TABLE_NAME") }
+            ExposedR2dbcSchemaInitializer.resetFor(db)
+            tableDropped.countDown()
+        }
+        val lock = ExposedR2dbcGroupLock(
+            db,
+            randomName(),
+            slot = 0,
+            retryStrategy = RetryStrategy.Jitter(),
+            useDbTime = true,
+            onAvailabilityChanged = { available ->
+                if (available) {
+                    callbackEntered.countDown()
+                    tableDropped.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                    throw callbackFailure
+                }
+            },
+        )
+
+        try {
+            val thrown = assertFailsWith<IllegalStateException> {
+                lock.tryLock(Duration.ZERO, 1.seconds)
+            }
+            dropper.await()
+
+            thrown shouldBeEqualTo callbackFailure
+            thrown.suppressed
+                .any { it.message?.contains("보상 슬롯 해제 실패") == true }
+                .shouldBeTrue()
+        } finally {
+            dropper.cancel()
+            ExposedR2dbcSchemaInitializer.ensureSchema(db)
+            cleanTables(db)
+        }
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Summary

Closes #721

R2DBC group availability callback 오류가 DB fallback으로 흡수되지 않도록 경계를 분리하고, JDBC async와 R2DBC의 취소·terminal cleanup 계약을 실행 모델 전반에서 일관되게 보존합니다.

## Background

Issue #721과 milestone `1.0.0`에서 availability callback 예외·취소가 선출 상태와 감사 이력에 정확히 반영되고, unlock 결과와 원래 DB 원인이 손실되지 않아야 한다는 회귀가 확인되었습니다.

## What This Solves

- R2DBC availability callback 실패와 DB 조회 실패를 구분하고 callback 예외를 호출자에게 전파합니다.
- JDBC async 작업 및 slot 획득 취소가 terminal 감사 이력과 단일 cleanup 완료 전에 성공/실패로 조기 노출되지 않게 합니다.
- 공개 `unlock(): Unit` ABI를 유지하면서 내부 unlock 결과를 `RELEASED`, `NOT_HELD`, `FAILED`로 구분합니다.

## Work Done

- R2DBC callback 경계: 원래 DB cause를 보존하고, 획득 후 callback 실패 시 bounded `NonCancellable` 보상 unlock을 수행합니다.
- JDBC async 취소 전파: 반환 `CompletableFuture` 취소를 내부 action과 slot 획득 루프에 전달하고 terminal cleanup을 한 번만 수행합니다.
- 회귀 보호: callback 예외·취소, cleanup ordering, action/acquisition cancellation, unlock outcome 계약을 JDBC/R2DBC 테스트로 고정했습니다.
- 재발 방지: `docs/lessons/2026-08-28-issue-721-cancellation-parity.md`에 취소 경계와 ABI 보존 규칙을 기록했습니다.

## Validation

- `./gradlew :bluetape4k-leader-exposed-jdbc:test :bluetape4k-leader-exposed-r2dbc:test`: PASS (JDBC 319, R2DBC 347, failures=0, errors=0, skipped=0)
- 변경 모듈 `detekt`: PASS
- `./gradlew checkBinaryCompatibility`: PASS (`unknown=0`)
- `git diff --check`: PASS

## Review Notes

- P0/P1: 0건
- P2: 0건
- P3: 취소 직후 이미 시작한 DB transaction 또는 한 번의 retry sleep은 완료될 수 있으나 이후 획득·action은 중단되고 race-acquired slot은 즉시 해제됩니다. 차단 항목이 아닙니다.
- Review evidence: 독립 code-reviewer `APPROVE`, architect `CLEAR` (blockers=0)

## Metadata

- Issue: #721, milestone `1.0.0`, assignee `debop`
- PR: #831, head `fdd130b6965b03f6b642c42b7080617e5ddaba32`, milestone `1.0.0`, assignee `debop`
- CI: [run 33178808738](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33178808738), exact head `fdd130b6`, 20 success, 27 path-scoped N/A, failure/cancel/pending=0

## DoD Status

Required checks: 16/16; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01 - Authority | 현재 guidance와 승인 범위를 재확인 | PASS | Type C, repo `bluetape4k-leader`, base `develop`, head `fix/issue-721-r2dbc-cancellation-parity` | 없음 |
| CG-02 - Evidence | GNO와 live Issue를 조회 | PASS | Issue #721 OPEN, milestone `1.0.0` | 없음 |
| CG-03 - Boundaries | feature branch와 7개 변경 경로를 확인 | PASS | exact base `826b463c`, clean worktree | 없음 |
| CG-04 - Policy | Kotlin·한국어 공개 prose·ABI 경계를 적용 | PASS | governing AGENTS hierarchy와 selected skills | 없음 |
| CG-05 - Patterns | 기존 JDBC/R2DBC 계약과 public ABI를 재사용 | PASS | 새 dependency/공개 abstraction 없음 | 없음 |
| CG-06 - Contracts | API/문서 계약을 검증 | PASS | public `unlock(): Unit` 유지, lesson 추가 | 없음 |
| CG-07 - Targeted proof | RED/GREEN과 전체 affected tests 수행 | PASS | JDBC 319, R2DBC 347, failures/errors/skipped=0 | 없음 |
| CG-08 - Heavy checks | DB-backed 검증을 직렬 실행 | PASS | JDBC 후 R2DBC 전체 suite | 없음 |
| CG-09 - Lesson | 재발 방지 lesson 작성·검색 검증 | PASS | `docs/lessons/2026-08-28-issue-721-cancellation-parity.md` | 없음 |
| CG-10 - Pre-PR proof | 정적·ABI·독립 리뷰 수렴 | PASS | detekt PASS, ABI `unknown=0`, P0/P1/P2=0 | 없음 |
| CG-11 - PR authority | repo/base/head와 PR 생성 승인을 확인 | PASS | 사용자 승인과 workflow receipt | 없음 |
| CG-12 - Exact head push | non-force push 후 SHA read-back | PASS | local/remote `fdd130b6965b03f6b642c42b7080617e5ddaba32` | 없음 |
| CG-12A - Guidance refresh | PR 직전 AGENTS·skills·gates·template·Issue 재조회 | PASS | content hash 무변경, Issue metadata 무변경 | 없음 |
| CG-13 - PR create/read-back | PR 생성·metadata·본문 live 검증 | PASS | PR #831, exact head `fdd130b6`, assignee·labels·milestone 일치 | 없음 |
| CG-14 - CI/review | exact-head CI와 live review/thread 확인 | PASS | run `33178808738`: 20 success, 27 path-scoped N/A, 0 failure/cancel/pending; JDBC/R2DBC 6개 provider와 Spring PASS; reviews/comments/threads=0; 독립 review P0/P1=0 | human review subgate `N/A (single-developer lane: owner/assignee debop, 추가 reviewer 요청 없음)` |
| CG-15 - Merge-ready | 최종 mergeability와 DoD 확인 | PASS | PR OPEN, CLEAN, MERGEABLE, exact head `fdd130b6`, unchecked=none | fresh 명시적 병합 승인 전 정지 |

Final status: MERGE_READY - exact-head CI와 review/thread read-back 완료, 병합 승인 대기

Unchecked required items: none
