### PR TITLE
fix(prometheus): connectivity alert가 실제 probe metric producer를 갖도록 정합성 보장

### DIFF
--- a/docs/lessons/2026-08-29-issue-827-prometheus-connectivity-probe.md
+++ b/docs/lessons/2026-08-29-issue-827-prometheus-connectivity-probe.md
@@ -1,0 +1,70 @@
+# Issue #827: Prometheus connectivity alert producer 정합성
+
+## 맥락
+
+Prometheus alert rule은 `leader_backend_connectivity_total`의 `DOWN`,
+`UNKNOWN`, `PROVIDER_EXCEPTION` 상태를 감시했지만 예제 애플리케이션이
+해당 counter를 주기적으로 생성하지 않았다. AOP 계측은 실제 선출 호출이
+있을 때만 connectivity를 기록하므로, idle 상태에서는 alert가 읽을 series가
+존재하지 않았다.
+
+## 결정
+
+`PrometheusBackendConnectivityProbe`를 예제 애플리케이션에 추가해 기존
+`lettuceLeaderElector`와 같은 `StatefulRedisConnection`을 사용하는
+`InstrumentedLeaderElector`의 `backendDiagnosticsProvider`를 재사용한다. 별도
+Redis client를 만들지 않고,
+설정 가능한 fixed delay와 양수 millisecond timeout으로 주기적인 active probe를
+실행한다. Spring context에는 diagnostics-capable elector가 여러 개이므로
+probe는 명시적인 `prometheusBackendDiagnosticsProvider` qualifier를 사용한다.
+
+현재 Lettuce provider의 계약도 그대로 보존한다. open client state만 확인한
+결과는 backend round trip이 없으므로 `UNKNOWN`/`CLIENT_STATE_UNCONFIRMED`,
+닫힌 client state는 `DOWN`/`DISCONNECTED`로 보고한다. 실제 `UP`과
+`PROVIDER_EXCEPTION` 라벨은 instrumented provider 단위 테스트와 실제
+Testcontainers Redis의 Lettuce connection 경로로 검증한다. 운영 compose와 같은
+Prometheus `v2.55.1`의 `promtool test rules`를 사용해 세 alert의 firing,
+`for` 지연, label/annotation/runbook 경로를 실행 평가한다.
+
+## 결과
+
+예제 설정과 영어/한국어 README에 probe 주기·timeout과 metric producer를
+기록했다. 기존 alert rule과 runbook의 status/reason 의미를 변경하지 않았고,
+실제 Redis connection 종료는 `DOWN`으로, `isOpen` 예외는 provider 계약대로
+`UNKNOWN`/`PROVIDER_EXCEPTION`으로 계측된다. passive `NOT_CHECKED` diagnostics는
+계속 counter를 만들지 않으며, 단위 테스트의 두 번의 probe 호출과 Spring context의
+fixed delay scrape 검증(누적 sample `> 1.0`)은 probe가 반복 실행되어 counter가
+증가함을 확인한다.
+
+## 검증
+
+- RED: producer가 없던 상태에서 `PrometheusScrapeTest`의
+  `UNKNOWN`/`CLIENT_STATE_UNCONFIRMED` series 검증이 실패했다.
+- GREEN: `prometheus-dashboard` 전체 테스트 13개, 실패 0, 오류 0, skipped 0.
+- GREEN: `PrometheusBackendConnectivityProbeTest`에서 `UP`, `DOWN`,
+  `UNKNOWN`, `PROVIDER_EXCEPTION`, timeout 전달과 0 timeout 거부, 반복 counter
+  증가와 passive diagnostics 무계측을 검증했다.
+- GREEN: `PrometheusScrapeTest`는 `demo.backend-probe.fixed-delay-ms=200`과
+  `initial-delay-ms=0` Spring scheduler가 실제 Actuator scrape에서
+  `UNKNOWN/CLIENT_STATE_UNCONFIRMED` counter를 최소 두 번 누적(`> 1.0`)했는지
+  확인해 cadence producer를 검증했다.
+- GREEN: `PrometheusLettuceConnectivityProbeTest`에서 실제 Redis Testcontainers의
+  closed connection `DOWN`과 `isOpen` provider exception `UNKNOWN` 경로를
+  `leader_backend_connectivity_total`로 확인했다.
+- GREEN: `PrometheusAlertRulesTest`가 production `leader-alerts.yml`을
+  `promtool test rules`로 실행해 DOWN/UNKNOWN/PROVIDER_EXCEPTION alert firing,
+  `for` 지연과 runbook annotation을 검증했다.
+- GREEN: `leader-micrometer` 132개와 `leader-redis-lettuce` 318개 테스트가
+  모두 통과했다.
+- GREEN: 예제 Detekt와 `git diff --check`가 통과했다.
+
+## 향후 지침
+
+1. Alert rule에 metric을 추가할 때는 동일 변경에서 runtime producer와
+   scrape-level series 회귀 테스트를 함께 추가한다.
+2. Connectivity 상태와 reason을 임의로 합치거나 `UNKNOWN`을 `DOWN`으로
+   재작성하지 않는다. provider가 보장하지 않는 `UP`을 client-local 상태만으로
+   주장하지 않는다.
+3. 주기적인 active probe에는 양수 bounded timeout을 요구하고, 기존 backend
+   connection·instrumentation 경로를 재사용해 중복 client와 metric registry를
+   만들지 않는다.

--- a/docs/superpowers/checklists/2026-08-29-issue-827-prometheus-connectivity-probe.md
+++ b/docs/superpowers/checklists/2026-08-29-issue-827-prometheus-connectivity-probe.md
@@ -36,7 +36,7 @@
   - **Failure:** 최종 상태를 BLOCKED로 남긴다.
 - [x] **CL-07 — Refresh irreversible holds**
   - **Action:** PR 생성·merge 같은 외부 side effect 직전에 authority와 target을 다시 읽는다.
-  - **Evidence:** PR 생성 직전 live issue #827, repository `bluetape4k/bluetape4k-leader`, base `develop`, head `fix/issue-827-prometheus-connectivity-probe`, local implementation head `07d8fec4bd0555a41b0bf8810a5dfbbff5132e8a`를 재확인했다. PR #836 생성 후 follow-up checklist head `e60875e9268991caeee3890713c4fda7de1352d3`와 metadata/exact-head hosted CI를 다시 read-back했다.
+  - **Evidence:** PR 생성 직전 live issue #827, repository `bluetape4k/bluetape4k-leader`, base `develop`, head `fix/issue-827-prometheus-connectivity-probe`를 재확인했다. PR #836 생성 후 매 push마다 local `HEAD`와 remote branch SHA, PR metadata, terminal hosted CI를 다시 read-back한다.
   - **Failure:** side effect를 실행하지 않는다.
 - [x] **CL-08 — Count before completion**
   - **Action:** 최종 보고 전에 `Required checks: X/Y; N/A: N; Blocked: N`을 계산한다.
@@ -71,7 +71,7 @@
   - **Failure:** reusable rule을 누락하지 않는다.
 - [x] **C-07 — Complete authorized PR delivery through live CI and review**
   - **Action:** exact head를 publish하고 Korean PR, live metadata, review/thread, exact-head CI를 수렴한다.
-  - **Evidence:** [PR #836](https://github.com/bluetape4k/bluetape4k-leader/pull/836)가 `develop` base와 semantic head로 생성되었고 `debop`, `bug/integration/test/example`, milestone `1.0.0`을 확인했다. 독립 리뷰 APPROVE(P0/P1/P2/P3=0)와 final hosted CI run `33241472298`(11 success, 37 intended skip, failed/cancelled 0)을 read-back했다.
+  - **Evidence:** [PR #836](https://github.com/bluetape4k/bluetape4k-leader/pull/836)가 `develop` base와 semantic head로 생성되었고 `debop`, `bug/integration/test/example`, milestone `1.0.0`을 확인했다. 독립 리뷰 APPROVE(P0/P1/P2/P3=0)와 최종 remote head의 terminal hosted CI(실행 job success, path-filter intended skip, failed/cancelled 0)를 read-back했다.
   - **Failure:** stale/missing evidence를 repair하고 merge gate로 가지 않는다.
 - [x] **C-08 — Report merge readiness or no-delivery completion**
   - **Action:** Type C row와 CG-11~15를 재확인하고 merge-ready report를 작성한 뒤 CG-16에서 멈춘다.
@@ -142,11 +142,11 @@
   - **Failure:** live PR을 repair한다.
 - [x] **CG-14 — Pass CI and live human review**
   - **Action:** exact-head required CI, review/thread, independent review와 적용 artifact를 확인한다.
-  - **Evidence:** PR #836 final head `e60875e9268991caeee3890713c4fda7de1352d3`의 run `33241472298`에서 11개 실행 job이 성공하고 37개 path-filter intended skip, failed/cancelled 0이었다. 독립 review artifact는 APPROVE(P0/P1/P2/P3=0), unresolved blocker 0이며, GitHub human review는 single-developer lane으로 N/A 처리한다.
+  - **Evidence:** PR #836 최종 remote head의 hosted CI에서 11개 실행 job이 성공하고 37개 path-filter intended skip, failed/cancelled 0이었다. 독립 review artifact는 APPROVE(P0/P1/P2/P3=0), unresolved blocker 0이며, GitHub human review는 single-developer lane으로 N/A 처리한다.
   - **Failure:** PENDING은 기다리고 FAIL은 repair한다.
 - [x] **CG-15 — Report merge-ready**
   - **Action:** 모든 row와 count를 재확인하고 exact PR/head merge-ready report를 낸다.
-  - **Evidence:** PR #836, final head `e60875e9…`, CI/review evidence와 `Required checks: 45/49; N/A: 2; Blocked: 0`을 user-visible report로 수렴했다. `C-09`, `CG-16`~`CG-18`은 fresh merge approval 대기다.
+  - **Evidence:** PR #836의 최종 remote head, CI/review evidence와 `Required checks: 45/49; N/A: 2; Blocked: 0`을 user-visible report로 수렴했다. `C-09`, `CG-16`~`CG-18`은 fresh merge approval 대기다.
   - **Failure:** merge approval을 요청하지 않고 누락을 repair한다.
 - [ ] **CG-16 — Obtain fresh merge approval**
   - **Action:** CG-15 이후 exact PR/head에 대한 fresh merge approval을 기다린다.

--- a/docs/superpowers/checklists/2026-08-29-issue-827-prometheus-connectivity-probe.md
+++ b/docs/superpowers/checklists/2026-08-29-issue-827-prometheus-connectivity-probe.md
@@ -34,13 +34,13 @@
   - **Action:** 누락·순서 위반을 repair하고 영향받은 dependent proof를 다시 실행한다.
   - **Evidence:** 첫 regex escaping 오류를 production 변경으로 오인하지 않고 helper를 repair한 뒤 scrape RED를 다시 확인하고 GREEN/전체 테스트를 재실행했다.
   - **Failure:** 최종 상태를 BLOCKED로 남긴다.
-- [ ] **CL-07 — Refresh irreversible holds**
+- [x] **CL-07 — Refresh irreversible holds**
   - **Action:** PR 생성·merge 같은 외부 side effect 직전에 authority와 target을 다시 읽는다.
-  - **Evidence:** fresh issue/branch/head/CI/review read-back.
+  - **Evidence:** PR 생성 직전 live issue #827, repository `bluetape4k/bluetape4k-leader`, base `develop`, head `fix/issue-827-prometheus-connectivity-probe`, local head `07d8fec4bd0555a41b0bf8810a5dfbbff5132e8a`를 재확인했다. PR #836 생성 후 metadata와 exact-head hosted CI를 read-back했다.
   - **Failure:** side effect를 실행하지 않는다.
-- [ ] **CL-08 — Count before completion**
+- [x] **CL-08 — Count before completion**
   - **Action:** 최종 보고 전에 `Required checks: X/Y; N/A: N; Blocked: N`을 계산한다.
-  - **Evidence:** 이 파일의 최종 count와 unchecked ID 목록.
+  - **Evidence:** 현재 PR delivery gate 기준 `Required checks: 45/49; N/A: 2; Blocked: 0`으로 계산했다. 미완료 required ID는 `C-09`, `CG-16`, `CG-17`, `CG-18`이며 모두 fresh merge approval 이후 단계다.
   - **Failure:** completion claim을 금지한다.
 
 ## Type C bugfix lifecycle
@@ -69,13 +69,13 @@
   - **Action:** dead alert와 active producer 계약에서 재사용 가능한 운영 규칙을 lesson으로 기록하고 GNO를 갱신한다.
   - **Evidence:** `docs/lessons/2026-08-29-issue-827-prometheus-connectivity-probe.md`를 작성했고 temporary GNO collection `bluetape4k-leader-issue827`에서 `gno update`, `gno embed --collection bluetape4k-leader-issue827`, representative search hit `#0602cb75`를 확인한 뒤 collection을 제거했다.
   - **Failure:** reusable rule을 누락하지 않는다.
-- [ ] **C-07 — Complete authorized PR delivery through live CI and review**
+- [x] **C-07 — Complete authorized PR delivery through live CI and review**
   - **Action:** exact head를 publish하고 Korean PR, live metadata, review/thread, exact-head CI를 수렴한다.
-  - **Evidence:** PR URL/metadata, P0/P1=0, required checks, review artifact.
+  - **Evidence:** [PR #836](https://github.com/bluetape4k/bluetape4k-leader/pull/836)가 `develop` base와 semantic head로 생성되었고 `debop`, `bug/integration/test/example`, milestone `1.0.0`을 확인했다. 독립 리뷰 APPROVE(P0/P1/P2/P3=0)와 hosted CI run `33241153760`(11 success, 37 intended skip, failed/cancelled 0)을 read-back했다.
   - **Failure:** stale/missing evidence를 repair하고 merge gate로 가지 않는다.
-- [ ] **C-08 — Report merge readiness or no-delivery completion**
+- [x] **C-08 — Report merge readiness or no-delivery completion**
   - **Action:** Type C row와 CG-11~15를 재확인하고 merge-ready report를 작성한 뒤 CG-16에서 멈춘다.
-  - **Evidence:** exact PR/head와 reconciled count.
+  - **Evidence:** PR #836 exact head/CI/review와 `Required checks: 45/49; N/A: 2; Blocked: 0`을 reconciled했으며, merge는 CG-16 fresh approval 전까지 보류한다.
   - **Failure:** merge-ready 또는 DONE을 주장하지 않고 누락 row를 repair한다.
 - [ ] **C-09 — Close out only after fresh merge approval**
   - **Action:** exact PR/head에 대한 fresh approval 후 merge, sync, cleanup을 수행한다.
@@ -124,29 +124,29 @@
   - **Action:** Kotlin final checklist와 final diff/review를 수렴하고 commit한다.
   - **Evidence:** 최신 staged diff에 대한 독립 재리뷰가 APPROVE(P0=0/P1=0/P2=0/P3=0)였고, `PrometheusScrapeTest`의 fixed-delay cadence 보강 후 example 전체 13 tests와 Detekt, `git diff --cached --check`가 fresh 통과했다. 커밋은 다음 gate에서 생성한다.
   - **Failure:** PR 생성 전 repair한다.
-- [ ] **CG-11 — Verify PR delivery authority**
+- [x] **CG-11 — Verify PR delivery authority**
   - **Action:** 승인된 계획의 repo/base/head와 CG-01~10 PASS를 확인한다.
-  - **Evidence:** repository `bluetape4k/bluetape4k-leader`, base `develop`, head branch.
+  - **Evidence:** repository `bluetape4k/bluetape4k-leader`, base `develop`, head `fix/issue-827-prometheus-connectivity-probe`, CG-01~10 pre-PR gate와 승인 계획을 확인했다.
   - **Failure:** PR 생성 전에 authority를 repair한다.
-- [ ] **CG-12 — Publish the exact head branch**
+- [x] **CG-12 — Publish the exact head branch**
   - **Action:** converged feature head를 force 없이 push하고 remote SHA를 읽는다.
-  - **Evidence:** local/remote matching SHA.
+  - **Evidence:** `git push --set-upstream origin fix/issue-827-prometheus-connectivity-probe`를 force 없이 실행했고 초기 implementation head `07d8fec4bd0555a41b0bf8810a5dfbbff5132e8a`의 local/remote 일치를 확인했다.
   - **Failure:** mismatch를 repair한다.
-- [ ] **CG-12A — Refresh guidance before PR creation**
+- [x] **CG-12A — Refresh guidance before PR creation**
   - **Action:** PR 직전에 AGENTS/leaf/common/PR template/issue metadata를 다시 읽는다.
-  - **Evidence:** no-drift 또는 affected gate 재검증 결과.
+  - **Evidence:** PR 직전 authority/leaf/common guidance, PR template 부재, issue #827 metadata, clean worktree와 branch/head를 read-back했으며 drift가 없었다.
   - **Failure:** PR create/update를 중지한다.
-- [ ] **CG-13 — Create and verify the PR**
+- [x] **CG-13 — Create and verify the PR**
   - **Action:** issue-linked Korean PR을 만들고 `debop`, milestone, labels, final `## DoD Status`를 검증한다.
-  - **Evidence:** live PR URL/number, head SHA, metadata, final heading.
+  - **Evidence:** [PR #836](https://github.com/bluetape4k/bluetape4k-leader/pull/836), Korean body의 `## DoD Status`, base/head, assignee `debop`, labels `bug/integration/test/example`, milestone `1.0.0`을 live read-back했다.
   - **Failure:** live PR을 repair한다.
-- [ ] **CG-14 — Pass CI and live human review**
+- [x] **CG-14 — Pass CI and live human review**
   - **Action:** exact-head required CI, review/thread, independent review와 적용 artifact를 확인한다.
-  - **Evidence:** green required checks, P0/P1=0, unresolved blocker 0; human-review N/A면 solo-lane 근거.
+  - **Evidence:** PR #836 exact implementation head의 run `33241153760`에서 11개 실행 job이 성공하고 37개 path-filter intended skip, failed/cancelled 0이었다. 독립 review artifact는 APPROVE(P0/P1/P2/P3=0), unresolved blocker 0이며, GitHub human review는 single-developer lane으로 N/A 처리한다.
   - **Failure:** PENDING은 기다리고 FAIL은 repair한다.
-- [ ] **CG-15 — Report merge-ready**
+- [x] **CG-15 — Report merge-ready**
   - **Action:** 모든 row와 count를 재확인하고 exact PR/head merge-ready report를 낸다.
-  - **Evidence:** user-visible report와 `Required checks: X/Y; N/A: N; Blocked: 0`.
+  - **Evidence:** PR #836, implementation head `07d8fec4…`, CI/review evidence와 `Required checks: 45/49; N/A: 2; Blocked: 0`을 user-visible report로 수렴했다. `C-09`, `CG-16`~`CG-18`은 fresh merge approval 대기다.
   - **Failure:** merge approval을 요청하지 않고 누락을 repair한다.
 - [ ] **CG-16 — Obtain fresh merge approval**
   - **Action:** CG-15 이후 exact PR/head에 대한 fresh merge approval을 기다린다.
@@ -232,5 +232,5 @@
 
 - Required: 모든 Type C, Common, Kotlin 항목. `CG-14` human-review subgate는 single-developer lane 근거가 확인될 때만 N/A.
 - Conditional N/A 후보: `KT-TEST-04` (HTTP endpoint 변경 없음), `KT-FIN-05` (Exposed 변경 없음), diagram artifact rows (diagram 변경 없음), release/tag/publish branch (사용자 요청 범위 밖).
-- `X/Y`와 N/A count는 모든 applicable row의 fresh evidence를 기록한 뒤 계산한다.
-- 최종 unchecked IDs: 아직 계산하지 않음.
+- `Required checks: 45/49; N/A: 2; Blocked: 0`으로 계산했다. N/A는 `KT-TEST-04`, `KT-FIN-05`이고, human-review subgate는 `CG-14` evidence에서 solo-developer lane으로 별도 N/A 처리했다.
+- 최종 unchecked IDs: `C-09`, `CG-16`, `CG-17`, `CG-18` (fresh merge approval 및 이후 merge/sync/cleanup).

--- a/docs/superpowers/checklists/2026-08-29-issue-827-prometheus-connectivity-probe.md
+++ b/docs/superpowers/checklists/2026-08-29-issue-827-prometheus-connectivity-probe.md
@@ -36,7 +36,7 @@
   - **Failure:** 최종 상태를 BLOCKED로 남긴다.
 - [x] **CL-07 — Refresh irreversible holds**
   - **Action:** PR 생성·merge 같은 외부 side effect 직전에 authority와 target을 다시 읽는다.
-  - **Evidence:** PR 생성 직전 live issue #827, repository `bluetape4k/bluetape4k-leader`, base `develop`, head `fix/issue-827-prometheus-connectivity-probe`, local head `07d8fec4bd0555a41b0bf8810a5dfbbff5132e8a`를 재확인했다. PR #836 생성 후 metadata와 exact-head hosted CI를 read-back했다.
+  - **Evidence:** PR 생성 직전 live issue #827, repository `bluetape4k/bluetape4k-leader`, base `develop`, head `fix/issue-827-prometheus-connectivity-probe`, local implementation head `07d8fec4bd0555a41b0bf8810a5dfbbff5132e8a`를 재확인했다. PR #836 생성 후 follow-up checklist head `e60875e9268991caeee3890713c4fda7de1352d3`와 metadata/exact-head hosted CI를 다시 read-back했다.
   - **Failure:** side effect를 실행하지 않는다.
 - [x] **CL-08 — Count before completion**
   - **Action:** 최종 보고 전에 `Required checks: X/Y; N/A: N; Blocked: N`을 계산한다.
@@ -71,7 +71,7 @@
   - **Failure:** reusable rule을 누락하지 않는다.
 - [x] **C-07 — Complete authorized PR delivery through live CI and review**
   - **Action:** exact head를 publish하고 Korean PR, live metadata, review/thread, exact-head CI를 수렴한다.
-  - **Evidence:** [PR #836](https://github.com/bluetape4k/bluetape4k-leader/pull/836)가 `develop` base와 semantic head로 생성되었고 `debop`, `bug/integration/test/example`, milestone `1.0.0`을 확인했다. 독립 리뷰 APPROVE(P0/P1/P2/P3=0)와 hosted CI run `33241153760`(11 success, 37 intended skip, failed/cancelled 0)을 read-back했다.
+  - **Evidence:** [PR #836](https://github.com/bluetape4k/bluetape4k-leader/pull/836)가 `develop` base와 semantic head로 생성되었고 `debop`, `bug/integration/test/example`, milestone `1.0.0`을 확인했다. 독립 리뷰 APPROVE(P0/P1/P2/P3=0)와 final hosted CI run `33241472298`(11 success, 37 intended skip, failed/cancelled 0)을 read-back했다.
   - **Failure:** stale/missing evidence를 repair하고 merge gate로 가지 않는다.
 - [x] **C-08 — Report merge readiness or no-delivery completion**
   - **Action:** Type C row와 CG-11~15를 재확인하고 merge-ready report를 작성한 뒤 CG-16에서 멈춘다.
@@ -142,11 +142,11 @@
   - **Failure:** live PR을 repair한다.
 - [x] **CG-14 — Pass CI and live human review**
   - **Action:** exact-head required CI, review/thread, independent review와 적용 artifact를 확인한다.
-  - **Evidence:** PR #836 exact implementation head의 run `33241153760`에서 11개 실행 job이 성공하고 37개 path-filter intended skip, failed/cancelled 0이었다. 독립 review artifact는 APPROVE(P0/P1/P2/P3=0), unresolved blocker 0이며, GitHub human review는 single-developer lane으로 N/A 처리한다.
+  - **Evidence:** PR #836 final head `e60875e9268991caeee3890713c4fda7de1352d3`의 run `33241472298`에서 11개 실행 job이 성공하고 37개 path-filter intended skip, failed/cancelled 0이었다. 독립 review artifact는 APPROVE(P0/P1/P2/P3=0), unresolved blocker 0이며, GitHub human review는 single-developer lane으로 N/A 처리한다.
   - **Failure:** PENDING은 기다리고 FAIL은 repair한다.
 - [x] **CG-15 — Report merge-ready**
   - **Action:** 모든 row와 count를 재확인하고 exact PR/head merge-ready report를 낸다.
-  - **Evidence:** PR #836, implementation head `07d8fec4…`, CI/review evidence와 `Required checks: 45/49; N/A: 2; Blocked: 0`을 user-visible report로 수렴했다. `C-09`, `CG-16`~`CG-18`은 fresh merge approval 대기다.
+  - **Evidence:** PR #836, final head `e60875e9…`, CI/review evidence와 `Required checks: 45/49; N/A: 2; Blocked: 0`을 user-visible report로 수렴했다. `C-09`, `CG-16`~`CG-18`은 fresh merge approval 대기다.
   - **Failure:** merge approval을 요청하지 않고 누락을 repair한다.
 - [ ] **CG-16 — Obtain fresh merge approval**
   - **Action:** CG-15 이후 exact PR/head에 대한 fresh merge approval을 기다린다.

--- a/docs/superpowers/checklists/2026-08-29-issue-827-prometheus-connectivity-probe.md
+++ b/docs/superpowers/checklists/2026-08-29-issue-827-prometheus-connectivity-probe.md
@@ -1,0 +1,236 @@
+# Issue #827 Prometheus connectivity probe checklist
+
+- 이슈: [#827](https://github.com/bluetape4k/bluetape4k-leader/issues/827)
+- 분류: Type C bugfix (`bluetape-bugfix`)
+- 범위: `examples/prometheus-dashboard`와 기존 Micrometer diagnostics 연결
+- 기준 브랜치: `develop`
+- 작업 브랜치: `fix/issue-827-prometheus-connectivity-probe`
+- 승인: 사용자가 2026-08-29에 구체 계획을 승인함
+- 원칙: Core API 변경과 unrelated cleanup은 범위 밖
+
+## Checklist state
+
+- [x] **CL-01 — Create before mutation**
+  - **Action:** 이 router/common/leaf checklist를 첫 코드 변경 전에 생성한다.
+  - **Evidence:** 이 파일을 코드 변경 전에 생성했다.
+  - **Failure:** 코드 변경을 중지하고 checklist를 복구한다.
+- [x] **CL-02 — Classify every item**
+  - **Action:** 모든 leaf/common/Kotlin 항목을 required, conditional 또는 N/A로 분류한다.
+  - **Evidence:** 모든 Type C/Common/Kotlin row와 conditional N/A 후보를 아래 적용성 표에 기록했다.
+  - **Failure:** 미분류 항목을 required 미검증으로 유지한다.
+- [x] **CL-03 — Respect dependency order**
+  - **Action:** 행을 위에서 아래 순서로 실행하고 RED 후 GREEN, pre-PR 후 PR 순서를 지킨다.
+  - **Evidence:** RED scrape/unit 재현 후 producer 구현, targeted GREEN, `promtool` rule-engine 평가와 실제 Lettuce 장애 fixture, full example, Micrometer/Lettuce, Detekt 순서로 fresh 검증했다.
+  - **Failure:** 영향을 받은 이후 증명을 재실행한다.
+- [x] **CL-04 — Record evidence immediately**
+  - **Action:** 각 항목을 확인하는 즉시 명령·파일·URL·count를 기록한다.
+  - **Evidence:** RED/GREEN, GNO, test XML count와 static command 결과를 각 gate Evidence 필드에 기록했다.
+  - **Failure:** evidence가 없는 row는 unchecked로 둔다.
+- [x] **CL-05 — Fail closed**
+  - **Action:** PENDING/FAIL 항목의 downstream 작업을 진행하지 않는다.
+  - **Evidence:** PR/merge 관련 row는 exact-head 외부 증거 전까지 unchecked로 유지하고, RED escaping 오류는 수정 후 재실행했다.
+  - **Failure:** 잘못 진행한 downstream 증명을 폐기하고 재검증한다.
+- [x] **CL-06 — Repair skipped or reordered work**
+  - **Action:** 누락·순서 위반을 repair하고 영향받은 dependent proof를 다시 실행한다.
+  - **Evidence:** 첫 regex escaping 오류를 production 변경으로 오인하지 않고 helper를 repair한 뒤 scrape RED를 다시 확인하고 GREEN/전체 테스트를 재실행했다.
+  - **Failure:** 최종 상태를 BLOCKED로 남긴다.
+- [ ] **CL-07 — Refresh irreversible holds**
+  - **Action:** PR 생성·merge 같은 외부 side effect 직전에 authority와 target을 다시 읽는다.
+  - **Evidence:** fresh issue/branch/head/CI/review read-back.
+  - **Failure:** side effect를 실행하지 않는다.
+- [ ] **CL-08 — Count before completion**
+  - **Action:** 최종 보고 전에 `Required checks: X/Y; N/A: N; Blocked: N`을 계산한다.
+  - **Evidence:** 이 파일의 최종 count와 unchecked ID 목록.
+  - **Failure:** completion claim을 금지한다.
+
+## Type C bugfix lifecycle
+
+- [x] **C-01 — Prove the defect and root cause**
+  - **Action:** 현재 HEAD에서 connectivity series 부재를 재현하고 provider·decorator·scrape 경계를 추적한다.
+  - **Evidence:** alert rules와 active probe recorder 경계를 대조해 예제의 active diagnostics 호출 부재를 확인했다. RED test는 PrometheusScrapeTest의 connectivity series assertion에서 missing series로 실패했다. Root cause는 producer 부재이며, 추가 `promtool` 평가로 rule expression 자체도 실행 검증했다.
+  - **Failure:** 재현 또는 원인이 불충분하면 편집하지 않고 진단을 계속한다.
+- [x] **C-02 — Confirm scope and issue gate**
+  - **Action:** #827의 live metadata와 예제 전용 surgical fix 범위를 확인한다.
+  - **Evidence:** issue URL, OPEN state, assignee `debop`, labels `bug/integration/test/example`, milestone `1.0.0`.
+  - **Failure:** 범위를 넓히거나 중복 issue/PR을 만들지 않는다.
+- [x] **C-03 — Lock the regression RED**
+  - **Action:** active probe producer와 상태별 metric 계약을 검증하는 최소 테스트를 먼저 추가한다.
+  - **Evidence:** 구현 전에 redis-lettuce/UNKNOWN/CLIENT_STATE_UNCONFIRMED series assertion을 추가했다. regex escaping 오류를 수정한 뒤 재실행해 의도한 missing-series assertion RED를 확인했고, rule-engine/실제 Lettuce DOWN·PROVIDER_EXCEPTION fixture를 추가해 상태 경계를 고정했다.
+  - **Failure:** compilation/fixture 실패를 RED로 인정하지 않는다.
+- [x] **C-04 — Apply the surgical fix**
+  - **Action:** 기존 `LeaderBackendDiagnosticsProvider`와 `InstrumentedLeaderElector`를 재사용해 예제 producer만 연결한다.
+  - **Evidence:** `PrometheusBackendConnectivityProbe`가 기존 `lettuceLeaderElector`의 diagnostics provider를 `InstrumentedLeaderElector`로 감싸고 bounded timeout을 전달한다. `application.yml`, EN/KO README, 회귀 테스트만 추가했으며 dependency/API 변경은 없다.
+  - **Failure:** unrelated refactor를 제거하고 범위를 재분류한다.
+- [x] **C-05 — Prove GREEN and blast radius**
+  - **Action:** regression, example AOT/test, 관련 Micrometer test, lint/static/broader proof를 순서대로 실행한다.
+  - **Evidence:** example 전체 13 tests (`skipped=0`, failures/errors=0), `leader-micrometer` 132 tests, `leader-redis-lettuce` 318 tests, targeted Detekt와 `git diff --check`가 모두 통과했다. `PrometheusScrapeTest`는 fixed delay 200ms/initial delay 0인 Spring scheduler의 connectivity counter가 실제 scrape에서 `> 1.0`으로 누적되는 cadence를 확인했다. `promtool` v2.55.1이 production alert rule의 DOWN/UNKNOWN/PROVIDER_EXCEPTION firing과 runbook annotation을 평가했고, Testcontainers Redis의 실제 Lettuce closed connection/예외 정규화도 검증했다.
+  - **Failure:** diagnosis로 돌아가 전체 proof sequence를 다시 실행한다.
+- [x] **C-06 — Capture reusable learning when applicable**
+  - **Action:** dead alert와 active producer 계약에서 재사용 가능한 운영 규칙을 lesson으로 기록하고 GNO를 갱신한다.
+  - **Evidence:** `docs/lessons/2026-08-29-issue-827-prometheus-connectivity-probe.md`를 작성했고 temporary GNO collection `bluetape4k-leader-issue827`에서 `gno update`, `gno embed --collection bluetape4k-leader-issue827`, representative search hit `#0602cb75`를 확인한 뒤 collection을 제거했다.
+  - **Failure:** reusable rule을 누락하지 않는다.
+- [ ] **C-07 — Complete authorized PR delivery through live CI and review**
+  - **Action:** exact head를 publish하고 Korean PR, live metadata, review/thread, exact-head CI를 수렴한다.
+  - **Evidence:** PR URL/metadata, P0/P1=0, required checks, review artifact.
+  - **Failure:** stale/missing evidence를 repair하고 merge gate로 가지 않는다.
+- [ ] **C-08 — Report merge readiness or no-delivery completion**
+  - **Action:** Type C row와 CG-11~15를 재확인하고 merge-ready report를 작성한 뒤 CG-16에서 멈춘다.
+  - **Evidence:** exact PR/head와 reconciled count.
+  - **Failure:** merge-ready 또는 DONE을 주장하지 않고 누락 row를 repair한다.
+- [ ] **C-09 — Close out only after fresh merge approval**
+  - **Action:** exact PR/head에 대한 fresh approval 후 merge, sync, cleanup을 수행한다.
+  - **Evidence:** approval, merge SHA, canonical sync, cleanup 결과.
+  - **Failure:** approval 전 merge/삭제를 하지 않는다.
+
+## Common gates
+
+- [x] **CG-01 — Re-read authority**
+  - **Action:** user/workspace/repository `AGENTS.md`, leaf skills, status/diff, approved plan을 다시 읽는다.
+  - **Evidence:** user/workspace/repository authority와 workflow, bugfix, Kotlin pattern skill, 승인 계획을 다시 확인했다. Canonical develop은 712d760cd55e8fbec875d2daff3e47d4d73ab9c0이며 pre-existing .flow-inputs/만 있다.
+  - **Failure:** 편집을 중지한다.
+- [x] **CG-02 — Query historical/current evidence**
+  - **Action:** GNO discovery와 live `gh` issue/PR/worktree evidence를 기록한다.
+  - **Evidence:** GNO bluetape4k-github 검색과 gh issue view 827에서 #827 historical/live metadata를 확인했다. gh pr list --search 827 결과는 빈 목록이었다.
+  - **Failure:** current-state 의존 결정을 중지한다.
+- [x] **CG-03 — Protect user work and boundaries**
+  - **Action:** canonical dirty state를 보존하고 isolated worktree/semantic branch에서만 구현한다.
+  - **Evidence:** canonical `develop` status와 feature worktree/head.
+  - **Failure:** default branch를 편집하지 않는다.
+- [x] **CG-04 — Apply policy and audience boundaries**
+  - **Action:** Korean user-facing docs, Kotlin rules, example scope와 permission boundaries를 적용한다.
+  - **Evidence:** Kotlin source/test와 EN/KO example README만 scope에 포함하며 기존 API·metric token과 한국어 user-facing prose 규칙을 유지한다.
+  - **Failure:** 언어·범위 drift를 repair한다.
+- [x] **CG-05 — Reuse ecosystem patterns**
+  - **Action:** 기존 diagnostics/decorator/Testcontainers/assertion 패턴을 조사하고 재사용한다.
+  - **Evidence:** existing diagnostics provider, instrumented elector, Lettuce backend, RedisServer/PrometheusServer launcher, `promtool`, bluetape assertions를 재사용하고 dependency를 추가하지 않는다.
+  - **Failure:** 새 abstraction/dependency를 중지한다.
+- [x] **CG-06 — Prove public and documentation contracts**
+  - **Action:** producer 설정·runbook·EN/KO README와 asset test를 정렬한다.
+  - **Evidence:** 기존 metric name/status/reason schema와 public API를 유지하고, `PrometheusAssetsTest` 5 tests가 alert rule, config, EN/KO README와 producer/token parity를 통과했다.
+  - **Failure:** 문서화되지 않은 동작을 PR에 넣지 않는다.
+- [x] **CG-07 — Lock behavior and run targeted proof**
+  - **Action:** TDD RED/GREEN 후 최소 diagnostics/compile/lint/test를 실행한다.
+  - **Evidence:** RED scrape XML `tests=1 failures=1`, unit compile RED 후 implementation, unit 4 tests, rule-engine 1 test, actual Lettuce 2 tests, scrape 1 test GREEN을 `--rerun-tasks`로 재실행했다.
+  - **Failure:** 구현으로 돌아가 repair한다.
+- [x] **CG-08 — Serialize heavyweight checks**
+  - **Action:** Testcontainers/실제 Redis 검증을 다른 heavyweight check와 겹치지 않게 순차 실행한다.
+  - **Evidence:** full example → Micrometer → Lettuce를 겹치지 않게 순차 실행했고 각각 XML 결과를 읽었다. example은 Testcontainers Redis scrape를 포함한다.
+  - **Failure:** ambiguous evidence를 폐기하고 재실행한다.
+- [x] **CG-09 — Evaluate the lesson gate**
+  - **Action:** dead alert 재발 방지 규칙을 lesson으로 남기고 GNO에 인덱싱한다.
+  - **Evidence:** lesson path와 temporary collection의 `gno update`/`gno embed`/search hit을 확인했으며 wiki canonical status는 변경 없이 보존됐다.
+  - **Failure:** lesson evidence 없이는 pre-PR로 진행하지 않는다.
+- [x] **CG-10 — Converge the final pre-PR proof**
+  - **Action:** Kotlin final checklist와 final diff/review를 수렴하고 commit한다.
+  - **Evidence:** 최신 staged diff에 대한 독립 재리뷰가 APPROVE(P0=0/P1=0/P2=0/P3=0)였고, `PrometheusScrapeTest`의 fixed-delay cadence 보강 후 example 전체 13 tests와 Detekt, `git diff --cached --check`가 fresh 통과했다. 커밋은 다음 gate에서 생성한다.
+  - **Failure:** PR 생성 전 repair한다.
+- [ ] **CG-11 — Verify PR delivery authority**
+  - **Action:** 승인된 계획의 repo/base/head와 CG-01~10 PASS를 확인한다.
+  - **Evidence:** repository `bluetape4k/bluetape4k-leader`, base `develop`, head branch.
+  - **Failure:** PR 생성 전에 authority를 repair한다.
+- [ ] **CG-12 — Publish the exact head branch**
+  - **Action:** converged feature head를 force 없이 push하고 remote SHA를 읽는다.
+  - **Evidence:** local/remote matching SHA.
+  - **Failure:** mismatch를 repair한다.
+- [ ] **CG-12A — Refresh guidance before PR creation**
+  - **Action:** PR 직전에 AGENTS/leaf/common/PR template/issue metadata를 다시 읽는다.
+  - **Evidence:** no-drift 또는 affected gate 재검증 결과.
+  - **Failure:** PR create/update를 중지한다.
+- [ ] **CG-13 — Create and verify the PR**
+  - **Action:** issue-linked Korean PR을 만들고 `debop`, milestone, labels, final `## DoD Status`를 검증한다.
+  - **Evidence:** live PR URL/number, head SHA, metadata, final heading.
+  - **Failure:** live PR을 repair한다.
+- [ ] **CG-14 — Pass CI and live human review**
+  - **Action:** exact-head required CI, review/thread, independent review와 적용 artifact를 확인한다.
+  - **Evidence:** green required checks, P0/P1=0, unresolved blocker 0; human-review N/A면 solo-lane 근거.
+  - **Failure:** PENDING은 기다리고 FAIL은 repair한다.
+- [ ] **CG-15 — Report merge-ready**
+  - **Action:** 모든 row와 count를 재확인하고 exact PR/head merge-ready report를 낸다.
+  - **Evidence:** user-visible report와 `Required checks: X/Y; N/A: N; Blocked: 0`.
+  - **Failure:** merge approval을 요청하지 않고 누락을 repair한다.
+- [ ] **CG-16 — Obtain fresh merge approval**
+  - **Action:** CG-15 이후 exact PR/head에 대한 fresh merge approval을 기다린다.
+  - **Evidence:** approval message와 refreshed hold.
+  - **Failure:** PENDING으로 유지하고 merge하지 않는다.
+- [ ] **CG-17 — Execute and verify the merge**
+  - **Action:** 승인된 merge strategy로 merge하고 live merged state/SHA를 검증한다.
+  - **Evidence:** merge URL, strategy, merged state, SHA.
+  - **Failure:** 중지하고 diagnose한다.
+- [ ] **CG-18 — Synchronize and clean up**
+  - **Action:** canonical checkout을 merged SHA로 sync하고 proven merged worktree만 정리한다.
+  - **Evidence:** local/upstream SHA, preserved dirty state, cleanup list.
+  - **Failure:** ambiguous target은 보존하고 PENDING으로 보고한다.
+
+## Kotlin triggered checks
+
+- [x] **KT-TEST-01 — Use project test idioms**
+  - **Action:** JUnit 5, `io.bluetape4k.assertions`, descriptive backtick tests와 기존 fixtures를 사용한다.
+  - **Evidence:** JUnit 5 descriptive backtick tests와 `io.bluetape4k.assertions`의 `assertFailsWith`, `shouldBeEqualTo`, `shouldBeSameInstanceAs`, `shouldBeTrue`, `shouldBeFalse`, `shouldBeGreaterThan`, `shouldNotBeNull`을 사용했다.
+  - **Failure:** incompatible assertion을 교체한다.
+- [x] **KT-TEST-02 — Prove concurrency and cancellation**
+  - **Action:** scheduler/probe lifecycle risk를 검증하고 ad hoc stress가 필요하면 근거를 기록한다.
+  - **Evidence:** 새 코드는 Spring scheduled blocking probe이며 coroutine/cancellation/lock lifecycle API를 변경하지 않는다. provider exception rethrow와 기존 Micrometer cancellation/interrupt 계약은 `leader-micrometer` 전체 132 tests에서 재검증했다. 별도 stress/cancellation fixture는 N/A.
+  - **Failure:** fake cancellation proof를 인정하지 않는다.
+- [x] **KT-TEST-03 — Reuse safe infrastructure fixtures**
+  - **Action:** `RedisServer.Launcher`와 순차 Testcontainers 실행을 사용한다.
+  - **Evidence:** Spring scrape와 Lettuce 장애 fixture는 기존 `RedisServer.Launcher.redis` singleton을 사용했고, Prometheus rule-engine과 real Redis Testcontainers 검증을 Micrometer/Lettuce와 직렬화했다. full example 13 tests와 Lettuce 318 tests가 통과했다.
+  - **Failure:** raw duplicate container 또는 retry-only pass를 조사한다.
+- [x] **KT-TEST-04 — Cover HTTP lifecycle contracts**
+  - **Action:** HTTP endpoint를 변경하지 않으면 N/A 근거를 기록한다.
+  - **Evidence:** HTTP endpoint/controller 계약은 변경하지 않았고 기존 `/actuator/prometheus` scrape만 integration assertion으로 소비하므로 별도 HTTP adapter lifecycle은 N/A이다.
+  - **Failure:** endpoint behavior를 누락한 채 진행하지 않는다.
+- [x] **KT-TEST-05 — Run fresh targeted then module validation**
+  - **Action:** smallest test, affected compile/test, full module test와 report-only coverage를 순서대로 실행한다.
+  - **Evidence:** targeted unit 4, rule-engine 1, actual Lettuce 2, scrape 1, assets 5 후 example 전체 13; `leader-micrometer` 132와 `leader-redis-lettuce` 318을 모두 `--rerun-tasks`로 실행하고 skipped/failures/errors 모두 0을 확인했다.
+  - **Failure:** stale cache evidence를 거부한다.
+- [x] **KT-FIN-01 — Inspect the current surface**
+  - **Action:** source, callers, tests, README와 alert assets를 최종 재검토한다.
+  - **Evidence:** `PrometheusDashboardApp.kt`, `PrometheusBackendConnectivityProbe.kt`, `application.yml`, `PrometheusScrapeTest.kt`, `PrometheusAssetsTest.kt`, `PrometheusAlertRulesTest.kt`, `PrometheusLettuceConnectivityProbeTest.kt`, rule fixture, EN/KO README, alert rule과 existing diagnostics/decorator source를 최종 read-back했다.
+  - **Failure:** discovery를 재개한다.
+- [x] **KT-FIN-02 — Preserve validation contracts**
+  - **Action:** touched timeout/config validation이 project helpers와 호환 exception을 사용하는지 확인한다.
+  - **Evidence:** probe timeout은 기존 `requirePositiveNumber` helper로 양수를 강제하고 0 입력 회귀 테스트가 `IllegalArgumentException`을 확인한다. backend diagnostic status/reason contract는 변경하지 않았다.
+  - **Failure:** contract drift를 repair한다.
+- [x] **KT-FIN-03 — Exclude unsafe Kotlin constructs**
+  - **Action:** 새 production `!!`, suspend `runCatching`, swallowed cancellation, event-loop blocking을 검색한다.
+  - **Evidence:** 신규 production source에서 `!!`, `runCatching`, cancellation swallow, event-loop blocking을 사용하지 않는다. `git diff`와 targeted Detekt가 통과했고 ordinary exception은 instrumentation contract대로 rethrow한다.
+  - **Failure:** unsafe construct를 제거한다.
+- [x] **KT-FIN-04 — Prove lifecycle ownership**
+  - **Action:** Redis connection/provider/probe scheduler의 ownership·timeout·exception 경로를 검증한다.
+  - **Evidence:** probe는 기존 `lettuceLeaderElector`와 connection을 소유하지 않고 provider만 참조하며, timeout을 호출 단위로 전달한다. Redis client/connection destroy method는 기존 App bean이 소유하고 scheduler는 provider exception을 숨기지 않는다.
+  - **Failure:** 명시적 ownership proof를 추가한다.
+- [x] **KT-FIN-05 — Verify Exposed boundaries**
+  - **Action:** Exposed를 변경하지 않으면 scope 기반 N/A를 기록한다.
+  - **Evidence:** 변경 경로는 `examples/prometheus-dashboard`와 lesson/checklist이며 Exposed 모듈/API/transaction을 건드리지 않는다. N/A.
+  - **Failure:** Exposed boundary가 있으면 검증한다.
+- [x] **KT-FIN-06 — Apply triggered references**
+  - **Action:** Spring Boot, testing, Testcontainers reference checklist를 모두 완료한다.
+  - **Evidence:** Kotlin pattern/testing, Spring Boot scheduling/qualifier, Micrometer instrumentation, Testcontainers fixture reference를 적용했고 example/Micrometer/Lettuce 검증을 완료했다. HTTP/Exposed는 scope N/A로 기록했다.
+  - **Failure:** partial reference 적용을 차단한다.
+- [x] **KT-FIN-07 — Prove named test behavior**
+  - **Action:** 새 테스트가 producer/status/passive contract 없이는 통과할 수 없는지 확인한다.
+  - **Evidence:** producer 부재 RED, 구현 후 status별 metric scrape, 두 번의 unit probe와 Spring fixed-delay scrape에서 `> 1.0` cadence counter 증가, passive diagnostics 무계측, 실제 Lettuce DOWN/PROVIDER_EXCEPTION, `promtool` firing/runbook annotation 및 exception identity/timeout validation GREEN을 확인했다. 예외 test도 `PROVIDER_EXCEPTION` scrape series를 직접 검사한다.
+  - **Failure:** test를 강화한다.
+- [x] **KT-FIN-08 — Synchronize public documentation**
+  - **Action:** producer config/runbook과 EN/KO README를 정렬하고 diagram scope를 판정한다.
+  - **Evidence:** source producer, application properties, alert rule/runbook, EN/KO README, asset test가 동일한 metric/status/reason/timeout 계약을 사용한다. diagram 파일은 변경하지 않아 N/A이다.
+  - **Failure:** drift를 repair한다.
+- [x] **KT-FIN-09 — Clear diagnostics**
+  - **Action:** compile/import/deprecation/IDE fallback diagnostics를 확인한다.
+  - **Evidence:** example compile/test와 targeted Detekt가 `BUILD SUCCESSFUL`; 신규 rule-engine/실제 Lettuce 테스트 compile을 포함해 deprecation/unresolved diagnostics가 없었다.
+  - **Failure:** touched-code unresolved diagnostics를 남기지 않는다.
+- [x] **KT-FIN-10 — Run fresh validation**
+  - **Action:** targeted compile/tests와 `git diff --check`를 fresh 상태로 실행한다.
+  - **Evidence:** example 13, Micrometer 132, Lettuce 318 tests, targeted scrape/unit/rule-engine/actual-Lettuce/assets rerun, Detekt와 `git diff --check`가 fresh 성공했다.
+  - **Failure:** exact gap을 기록하고 completion을 막는다.
+- [x] **KT-FIN-11 — Converge final scope**
+  - **Action:** final commit/PR scope와 parent findings를 확인한다.
+  - **Evidence:** staged scope는 예제 production/test/config/README와 lesson/checklist로 제한되고 unrelated change가 없다. 독립 최종 리뷰가 P0=0/P1=0/P2=0/P3=0으로 APPROVE했으며, 이전 P2(cadence)도 `> 1.0` Spring scrape assertion으로 해소했다.
+  - **Failure:** scope를 분리하거나 findings를 repair한다.
+
+## Applicability and count
+
+- Required: 모든 Type C, Common, Kotlin 항목. `CG-14` human-review subgate는 single-developer lane 근거가 확인될 때만 N/A.
+- Conditional N/A 후보: `KT-TEST-04` (HTTP endpoint 변경 없음), `KT-FIN-05` (Exposed 변경 없음), diagram artifact rows (diagram 변경 없음), release/tag/publish branch (사용자 요청 범위 밖).
+- `X/Y`와 N/A count는 모든 applicable row의 fresh evidence를 기록한 뒤 계산한다.
+- 최종 unchecked IDs: 아직 계산하지 않음.

--- a/examples/prometheus-dashboard/README.ko.md
+++ b/examples/prometheus-dashboard/README.ko.md
@@ -37,6 +37,9 @@ scrape하고 Grafana가 사전 provision된 dashboard를 렌더링합니다.
 - `@Scheduled` trigger가 `dashboard-job` 이름의 proxied `@LeaderElection` 작업을 호출
 - Lettuce Redis backend, `bootRun` 시 Testcontainers Redis 자동 fallback
 - Spring Boot Actuator를 통한 Micrometer leader AOP 메트릭 노출
+- 기존 Redis diagnostics provider를 bounded timeout으로 호출해
+  `leader_backend_connectivity_total`을 기록하는 주기적
+  `PrometheusBackendConnectivityProbe`
 - leader Micrometer Observation을 확인하는 로컬 demo `ObservationHandler`
 - Prometheus scrape 설정과 직접 작성한 Grafana dashboard
 - 예제 범위의 Prometheus alert rule과 runbook 안내
@@ -153,6 +156,13 @@ Backend connectivity counter는 Prometheus 이름 변환 후
 `notification: no-page`를 사용합니다. `UNKNOWN`을 `DOWN`으로 다시 쓰지 않으며,
 passive `NOT_CHECKED` diagnostics는 series를 만들지 않습니다.
 
+`PrometheusBackendConnectivityProbe`가 이 counter를 생성합니다. 별도 Redis
+client를 만들지 않고 기존 Lettuce connection의 diagnostics provider를 재사용하며,
+설정한 fixed delay마다 `DEMO_BACKEND_PROBE_TIMEOUT_MS`를 bounded probe budget으로
+전달합니다. 현재 Lettuce provider는 backend round trip 없이 open client state만
+확인하므로 `CLIENT_STATE_UNCONFIRMED` reason의 `UNKNOWN`을 반환하며 `UP`이라고
+단정하지 않습니다. 닫힌 client state는 `DISCONNECTED` reason의 `DOWN`을 보고합니다.
+
 이 demo는 `MicrometerSafeLeaderHistoryRecorder`를 `NoopLeaderHistorySink`와
 함께 등록해 `leader_history_*` meter가 보이게 합니다. Alert rule은 no-op sink가
 의도적으로 acquire key를 반환하지 않으므로 해당 sink를 제외합니다. 실제 서비스에서는
@@ -196,6 +206,9 @@ sum by (backend_name, reason) (rate(leader_backend_connectivity_total{status="UN
 | `DEMO_REDIS_URL` / `demo.redis.url` | Testcontainers Redis | Lettuce가 사용할 Redis URI |
 | `DEMO_JOB_FIXED_DELAY_MS` / `demo.job.fixed-delay-ms` | `5000` | Scheduler fixed delay |
 | `DEMO_JOB_INITIAL_DELAY_MS` / `demo.job.initial-delay-ms` | `1000` | Scheduler initial delay |
+| `DEMO_BACKEND_PROBE_FIXED_DELAY_MS` / `demo.backend-probe.fixed-delay-ms` | `5000` | Connectivity probe fixed delay |
+| `DEMO_BACKEND_PROBE_INITIAL_DELAY_MS` / `demo.backend-probe.initial-delay-ms` | `1000` | Initial connectivity probe delay |
+| `DEMO_BACKEND_PROBE_TIMEOUT_MS` / `demo.backend-probe.timeout-ms` | `500` | 기존 diagnostics provider에 전달하는 양수 timeout |
 | `DEMO_OBSERVATION_LOGGING_HANDLER_ENABLED` / `demo.observation.logging-handler-enabled` | `true` | 로컬 demo Observation handler 활성화 |
 | `bluetape4k.leader.aop.metrics.tags.lock-name.mode` | `RAW` | 정적 `dashboard-job` label을 Prometheus에서 보여주기 위한 demo 전용 opt-in |
 | `SERVER_PORT` | `8080` | HTTP port |
@@ -235,4 +248,7 @@ AOT 태스크도 `bootRun`과 같은 Testcontainers Redis fallback을 사용하�
 
 테스트는 Spring Boot를 random port로 시작하고, `RedisServer.Launcher.redis`
 Testcontainers singleton을 사용해 `/actuator/prometheus`에 `dashboard-job`의
-`leader_aop_*` 메트릭이 노출되는지 검증합니다.
+`leader_aop_*` 메트릭과 `PrometheusBackendConnectivityProbe`가 생성한
+`UNKNOWN`/`CLIENT_STATE_UNCONFIRMED` connectivity series가 노출되는지 검증합니다.
+단위 테스트는 별도 Redis client를 만들지 않고 `UP`, `DOWN`,
+`PROVIDER_EXCEPTION` label도 확인합니다.

--- a/examples/prometheus-dashboard/README.md
+++ b/examples/prometheus-dashboard/README.md
@@ -37,6 +37,8 @@ the app while Grafana renders the pre-provisioned dashboard.
 - `@Scheduled` trigger that calls a proxied `@LeaderElection` job named `dashboard-job`
 - Lettuce Redis backend with a local Testcontainers fallback for `bootRun`
 - Micrometer leader AOP metrics exposed through Spring Boot Actuator
+- Scheduled `PrometheusBackendConnectivityProbe` that records the existing Redis diagnostics provider
+  as `leader_backend_connectivity_total` with a bounded timeout
 - Local demo `ObservationHandler` for leader Micrometer Observations
 - Prometheus scrape config and a hand-authored Grafana dashboard
 - Example-scoped Prometheus alert rules and runbook guidance
@@ -154,6 +156,13 @@ the four status values, and the six bounded reason values. The rules above use
 `for` windows and `notification: no-page`; `UNKNOWN` is never rewritten as
 `DOWN`, and passive `NOT_CHECKED` diagnostics do not produce a series.
 
+`PrometheusBackendConnectivityProbe` is the producer for this counter. It reuses
+the existing Lettuce connection through its diagnostics provider, runs on the
+configured fixed delay, and passes `DEMO_BACKEND_PROBE_TIMEOUT_MS` as a bounded
+probe budget. The current Lettuce provider reports an open client state as
+`UNKNOWN` with `CLIENT_STATE_UNCONFIRMED`; it does not claim `UP` without a
+backend round trip. Closed client state reports `DOWN` with `DISCONNECTED`.
+
 This demo registers `MicrometerSafeLeaderHistoryRecorder` with
 `NoopLeaderHistorySink` so `leader_history_*` meters are visible. The alert
 rules exclude that no-op sink because it intentionally returns no acquire key.
@@ -198,6 +207,9 @@ multi-instance deployments. The gauge is JVM-local, so `sum` can over-count.
 | `DEMO_REDIS_URL` / `demo.redis.url` | Testcontainers Redis | Redis URI used by Lettuce |
 | `DEMO_JOB_FIXED_DELAY_MS` / `demo.job.fixed-delay-ms` | `5000` | Scheduler fixed delay |
 | `DEMO_JOB_INITIAL_DELAY_MS` / `demo.job.initial-delay-ms` | `1000` | Initial scheduler delay |
+| `DEMO_BACKEND_PROBE_FIXED_DELAY_MS` / `demo.backend-probe.fixed-delay-ms` | `5000` | Connectivity probe fixed delay |
+| `DEMO_BACKEND_PROBE_INITIAL_DELAY_MS` / `demo.backend-probe.initial-delay-ms` | `1000` | Initial connectivity probe delay |
+| `DEMO_BACKEND_PROBE_TIMEOUT_MS` / `demo.backend-probe.timeout-ms` | `500` | Positive timeout passed to the existing diagnostics provider |
 | `DEMO_OBSERVATION_LOGGING_HANDLER_ENABLED` / `demo.observation.logging-handler-enabled` | `true` | Enables the local demo Observation handler |
 | `bluetape4k.leader.aop.metrics.tags.lock-name.mode` | `RAW` | Demo-only opt-in so the static `dashboard-job` label is visible in Prometheus |
 | `SERVER_PORT` | `8080` | HTTP port |
@@ -237,6 +249,9 @@ set.
   :examples:prometheus-dashboard:test
 ```
 
-The test starts Spring Boot on a random port, uses the shared
-`RedisServer.Launcher.redis` Testcontainers singleton, and verifies the
-Prometheus scrape contains `leader_aop_*` metrics for `dashboard-job`.
+The tests start Spring Boot on a random port, use the shared
+`RedisServer.Launcher.redis` Testcontainers singleton, and verify the
+Prometheus scrape contains `leader_aop_*` metrics for `dashboard-job` plus the
+`UNKNOWN`/`CLIENT_STATE_UNCONFIRMED` connectivity series emitted by
+`PrometheusBackendConnectivityProbe`. Unit coverage also exercises `UP`,
+`DOWN`, and `PROVIDER_EXCEPTION` labels without creating another Redis client.

--- a/examples/prometheus-dashboard/src/main/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusBackendConnectivityProbe.kt
+++ b/examples/prometheus-dashboard/src/main/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusBackendConnectivityProbe.kt
@@ -1,0 +1,35 @@
+package io.bluetape4k.leader.examples.prometheus
+
+import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
+import io.bluetape4k.support.requirePositiveNumber
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Prometheus alert rule이 읽는 backend connectivity counter를 주기적으로 생성합니다.
+ *
+ * 기존 elector가 보유한 diagnostics provider를 재사용하고, probe timeout은 설정 가능한
+ * 양수 millisecond 값으로 제한해 scheduler 호출이 무기한 대기하지 않도록 합니다.
+ */
+@Component
+class PrometheusBackendConnectivityProbe(
+    @Qualifier("prometheusBackendDiagnosticsProvider")
+    private val provider: LeaderBackendDiagnosticsProvider,
+    @Value("\${demo.backend-probe.timeout-ms:500}") timeoutMillis: Long,
+) {
+
+    private val timeout = timeoutMillis
+        .requirePositiveNumber("demo.backend-probe.timeout-ms")
+        .milliseconds
+
+    @Scheduled(
+        fixedDelayString = "\${demo.backend-probe.fixed-delay-ms:5000}",
+        initialDelayString = "\${demo.backend-probe.initial-delay-ms:1000}",
+    )
+    fun probe() {
+        provider.checkConnectivity(timeout)
+    }
+}

--- a/examples/prometheus-dashboard/src/main/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusDashboardApp.kt
+++ b/examples/prometheus-dashboard/src/main/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusDashboardApp.kt
@@ -1,8 +1,12 @@
 package io.bluetape4k.leader.examples.prometheus
 
 import io.bluetape4k.leader.annotation.LeaderElection
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
 import io.bluetape4k.leader.examples.support.startExampleContainer
 import io.bluetape4k.leader.history.NoopLeaderHistorySink
+import io.bluetape4k.leader.micrometer.InstrumentedLeaderElector
+import io.bluetape4k.leader.micrometer.LeaderMetricTagOptions
 import io.bluetape4k.leader.micrometer.LeaderMetricTagSanitizer
 import io.bluetape4k.leader.micrometer.MicrometerLeaderAopMetricsRecorder
 import io.bluetape4k.leader.micrometer.history.MicrometerSafeLeaderHistoryRecorder
@@ -15,6 +19,7 @@ import io.lettuce.core.codec.StringCodec
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.observation.Observation
 import io.micrometer.observation.ObservationHandler
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
@@ -48,6 +53,22 @@ class PrometheusDashboardApp {
     @Bean(destroyMethod = "close")
     fun redisConnection(client: RedisClient): StatefulRedisConnection<String, String> =
         client.connect(StringCodec.UTF8)
+
+    @Bean
+    @ConditionalOnMissingBean(name = ["prometheusBackendDiagnosticsProvider"])
+    fun prometheusBackendDiagnosticsProvider(
+        @Qualifier("lettuceLeaderElector") delegate: LeaderElector,
+        registry: MeterRegistry,
+    ): LeaderBackendDiagnosticsProvider =
+        checkNotNull(
+            InstrumentedLeaderElector(
+                delegate = delegate,
+                registry = registry,
+                tagOptions = LeaderMetricTagOptions.Default,
+            ).backendDiagnosticsProvider,
+        ) {
+            "Redis diagnostics provider must be available for the Prometheus example"
+        }
 
     // Keep the recorder explicit so pre-registration works in normal and AOT test contexts.
     @Bean

--- a/examples/prometheus-dashboard/src/main/resources/application.yml
+++ b/examples/prometheus-dashboard/src/main/resources/application.yml
@@ -24,6 +24,10 @@ demo:
     initial-delay-ms: ${DEMO_JOB_INITIAL_DELAY_MS:1000}
   redis:
     url: ${DEMO_REDIS_URL:}
+  backend-probe:
+    fixed-delay-ms: ${DEMO_BACKEND_PROBE_FIXED_DELAY_MS:5000}
+    initial-delay-ms: ${DEMO_BACKEND_PROBE_INITIAL_DELAY_MS:1000}
+    timeout-ms: ${DEMO_BACKEND_PROBE_TIMEOUT_MS:500}
   observation:
     logging-handler-enabled: ${DEMO_OBSERVATION_LOGGING_HANDLER_ENABLED:true}
 

--- a/examples/prometheus-dashboard/src/test/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusAlertRulesTest.kt
+++ b/examples/prometheus-dashboard/src/test/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusAlertRulesTest.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.leader.examples.prometheus
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.testcontainers.infra.PrometheusServer
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.testcontainers.utility.MountableFile
+import java.nio.file.Files
+import java.nio.file.Path
+
+class PrometheusAlertRulesTest {
+
+    @Test
+    fun `promtool evaluates connectivity alerts and runbook annotations`(@TempDir tempDir: Path) {
+        val testRules = tempDir.resolve("leader-alert-rules-test.yml")
+        Files.copy(testRulesResource, testRules)
+
+        PrometheusServer(tag = PROMETHEUS_TAG, reuse = false).apply {
+            withCopyFileToContainer(
+                MountableFile.forHostPath(prometheusRulesPath),
+                "/tmp/leader-alerts.yml",
+            )
+            withCopyFileToContainer(
+                MountableFile.forHostPath(testRules),
+                "/tmp/leader-alert-rules-test.yml",
+            )
+            start()
+        }.use { prometheus ->
+            val result = prometheus.execInContainer(
+                "/bin/promtool",
+                "test",
+                "rules",
+                "/tmp/leader-alert-rules-test.yml",
+            )
+
+            result.exitCode shouldBeEqualTo 0
+            result.stdout shouldContain "SUCCESS"
+        }
+    }
+
+    companion object {
+        private const val PROMETHEUS_TAG = "v2.55.1"
+        private val projectRoot = findProjectRoot(Path.of("").toAbsolutePath().normalize())
+        private val prometheusRulesPath =
+            projectRoot.resolve("examples/prometheus-dashboard/provisioning/prometheus/rules/leader-alerts.yml")
+        private val testRulesResource =
+            PrometheusAlertRulesTest::class.java.getResource("/prometheus/leader-alert-rules-test.yml")
+                ?.toURI()
+                ?.let(Path::of)
+                ?: error("Prometheus alert rule test resource is missing")
+
+        private fun findProjectRoot(start: Path): Path =
+            generateSequence(start) { it.parent }
+                .first { Files.exists(it.resolve("settings.gradle.kts")) }
+    }
+}

--- a/examples/prometheus-dashboard/src/test/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusAssetsTest.kt
+++ b/examples/prometheus-dashboard/src/test/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusAssetsTest.kt
@@ -39,6 +39,9 @@ class PrometheusAssetsTest {
         rules.contains("leader_backend_connectivity_total").shouldBeTrue()
         rules.contains("""leader_backend_connectivity_total{status="DOWN",reason="DISCONNECTED"}""").shouldBeTrue()
         rules.contains(
+            """leader_backend_connectivity_total{status="UNKNOWN",reason=~"CLIENT_STATE_UNCONFIRMED|PROVIDER_UNSUPPORTED"}""",
+        ).shouldBeTrue()
+        rules.contains(
             """leader_backend_connectivity_total{status="UNKNOWN",reason="PROVIDER_EXCEPTION"}""",
         ).shouldBeTrue()
         rules.contains("notification: no-page").shouldBeTrue()
@@ -78,6 +81,10 @@ class PrometheusAssetsTest {
         config.contains("mode: REDACT").shouldBeTrue()
         config.contains("redacted-value: redacted-lock").shouldBeTrue()
         config.contains("mode: RAW").shouldBeFalse()
+        config.contains("backend-probe:").shouldBeTrue()
+        config.contains("DEMO_BACKEND_PROBE_FIXED_DELAY_MS").shouldBeTrue()
+        config.contains("DEMO_BACKEND_PROBE_INITIAL_DELAY_MS").shouldBeTrue()
+        config.contains("DEMO_BACKEND_PROBE_TIMEOUT_MS").shouldBeTrue()
     }
 
     @Test
@@ -98,6 +105,8 @@ class PrometheusAssetsTest {
             readme.contains("LeaderBackendConnectivityUnknown").shouldBeTrue()
             readme.contains("LeaderBackendConnectivityProbeExceptions").shouldBeTrue()
             readme.contains("leader_backend_connectivity_total").shouldBeTrue()
+            readme.contains("PrometheusBackendConnectivityProbe").shouldBeTrue()
+            readme.contains("DEMO_BACKEND_PROBE_TIMEOUT_MS").shouldBeTrue()
             readme.contains("PROVIDER_EXCEPTION").shouldBeTrue()
             readme.contains("LeaderHistorySinkFailures").shouldBeTrue()
             readme.contains("max by (lock_name) (leader_aop_active)").shouldBeTrue()

--- a/examples/prometheus-dashboard/src/test/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusBackendConnectivityProbeTest.kt
+++ b/examples/prometheus-dashboard/src/test/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusBackendConnectivityProbeTest.kt
@@ -1,0 +1,179 @@
+package io.bluetape4k.leader.examples.prometheus
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeSameInstanceAs
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivity
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityReason
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityStatus
+import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
+import io.bluetape4k.leader.diagnostics.LocalLeaderBackendDiagnostics
+import io.bluetape4k.leader.micrometer.InstrumentedLeaderElector
+import io.bluetape4k.leader.micrometer.LeaderMetricTagOptions
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.Instant
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PrometheusBackendConnectivityProbeTest {
+
+    @Test
+    fun `probe records UP, DOWN, and UNKNOWN connectivity states`() {
+        listOf(
+            LeaderBackendConnectivity.up(
+                checkedAt = Instant.EPOCH,
+                reason = LeaderBackendConnectivityReason.CONNECTED,
+            ),
+            LeaderBackendConnectivity.down(
+                checkedAt = Instant.EPOCH,
+                reason = LeaderBackendConnectivityReason.DISCONNECTED,
+            ),
+            LeaderBackendConnectivity.unknown(
+                checkedAt = Instant.EPOCH,
+                reason = LeaderBackendConnectivityReason.CLIENT_STATE_UNCONFIRMED,
+            ),
+        ).forEach { expected ->
+            val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+            val provider = FixedDiagnosticsProvider(expected)
+            val probe = PrometheusBackendConnectivityProbe(
+                provider = instrumentedProvider(provider, registry),
+                timeoutMillis = 500,
+            )
+
+            probe.probe()
+            probe.probe()
+
+            provider.observedTimeout shouldBeEqualTo 500.milliseconds
+            provider.probeCount shouldBeEqualTo 2
+            registry.connectivityCount(expected.status, expected.reason) shouldBeEqualTo 2.0
+            registry.scrape().hasConnectivitySeries(expected.status, expected.reason).shouldBeTrue()
+        }
+    }
+
+    @Test
+    fun `probe records provider exceptions as UNKNOWN without replacing the failure`() {
+        val failure = IllegalStateException("redis probe failed")
+        val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        val probe = PrometheusBackendConnectivityProbe(
+            provider = instrumentedProvider(FixedDiagnosticsProvider(failure = failure), registry),
+            timeoutMillis = 500,
+        )
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            probe.probe()
+        }
+
+        thrown shouldBeSameInstanceAs failure
+        registry.connectivityCount(
+            LeaderBackendConnectivityStatus.UNKNOWN,
+            LeaderBackendConnectivityReason.PROVIDER_EXCEPTION,
+        ) shouldBeEqualTo 1.0
+        registry.scrape()
+            .hasConnectivitySeries(
+                LeaderBackendConnectivityStatus.UNKNOWN,
+                LeaderBackendConnectivityReason.PROVIDER_EXCEPTION,
+            ).shouldBeTrue()
+    }
+
+    @Test
+    fun `probe rejects a non-positive timeout`() {
+        val provider = FixedDiagnosticsProvider(LeaderBackendConnectivity.unknown(Instant.EPOCH))
+
+        assertFailsWith<IllegalArgumentException> {
+            PrometheusBackendConnectivityProbe(provider, timeoutMillis = 0)
+        }
+    }
+
+    @Test
+    fun `passive diagnostics do not create connectivity series`() {
+        val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        val provider = instrumentedProvider(
+            FixedDiagnosticsProvider(
+                connectivity = LeaderBackendConnectivity.unknown(Instant.EPOCH),
+            ),
+            registry,
+        )
+
+        provider.diagnostics(probe = false)
+
+        registry.scrape().contains("leader_backend_connectivity_total").shouldBeFalse()
+    }
+
+    private fun instrumentedProvider(
+        provider: LeaderBackendDiagnosticsProvider,
+        registry: PrometheusMeterRegistry,
+    ): LeaderBackendDiagnosticsProvider {
+        val delegate = object :
+            LeaderElector by StubLeaderElector,
+            LeaderBackendDiagnosticsProvider by provider {}
+        return requireNotNull(InstrumentedLeaderElector(delegate, registry).backendDiagnosticsProvider)
+    }
+
+    private fun PrometheusMeterRegistry.connectivityCount(
+        status: LeaderBackendConnectivityStatus,
+        reason: LeaderBackendConnectivityReason,
+    ): Double =
+        find(BACKEND_CONNECTIVITY_METER)
+            .tag(LeaderMetricTagOptions.TAG_BACKEND_NAME, "redis-lettuce")
+            .tag("status", status.name)
+            .tag("reason", reason.name)
+            .counter()
+            .shouldNotBeNull()
+            .count()
+
+    private fun String.hasConnectivitySeries(
+        status: LeaderBackendConnectivityStatus,
+        reason: LeaderBackendConnectivityReason,
+    ): Boolean {
+        val labels = listOf(
+            "backend_name=\"redis-lettuce\"",
+            "status=\"" + status.name + "\"",
+            "reason=\"" + reason.name + "\"",
+        ).joinToString(separator = "") { "(?=[^}]*${Regex.escape(it)})" }
+        return Regex("""leader_backend_connectivity_total\{${labels}[^}]*}\s+[0-9.Ee+-]+""")
+            .containsMatchIn(this)
+    }
+
+    private class FixedDiagnosticsProvider(
+        private val connectivity: LeaderBackendConnectivity? = null,
+        private val failure: RuntimeException? = null,
+    ) : LeaderBackendDiagnosticsProvider {
+
+        var observedTimeout: Duration? = null
+        var probeCount: Int = 0
+
+        override val backendDescriptor =
+            LocalLeaderBackendDiagnostics.backendDescriptor.copy(backendId = "redis-lettuce")
+
+        override fun checkConnectivity(timeout: Duration): LeaderBackendConnectivity {
+            observedTimeout = timeout
+            probeCount++
+            failure?.let { throw it }
+            return requireNotNull(connectivity)
+        }
+    }
+
+    private object StubLeaderElector : LeaderElector {
+        override fun <T> runIfLeader(lockName: String, action: () -> T): T? = null
+
+        override fun <T> runAsyncIfLeader(
+            lockName: String,
+            executor: Executor,
+            action: () -> CompletableFuture<T>,
+        ): CompletableFuture<T?> = CompletableFuture.completedFuture(null)
+    }
+
+    private companion object {
+        const val BACKEND_CONNECTIVITY_METER = "leader.backend.connectivity"
+    }
+}

--- a/examples/prometheus-dashboard/src/test/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusLettuceConnectivityProbeTest.kt
+++ b/examples/prometheus-dashboard/src/test/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusLettuceConnectivityProbeTest.kt
@@ -1,0 +1,164 @@
+package io.bluetape4k.leader.examples.prometheus
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.leader.LeaderElector
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityReason
+import io.bluetape4k.leader.diagnostics.LeaderBackendConnectivityStatus
+import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
+import io.bluetape4k.leader.lettuce.LettuceLeaderBackendDiagnostics
+import io.bluetape4k.leader.micrometer.InstrumentedLeaderElector
+import io.bluetape4k.leader.micrometer.LeaderMetricTagOptions
+import io.bluetape4k.testcontainers.storage.RedisServer
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.codec.StringCodec
+import io.micrometer.prometheusmetrics.PrometheusConfig
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import org.junit.jupiter.api.Test
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+class PrometheusLettuceConnectivityProbeTest {
+
+    @Test
+    fun `closed real Lettuce connection exports DOWN through the example probe`() {
+        val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        val connection = RedisServer.Launcher.LettuceLib.getRedisClient()
+            .connect(StringCodec.UTF8)
+
+        try {
+            val provider = instrumentedProvider(LettuceLeaderBackendDiagnostics(connection), registry)
+            val probe = PrometheusBackendConnectivityProbe(provider, timeoutMillis = 500)
+
+            connection.close()
+            await.atMost(Duration.ofSeconds(5)).untilAsserted {
+                connection.isOpen.shouldBeFalse()
+            }
+            val connectivity = LettuceLeaderBackendDiagnostics(connection)
+                .checkConnectivity(500.milliseconds)
+            connectivity.status shouldBeEqualTo LeaderBackendConnectivityStatus.DOWN
+            connectivity.reason shouldBeEqualTo LeaderBackendConnectivityReason.DISCONNECTED
+            probe.probe()
+
+            registry.connectivityCount(
+                LeaderBackendConnectivityStatus.DOWN,
+                LeaderBackendConnectivityReason.DISCONNECTED,
+            ) shouldBeEqualTo 1.0
+            registry.scrape()
+                .hasConnectivitySeries(
+                    LeaderBackendConnectivityStatus.DOWN,
+                    LeaderBackendConnectivityReason.DISCONNECTED,
+                ).shouldBeTrue()
+        } finally {
+            connection.close()
+        }
+    }
+
+    @Test
+    fun `real Lettuce connection provider exception exports UNKNOWN`() {
+        val failure = IllegalStateException("redis connectivity probe failed")
+        val registry = PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
+        val connection = RedisServer.Launcher.LettuceLib.getRedisClient()
+            .connect(StringCodec.UTF8)
+
+        try {
+            val failingConnection = connection.withIsOpenFailure(failure)
+            val diagnostics = LettuceLeaderBackendDiagnostics(failingConnection)
+            val connectivity = diagnostics.checkConnectivity(500.milliseconds)
+            connectivity.status shouldBeEqualTo LeaderBackendConnectivityStatus.UNKNOWN
+            connectivity.reason shouldBeEqualTo LeaderBackendConnectivityReason.PROVIDER_EXCEPTION
+
+            val provider = instrumentedProvider(diagnostics, registry)
+            val probe = PrometheusBackendConnectivityProbe(provider, timeoutMillis = 500)
+
+            probe.probe()
+            registry.connectivityCount(
+                LeaderBackendConnectivityStatus.UNKNOWN,
+                LeaderBackendConnectivityReason.PROVIDER_EXCEPTION,
+            ) shouldBeEqualTo 1.0
+            registry.scrape()
+                .hasConnectivitySeries(
+                    LeaderBackendConnectivityStatus.UNKNOWN,
+                    LeaderBackendConnectivityReason.PROVIDER_EXCEPTION,
+                ).shouldBeTrue()
+        } finally {
+            connection.close()
+        }
+    }
+
+    private fun instrumentedProvider(
+        provider: LeaderBackendDiagnosticsProvider,
+        registry: PrometheusMeterRegistry,
+    ): LeaderBackendDiagnosticsProvider {
+        val delegate = object :
+            LeaderElector by StubLeaderElector,
+            LeaderBackendDiagnosticsProvider by provider {}
+        return requireNotNull(
+            InstrumentedLeaderElector(
+                delegate = delegate,
+                registry = registry,
+                tagOptions = LeaderMetricTagOptions.Default,
+            ).backendDiagnosticsProvider,
+        )
+    }
+
+    private fun PrometheusMeterRegistry.connectivityCount(
+        status: LeaderBackendConnectivityStatus,
+        reason: LeaderBackendConnectivityReason,
+    ): Double =
+        find("leader.backend.connectivity")
+            .tag(LeaderMetricTagOptions.TAG_BACKEND_NAME, "redis-lettuce")
+            .tag("status", status.name)
+            .tag("reason", reason.name)
+            .counter()
+            ?.count()
+            ?: error("connectivity meter is missing for $status/$reason")
+
+    private fun String.hasConnectivitySeries(
+        status: LeaderBackendConnectivityStatus,
+        reason: LeaderBackendConnectivityReason,
+    ): Boolean {
+        val labels = listOf(
+            "backend_name=\"redis-lettuce\"",
+            "status=\"" + status.name + "\"",
+            "reason=\"" + reason.name + "\"",
+        ).joinToString(separator = "") { "(?=[^}]*${Regex.escape(it)})" }
+        return Regex("""leader_backend_connectivity_total\{${labels}[^}]*}\s+([1-9][0-9.Ee+-]*)""")
+            .containsMatchIn(this)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun StatefulRedisConnection<String, String>.withIsOpenFailure(
+        failure: RuntimeException,
+    ): StatefulRedisConnection<String, String> {
+        val handler = InvocationHandler { _: Any, method: Method, args: Array<out Any?>? ->
+            if (method.name == "isOpen" && method.parameterCount == 0) {
+                throw failure
+            }
+            method.invoke(this, *(args ?: emptyArray()))
+        }
+        return Proxy.newProxyInstance(
+            StatefulRedisConnection::class.java.classLoader,
+            arrayOf(StatefulRedisConnection::class.java),
+            handler,
+        ) as StatefulRedisConnection<String, String>
+    }
+
+    private object StubLeaderElector : LeaderElector {
+        override fun <T> runIfLeader(lockName: String, action: () -> T): T? = null
+
+        override fun <T> runAsyncIfLeader(
+            lockName: String,
+            executor: Executor,
+            action: () -> CompletableFuture<T>,
+        ): CompletableFuture<T?> = CompletableFuture.completedFuture(null)
+    }
+}

--- a/examples/prometheus-dashboard/src/test/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusScrapeTest.kt
+++ b/examples/prometheus-dashboard/src/test/kotlin/io/bluetape4k/leader/examples/prometheus/PrometheusScrapeTest.kt
@@ -27,6 +27,9 @@ import java.time.Duration
     properties = [
         "demo.job.fixed-delay-ms=200",
         "demo.job.initial-delay-ms=0",
+        "demo.backend-probe.fixed-delay-ms=200",
+        "demo.backend-probe.initial-delay-ms=0",
+        "demo.backend-probe.timeout-ms=500",
     ],
 )
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -54,6 +57,16 @@ class PrometheusScrapeTest {
                     .shouldBeTrue()
                 scrape.contains("""leader_history_acquire_missing_total{sink="NoopLeaderHistorySink"}""")
                     .shouldBeTrue()
+                scrape.hasConnectivitySeries(
+                    backendName = "redis-lettuce",
+                    status = "UNKNOWN",
+                    reason = "CLIENT_STATE_UNCONFIRMED",
+                ).shouldBeTrue()
+                scrape.connectivitySampleValue(
+                    backendName = "redis-lettuce",
+                    status = "UNKNOWN",
+                    reason = "CLIENT_STATE_UNCONFIRMED",
+                ) shouldBeGreaterThan 1.0
 
                 val attempts = scrape.sampleValue("leader_aop_attempts_total")
                 val acquired = scrape.sampleValue("leader_aop_acquired_total")
@@ -82,6 +95,38 @@ class PrometheusScrapeTest {
         val regex = Regex("""$metricName\{[^}]*lock_name="$EXPORTED_LOCK_NAME"[^}]*}\s+([0-9.Ee+-]+)""")
         return requireNotNull(regex.find(this)) {
             "$metricName for $EXPORTED_LOCK_NAME not found in scrape"
+        }.groupValues[1].toDouble()
+    }
+
+    private fun String.hasConnectivitySeries(
+        backendName: String,
+        status: String,
+        reason: String,
+    ): Boolean {
+        val labels = listOf(
+            """backend_name="$backendName"""",
+            """status="$status"""",
+            """reason="$reason"""",
+        ).joinToString(separator = "") { "(?=[^}]*${Regex.escape(it)})" }
+        return Regex("""leader_backend_connectivity_total\{${labels}[^}]*}\s+[0-9.Ee+-]+""")
+            .containsMatchIn(this)
+    }
+
+    private fun String.connectivitySampleValue(
+        backendName: String,
+        status: String,
+        reason: String,
+    ): Double {
+        val labels = listOf(
+            "backend_name=\"$backendName\"",
+            "status=\"$status\"",
+            "reason=\"$reason\"",
+        ).joinToString(separator = "") { "(?=[^}]*${Regex.escape(it)})" }
+        return requireNotNull(
+            Regex("""leader_backend_connectivity_total\{${labels}[^}]*}\s+([0-9.Ee+-]+)""")
+                .find(this),
+        ) {
+            "connectivity sample is missing for $backendName/$status/$reason"
         }.groupValues[1].toDouble()
     }
 

--- a/examples/prometheus-dashboard/src/test/resources/prometheus/leader-alert-rules-test.yml
+++ b/examples/prometheus-dashboard/src/test/resources/prometheus/leader-alert-rules-test.yml
@@ -1,0 +1,53 @@
+rule_files:
+  - /tmp/leader-alerts.yml
+
+evaluation_interval: 1m
+
+tests:
+  - name: connectivity probe statuses fire the matching alert rules
+    interval: 1m
+    input_series:
+      - series: 'leader_backend_connectivity_total{backend_name="redis-lettuce",status="DOWN",reason="DISCONNECTED"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10 11 12'
+      - series: 'leader_backend_connectivity_total{backend_name="redis-lettuce",status="UNKNOWN",reason="CLIENT_STATE_UNCONFIRMED"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10 11 12'
+      - series: 'leader_backend_connectivity_total{backend_name="redis-lettuce",status="UNKNOWN",reason="PROVIDER_EXCEPTION"}'
+        values: '0 1 2 3 4 5 6 7 8 9 10 11 12'
+    alert_rule_test:
+      - eval_time: 7m
+        alertname: LeaderBackendConnectivityDown
+        exp_alerts:
+          - exp_labels:
+              backend_name: redis-lettuce
+              severity: warning
+              notification: no-page
+              component: leader-backend
+            exp_annotations:
+              summary: "A backend connectivity probe is reporting DOWN"
+              description: "Backend redis-lettuce has reported DISCONNECTED for 5 minutes."
+              runbook_url: "https://github.com/bluetape4k/bluetape4k-leader/blob/develop/examples/prometheus-dashboard/README.md#alert-runbooks"
+      - eval_time: 12m
+        alertname: LeaderBackendConnectivityUnknown
+        exp_alerts:
+          - exp_labels:
+              backend_name: redis-lettuce
+              reason: CLIENT_STATE_UNCONFIRMED
+              severity: info
+              notification: no-page
+              component: leader-backend
+            exp_annotations:
+              summary: "A backend connectivity probe remains UNKNOWN"
+              description: "Backend redis-lettuce has reason CLIENT_STATE_UNCONFIRMED; this is not a DOWN signal."
+              runbook_url: "https://github.com/bluetape4k/bluetape4k-leader/blob/develop/examples/prometheus-dashboard/README.md#alert-runbooks"
+      - eval_time: 12m
+        alertname: LeaderBackendConnectivityProbeExceptions
+        exp_alerts:
+          - exp_labels:
+              backend_name: redis-lettuce
+              severity: warning
+              notification: no-page
+              component: leader-backend
+            exp_annotations:
+              summary: "Backend connectivity probes are raising provider exceptions"
+              description: "Backend redis-lettuce has normalized PROVIDER_EXCEPTION results for 10 minutes."
+              runbook_url: "https://github.com/bluetape4k/bluetape4k-leader/blob/develop/examples/prometheus-dashboard/README.md#alert-runbooks"


### PR DESCRIPTION
## 변경 배경

Prometheus alert rule은 `leader_backend_connectivity_total`의 `DOWN`, `UNKNOWN`, `PROVIDER_EXCEPTION` 상태를 감시하지만 예제 애플리케이션이 idle 상태에서 해당 counter를 생성하지 않았습니다. 실제 backend connectivity producer와 alert rule 평가 경로를 연결합니다.

Closes #827

## 변경 내용

- 기존 `lettuceLeaderElector`가 보유한 `LeaderBackendDiagnosticsProvider`를 재사용하는 `PrometheusBackendConnectivityProbe`를 추가했습니다.
- `fixed-delay`와 양수 millisecond timeout을 설정으로 노출해 bounded active probe를 실행합니다.
- 별도 Redis client나 connection을 만들지 않고 기존 instrumentation과 metric tag 계약을 유지합니다.
- UP/DOWN/UNKNOWN/PROVIDER_EXCEPTION, passive `NOT_CHECKED`, 반복 probe cadence 회귀 테스트를 추가했습니다.
- 실제 Lettuce connection 종료·provider exception fixture와 Prometheus `v2.55.1` `promtool test rules` alert firing/runbook 평가를 추가했습니다.
- 영어/한국어 README, application 설정, 운영 lesson/checklist를 정렬했습니다.

## 운영·호환성

- 현재 Lettuce provider는 open client state를 `UNKNOWN/CLIENT_STATE_UNCONFIRMED`, 닫힌 state를 `DOWN/DISCONNECTED`로 보고합니다.
- provider가 보장하지 않는 `UP`을 client-local state만으로 주장하지 않습니다.
- 기존 public API, metric status/reason schema, dependency와 shared Redis lifecycle은 변경하지 않았습니다.

## 검증

- RED: producer가 없던 기준선에서 `PrometheusScrapeTest` connectivity series assertion 실패를 확인했습니다.
- `prometheus-dashboard`: 13 tests, failures 0, errors 0, skipped 0
- `leader-micrometer`: 132 tests, failures 0, errors 0, skipped 0
- `leader-redis-lettuce`: 318 tests, failures 0, errors 0, skipped 0
- Detekt: PASS
- Prometheus `v2.55.1` `promtool test rules`: 세 connectivity alert firing, `for` 지연, labels/annotations/runbook URL PASS
- 실제 Testcontainers Lettuce: closed connection `DOWN/DISCONNECTED`, `isOpen` exception `UNKNOWN/PROVIDER_EXCEPTION` PASS
- Spring scrape: fixed delay 200ms/initial delay 0에서 connectivity counter `> 1.0` 누적 PASS
- `git diff --cached --check`: PASS
- 독립 최종 리뷰: APPROVE, P0/P1/P2/P3 = 0
- [Hosted exact-head CI run 33242022505](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33242022505): 실행 11/11 success, failed/cancelled 0, path-filter intended skip 37

## 메타데이터

- PR: #836
- Base/head: `develop` ← `fix/issue-827-prometheus-connectivity-probe`
- Exact head: `c80b0a98e47f66d4d5e80d0a64d3eaae9b53c7ea`
- Assignee: `debop`; labels: `bug/integration/test/example`; milestone: `1.0.0`
- PR 상태: OPEN, non-draft
- Merge는 exact-head 검증 이후 fresh merge approval 전까지 수행하지 않습니다.

## DoD Status

| 항목 | 상태 | 근거 |
|---|---|---|
| 승인된 Issue #827 범위 | PASS | `develop` base와 semantic head에 예제 connectivity producer 범위로 구현 |
| 로컬 회귀·정적 검증 | PASS | example 13, Micrometer 132, Lettuce 318, Detekt, diff check |
| 독립 리뷰 | PASS | P0/P1/P2/P3 = 0, APPROVE |
| PR metadata·exact head | PASS | PR #836, head `c80b0a98…`, assignee/labels/milestone 일치 |
| Hosted exact-head CI | PASS | run 33242022505, 11 success, 37 intended skip, failed/cancelled 0 |
| merge approval/merge/cleanup | PENDING | fresh merge approval 이후 별도 수행 |