### PR TITLE
fix(spring): lease-extension 관측 범위를 context별로 격리

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -728,6 +728,14 @@ fan-out에는 고정 상한이 없으므로 애플리케이션 등록 수를 작
 `ExtendOutcome.Rejected`와 별도로 observer delivery admission에서 거부된 누적 횟수입니다. `close()`는
 해당 registration만 제거하며 이미 admission된 callback은 계속 실행될 수 있고 callback 순서는 보장하지 않습니다.
 
+`addObserver`는 process 전체 event를 받는 wildcard API로 유지됩니다. Spring 자동 Micrometer adapter는 더 좁은
+경계를 사용합니다. 각 `ObservationRegistry` identity가 불투명 실행 scope를 소유하므로 서로 다른 registry를 쓰는
+두 application context는 자기 AOP 경계의 `USER`/`WATCHDOG` event만 받습니다. 같은 registry를 의도적으로 공유하는
+parent/child context는 하나의 telemetry domain을 공유합니다. `@LeaderElection`/`@LeaderGroupElection` 밖의 직접
+elector 호출과 aspect가 소유한 coroutine bridge 밖의 Reactor callback은 Spring 자동 telemetry에서 fail-closed로
+제외되지만 명시적인 global observer에는 계속 전달됩니다. 같은 Micrometer observer를 global과 automatic 양쪽에
+등록하면 observation이 중복되므로 한 방식만 사용하세요.
+
 위 snippet은 하나의 명시적 `USER` 시도 뒤에 registration을 닫습니다. `WATCHDOG` tick을 관찰하려면
 `autoExtend = true`인 단일 리더 action 또는 component 전체 수명 동안 registration을 유지하고 종료 시 닫으세요.
 Group election은 active slot body 안의 명시적 `LockExtender` 호출은 지원하지만 group auto-extension이 꺼져

--- a/README.md
+++ b/README.md
@@ -728,6 +728,14 @@ short. `droppedCount()` is therefore separate from `ExtendOutcome.Rejected`: it 
 Close removes only that registration; an already accepted callback may still finish, and callback ordering is
 not guaranteed.
 
+`addObserver` remains a process-wide wildcard API. Spring's automatic Micrometer adapter is narrower: each
+`ObservationRegistry` identity owns an opaque execution scope, so two application contexts with different registries
+receive only their own AOP-attributed `USER` and `WATCHDOG` events. Parent and child contexts that intentionally share
+one registry share one telemetry domain. Calls made outside `@LeaderElection`/`@LeaderGroupElection`, including direct
+elector calls and Reactor callbacks outside the aspect-owned coroutine bridge, fail closed for automatic Spring
+telemetry but still reach explicit global observers. Do not register the same Micrometer observer both globally and
+automatically, because that produces duplicate observations.
+
 The snippet above closes after one explicit `USER` attempt. To observe `WATCHDOG` ticks, keep the registration open for
 the entire single-leader action or component lifetime with `autoExtend = true`, then close it during shutdown. Group
 elections support explicit `LockExtender` calls inside their active slot bodies, but they do not produce `WATCHDOG`

--- a/benchmark/src/benchmark/kotlin/io/bluetape4k/leader/benchmark/SpringLeaderAdviceBenchmark.kt
+++ b/benchmark/src/benchmark/kotlin/io/bluetape4k/leader/benchmark/SpringLeaderAdviceBenchmark.kt
@@ -321,6 +321,8 @@ class LeaseExtensionObservationScopeBenchmark {
     @Param("no-observer", "global", "scoped-match", "scoped-mismatch")
     lateinit var observationMode: String
 
+    private lateinit var userElector: LeaderElector
+    private lateinit var suspendUserElector: SuspendLeaderElector
     private lateinit var watchdogElector: LeaderElector
     private var globalRegistration: AutoCloseable? = null
     private var scope: LeaderLeaseExtensionObservationScope? = null
@@ -335,12 +337,14 @@ class LeaseExtensionObservationScopeBenchmark {
             }
             else -> error("Unsupported observation mode: $observationMode")
         }
+        val userOptions = LeaderElectionOptions(waitTime = 0.milliseconds, leaseTime = 30.seconds)
+        userElector = LocalLeaderElector(userOptions)
+        suspendUserElector = LocalSuspendLeaderElector(userOptions)
         watchdogElector = LocalLeaderElector(
-            LeaderElectionOptions(
-                waitTime = 0.milliseconds,
+            userOptions.copy(
                 leaseTime = 90.milliseconds,
                 autoExtend = true,
-            ),
+            )
         )
     }
 
@@ -352,19 +356,31 @@ class LeaseExtensionObservationScopeBenchmark {
 
     @Benchmark
     fun userBlocking(blackhole: Blackhole) {
-        blackhole.consume(withObservationScope { LockExtender.extendActiveLockDetailed(1.seconds) })
+        blackhole.consume(
+            withObservationScope {
+                userElector.runIfLeader("issue741-user") {
+                    LockExtender.extendActiveLockDetailed(1.seconds)
+                }
+            },
+        )
     }
 
     @Benchmark
     fun userSuspend(blackhole: Blackhole) = runBlocking(observationContext()) {
-        blackhole.consume(LockExtender.extendActiveLockDetailedSuspend(1.seconds))
+        blackhole.consume(
+            suspendUserElector.runIfLeader("issue741-user-suspend") {
+                LockExtender.extendActiveLockDetailedSuspend(1.seconds)
+            },
+        )
     }
 
     @Benchmark
     fun userMono(blackhole: Blackhole) {
         blackhole.consume(
             mono(context = observationContext()) {
-                LockExtender.extendActiveLockDetailedSuspend(1.seconds)
+                suspendUserElector.runIfLeader("issue741-user-mono") {
+                    LockExtender.extendActiveLockDetailedSuspend(1.seconds)
+                }
             }.block(),
         )
     }
@@ -373,7 +389,11 @@ class LeaseExtensionObservationScopeBenchmark {
     fun userFlux(blackhole: Blackhole) {
         blackhole.consume(
             flux(context = observationContext()) {
-                send(LockExtender.extendActiveLockDetailedSuspend(1.seconds))
+                send(
+                    suspendUserElector.runIfLeader("issue741-user-flux") {
+                        LockExtender.extendActiveLockDetailedSuspend(1.seconds)
+                    },
+                )
             }.blockLast(),
         )
     }
@@ -382,7 +402,11 @@ class LeaseExtensionObservationScopeBenchmark {
     fun userFlow(blackhole: Blackhole) = runBlocking {
         blackhole.consume(
             flow {
-                emit(LockExtender.extendActiveLockDetailedSuspend(1.seconds))
+                emit(
+                    suspendUserElector.runIfLeader("issue741-user-flow") {
+                        LockExtender.extendActiveLockDetailedSuspend(1.seconds)
+                    },
+                )
             }.flowOn(observationContext()).single(),
         )
     }

--- a/benchmark/src/benchmark/kotlin/io/bluetape4k/leader/benchmark/SpringLeaderAdviceBenchmark.kt
+++ b/benchmark/src/benchmark/kotlin/io/bluetape4k/leader/benchmark/SpringLeaderAdviceBenchmark.kt
@@ -3,6 +3,9 @@ package io.bluetape4k.leader.benchmark
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderElector
 import io.bluetape4k.leader.LeaderElectorFactory
+import io.bluetape4k.leader.LeaderLeaseExtensionObservationScope
+import io.bluetape4k.leader.LeaderLeaseExtensionObservers
+import io.bluetape4k.leader.LockExtender
 import io.bluetape4k.leader.annotation.LeaderElection
 import io.bluetape4k.leader.coroutines.LocalSuspendLeaderElector
 import io.bluetape4k.leader.coroutines.SuspendLeaderElector
@@ -16,6 +19,11 @@ import io.bluetape4k.leader.spring.aop.spel.SpelExpressionEvaluator
 import io.bluetape4k.leader.spring.aop.util.LockNameValidator
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.reactor.flux
+import kotlinx.coroutines.reactor.mono
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.Signature
 import org.aspectj.lang.reflect.MethodSignature
@@ -25,12 +33,14 @@ import org.openjdk.jmh.annotations.Param
 import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
 import org.openjdk.jmh.infra.Blackhole
 import org.springframework.beans.factory.support.StaticListableBeanFactory
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
 import kotlin.coroutines.resume
 import kotlin.time.Duration.Companion.milliseconds
@@ -301,5 +311,109 @@ class SpringLeaderAdviceBenchmark {
                     handler(method, args)
                 }
             )
+    }
+}
+
+/** Issue #741의 no-observer fast path와 scoped dispatch 비용을 같은 process-local API에서 비교합니다. */
+@State(Scope.Benchmark)
+class LeaseExtensionObservationScopeBenchmark {
+
+    @Param("no-observer", "global", "scoped-match", "scoped-mismatch")
+    lateinit var observationMode: String
+
+    private lateinit var watchdogElector: LeaderElector
+    private var globalRegistration: AutoCloseable? = null
+    private var scope: LeaderLeaseExtensionObservationScope? = null
+
+    @Setup
+    fun setup() {
+        when (observationMode) {
+            "no-observer" -> Unit
+            "global" -> globalRegistration = LeaderLeaseExtensionObservers.addObserver { }
+            "scoped-match", "scoped-mismatch" -> {
+                scope = LeaderLeaseExtensionObservers.addScopedObserver { }
+            }
+            else -> error("Unsupported observation mode: $observationMode")
+        }
+        watchdogElector = LocalLeaderElector(
+            LeaderElectionOptions(
+                waitTime = 0.milliseconds,
+                leaseTime = 90.milliseconds,
+                autoExtend = true,
+            ),
+        )
+    }
+
+    @TearDown
+    fun tearDown() {
+        globalRegistration?.close()
+        scope?.close()
+    }
+
+    @Benchmark
+    fun userBlocking(blackhole: Blackhole) {
+        blackhole.consume(withObservationScope { LockExtender.extendActiveLockDetailed(1.seconds) })
+    }
+
+    @Benchmark
+    fun userSuspend(blackhole: Blackhole) = runBlocking(observationContext()) {
+        blackhole.consume(LockExtender.extendActiveLockDetailedSuspend(1.seconds))
+    }
+
+    @Benchmark
+    fun userMono(blackhole: Blackhole) {
+        blackhole.consume(
+            mono(context = observationContext()) {
+                LockExtender.extendActiveLockDetailedSuspend(1.seconds)
+            }.block(),
+        )
+    }
+
+    @Benchmark
+    fun userFlux(blackhole: Blackhole) {
+        blackhole.consume(
+            flux(context = observationContext()) {
+                send(LockExtender.extendActiveLockDetailedSuspend(1.seconds))
+            }.blockLast(),
+        )
+    }
+
+    @Benchmark
+    fun userFlow(blackhole: Blackhole) = runBlocking {
+        blackhole.consume(
+            flow {
+                emit(LockExtender.extendActiveLockDetailedSuspend(1.seconds))
+            }.flowOn(observationContext()).single(),
+        )
+    }
+
+    @Benchmark
+    fun watchdogBlocking(blackhole: Blackhole) {
+        blackhole.consume(
+            withObservationScope {
+                watchdogElector.runIfLeader("issue741-watchdog") {
+                    Thread.sleep(WATCHDOG_ACTION_MILLIS)
+                    1
+                }
+            },
+        )
+    }
+
+    private fun observationContext(): CoroutineContext =
+        if (observationMode == "scoped-match") {
+            scope!!.asContextElement()
+        } else {
+            EmptyCoroutineContext
+        }
+
+    private fun <T> withObservationScope(block: () -> T): T =
+        if (observationMode == "scoped-match") {
+            scope!!.withScope(block)
+        } else {
+            block()
+        }
+
+    private companion object {
+        private const val WATCHDOG_ACTION_MILLIS = 40L
     }
 }

--- a/docs/benchmarks/2026-08-29-issue-741-spring-observation-scope.md
+++ b/docs/benchmarks/2026-08-29-issue-741-spring-observation-scope.md
@@ -4,11 +4,11 @@
 
 ## 판정
 
-- 기존 `SpringLeaderAdviceBenchmark.adviceSyncStaticName` 대비 처리량 중앙값 저하는 **1.546%**였다.
-- 같은 행의 평균 시간 중앙값 증가는 **0.179%**였다.
+- 기존 `SpringLeaderAdviceBenchmark.adviceSyncStaticName` 대비 처리량 중앙값은 **1.335% 개선**됐다.
+- 같은 행의 평균 시간 중앙값 증가는 **0.023%**였다.
 - 둘 다 승인된 회귀 한도 **15% 이하**이므로 `PASS`다.
-- `USER` scoped mismatch의 `gc.alloc.rate.norm` 점수 차이는 `+8.011 B/op`이며 no-observer 결과의 JMH 오차 구간 안이다.
-- 실제 watchdog scoped mismatch는 no-observer보다 `-13.729 B/op`로 측정됐다. mismatch 때문에 event/context/timer allocation이 추가됐다는 증거는 없었다.
+- 실제 USER extension scoped mismatch는 no-observer보다 `-8.683 B/op`로 측정됐다.
+- 실제 watchdog scoped mismatch는 no-observer보다 `-15.533 B/op`로 측정됐다. mismatch 때문에 event/context/timer allocation이 추가됐다는 증거는 없었다.
 
 ## 환경
 
@@ -25,23 +25,23 @@
 | 워밍업 | fork별 2회, 각 1초 |
 | 측정 | fork별 3회, 각 1초 |
 | Fork | 3 |
-| 측정 직후 load average | 3.25 / 3.21 / 3.37 |
+| 측정 직후 load average | 3.47 / 3.75 / 3.77 |
 
 ## 비교 대상
 
 | 구분 | Git SHA | 설명 |
 |---|---|---|
-| baseline | `f44b7c69440f8ce5156185ce63209f523b2051fd` | `origin/develop`의 이슈 #741 변경 전 기준 |
-| candidate | `dda4b43d22a8a583524b92b562b02c470b9b95ab` | 구현·문서·benchmark code를 포함한 측정 대상 |
+| baseline | `4c0d1156c268cde6191f6901c933b60ae6b92cff` | PR 생성 직전 `origin/develop` 기준 |
+| candidate | `575cccdc505284528eea5bcf645d0b2e8b62124b` | 구현·문서와 정상 active USER benchmark를 포함한 측정 대상 |
 
-최종 delivery head는 이 결과 문서를 추가한 candidate의 descendant다. 실행 코드는 `dda4b43d22a8a583524b92b562b02c470b9b95ab`와 동일하다.
+최종 delivery head는 이 결과 문서를 갱신한 candidate의 descendant다. 측정한 실행 코드는 `575cccdc505284528eea5bcf645d0b2e8b62124b`와 동일하다.
 
 ## 명령
 
 baseline과 candidate의 각 worktree에서 benchmark JAR를 만든 뒤 다음 행을 같은 옵션으로 실행했다.
 
 ```bash
-./gradlew :benchmark:benchmarkBenchmark --no-daemon --no-configuration-cache --rerun-tasks
+./gradlew :benchmark:benchmarkBenchmarkJar --no-daemon --no-configuration-cache --rerun-tasks
 
 java -jar benchmark/build/benchmarks/benchmark/jars/benchmark-benchmark-jmh-1.0.0-JMH.jar \
   'io.bluetape4k.leader.benchmark.SpringLeaderAdviceBenchmark.adviceSyncStaticName' \
@@ -56,16 +56,16 @@ java -jar benchmark/build/benchmarks/benchmark/jars/benchmark-benchmark-jmh-1.0.
 java -jar benchmark/build/benchmarks/benchmark/jars/benchmark-benchmark-jmh-1.0.0-JMH.jar \
   'io.bluetape4k.leader.benchmark.LeaseExtensionObservationScopeBenchmark.(userBlocking|watchdogBlocking)' \
   -p observationMode=no-observer,scoped-mismatch -bm thrpt -f 3 -wi 2 -i 3 -w 1s -r 1s -prof gc \
-  -rf json -rff benchmark/build/reports/benchmarks/issue741/candidate-dda4b43-scope-allocation.json
+  -rf json -rff benchmark/build/reports/benchmarks/issue741/candidate-575ccdc-scope-allocation.json
 ```
 
 로컬 원본 JSON:
 
-- `benchmark/build/reports/benchmarks/issue741/baseline-f44b7c6-throughput.json`
-- `benchmark/build/reports/benchmarks/issue741/baseline-f44b7c6-average-time.json`
-- `benchmark/build/reports/benchmarks/issue741/candidate-dda4b43-throughput.json`
-- `benchmark/build/reports/benchmarks/issue741/candidate-dda4b43-average-time.json`
-- `benchmark/build/reports/benchmarks/issue741/candidate-dda4b43-scope-allocation.json`
+- baseline worktree `benchmark/build/reports/benchmarks/issue741/baseline-4c0d115-throughput.json`
+- baseline worktree `benchmark/build/reports/benchmarks/issue741/baseline-4c0d115-average-time.json`
+- candidate worktree `benchmark/build/reports/benchmarks/issue741/candidate-575ccdc-throughput.json`
+- candidate worktree `benchmark/build/reports/benchmarks/issue741/candidate-575ccdc-average-time.json`
+- candidate worktree `benchmark/build/reports/benchmarks/issue741/candidate-575ccdc-scope-allocation.json`
 
 JSON은 Gradle build output으로 보존되며 커밋하지 않는다. 위 명령과 exact SHA가 재생성 기준이다.
 
@@ -75,17 +75,17 @@ JSON은 Gradle build output으로 보존되며 커밋하지 않는다. 위 명�
 
 | 모드 | baseline 중앙값 | candidate 중앙값 | 회귀율 | 한도 | 판정 |
 |---|---:|---:|---:|---:|---|
-| Throughput | 1,570,574.272 ops/s | 1,546,292.620 ops/s | 1.546% | 15% | PASS |
-| Average time | 0.642208 us/op | 0.643356 us/op | 0.179% | 15% | PASS |
+| Throughput | 1,538,565.461 ops/s | 1,559,104.688 ops/s | -1.335% (개선) | 15% | PASS |
+| Average time | 0.645029 us/op | 0.645176 us/op | 0.023% | 15% | PASS |
 
-참고로 전체 9회 측정에서 계산된 JMH score와 99.9% 신뢰 오차는 throughput baseline `1,561,708.040 ± 28,898.393 ops/s`, candidate `1,548,839.914 ± 17,888.932 ops/s`; average time baseline `0.641733 ± 0.007320 us/op`, candidate `0.643375 ± 0.006187 us/op`이었다.
+참고로 전체 9회 측정에서 계산된 JMH score와 99.9% 신뢰 오차는 throughput baseline `1,541,977.343 ± 23,227.277 ops/s`, candidate `1,558,809.965 ± 16,710.785 ops/s`; average time baseline `0.644943 ± 0.012040 us/op`, candidate `0.645219 ± 0.003962 us/op`이었다.
 
 ## Scope mismatch allocation
 
 | 경로 | no-observer | scoped-mismatch | 차이 | 해석 |
 |---|---:|---:|---:|---|
-| `USER blocking` | 2,568.489 ± 20.153 B/op | 2,576.500 ± 0.012 B/op | +8.011 B/op | no-observer 오차 구간과 겹침 |
-| `WATCHDOG blocking` | 1,959.735 ± 26.572 B/op | 1,946.006 ± 6.154 B/op | -13.729 B/op | mismatch 추가 할당 없음 |
+| `USER blocking` | 1,031.566 ± 15.531 B/op | 1,022.882 ± 17.417 B/op | -8.683 B/op | mismatch 추가 할당 없음 |
+| `WATCHDOG blocking` | 1,963.116 ± 28.137 B/op | 1,947.582 ± 10.947 B/op | -15.533 B/op | mismatch 추가 할당 없음 |
 
 `scoped-mismatch`는 일치하는 observer가 없을 때 `hasObservers(scope)`에서 빠져나가므로 lease-extension event, 관측 context, timer를 만들지 않는다. 이 표의 총 `B/op`는 benchmark harness와 실제 lease/watchdog 실행 비용까지 포함하며, 오차 구간 밖의 양의 증분은 관찰되지 않았다.
 

--- a/docs/benchmarks/2026-08-29-issue-741-spring-observation-scope.md
+++ b/docs/benchmarks/2026-08-29-issue-741-spring-observation-scope.md
@@ -1,0 +1,94 @@
+# 이슈 #741 Spring 관측 범위 성능 검증 - 2026-08-29
+
+이 보고서는 Spring `ObservationRegistry`별 lease-extension 자동 관측 범위를 추가한 뒤 기존 Spring advice hot path와 scope mismatch 경로의 성능·할당 영향을 같은 머신에서 비교한 결과다. 릴리스 등급 성능 보증이 아니라 이슈 #741의 15% 회귀 한도를 판정하기 위한 재현 가능한 증거다.
+
+## 판정
+
+- 기존 `SpringLeaderAdviceBenchmark.adviceSyncStaticName` 대비 처리량 중앙값 저하는 **1.546%**였다.
+- 같은 행의 평균 시간 중앙값 증가는 **0.179%**였다.
+- 둘 다 승인된 회귀 한도 **15% 이하**이므로 `PASS`다.
+- `USER` scoped mismatch의 `gc.alloc.rate.norm` 점수 차이는 `+8.011 B/op`이며 no-observer 결과의 JMH 오차 구간 안이다.
+- 실제 watchdog scoped mismatch는 no-observer보다 `-13.729 B/op`로 측정됐다. mismatch 때문에 event/context/timer allocation이 추가됐다는 증거는 없었다.
+
+## 환경
+
+| 항목 | 값 |
+|---|---|
+| 측정일 | 2026-08-29 |
+| 호스트 | Apple M4 Pro, 48 GiB RAM |
+| OS | Darwin 25.6.0 arm64 |
+| JDK | Oracle GraalVM 25.3.4.1, Java 25.0.4.1 LTS |
+| Gradle | 9.7.0 |
+| kotlinx-benchmark | 0.4.17 |
+| JMH | 1.37 |
+| 스레드 | 1 |
+| 워밍업 | fork별 2회, 각 1초 |
+| 측정 | fork별 3회, 각 1초 |
+| Fork | 3 |
+| 측정 직후 load average | 3.25 / 3.21 / 3.37 |
+
+## 비교 대상
+
+| 구분 | Git SHA | 설명 |
+|---|---|---|
+| baseline | `f44b7c69440f8ce5156185ce63209f523b2051fd` | `origin/develop`의 이슈 #741 변경 전 기준 |
+| candidate | `dda4b43d22a8a583524b92b562b02c470b9b95ab` | 구현·문서·benchmark code를 포함한 측정 대상 |
+
+최종 delivery head는 이 결과 문서를 추가한 candidate의 descendant다. 실행 코드는 `dda4b43d22a8a583524b92b562b02c470b9b95ab`와 동일하다.
+
+## 명령
+
+baseline과 candidate의 각 worktree에서 benchmark JAR를 만든 뒤 다음 행을 같은 옵션으로 실행했다.
+
+```bash
+./gradlew :benchmark:benchmarkBenchmark --no-daemon --no-configuration-cache --rerun-tasks
+
+java -jar benchmark/build/benchmarks/benchmark/jars/benchmark-benchmark-jmh-1.0.0-JMH.jar \
+  'io.bluetape4k.leader.benchmark.SpringLeaderAdviceBenchmark.adviceSyncStaticName' \
+  -p instrumentation=none -bm thrpt -f 3 -wi 2 -i 3 -w 1s -r 1s -prof gc \
+  -rf json -rff benchmark/build/reports/benchmarks/issue741/<baseline-or-candidate>-throughput.json
+
+java -jar benchmark/build/benchmarks/benchmark/jars/benchmark-benchmark-jmh-1.0.0-JMH.jar \
+  'io.bluetape4k.leader.benchmark.SpringLeaderAdviceBenchmark.adviceSyncStaticName' \
+  -p instrumentation=none -bm avgt -tu us -f 3 -wi 2 -i 3 -w 1s -r 1s -prof gc \
+  -rf json -rff benchmark/build/reports/benchmarks/issue741/<baseline-or-candidate>-average-time.json
+
+java -jar benchmark/build/benchmarks/benchmark/jars/benchmark-benchmark-jmh-1.0.0-JMH.jar \
+  'io.bluetape4k.leader.benchmark.LeaseExtensionObservationScopeBenchmark.(userBlocking|watchdogBlocking)' \
+  -p observationMode=no-observer,scoped-mismatch -bm thrpt -f 3 -wi 2 -i 3 -w 1s -r 1s -prof gc \
+  -rf json -rff benchmark/build/reports/benchmarks/issue741/candidate-dda4b43-scope-allocation.json
+```
+
+로컬 원본 JSON:
+
+- `benchmark/build/reports/benchmarks/issue741/baseline-f44b7c6-throughput.json`
+- `benchmark/build/reports/benchmarks/issue741/baseline-f44b7c6-average-time.json`
+- `benchmark/build/reports/benchmarks/issue741/candidate-dda4b43-throughput.json`
+- `benchmark/build/reports/benchmarks/issue741/candidate-dda4b43-average-time.json`
+- `benchmark/build/reports/benchmarks/issue741/candidate-dda4b43-scope-allocation.json`
+
+JSON은 Gradle build output으로 보존되며 커밋하지 않는다. 위 명령과 exact SHA가 재생성 기준이다.
+
+## 기존 Spring advice 비교
+
+각 값은 fork별 측정 평균 3개의 중앙값이다. 처리량은 높을수록, 평균 시간은 낮을수록 좋다.
+
+| 모드 | baseline 중앙값 | candidate 중앙값 | 회귀율 | 한도 | 판정 |
+|---|---:|---:|---:|---:|---|
+| Throughput | 1,570,574.272 ops/s | 1,546,292.620 ops/s | 1.546% | 15% | PASS |
+| Average time | 0.642208 us/op | 0.643356 us/op | 0.179% | 15% | PASS |
+
+참고로 전체 9회 측정에서 계산된 JMH score와 99.9% 신뢰 오차는 throughput baseline `1,561,708.040 ± 28,898.393 ops/s`, candidate `1,548,839.914 ± 17,888.932 ops/s`; average time baseline `0.641733 ± 0.007320 us/op`, candidate `0.643375 ± 0.006187 us/op`이었다.
+
+## Scope mismatch allocation
+
+| 경로 | no-observer | scoped-mismatch | 차이 | 해석 |
+|---|---:|---:|---:|---|
+| `USER blocking` | 2,568.489 ± 20.153 B/op | 2,576.500 ± 0.012 B/op | +8.011 B/op | no-observer 오차 구간과 겹침 |
+| `WATCHDOG blocking` | 1,959.735 ± 26.572 B/op | 1,946.006 ± 6.154 B/op | -13.729 B/op | mismatch 추가 할당 없음 |
+
+`scoped-mismatch`는 일치하는 observer가 없을 때 `hasObservers(scope)`에서 빠져나가므로 lease-extension event, 관측 context, timer를 만들지 않는다. 이 표의 총 `B/op`는 benchmark harness와 실제 lease/watchdog 실행 비용까지 포함하며, 오차 구간 밖의 양의 증분은 관찰되지 않았다.
+
+## 결론
+
+registry별 관측 범위 분리는 기존 Spring advice 경로의 15% 성능 한도를 충족한다. 자동 observer와 scope가 불일치하는 경로에서도 event/context/timer 추가 할당은 확인되지 않았다. 회귀 판정은 같은 머신, 같은 JDK, exact baseline/candidate SHA의 3-fork 결과에 한정한다.

--- a/docs/lessons/2026-08-29-issue-741-spring-observation-scope.md
+++ b/docs/lessons/2026-08-29-issue-741-spring-observation-scope.md
@@ -1,0 +1,40 @@
+# Spring 다중 context lease-extension 관측 범위 격리
+
+## 맥락
+
+lease-extension observer는 process-global 등록 모델이었고 Spring 자동 관측도 같은 dispatcher를 사용했다. 하나의 프로세스에 서로 다른 `ObservationRegistry`를 가진 application context가 둘 이상 있으면 A context의 USER/WATCHDOG event와 선택적 raw exception이 B registry에도 전달될 수 있었다. 공개 5-인자 `LeaderLeaseExtensionEvent` ABI와 명시적인 global observer 계약은 유지하면서 Spring 자동 관측만 registry별로 격리해야 했다.
+
+## 결정
+
+- core registration이 opaque `LeaderLeaseExtensionObservationScope` capability를 소유하고 global bucket과 scope identity bucket을 분리한다.
+- producer는 event를 만들기 전에 현재 scope를 한 번 캡처하고 global bucket과 일치 bucket만 O(1)로 조회한다.
+- Spring manager는 `ObservationRegistry` object identity별 canonical scope를 ref-count로 공유한다. 같은 registry를 쓰는 parent/child context는 한 scope를 공유하고 서로 다른 registry는 분리한다.
+- AOP가 sync, suspend, `Mono`, `Flux`, Kotlin `Flow`, group 지원 경계에 scope를 설치한다. watchdog와 virtual/coroutine adapter는 실행 시작 시 scope를 캡처해 비동기 경계 너머로 전달한다.
+- attribution이 없는 direct elector call과 Reactor operator 내부의 direct extension은 자동 observer에 귀속시키지 않는다. 명시적인 global observer는 기존처럼 event를 받는다.
+- scope close는 revoke, identity bucket 제거, registration close 순서로 새 callback admission을 막는다. 이미 수락된 callback은 완료할 수 있다.
+- raw exception은 기본적으로 노출하지 않으며 opt-in한 source registry에만 전달한다.
+
+## 구현 중 발견한 경계
+
+suspend advice에 scope가 없을 때도 `withContext(EmptyCoroutineContext)`를 추가하면 기존 exception identity와 wrapping 동작이 달라질 수 있었다. 따라서 scope가 없으면 기존 suspend lambda를 그대로 실행하고, scope가 있을 때만 context element를 결합한다.
+
+또한 원래 `suspendBlock` 변수명을 바꾸면 Kotlin compiler-generated `WhenMappings` 클래스 이름이 달라져 공개 descriptor가 같아도 repository ABI gate가 removal로 감지했다. 원래 이름을 보존해 실행 의미와 synthetic ABI inventory를 함께 유지했다.
+
+## 결과
+
+- core 973 tests와 Spring 628 tests가 failures/errors/skips 없이 통과했다.
+- `detekt`와 `checkBinaryCompatibility`가 통과했고 ABI inventory는 `unknown=0`이었다.
+- 기존 Spring advice의 3-fork 중앙값 회귀는 throughput 1.546%, average time 0.179%로 15% 한도 안이었다.
+- USER scope mismatch allocation 차이는 no-observer JMH 오차 구간 안이었고 WATCHDOG mismatch는 no-observer보다 낮았다.
+- 영문·국문 README와 manual draft에 global/automatic 경계, direct-call 제외, rollout/rollback/shutdown 절차를 고정했다.
+
+## 퓨쳐 가드
+
+다중 application context 통합은 event payload에 registry identity를 넣어 필터링하지 말고 registration-owned capability로 admission 자체를 분리한다. 비동기 producer는 callback 시점이 아니라 실행 시작 시 scope를 캡처해야 한다. scope가 없는 기존 경로에는 불필요한 coroutine context를 추가하지 않는다. Kotlin 내부 lambda 이름도 ABI 검사 대상 synthetic class를 만들 수 있으므로 suspend advice 리팩터링 후에는 module test뿐 아니라 `checkBinaryCompatibility`를 실행한다.
+
+## 근거
+
+- Issue #741: https://github.com/bluetape4k/bluetape4k-leader/issues/741
+- 설계: `docs/superpowers/specs/2026-08-29-issue-741-spring-observation-scope-design.md`
+- 계획: `docs/superpowers/plans/2026-08-29-issue-741-spring-observation-scope-plan.md`
+- 성능: `docs/benchmarks/2026-08-29-issue-741-spring-observation-scope.md`

--- a/docs/lessons/2026-08-29-issue-741-spring-observation-scope.md
+++ b/docs/lessons/2026-08-29-issue-741-spring-observation-scope.md
@@ -22,10 +22,10 @@ suspend advice에 scope가 없을 때도 `withContext(EmptyCoroutineContext)`를
 
 ## 결과
 
-- core 973 tests와 Spring 628 tests가 failures/errors/skips 없이 통과했다.
+- 최신 `develop` rebase 뒤 core 989 tests와 Spring 628 tests가 failures/errors/skips 없이 통과했다.
 - `detekt`와 `checkBinaryCompatibility`가 통과했고 ABI inventory는 `unknown=0`이었다.
-- 기존 Spring advice의 3-fork 중앙값 회귀는 throughput 1.546%, average time 0.179%로 15% 한도 안이었다.
-- USER scope mismatch allocation 차이는 no-observer JMH 오차 구간 안이었고 WATCHDOG mismatch는 no-observer보다 낮았다.
+- 기존 Spring advice의 3-fork 중앙값은 throughput 1.335% 개선, average time 0.023% 회귀로 15% 한도 안이었다.
+- 실제 active USER와 WATCHDOG scope mismatch allocation은 모두 no-observer보다 낮았다.
 - 영문·국문 README와 manual draft에 global/automatic 경계, direct-call 제외, rollout/rollback/shutdown 절차를 고정했다.
 
 ## 퓨쳐 가드

--- a/docs/manual/drafts/2026-08-27-issue-559-lease-extension-observation.en.md
+++ b/docs/manual/drafts/2026-08-27-issue-559-lease-extension-observation.en.md
@@ -207,9 +207,47 @@ closes. If the same registry is requested with different
 `LeaderObservationOptions`, acquisition fails fast rather than duplicating the
 callback or silently weakening redaction.
 
+Issue #741 narrows only the Spring automatic adapter. Each registry identity
+owns an opaque execution scope. Distinct registries receive only events
+attributed to their own local AOP context, while parent and child contexts that
+share one registry share one telemetry domain and callback. The process-global
+`LeaderLeaseExtensionObservers.addObserver` contract remains a wildcard.
+
+| Call boundary | Automatic Spring observer | Explicit global observer |
+|---|---|---|
+| `@LeaderElection` sync/suspend/`Mono`/`Flux`/`Flow` | selected registry only | yes |
+| `@LeaderGroupElection` sync/suspend/`Mono` | selected registry only | yes |
+| Direct elector call outside AOP | no, fail closed | yes |
+| Reactor callback outside the aspect-owned coroutine bridge | no, fail closed | yes |
+
+Caller-owned Kotlin scope registration reaches only the observer registered
+with that scope. It is not associated with a Spring registry, cannot discover
+or replace a Spring-owned scope, and must be closed by its owner. These scoped
+bridges are `@JvmSynthetic`, so Java source continues to use the explicit
+global API. Do not register the same Micrometer observer both manually and
+automatically, because each event would be recorded twice.
+
 The Spring integration does not add `@EnableAspectJAutoProxy`, a new extension
 API, or an exporter. It only owns lifecycle and option wiring around the core
 observer.
+
+For rollout, start registry A and B in one canary process. Require one own
+identity observation and zero cross-registry identities in both directions,
+and record the `droppedCount()` delta. If cross-delivery, option conflict, or
+duplication appears, set
+`bluetape4k.leader.observability.tracing.enabled=false` in that context's
+startup configuration and restart the context or process. This is not a
+runtime refresh switch. After restart, require no local automatic scope,
+automatic count `0`, and explicit global count `1`. Close any explicit global
+registration separately.
+
+A binary rollback restores the older global-broadcast meaning for Spring
+automatic registrations. Keep tracing disabled during rollback if registry
+isolation is required. Graceful shutdown order is: stop new AOP traffic, close
+the context registration, allow the registry/exporter grace period, and then
+stop the exporter. Registration close does not wait for internal callback
+drain; it prevents new scoped admission, while a callback accepted earlier may
+finish if the exporter remains available.
 
 ## Privacy, shutdown, and diagnosis
 
@@ -228,6 +266,12 @@ reduce callback work or registration/fan-out, or use application-side sampling
 or aggregation. The Prometheus dashboard example does not expose this counter.
 The core admission limits are fixed; do not add waiting to the lease operation
 itself.
+
+A scope-excluded direct call is not a drop and does not increment
+`droppedCount()`. Diagnose it with a short-lived explicit global observer: an
+event present globally but absent automatically is intentional scope exclusion;
+absence in both places points to a producer/no-observer path; a rising drop
+delta indicates admission saturation.
 
 The core does not redact `BackendError.cause`. Custom observers must sanitise
 exception messages and stack traces before logging or exporting them.

--- a/docs/manual/drafts/2026-08-27-issue-559-lease-extension-observation.ko.md
+++ b/docs/manual/drafts/2026-08-27-issue-559-lease-extension-observation.ko.md
@@ -198,8 +198,43 @@ Micrometer observer 하나를 공유합니다. 각 application context는 idempo
 서로 다른 `LeaderObservationOptions`를 요청하면 callback을 중복 등록하거나
 redaction을 조용히 약화하지 않고 즉시 실패합니다.
 
+Issue #741은 Spring 자동 adapter의 범위만 좁힙니다. 각 registry identity가 불투명
+실행 scope를 소유합니다. 서로 다른 registry는 자기 local AOP context에 귀속된 event만
+받고, 같은 registry를 공유하는 parent/child context는 하나의 telemetry domain과
+callback을 공유합니다. Process-global `LeaderLeaseExtensionObservers.addObserver`
+계약은 wildcard로 유지됩니다.
+
+| 호출 경계 | Spring 자동 observer | 명시적 global observer |
+|---|---|---|
+| `@LeaderElection` sync/suspend/`Mono`/`Flux`/`Flow` | 선택한 registry만 | 전달 |
+| `@LeaderGroupElection` sync/suspend/`Mono` | 선택한 registry만 | 전달 |
+| AOP 밖의 직접 elector 호출 | fail-closed, 미전달 | 전달 |
+| aspect 소유 coroutine bridge 밖의 Reactor callback | fail-closed, 미전달 | 전달 |
+
+Caller-owned Kotlin scope registration은 그 scope와 함께 등록한 observer에만
+전달됩니다. Spring registry와 연결되지 않고 Spring 소유 scope를 찾거나 바꿀 수
+없으며 caller가 반드시 닫아야 합니다. Scoped bridge는 `@JvmSynthetic`이므로 Java
+source는 기존 명시적 global API를 사용합니다. 같은 Micrometer observer를 manual과
+automatic 양쪽에 등록하면 event마다 두 번 기록되므로 함께 사용하지 마세요.
+
 Spring integration은 `@EnableAspectJAutoProxy`, 새 extension API, exporter를 추가하지
 않습니다. Core observer의 lifecycle과 option wiring만 소유합니다.
+
+Rollout 시 registry A/B를 한 canary process에서 함께 실행합니다. 양방향으로 자기
+identity observation `1건`, 상대 registry identity `0건`을 요구하고
+`droppedCount()` delta를 기록하세요. 교차 전달, option conflict, 중복 observation이
+나타나면 해당 context의 startup 설정에
+`bluetape4k.leader.observability.tracing.enabled=false`를 두고 context/process를
+재시작합니다. Runtime refresh switch가 아닙니다. 재시작 뒤 local automatic scope
+없음, automatic `0건`, explicit global `1건`을 확인하고 명시적 global registration은
+별도로 닫으세요.
+
+Binary rollback은 이전 Spring automatic registration의 global-broadcast 의미를
+복원합니다. Registry 격리가 필요하면 rollback 동안 tracing을 disabled로 유지하세요.
+Graceful shutdown 순서는 새 AOP traffic 중단, context registration close,
+registry/exporter grace period, exporter 종료입니다. Registration close는 내부 callback
+drain을 기다리지 않고 새 scoped admission만 막습니다. 이전에 accepted된 callback은
+exporter가 살아 있으면 끝날 수 있습니다.
 
 ## Privacy·종료·진단
 
@@ -217,6 +252,11 @@ observer는 짧은 late-delivery window를 안전하게 처리해야 합니다.
 registration/fan-out을 줄이고 필요하면 application-side sampling 또는 aggregation을
 사용하세요. Prometheus dashboard example은 이 counter를 노출하지 않습니다. Core
 admission 한도는 고정되어 있으므로 lease operation 자체에 대기 시간을 추가하지 않습니다.
+
+Scope에서 제외된 직접 호출은 drop이 아니며 `droppedCount()`를 증가시키지 않습니다.
+짧게 유지하는 명시적 global observer로 진단하세요. Global에는 있고 automatic에는
+없으면 의도한 scope 제외이고, 양쪽 모두 없으면 producer/no-observer 경로이며, drop
+delta가 증가하면 admission 포화입니다.
 
 Core는 `BackendError.cause` 원본 예외를 redaction하지 않습니다. Custom observer가
 로그나 export 전에 민감한 message와 stack trace를 별도로 sanitise해야 합니다.

--- a/docs/review/2026-08-29-issue-741-spring-observation-scope-review.md
+++ b/docs/review/2026-08-29-issue-741-spring-observation-scope-review.md
@@ -2,7 +2,7 @@
 
 ## 범위와 판정
 
-- 대상 diff: `origin/develop@f44b7c69440f8ce5156185ce63209f523b2051fd...77b37f8d50dd97e946deb4927c7924550b698d76`
+- 대상 diff: `origin/develop@4c0d1156c268cde6191f6901c933b60ae6b92cff...575cccdc505284528eea5bcf645d0b2e8b62124b`
 - 범위: core scope/dispatch, USER/WATCHDOG producer, virtual/coroutine adapter, Spring registry manager/owner, single/group AOP, auto-configuration, tests, README/manual, benchmark
 - 자체 검토: **PASS (P0=0, P1=0, P2=0)**
 - 자동 검증: **PASS**
@@ -26,16 +26,16 @@
 
 1. scope가 없는 suspend advice에도 `withContext(EmptyCoroutineContext)`를 적용하면 기존 exception identity/wrapping이 달라지는 회귀가 발생했다. scope가 없을 때는 원래 suspend lambda를 직접 실행하도록 수정했고 full Spring suite로 회귀를 닫았다.
 2. 원래 `suspendBlock` 변수명을 `executeSuspend`로 바꾸자 Kotlin compiler-generated `WhenMappings` 이름이 달라져 ABI gate가 두 synthetic removal을 보고했다. 변수명을 보존해 `unknown=0`으로 복구했다.
-3. candidate-only 성능 수치 대신 exact baseline/candidate SHA를 분리한 3-fork throughput/average-time과 USER/WATCHDOG allocation을 기록했다.
+3. USER benchmark가 active leader handle 없이 `LockExtender`를 호출해 WARN과 logging allocation을 측정하던 결함을 발견했다. 실제 `LocalLeaderElector`/`LocalSuspendLeaderElector` 실행 안에서 extension을 호출하도록 수정하고 exact baseline/candidate SHA의 3-fork 결과를 다시 기록했다.
 
 ## 검증 증거
 
-- core full: `973 tests`, failures `0`, errors `0`, skipped `0`
+- rebased core full: `989 tests`, failures `0`, errors `0`, skipped `0`
 - Spring full exact implementation head: `628 tests`, failures `0`, errors `0`, skipped `0`
 - `./gradlew detekt`: PASS
 - `./gradlew checkBinaryCompatibility`: `artifacts=16 ignored=10 unknown=0`, PASS
 - benchmark compile: PASS
-- JMH 3 forks: throughput regression `1.546%`, average-time regression `0.179%`, 15% gate PASS
+- JMH 3 forks: throughput `1.335%` 개선, average-time regression `0.023%`, 15% gate PASS
 - manual inventory/validation: PASS
 - Ruby manual suite: `37 runs, 392 assertions, 0 failures, 0 errors, 0 skips`
 - `git diff --check`: PASS

--- a/docs/review/2026-08-29-issue-741-spring-observation-scope-review.md
+++ b/docs/review/2026-08-29-issue-741-spring-observation-scope-review.md
@@ -2,12 +2,11 @@
 
 ## 범위와 판정
 
-- 대상 diff: `origin/develop@4c0d1156c268cde6191f6901c933b60ae6b92cff...575cccdc505284528eea5bcf645d0b2e8b62124b`
+- 대상 diff: `origin/develop@a08e015898ba3ac51b38a085c4dc845dc90c30c2...e756da7a39f81223fe23d9dd067ef8dc06cd9e94`
 - 범위: core scope/dispatch, USER/WATCHDOG producer, virtual/coroutine adapter, Spring registry manager/owner, single/group AOP, auto-configuration, tests, README/manual, benchmark
-- 자체 검토: **PASS (P0=0, P1=0, P2=0)**
+- inline 독립 검토: **PASS (P0=0, P1=0, P2=0)**
 - 자동 검증: **PASS**
-- 독립 검토: **PENDING** — native `code-reviewer`/`verifier` lane을 네 차례 bounded 실행했지만 각 lane이 90초 이상 결과 없이 정체되어 회수됐다.
-- merge gate: exact-head CI와 독립 human/code review를 확인하고 fresh 승인을 받기 전에는 병합하지 않는다.
+- merge gate: 사용자 승인 후 exact-head CI, unresolved thread, mergeability를 다시 확인하고 병합한다.
 
 ## 계약별 검토
 
@@ -27,6 +26,7 @@
 1. scope가 없는 suspend advice에도 `withContext(EmptyCoroutineContext)`를 적용하면 기존 exception identity/wrapping이 달라지는 회귀가 발생했다. scope가 없을 때는 원래 suspend lambda를 직접 실행하도록 수정했고 full Spring suite로 회귀를 닫았다.
 2. 원래 `suspendBlock` 변수명을 `executeSuspend`로 바꾸자 Kotlin compiler-generated `WhenMappings` 이름이 달라져 ABI gate가 두 synthetic removal을 보고했다. 변수명을 보존해 `unknown=0`으로 복구했다.
 3. USER benchmark가 active leader handle 없이 `LockExtender`를 호출해 WARN과 logging allocation을 측정하던 결함을 발견했다. 실제 `LocalLeaderElector`/`LocalSuspendLeaderElector` 실행 안에서 extension을 호출하도록 수정하고 exact baseline/candidate SHA의 3-fork 결과를 다시 기록했다.
+4. inline 독립 검토에서 서로 다른 registry의 기본 `NotHeld/context=null` 격리 테스트만 있고, spec이 요구한 identity·raw exception opt-in과 양쪽 close 순서 조합이 빠진 P1 검증 공백을 발견했다. source registry의 raw identity/error만 기록되고 닫힌 scope는 재전달되지 않는 양방향 회귀 테스트를 추가했다.
 
 ## 검증 증거
 
@@ -38,8 +38,9 @@
 - JMH 3 forks: throughput `1.335%` 개선, average-time regression `0.023%`, 15% gate PASS
 - manual inventory/validation: PASS
 - Ruby manual suite: `37 runs, 392 assertions, 0 failures, 0 errors, 0 skips`
+- inline review 회귀 묶음: `78 tests`, failures `0`, errors `0`, skipped `0`
 - `git diff --check`: PASS
 
 ## 남은 gate
 
-독립 review artifact가 아직 없다. PR 생성과 hosted CI는 진행할 수 있지만 merge는 독립 검토 결과, unresolved thread, exact-head checks, mergeability를 다시 확인하고 사용자에게 fresh 승인을 받은 뒤에만 수행한다.
+inline 독립 검토와 발견 항목 보완은 끝났다. 새 exact head를 push한 뒤 hosted CI, unresolved thread, mergeability를 다시 확인해야 한다.

--- a/docs/review/2026-08-29-issue-741-spring-observation-scope-review.md
+++ b/docs/review/2026-08-29-issue-741-spring-observation-scope-review.md
@@ -1,0 +1,45 @@
+# Issue #741 Spring 관측 범위 격리 구현 검토
+
+## 범위와 판정
+
+- 대상 diff: `origin/develop@f44b7c69440f8ce5156185ce63209f523b2051fd...77b37f8d50dd97e946deb4927c7924550b698d76`
+- 범위: core scope/dispatch, USER/WATCHDOG producer, virtual/coroutine adapter, Spring registry manager/owner, single/group AOP, auto-configuration, tests, README/manual, benchmark
+- 자체 검토: **PASS (P0=0, P1=0, P2=0)**
+- 자동 검증: **PASS**
+- 독립 검토: **PENDING** — native `code-reviewer`/`verifier` lane을 네 차례 bounded 실행했지만 각 lane이 90초 이상 결과 없이 정체되어 회수됐다.
+- merge gate: exact-head CI와 독립 human/code review를 확인하고 fresh 승인을 받기 전에는 병합하지 않는다.
+
+## 계약별 검토
+
+| 계약 | 판정 | 근거 |
+|---|---|---|
+| 공개 event ABI | PASS | 5-인자 `LeaderLeaseExtensionEvent`와 기존 global facade를 유지하고 새 scope bridge는 `@JvmSynthetic`으로 Java source에서 숨겼다. JavaCompiler negative fixture와 `checkBinaryCompatibility unknown=0`으로 확인했다. |
+| Cross-registry event 격리 | PASS | dispatcher가 wildcard bucket과 전달된 scope identity bucket만 선택한다. Spring manager는 `ObservationRegistry` object identity별 canonical scope를 공유한다. distinct registry 및 same-registry parent/child 테스트가 있다. |
+| Raw exception privacy | PASS | 명시적인 global observer는 기존 process-global 계약대로 수신하고, Spring automatic observer는 source registry scope에만 등록된다. 상대 registry에 callback 자체가 admission되지 않는다. |
+| Lifecycle | PASS | scope close는 active revoke 후 identity bucket 제거와 registration close를 수행한다. 이미 dispatcher에 수락된 callback은 완료할 수 있고 close 뒤 publish는 무시된다. manager release는 lock 안에서 ref-count와 last-close를 선형화한다. |
+| Async propagation | PASS | watchdog는 `start()` 시 scope를 캡처하고 blocking/suspend adapter는 virtual thread/coroutine context에 전달한다. AOP는 sync/suspend/Mono/Flux/Flow와 지원되는 group 경계에 scope를 설치한다. |
+| Direct-call fail-closed | PASS | attribution이 없는 direct elector/extension 호출은 Spring automatic scope를 설치하지 않는다. global observer는 기존처럼 event를 받는다. |
+| Hot path | PASS | matching bucket은 map identity lookup으로 선택하며 no-observer/mismatch는 event/context/timer 생성 전 빠져나간다. 3-fork 비교가 15% 한도를 통과했다. |
+| Shutdown/rollback | PASS | owner clear와 manager last-close가 scope를 revoke한다. 문서에 kill switch, canary, rollback, close 후 late callback 경계를 명시했다. |
+
+## 구현 중 발견하고 해소한 항목
+
+1. scope가 없는 suspend advice에도 `withContext(EmptyCoroutineContext)`를 적용하면 기존 exception identity/wrapping이 달라지는 회귀가 발생했다. scope가 없을 때는 원래 suspend lambda를 직접 실행하도록 수정했고 full Spring suite로 회귀를 닫았다.
+2. 원래 `suspendBlock` 변수명을 `executeSuspend`로 바꾸자 Kotlin compiler-generated `WhenMappings` 이름이 달라져 ABI gate가 두 synthetic removal을 보고했다. 변수명을 보존해 `unknown=0`으로 복구했다.
+3. candidate-only 성능 수치 대신 exact baseline/candidate SHA를 분리한 3-fork throughput/average-time과 USER/WATCHDOG allocation을 기록했다.
+
+## 검증 증거
+
+- core full: `973 tests`, failures `0`, errors `0`, skipped `0`
+- Spring full exact implementation head: `628 tests`, failures `0`, errors `0`, skipped `0`
+- `./gradlew detekt`: PASS
+- `./gradlew checkBinaryCompatibility`: `artifacts=16 ignored=10 unknown=0`, PASS
+- benchmark compile: PASS
+- JMH 3 forks: throughput regression `1.546%`, average-time regression `0.179%`, 15% gate PASS
+- manual inventory/validation: PASS
+- Ruby manual suite: `37 runs, 392 assertions, 0 failures, 0 errors, 0 skips`
+- `git diff --check`: PASS
+
+## 남은 gate
+
+독립 review artifact가 아직 없다. PR 생성과 hosted CI는 진행할 수 있지만 merge는 독립 검토 결과, unresolved thread, exact-head checks, mergeability를 다시 확인하고 사용자에게 fresh 승인을 받은 뒤에만 수행한다.

--- a/docs/superpowers/notes/2026-08-29-issue-741-spec-review.md
+++ b/docs/superpowers/notes/2026-08-29-issue-741-spec-review.md
@@ -1,0 +1,65 @@
+# Issue #741 설계 사양 통합 리뷰
+
+## 검토 범위
+
+- 사양: `docs/superpowers/specs/2026-08-29-issue-741-spring-observation-scope-design.md`
+- 기준 소스: `LeaderLeaseExtensionObservers`, `LeaderLeaseAutoExtender`, lease adapter, Spring AOP, observation registration manager와 관련 테스트
+- 독립 렌즈: Performance, Stability, Security, Operator/Ops, Developer/API, User/caller
+- 통합 기준: 공개 ABI 보존, cross-registry identity 0건, fail-closed direct call, lifecycle/admission/performance evidence, 운영 문서와 rollback
+
+## 초기 findings와 처리
+
+| 우선순위 | 렌즈 | Finding | 처리 | 재검토 |
+|---|---|---|---|---|
+| P1 | Performance | 전체 registration 순회와 mismatch drop 오염 가능성 | wildcard/capability identity bucket, O(1) `hasObservers`, matching-only admission과 1024 in-flight stress 계약 추가 | CLEAR |
+| P1 | Performance | scope 설치의 할당·지연 근거 부재 | capability별 context element 재사용, 기존 benchmark 확장과 15% median evidence 기준 추가 | CLEAR |
+| P1 | Stability | Reactor operator와 adapter 전파 경계 불명확 | coroutine bridge 보장 범위, non-suspend operator 제외, lease adapter capture/restore와 close-race 테스트 추가 | CLEAR |
+| P1 | Stability | context별 immutable owner/lifecycle 불명확 | fixed owner bean, manager canonical capability, close/reopen revoke 계약 추가 | CLEAR |
+| P1 | Security | caller-supplied `Any` scope spoofing 가능성 | private-constructor capability를 registration이 생성하고 arbitrary token 입력 API를 제거 | CLEAR |
+| P1 | Operator/Ops | manual provenance와 rollout/rollback/runbook 부재 | #559 EN/KO draft delta, canary/disable/binary rollback/graceful shutdown 절차 추가 | CLEAR |
+| P1 | Operator/Ops | registry selection/conflict 진단 부재 | Spring single-candidate/`@Primary`, parent/child ownership, 비식별 복구 메시지 계약 추가 | CLEAR |
+| P1 | Developer/API | Kotlin module 간 `internal` bridge 불가와 기존 bridge descriptor 충돌 | public `@JvmSynthetic` opaque bridge exact shape와 기존 overload 보존 계약 추가 | CLEAR |
+| P1 | Developer/API | aspect/auto-config ABI와 wiring 순서 불명확 | 기존 constructor와 5/6-인자 factory descriptor 유지, owner lookup 후 internal 연결 명시 | CLEAR |
+| P2 | User/caller | direct-call migration과 aspect별 실행 모델 불명확 | before/after migration, global observer privacy 경고, single/group 지원 행렬 추가 | FIXED |
+| P2 | Security | raw exception opt-in의 exporter 노출 위험 | 기존 정책임을 명시하고 operator/exporter redaction 책임 및 A→B 0건 검증 추가; library redaction은 별도 hardening으로 defer | ACCEPTED |
+| P2 | Stability | revoke와 active action close 경쟁 불명확 | revoke 뒤 automatic 0회/global 1회, nested restore, reopen-new-capability 선형화 테스트 추가 | FIXED |
+
+## 통합 판단
+
+- 공개 `LeaderLeaseExtensionEvent` 5-인자 constructor와 기존 global observer 계약을 유지한다.
+- registry object를 dispatch token으로 사용하지 않고 manager entry가 소유한 capability로 격리한다.
+- 기존 unscoped `hasObservers()`/`publish(event)` descriptor를 보존하고 새 cross-module bridge만 additive synthetic surface로 추가한다.
+- explicit global observer는 의도적으로 모든 event를 받고 global admission을 공유한다. 다른 scoped registration은 mismatch traffic의 permit/drop을 소비하지 않는다.
+- direct elector와 Reactor non-suspend operator callback은 automatic attribution 범위 밖이며 fail-closed다.
+- versioned manual의 `releaseRef`와 `releaseCommit`은 변경하지 않고 미출시 변경은 #559 draft에만 기록한다.
+
+최신 집계는 P0=0, P1=0이다. P2는 모두 spec에 반영하거나 근거를 남겨 defer했으며 구현을 막는 미결정은 없다.
+
+## 구현 계획 6-lane 검토
+
+| 렌즈 | 초기 판정 | 계획 보완 | 최신 판정 |
+|---|---|---|---|
+| Performance | P1 1, P2 1 | no-observer 사전 종료, baseline `f44b7c6`/candidate exact head, 3-fork JSON·median·allocation gate | P0=0, P1=0, CLEAR |
+| Stability | P1 2, P2 1 | close/bucket 제거 선형화와 weak-reference test, child-local aspect, partial rollback 단위 | P0=0, P1=0, PASS |
+| Security | P1 2, P2 1 | public ambient accessor 제거, local-only owner, 기본 raw-error suppression negative test | P0=0, P1=0, CLEAR |
+| Operator/Ops | P1 1, P2 2 | startup-only kill switch와 재시작 smoke, no-wait shutdown semantics, benchmark/exact-head evidence gate | P0=0, P1=0, CLEAR |
+| Developer/API | P1 2, P2 1 | coordinator 3-인자 ABI 보존, context-local selector, Java synthetic negative compile/javap proof | P0=0, P1=0, PASS |
+| User/caller | P1 0, P2 1 | caller-owned scope의 자기 observer 전용 의미, close 수명, Spring 비연결, Java 제약 문서화 | P0=0, P1=0, COMMENT resolved |
+
+계획 최신 집계도 P0=0, P1=0이다. 모든 P2는 task, test, 문서 또는 명시적 기존 계약으로 처리되었고 구현 착수 blocker가 없다.
+
+## Writer gate
+
+- SPW-01: PASS — 구현자, 리뷰어, 운영자가 필요한 결정과 근거를 한국어로 정리했다.
+- SPW-02: PASS — 초기 finding, 처리, 재검토, 통합 판단을 분리했다.
+- SPW-03: PASS — 기술 식별자를 보존하고 중복 문장을 제거했다.
+- SPW-04: PASS — 각 finding을 사양의 구체적 계약과 독립 렌즈 결과에 연결했다.
+- SPW-05: PASS — P0/P1 수렴, P2 disposition, 공개 ABI와 문서 경계를 최종 read-back했다.
+
+## Step DoD
+
+- A-03 설계 승인 및 spec review: PASS
+- 6개 독립 렌즈: PASS
+- 영향 렌즈 재검토: PASS
+- 최신 P0/P1: 0/0
+- 구현 계획 진행 가능: YES

--- a/docs/superpowers/plans/2026-08-29-issue-741-spring-observation-scope-plan.md
+++ b/docs/superpowers/plans/2026-08-29-issue-741-spring-observation-scope-plan.md
@@ -1,0 +1,598 @@
+# Issue #741 Spring observation scope 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 서로 다른 Spring `ObservationRegistry` 사이에서 lease-extension event와 선택적 identity가 교차 기록되지 않도록 하면서 공개 event ABI와 process-global observer 계약을 유지한다.
+
+**Architecture:** core가 registration과 함께 opaque `LeaderLeaseExtensionObservationScope` capability를 만들고 wildcard/capability bucket으로 dispatch한다. Spring은 registry identity별 manager entry에서 capability를 공유하고 context-fixed owner를 AOP에 연결한다. AOP, lease adapter, watchdog는 실행 시작 시 capability를 캡처하며 attribution이 없는 direct call은 automatic observer에서 제외한다.
+
+**Tech Stack:** Kotlin/JVM, Kotlin Coroutines, Reactor/Flow bridge, Spring Boot auto-configuration, Micrometer Observation, JUnit 5, MockK, Kluent/bluetape assertions, kotlinx-benchmark/JMH, Gradle.
+
+---
+
+## 파일 구조와 책임
+
+| 파일 | 책임 |
+|---|---|
+| `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObservationScope.kt` | opaque capability, `ThreadLocal` save/restore, cached coroutine context element, revoke 상태 |
+| `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObserver.kt` | wildcard/capability bucket registration, matching-only admission과 dispatch |
+| `leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt` | 현재 capability로 USER event allocation/publish |
+| `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt` | `start()` 시 capability capture 후 WATCHDOG event publish |
+| `leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderElectorLeaseAdapter.kt` | virtual-thread 경계 scope capture/restore |
+| `leader-core/src/main/kotlin/io/bluetape4k/leader/internal/SuspendLeaderElectorLeaseAdapter.kt` | IO coroutine 경계 scope context 결합 |
+| `leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObservationScopeTest.kt` | nested/coroutine/revoke/capability identity 계약 |
+| `leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObserversTest.kt` | wildcard/scoped matching, saturation/drop, close/reopen 회귀 |
+| `leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionApiContractTest.kt` | 기존 및 additive synthetic descriptor, 5-인자 event ABI |
+| `leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionBoundaryContractTest.kt` | USER/WATCHDOG blocking/suspend/virtual 경계 |
+| `leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LeaderElectorLeaseAdapterTest.kt` | adapter thread/coroutine scope 전파와 direct-call 제외 |
+| `leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/metrics/LeaseExtensionObservationScopeOwner.kt` | context-fixed, one-shot capability activation과 close 후 fail-closed |
+| `leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/metrics/LeaseExtensionObservationRegistrationManager.kt` | registry identity entry, canonical capability와 ref-count |
+| `leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/metrics/LeaderObservationAutoConfiguration.kt` | owner bean 생성, late coordinator activation과 shutdown |
+| `leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderBeanSelector.kt` | 현재 BeanFactory의 fixed owner bean 조회 |
+| `leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/autoconfigure/LeaderAopAutoConfiguration.kt` | 기존 factory descriptor를 유지하며 aspect에 owner 연결 |
+| `leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt` | single sync/suspend/Mono/Flux/Flow 실행 scope |
+| `leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt` | group sync/suspend/Mono 실행 scope와 Flux/Flow 기존 거부 유지 |
+| `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/metrics/LeaseExtensionObservationRegistrationManagerTest.kt` | distinct/same registry, close order, option conflict, stale scope |
+| `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/metrics/LeaderObservationAutoConfigurationTest.kt` | owner/coordinator 조건과 parent/child registry 선택 |
+| `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderLeaseExtensionObservationScopeAspectTest.kt` | aspect별 execution model, fail-open/reentrant/cancellation/close race |
+| `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/compatibility/PublicJvmAbiCompatibilityTest.kt` | 기존 aspect/auto-config JVM descriptor 보존 |
+| `benchmark/src/benchmark/kotlin/io/bluetape4k/leader/benchmark/SpringLeaderAdviceBenchmark.kt` | scope match/mismatch/global의 throughput, average time, allocation evidence |
+| `docs/benchmarks/2026-08-29-issue-741-spring-observation-scope.md` | exact baseline/candidate SHA, JSON 경로, fork median과 allocation 판정 |
+| root/Spring `README.md`, `README.ko.md` | global/automatic 경계, 지원 행렬, migration, rollout/rollback |
+| `docs/manual/drafts/2026-08-27-issue-559-lease-extension-observation.{en,ko}.md` | 미출시 #741 delta와 운영 절차 |
+
+## 수용 기준 추적
+
+| Spec 기준 | 구현/테스트 task |
+|---|---|
+| global observer와 5-인자 event ABI | Task 1, 2 |
+| A/B USER/WATCHDOG cross-delivery 0 | Task 3, 6, 7 |
+| identity opt-in 상대 registry 0 | Task 7 |
+| same-registry parent/child ref-count | Task 5, 7 |
+| A→B/B→A close, revoke/reopen | Task 2, 5, 7 |
+| sync/suspend/reactive/watchdog/adapter 전파 | Task 3, 4, 6 |
+| direct call와 Reactor operator fail-closed | Task 6, 7, 9 |
+| caller-owned scope 의미·수명·Java 제약 | Task 1, 6, 9 |
+| indexed dispatch/admission/drop/performance | Task 2, 8 |
+| rollout/rollback/shutdown/manual provenance | Task 9 |
+| module tests, detekt, ABI, manual, diff | Task 10 |
+
+### Task 1: Opaque scope capability와 JVM ABI를 RED/GREEN으로 고정
+
+**Complexity:** Medium. Task 2~7의 선행 조건이다.
+
+**Files:**
+- Create: `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObservationScope.kt`
+- Create: `leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObservationScopeTest.kt`
+- Modify: `leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionApiContractTest.kt`
+
+- [ ] **Step 1: capability 생성·nested restore·coroutine 전파·revoke RED test를 작성한다.**
+
+```kotlin
+@Test
+fun `scope is restored after nested blocking and coroutine boundaries`() = runTest {
+    val outer = LeaderLeaseExtensionObservers.addScopedObserver { }
+    val inner = LeaderLeaseExtensionObservers.addScopedObserver { }
+    outer.use {
+        inner.use {
+            outer.withScope {
+                LeaderLeaseExtensionObservationScope.currentOrNull() shouldBeSameInstanceAs outer
+                inner.withScope {
+                    LeaderLeaseExtensionObservationScope.currentOrNull() shouldBeSameInstanceAs inner
+                }
+                LeaderLeaseExtensionObservationScope.currentOrNull() shouldBeSameInstanceAs outer
+            }
+            withContext(outer.asContextElement() + Dispatchers.Default) {
+                LeaderLeaseExtensionObservationScope.currentOrNull() shouldBeSameInstanceAs outer
+            }
+        }
+    }
+    LeaderLeaseExtensionObservationScope.currentOrNull().shouldBeNull()
+}
+```
+
+- [ ] **Step 2: RED를 확인한다.**
+
+Run: `./gradlew :bluetape4k-leader-core:test --tests '*LeaderLeaseExtensionObservationScopeTest' --rerun-tasks`
+
+Expected: compile FAIL because scope class/factory does not exist.
+
+- [ ] **Step 3: 최소 capability를 구현한다.**
+
+```kotlin
+class LeaderLeaseExtensionObservationScope private constructor(
+    internal val observer: LeaderLeaseExtensionObserver,
+    private val closeAction: (LeaderLeaseExtensionObservationScope) -> Unit,
+) : AutoCloseable {
+    private val active = AtomicBoolean(true)
+    private val contextElement by lazy(LazyThreadSafetyMode.PUBLICATION) { scopes.asContextElement(this) }
+
+    @JvmSynthetic
+    fun <T> withScope(block: () -> T): T = withOptionalScope(if (active.get()) this else null, block)
+
+    @JvmSynthetic
+    fun asContextElement(): ThreadContextElement<LeaderLeaseExtensionObservationScope?> = contextElement
+
+    override fun close() {
+        if (active.compareAndSet(true, false)) closeAction(this)
+    }
+
+    internal fun isActive(): Boolean = active.get()
+
+    companion object {
+        private val scopes = ThreadLocal<LeaderLeaseExtensionObservationScope?>()
+        internal fun currentOrNull(): LeaderLeaseExtensionObservationScope? = scopes.get()?.takeIf { it.isActive() }
+        internal fun create(
+            observer: LeaderLeaseExtensionObserver,
+            closeAction: (LeaderLeaseExtensionObservationScope) -> Unit,
+        ) = LeaderLeaseExtensionObservationScope(observer, closeAction)
+    }
+}
+```
+
+Implementation keeps constructor private, caches one context element, restores nested values, and makes a revoked current scope read as `null`. `LeaderLeaseExtensionObservationScope.currentOrNull()` is core `internal`; there is no public ambient-scope accessor that a callback can use to retain another registration's capability. Add Korean KDoc to the public Kotlin handle/factory: caller-owned scope reaches only its own observer, has no Spring registry affiliation, must be closed, and is hidden from Java source by `@JvmSynthetic`.
+
+- [ ] **Step 4: API contract를 additive exact signatures로 갱신한다.**
+
+Preserve non-synthetic methods `addObserver`, `removeObserver`, `droppedCount`; preserve old `hasObservers()` and `publish(event)` synthetic descriptors; assert new `addScopedObserver`, `hasObservers(scope)`, `publish(event, scope)`, scope private constructor and event 5-arg constructor. Also assert that no public `current()`/ambient capability accessor exists. Add a `JavaCompiler` negative fixture that attempts to call `addScopedObserver`, `withScope`, `asContextElement`, scoped `hasObservers` and `publish`; compilation must fail because the methods are `ACC_SYNTHETIC`. Confirm flags with `javap -v` in the ABI evidence.
+
+- [ ] **Step 5: GREEN과 ABI check를 확인한다.**
+
+Run: `./gradlew :bluetape4k-leader-core:test --tests '*LeaderLeaseExtensionObservationScopeTest' --tests '*LeaderLeaseExtensionApiContractTest' --rerun-tasks`
+
+Expected: both test classes PASS, no scope value in `toString()` or reflection-visible constructor.
+
+Rollback: remove the new class and restore the exact API test before Task 2 if descriptor shape is not implementable without breaking old methods.
+
+### Task 2: Indexed scoped dispatch와 admission accounting 구현
+
+**Complexity:** High. Concurrency/hot-path risk; `$bluetape-kotlin-patterns`, `$test-driven-development` and performance/stability scan required.
+
+**Files:**
+- Modify: `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObserver.kt`
+- Modify: `leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObserversTest.kt`
+
+- [ ] **Step 1: wildcard/scoped matching과 saturation RED tests를 추가한다.**
+
+```kotlin
+@Test
+fun `scoped observers receive only their capability and wildcard receives all`() {
+    val globalEvents = CopyOnWriteArrayList<LeaderLeaseExtensionEvent>()
+    val aEvents = CopyOnWriteArrayList<LeaderLeaseExtensionEvent>()
+    val bEvents = CopyOnWriteArrayList<LeaderLeaseExtensionEvent>()
+    val global = LeaderLeaseExtensionObservers.addObserver(globalEvents::add)
+    val a = LeaderLeaseExtensionObservers.addScopedObserver(aEvents::add)
+    val b = LeaderLeaseExtensionObservers.addScopedObserver(bEvents::add)
+    global.use { a.use { b.use {
+        LeaderLeaseExtensionObservers.publish(testEvent(), a)
+        awaitCondition { globalEvents.size == 1 && aEvents.size == 1 }
+        bEvents.shouldBeEmpty()
+    } } }
+}
+```
+
+Add a deterministic dispatcher/barrier test that fills 1024 global permits, publishes A and B concurrently, and asserts mismatch traffic does not change B callback count or matched-only drop delta. Add close/publish linearization, repeated-close idempotency, and weak-reference collection tests so a closed capability bucket cannot remain reachable from the dispatcher.
+
+- [ ] **Step 2: RED를 확인한다.**
+
+Run: `./gradlew :bluetape4k-leader-core:test --tests '*LeaderLeaseExtensionObserversTest' --rerun-tasks`
+
+Expected: new scoped tests fail before indexed registration exists.
+
+- [ ] **Step 3: wildcard와 capability bucket을 최소 구현한다.**
+
+```kotlin
+private val wildcardRegistrations = CopyOnWriteArrayList<Registration>()
+private val scopedRegistrations = ConcurrentHashMap<LeaderLeaseExtensionObservationScope, CopyOnWriteArrayList<Registration>>()
+
+@JvmSynthetic
+fun addScopedObserver(observer: LeaderLeaseExtensionObserver): LeaderLeaseExtensionObservationScope {
+    lateinit var registration: Registration
+    val scope = LeaderLeaseExtensionObservationScope.create(observer) { closedScope ->
+        scopedRegistrations.remove(closedScope)?.clear()
+        registration.closed.set(true)
+    }
+    registration = Registration(observer, scope)
+    scopedRegistrations.computeIfAbsent(scope) { CopyOnWriteArrayList() }.add(registration)
+    return scope
+}
+
+@JvmSynthetic
+fun hasObservers(scope: LeaderLeaseExtensionObservationScope?): Boolean =
+    wildcardRegistrations.isNotEmpty() || (scope?.takeIf { it.isActive() }?.let(scopedRegistrations::get)?.isNotEmpty() == true)
+```
+
+Dispatch wildcard bucket contents first and only `scopedRegistrations[scope]` when active. Saturation records drops only for the two selected bucket contents. Scope close linearizes once as `active=false` → identity bucket removal → `registration.closed=true`; callbacks already accepted before that point may finish, while no new scoped callback is admitted after revocation. Repeated close is a no-op.
+
+`removeObserver(observer)`는 wildcard와 모든 capability bucket에서 동일 object identity registration을 제거하고 해당 scoped capability를 revoke한다. 마지막 registration이 제거된 빈 bucket은 map에서 제거해 lifecycle leak을 막는다.
+
+- [ ] **Step 4: legacy remove/close/callback error/race tests를 유지하며 GREEN을 확인한다.**
+
+Run: `./gradlew :bluetape4k-leader-core:test --tests '*LeaderLeaseExtensionObserversTest' --tests '*LeaderLeaseExtensionApiContractTest' --rerun-tasks`
+
+Expected: existing and new tests PASS, `droppedCount()` delta excludes mismatch registrations.
+
+Rollback: revert Task 2 only; Task 1 capability can remain unused while the previous global facade is restored.
+
+### Task 3: USER, WATCHDOG, lease adapter scope 전파
+
+**Complexity:** High. Thread/coroutine/lifecycle ordering risk.
+
+**Files:**
+- Modify: `leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt`
+- Modify: `leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt`
+- Modify: `leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderElectorLeaseAdapter.kt`
+- Modify: `leader-core/src/main/kotlin/io/bluetape4k/leader/internal/SuspendLeaderElectorLeaseAdapter.kt`
+- Modify: `leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionBoundaryContractTest.kt`
+- Modify: `leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LeaderElectorLeaseAdapterTest.kt`
+
+- [ ] **Step 1: USER/WATCHDOG/adapter RED matrix를 추가한다.**
+
+Cover blocking, suspend, async virtual watchdog, suspend watchdog, blocking adapter virtual thread and suspend adapter IO coroutine. Each case registers global/A/B, installs A, then asserts global=1, A=1, B=0. Direct adapter outside scope must produce global=1 and A/B=0.
+
+- [ ] **Step 2: RED를 확인한다.**
+
+Run: `./gradlew :bluetape4k-leader-core:test --tests '*LeaderLeaseExtensionBoundaryContractTest' --tests '*LeaderElectorLeaseAdapterTest' --rerun-tasks`
+
+Expected: scoped observers miss async boundaries or both registries receive before implementation.
+
+- [ ] **Step 3: producer scope를 한 번 캡처해 전달한다.**
+
+```kotlin
+val observationScope = LeaderLeaseExtensionObservationScope.currentOrNull()
+if (LeaderLeaseExtensionObservers.hasObservers(observationScope)) {
+    // 이 분기 안에서만 timer/context/event를 만든다.
+    LeaderLeaseExtensionObservers.publish(event, observationScope)
+}
+```
+
+USER helper와 WATCHDOG tick은 `hasObservers(observationScope) == false`이면 timer/context/event를 만들기 전에 observation path를 반환한다. 실제 lease extension 결과/예외 흐름은 그대로 계속한다. `LeaderLeaseAutoExtender.start()` stores `observationScope` beside captured admission. Blocking adapter wraps the virtual-thread body with `observationScope?.withScope { ... }`; suspend adapter combines `observationScope?.asContextElement()` with admission context in the launched coroutine.
+
+- [ ] **Step 4: close/reopen와 cancellation GREEN을 확인한다.**
+
+Add tests that revoke A while an action/tick is blocked, open new A2, release the old action, and assert old automatic callbacks are 0 for A2 while global remains 1. Verify cancellation propagates and ThreadLocal is cleared.
+
+Run: `./gradlew :bluetape4k-leader-core:test --tests '*LeaderLeaseExtension*' --tests '*LeaderElectorLeaseAdapterTest' --rerun-tasks`
+
+Expected: PASS with no skipped tests.
+
+Rollback: revert producer wiring together; do not leave only USER or only WATCHDOG scoped.
+
+### Task 4: Spring context owner와 registry manager canonical capability
+
+**Complexity:** High. Same-registry ref-count and startup lifecycle risk.
+
+**Files:**
+- Create: `leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/metrics/LeaseExtensionObservationScopeOwner.kt`
+- Modify: `leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/metrics/LeaseExtensionObservationRegistrationManager.kt`
+- Modify: `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/metrics/LeaseExtensionObservationRegistrationManagerTest.kt`
+
+- [ ] **Step 1: manager RED tests를 수정한다.**
+
+Change the defect expectation so distinct registry B receives zero A event. Add same-registry shared scope identity, A→B/B→A close, conflict message, last-close revoke, and close/reopen new capability tests.
+
+- [ ] **Step 2: RED를 확인한다.**
+
+Run: `./gradlew :bluetape4k-leader-spring-boot:test --tests '*LeaseExtensionObservationRegistrationManagerTest' --rerun-tasks`
+
+Expected: current manager broadcasts to both registries and has no scope handle.
+
+- [ ] **Step 3: canonical entry와 context handle을 구현한다.**
+
+```kotlin
+internal data class ManagedRegistration(
+    val scope: LeaderLeaseExtensionObservationScope,
+    val closeHandle: AutoCloseable,
+) : AutoCloseable by closeHandle
+
+private class Entry(
+    val options: LeaderObservationOptions,
+    val scope: LeaderLeaseExtensionObservationScope,
+    var referenceCount: Int = 1,
+)
+```
+
+First acquire creates Micrometer observer and `addScopedObserver`; later same-identity acquire returns the same scope with a new idempotent context handle. Last release closes/revokes the core scope. Conflict message instructs option alignment or `bluetape4k.leader.observability.tracing.enabled=false` without registry `toString()`.
+
+- [ ] **Step 4: one-shot owner를 구현한다.**
+
+```kotlin
+internal class LeaseExtensionObservationScopeOwner(
+    val registry: ObservationRegistry,
+) {
+    private val scope = AtomicReference<LeaderLeaseExtensionObservationScope?>()
+    fun activate(value: LeaderLeaseExtensionObservationScope) {
+        check(scope.compareAndSet(null, value)) { "Lease extension observation scope is already active" }
+    }
+    fun current(): LeaderLeaseExtensionObservationScope? = scope.get()?.takeIf { it.isActive() }
+    fun clear(expected: LeaderLeaseExtensionObservationScope) { scope.compareAndSet(expected, null) }
+}
+```
+
+- [ ] **Step 5: GREEN을 확인한다.**
+
+Run: `./gradlew :bluetape4k-leader-spring-boot:test --tests '*LeaseExtensionObservationRegistrationManagerTest' --rerun-tasks`
+
+Expected: distinct registry isolation, same-registry single callback/ref-count, both close orders and reopen PASS.
+
+Rollback: restore manager global registration and remove owner; do not proceed to AOP wiring if lifecycle tests fail.
+
+### Task 5: Observation auto-configuration과 fixed owner wiring
+
+**Complexity:** Medium. Auto-configuration condition/order and JVM factory compatibility risk.
+
+**Files:**
+- Modify: `leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/metrics/LeaderObservationAutoConfiguration.kt`
+- Modify: `leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderBeanSelector.kt`
+- Modify: `leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/autoconfigure/LeaderAopAutoConfiguration.kt`
+- Modify: `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/metrics/LeaderObservationAutoConfigurationTest.kt`
+- Modify: `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderBeanSelectorTest.kt`
+- Modify: `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/compatibility/PublicJvmAbiCompatibilityTest.kt`
+
+- [ ] **Step 1: auto-config RED tests를 추가한다.**
+
+Assert owner bean exists only when normal non-NOOP registry and tracing are enabled, selected `@Primary` registry activates the owner, parent/child same registry shares core scope, distinct registries get distinct owners, disabled/NOOP has no active owner, and manual aspect construction remains no-op. Build real parent/child application contexts, assert selector object identity is distinct and each selector holds its own context `BeanFactory`, invoke annotated methods concurrently in both contexts, and verify that a child with only a parent owner remains automatic-observation no-op.
+
+- [ ] **Step 2: RED를 확인한다.**
+
+Run: `./gradlew :bluetape4k-leader-spring-boot:test --tests '*LeaderObservationAutoConfigurationTest' --tests '*LeaderBeanSelectorTest' --tests '*PublicJvmAbiCompatibilityTest' --rerun-tasks`
+
+Expected: owner bean/lookup assertions fail; old aspect/coordinator descriptor assertions continue PASS.
+
+- [ ] **Step 3: fixed bean-name lookup과 coordinator activation을 구현한다.**
+
+Define one internal bean name constant. Declare the `leaderBeanSelector`, owner, and aspect bean methods with `@ConditionalOnMissingBean(search = SearchStrategy.CURRENT)` so each application context owns its local selector/wiring. `LeaderBeanSelector` casts to `HierarchicalBeanFactory`, checks `containsLocalBean(fixedName)`, then calls `getBean(fixedName, LeaseExtensionObservationScopeOwner::class.java)` only after that local check; it never falls back to a parent owner. Preserve the existing public three-argument `leaseExtensionObserverRegistrationCoordinator(ConfigurableListableBeanFactory, LeaderProperties, LeaderAopProperties)` descriptor exactly; its body/coordinator resolves the fixed-name local owner without adding a factory parameter, calls `manager.acquire(owner.registry, options)`, activates with `managed.scope`, registers close handle, and clears owner before releasing the context handle during destroy.
+
+- [ ] **Step 4: existing factory signatures를 유지하며 aspect property를 연결한다.**
+
+Both annotated and legacy factory methods construct aspects with the same existing arguments, then apply an internal nullable owner property. Do not add constructor or factory parameters. Add ABI assertions for the existing coordinator three-argument descriptor as well as the existing single/group aspect factory descriptors.
+
+- [ ] **Step 5: GREEN과 ABI를 확인한다.**
+
+Run: `./gradlew :bluetape4k-leader-spring-boot:test --tests '*LeaderObservationAutoConfigurationTest' --tests '*LeaderBeanSelectorTest' --tests '*PublicJvmAbiCompatibilityTest' --rerun-tasks`
+
+Expected: all tests PASS and previous 5/6-arg aspect plus 3-arg coordinator descriptors remain present.
+
+Rollback: remove owner bean/lookup and restore coordinator signature; manager/core changes remain isolated but unused by Spring.
+
+### Task 6: Single/group AOP execution scope TDD
+
+**Complexity:** High. Sync, coroutine, Reactor, Flow, reentrant, fail-open and cancellation paths.
+
+**Files:**
+- Modify: `leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt`
+- Modify: `leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt`
+- Create: `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderLeaseExtensionObservationScopeAspectTest.kt`
+- Reuse: existing aspect tests named in the file map
+
+- [ ] **Step 1: execution-model RED matrix를 작성한다.**
+
+For `LeaderElectionAspect`: sync, suspend, Mono, Flux, Flow, fail-open, reentrant. For group: sync, suspend, Mono; assert Flux/Flow existing validation error happens before scope/event. Each supported case publishes a USER event and asserts current context registry 1, other registry 0, global 1.
+
+- [ ] **Step 2: cancellation/exception/Reactor negative RED cases를 추가한다.**
+
+Cancel each suspend/reactive path and throw from action, then reuse the thread and assert current scope null. A Reactor `map` direct extender call outside coroutine continuation must automatic=0/global=1. Close context during active action and assert post-revoke automatic=0/global=1. From an A callback, verify there is no public ambient accessor to retain A's canonical capability; retaining and later reinstalling a separately registered caller-owned capability must notify only that caller-owned observer, never A or B automatic observers.
+
+- [ ] **Step 3: RED를 확인한다.**
+
+Run: `./gradlew :bluetape4k-leader-spring-boot:test --tests '*LeaderLeaseExtensionObservationScopeAspectTest' --rerun-tasks`
+
+Expected: current aspect does not install owner scope.
+
+- [ ] **Step 4: 최소 scope wrapper를 모든 supported action 경계에 적용한다.**
+
+```kotlin
+private fun <T> withObservationScope(block: () -> T): T =
+    observationScopeOwner?.current()?.withScope(block) ?: block()
+
+private suspend fun <T> withObservationScopeSuspend(block: suspend () -> T): T {
+    val scope = observationScopeOwner?.current() ?: return block()
+    return withContext(scope.asContextElement()) { block() }
+}
+```
+
+Wrap actual elector/action execution, including reentrant/fail-open action. Do not wrap metadata-resolution bypass. For Flux/Flow, install scope at subscription/collection coroutine bridge, not per signal.
+
+- [ ] **Step 5: GREEN과 existing aspect suite를 확인한다.**
+
+Run: `./gradlew :bluetape4k-leader-spring-boot:test --tests '*LeaderElectionAspect*' --tests '*LeaderGroupElectionAspect*' --tests '*LeaderLeaseExtensionObservationScopeAspectTest' --rerun-tasks`
+
+Expected: all supported model, cleanup, negative and existing tests PASS with no skips.
+
+Rollback: revert both aspect files together so single/group parity is never partial.
+
+Spring partial rollback is not a supported steady state:
+
+| Failed slice | Required rollback unit | Smoke evidence |
+|---|---|---|
+| Task 4 manager/owner | restore global manager registration and remove owner together | explicit global observer still receives one event; automatic observation matches pre-change behavior |
+| Task 5 auto-configuration | revert owner bean, coordinator activation, and manager scoped registration together, or set `bluetape4k.leader.observability.tracing.enabled=false` | disabled context starts cleanly and explicit global observer remains functional |
+| Task 6 AOP scope | revert both single/group aspect wiring plus Spring scoped registration, or disable tracing for the affected context | no owner-only/scoped-registration-only state; automatic telemetry is either fully old-path or intentionally off |
+
+The rollback smoke test must cover application startup, one explicit wildcard callback, and zero silent automatic observations from a partially wired owner.
+
+### Task 7: Cross-context integration과 raw-error boundary 검증
+
+**Complexity:** High. Security/lifecycle integration gate.
+
+**Files:**
+- Modify: `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/metrics/LeaseExtensionObservationRegistrationManagerTest.kt`
+- Modify: `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/metrics/LeaderObservationAutoConfigurationTest.kt`
+- Modify: `leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderLeaseExtensionObservationScopeAspectTest.kt`
+
+- [ ] **Step 1: two-context integration fixture를 완성한다.**
+
+Create registry A/B with capturing observation handlers and `includeLockName=true`, `includeLeaderId=true`, `includeExceptionDetails=true`. Run A and B events in both directions and assert own identity once, other identity zero.
+
+- [ ] **Step 2: lifecycle matrix를 실행한다.**
+
+Test A→B and B→A close order, same-registry parent/child single callback/ref-count, distinct parent/child concurrent calls, conflict startup recovery message, close/reopen stale action/watchdog and accepted-late callback semantics. Add shutdown smoke with a blocked accepted callback: context registration close returns without an internal drain wait, new automatic admission is zero, and releasing the callback while the exporter is still alive may complete under the existing in-flight contract.
+
+- [ ] **Step 3: raw-error security boundary를 고정한다.**
+
+With default/`includeExceptionDetails=false`, publish `IllegalStateException("jdbc:password=secret-token")` from A and assert no raw throwable/error payload is created or exported. Then opt in with `includeExceptionDetails=true`: assert A handler gets the existing raw throwable, B gets zero observation/error, and capability plus secret payload are absent from tags, logs, and non-error representations. The opted-in source handler may receive the raw throwable by existing contract.
+
+- [ ] **Step 4: targeted integration GREEN을 확인한다.**
+
+Run: `./gradlew :bluetape4k-leader-spring-boot:test --tests '*LeaseExtensionObservation*' --tests '*LeaderLeaseExtensionObservationScopeAspectTest' --rerun-tasks`
+
+Expected: A↔B cross-delivery and cross-identity counts are all zero; no skipped tests.
+
+Rollback: return to Task 4/6 depending on whether manager delivery or AOP attribution fails; do not weaken expected zero counts.
+
+### Task 8: Performance와 stability evidence
+
+**Complexity:** Medium. Benchmark is non-CI evidence; no new dependency/module.
+
+**Files:**
+- Modify: `benchmark/src/benchmark/kotlin/io/bluetape4k/leader/benchmark/SpringLeaderAdviceBenchmark.kt`
+- Create: `docs/benchmarks/2026-08-29-issue-741-spring-observation-scope.md`
+
+- [ ] **Step 1: benchmark states를 추가한다.**
+
+Add no-observer, global, scoped-match and scoped-mismatch states for sync/suspend/Mono/Flux/Flow plus watchdog publish. Reuse one scope/context element per trial; do not allocate registration per invocation. Use the generated JMH jar with an explicit `-f 3`; leave the repository-wide `main`/`averageTime` fork settings unchanged.
+
+- [ ] **Step 2: benchmark compile을 확인한다.**
+
+Run: `./gradlew :benchmark:compileBenchmarkKotlin --no-configuration-cache`
+
+Expected: PASS with no benchmark API/type errors.
+
+- [ ] **Step 3: before/after comparable benchmark를 실행하고 JSON을 기록한다.**
+
+Run the comparable existing advice rows at detached baseline `f44b7c69440f8ce5156185ce63209f523b2051fd`, then run the same exact filter at the final candidate head. Use the generated JMH jar with `-f 3 -prof gc` and write artifacts to:
+
+- `benchmark/build/reports/benchmarks/issue741/baseline-f44b7c6-throughput.json`
+- `benchmark/build/reports/benchmarks/issue741/baseline-f44b7c6-average-time.json`
+- `benchmark/build/reports/benchmarks/issue741/candidate-<exact-head>-throughput.json`
+- `benchmark/build/reports/benchmarks/issue741/candidate-<exact-head>-average-time.json`
+
+The command shape is `java -jar <benchmark-jmh-jar> '<exact SpringLeaderAdviceBenchmark row filter>' -f 3 -wi 2 -i 3 -r 1s -prof gc -rf json -rff <artifact>`, with `-bm thrpt -tu s` and `-bm avgt -tu us` runs. Record host/JDK/load, exact SHA, row filter, and all four paths in the result document. For each comparable row, calculate the median of the three fork-level `rawData` values; throughput regression is `(baselineMedian - candidateMedian) / baselineMedian`, average-time regression is `(candidateMedian - baselineMedian) / baselineMedian`.
+
+Expected: all four JSON reports exist; the candidate-only no-observer USER/WATCHDOG rows have `gc.alloc.rate.norm` equal to their no-instrumentation control within JMH measurement resolution and show no event/context/timer allocation, while comparable throughput/average-time fork medians regress by no more than 15%. If environment noise exceeds 15%, rerun once with the same JVM/load and keep both result sets; persistent regression returns to Task 2/6.
+
+- [ ] **Step 4: performance/stability scan을 기록한다.**
+
+Confirm matching-only bucket traversal, no per-signal context creation, no blocking call added to reactive paths, capability buckets removed on close, scheduled/coroutine resources unchanged.
+
+Rollback: remove benchmark cases only if they cannot represent the real path; implementation rollback is required for persistent measured regression.
+
+### Task 9: EN/KO docs, migration, rollout/rollback and manual draft
+
+**Complexity:** Medium. Public behavior and operations documentation.
+
+**Files:**
+- Modify: `README.md`
+- Modify: `README.ko.md`
+- Modify: `leader-spring-boot/README.md`
+- Modify: `leader-spring-boot/README.ko.md`
+- Modify: `docs/manual/drafts/2026-08-27-issue-559-lease-extension-observation.en.md`
+- Modify: `docs/manual/drafts/2026-08-27-issue-559-lease-extension-observation.ko.md`
+
+- [ ] **Step 1: source behavior가 green인 뒤 문서를 갱신한다.**
+
+Document global explicit vs registry-scoped automatic observer, same-registry parent/child, distinct registry ownership, direct-call and Reactor non-suspend fail-closed behavior, single/group support matrix, manual+automatic duplicate warning and migration example. Add an EN/KO migration matrix: AOP automatic is registry-scoped; direct/Reactor non-suspend is automatic 0 and explicit global 1; caller-owned scope reaches only its own observer, cannot impersonate a Spring registry, must be closed, and is unavailable to Java source because the bridge is `@JvmSynthetic`.
+
+- [ ] **Step 2: 운영 절차를 EN/KO에 맞춘다.**
+
+Include canary A/B zero-cross-count, `bluetape4k.leader.observability.tracing.enabled=false` as an `ApplicationContext` startup-only setting that requires context/process restart, post-restart local owner absent/automatic 0/global 1 smoke, binary rollback semantics, explicit observer close, graceful shutdown order, no internal drain wait, accepted-callback delivery caveat, scope-excluded/no-observer/admission-drop diagnosis and raw exception exporter responsibility.
+
+- [ ] **Step 3: manual provenance를 유지한다.**
+
+Update only #559 drafts for the unshipped #741 delta. Do not change `docs/manual/manifest.yaml` releaseRef `0.5.0` or releaseCommit `721a9a3808f67489d2bdb8177734325981c24977` and do not claim the change in versioned manual pages.
+
+- [ ] **Step 4: locale/naturalness and manual validation을 실행한다.**
+
+Run:
+
+```bash
+node ~/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs README.ko.md leader-spring-boot/README.ko.md docs/manual/drafts/2026-08-27-issue-559-lease-extension-observation.ko.md
+./gradlew exportManualModuleInventory
+ruby scripts/manual/release_inventory.rb 0.5.0 721a9a3808f67489d2bdb8177734325981c24977 build/manual/module-inventory.json build/manual/release-module-inventory.json 35
+ruby scripts/manual/validate_manuals.rb build/manual/release-module-inventory.json
+ruby scripts/manual/validate_release_manuals.rb 0.5.0 721a9a3808f67489d2bdb8177734325981c24977
+ruby scripts/manual/export_manifest.rb --check
+ruby -I scripts/manual -e 'Dir["scripts/manual/*_test.rb"].sort.each { |file| require File.expand_path(file) }'
+```
+
+Expected: terminology findings fixed or explicitly classified, all manual commands PASS, manifest unchanged.
+
+Rollback: revert all six locale files together if source behavior changes; never leave EN/KO contracts divergent.
+
+### Task 10: Full verification, review, lesson and delivery readiness
+
+**Complexity:** High verification breadth, no new architecture.
+
+**Files:**
+- Create later: `docs/review/2026-08-29-issue-741-spring-observation-scope-review.md`
+- Create later: `docs/lessons/2026-08-29-issue-741-spring-observation-scope.md`
+- Review: all branch changes against `origin/develop`
+
+- [ ] **Step 1: targeted then module validation을 실행한다.**
+
+```bash
+./gradlew :bluetape4k-leader-core:test --tests '*LeaderLeaseExtension*' --tests '*LeaderElectorLeaseAdapterTest' --rerun-tasks
+./gradlew :bluetape4k-leader-spring-boot:test --tests '*LeaseExtensionObservation*' --tests '*LeaderElectionAspect*' --tests '*LeaderGroupElectionAspect*' --rerun-tasks
+./gradlew :bluetape4k-leader-core:test :bluetape4k-leader-spring-boot:test
+```
+
+Expected: all tasks SUCCESS, JUnit executed count recorded, skipped=0.
+
+- [ ] **Step 2: static/ABI/docs checks를 실행한다.**
+
+```bash
+./gradlew detekt
+./gradlew checkBinaryCompatibility
+git diff --check
+git status --short
+```
+
+Expected: PASS; status contains only approved files.
+
+- [ ] **Step 2a: benchmark evidence와 exact-head CI 기록을 고정한다.**
+
+Verify `docs/benchmarks/2026-08-29-issue-741-spring-observation-scope.md` exists and records baseline SHA `f44b7c69440f8ce5156185ce63209f523b2051fd`, candidate exact head, all four JSON paths, three-fork medians, `gc.alloc.rate.norm`, and the 15% decision. Before final DoD, record the exact remote head and the URL/status of every exact-head CI job; path-filtered skips must be identified separately from executed success.
+
+- [ ] **Step 3: spec/plan verifier와 six-lens pre-PR review를 완료한다.**
+
+Map every spec acceptance row to source/tests/docs/commands. Run Performance, Stability, Security, Operator/Ops, Developer/API, User/caller independent read-only reviews, integrate at P0=0/P1=0, fix blockers and rerun affected lanes.
+
+- [ ] **Step 4: durable lesson을 작성·검증·커밋한다.**
+
+Lesson records why global facade stays wildcard, why capability is registration-owned, Reactor/direct-call fail-closed boundary, admission indexing, late callback/revoke behavior, validation evidence and future guard. Complete SPW-01~05 before commit.
+
+- [ ] **Step 5: Lore commits and PR delivery를 완료한다.**
+
+Commit spec/plan before implementation, then RED/GREEN implementation slices, docs/review/lesson. Commit messages are Korean intent lines with `Constraint`, `Rejected`, `Confidence`, `Scope-risk`, `Directive`, `Tested`, `Not-tested` trailers. Push `fix/issue-741-spring-observation-scope`, create Korean PR to `develop`, assign `debop`, mirror `bug`, `integration`, `security`, `spring`, milestone `1.0.0`, and end body with `## DoD Status`.
+
+- [ ] **Step 6: exact-head CI와 live review gate를 확인한다.**
+
+Verify remote head equals local head, required checks terminal `SUCCESS` or evidence-backed path N/A, reviews/threads 0 blockers, mergeability. Stop at CG-16 with merge unchecked; do not enable auto-merge or merge without fresh approval.
+
+## Risk prediction
+
+| Risk | Signal | Mitigation | Rollback/rerun |
+|---|---|---|---|
+| capability bucket close/publish race | stale callback reaches reopened registry | active flag + bucket removal + new capability per entry; close-race tests | Task 2/4 rerun |
+| global cap still couples wildcard observer | scoped latency/drop rises under global callback load | document intentional wildcard sharing; matched-only accounting stress | Task 2 performance rerun |
+| Reactor operator loses ThreadLocal | direct extension automatic count 0 | explicit unsupported boundary and negative test | Task 6; do not add lifter without design approval |
+| aspect descriptor regression | reflection/ABI test fails | internal property wiring, no new factory args | Task 5 rollback |
+| same registry parent/child duplicate | event count 2 or early close | manager identity entry/ref-count canonical scope | Task 4/7 rerun |
+| benchmark noise | >15% inconsistent regression | same-JVM same-load one retry, record caveat | persistent result blocks review |
+| raw Throwable exposes secret | source exporter sees raw message | opt-in warning/exporter redaction; assert other registry 0 | disable option; redaction remains separate issue |
+| manual release drift | versioned manual claims unreleased behavior | draft-only edit; manifest exact check | revert docs task |
+
+## Writer gate
+
+- SPW-01: PASS — 독자는 구현자와 검증자이며 승인된 spec, current source/test, repo commands를 근거로 했다.
+- SPW-02: PASS — dependency order, exact files, RED/GREEN, validation, docs, rollback, PR stop gate를 포함했다.
+- SPW-03: PASS — KO-01~KO-06을 적용해 기술 식별자를 보존하고 모호한 지시를 제거했다. KO-07은 plan 파일에 대해 Task 9 실행 전에 수행한다.
+- SPW-04: PASS — spec의 11개 acceptance 영역을 Task 1~10에 매핑하고 모든 P1 repair를 task/command로 연결했다.
+- SPW-05: PASS — Markdown 구조, 코드 fence, task ordering, exact commands, `releaseRef`/commit, CG-16 stop 조건을 최종 read-back했다.
+
+## Step DoD
+
+- A-04 implementation plan draft: PASS
+- Plan review 6-lane + integration: PASS — P0=0, P1=0
+- Spec/plan commit: READY
+- Implementation authorization: YES — approved design and converged plan

--- a/docs/superpowers/specs/2026-08-29-issue-741-spring-observation-scope-design.md
+++ b/docs/superpowers/specs/2026-08-29-issue-741-spring-observation-scope-design.md
@@ -1,0 +1,329 @@
+# Issue #741 Spring lease-extension observation scope 설계
+
+## 목적
+
+동일 JVM에서 서로 다른 `ObservationRegistry`를 사용하는 Spring application context가 함께 실행될 때, 한 context의 lease-extension event와 선택적으로 노출한 `lockName`/`auditLeaderId`가 다른 context의 telemetry에 기록되지 않도록 한다.
+
+기존 core 사용자의 process-local global observer 계약과 공개 `LeaderLeaseExtensionEvent` ABI는 유지한다. Spring 자동 관찰은 attribution이 가능한 Spring AOP 실행 경계만 context scope에 귀속하며, attribution이 없는 직접 elector 호출은 자동 Spring registry에 전달하지 않는 fail-closed 기본값을 사용한다.
+
+## 현재 증거
+
+- `LeaderLeaseExtensionObservers`는 process-global registration 목록의 읽기 시점 사본을 만든 뒤 모든 observer에 같은 event를 전달한다.
+- `LeaseExtensionObservationRegistrationManager`는 `ObservationRegistry` identity별 observer 수명만 관리하고 event producer ownership은 알지 못한다.
+- `MicrometerObservationLeaderLeaseExtensionObserver`는 전달받은 event를 별도 필터 없이 자기 registry에 기록한다.
+- `LeaderLeaseExtensionContext`에는 `lockName`과 `auditLeaderId`만 있고 Spring context owner는 없다.
+- `WATCHDOG` event의 `context`는 의도적으로 `null`이며 scheduler, virtual thread 또는 coroutine에서 나중에 실행된다.
+- 현재 `LeaseExtensionObservationRegistrationManagerTest`는 서로 다른 두 registry가 동일 event를 모두 받는 결함 동작을 기대한다.
+- `LeaderLeaseExtensionApiContractTest`는 공개 event의 5-인자 constructor와 facade method 집합을 호환성 경계로 고정한다.
+
+따라서 registry ref-count 변경이나 lock/leader identity 비교만으로는 안전하게 격리할 수 없다. producer 실행 시점에만 알 수 있는 opaque scope를 dispatch metadata로 전달해야 한다.
+
+## 요구사항
+
+1. 기존 `LeaderLeaseExtensionObservers.addObserver(observer)`는 scoped/unscoped event를 모두 받는 global wildcard 계약을 유지한다.
+2. 공개 `LeaderLeaseExtensionEvent`와 `LeaderLeaseExtensionContext`에 Spring type, registry, scope token을 추가하지 않는다.
+3. Spring 자동 observer는 자기 registry entry가 소유한 opaque capability와 같은 scope에서 발생한 event만 받는다.
+4. 서로 다른 registry A/B에서 A event가 B에, B event가 A에 전달되는 횟수는 모두 0이어야 한다.
+5. `includeLockName=true`, `includeLeaderId=true`에서도 상대 context identity가 노출되지 않아야 한다.
+6. USER blocking/suspend와 WATCHDOG blocking/suspend 경로에서 scope를 잃지 않는다.
+7. 같은 registry를 공유하는 parent/child context는 동일 telemetry domain으로 취급하며 event당 callback 한 번과 기존 ref-count/last-close 계약을 유지한다.
+8. 서로 다른 registry의 context는 A→B와 B→A close 순서 모두에서 남은 context만 자기 event를 계속 받는다.
+9. observer callback 오류, bounded admission, close 시점 callback semantics와 extension 결과는 기존과 같아야 한다.
+10. Spring scope 밖의 직접 elector 호출은 자동 Spring observer에 전달하지 않으며, 명시적으로 등록한 global observer에는 계속 전달한다.
+
+## 범위
+
+### 포함
+
+- core observer registration의 wildcard/scoped matching
+- core execution scope carrier와 coroutine context 전파
+- AOP 실행 안에서 새 thread/coroutine을 만드는 core lease adapter의 scope capture/restore
+- watchdog 시작 시 scope capture
+- Spring registry identity entry가 소유하는 private scope capability registration
+- `LeaderElectionAspect`와 `LeaderGroupElectionAspect`의 sync/suspend/reactive 실행 scope
+- 서로 다른 registry, identity opt-in, close 순서, global compatibility 회귀 테스트
+- root 및 Spring README의 EN/KO 계약 갱신
+- #559 manual draft EN/KO delta와 rollout/rollback/shutdown runbook 갱신
+
+### 제외
+
+- 공개 event constructor에 owner field 추가
+- 모든 backend constructor/options에 Spring scope 주입
+- Spring AOP를 거치지 않는 임의의 user-defined elector bean 자동 wrapping
+- lock name, leader id, thread name 또는 application name을 이용한 추론형 filtering
+- dispatcher, admission 상한, observation name/tag schema 변경
+- dependency, module, workflow, BOM 변경
+
+## 대안
+
+### 대안 A — 채택: core opaque scope와 Spring AOP execution scope
+
+core dispatch는 event와 별도의 opaque scope capability를 사용한다. 기존 global registration은 wildcard이고, Spring manager가 만든 registration만 같은 capability를 사용한다. Spring AOP는 elector 호출 전체에 context owner가 받은 capability를 적용하고, watchdog는 `start()` 시점의 capability를 값으로 캡처한다.
+
+장점:
+
+- 공개 event/observer API의 기존 의미와 ABI를 보존한다.
+- WATCHDOG의 `context=null` 정책을 바꾸지 않고 정확히 분리한다.
+- 다른 registry의 event가 admission permit이나 drop count를 소비하지 않게 할 수 있다.
+- attribution이 없는 event를 자동 telemetry에서 제외해 identity 오염을 fail-closed로 막는다.
+
+제약:
+
+- Spring AOP 밖의 직접 elector 호출은 자동 registry에 귀속되지 않는다.
+- 모든 AOP 실행 모델에서 scope 적용 지점을 빠짐없이 검증해야 한다.
+
+### 대안 B — 기각: 모든 backend/options에 producer scope 저장
+
+Spring이 만든 모든 elector option, handle, watchdog에 context token을 명시적으로 저장하면 직접 bean 호출까지 귀속할 수 있다. 그러나 backend 전반의 constructor/call site와 serialization/equality 경계가 바뀌고, public compatibility 위험과 검증 행렬이 크게 증가한다. Issue #741의 승인 범위보다 넓으므로 기각한다.
+
+### 대안 C — 기각: global broadcast 유지 또는 두 번째 registry 거부
+
+identity option을 문서로 경고하거나 multi-registry에서 두 번째 자동 등록을 거부할 수 있다. 전자는 보안 위험을 남기고, 후자는 정상 multi-context telemetry를 소실한다. 양쪽 context가 독립 telemetry를 유지해야 하는 완료 조건을 만족하지 못한다.
+
+## 상세 설계
+
+### 1. Core scope carrier
+
+core에 Spring type을 모르는 실행 scope carrier를 둔다.
+
+- capability는 scoped registration 생성 시 core가 만들며 외부 caller가 token 값을 주입하는 API를 제공하지 않는다.
+- capability class의 constructor는 외부 호출에 닫고 equality를 재정의하지 않아 referential identity로 비교한다.
+- blocking 경계는 `ThreadLocal` save/set/restore를 사용한다.
+- coroutine 경계는 capability마다 한 번 만든 같은 `ThreadLocal`의 `ThreadContextElement`를 재사용한다.
+- scope token은 event, log, `toString()`, exception, metric tag에 포함하지 않는다.
+- cross-module bridge는 registration handle의 instance operation으로만 제공하고 Java source 호출은 `@JvmSynthetic`로 막는다. ambient capability를 읽는 accessor는 core `internal`로 유지하며 binary API test로 public `current()` descriptor가 없음을 고정한다.
+
+중첩 scope는 이전 값을 복원한다. scope가 없으면 `null`이며 scoped Spring observer와 일치하지 않는다.
+외부 Kotlin caller가 자기 scoped observer/capability를 만들 수 있어도 ambient capability를 읽는 public API가 없고 다른 registration의 capability를 얻거나 지정할 수 없으므로 다른 Spring context를 impersonate할 수 없다. Spring context owner bean과 manager entry는 `internal`로 유지한다.
+
+정확한 cross-module bridge shape은 다음과 같다.
+
+- `LeaderLeaseExtensionObservationScope`: public opaque final class, private constructor, `AutoCloseable` 구현
+- `LeaderLeaseExtensionObservers.addScopedObserver(observer): LeaderLeaseExtensionObservationScope`: public `@JvmSynthetic`; caller-supplied scope parameter 없음
+- `LeaderLeaseExtensionObservationScope.withScope(block)`와 `asContextElement()`: public `@JvmSynthetic` instance operation; caller가 등록 시 받은 자기 capability만 설치 가능
+- ambient scope lookup은 core module의 `internal currentOrNull()`만 제공하며 public Kotlin/JVM ABI에는 `current()` accessor가 없다.
+- 기존 `LeaderLeaseExtensionObservers.hasObservers()`와 `publish(event)` descriptor는 그대로 보존하며 unscoped/wildcard path를 의미한다.
+- 새 `hasObservers(scope)`와 `publish(event, scope)` overload는 public `@JvmSynthetic` additive bridge이고 core watchdog/adapter가 캡처한 capability만 받는다.
+
+따라서 Kotlin `internal`을 module 간 계약으로 사용하지 않는다. `LeaderLeaseExtensionApiContractTest`는 기존 bridge와 새 overload/factory의 exact public-synthetic signature, scope private constructor, event 5-인자 constructor를 함께 고정한다.
+
+Public Kotlin caller가 `addScopedObserver`로 받는 handle은 그 caller가 등록한 observer만 위한 scope다. 이 handle은 Spring `ObservationRegistry`와 연결되지 않고 Spring manager의 canonical capability를 읽거나 대체하지 못한다. caller는 `use`/`close`로 수명을 끝내야 하며 close 뒤 재설치해도 scoped callback은 발생하지 않는다. Java source에서는 `@JvmSynthetic` bridge가 보이지 않으므로 explicit global `addObserver`만 기존 public Java surface로 유지된다.
+
+### 2. Registration matching
+
+registration은 observer와 선택적 capability를 함께 가진다.
+
+- 기존 `addObserver(observer)`는 scope가 없는 wildcard registration을 만든다.
+- Spring용 scoped registration factory는 non-null capability와 registration handle을 함께 반환하며 caller-supplied token을 받지 않는다.
+- wildcard registrations와 capability별 registrations는 별도 copy-on-write bucket에 저장한다. capability bucket index는 capability의 identity semantics를 사용한다.
+- `hasObservers(scope)`는 wildcard bucket 또는 해당 capability bucket의 비어 있지 않은 상태만 O(1), 무할당으로 확인한다.
+- `publish`는 wildcard와 해당 capability bucket의 읽기 시점 항목만 순회하고 다른 scope registration은 복사하거나 검사하지 않는다.
+- matching되지 않은 registration에는 global/per-observer admission permit을 요청하지 않고 drop count도 증가시키지 않는다.
+- scope close는 한 번만 `active=false`로 선형화한 뒤 registration을 닫고 identity bucket을 map에서 제거한다. 반복 close는 no-op이고 accepted task의 late callback 정책은 유지한다. close/publish race와 weak-reference collection test로 dispatcher가 닫힌 capability를 계속 보유하지 않음을 검증한다.
+
+global admission이 포화된 경우에도 남은 wildcard와 같은 capability registration만 drop으로 기록한다. 다른 capability traffic은 permit이나 drop delta를 직접 소비하지 않는다. process-global wildcard observer callback은 모든 event를 받는 기존 계약이므로 global cap을 공유하며 scoped delivery의 cap을 간접 소비할 수 있다.
+
+### 3. USER event
+
+`LockExtender`는 publish 직전에 현재 execution scope를 읽는다.
+
+- Spring AOP action 안에서는 context owner의 capability scope가 존재한다.
+- blocking과 fail-open sync path는 `ThreadLocal` scope를 사용한다.
+- suspend/Mono/Flux/Flow path는 coroutine context element로 dispatcher 전환 후에도 같은 scope를 복원한다.
+- active handle이 없거나 이름이 일치하지 않는 USER event도 현재 Spring execution scope가 있으면 해당 registry에만 전달한다.
+- Spring scope 밖이면 global observer만 받는다.
+- `hasObservers(currentScope) == false`이면 timer/context/event를 만들기 전에 observation 분기만 종료하고 실제 lease extension 결과/예외 흐름은 그대로 유지한다.
+
+`LeaderElectorLeaseAdapter`와 `SuspendLeaderElectorLeaseAdapter`가 AOP 실행 안에서 새 virtual thread 또는 coroutine을 만들 때는 현재 capability를 생성 시점에 캡처하고 그 실행 경계에서 복원한다. scope 밖에서 직접 호출된 adapter는 계속 unscoped다.
+
+### 4. WATCHDOG event
+
+`LeaderLeaseAutoExtender.start()`는 호출 시점의 capability를 local immutable value로 캡처한다. 각 tick은 current thread의 ambient 값에 의존하지 않고 캡처한 capability를 `hasObservers`와 `publish`에 직접 전달한다.
+
+WATCHDOG도 matching observer가 없으면 timer/context/event 생성 전에 observation 분기를 종료한다.
+
+이 방식은 다음 전환에 동일하게 적용한다.
+
+- shared scheduled executor
+- optional virtual-thread blocking extension
+- suspend watchdog의 `CoroutineScope(Dispatchers.Default)`
+
+watchdog tick 종료, rejection, backend error, cancellation 의미는 바꾸지 않는다. close와 경쟁해 이미 accept된 callback은 기존 close/in-flight 계약대로 끝날 수 있지만 capability revoke 뒤에는 새 scoped callback을 accept하지 않는다. 실행 중 USER sync/suspend/Mono/Flux/Flow action이 revoke된 capability로 event를 만들면 automatic observer에는 0회이고 explicit global observer에는 기존 wildcard 계약대로 전달된다. `withScope`/`ThreadContextElement` 종료 시에는 revoke 여부와 무관하게 이전 nested scope를 복원한다. 같은 registry가 나중에 다시 등록되면 새 manager entry와 새 capability를 사용하므로 이전 action/watchdog event는 새 context에 귀속되지 않는다.
+
+### 5. Spring scope ownership
+
+Spring automatic observation의 telemetry domain은 선택된 `ObservationRegistry` object identity로 결정하지만, dispatch token은 registry object 자체가 아니라 manager entry가 소유한 opaque capability다.
+
+- 같은 registry를 공유하는 parent/child context는 같은 scope와 telemetry domain을 공유한다.
+- 서로 다른 registry는 서로 다른 scope가 된다.
+- manager는 기존 registry identity map, option conflict fail-fast, ref-count, last-close를 유지하며 entry마다 하나의 capability를 소유한다.
+- 새 core registration만 scoped registration으로 바꾼다.
+- coordinator의 late registration과 NOOP registry 판정 순서를 유지한다.
+
+각 application context는 하나의 internal scope owner bean을 가지며 aspect는 생성 시 그 owner identity에 고정된다. coordinator는 registry post-processing 뒤 manager에서 얻은 canonical capability를 owner에 정확히 한 번 활성화한다. 같은 registry를 공유하는 parent/child owner는 같은 manager-entry capability를 받고, 서로 다른 registry owner는 다른 capability를 받는다. context close는 자기 handle만 release하며 last-close가 registration과 capability를 revoke한다.
+
+`LeaderObservationAutoConfiguration`은 `@ConditionalOnMissingBean(search = SearchStrategy.CURRENT)`로 각 context에 선택된 registry identity를 보유하는 고정 이름의 internal owner bean을 먼저 만든다. 기존 public 3-인자 coordinator factory descriptor는 그대로 두고 factory body/coordinator가 같은 local `BeanFactory`의 owner를 조회한다. coordinator가 `afterSingletonsInstantiated()`에서 manager registration을 획득하면 그 owner를 canonical capability로 한 번 활성화한다. `LeaderBeanSelector` bean 자체와 aspect bean도 `SearchStrategy.CURRENT`로 context-local 생성하고, selector는 `HierarchicalBeanFactory.containsLocalBean`으로 자기 `BeanFactory`의 고정 이름 owner만 조회하며 parent의 다른 owner를 후보 선택하지 않는다.
+
+`LeaderAopAutoConfiguration`은 기존 factory parameter/descriptor를 바꾸지 않고, aspect 생성 직후 selector가 반환한 fixed owner를 internal property로 연결한다. 수동 생성 aspect와 owner bean이 없는 경우는 no-op scope다. owner는 활성화 전/close 후 `null`을 반환해 fail-closed하고 다른 registry를 동적으로 resolve하지 않는다. 기존 5/6-인자 factory와 aspect constructor descriptor는 모두 유지한다.
+
+registry 선택은 Spring의 기존 single-candidate/`@Primary` 규칙을 따른다. 같은 registry parent/child는 하나의 manager entry와 capability를 공유하고, distinct registry는 context마다 자기 owner에 고정된다. 동일 registry가 다른 options로 두 번째 등록되면 startup을 fail-fast하며 예외는 원인과 복구 방법(옵션 통일 또는 해당 context tracing 비활성화)을 포함하되 registry object/string identity를 노출하지 않는다.
+
+### 6. AOP 적용 경계
+
+`LeaderElectionAspect`와 `LeaderGroupElectionAspect`는 backend elector를 호출하고 action이 끝나는 전체 구간에 scope를 적용한다.
+
+- sync: owner가 제공한 `LeaderLeaseExtensionObservationScope.withScope { ... }`
+- suspend/reactive coroutine bridge: manager entry에서 재사용하는 `ThreadContextElement`로 `withContext`를 적용한다.
+- reentrant와 fail-open action도 같은 scope 안에 둔다.
+- stream은 subscription/collection 시점의 실제 elector 실행을 scope로 감싼다.
+
+Mono/Flux의 보장은 aspect가 소유한 coroutine bridge와 그 안의 suspend continuation에 한정한다. Reactor `map`/`filter`처럼 coroutine continuation 밖에서 실행되는 임의 operator callback에 `ThreadLocal`을 전파한다고 주장하지 않는다. 그런 callback에서 직접 `LockExtender`를 호출하면 fail-closed unscoped event가 되며 automatic Spring observer에는 전달하지 않는다. signal마다 scope/context element를 새로 만들거나 설치하지 않는다.
+
+metadata resolution bypass에는 scope를 적용하지 않는다. 해당 호출은 leader execution이 아니므로 lease-extension automatic ownership을 주장하지 않는다.
+
+지원 행렬은 다음과 같다.
+
+| Aspect | sync | suspend | Mono | Flux | Flow |
+|---|---:|---:|---:|---:|---:|
+| `LeaderElectionAspect` | 지원 | 지원 | 지원 | 지원 | 지원 |
+| `LeaderGroupElectionAspect` | 지원 | 지원 | 지원 | 미지원/기존 검증 오류 | 미지원/기존 검증 오류 |
+
+group `Flux`/`Flow`는 scope 설치 전에 기존 validation에서 거부되며 telemetry event를 만들지 않는다.
+
+## 실패 모드와 대응
+
+| 실패 모드 | 영향 | 대응 |
+|---|---|---|
+| scope를 event public field에 추가 | 5-인자 constructor ABI 파손 및 token 노출 | event 외부 dispatch metadata로 제한하고 API contract test를 유지한다. |
+| caller-supplied registry/token으로 scope 설치 | 다른 context scope impersonation | core가 registration과 capability를 함께 만들고 arbitrary token 입력 API를 제공하지 않는다. |
+| watchdog가 ambient ThreadLocal을 tick 시점에 조회 | scheduler thread의 다른/없는 scope로 오귀속 | `start()`에서 immutable scope를 캡처하고 tick publish에 명시적으로 전달한다. |
+| matching 전에 admission permit 획득 | 다른 context traffic이 registry quota/drop count를 오염 | scope matching 후 permit을 획득한다. |
+| suspend/reactive에서 scope context element 누락 | dispatcher 전환 후 event가 unscoped 처리 | blocking/suspend/Mono/Flux/Flow 경계별 회귀 테스트를 둔다. |
+| same-registry context마다 core registration 추가 | event 중복 기록 | 기존 registry identity manager의 단일 entry/ref-count를 유지한다. |
+| close와 accepted callback 경쟁 | 닫힌 context resource에 late callback | 기존 close 시점 semantics를 문서화하고 새 event acceptance만 차단한다. 이미 accepted된 callback은 기존 계약대로 완료될 수 있다. |
+| 직접 elector 호출을 잘못된 context에 추론 귀속 | identity 교차 노출 | automatic registry에는 전달하지 않는 fail-closed 정책을 문서화하고 global explicit observer만 유지한다. |
+| close 후 stale watchdog가 재등록 context에 전달 | 종료된 context identity의 새 registry 오염 | last-close로 capability를 revoke하고 재등록 entry는 새 capability를 사용한다. |
+
+## 호환성
+
+- `LeaderLeaseExtensionEvent` 5-인자 constructor를 유지한다.
+- `LeaderLeaseExtensionObservers`의 기존 non-synthetic public method set을 유지한다.
+- `addObserver`는 모든 process-local event를 받는다.
+- Micrometer observation name, low/high-cardinality key, error detail 정책을 유지한다.
+- same-registry option conflict와 close/ref-count 의미를 유지한다.
+- 새 internal/synthetic scope bridge는 Spring integration을 위한 additive surface다.
+- binary compatibility와 public facade reflection test를 실행한다.
+
+`includeExceptionDetails=true`의 기존 `Throwable` 전달 정책은 이번 변경이 추가하거나 확장하는 데이터 경계가 아니므로 유지한다. 이 opt-in은 raw exception message와 causal chain이 exporter에 전달될 수 있음을 의미하며 library가 SQL, credential, token을 redact한다고 가정하지 않는다. 운영자는 secret-bearing exception을 만들지 않거나 exporter-side redaction을 적용하고, 보장할 수 없으면 `includeExceptionDetails=false`를 유지한다. library-level exception redaction은 별도 security hardening 범위로 defer한다. 이번 PR은 A의 raw error가 B registry로 교차 전달되지 않음과 scope capability 자체가 error/tag에 포함되지 않음을 검증한다.
+
+### 사용자 마이그레이션
+
+- 기존 Spring AOP annotation 경로는 설정 변경 없이 registry별 automatic telemetry를 받는다.
+- AOP 밖에서 elector/adapter를 직접 호출하며 automatic lease-extension telemetry에 의존한 사용자는 해당 실행을 `@LeaderElection`/`@LeaderGroupElection` 경계로 옮기거나 명시적 process-global `LeaderLeaseExtensionObservers.addObserver`를 등록한다.
+- explicit global observer는 모든 context event를 받으므로 privacy/tenant 격리가 필요한 registry exporter 대체재가 아니다.
+- 같은 Micrometer observer를 manual global과 Spring automatic에 동시에 등록하면 중복 기록되므로 둘 중 하나만 사용한다. 진단 시 동일 event의 observation count가 2배인지 확인한다.
+- EN/KO README는 변경 전 global broadcast와 변경 후 scoped automatic/fail-closed direct-call behavior를 before/after 예제로 설명한다.
+
+### Rollout, rollback, shutdown
+
+- canary는 서로 다른 registry A/B를 동시에 실행해 각 registry에서 자기 lock/leader identity만 1회, 상대 identity 0회인지 확인하고 `droppedCount()` delta도 기록한다.
+- cross-context event, startup option conflict, unexpected duplicate observation이 발견되면 해당 `ApplicationContext`의 startup configuration에 `bluetape4k.leader.observability.tracing.enabled=false`를 설정하고 context/process를 재시작해 automatic lease-extension observation을 비활성화한다. runtime refresh switch가 아니며 이미 시작된 context에는 소급 적용되지 않는다. 재시작 뒤 local owner bean 부재, automatic 0건, explicit global observer 1건을 확인한다. 이 switch는 explicit global observer를 제거하지 않으므로 별도 close가 필요하다.
+- binary rollback은 이전 artifact로 되돌린 뒤 multi-registry automatic observer가 다시 global broadcast 의미가 됨을 운영자가 인지하고, 격리 요구가 있으면 tracing을 disabled 상태로 유지한다.
+- graceful shutdown은 AOP traffic 중단, context registration close, registry/exporter의 자체 grace period, exporter 종료 순서로 수행한다. library registration close는 내부 drain 대기 없이 유한 시간에 반환하고 close 이후 새 scoped admission만 차단한다. 이미 accepted된 callback의 exporter 전달은 보장하지 않으며 운영자는 exporter의 기존 shutdown timeout으로만 수용한다. shutdown smoke는 blocked callback 중 close가 즉시 반환하는지, 새 automatic callback이 0건인지, exporter가 살아 있는 동안 해제한 accepted callback이 기존 in-flight 계약대로 끝날 수 있는지 구분해 기록한다.
+- scope-excluded direct call은 drop이 아니므로 `droppedCount()`를 증가시키지 않는다. 장애 구분은 bounded explicit global observer로 동일 event 존재를 확인한 뒤 automatic registry 0건이면 intentional scope exclusion, global observer도 0건이면 producer/no-observer 경로, `droppedCount()` 증가면 admission saturation으로 판정한다.
+
+## 테스트 전략
+
+### Core
+
+1. global observer가 scoped A, scoped B, unscoped event를 모두 받는다.
+2. scoped observer A/B는 자기 scope만 받으며 unscoped event를 받지 않는다.
+3. scope mismatch event가 admission/drop count를 소비하지 않는다.
+4. nested blocking scope가 이전 값을 복원한다.
+5. coroutine dispatcher 전환 후 scope가 유지되고 종료 후 제거된다.
+6. USER blocking/suspend event가 올바른 scope로 한 번 전달된다.
+7. WATCHDOG blocking/suspend/virtual-thread event가 시작 시 scope로 전달된다.
+8. callback failure, close 시점, bounded admission 기존 테스트가 계속 통과한다.
+9. 공개 event/facade API contract가 변하지 않는다.
+10. 1024 global in-flight 포화와 A/B 동시 traffic에서도 mismatched scope의 permit/drop delta는 0이고 matched/wildcard delivery만 drop으로 집계된다.
+11. lease adapter가 만든 virtual thread/IO coroutine은 AOP scope를 보존하고 direct adapter 호출은 unscoped다.
+12. close/reopen 시 이전 capability watchdog event가 새 scoped registration에 전달되지 않는다.
+13. public JVM/Kotlin ABI에는 ambient `current()` accessor가 없고, caller-owned scope를 보유·재사용해도 다른 Spring automatic registration을 impersonate하지 못한다.
+14. caller-owned scope의 Korean KDoc과 EN/KO migration matrix가 자기 observer 전용, Spring registry 비연결, close 수명, Java `@JvmSynthetic` 제약을 설명한다.
+
+### Spring
+
+1. 서로 다른 registry A/B와 `includeLockName=true`, `includeLeaderId=true`에서 A identity가 A에만, B identity가 B에만 기록된다.
+2. A→B와 B→A close 순서 후 남은 context만 자기 event를 받는다.
+3. 같은 registry parent/child는 event당 callback 한 번과 ref-count를 유지한다.
+4. conflicting options는 두 번째 scoped registration 없이 fail-fast한다.
+5. NOOP registry와 tracing disabled에서는 registration이 없다.
+6. sync/suspend/Mono/Flux/Flow 및 fail-open/reentrant 실행에서 scope를 잃지 않는다.
+7. scope 밖 직접 `LockExtender` event는 automatic registry에는 0회, explicit global observer에는 1회 전달된다.
+8. Reactor non-suspend operator callback은 자동 scope 보장 범위 밖이며 direct extension이 automatic registry에 0회임을 고정한다.
+9. distinct parent/child registry의 동시 실행은 각 context-fixed owner에만 기록된다.
+10. sync/suspend/Mono/Flux/Flow/group의 exception, cancellation, nested scope, thread reuse 후 scope가 제거된다.
+11. A/B 양방향 close race와 watchdog first-tick/in-flight/shutdown/restart 경계에서 새 admission과 재등록 오귀속이 없다.
+12. option conflict 예외가 registry identity를 노출하지 않고 옵션 통일/비활성화 복구를 안내한다.
+13. `includeExceptionDetails=true`의 secret-like exception은 source registry에만 전달되고 상대 registry에는 0건이며 scope capability는 error/tag/log에 노출되지 않는다. raw payload redaction 책임은 exporter/operator에 있음을 문서화한다.
+14. active sync/suspend/Mono/Flux/Flow action과 context close가 경쟁하면 revoke 뒤 automatic callback은 0회, explicit global callback은 1회이며 nested scope 복원과 reopen-new-capability 격리가 유지된다.
+15. 기본값과 `includeExceptionDetails=false`에서는 raw throwable/error payload를 만들거나 exporter에 전달하지 않는다.
+
+### 성능
+
+1. `hasObservers(scope)`는 O(1), 무할당이고 `publish`는 wildcard와 matching capability bucket만 순회한다.
+2. capability별 `ThreadContextElement`는 manager entry 수명 동안 재사용하며 event/signal당 만들지 않는다.
+3. 기존 Spring advice JMH에 no-observer, scoped-match, scoped-mismatch, global과 sync/suspend/Mono/Flux/Flow/watchdog case를 추가한다.
+4. 동일 환경의 변경 전/후 3-fork 비교에서 `gc.alloc.rate.norm`이 새 per-event allocation을 보이지 않고 throughput/average-time median 회귀가 15% 이내인지 기록한다. 이 수치는 비결정적 CI fail gate가 아니라 구현 검토 evidence다.
+
+### 검증 명령
+
+```bash
+./gradlew :bluetape4k-leader-core:test --tests '*LeaderLeaseExtension*' --rerun-tasks
+./gradlew :bluetape4k-leader-spring-boot:test --tests '*LeaseExtensionObservation*' --rerun-tasks
+./gradlew :bluetape4k-leader-spring-boot:test --tests '*LeaderElectionAspect*' --rerun-tasks
+./gradlew :bluetape4k-leader-core:test :bluetape4k-leader-spring-boot:test
+./gradlew detekt
+./gradlew checkBinaryCompatibility
+./gradlew :benchmark:benchmarkBenchmark :benchmark:benchmarkAverageTimeBenchmark --no-configuration-cache --rerun-tasks
+./gradlew exportManualModuleInventory
+ruby scripts/manual/release_inventory.rb 0.5.0 721a9a3808f67489d2bdb8177734325981c24977 build/manual/module-inventory.json build/manual/release-module-inventory.json 35
+ruby scripts/manual/validate_manuals.rb build/manual/release-module-inventory.json
+ruby scripts/manual/validate_release_manuals.rb 0.5.0 721a9a3808f67489d2bdb8177734325981c24977
+ruby scripts/manual/export_manifest.rb --check
+ruby -I scripts/manual -e 'Dir["scripts/manual/*_test.rb"].sort.each { |file| require File.expand_path(file) }'
+git diff --check
+```
+
+## 문서
+
+- root `README.md`와 `README.ko.md`: global explicit observer와 Spring scoped automatic observer 경계를 구분한다.
+- `leader-spring-boot/README.md`와 `README.ko.md`: registry identity ownership, same-registry 공유, direct elector fail-closed, close semantics를 설명한다.
+- Spring EN/KO README에 `LeaderElectionAspect`/`LeaderGroupElectionAspect` 실행 모델 지원 행렬과 direct-call migration 예제를 추가한다.
+- `docs/manual/drafts/2026-08-27-issue-559-lease-extension-observation.{en,ko}.md`에 #741 delta, registry ownership, rollout/rollback/shutdown 절차를 추가한다. versioned manual의 `releaseRef`/`releaseCommit`은 변경하지 않고 미출시 주장은 draft에만 둔다.
+- 기존 #559의 process-local global facade 결정은 폐기하지 않고 Spring automatic registration에만 scoped dispatch를 추가한 것으로 기록한다.
+
+## 수용 기준
+
+- [ ] public global observer와 event ABI가 유지된다.
+- [ ] 서로 다른 Spring registry 사이 USER/WATCHDOG cross-delivery가 0이다.
+- [ ] identity opt-in에서도 상대 lock/leader identity가 0건이다.
+- [ ] same-registry parent/child callback/ref-count 계약이 유지된다.
+- [ ] 서로 다른 registry의 양쪽 close 순서가 안전하다.
+- [ ] sync/suspend/reactive scope 전파와 watchdog capture가 검증된다.
+- [ ] adapter thread/coroutine 전파와 Reactor non-suspend operator 제외 경계가 검증된다.
+- [ ] scope 밖 직접 호출은 automatic telemetry에서 제외되고 global observer에는 유지된다.
+- [ ] indexed dispatch, mismatch admission/drop, allocation/latency evidence가 검증된다.
+- [ ] rollout/rollback/shutdown 및 manual draft provenance가 EN/KO로 검증된다.
+- [ ] raw exception opt-in의 운영 전제와 cross-registry 0건이 검증된다.
+- [ ] core/Spring targeted 및 module test, detekt, ABI, diff check가 통과한다.
+- [ ] EN/KO 문서가 동일한 안전 경계를 설명한다.
+
+## 승인 및 writer gate
+
+- 사용자 승인: 2026-08-29, 대안 A와 direct-elector fail-closed 경계를 명시적으로 승인함.
+- SPW-01: PASS — 독자는 Issue #741 구현/검토자이며 코드 식별자를 보존한 한국어 기술 문서로 작성했다.
+- SPW-02: PASS — 문제, 대안, 선택, 경계, 실패 모드, 검증과 DoD를 분리했다.
+- SPW-03: PASS — 한국어 문장 흐름과 EN/KO artifact 역할을 점검했다.
+- SPW-04: PASS — 모든 핵심 주장을 현재 source/test/issue 증거에 연결했다.
+- SPW-05: PASS — scope, registry identity, global compatibility, direct-call 제외가 서로 모순되지 않도록 최종 read-back했다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseAutoExtender.kt
@@ -32,6 +32,7 @@ import io.bluetape4k.support.requirePositiveNumber
 
 private fun publishLeaderLeaseWatchdogEvent(
     observing: Boolean,
+    observationScope: LeaderLeaseExtensionObservationScope?,
     execution: LeaderLeaseExtensionExecution,
     outcome: ExtendOutcome,
     elapsedNanos: Long,
@@ -45,6 +46,7 @@ private fun publishLeaderLeaseWatchdogEvent(
             elapsedNanos = elapsedNanos,
             context = null,
         ),
+        observationScope,
     )
 }
 
@@ -170,6 +172,7 @@ object LeaderLeaseAutoExtender : KLogging() {
         val capturedAsyncExtend = asyncExtendEnabled
         val extendInFlight = AtomicBoolean(false)
         val admission = LeaderLeaseWatchdogAdmission.current()
+        val observationScope = LeaderLeaseExtensionObservationScope.currentOrNull()
 
         val doTick: () -> Unit = doTick@{
             if (closed.get()) {
@@ -183,7 +186,7 @@ object LeaderLeaseAutoExtender : KLogging() {
                 return@doTick
             }
 
-            val observing = LeaderLeaseExtensionObservers.hasObservers()
+            val observing = LeaderLeaseExtensionObservers.hasObservers(observationScope)
             val delegateStartedAtNanos = if (observing) System.nanoTime() else 0L
             var delegateRejected = false
             var delegateElapsedNanos = 0L
@@ -191,6 +194,7 @@ object LeaderLeaseAutoExtender : KLogging() {
             if (admission != null && watchdogReservation == null) {
                 publishLeaderLeaseWatchdogEvent(
                     observing,
+                    observationScope,
                     LeaderLeaseExtensionExecution.BLOCKING,
                     ExtendOutcome.Rejected,
                     0L,
@@ -232,6 +236,7 @@ object LeaderLeaseAutoExtender : KLogging() {
 
             publishLeaderLeaseWatchdogEvent(
                 observing,
+                observationScope,
                 LeaderLeaseExtensionExecution.BLOCKING,
                 outcome,
                 delegateElapsedNanos,
@@ -311,6 +316,7 @@ object LeaderLeaseAutoExtender : KLogging() {
         val extendInFlight = AtomicBoolean(false)
         val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
         val admission = LeaderLeaseWatchdogAdmission.current()
+        val observationScope = LeaderLeaseExtensionObservationScope.currentOrNull()
 
         fun cancelScopeIfIdle() {
             if (closed.get() && !extendInFlight.get()) {
@@ -330,7 +336,7 @@ object LeaderLeaseAutoExtender : KLogging() {
                 return
             }
 
-            val observing = LeaderLeaseExtensionObservers.hasObservers()
+            val observing = LeaderLeaseExtensionObservers.hasObservers(observationScope)
             val delegateStartedAtNanos = if (observing) System.nanoTime() else 0L
             var delegateRejected = false
             var delegateElapsedNanos = 0L
@@ -338,6 +344,7 @@ object LeaderLeaseAutoExtender : KLogging() {
             if (admission != null && watchdogReservation == null) {
                 publishLeaderLeaseWatchdogEvent(
                     observing,
+                    observationScope,
                     LeaderLeaseExtensionExecution.SUSPEND,
                     ExtendOutcome.Rejected,
                     0L,
@@ -377,6 +384,7 @@ object LeaderLeaseAutoExtender : KLogging() {
 
             publishLeaderLeaseWatchdogEvent(
                 observing,
+                observationScope,
                 LeaderLeaseExtensionExecution.SUSPEND,
                 outcome,
                 delegateElapsedNanos,

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObservationScope.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObservationScope.kt
@@ -54,7 +54,7 @@ class LeaderLeaseExtensionObservationScope private constructor(
     }
 
     @JvmSynthetic
-    internal fun isActive(): Boolean = active.get()
+    fun isActive(): Boolean = active.get()
 
     override fun toString(): String = "LeaderLeaseExtensionObservationScope(<opaque>)"
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObservationScope.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObservationScope.kt
@@ -1,0 +1,75 @@
+package io.bluetape4k.leader
+
+import kotlinx.coroutines.ThreadContextElement
+import kotlinx.coroutines.asContextElement
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * 호출자가 등록한 lease extension observer에만 event를 연결하는 불투명 scope입니다.
+ *
+ * 이 handle은 Spring `ObservationRegistry`와 연결되지 않으며 Spring 자동 관측 scope를
+ * 가장할 수 없습니다. 사용이 끝나면 반드시 [close]해야 합니다. Kotlin 전용 context
+ * bridge는 Java source에서 보이지 않도록 `@JvmSynthetic`으로 제한합니다.
+ */
+class LeaderLeaseExtensionObservationScope private constructor(
+    @get:JvmSynthetic
+    internal val observer: LeaderLeaseExtensionObserver,
+    private val closeAction: (LeaderLeaseExtensionObservationScope) -> Unit,
+) : AutoCloseable {
+
+    private val active = AtomicBoolean(true)
+    private val contextElement by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        scopes.asContextElement(this)
+    }
+
+    /** 이 scope를 현재 blocking 실행 경계에 설치하고 이전 scope를 복원합니다. */
+    @JvmSynthetic
+    fun <T> withScope(block: () -> T): T {
+        val previous = scopes.get()
+        val installed = takeIf { isActive() }
+        if (installed == null) {
+            scopes.remove()
+        } else {
+            scopes.set(installed)
+        }
+        return try {
+            block()
+        } finally {
+            if (previous == null) {
+                scopes.remove()
+            } else {
+                scopes.set(previous)
+            }
+        }
+    }
+
+    /** coroutine 전환에서도 이 scope를 전파하고 이전 thread-local 값을 복원합니다. */
+    @JvmSynthetic
+    fun asContextElement(): ThreadContextElement<LeaderLeaseExtensionObservationScope?> = contextElement
+
+    override fun close() {
+        if (active.compareAndSet(true, false)) {
+            closeAction(this)
+        }
+    }
+
+    @JvmSynthetic
+    internal fun isActive(): Boolean = active.get()
+
+    override fun toString(): String = "LeaderLeaseExtensionObservationScope(<opaque>)"
+
+    companion object {
+        private val scopes = ThreadLocal<LeaderLeaseExtensionObservationScope?>()
+
+        @JvmSynthetic
+        internal fun currentOrNull(): LeaderLeaseExtensionObservationScope? =
+            scopes.get()?.takeIf { it.isActive() }
+
+        @JvmSynthetic
+        internal fun create(
+            observer: LeaderLeaseExtensionObserver,
+            closeAction: (LeaderLeaseExtensionObservationScope) -> Unit,
+        ): LeaderLeaseExtensionObservationScope =
+            LeaderLeaseExtensionObservationScope(observer, closeAction)
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObserver.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObserver.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.logging.warn
 import io.bluetape4k.support.requireGe
 import io.bluetape4k.support.requireNotBlank
 import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
 import java.util.concurrent.Semaphore
 import java.util.concurrent.atomic.AtomicBoolean
@@ -100,7 +101,9 @@ object LeaderLeaseExtensionObservers {
     private const val MAX_IN_FLIGHT_PER_OBSERVER = 256
     private const val WARNING_INTERVAL_NANOS = 1_000_000_000L
 
-    private val registrations = CopyOnWriteArrayList<Registration>()
+    private val wildcardRegistrations = CopyOnWriteArrayList<Registration>()
+    private val scopedRegistrations =
+        ConcurrentHashMap<LeaderLeaseExtensionObservationScope, CopyOnWriteArrayList<Registration>>()
     private val globalInFlight = Semaphore(MAX_IN_FLIGHT)
     private val dropped = AtomicLong(0L)
 
@@ -108,19 +111,37 @@ object LeaderLeaseExtensionObservers {
     @JvmStatic
     fun addObserver(observer: LeaderLeaseExtensionObserver): AutoCloseable {
         val registration = Registration(observer)
-        registrations.add(registration)
+        wildcardRegistrations.add(registration)
         return AutoCloseable {
             if (registration.closed.compareAndSet(false, true)) {
-                registrations.remove(registration)
+                wildcardRegistrations.remove(registration)
             }
         }
+    }
+
+    /**
+     * caller-owned observer와 불투명 scope를 함께 등록합니다.
+     *
+     * 반환 scope는 이 observer만 선택하며 Spring registry 귀속을 뜻하지 않습니다.
+     * 사용이 끝나면 반드시 닫아야 합니다.
+     */
+    @JvmSynthetic
+    fun addScopedObserver(observer: LeaderLeaseExtensionObserver): LeaderLeaseExtensionObservationScope {
+        lateinit var registration: Registration
+        val scope = LeaderLeaseExtensionObservationScope.create(observer) { closedScope ->
+            scopedRegistrations.remove(closedScope)?.clear()
+            registration.closed.set(true)
+        }
+        registration = Registration(observer, scope)
+        scopedRegistrations[scope] = CopyOnWriteArrayList<Registration>().apply { add(registration) }
+        return scope
     }
 
     /** 동일 object identity의 registration을 모두 제거합니다. */
     @JvmStatic
     fun removeObserver(observer: LeaderLeaseExtensionObserver): Boolean {
         val removed = AtomicBoolean(false)
-        registrations.removeIf { registration ->
+        wildcardRegistrations.removeIf { registration ->
             if (registration.observer === observer) {
                 registration.closed.set(true)
                 removed.set(true)
@@ -129,6 +150,16 @@ object LeaderLeaseExtensionObservers {
                 false
             }
         }
+        scopedRegistrations.values
+            .asSequence()
+            .flatMap { it.asSequence() }
+            .filter { it.observer === observer }
+            .mapNotNull { it.scope }
+            .toList()
+            .forEach { scope ->
+                removed.set(true)
+                scope.close()
+            }
         return removed.get()
     }
 
@@ -138,13 +169,41 @@ object LeaderLeaseExtensionObservers {
 
     /** event/context allocation 전에 observer 존재 여부를 확인하는 internal bridge입니다. */
     @JvmSynthetic
-    internal fun hasObservers(): Boolean = registrations.isNotEmpty()
+    internal fun hasObservers(): Boolean = wildcardRegistrations.isNotEmpty()
+
+    /** global observer 또는 일치하는 active scope observer 존재 여부를 확인합니다. */
+    @JvmSynthetic
+    fun hasObservers(scope: LeaderLeaseExtensionObservationScope?): Boolean =
+        wildcardRegistrations.isNotEmpty() ||
+            (scope?.takeIf { it.isActive() }?.let(scopedRegistrations::get)?.isNotEmpty() == true)
 
     /** caller가 만든 terminal event를 bounded virtual-thread dispatcher에 제출합니다. */
     @JvmSynthetic
     @Suppress("TooGenericExceptionCaught")
     internal fun publish(event: LeaderLeaseExtensionEvent) {
-        val snapshot = registrations.toTypedArray()
+        publishSelected(event, wildcardRegistrations.toTypedArray())
+    }
+
+    /** global observer와 일치하는 active scope bucket에만 event를 제출합니다. */
+    @JvmSynthetic
+    fun publish(event: LeaderLeaseExtensionEvent, scope: LeaderLeaseExtensionObservationScope?) {
+        val wildcardSnapshot = wildcardRegistrations.toTypedArray()
+        val scopedSnapshot = scope
+            ?.takeIf { it.isActive() }
+            ?.let(scopedRegistrations::get)
+            ?.toTypedArray()
+            ?: emptyArray()
+        if (wildcardSnapshot.isEmpty()) {
+            publishSelected(event, scopedSnapshot)
+        } else if (scopedSnapshot.isEmpty()) {
+            publishSelected(event, wildcardSnapshot)
+        } else {
+            publishSelected(event, wildcardSnapshot + scopedSnapshot)
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun publishSelected(event: LeaderLeaseExtensionEvent, snapshot: Array<Registration>) {
         if (snapshot.isEmpty()) return
 
         var index = 0
@@ -221,6 +280,7 @@ object LeaderLeaseExtensionObservers {
 
     private class Registration(
         val observer: LeaderLeaseExtensionObserver,
+        val scope: LeaderLeaseExtensionObservationScope? = null,
     ) {
         val closed = AtomicBoolean(false)
         val inFlight = Semaphore(MAX_IN_FLIGHT_PER_OBSERVER)

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/LockExtender.kt
@@ -153,7 +153,8 @@ object LockExtender : KLogging() {
 
     @Suppress("TooGenericExceptionCaught")
     private fun extendDetailedInternal(handle: LeaderLockHandle, lockAtMostFor: Duration): ExtendOutcome {
-        val observing = LeaderLeaseExtensionObservers.hasObservers()
+        val observationScope = LeaderLeaseExtensionObservationScope.currentOrNull()
+        val observing = LeaderLeaseExtensionObservers.hasObservers(observationScope)
         val context = if (observing) extensionContext(handle) else null
 
         if (handle is LeaderLockHandle.FailOpen) {
@@ -161,6 +162,7 @@ object LockExtender : KLogging() {
             val outcome = ExtendOutcome.NotHeld
             publishUserEvent(
                 observing,
+                observationScope,
                 LeaderLeaseExtensionExecution.BLOCKING,
                 outcome,
                 context,
@@ -180,6 +182,7 @@ object LockExtender : KLogging() {
             }
             publishUserEvent(
                 observing,
+                observationScope,
                 LeaderLeaseExtensionExecution.BLOCKING,
                 outcome,
                 context,
@@ -191,6 +194,7 @@ object LockExtender : KLogging() {
         } catch (ex: Exception) {
             publishUserEvent(
                 observing,
+                observationScope,
                 LeaderLeaseExtensionExecution.BLOCKING,
                 ExtendOutcome.BackendError(ex),
                 context,
@@ -205,7 +209,8 @@ object LockExtender : KLogging() {
         handle: LeaderLockHandle,
         lockAtMostFor: Duration,
     ): ExtendOutcome {
-        val observing = LeaderLeaseExtensionObservers.hasObservers()
+        val observationScope = LeaderLeaseExtensionObservationScope.currentOrNull()
+        val observing = LeaderLeaseExtensionObservers.hasObservers(observationScope)
         val context = if (observing) extensionContext(handle) else null
 
         if (handle is LeaderLockHandle.FailOpen) {
@@ -213,6 +218,7 @@ object LockExtender : KLogging() {
             val outcome = ExtendOutcome.NotHeld
             publishUserEvent(
                 observing,
+                observationScope,
                 LeaderLeaseExtensionExecution.SUSPEND,
                 outcome,
                 context,
@@ -232,6 +238,7 @@ object LockExtender : KLogging() {
             }
             publishUserEvent(
                 observing,
+                observationScope,
                 LeaderLeaseExtensionExecution.SUSPEND,
                 outcome,
                 context,
@@ -243,6 +250,7 @@ object LockExtender : KLogging() {
         } catch (ex: Exception) {
             publishUserEvent(
                 observing,
+                observationScope,
                 LeaderLeaseExtensionExecution.SUSPEND,
                 ExtendOutcome.BackendError(ex),
                 context,
@@ -258,7 +266,8 @@ object LockExtender : KLogging() {
     private fun outsideScope(execution: LeaderLeaseExtensionExecution): ExtendOutcome {
         log.warn { "LockExtender called outside an active @LeaderElection scope — returning NotHeld" }
         val outcome = ExtendOutcome.NotHeld
-        if (LeaderLeaseExtensionObservers.hasObservers()) {
+        val observationScope = LeaderLeaseExtensionObservationScope.currentOrNull()
+        if (LeaderLeaseExtensionObservers.hasObservers(observationScope)) {
             LeaderLeaseExtensionObservers.publish(
                 LeaderLeaseExtensionEvent(
                     source = LeaderLeaseExtensionSource.USER,
@@ -267,6 +276,7 @@ object LockExtender : KLogging() {
                     elapsedNanos = 0L,
                     context = null,
                 ),
+                observationScope,
             )
         }
         return outcome
@@ -279,6 +289,7 @@ object LockExtender : KLogging() {
 
     private fun publishUserEvent(
         observing: Boolean,
+        observationScope: LeaderLeaseExtensionObservationScope?,
         execution: LeaderLeaseExtensionExecution,
         outcome: ExtendOutcome,
         context: LeaderLeaseExtensionContext?,
@@ -293,6 +304,7 @@ object LockExtender : KLogging() {
                 elapsedNanos = elapsedNanos,
                 context = context,
             ),
+            observationScope,
         )
     }
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderElectorLeaseAdapter.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderElectorLeaseAdapter.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.leader.LeaderElector
 import io.bluetape4k.leader.LeaderLeaseAcquirer
 import io.bluetape4k.leader.LeaderLeaseHandle
 import io.bluetape4k.leader.LeaderLeaseDefaults
+import io.bluetape4k.leader.LeaderLeaseExtensionObservationScope
 import io.bluetape4k.leader.LeaderLeaseWatchdogAdmission
 import io.bluetape4k.leader.LeaderLockHandle
 import io.bluetape4k.leader.LeaderSlot
@@ -43,27 +44,35 @@ class LeaderElectorLeaseAdapter(
         val session = SyncSession(slot, configuredOptions.leaseTime)
         val elected = CompletableFuture<SyncSession?>()
         val admission = LeaderLeaseWatchdogAdmission.current()
+        val observationScope = LeaderLeaseExtensionObservationScope.currentOrNull()
         val owner = Thread.startVirtualThread {
-            LeaderLeaseWatchdogAdmission.withOptionalProvider(admission) {
-                try {
-                    electorProvider().runIfLeader(slot) {
-                        val captured = AopScopeAccess.peekSyncMatching(slot.lockName)
-                        session.install(captured)
-                        if (captured !is LeaderLockHandle.Real || session.cancelled.get()) {
-                            session.cancelled.set(true)
-                            session.requestRelease()
-                        } else {
-                            elected.complete(session)
-                            session.awaitRelease()
+            val runElection = {
+                LeaderLeaseWatchdogAdmission.withOptionalProvider(admission) {
+                    try {
+                        electorProvider().runIfLeader(slot) {
+                            val captured = AopScopeAccess.peekSyncMatching(slot.lockName)
+                            session.install(captured)
+                            if (captured !is LeaderLockHandle.Real || session.cancelled.get()) {
+                                session.cancelled.set(true)
+                                session.requestRelease()
+                            } else {
+                                elected.complete(session)
+                                session.awaitRelease()
+                            }
+                            Unit
                         }
-                        Unit
+                        if (!elected.isDone) elected.complete(null)
+                        session.completed.complete(Unit)
+                    } catch (failure: Throwable) {
+                        if (!elected.isDone) elected.completeExceptionally(failure)
+                        session.completed.completeExceptionally(failure)
                     }
-                    if (!elected.isDone) elected.complete(null)
-                    session.completed.complete(Unit)
-                } catch (failure: Throwable) {
-                    if (!elected.isDone) elected.completeExceptionally(failure)
-                    session.completed.completeExceptionally(failure)
                 }
+            }
+            if (observationScope == null) {
+                runElection()
+            } else {
+                observationScope.withScope(runElection)
             }
         }
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/SuspendLeaderElectorLeaseAdapter.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/SuspendLeaderElectorLeaseAdapter.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.leader.LeaderLockHandle
 import io.bluetape4k.leader.LeaseOwnershipStatus
 import io.bluetape4k.leader.LeaderLeaseWatchdogAdmission
 import io.bluetape4k.leader.LeaderLeaseDefaults
+import io.bluetape4k.leader.LeaderLeaseExtensionObservationScope
 import io.bluetape4k.leader.coroutines.LockHandleElement
 import io.bluetape4k.leader.coroutines.SuspendLeaderElector
 import io.bluetape4k.leader.coroutines.SuspendLeaderLeaseAcquirer
@@ -56,7 +57,11 @@ class SuspendLeaderElectorLeaseAdapter(
         val published = CompletableDeferred<SuspendSession?>()
         val admission = LeaderLeaseWatchdogAdmission.current()
         val admissionContext = admission?.let(LeaderLeaseWatchdogAdmission::asContextElement)
-        val job = scope.launch(admissionContext ?: EmptyCoroutineContext) {
+        val observationScope = LeaderLeaseExtensionObservationScope.currentOrNull()
+        val observationContext = observationScope?.asContextElement()
+        val propagationContext =
+            (admissionContext ?: EmptyCoroutineContext) + (observationContext ?: EmptyCoroutineContext)
+        val job = scope.launch(propagationContext) {
             try {
                 electorProvider().runIfLeader(slot) {
                     val captured = captureSuspendHandle()

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionApiContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionApiContractTest.kt
@@ -79,6 +79,7 @@ class LeaderLeaseExtensionApiContractTest {
         scopeClass.declaredMethods.single { it.name == "withScope" && it.parameterCount == 1 }
             .isSynthetic.shouldBeTrue()
         scopeClass.getDeclaredMethod("asContextElement").isSynthetic.shouldBeTrue()
+        scopeClass.getDeclaredMethod("isActive").isSynthetic.shouldBeTrue()
         scopeClass.declaredMethods
             .any { Modifier.isPublic(it.modifiers) && it.name.startsWith("current") }
             .shouldBeFalse()
@@ -104,6 +105,7 @@ class LeaderLeaseExtensionApiContractTest {
                         LeaderLeaseExtensionObservers.INSTANCE.addScopedObserver(ignored -> {});
                     scope.withScope(() -> null);
                     scope.asContextElement();
+                    scope.isActive();
                     LeaderLeaseExtensionObservers.INSTANCE.hasObservers(scope);
                     LeaderLeaseExtensionObservers.INSTANCE.publish(event, scope);
                 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionApiContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionApiContractTest.kt
@@ -1,9 +1,12 @@
 package io.bluetape4k.leader
 
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import org.junit.jupiter.api.Test
 import java.lang.reflect.Modifier
+import java.nio.file.Files
+import javax.tools.ToolProvider
 
 class LeaderLeaseExtensionApiContractTest {
 
@@ -36,7 +39,8 @@ class LeaderLeaseExtensionApiContractTest {
         val facade = LeaderLeaseExtensionObservers::class.java
         val bridgeMethods = facade.declaredMethods.filter {
             Modifier.isPublic(it.modifiers) &&
-                (it.name.startsWith("hasObservers") || it.name.startsWith("publish"))
+                ((it.name.startsWith("hasObservers") && it.parameterCount == 0) ||
+                    (it.name.startsWith("publish") && it.parameterCount == 1))
         }
 
         bridgeMethods.size shouldBeEqualTo 2
@@ -51,5 +55,75 @@ class LeaderLeaseExtensionApiContractTest {
             Long::class.javaPrimitiveType,
             LeaderLeaseExtensionContext::class.java,
         )
+    }
+
+    @Test
+    fun `scoped Kotlin bridges are synthetic and scope has no public ambient accessor`() {
+        val facadeMethods = LeaderLeaseExtensionObservers::class.java.declaredMethods
+        val scopedBridges = facadeMethods.filter { method ->
+            Modifier.isPublic(method.modifiers) &&
+                (method.name == "addScopedObserver" ||
+                    (method.name == "hasObservers" && method.parameterCount == 1) ||
+                    (method.name == "publish" && method.parameterCount == 2))
+        }
+
+        scopedBridges.size shouldBeEqualTo 3
+        scopedBridges.all { it.isSynthetic }.shouldBeTrue()
+        scopedBridges.all { Modifier.isPublic(it.modifiers) }.shouldBeTrue()
+
+        val scopeClass = LeaderLeaseExtensionObservationScope::class.java
+        scopeClass.declaredConstructors
+            .filterNot { it.isSynthetic }
+            .all { Modifier.isPrivate(it.modifiers) }
+            .shouldBeTrue()
+        scopeClass.declaredMethods.single { it.name == "withScope" && it.parameterCount == 1 }
+            .isSynthetic.shouldBeTrue()
+        scopeClass.getDeclaredMethod("asContextElement").isSynthetic.shouldBeTrue()
+        scopeClass.declaredMethods
+            .any { Modifier.isPublic(it.modifiers) && it.name.startsWith("current") }
+            .shouldBeFalse()
+        LeaderLeaseExtensionObservationScope.Companion::class.java.declaredMethods
+            .filter { Modifier.isPublic(it.modifiers) && it.name.startsWith("current") }
+            .all { it.isSynthetic }
+            .shouldBeTrue()
+    }
+
+    @Test
+    fun `Java source cannot call scoped Kotlin bridges`() {
+        val compiler = ToolProvider.getSystemJavaCompiler()
+        val sourceDir = Files.createTempDirectory("leader-scope-java-api")
+        val source = sourceDir.resolve("ScopedObserverJavaFixture.java")
+        Files.writeString(
+            source,
+            """
+            import io.bluetape4k.leader.*;
+
+            final class ScopedObserverJavaFixture {
+                void invoke(LeaderLeaseExtensionEvent event) {
+                    LeaderLeaseExtensionObservationScope scope =
+                        LeaderLeaseExtensionObservers.INSTANCE.addScopedObserver(ignored -> {});
+                    scope.withScope(() -> null);
+                    scope.asContextElement();
+                    LeaderLeaseExtensionObservers.INSTANCE.hasObservers(scope);
+                    LeaderLeaseExtensionObservers.INSTANCE.publish(event, scope);
+                }
+            }
+            """.trimIndent(),
+        )
+
+        try {
+            val exitCode = compiler.run(
+                null,
+                null,
+                null,
+                "-classpath",
+                System.getProperty("java.class.path"),
+                source.toString(),
+            )
+            (exitCode == 0).shouldBeFalse()
+        } finally {
+            Files.deleteIfExists(source)
+            Files.deleteIfExists(sourceDir)
+        }
     }
 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionBoundaryContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionBoundaryContractTest.kt
@@ -38,6 +38,126 @@ import kotlin.time.toJavaDuration
 class LeaderLeaseExtensionBoundaryContractTest {
 
     @Test
+    fun `blocking and suspend user events stay in the installed observation scope`() = runSuspendIO {
+        val previous = leaderLeaseExtensionDispatcher
+        val globalEvents = CopyOnWriteArrayList<LeaderLeaseExtensionEvent>()
+        val aEvents = CopyOnWriteArrayList<LeaderLeaseExtensionEvent>()
+        val bEvents = CopyOnWriteArrayList<LeaderLeaseExtensionEvent>()
+        leaderLeaseExtensionDispatcher = Executor { runnable -> runnable.run() }
+        val global = LeaderLeaseExtensionObservers.addObserver(globalEvents::add)
+        val a = LeaderLeaseExtensionObservers.addScopedObserver(aEvents::add)
+        val b = LeaderLeaseExtensionObservers.addScopedObserver(bEvents::add)
+
+        try {
+            a.withScope {
+                LockStateHolder.withPushed(realHandle(RecordingDelegate { ExtendOutcome.NotHeld })) {
+                    LockExtender.extendActiveLockDetailed(30.seconds)
+                }
+            }
+            withContext(a.asContextElement() + LockHandleElement(realHandle(RecordingSuspendDelegate {
+                ExtendOutcome.NotHeld
+            }))) {
+                LockExtender.extendActiveLockDetailedSuspend(30.seconds)
+            }
+
+            globalEvents.size shouldBeEqualTo 2
+            aEvents.size shouldBeEqualTo 2
+            bEvents.size shouldBeEqualTo 0
+        } finally {
+            global.close()
+            a.close()
+            b.close()
+            leaderLeaseExtensionDispatcher = previous
+        }
+    }
+
+    @Test
+    fun `blocking and suspend watchdog capture the scope installed at start`() {
+        val previous = leaderLeaseExtensionDispatcher
+        val globalEvents = CopyOnWriteArrayList<LeaderLeaseExtensionEvent>()
+        val aEvents = CopyOnWriteArrayList<LeaderLeaseExtensionEvent>()
+        val bEvents = CopyOnWriteArrayList<LeaderLeaseExtensionEvent>()
+        leaderLeaseExtensionDispatcher = Executor { runnable -> runnable.run() }
+        val global = LeaderLeaseExtensionObservers.addObserver(globalEvents::add)
+        val a = LeaderLeaseExtensionObservers.addScopedObserver(aEvents::add)
+        val b = LeaderLeaseExtensionObservers.addScopedObserver(bEvents::add)
+        val blocking = a.withScope {
+            LeaderLeaseAutoExtender.start(
+                enabled = true,
+                leaseTime = 75.milliseconds,
+                delegate = RecordingDelegate { ExtendOutcome.NotHeld },
+            )
+        }
+        val suspend = a.withScope {
+            LeaderLeaseAutoExtender.start(
+                enabled = true,
+                leaseTime = 75.milliseconds,
+                delegate = RecordingSuspendDelegate { ExtendOutcome.NotHeld },
+            )
+        }
+
+        try {
+            await.atMost(5.seconds).untilAsserted {
+                globalEvents.count { it.source == LeaderLeaseExtensionSource.WATCHDOG } shouldBeEqualTo 2
+                aEvents.count { it.source == LeaderLeaseExtensionSource.WATCHDOG } shouldBeEqualTo 2
+            }
+            bEvents.size shouldBeEqualTo 0
+        } finally {
+            blocking.close()
+            suspend.close()
+            global.close()
+            a.close()
+            b.close()
+            leaderLeaseExtensionDispatcher = previous
+        }
+    }
+
+    @Test
+    fun `revoked scope from an in-flight user extension cannot target a replacement scope`() {
+        val previous = leaderLeaseExtensionDispatcher
+        val entered = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val globalEvents = CopyOnWriteArrayList<LeaderLeaseExtensionEvent>()
+        val replacementEvents = CopyOnWriteArrayList<LeaderLeaseExtensionEvent>()
+        val failure = AtomicReference<Throwable>()
+        leaderLeaseExtensionDispatcher = Executor { runnable -> runnable.run() }
+        val global = LeaderLeaseExtensionObservers.addObserver(globalEvents::add)
+        val stale = LeaderLeaseExtensionObservers.addScopedObserver { }
+        val owner = Thread.startVirtualThread {
+            try {
+                stale.withScope {
+                    LockStateHolder.withPushed(realHandle(RecordingDelegate {
+                        entered.countDown()
+                        release.await(5, TimeUnit.SECONDS)
+                        ExtendOutcome.NotHeld
+                    })) {
+                        LockExtender.extendActiveLockDetailed(30.seconds)
+                    }
+                }
+            } catch (ex: Throwable) {
+                failure.set(ex)
+            }
+        }
+
+        entered.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        stale.close()
+        val replacement = LeaderLeaseExtensionObservers.addScopedObserver(replacementEvents::add)
+        try {
+            release.countDown()
+            owner.join(5_000)
+            failure.get() shouldBeEqualTo null
+            globalEvents.size shouldBeEqualTo 1
+            replacementEvents.size shouldBeEqualTo 0
+        } finally {
+            release.countDown()
+            global.close()
+            stale.close()
+            replacement.close()
+            leaderLeaseExtensionDispatcher = previous
+        }
+    }
+
+    @Test
     fun `blocking detailed extension publishes one user event after deadline update`() {
         withManualDispatcher { submitted, events ->
             val expireAt = Instant.now().plusSeconds(30)

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObservationScopeTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObservationScopeTest.kt
@@ -1,0 +1,61 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Test
+
+class LeaderLeaseExtensionObservationScopeTest {
+
+    @Test
+    fun `scope is restored after nested blocking and coroutine boundaries`() = runTest {
+        val outer = LeaderLeaseExtensionObservers.addScopedObserver { }
+        val inner = LeaderLeaseExtensionObservers.addScopedObserver { }
+
+        outer.use {
+            inner.use {
+                outer.withScope {
+                    LeaderLeaseExtensionObservationScope.currentOrNull() shouldBeSameInstanceAs outer
+                    inner.withScope {
+                        LeaderLeaseExtensionObservationScope.currentOrNull() shouldBeSameInstanceAs inner
+                    }
+                    LeaderLeaseExtensionObservationScope.currentOrNull() shouldBeSameInstanceAs outer
+                }
+                withContext(Dispatchers.Default + outer.asContextElement()) {
+                    LeaderLeaseExtensionObservationScope.currentOrNull() shouldBeSameInstanceAs outer
+                }
+            }
+        }
+
+        LeaderLeaseExtensionObservationScope.currentOrNull().shouldBeNull()
+    }
+
+    @Test
+    fun `closed scope cannot be installed and close is idempotent`() {
+        val scope = LeaderLeaseExtensionObservers.addScopedObserver { }
+
+        scope.close()
+        scope.close()
+
+        scope.isActive().shouldBeFalse()
+        scope.withScope {
+            LeaderLeaseExtensionObservationScope.currentOrNull().shouldBeNull()
+        }
+    }
+
+    @Test
+    fun `scope handle does not reveal capability state`() {
+        val scope = LeaderLeaseExtensionObservers.addScopedObserver { }
+
+        try {
+            scope.toString().contains("observer", ignoreCase = true).shouldBeFalse()
+            scope.toString().contains("scope", ignoreCase = true).shouldBeTrue()
+        } finally {
+            scope.close()
+        }
+    }
+}

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObserversTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/LeaderLeaseExtensionObserversTest.kt
@@ -215,6 +215,152 @@ class LeaderLeaseExtensionObserversTest {
     }
 
     @Test
+    fun `scoped observers receive only their capability and wildcard receives all`() {
+        withManualDispatcher { submitted ->
+            val globalCalls = AtomicInteger()
+            val aCalls = AtomicInteger()
+            val bCalls = AtomicInteger()
+            val global = LeaderLeaseExtensionObservers.addObserver { globalCalls.incrementAndGet() }
+            val a = LeaderLeaseExtensionObservers.addScopedObserver { aCalls.incrementAndGet() }
+            val b = LeaderLeaseExtensionObservers.addScopedObserver { bCalls.incrementAndGet() }
+
+            try {
+                LeaderLeaseExtensionObservers.publish(testEvent(), a)
+                submitted.size shouldBeEqualTo 2
+                submitted.forEach(Runnable::run)
+
+                globalCalls.get() shouldBeEqualTo 1
+                aCalls.get() shouldBeEqualTo 1
+                bCalls.get() shouldBeEqualTo 0
+            } finally {
+                global.close()
+                a.close()
+                b.close()
+            }
+        }
+    }
+
+    @Test
+    fun `accepted scoped callback may finish after close but later publish is rejected`() {
+        withManualDispatcher { submitted ->
+            val calls = AtomicInteger()
+            val scope = LeaderLeaseExtensionObservers.addScopedObserver { calls.incrementAndGet() }
+
+            LeaderLeaseExtensionObservers.publish(testEvent(), scope)
+            submitted.size shouldBeEqualTo 1
+            scope.close()
+            submitted.single().run()
+
+            calls.get() shouldBeEqualTo 1
+            LeaderLeaseExtensionObservers.publish(testEvent(), scope)
+            submitted.size shouldBeEqualTo 1
+            calls.get() shouldBeEqualTo 1
+        }
+    }
+
+    @Test
+    fun `saturated admission counts only wildcard and matching scoped observers as drops`() {
+        val entered = CountDownLatch(1024)
+        val completed = CountDownLatch(1024)
+        val release = CountDownLatch(1)
+        val wildcardRegistrations = (1..4).map {
+            LeaderLeaseExtensionObservers.addObserver {
+                entered.countDown()
+                try {
+                    release.await(5, TimeUnit.SECONDS)
+                } finally {
+                    completed.countDown()
+                }
+            }
+        }
+        val aCalls = AtomicInteger()
+        val bCalls = AtomicInteger()
+        val a = LeaderLeaseExtensionObservers.addScopedObserver { aCalls.incrementAndGet() }
+        val b = LeaderLeaseExtensionObservers.addScopedObserver { bCalls.incrementAndGet() }
+
+        try {
+            repeat(256) { LeaderLeaseExtensionObservers.publish(testEvent()) }
+            entered.await(10, TimeUnit.SECONDS).shouldBeTrue()
+
+            val droppedBefore = LeaderLeaseExtensionObservers.droppedCount()
+            LeaderLeaseExtensionObservers.publish(testEvent(), a)
+            await
+                .atMost(5.seconds)
+                .withPollInterval(25.milliseconds)
+                .untilAsserted {
+                    LeaderLeaseExtensionObservers.droppedCount() shouldBeEqualTo droppedBefore + 5
+                }
+            aCalls.get() shouldBeEqualTo 0
+            bCalls.get() shouldBeEqualTo 0
+        } finally {
+            release.countDown()
+            val drained = try {
+                completed.await(10, TimeUnit.SECONDS)
+            } finally {
+                wildcardRegistrations.forEach(AutoCloseable::close)
+                a.close()
+                b.close()
+            }
+            drained.shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `closed scoped capability is not reused by a replacement registration`() {
+        withManualDispatcher { submitted ->
+            val staleCalls = AtomicInteger()
+            val replacementCalls = AtomicInteger()
+            val stale = LeaderLeaseExtensionObservers.addScopedObserver { staleCalls.incrementAndGet() }
+            stale.close()
+            val replacement = LeaderLeaseExtensionObservers.addScopedObserver { replacementCalls.incrementAndGet() }
+
+            try {
+                LeaderLeaseExtensionObservers.publish(testEvent(), stale)
+                submitted.size shouldBeEqualTo 0
+                LeaderLeaseExtensionObservers.publish(testEvent(), replacement)
+                submitted.size shouldBeEqualTo 1
+                submitted.single().run()
+
+                staleCalls.get() shouldBeEqualTo 0
+                replacementCalls.get() shouldBeEqualTo 1
+            } finally {
+                replacement.close()
+            }
+        }
+    }
+
+    @Test
+    fun `scoped hasObservers ignores mismatched and revoked capabilities`() {
+        val a = LeaderLeaseExtensionObservers.addScopedObserver { }
+        val b = LeaderLeaseExtensionObservers.addScopedObserver { }
+
+        try {
+            LeaderLeaseExtensionObservers.hasObservers(a).shouldBeTrue()
+            LeaderLeaseExtensionObservers.hasObservers(b).shouldBeTrue()
+            a.close()
+            LeaderLeaseExtensionObservers.hasObservers(a).shouldBeFalse()
+            LeaderLeaseExtensionObservers.hasObservers(b).shouldBeTrue()
+        } finally {
+            a.close()
+            b.close()
+        }
+    }
+
+    @Test
+    fun `removeObserver revokes its scoped capability`() {
+        val observer = LeaderLeaseExtensionObserver { }
+        val scope = LeaderLeaseExtensionObservers.addScopedObserver(observer)
+
+        try {
+            LeaderLeaseExtensionObservers.removeObserver(observer).shouldBeTrue()
+            scope.isActive().shouldBeFalse()
+            LeaderLeaseExtensionObservers.hasObservers(scope).shouldBeFalse()
+        } finally {
+            scope.close()
+        }
+    }
+
+    @Test
     fun `Java fixture can construct and register through the public facade`() {
         val event = LeaderLeaseExtensionJavaApiFixture.event()
 

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LeaderElectorLeaseAdapterTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LeaderElectorLeaseAdapterTest.kt
@@ -5,22 +5,99 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderLeaseExtensionEvent
+import io.bluetape4k.leader.LeaderLeaseExtensionObservers
+import io.bluetape4k.leader.LeaderLeaseExtensionSource
 import io.bluetape4k.leader.LeaderLeaseWatchdogAdmission
 import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.LeaseOwnershipStatus
 import io.bluetape4k.leader.coroutines.LocalSuspendLeaderElector
 import io.bluetape4k.leader.coroutines.LockHandleElement
 import io.bluetape4k.leader.local.LocalLeaderElector
+import io.bluetape4k.leader.leaderLeaseExtensionDispatcher
+import kotlinx.coroutines.withContext
 import org.awaitility.kotlin.atMost
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.coroutines.coroutineContext
 
 class LeaderElectorLeaseAdapterTest {
+
+    @Test
+    fun `blocking and suspend adapters carry observation scope to backend owner`() = runSuspendIO {
+        val previous = leaderLeaseExtensionDispatcher
+        val globalEvents = CopyOnWriteArrayList<LeaderLeaseExtensionEvent>()
+        val aEvents = CopyOnWriteArrayList<LeaderLeaseExtensionEvent>()
+        val bEvents = CopyOnWriteArrayList<LeaderLeaseExtensionEvent>()
+        leaderLeaseExtensionDispatcher = Executor { runnable -> runnable.run() }
+        val global = LeaderLeaseExtensionObservers.addObserver(globalEvents::add)
+        val a = LeaderLeaseExtensionObservers.addScopedObserver(aEvents::add)
+        val b = LeaderLeaseExtensionObservers.addScopedObserver(bEvents::add)
+        val options = LeaderElectionOptions(waitTime = 2.seconds, leaseTime = 90.milliseconds, autoExtend = true)
+        val blocking = LeaderElectorLeaseAdapter({ LocalLeaderElector(options) }, options)
+        val suspend = SuspendLeaderElectorLeaseAdapter({ LocalSuspendLeaderElector(options) }, options)
+
+        try {
+            val blockingHandle = a.withScope {
+                blocking.tryAcquire(LeaderSlot("scoped-blocking-adapter", "request-node"))
+            }.shouldNotBeNull()
+            val suspendHandle = withContext(a.asContextElement()) {
+                suspend.tryAcquire(LeaderSlot("scoped-suspend-adapter", "request-node"))
+            }.shouldNotBeNull()
+
+            await.atMost(5.seconds).untilAsserted {
+                (globalEvents.count { it.source == LeaderLeaseExtensionSource.WATCHDOG } > 0).shouldBeTrue()
+                (aEvents.count { it.source == LeaderLeaseExtensionSource.WATCHDOG } > 0).shouldBeTrue()
+            }
+            bEvents.size shouldBeEqualTo 0
+            blockingHandle.release()
+            suspendHandle.release()
+        } finally {
+            suspend.close()
+            global.close()
+            a.close()
+            b.close()
+            leaderLeaseExtensionDispatcher = previous
+        }
+    }
+
+    @Test
+    fun `direct adapter acquisition remains unscoped while global observer receives watchdog`() = runSuspendIO {
+        val previous = leaderLeaseExtensionDispatcher
+        val globalEvents = CopyOnWriteArrayList<LeaderLeaseExtensionEvent>()
+        val scopedEvents = CopyOnWriteArrayList<LeaderLeaseExtensionEvent>()
+        leaderLeaseExtensionDispatcher = Executor { runnable -> runnable.run() }
+        val global = LeaderLeaseExtensionObservers.addObserver(globalEvents::add)
+        val scoped = LeaderLeaseExtensionObservers.addScopedObserver(scopedEvents::add)
+        val options = LeaderElectionOptions(waitTime = 2.seconds, leaseTime = 90.milliseconds, autoExtend = true)
+        val blocking = LeaderElectorLeaseAdapter({ LocalLeaderElector(options) }, options)
+        val suspend = SuspendLeaderElectorLeaseAdapter({ LocalSuspendLeaderElector(options) }, options)
+
+        try {
+            val blockingHandle = blocking.tryAcquire(LeaderSlot("direct-blocking-adapter", "request-node"))
+                .shouldNotBeNull()
+            val suspendHandle = suspend.tryAcquire(LeaderSlot("direct-suspend-adapter", "request-node"))
+                .shouldNotBeNull()
+
+            await.atMost(5.seconds).untilAsserted {
+                (globalEvents.count { it.source == LeaderLeaseExtensionSource.WATCHDOG } > 0).shouldBeTrue()
+            }
+            scopedEvents.size shouldBeEqualTo 0
+            blockingHandle.release()
+            suspendHandle.release()
+        } finally {
+            suspend.close()
+            global.close()
+            scoped.close()
+            leaderLeaseExtensionDispatcher = previous
+        }
+    }
 
     @Test
     fun `blocking adapter preserves caller slot and delegates lifecycle`() {

--- a/leader-spring-boot/README.ko.md
+++ b/leader-spring-boot/README.ko.md
@@ -420,6 +420,27 @@ Spring은 다음 규칙으로 registration 수명주기를 관리합니다.
 - 같은 registry에 서로 다른 `LeaderObservationOptions`가 들어오면 redaction을
   조용히 약화하거나 callback을 중복 등록하지 않고 즉시 실패합니다.
 
+자동 lease-extension 전달은 각 local application context가 선택한 registry에 귀속됩니다. 같은 registry를 공유하는
+parent/child context는 scope와 callback 하나를 공유하고, 서로 다른 registry는 상대 event나 opt-in identity를 받지
+않습니다. 귀속 경계는 aspect가 소유한 실행 구간입니다.
+
+| Aspect | Sync | Suspend | `Mono` | `Flux` | Kotlin `Flow` |
+|---|---:|---:|---:|---:|---:|
+| `@LeaderElection` | 지원 | 지원 | 지원 | 지원 | 지원 |
+| `@LeaderGroupElection` | 지원 | 지원 | 지원 | 거부 | 거부 |
+
+이 aspect 밖의 직접 elector 호출과 aspect가 소유한 coroutine bridge 밖의 Reactor callback에서 실행한 직접
+`LockExtender` 호출은 Spring 자동 lease-extension observation을 만들지 않습니다. 다만 명시적으로 등록한
+process-global `LeaderLeaseExtensionObservers.addObserver`에는 계속 전달됩니다. 자동 귀속이 필요하면 annotation
+경계 안으로 옮기거나 명시적인 global observer 하나를 애플리케이션이 소유하고 종료 시 닫으세요. 같은 Micrometer
+adapter에 두 방식을 함께 사용하지 마세요.
+
+Canary에서는 registry A/B를 함께 실행해 자기 identity `1건`, 상대 identity `0건`, 예상 밖 `droppedCount()` delta
+없음을 확인합니다. `bluetape4k.leader.observability.tracing.enabled=false`는 startup-only rollback switch이므로
+context/process 재시작이 필요합니다. 재시작 뒤 automatic `0건`, explicit global `1건`을 확인하세요. 종료 순서는
+AOP traffic 중단, context registration close, registry/exporter grace period, exporter 종료입니다. Registration close는
+이미 accepted된 callback의 drain을 기다리지 않고 새 scoped admission만 막습니다.
+
 Core event는 `USER`/`WATCHDOG` source와 `BLOCKING`/`SUSPEND` execution을 그대로
 구분합니다. Micrometer는 앞서 설명한 bounded `source`, `execution`, `outcome`,
 `result` 값만 기본으로 내보냅니다. Lock name과 leader ID는 명시적으로 켰을 때

--- a/leader-spring-boot/README.md
+++ b/leader-spring-boot/README.md
@@ -443,6 +443,27 @@ Spring manages the registration lifecycle as follows:
 - conflicting `LeaderObservationOptions` for the same registry fail fast rather
   than silently weakening redaction or duplicating callbacks.
 
+Automatic lease-extension delivery is scoped to the registry selected by each local application context. Parent and
+child contexts that share the same registry share one scope and one callback; distinct registries never receive each
+other's events or opted-in identities. The attribution boundary is the aspect-owned execution:
+
+| Aspect | Sync | Suspend | `Mono` | `Flux` | Kotlin `Flow` |
+|---|---:|---:|---:|---:|---:|
+| `@LeaderElection` | yes | yes | yes | yes | yes |
+| `@LeaderGroupElection` | yes | yes | yes | rejected | rejected |
+
+Direct elector calls outside these aspects and direct `LockExtender` calls from Reactor callbacks outside the
+aspect-owned coroutine bridge produce no automatic Spring lease-extension observation. They still reach an explicitly
+registered process-global `LeaderLeaseExtensionObservers.addObserver`. Move code that needs automatic attribution into
+an annotation boundary, or own and close one explicit global observer; do not combine both for the same Micrometer
+adapter.
+
+For a canary, run registry A and B together and require own identity count `1`, cross identity count `0`, and no
+unexpected `droppedCount()` delta. `bluetape4k.leader.observability.tracing.enabled=false` is a startup-only rollback
+switch: restart the context/process, then verify automatic count `0` and explicit global count `1`. Shutdown order is
+stop AOP traffic, close the context registration, allow the registry/exporter grace period, then stop the exporter.
+Registration close does not wait for accepted callbacks to drain; it only prevents new scoped admission.
+
 The core event keeps `USER`/`WATCHDOG` source and `BLOCKING`/`SUSPEND` execution
 parity. Micrometer exports the bounded `source`, `execution`, `outcome`, and
 `result` values described above. Lock name and leader ID are opt-in and pass

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderBeanSelector.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderBeanSelector.kt
@@ -6,7 +6,10 @@ import io.bluetape4k.leader.annotation.LeaderElectionBackend
 import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
 import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElectorFactory
 import io.bluetape4k.leader.spring.aop.util.findMergedAnnotationOrNull
+import io.bluetape4k.leader.spring.metrics.LEASE_EXTENSION_OBSERVATION_SCOPE_OWNER_BEAN_NAME
+import io.bluetape4k.leader.spring.metrics.LeaseExtensionObservationScopeOwner
 import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.HierarchicalBeanFactory
 import org.springframework.beans.factory.ListableBeanFactory
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException
@@ -21,6 +24,16 @@ import java.lang.reflect.Method
 class LeaderBeanSelector(
     private val beanFactory: BeanFactory,
 ) {
+
+    internal fun observationScopeOwner(): LeaseExtensionObservationScopeOwner? =
+        (beanFactory as? HierarchicalBeanFactory)
+            ?.takeIf { it.containsLocalBean(LEASE_EXTENSION_OBSERVATION_SCOPE_OWNER_BEAN_NAME) }
+            ?.let {
+                beanFactory.getBean(
+                    LEASE_EXTENSION_OBSERVATION_SCOPE_OWNER_BEAN_NAME,
+                    LeaseExtensionObservationScopeOwner::class.java,
+                )
+            }
 
     /**
      * `selectElectionFactory` 호출은 Spring Boot integration 계약의 일부 동작을 수행합니다.

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -20,6 +20,7 @@ import io.bluetape4k.leader.spring.aop.internal.AdviceBranch
 import io.bluetape4k.leader.spring.aop.internal.AdviceMetadata
 import io.bluetape4k.leader.spring.aop.internal.BodyThrownMarker
 import io.bluetape4k.leader.spring.aop.internal.InvalidLockNameException
+import io.bluetape4k.leader.spring.metrics.LeaseExtensionObservationScopeOwner
 import io.bluetape4k.leader.spring.aop.properties.LeaderAopProperties
 import io.bluetape4k.leader.spring.aop.spel.SpelExpressionEvaluator
 import io.bluetape4k.leader.spring.aop.util.AnnotationLookup
@@ -37,6 +38,7 @@ import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
@@ -50,6 +52,8 @@ import java.lang.reflect.Method
 import kotlinx.coroutines.CancellationException
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
 import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.time.Duration.Companion.nanoseconds
@@ -90,6 +94,8 @@ class LeaderElectionAspect(
     private val suspendElectorCache = ConcurrentHashMap<FactoryCacheKey, SuspendLeaderElector>()
     private val hasRecorders = recorders.isNotEmpty()
 
+    internal var observationScopeOwner: LeaseExtensionObservationScopeOwner? = null
+
     @Around(
         "execution(* *(..)) && (" +
             "@annotation(io.bluetape4k.leader.annotation.LeaderElection) || " +
@@ -98,6 +104,12 @@ class LeaderElectionAspect(
     )
     @Suppress("CyclomaticComplexMethod", "LongMethod", "ReturnCount", "ThrowsCount")
     fun aroundLeader(pjp: ProceedingJoinPoint): Any? {
+        val scope = observationScopeOwner?.current() ?: return aroundLeaderInternal(pjp)
+        return scope.withScope { aroundLeaderInternal(pjp) }
+    }
+
+    @Suppress("CyclomaticComplexMethod", "LongMethod", "ReturnCount", "ThrowsCount")
+    private fun aroundLeaderInternal(pjp: ProceedingJoinPoint): Any? {
         val method = (pjp.signature as MethodSignature).method
         val target = pjp.target
         val args = pjp.args
@@ -275,7 +287,7 @@ class LeaderElectionAspect(
         val start = System.nanoTime()
         val method = (pjp.signature as MethodSignature).method
 
-        val suspendBlock: suspend () -> Any? = {
+        val executeSuspend: suspend () -> Any? = {
             var lockName: String? = null
             var resolvedIdentity: LockIdentity? = null
 
@@ -415,6 +427,12 @@ class LeaderElectionAspect(
                 }
             }
         }
+        val scope = observationScopeOwner?.current()
+        val suspendBlock: suspend () -> Any? = if (scope == null) {
+            executeSuspend
+        } else {
+            { withContext(scope.asContextElement()) { executeSuspend() } }
+        }
         return suspendBlock.startCoroutineUninterceptedOrReturn(continuation)
     }
 
@@ -431,7 +449,7 @@ class LeaderElectionAspect(
                 return@defer Flux.error(streamConfigurationException(method, meta, "Flux"))
             }
 
-            flux<Any> {
+            flux<Any>(context = observationCoroutineContext()) {
                 val start = System.nanoTime()
                 var lockName: String? = null
                 var resolvedIdentity: LockIdentity? = null
@@ -705,7 +723,7 @@ class LeaderElectionAspect(
                     }
                 }
             }
-        }.buffer(Channel.RENDEZVOUS)
+        }.flowOn(observationCoroutineContext()).buffer(Channel.RENDEZVOUS)
 
     /**
      * `aroundLeaderMono` 호출은 Spring Boot integration 계약의 일부 동작을 수행합니다.
@@ -717,7 +735,7 @@ class LeaderElectionAspect(
 
         return Mono.defer {
             val start = System.nanoTime()
-            mono {
+            mono(context = observationCoroutineContext()) {
                 var lockName: String? = null
                 var resolvedIdentity: LockIdentity? = null
 
@@ -837,6 +855,9 @@ class LeaderElectionAspect(
             }
         }
     }
+
+    private fun observationCoroutineContext(): CoroutineContext =
+        observationScopeOwner?.current()?.asContextElement() ?: EmptyCoroutineContext
 
     private fun executeBody(pjp: ProceedingJoinPoint, lockName: String, start: Long): Any? {
         return try {

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderElectionAspect.kt
@@ -287,7 +287,7 @@ class LeaderElectionAspect(
         val start = System.nanoTime()
         val method = (pjp.signature as MethodSignature).method
 
-        val executeSuspend: suspend () -> Any? = {
+        val suspendBlock: suspend () -> Any? = {
             var lockName: String? = null
             var resolvedIdentity: LockIdentity? = null
 
@@ -428,12 +428,12 @@ class LeaderElectionAspect(
             }
         }
         val scope = observationScopeOwner?.current()
-        val suspendBlock: suspend () -> Any? = if (scope == null) {
-            executeSuspend
+        val scopedSuspendBlock: suspend () -> Any? = if (scope == null) {
+            suspendBlock
         } else {
-            { withContext(scope.asContextElement()) { executeSuspend() } }
+            { withContext(scope.asContextElement()) { suspendBlock() } }
         }
-        return suspendBlock.startCoroutineUninterceptedOrReturn(continuation)
+        return scopedSuspendBlock.startCoroutineUninterceptedOrReturn(continuation)
     }
 
     /**

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -19,6 +19,7 @@ import io.bluetape4k.leader.spring.aop.cache.GroupFactoryCacheKey
 import io.bluetape4k.leader.spring.aop.internal.AdviceBranch
 import io.bluetape4k.leader.spring.aop.internal.BodyThrownMarker
 import io.bluetape4k.leader.spring.aop.internal.InvalidLockNameException
+import io.bluetape4k.leader.spring.metrics.LeaseExtensionObservationScopeOwner
 import io.bluetape4k.leader.spring.aop.properties.LeaderAopProperties
 import io.bluetape4k.leader.spring.aop.spel.SpelExpressionEvaluator
 import io.bluetape4k.leader.spring.aop.util.AnnotationLookup
@@ -44,6 +45,8 @@ import reactor.core.publisher.Mono
 import java.lang.reflect.Method
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
 import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.time.Duration.Companion.nanoseconds
@@ -60,7 +63,7 @@ import kotlin.time.toKotlinDuration
  * @property recorders Spring Boot integration 계약에서 사용하는 속성입니다.
  * @property groupProperties 공통 Spring group 정책과 annotation 정책을 결합하는 설정입니다.
  */
-@Suppress("ReactiveStreamsUnusedPublisher")
+@Suppress("ReactiveStreamsUnusedPublisher", "TooManyFunctions")
 @Aspect
 class LeaderGroupElectionAspect(
     private val beanSelector: LeaderBeanSelector,
@@ -85,8 +88,16 @@ class LeaderGroupElectionAspect(
     private val suspendElectorCache = ConcurrentHashMap<GroupFactoryCacheKey, SuspendLeaderGroupElector>()
     private val hasRecorders = recorders.isNotEmpty()
 
+    internal var observationScopeOwner: LeaseExtensionObservationScopeOwner? = null
+
     @Around("@annotation(io.bluetape4k.leader.annotation.LeaderGroupElection)")
     fun aroundLeader(pjp: ProceedingJoinPoint): Any? {
+        val scope = observationScopeOwner?.current() ?: return aroundLeaderInternal(pjp)
+        return scope.withScope { aroundLeaderInternal(pjp) }
+    }
+
+    @Suppress("CyclomaticComplexMethod", "LongMethod", "ReturnCount", "ThrowsCount")
+    private fun aroundLeaderInternal(pjp: ProceedingJoinPoint): Any? {
         val method = (pjp.signature as MethodSignature).method
         val target = pjp.target
         val args = pjp.args
@@ -252,7 +263,7 @@ class LeaderGroupElectionAspect(
         val method = (pjp.signature as MethodSignature).method
         val coreOpts = meta.options.toCoreOptions()
 
-        val suspendBlock: suspend () -> Any? = {
+        val executeSuspend: suspend () -> Any? = {
             var lockName: String? = null
             var resolvedIdentity: LockIdentity? = null
 
@@ -392,6 +403,12 @@ class LeaderGroupElectionAspect(
                 }
             }
         }
+        val scope = observationScopeOwner?.current()
+        val suspendBlock: suspend () -> Any? = if (scope == null) {
+            executeSuspend
+        } else {
+            { withContext(scope.asContextElement()) { executeSuspend() } }
+        }
         return suspendBlock.startCoroutineUninterceptedOrReturn(continuation)
     }
 
@@ -406,7 +423,7 @@ class LeaderGroupElectionAspect(
 
         return Mono.defer {
             val start = System.nanoTime()
-            mono {
+            mono(context = observationCoroutineContext()) {
                 var lockName: String? = null
                 var resolvedIdentity: LockIdentity? = null
 
@@ -551,6 +568,9 @@ class LeaderGroupElectionAspect(
             }
         }
     }
+
+    private fun observationCoroutineContext(): CoroutineContext =
+        observationScopeOwner?.current()?.asContextElement() ?: EmptyCoroutineContext
 
     private fun executeBody(pjp: ProceedingJoinPoint, lockName: String, start: Long): Any? {
         return try {

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/LeaderGroupElectionAspect.kt
@@ -263,7 +263,7 @@ class LeaderGroupElectionAspect(
         val method = (pjp.signature as MethodSignature).method
         val coreOpts = meta.options.toCoreOptions()
 
-        val executeSuspend: suspend () -> Any? = {
+        val suspendBlock: suspend () -> Any? = {
             var lockName: String? = null
             var resolvedIdentity: LockIdentity? = null
 
@@ -404,12 +404,12 @@ class LeaderGroupElectionAspect(
             }
         }
         val scope = observationScopeOwner?.current()
-        val suspendBlock: suspend () -> Any? = if (scope == null) {
-            executeSuspend
+        val scopedSuspendBlock: suspend () -> Any? = if (scope == null) {
+            suspendBlock
         } else {
-            { withContext(scope.asContextElement()) { executeSuspend() } }
+            { withContext(scope.asContextElement()) { suspendBlock() } }
         }
-        return suspendBlock.startCoroutineUninterceptedOrReturn(continuation)
+        return scopedSuspendBlock.startCoroutineUninterceptedOrReturn(continuation)
     }
 
     /**

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/autoconfigure/LeaderAopAutoConfiguration.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/aop/autoconfigure/LeaderAopAutoConfiguration.kt
@@ -22,6 +22,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.autoconfigure.condition.SearchStrategy
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Role
@@ -40,13 +41,13 @@ import org.springframework.core.annotation.Order
 class LeaderAopAutoConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(search = SearchStrategy.CURRENT)
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     fun leaderBeanSelector(beanFactory: BeanFactory): LeaderBeanSelector =
         LeaderBeanSelector(beanFactory)
 
     @Bean
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(search = SearchStrategy.CURRENT)
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     fun leaderAopSpelExpressionEvaluator(
         beanFactory: ConfigurableBeanFactory,
@@ -57,7 +58,7 @@ class LeaderAopAutoConfiguration {
     )
 
     @Bean
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(search = SearchStrategy.CURRENT)
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     fun leaderLockNameValidator(
         beanFactory: ConfigurableBeanFactory,
@@ -81,7 +82,7 @@ class LeaderAopAutoConfiguration {
     @Bean
     @Order(LeaderAspectOrder.AOP_ORDER)
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(search = SearchStrategy.CURRENT)
     fun leaderElectionAspect(
         beanSelector: LeaderBeanSelector,
         props: LeaderAopProperties,
@@ -96,7 +97,7 @@ class LeaderAopAutoConfiguration {
         lockNameValidator = lockNameValidator,
         recorders = recordersProvider.orderedStream().toList(),
         scheduledPolicyRegistry = scheduledPolicyRegistryProvider.getIfAvailable(),
-    )
+    ).apply { observationScopeOwner = beanSelector.observationScopeOwner() }
 
     /** `0.5.0`에서 공개된 scheduled-policy 이전의 JVM factory descriptor를 보존합니다. */
     fun leaderElectionAspect(
@@ -112,12 +113,12 @@ class LeaderAopAutoConfiguration {
         lockNameValidator = lockNameValidator,
         recorders = recordersProvider.orderedStream().toList(),
         scheduledPolicyRegistry = null,
-    )
+    ).apply { observationScopeOwner = beanSelector.observationScopeOwner() }
 
     @Bean
     @Order(LeaderAspectOrder.AOP_ORDER)
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
-    @ConditionalOnMissingBean
+    @ConditionalOnMissingBean(search = SearchStrategy.CURRENT)
     fun leaderGroupElectionAspect(
         beanSelector: LeaderBeanSelector,
         props: LeaderAopProperties,
@@ -132,7 +133,7 @@ class LeaderAopAutoConfiguration {
         lockNameValidator = lockNameValidator,
         recorders = recordersProvider.orderedStream().toList(),
         groupProperties = leaderProperties.group,
-    )
+    ).apply { observationScopeOwner = beanSelector.observationScopeOwner() }
 
     /** `useDbTime` 정책 추가 전에 공개된 다섯 인자 factory 메서드 descriptor를 보존합니다. */
     fun leaderGroupElectionAspect(
@@ -148,7 +149,7 @@ class LeaderAopAutoConfiguration {
         lockNameValidator = lockNameValidator,
         recorders = recordersProvider.orderedStream().toList(),
         groupProperties = LeaderGroupProperties(),
-    )
+    ).apply { observationScopeOwner = beanSelector.observationScopeOwner() }
 
     @Bean
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/metrics/LeaderObservationAutoConfiguration.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/metrics/LeaderObservationAutoConfiguration.kt
@@ -18,6 +18,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.autoconfigure.condition.SearchStrategy
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Conditional
@@ -47,6 +48,24 @@ import kotlin.concurrent.withLock
 )
 @EnableConfigurationProperties(LeaderProperties::class, LeaderAopProperties::class)
 class LeaderObservationAutoConfiguration {
+
+    @Bean(name = [LEASE_EXTENSION_OBSERVATION_SCOPE_OWNER_BEAN_NAME])
+    @ConditionalOnBean(ObservationRegistry::class)
+    @Conditional(ObservationRegistryNotNoopCondition::class)
+    @ConditionalOnMissingBean(
+        value = [LeaseExtensionObservationScopeOwner::class],
+        search = SearchStrategy.CURRENT,
+    )
+    @ConditionalOnProperty(
+        prefix = "bluetape4k.leader.observability.tracing",
+        name = ["enabled"],
+        havingValue = "true",
+        matchIfMissing = true,
+    )
+    @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+    internal fun leaseExtensionObservationScopeOwner(
+        registry: ObservationRegistry,
+    ): LeaseExtensionObservationScopeOwner = LeaseExtensionObservationScopeOwner(registry)
 
     /**
      * Spring Boot integration 계약을 설명하는 한국어 KDoc입니다.
@@ -125,16 +144,19 @@ internal class ObservationRegistryLeaseExtensionCoordinator(
 ) : SmartInitializingSingleton, DisposableBean {
 
     private val lock = ReentrantLock()
-    private var registration: AutoCloseable? = null
+    private var registration: LeaseExtensionObservationRegistrationManager.ManagedRegistration? = null
+    private var owner: LeaseExtensionObservationScopeOwner? = null
 
     override fun afterSingletonsInstantiated() {
-        beanFactory
-            .getBeanProvider(ObservationRegistry::class.java)
-            .getIfAvailable()
-            ?.let(::register)
+        if (!beanFactory.containsLocalBean(LEASE_EXTENSION_OBSERVATION_SCOPE_OWNER_BEAN_NAME)) return
+        beanFactory.getBean(
+            LEASE_EXTENSION_OBSERVATION_SCOPE_OWNER_BEAN_NAME,
+            LeaseExtensionObservationScopeOwner::class.java,
+        ).let(::register)
     }
 
-    private fun register(registry: ObservationRegistry) {
+    private fun register(owner: LeaseExtensionObservationScopeOwner) {
+        val registry = owner.registry
         if (registry.isNoop) return
 
         lock.withLock {
@@ -142,9 +164,12 @@ internal class ObservationRegistryLeaseExtensionCoordinator(
 
             val handle = LeaseExtensionObservationRegistrationManager.acquire(registry, options)
             try {
+                owner.activate(handle.scope)
                 beanFactory.registerSingleton(LEASE_EXTENSION_REGISTRATION_BEAN_NAME, handle)
                 registration = handle
+                this.owner = owner
             } catch (ex: IllegalStateException) {
+                owner.clear(handle.scope)
                 handle.close()
                 throw ex
             }
@@ -153,8 +178,13 @@ internal class ObservationRegistryLeaseExtensionCoordinator(
 
     override fun destroy() {
         lock.withLock {
-            registration?.close()
+            val handle = registration
+            if (handle != null) {
+                owner?.clear(handle.scope)
+                handle.close()
+            }
             registration = null
+            owner = null
         }
     }
 

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/metrics/LeaseExtensionObservationRegistrationManager.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/metrics/LeaseExtensionObservationRegistrationManager.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.spring.metrics
 
 import io.bluetape4k.leader.LeaderLeaseExtensionObservers
+import io.bluetape4k.leader.LeaderLeaseExtensionObservationScope
 import io.bluetape4k.leader.micrometer.LeaderObservationOptions
 import io.bluetape4k.leader.micrometer.MicrometerObservationLeaderLeaseExtensionObserver
 import io.micrometer.observation.ObservationRegistry
@@ -18,27 +19,32 @@ import kotlin.concurrent.withLock
  */
 internal object LeaseExtensionObservationRegistrationManager {
 
+    internal data class ManagedRegistration(
+        val scope: LeaderLeaseExtensionObservationScope,
+        private val closeHandle: AutoCloseable,
+    ) : AutoCloseable by closeHandle
+
     private val lock = ReentrantLock()
     private val entries = IdentityHashMap<ObservationRegistry, Entry>()
 
     fun acquire(
         registry: ObservationRegistry,
         options: LeaderObservationOptions,
-    ): AutoCloseable = lock.withLock {
+    ): ManagedRegistration = lock.withLock {
         val existing = entries[registry]
         if (existing != null) {
             check(existing.options == options) {
                 "ObservationRegistry is already registered with different LeaderObservationOptions"
             }
             existing.referenceCount++
-            return@withLock RegistrationHandle(registry, existing)
+            return@withLock ManagedRegistration(existing.scope, RegistrationHandle(registry, existing))
         }
 
         val observer = MicrometerObservationLeaderLeaseExtensionObserver(registry, options)
-        val coreRegistration = LeaderLeaseExtensionObservers.addObserver(observer)
-        val entry = Entry(options, coreRegistration)
+        val scope = LeaderLeaseExtensionObservers.addScopedObserver(observer)
+        val entry = Entry(options, scope)
         entries[registry] = entry
-        RegistrationHandle(registry, entry)
+        ManagedRegistration(scope, RegistrationHandle(registry, entry))
     }
 
     internal fun registryCount(): Int = lock.withLock { entries.size }
@@ -57,14 +63,14 @@ internal object LeaseExtensionObservationRegistrationManager {
             entry.referenceCount--
             if (entry.referenceCount == 0) {
                 entries.remove(registry)
-                entry.coreRegistration.close()
+                entry.scope.close()
             }
         }
     }
 
     private class Entry(
         val options: LeaderObservationOptions,
-        val coreRegistration: AutoCloseable,
+        val scope: LeaderLeaseExtensionObservationScope,
         var referenceCount: Int = 1,
     )
 

--- a/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/metrics/LeaseExtensionObservationScopeOwner.kt
+++ b/leader-spring-boot/src/main/kotlin/io/bluetape4k/leader/spring/metrics/LeaseExtensionObservationScopeOwner.kt
@@ -1,0 +1,24 @@
+package io.bluetape4k.leader.spring.metrics
+
+import io.bluetape4k.leader.LeaderLeaseExtensionObservationScope
+import io.micrometer.observation.ObservationRegistry
+import java.util.concurrent.atomic.AtomicReference
+
+internal const val LEASE_EXTENSION_OBSERVATION_SCOPE_OWNER_BEAN_NAME =
+    "leaseExtensionObservationScopeOwner"
+
+internal class LeaseExtensionObservationScopeOwner(
+    val registry: ObservationRegistry,
+) {
+    private val scope = AtomicReference<LeaderLeaseExtensionObservationScope?>()
+
+    fun activate(value: LeaderLeaseExtensionObservationScope) {
+        check(scope.compareAndSet(null, value)) { "Lease extension observation scope is already active" }
+    }
+
+    fun current(): LeaderLeaseExtensionObservationScope? = scope.get()?.takeIf { it.isActive() }
+
+    fun clear(expected: LeaderLeaseExtensionObservationScope) {
+        scope.compareAndSet(expected, null)
+    }
+}

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderLeaseExtensionObservationScopeAspectTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/aop/LeaderLeaseExtensionObservationScopeAspectTest.kt
@@ -1,0 +1,299 @@
+package io.bluetape4k.leader.spring.aop
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.LeaderElectorFactory
+import io.bluetape4k.leader.LeaderGroupElector
+import io.bluetape4k.leader.LeaderGroupElectorFactory
+import io.bluetape4k.leader.LeaderGroupState
+import io.bluetape4k.leader.LeaderLeaseExtensionObservationScope
+import io.bluetape4k.leader.LeaderLeaseExtensionObservers
+import io.bluetape4k.leader.LeaderRunResult
+import io.bluetape4k.leader.LockExtender
+import io.bluetape4k.leader.annotation.LeaderElection
+import io.bluetape4k.leader.annotation.LeaderGroupElection
+import io.bluetape4k.leader.coroutines.SuspendLeaderElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderElectorFactory
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElector
+import io.bluetape4k.leader.coroutines.SuspendLeaderGroupElectorFactory
+import io.bluetape4k.leader.spring.aop.properties.LeaderAopProperties
+import io.bluetape4k.leader.spring.aop.spel.SpelExpressionEvaluator
+import io.bluetape4k.leader.spring.aop.util.LockNameValidator
+import io.bluetape4k.leader.spring.metrics.LeaseExtensionObservationScopeOwner
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.test.runTest
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.reflect.MethodSignature
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.resume
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+
+class LeaderLeaseExtensionObservationScopeAspectTest {
+
+    private interface SingleService {
+        @LeaderElection(name = "scope-sync")
+        fun sync(): String
+
+        @LeaderElection(name = "scope-suspend")
+        suspend fun suspending(): String
+
+        @LeaderElection(name = "scope-mono")
+        fun mono(): Mono<String>
+
+        @LeaderElection(name = "scope-flux", streamBounded = true)
+        fun flux(): Flux<String>
+
+        @LeaderElection(name = "scope-flow", streamBounded = true)
+        fun flow(): Flow<String>
+    }
+
+    private interface GroupService {
+        @LeaderGroupElection(name = "scope-group-sync", maxLeaders = 2)
+        fun sync(): String
+
+        @LeaderGroupElection(name = "scope-group-suspend", maxLeaders = 2)
+        suspend fun suspending(): String
+
+        @LeaderGroupElection(name = "scope-group-mono", maxLeaders = 2)
+        fun mono(): Mono<String>
+    }
+
+    @Test
+    fun `single AOP는 현재 context scope와 global observer에만 전달한다`() = runTest {
+        withObservationScopes { first, second, global ->
+            val aspect = newSingleAspect(first.owner)
+            val pjp = singleJoinPoint("sync") {
+                LockExtender.extendActiveLockDetailed(1.seconds)
+                "ok"
+            }
+
+            aspect.aroundLeader(pjp) shouldBeEqualTo "ok"
+
+            awaitCounts(first.count, second.count, global, 1, 0, 1)
+        }
+    }
+
+    @Test
+    fun `single suspend Mono Flux Flow는 context scope를 coroutine 경계까지 전파한다`() = runTest {
+        withObservationScopes { first, second, global ->
+            val aspect = newSingleAspect(first.owner)
+
+            runSuspendAspect(aspect, singleJoinPoint("suspending") {
+                LockExtender.extendActiveLockDetailed(1.seconds)
+                "suspend"
+            }) shouldBeEqualTo "suspend"
+
+            val mono = singleJoinPoint("mono") {
+                Mono.fromCallable {
+                    LockExtender.extendActiveLockDetailed(1.seconds)
+                    "mono"
+                }
+            }
+            (aspect.aroundLeader(mono) as Mono<*>).block() shouldBeEqualTo "mono"
+
+            val flux = singleJoinPoint("flux") {
+                Flux.defer {
+                    LockExtender.extendActiveLockDetailed(1.seconds)
+                    Flux.just("flux")
+                }
+            }
+            (aspect.aroundLeader(flux) as Flux<*>).collectList().block() shouldBeEqualTo listOf("flux")
+
+            val flow = singleJoinPoint("flow") {
+                flow {
+                    LockExtender.extendActiveLockDetailed(1.seconds)
+                    emit("flow")
+                }
+            }
+            (aspect.aroundLeader(flow) as Flow<*>).toList() shouldBeEqualTo listOf("flow")
+
+            awaitCounts(first.count, second.count, global, 4, 0, 4)
+        }
+    }
+
+    @Test
+    fun `group sync suspend Mono도 현재 context scope와 global observer에만 전달한다`() = runTest {
+        withObservationScopes { first, second, global ->
+            val aspect = newGroupAspect(first.owner)
+
+            aspect.aroundLeader(groupJoinPoint("sync") {
+                LockExtender.extendActiveLockDetailed(1.seconds)
+                "sync"
+            }) shouldBeEqualTo "sync"
+
+            runSuspendGroupAspect(aspect, groupJoinPoint("suspending") {
+                LockExtender.extendActiveLockDetailed(1.seconds)
+                "suspend"
+            }) shouldBeEqualTo "suspend"
+
+            val mono = groupJoinPoint("mono") {
+                Mono.fromCallable {
+                    LockExtender.extendActiveLockDetailed(1.seconds)
+                    "mono"
+                }
+            }
+            (aspect.aroundLeader(mono) as Mono<*>).block() shouldBeEqualTo "mono"
+
+            awaitCounts(first.count, second.count, global, 3, 0, 3)
+        }
+    }
+
+    private fun newSingleAspect(owner: LeaseExtensionObservationScopeOwner): LeaderElectionAspect {
+        val election = mockk<LeaderElector>()
+        val action = slot<() -> Any?>()
+        every { election.runIfLeaderResult<Any?>(any<String>(), capture(action)) } answers {
+            LeaderRunResult.Elected(action.captured.invoke())
+        }
+        val suspendElection = object : SuspendLeaderElector {
+            override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? = action()
+        }
+        val selector = mockk<LeaderBeanSelector>()
+        every { selector.selectElectionFactory(any(), any()) } returns
+            LeaderBeanSelector.Selected("singleFactory", LeaderElectorFactory { election })
+        every { selector.selectSuspendElectorFactory(any(), any()) } returns
+            LeaderBeanSelector.Selected("singleSuspendFactory", SuspendLeaderElectorFactory { suspendElection })
+        return LeaderElectionAspect(
+            beanSelector = selector,
+            props = LeaderAopProperties(),
+            spel = SpelExpressionEvaluator({ it }, false),
+            lockNameValidator = LockNameValidator(""),
+            recorders = emptyList(),
+        ).apply { observationScopeOwner = owner }
+    }
+
+    private fun newGroupAspect(owner: LeaseExtensionObservationScopeOwner): LeaderGroupElectionAspect {
+        val election = mockk<LeaderGroupElector>()
+        val action = slot<() -> Any?>()
+        every { election.runIfLeaderResult<Any?>(any<String>(), capture(action)) } answers {
+            LeaderRunResult.Elected(action.captured.invoke())
+        }
+        val suspendElection = object : SuspendLeaderGroupElector {
+            override val maxLeaders: Int = 2
+
+            override suspend fun <T> runIfLeader(lockName: String, action: suspend () -> T): T? = action()
+
+            override fun activeCount(lockName: String): Int = 0
+
+            override fun availableSlots(lockName: String): Int = maxLeaders
+
+            override fun state(lockName: String): LeaderGroupState =
+                LeaderGroupState(lockName, maxLeaders, activeCount = 0)
+        }
+        val selector = mockk<LeaderBeanSelector>()
+        every { selector.selectGroupElectionFactory(any(), any()) } returns
+            LeaderBeanSelector.Selected("groupFactory", LeaderGroupElectorFactory { election })
+        every { selector.selectSuspendGroupElectorFactory(any(), any()) } returns
+            LeaderBeanSelector.Selected("groupSuspendFactory", SuspendLeaderGroupElectorFactory { suspendElection })
+        return LeaderGroupElectionAspect(
+            beanSelector = selector,
+            props = LeaderAopProperties(),
+            spel = SpelExpressionEvaluator({ it }, false),
+            lockNameValidator = LockNameValidator(""),
+            recorders = emptyList(),
+        ).apply { observationScopeOwner = owner }
+    }
+
+    private fun singleJoinPoint(methodName: String, proceed: () -> Any?): ProceedingJoinPoint =
+        joinPoint(SingleService::class.java, methodName, proceed)
+
+    private fun groupJoinPoint(methodName: String, proceed: () -> Any?): ProceedingJoinPoint =
+        joinPoint(GroupService::class.java, methodName, proceed)
+
+    private fun joinPoint(type: Class<*>, methodName: String, proceed: () -> Any?): ProceedingJoinPoint {
+        val isSuspend = methodName == "suspending"
+        val method = if (isSuspend) {
+            type.getDeclaredMethod(methodName, Continuation::class.java)
+        } else {
+            type.getDeclaredMethod(methodName)
+        }
+        val signature = mockk<MethodSignature>()
+        val pjp = mockk<ProceedingJoinPoint>()
+        every { signature.method } returns method
+        every { pjp.signature } returns signature
+        every { pjp.target } returns mockk(relaxed = true)
+        every { pjp.args } returns emptyArray()
+        every { pjp.proceed() } answers { proceed() }
+        every { pjp.proceed(any<Array<Any?>>()) } answers { proceed() }
+        return pjp
+    }
+
+    private suspend fun runSuspendAspect(aspect: LeaderElectionAspect, pjp: ProceedingJoinPoint): Any? =
+        suspendCancellableCoroutine { continuation ->
+            every { pjp.args } returns arrayOf<Any?>(continuation)
+            val result = aspect.aroundLeader(pjp)
+            if (result !== COROUTINE_SUSPENDED) continuation.resume(result)
+        }
+
+    private suspend fun runSuspendGroupAspect(aspect: LeaderGroupElectionAspect, pjp: ProceedingJoinPoint): Any? =
+        suspendCancellableCoroutine { continuation ->
+            every { pjp.args } returns arrayOf<Any?>(continuation)
+            val result = aspect.aroundLeader(pjp)
+            if (result !== COROUTINE_SUSPENDED) continuation.resume(result)
+        }
+
+    private fun awaitCounts(
+        first: AtomicInteger,
+        second: AtomicInteger,
+        global: AtomicInteger,
+        expectedFirst: Int,
+        expectedSecond: Int,
+        expectedGlobal: Int,
+    ) {
+        await.atMost(5.seconds.toJavaDuration()).untilAsserted {
+            first.get() shouldBeEqualTo expectedFirst
+            second.get() shouldBeEqualTo expectedSecond
+            global.get() shouldBeEqualTo expectedGlobal
+        }
+    }
+
+    private suspend inline fun withObservationScopes(
+        crossinline block: suspend (ScopeFixture, ScopeFixture, AtomicInteger) -> Unit,
+    ) {
+        val first = scopeFixture()
+        val second = scopeFixture()
+        val global = AtomicInteger()
+        val globalHandle = LeaderLeaseExtensionObservers.addObserver { global.incrementAndGet() }
+        try {
+            LockExtender.extendActiveLockDetailed(1.seconds)
+            awaitCounts(first.count, second.count, global, 0, 0, 1)
+            global.set(0)
+            block(first, second, global)
+        } finally {
+            globalHandle.close()
+            first.close()
+            second.close()
+        }
+    }
+
+    private fun scopeFixture(): ScopeFixture {
+        val count = AtomicInteger()
+        val scope = LeaderLeaseExtensionObservers.addScopedObserver { count.incrementAndGet() }
+        val owner = LeaseExtensionObservationScopeOwner(mockk(relaxed = true)).apply { activate(scope) }
+        return ScopeFixture(count, scope, owner)
+    }
+
+    private data class ScopeFixture(
+        val count: AtomicInteger,
+        val scope: LeaderLeaseExtensionObservationScope,
+        val owner: LeaseExtensionObservationScopeOwner,
+    ) : AutoCloseable {
+        override fun close() {
+            owner.clear(scope)
+            scope.close()
+        }
+    }
+}

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/metrics/LeaderObservationAutoConfigurationTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/metrics/LeaderObservationAutoConfigurationTest.kt
@@ -59,6 +59,7 @@ class LeaderObservationAutoConfigurationTest {
         runner
             .withUserConfiguration(ObservationRegistryConfig::class.java)
             .run { ctx ->
+                ctx.containsBean(LEASE_EXTENSION_OBSERVATION_SCOPE_OWNER_BEAN_NAME).shouldBeTrue()
                 ctx.containsBean("leaseExtensionObserverRegistration").shouldBeTrue()
                 ctx.getBean("leaseExtensionObserverRegistration")
                     .shouldBeInstanceOf<AutoCloseable>()
@@ -73,6 +74,10 @@ class LeaderObservationAutoConfigurationTest {
         runner
             .withUserConfiguration(NoopObservationRegistryConfig::class.java)
             .run { ctx ->
+                ctx.getBean(
+                    LEASE_EXTENSION_OBSERVATION_SCOPE_OWNER_BEAN_NAME,
+                    LeaseExtensionObservationScopeOwner::class.java,
+                ).current() shouldBeEqualTo null
                 ctx.containsBean("leaseExtensionObserverRegistration").shouldBeFalse()
                 LeaseExtensionObservationRegistrationManager.registryCount() shouldBeEqualTo 0
             }
@@ -131,6 +136,7 @@ class LeaderObservationAutoConfigurationTest {
             .withUserConfiguration(ObservationRegistryConfig::class.java)
             .withPropertyValues("bluetape4k.leader.observability.tracing.enabled=false")
             .run { ctx ->
+                ctx.containsBean(LEASE_EXTENSION_OBSERVATION_SCOPE_OWNER_BEAN_NAME).shouldBeFalse()
                 ctx.getBeansOfType<MicrometerObservationLeaderAopMetricsRecorder>().isEmpty().shouldBeTrue()
                 ctx.getBeansOfType<MicrometerObservationLeaderElectionListener>().isEmpty().shouldBeTrue()
             }

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/metrics/LeaseExtensionObservationRegistrationManagerTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/metrics/LeaseExtensionObservationRegistrationManagerTest.kt
@@ -5,8 +5,15 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.leader.ExtendOutcome
+import io.bluetape4k.leader.LeaderLeaseExtensionContext
+import io.bluetape4k.leader.LeaderLeaseExtensionEvent
+import io.bluetape4k.leader.LeaderLeaseExtensionExecution
+import io.bluetape4k.leader.LeaderLeaseExtensionObservers
+import io.bluetape4k.leader.LeaderLeaseExtensionSource
 import io.bluetape4k.leader.LockExtender
+import io.bluetape4k.leader.micrometer.LeaderMetricTagOptions
 import io.bluetape4k.leader.micrometer.LeaderObservationOptions
+import io.bluetape4k.leader.micrometer.TAG_LEADER_ID
 import io.micrometer.observation.Observation
 import io.micrometer.observation.ObservationHandler
 import io.micrometer.observation.ObservationRegistry
@@ -173,6 +180,13 @@ class LeaseExtensionObservationRegistrationManagerTest {
     }
 
     @Test
+    fun `different registries isolate opted-in identity and raw error in both close orders`() {
+        listOf(CloseOrder.FIRST_THEN_SECOND, CloseOrder.SECOND_THEN_FIRST).forEach { closeOrder ->
+            verifyOptedInIsolation(closeOrder)
+        }
+    }
+
+    @Test
     fun `conflicting options fail fast without adding a second observer`() {
         val registry = ObservationRegistry.create()
         val first = LeaseExtensionObservationRegistrationManager.acquire(registry, LeaderObservationOptions())
@@ -297,14 +311,139 @@ class LeaseExtensionObservationRegistrationManagerTest {
     }
 
     private class CollectingObservationHandler : ObservationHandler<Observation.Context> {
-        val stopped = CopyOnWriteArrayList<String>()
+        val stopped = CopyOnWriteArrayList<ObservationSnapshot>()
 
         override fun onStop(context: Observation.Context) {
-            stopped += context.name.orEmpty()
+            stopped += ObservationSnapshot(
+                name = context.name.orEmpty(),
+                low = context.lowCardinalityKeyValues.associate { it.key to it.value },
+                high = context.highCardinalityKeyValues.associate { it.key to it.value },
+                error = context.error,
+            )
         }
 
         override fun supportsContext(context: Observation.Context): Boolean = true
     }
+
+    private fun verifyOptedInIsolation(closeOrder: CloseOrder) {
+        val firstHandler = CollectingObservationHandler()
+        val secondHandler = CollectingObservationHandler()
+        val firstRegistry = ObservationRegistry.create().apply {
+            observationConfig().observationHandler(firstHandler)
+        }
+        val secondRegistry = ObservationRegistry.create().apply {
+            observationConfig().observationHandler(secondHandler)
+        }
+        val options = LeaderObservationOptions(
+            includeLockName = true,
+            includeLeaderId = true,
+            includeExceptionDetails = true,
+            tagOptions = LeaderMetricTagOptions.Raw,
+        )
+        val first = LeaseExtensionObservationRegistrationManager.acquire(firstRegistry, options)
+        val second = LeaseExtensionObservationRegistrationManager.acquire(secondRegistry, options)
+        val firstFailure = IllegalStateException("jdbc:password=first-secret")
+        val secondFailure = IllegalArgumentException("token=second-secret")
+
+        try {
+            LeaderLeaseExtensionObservers.publish(
+                extensionErrorEvent("first-lock", "first-leader", firstFailure),
+                first.scope,
+            )
+            await.atMost(5.seconds.toJavaDuration()).untilAsserted {
+                firstHandler.stopped.size shouldBeEqualTo 1
+                secondHandler.stopped.size shouldBeEqualTo 0
+            }
+            assertOwnIdentity(firstHandler.stopped.single(), "first-lock", "first-leader", firstFailure)
+
+            LeaderLeaseExtensionObservers.publish(
+                extensionErrorEvent("second-lock", "second-leader", secondFailure),
+                second.scope,
+            )
+            await.atMost(5.seconds.toJavaDuration()).untilAsserted {
+                firstHandler.stopped.size shouldBeEqualTo 1
+                secondHandler.stopped.size shouldBeEqualTo 1
+            }
+            assertOwnIdentity(secondHandler.stopped.single(), "second-lock", "second-leader", secondFailure)
+
+            val closed = if (closeOrder == CloseOrder.FIRST_THEN_SECOND) first else second
+            val remaining = if (closeOrder == CloseOrder.FIRST_THEN_SECOND) second else first
+            val closedHandler = if (closeOrder == CloseOrder.FIRST_THEN_SECOND) firstHandler else secondHandler
+            val remainingHandler = if (closeOrder == CloseOrder.FIRST_THEN_SECOND) secondHandler else firstHandler
+            val closedCount = closedHandler.stopped.size
+            val remainingCount = remainingHandler.stopped.size
+            closed.close()
+
+            LeaderLeaseExtensionObservers.publish(
+                extensionErrorEvent("closed-lock", "closed-leader", IllegalStateException("closed-secret")),
+                closed.scope,
+            )
+            val remainingFailure = IllegalStateException("remaining-secret")
+            LeaderLeaseExtensionObservers.publish(
+                extensionErrorEvent("remaining-lock", "remaining-leader", remainingFailure),
+                remaining.scope,
+            )
+            await.atMost(5.seconds.toJavaDuration()).untilAsserted {
+                closedHandler.stopped.size shouldBeEqualTo closedCount
+                remainingHandler.stopped.size shouldBeEqualTo remainingCount + 1
+            }
+            assertOwnIdentity(
+                remainingHandler.stopped.last(),
+                "remaining-lock",
+                "remaining-leader",
+                remainingFailure,
+            )
+        } finally {
+            first.close()
+            second.close()
+        }
+
+        LeaseExtensionObservationRegistrationManager.registryCount() shouldBeEqualTo 0
+    }
+
+    private fun extensionErrorEvent(
+        lockName: String,
+        leaderId: String,
+        failure: Exception,
+    ): LeaderLeaseExtensionEvent = LeaderLeaseExtensionEvent(
+        source = LeaderLeaseExtensionSource.USER,
+        execution = LeaderLeaseExtensionExecution.BLOCKING,
+        outcome = ExtendOutcome.BackendError(failure),
+        elapsedNanos = 1L,
+        context = LeaderLeaseExtensionContext(lockName, leaderId),
+    )
+
+    private fun assertOwnIdentity(
+        snapshot: ObservationSnapshot,
+        lockName: String,
+        leaderId: String,
+        failure: Throwable,
+    ) {
+        snapshot.name shouldBeEqualTo "bluetape4k.leader.lease.extension"
+        snapshot.low shouldBeEqualTo mapOf(
+            "source" to "user",
+            "execution" to "blocking",
+            "outcome" to "backend_error",
+            "result" to "error",
+        )
+        snapshot.high shouldBeEqualTo mapOf(
+            "lock.name" to lockName,
+            TAG_LEADER_ID to leaderId,
+        )
+        snapshot.error shouldBeSameInstanceAs failure
+    }
+
+    private enum class CloseOrder {
+        FIRST_THEN_SECOND,
+        SECOND_THEN_FIRST,
+    }
+
+    private data class ObservationSnapshot(
+        val name: String,
+        val low: Map<String, String>,
+        val high: Map<String, String>,
+        val error: Throwable?,
+    )
 
     private fun nonNoopRegistry(): ObservationRegistry = ObservationRegistry.create().apply {
         observationConfig().observationHandler(NonNoopObservationHandler)

--- a/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/metrics/LeaseExtensionObservationRegistrationManagerTest.kt
+++ b/leader-spring-boot/src/test/kotlin/io/bluetape4k/leader/spring/metrics/LeaseExtensionObservationRegistrationManagerTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.spring.metrics
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.leader.ExtendOutcome
 import io.bluetape4k.leader.LockExtender
@@ -38,18 +39,31 @@ class LeaseExtensionObservationRegistrationManagerTest {
         val second = openContext(registry)
 
         try {
+            val firstOwner = first.getBean(
+                LEASE_EXTENSION_OBSERVATION_SCOPE_OWNER_BEAN_NAME,
+                LeaseExtensionObservationScopeOwner::class.java,
+            )
+            val secondOwner = second.getBean(
+                LEASE_EXTENSION_OBSERVATION_SCOPE_OWNER_BEAN_NAME,
+                LeaseExtensionObservationScopeOwner::class.java,
+            )
             LeaseExtensionObservationRegistrationManager.registryCount() shouldBeEqualTo 1
             LeaseExtensionObservationRegistrationManager.referenceCount(registry) shouldBeEqualTo 2
             first.containsBean("leaseExtensionObserverRegistration").shouldBeTrue()
             second.containsBean("leaseExtensionObserverRegistration").shouldBeTrue()
+            firstOwner.current() shouldBeSameInstanceAs secondOwner.current()
 
-            LockExtender.extendActiveLockDetailed(1.seconds) shouldBeEqualTo ExtendOutcome.NotHeld
+            firstOwner.current()!!.withScope {
+                LockExtender.extendActiveLockDetailed(1.seconds) shouldBeEqualTo ExtendOutcome.NotHeld
+            }
             await.atMost(5.seconds.toJavaDuration()).untilAsserted {
                 handler.stopped.size shouldBeEqualTo 1
             }
 
             first.close()
-            LockExtender.extendActiveLockDetailed(1.seconds) shouldBeEqualTo ExtendOutcome.NotHeld
+            secondOwner.current()!!.withScope {
+                LockExtender.extendActiveLockDetailed(1.seconds) shouldBeEqualTo ExtendOutcome.NotHeld
+            }
             await.atMost(5.seconds.toJavaDuration()).untilAsserted {
                 handler.stopped.size shouldBeEqualTo 2
             }
@@ -72,9 +86,18 @@ class LeaseExtensionObservationRegistrationManagerTest {
         }
 
         try {
+            val parentOwner = parent.getBean(
+                LEASE_EXTENSION_OBSERVATION_SCOPE_OWNER_BEAN_NAME,
+                LeaseExtensionObservationScopeOwner::class.java,
+            )
+            val childOwner = child.getBean(
+                LEASE_EXTENSION_OBSERVATION_SCOPE_OWNER_BEAN_NAME,
+                LeaseExtensionObservationScopeOwner::class.java,
+            )
             LeaseExtensionObservationRegistrationManager.registryCount() shouldBeEqualTo 1
             LeaseExtensionObservationRegistrationManager.referenceCount(registry) shouldBeEqualTo 2
             child.containsBean("leaseExtensionObserverRegistration").shouldBeTrue()
+            parentOwner.current() shouldBeSameInstanceAs childOwner.current()
         } finally {
             child.close()
             LeaseExtensionObservationRegistrationManager.referenceCount(registry) shouldBeEqualTo 1
@@ -95,7 +118,10 @@ class LeaseExtensionObservationRegistrationManagerTest {
 
         try {
             LeaseExtensionObservationRegistrationManager.referenceCount(registry) shouldBeEqualTo 2
-            LockExtender.extendActiveLockDetailed(1.seconds) shouldBeEqualTo ExtendOutcome.NotHeld
+            first.scope shouldBeSameInstanceAs second.scope
+            first.scope.withScope {
+                LockExtender.extendActiveLockDetailed(1.seconds) shouldBeEqualTo ExtendOutcome.NotHeld
+            }
 
             await.atMost(5.seconds.toJavaDuration()).untilAsserted {
                 handler.stopped.size shouldBeEqualTo 1
@@ -125,8 +151,15 @@ class LeaseExtensionObservationRegistrationManagerTest {
 
         try {
             LeaseExtensionObservationRegistrationManager.registryCount() shouldBeEqualTo 2
-            LockExtender.extendActiveLockDetailed(1.seconds) shouldBeEqualTo ExtendOutcome.NotHeld
+            first.scope.withScope {
+                LockExtender.extendActiveLockDetailed(1.seconds) shouldBeEqualTo ExtendOutcome.NotHeld
+            }
 
+            await.atMost(5.seconds.toJavaDuration()).untilAsserted {
+                firstHandler.stopped.size shouldBeEqualTo 1
+                secondHandler.stopped.size shouldBeEqualTo 0
+            }
+            second.scope.withScope { LockExtender.extendActiveLockDetailed(1.seconds) }
             await.atMost(5.seconds.toJavaDuration()).untilAsserted {
                 firstHandler.stopped.size shouldBeEqualTo 1
                 secondHandler.stopped.size shouldBeEqualTo 1
@@ -205,7 +238,8 @@ class LeaseExtensionObservationRegistrationManagerTest {
             observationConfig().observationHandler(handler)
         }
         val pool = Executors.newFixedThreadPool(2)
-        var handle: AutoCloseable = LeaseExtensionObservationRegistrationManager.acquire(
+        var handle: LeaseExtensionObservationRegistrationManager.ManagedRegistration =
+            LeaseExtensionObservationRegistrationManager.acquire(
             registry,
             LeaderObservationOptions(),
         )
@@ -217,7 +251,7 @@ class LeaseExtensionObservationRegistrationManagerTest {
                     barrier.await(5, TimeUnit.SECONDS)
                     handle.close()
                 }
-                val acquireTask = pool.submit<AutoCloseable> {
+                val acquireTask = pool.submit<LeaseExtensionObservationRegistrationManager.ManagedRegistration> {
                     barrier.await(5, TimeUnit.SECONDS)
                     LeaseExtensionObservationRegistrationManager.acquire(registry, LeaderObservationOptions())
                 }
@@ -226,7 +260,9 @@ class LeaseExtensionObservationRegistrationManagerTest {
                 handle = acquireTask.get(5, TimeUnit.SECONDS)
                 LeaseExtensionObservationRegistrationManager.registryCount() shouldBeEqualTo 1
                 LeaseExtensionObservationRegistrationManager.referenceCount(registry) shouldBeEqualTo 1
-                LockExtender.extendActiveLockDetailed(1.seconds) shouldBeEqualTo ExtendOutcome.NotHeld
+                handle.scope.withScope {
+                    LockExtender.extendActiveLockDetailed(1.seconds) shouldBeEqualTo ExtendOutcome.NotHeld
+                }
                 await.atMost(5.seconds.toJavaDuration()).untilAsserted {
                     handler.stopped.size shouldBeEqualTo index + 1
                 }
@@ -285,7 +321,8 @@ class LeaseExtensionObservationRegistrationManagerTest {
         val registryQueue = ReferenceQueue<ObservationRegistry>()
         val handleQueue = ReferenceQueue<AutoCloseable>()
         val registry = ObservationRegistry.create()
-        val handle = LeaseExtensionObservationRegistrationManager.acquire(registry, LeaderObservationOptions())
+        val handle: AutoCloseable =
+            LeaseExtensionObservationRegistrationManager.acquire(registry, LeaderObservationOptions())
         val registryReference = WeakReference(registry, registryQueue)
         val handleReference = WeakReference(handle, handleQueue)
 


### PR DESCRIPTION
## 변경 배경

여러 Spring application context가 서로 다른 `ObservationRegistry`를 사용할 때 process-global lease-extension observer dispatcher 때문에 한 context의 USER/WATCHDOG event와 선택적 exception telemetry가 다른 registry에 전달될 수 있었습니다.

Closes #741

## 변경 내용

- core registration이 소유하는 opaque `LeaderLeaseExtensionObservationScope`와 global/scope identity bucket을 추가했습니다.
- USER extension, watchdog, virtual-thread adapter, coroutine adapter가 실행 시작 시 scope를 캡처하고 비동기 경계까지 전달합니다.
- Spring manager가 `ObservationRegistry` object identity별 canonical scope를 ref-count로 공유합니다.
- single/group AOP의 sync, suspend, `Mono`, `Flux`, Kotlin `Flow` 지원 경계에 registry-local scope를 설치합니다.
- attribution이 없는 direct elector/extension 호출은 Spring automatic observer에서 fail-closed로 제외하되 명시적인 global observer 계약은 유지합니다.
- 기존 5-인자 `LeaderLeaseExtensionEvent`, global observer facade, coordinator/aspect JVM descriptor를 보존하고 새 scope bridge는 `@JvmSynthetic`으로 제한했습니다.

## 운영·호환성

- 같은 `ObservationRegistry`를 공유하는 parent/child context는 하나의 scope와 registration을 공유합니다.
- 서로 다른 registry는 event, identity, opt-in raw exception을 교차 수신하지 않습니다.
- scope close는 새 automatic callback admission을 중단하며 이미 dispatcher에 수락된 callback은 완료할 수 있습니다.
- README와 manual draft에 global/automatic 경계, direct-call 제외, canary, startup kill switch, rollback, shutdown 절차를 추가했습니다.

## 검증

- rebased `leader-core`: 989 tests, failures 0, errors 0, skipped 0
- `leader-spring-boot`: 628 tests, failures 0, errors 0, skipped 0
- `./gradlew detekt`: PASS
- `./gradlew checkBinaryCompatibility`: `artifacts=16 ignored=10 unknown=0`, PASS
- manual inventory/validation 및 Ruby suite: 37 runs, 392 assertions, 0 failures/errors/skips
- JMH 3 forks (`4c0d1156` → `575cccdc`): throughput 1.335% 개선, average time 0.023% 회귀, 15% gate PASS
- mismatch allocation: USER -8.683 B/op, WATCHDOG -15.533 B/op
- inline review 보완 회귀 묶음: 78 tests, failures 0, errors 0, skipped 0
- `git diff --check`: PASS

## 리뷰 상태

- inline 독립 검토: P0=0, P1=0, P2=0
- 검토 중 identity·raw exception opt-in과 양쪽 close 순서 조합의 P1 검증 공백을 발견해 회귀 테스트로 해소했습니다.
- 최신 `develop` rebase 후 exact head `01bfabf796af369d959e423b7bf821339b4ec8d6`의 [hosted CI](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33236765469)가 47/47 성공했고 실패·skip은 0입니다.
- 사용자가 세 PR의 순차 병합을 명시적으로 승인했습니다.

## DoD Status

- [x] 승인된 Type A 설계와 계획 반영
- [x] core/Spring 구현 및 회귀 테스트
- [x] Detekt·binary compatibility·manual validation
- [x] exact SHA 3-fork 성능·allocation 증거
- [x] 한국어/영어 운영 문서와 benchmark 보고서
- [x] inline 독립 review artifact
- [x] PR exact-head hosted CI 재검증
- [x] fresh merge 승인
