### PR TITLE
fix(leader-ktor): diagnostics route 설정을 설치 시점에 검증

### DIFF
--- a/docs/lessons/2026-08-29-issue-740-ktor-route-validation.md
+++ b/docs/lessons/2026-08-29-issue-740-ktor-route-validation.md
@@ -1,0 +1,64 @@
+# Issue #740 — Ktor diagnostics route의 timeout과 경로 충돌을 설치 시점에 검증
+
+## 맥락
+
+`LeaderElectionPlugin`은 connectivity probe를 활성화할 때 timeout이 양수이면서
+유한한지 검증했지만, public `Application.leaderBackendDiagnosticsRoute` 직접 호출은
+동일 계약을 강제하지 않았습니다. 또한 management route와 diagnostics route가
+각자 선행 slash만 보정해, `internal/leader`와 `/internal/leader`가 같은 Ktor GET
+selector로 등록될 수 있었습니다.
+
+## 원인
+
+- timeout 검증이 plugin 설정 경계에만 있어 public route 직접 호출 경계와
+  비대칭이었습니다.
+- management와 diagnostics route가 같은 정규화 규칙을 중복 구현했으며, plugin은
+  두 경로를 실제 selector로 바꾸기 전에 충돌을 비교하지 않았습니다.
+
+## 결정
+
+- `normalizeLeaderRoutePath`를 두 route와 plugin collision 검사에서 공유합니다.
+  기존 호환성을 유지하기 위해 현재 계약인 선행 slash 보정만 수행합니다.
+- `validateBackendConnectivityCheckTimeout`을 public route와 plugin이 공유합니다.
+  probe를 활성화한 경우에만 검증하고, plugin의 기존
+  `backendConnectivityCheckTimeout` 오류 메시지 토큰을 보존합니다.
+- management와 diagnostics route를 동시에 활성화하면 plugin 설치 초기에 두
+  선행 slash를 보정한 path를 비교하고 같을 때 명확한 설정 오류를 냅니다.
+- Kotlin `Duration`은 `NaN`을 표현하지 않으므로 `Double.NaN.seconds`가 route 호출
+  전에 `IllegalArgumentException`을 던지는 type-level 경계도 회귀 테스트로
+  기록합니다.
+
+## 결과
+
+public route 직접 호출과 plugin 설치가 동일한 positive/finite timeout 계약을
+사용합니다. leading slash 표기만 다른 management/diagnostics 경로는 요청 처리
+순서에 의존하지 않고 설치 단계에서 거부됩니다. 기본 경로, probe 비활성 경로,
+기존 management JSON 응답은 변경하지 않았습니다.
+
+## 검증
+
+- RED: 기존 구현의 focused test는 `17 tests, 2 failed`로 direct invalid timeout과
+  normalized route collision을 재현했습니다. NaN type-level test는 기존 Kotlin
+  `Duration` 계약에 따라 통과했습니다.
+- GREEN: 최종 `LeaderBackendDiagnosticsRouteTest`는 `17 tests`, failures/errors/skipped
+  `0`으로 통과했습니다.
+- `./gradlew :bluetape4k-leader-ktor:test --no-daemon --rerun-tasks`는 `123 tests`,
+  failures/errors/skipped `0`으로 통과했습니다.
+- Colima와 Docker context를 확인했고 Testcontainers 실행 환경은 healthy였습니다.
+- `:bluetape4k-leader-ktor:detekt`, `checkBinaryCompatibility`
+  (`artifacts=16`, `unknown=0`), `git diff --check`를 통과했습니다.
+- 이번 변경이 추가한 한국어 prose 5개 파일은 terminology `findings=0`입니다.
+  management route의 기존 KDoc `snapshot` 2건은 diff 밖의 선행 항목으로 확인해
+  이번 bounded bugfix 범위에서는 변경하지 않았습니다.
+
+## 재발 방지
+
+- 실패한 판단: public helper와 plugin이 같은 이름의 설정을 받으면 검증 계약도
+  자동으로 같을 것이라고 보았습니다.
+- 발견 증거: direct route는 invalid timeout을 등록했고, leading slash가 다른 두
+  경로는 동일 selector로 설치됐습니다.
+- 수정 결정: 선행 slash 보정과 validation을 공유 함수로 올리고 plugin이 route
+  등록 전에 충돌을 검사하도록 했습니다.
+- 향후 예방 확인: framework adapter가 public direct API와 plugin/config API를 함께
+  제공하면 기본값뿐 아니라 invalid value, 정규화 형식, 충돌 우선순위를 양쪽
+  경계의 RED 테스트로 고정합니다.

--- a/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderBackendDiagnosticsRoute.kt
+++ b/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderBackendDiagnosticsRoute.kt
@@ -7,7 +7,6 @@ import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnostics
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
 import io.bluetape4k.leader.diagnostics.LeaderBackendModeSupport
 import io.bluetape4k.leader.diagnostics.LeaderExecutionModel
-import io.bluetape4k.support.requireNotBlank
 import io.ktor.http.ContentType
 import io.ktor.server.application.Application
 import io.ktor.server.response.respondText
@@ -30,8 +29,13 @@ fun Application.leaderBackendDiagnosticsRoute(
     connectivityCheckEnabled: Boolean = false,
     connectivityCheckTimeout: Duration = LeaderBackendDiagnosticsProvider.DefaultProbeTimeout,
 ) {
-    path.requireNotBlank("path")
-    val routePath = if (path.startsWith("/")) path else "/$path"
+    val routePath = normalizeLeaderRoutePath(path)
+    if (connectivityCheckEnabled) {
+        validateBackendConnectivityCheckTimeout(
+            timeout = connectivityCheckTimeout,
+            propertyName = "connectivityCheckTimeout",
+        )
+    }
 
     routing {
         get(routePath) {
@@ -47,6 +51,13 @@ fun Application.leaderBackendDiagnosticsRoute(
                 contentType = ContentType.Application.Json,
             )
         }
+    }
+}
+
+/** Connectivity probe timeout의 public route 계약을 검증합니다. */
+internal fun validateBackendConnectivityCheckTimeout(timeout: Duration, propertyName: String) {
+    require(timeout.isFinite() && timeout.isPositive()) {
+        "${propertyName}은 양수이면서 유한해야 합니다: $timeout"
     }
 }
 

--- a/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderElectionManagementRoute.kt
+++ b/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderElectionManagementRoute.kt
@@ -3,7 +3,6 @@ package io.bluetape4k.leader.ktor
 import io.bluetape4k.leader.coroutines.SuspendLeaderElector
 import io.bluetape4k.leader.ktor.statuspages.respondLeaderElectionError
 import io.bluetape4k.leader.validateLockName
-import io.bluetape4k.support.requireNotBlank
 import io.ktor.http.ContentType
 import io.ktor.server.application.Application
 import io.ktor.server.response.respondText
@@ -55,8 +54,7 @@ fun Application.leaderElectionManagementRoute(
     leaderElection: SuspendLeaderElector = resolveLeaderElection(),
     registry: LeaderElectionManagementRegistry = leaderElectionPluginConfig().managementRegistry,
 ) {
-    path.requireNotBlank("path")
-    val routePath = if (path.startsWith("/")) path else "/$path"
+    val routePath = normalizeLeaderRoutePath(path)
 
     routing {
         get(routePath) {

--- a/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderElectionPlugin.kt
+++ b/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderElectionPlugin.kt
@@ -27,6 +27,7 @@ val LeaderElectionPlugin = createApplicationPlugin(
     val leaderElection = requireNotNull(config.leaderElection) {
         "LeaderElectionPlugin 설치 전 leaderElection 을 반드시 설정해야 합니다."
     }
+    validateManagementDiagnosticsRoutePathCollision(config)
 
     // 외부 (예: leaderScheduled 확장) 에서 설정에 접근할 수 있도록 Application attributes 에 저장한다.
     application.attributes.put(LeaderElectionConfigKey, config)
@@ -74,11 +75,10 @@ val LeaderElectionPlugin = createApplicationPlugin(
             "backendDiagnosticsRouteEnabled=true 이면 leaderElection 이 backend diagnostics provider를 제공해야 합니다."
         }
         if (config.backendConnectivityCheckEnabled) {
-            val timeout = config.backendConnectivityCheckTimeout
-            require(timeout.isFinite() && timeout.isPositive()) {
-                "backendConnectivityCheckTimeout은 양수이면서 유한해야 합니다: " +
-                        timeout
-            }
+            validateBackendConnectivityCheckTimeout(
+                timeout = config.backendConnectivityCheckTimeout,
+                propertyName = "backendConnectivityCheckTimeout",
+            )
         }
         application.leaderBackendDiagnosticsRoute(
             path = config.backendDiagnosticsRoutePath,
@@ -114,6 +114,16 @@ val LeaderElectionPlugin = createApplicationPlugin(
             }
         }
         resourceRegistry.close()
+    }
+}
+
+private fun validateManagementDiagnosticsRoutePathCollision(config: LeaderElectionPluginConfig) {
+    if (!config.managementRouteEnabled || !config.backendDiagnosticsRouteEnabled) return
+
+    val managementPath = normalizeLeaderRoutePath(config.managementRoutePath)
+    val diagnosticsPath = normalizeLeaderRoutePath(config.backendDiagnosticsRoutePath)
+    require(managementPath != diagnosticsPath) {
+        "managementRoutePath와 backendDiagnosticsRoutePath는 서로 다른 route여야 합니다: $managementPath"
     }
 }
 

--- a/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderRoutePath.kt
+++ b/leader-ktor/src/main/kotlin/io/bluetape4k/leader/ktor/LeaderRoutePath.kt
@@ -1,0 +1,9 @@
+package io.bluetape4k.leader.ktor
+
+import io.bluetape4k.support.requireNotBlank
+
+/** Ktor leader route 경로를 선행 slash가 있는 형식으로 정규화합니다. */
+internal fun normalizeLeaderRoutePath(path: String): String {
+    path.requireNotBlank("path")
+    return if (path.startsWith('/')) path else "/$path"
+}

--- a/leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/LeaderBackendDiagnosticsRouteTest.kt
+++ b/leader-ktor/src/test/kotlin/io/bluetape4k/leader/ktor/LeaderBackendDiagnosticsRouteTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.ktor
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.ktor.testing.shouldHaveStatus
 import io.bluetape4k.leader.coroutines.LocalSuspendLeaderElector
@@ -27,6 +28,7 @@ import java.util.concurrent.CancellationException
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class LeaderBackendDiagnosticsRouteTest {
 
@@ -89,6 +91,35 @@ class LeaderBackendDiagnosticsRouteTest {
             elector.probeCalls.get() shouldBeEqualTo 1
             elector.lastTimeout shouldBeEqualTo 275.milliseconds
         }
+    }
+
+    @Test
+    fun `direct diagnostics route는 양수이면서 유한한 probe timeout만 허용한다`() = runSuspendIO {
+        listOf(Duration.ZERO, (-1).milliseconds, Duration.INFINITE).forEach { timeout ->
+            val error = assertFailsWith<IllegalArgumentException> {
+                testApplication {
+                    application {
+                        leaderBackendDiagnosticsRoute(
+                            provider = RecordingDiagnosticsElector(),
+                            connectivityCheckEnabled = true,
+                            connectivityCheckTimeout = timeout,
+                        )
+                    }
+                    startApplication()
+                }
+            }
+
+            error.message.orEmpty() shouldContain "connectivityCheckTimeout은 양수이면서 유한해야 합니다"
+        }
+    }
+
+    @Test
+    fun `NaN probe timeout은 Kotlin Duration 경계에서 생성되지 않는다`() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            Double.NaN.seconds
+        }
+
+        error.message.orEmpty() shouldContain "Duration value cannot be NaN"
     }
 
     @Test
@@ -274,6 +305,33 @@ class LeaderBackendDiagnosticsRouteTest {
             val response = client.get("/internal/leader-backend")
 
             response shouldHaveStatus HttpStatusCode.OK
+        }
+    }
+
+    @Test
+    fun `management와 diagnostics route가 정규화 후 같으면 plugin 설치에 실패한다`() = runSuspendIO {
+        listOf(
+            "/internal/leader" to "/internal/leader",
+            "internal/leader" to "/internal/leader",
+            "/internal/leader" to "internal/leader",
+        ).forEach { (managementPath, diagnosticsPath) ->
+            val error = assertFailsWith<IllegalArgumentException> {
+                testApplication {
+                    application {
+                        install(LeaderElectionPlugin) {
+                            leaderElection = RecordingDiagnosticsElector()
+                            managementRouteEnabled = true
+                            managementRoutePath = managementPath
+                            backendDiagnosticsRouteEnabled = true
+                            backendDiagnosticsRoutePath = diagnosticsPath
+                        }
+                    }
+                    startApplication()
+                }
+            }
+
+            error.message.orEmpty() shouldContain
+                    "managementRoutePath와 backendDiagnosticsRoutePath는 서로 다른 route여야 합니다"
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #740

Ktor backend diagnostics route의 잘못된 probe timeout과 management route 경로 충돌을 요청 처리 전에 검증합니다.

## Background

direct diagnostics API는 `0`, 음수, 무한 timeout을 받아 요청 시점까지 오류를 늦췄고, plugin은 선행 slash 표기가 다른 동일 GET route를 함께 등록할 수 있었습니다.

## What This Solves

- connectivity probe가 활성화되면 direct API와 plugin 모두 양수이면서 유한한 timeout만 허용합니다.
- `internal/leader`와 `/internal/leader`를 같은 route로 판정해 management/diagnostics 충돌을 설치 시점에 차단합니다.
- 기존 plugin validation 순서와 오류 메시지 토큰을 유지합니다.

## Work Done

- management와 diagnostics route가 공유하는 선행 slash 정규화 함수를 추가했습니다.
- connectivity timeout validation을 공유해 public direct API와 plugin 계약을 맞췄습니다.
- invalid timeout, Kotlin `Duration`의 NaN 생성 경계, literal/정규화 경로 충돌 회귀 테스트를 추가했습니다.
- 원인, 결정, 검증, 재발 방지 규칙을 운영 교훈 문서로 남겼습니다.

## Validation

- baseline focused test: RED (`17 tests`, `2 failed`)
- `./gradlew :bluetape4k-leader-ktor:test --tests '*LeaderBackendDiagnosticsRouteTest' --rerun-tasks`: PASS (`17 tests`, failures/errors/skipped `0`)
- `./gradlew :bluetape4k-leader-ktor:test --rerun-tasks`: PASS (`123 tests`, failures/errors/skipped `0`)
- `./gradlew :bluetape4k-leader-ktor:detekt`: PASS
- `./gradlew checkBinaryCompatibility`: PASS (`artifacts=16`, `ignored=10`, `unknown=0`)
- Korean terminology audit: PASS (`5 files`, `findings=0`)
- `git diff --check origin/develop...HEAD`: PASS
- Docker/Testcontainers environment: Colima healthy, Docker server `29.2.1`, override `/var/run/docker.sock`

## Review Notes

- code-reviewer: CRITICAL/HIGH/MEDIUM/LOW `0`, `APPROVE`
- architect: 차단 결함 `0`, `CLEAR`
- 설계 리뷰의 비차단 명확성 제안 2건을 반영한 뒤 두 리뷰어가 최종 트리를 재확인했습니다.

## Metadata

- Issue: #740, milestone `1.0.0`, assignee `debop`, labels `bug`, `integration`, `test`
- PR: #833, non-draft, `MERGEABLE`, review threads `0`
- Base/head: `develop` ← `fix/issue-740-ktor-route-validation`
- Exact head: `575bbd3aff007c37687aa357b2f0de4c8fb0695d`
- CI: [run 33189906976](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33189906976) PASS (실행 대상 `12/12 success`, failed/cancelled `0`; path-filter 의도된 skip `35`를 `CI Status`가 검증)

## DoD Status

Required checks: 8/9; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-03 - RED/GREEN | 결함 재현 후 수정 구현 검증 | PASS | RED 17/2, GREEN 17/0/skipped=0 | 없음 |
| C-05 - Type C verification | 모듈 test, detekt, ABI, diff, 용어 감사 | PASS | 123/0/skipped=0, detekt PASS, ABI unknown=0 | 없음 |
| CG-08 - Heavyweight backends | Docker/Testcontainers 경로 검증 | PASS | Colima healthy, leader-ktor 123/123, skipped=0 | 없음 |
| CG-10 - Preflight | base/head/scope/worktree/중복 PR 확인 | PASS | `origin/develop` → `575bbd3a`, clean 6-file diff, 중복 원격 head/PR 없음 | 없음 |
| CG-12A - Guidance refresh | 현재 AGENTS 계층, workflow, Type C leaf, common gates, Kotlin checklist, PR template, issue #740 재확인 | PASS | current hashes 및 live issue metadata read-back, drift 없음 | 없음 |
| CG-13 - PR delivery | 승인된 base/head로 PR 생성 및 metadata read-back | PASS | PR #833, `develop` ← authorized head, SHA·assignee·labels·milestone 일치 | 없음 |
| CG-14 - Exact-head CI | PR head의 모든 required check를 terminal 상태로 확인 | PASS | run 33189906976, exact `575bbd3a`, 실행 대상 12/12 success, failed/cancelled 0, intended skips 검증 | 없음 |
| CG-15 - Review convergence | review와 unresolved thread 확인 | PASS | 로컬 이중 재검토 전 등급 0, architect CLEAR, GitHub threads 0 | 없음 |
| CG-16 - Fresh merge approval | exact-head evidence 뒤 별도 merge 승인 확인 | PENDING | merge는 현재 요청 범위 밖 | 병합 전 fresh 승인 필요 |

Final status: DONE — PR #833 생성, exact-head CI, review convergence 완료; merge는 CG-16 fresh 승인 전까지 대기

Unchecked required items: CG-16
