### PR TITLE
docs: README 공개 릴리스와 개발선 경계를 정렬

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -7,7 +7,9 @@
 [![JVM](https://img.shields.io/badge/JVM-25-ED8B00?logo=openjdk)](https://openjdk.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-현재 안정 버전: `0.4.0`
+현재 안정 버전: `0.5.0`
+
+현재 개발 버전: `1.0.0-SNAPSHOT`
 
 ![bluetape4k 리더 선출 작업대 일러스트](./docs/assets/leader-election-workbench.png)
 
@@ -39,7 +41,7 @@ Spring Boot 4 자동 구성과 Ktor 3.x 통합을 1급으로 지원합니다.
 
 ## 매뉴얼
 
-[Leader 0.4 매뉴얼](docs/manual/ko/index.md)은 안정판 동작을 설명하는 기준 문서입니다. 선출 모델과 백엔드 선택, 실행 결과와 취소 규칙, Spring Boot·Ktor 연동, 운영 방법, 17개 실행 예제를 따라가는 학습 경로를 함께 다룹니다. README는 빠른 안내만 맡고, 상세한 사용법은 `docs/manual/`에서 관리합니다.
+[Leader 0.5.0 매뉴얼](docs/manual/ko/index.md)은 안정판 동작을 설명하는 기준 문서입니다. 선출 모델과 백엔드 선택, 실행 결과와 취소 규칙, Spring Boot·Ktor 연동, 운영 방법, 17개 실행 예제를 따라가는 학습 경로를 함께 다룹니다. README는 빠른 안내만 맡고, 상세한 사용법은 `docs/manual/`에서 관리합니다.
 
 ## 벤치마크
 
@@ -232,7 +234,7 @@ import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderGroupElector
 val options = ExposedJdbcLeaderGroupElectionOptions(
     leaderGroupOptions = LeaderGroupElectionOptions(
         maxLeaders = 3,
-        useDbTime = true, // 0.6.0+ develop: 그룹 소유권 판정에 DB server time 사용
+        useDbTime = true, // 1.0.0+ develop: 그룹 소유권 판정에 DB server time 사용
     ),
 )
 val groupElection = ExposedJdbcLeaderGroupElector(db, options)
@@ -248,10 +250,10 @@ val result = groupElection.runIfLeader("parallel-batch") {
 DB time을 사용할 수 없으면 그룹 상태를 보수적으로 보고하고
 `runIfLeader`는 소유권을 주장하지 않고 건너뜁니다.
 
-이 옵션은 `0.6.0+` develop 라인에서 제공됩니다. 버전 매뉴얼은 `0.5.0`
+이 옵션은 `1.0.0+` 개발선에서 제공됩니다. 버전 매뉴얼은 `0.5.0`
 release provenance에 계속 고정되어 있습니다.
 
-### Exposed R2DBC 그룹 (coroutine-native, 0.6.0+ develop)
+### Exposed R2DBC 그룹 (coroutine-native, 1.0.0+ develop)
 
 ```kotlin
 import io.bluetape4k.leader.LeaderGroupElectionOptions
@@ -618,7 +620,7 @@ Stream 반환 규칙:
 - lease window 안에 끝나는 것이 확실한 stream에만 `streamBounded = true`를 사용하세요.
 - 안전하지 않은 `Flux` / `Flow` 시그니처는 validator와 subscription/collection 시점에 빠르게 실패합니다.
 - `@LeaderGroupElection`은 `T?`, `suspend T?`, `Mono<T>`를 지원합니다.
-- `@LeaderGroupElection` `Flux<T>` / `Flow<T>` stream은 0.4.0 범위 밖입니다. slot별 group lease extension 의미가 정의되지 않았으므로 startup validation과 subscription/collection 시점에 다시 거부됩니다.
+- `@LeaderGroupElection` `Flux<T>` / `Flow<T>` stream은 `1.0.0+` 개발선에서도 지원하지 않습니다. slot별 group lease extension 의미가 정의되지 않았으므로 startup validation과 subscription/collection 시점에 다시 거부됩니다.
 
 ### `failureMode`
 
@@ -691,8 +693,8 @@ contract를 새로 만들지 말고 이 core event stream을 adapter로 사용�
 
 ### Lease-extension 관찰
 
-> **미배포 API:** 이 절은 현재 `develop` 구현을 설명합니다. 이 README의 의존성 예제는 배포된 `0.4.0`을 대상으로
-> 하며, 고정한 `0.5.0` 매뉴얼에는 이 hook이 없습니다. 초안의 promotion gate가 끝날 때까지는 일치하는
+> **미배포 API:** 이 절은 현재 `develop` 구현을 설명합니다. 이 README의 의존성 예제는 배포된 `0.5.0`을 대상으로
+> 하며, 같은 release에 고정한 매뉴얼에는 이 hook이 없습니다. 초안의 promotion gate가 끝날 때까지는 일치하는
 > `develop` 브랜치 또는 일치하는 미배포 빌드에서만 이 연동을 사용하세요.
 
 `LockExtender`와 `LeaderLeaseAutoExtender`는 같은 framework-neutral terminal event 계약을 발생시킵니다. lease

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ English | [한국어](README.ko.md)
 [![JVM](https://img.shields.io/badge/JVM-25-ED8B00?logo=openjdk)](https://openjdk.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Current stable version: `0.4.0`
+Current stable version: `0.5.0`
+
+Current development line: `1.0.0-SNAPSHOT`
 
 ![Bluetape4k leader election workbench](./docs/assets/leader-election-workbench.png)
 
@@ -40,7 +42,7 @@ Spring Boot 4 auto-configuration and Ktor 3.x integration are first-class.
 
 ## Manual
 
-The [Leader 0.4 manual](docs/manual/en/index.md) is the source of truth for release behavior. It covers model and backend selection, result and cancellation semantics, Spring Boot and Ktor integration, operations, and a progressive path through all 17 runnable examples. README files remain concise entry points; detailed guidance belongs in `docs/manual/`.
+The [Leader 0.5.0 manual](docs/manual/en/index.md) is the source of truth for release behavior. It covers model and backend selection, result and cancellation semantics, Spring Boot and Ktor integration, operations, and a progressive path through all 17 runnable examples. README files remain concise entry points; detailed guidance belongs in `docs/manual/`.
 
 ## Benchmarks
 
@@ -233,7 +235,7 @@ import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderGroupElector
 val options = ExposedJdbcLeaderGroupElectionOptions(
     leaderGroupOptions = LeaderGroupElectionOptions(
         maxLeaders = 3,
-        useDbTime = true, // 0.6.0+ develop: use database server time for group ownership
+        useDbTime = true, // 1.0.0+ develop: use database server time for group ownership
     ),
 )
 val groupElection = ExposedJdbcLeaderGroupElector(db, options)
@@ -249,10 +251,10 @@ transaction, so JVM clock skew does not change the lease boundary. It defaults
 to `false`; when database time is unavailable, group state is reported
 conservatively and `runIfLeader` skips rather than claiming ownership.
 
-The option is available on the `0.6.0+` development line. The versioned manual
+The option is available on the `1.0.0+` development line. The versioned manual
 pages remain pinned to the `0.5.0` release provenance.
 
-### Exposed R2DBC group (coroutine-native, 0.6.0+ develop)
+### Exposed R2DBC group (coroutine-native, 1.0.0+ develop)
 
 ```kotlin
 import io.bluetape4k.leader.LeaderGroupElectionOptions
@@ -617,7 +619,7 @@ Stream return rules:
 - Use `streamBounded = true` only when the stream is known to finish within the lease window.
 - Unsafe `Flux` / `Flow` signatures fail fast in the validator and at subscription/collection time.
 - `@LeaderGroupElection` supports `T?`, `suspend T?`, and `Mono<T>`.
-- `@LeaderGroupElection` `Flux<T>` / `Flow<T>` streams are out of scope for 0.4.0. They are rejected in startup validation and again at subscription/collection time because group lease extension is not defined per slot.
+- `@LeaderGroupElection` `Flux<T>` / `Flow<T>` streams remain unsupported on the `1.0.0+` development line. They are rejected in startup validation and again at subscription/collection time because group lease extension is not defined per slot.
 
 ### `failureMode`
 
@@ -691,7 +693,7 @@ introducing framework-specific event contracts.
 ### Lease-extension observation
 
 > **Unreleased API:** This section describes the current `develop` implementation. The dependency examples in this
-> README target released `0.4.0`, and the pinned `0.5.0` manual does not include this hook. Keep this integration on a
+> README target released `0.5.0`, and the manual pinned to that release does not include this hook. Keep this integration on a
 > matching develop/snapshot build until the promotion gate in the draft is complete.
 
 `LockExtender` and `LeaderLeaseAutoExtender` publish the same framework-neutral terminal event contract. Register an

--- a/docs/lessons/2026-08-29-issue-753-readme-release-boundary.md
+++ b/docs/lessons/2026-08-29-issue-753-readme-release-boundary.md
@@ -1,0 +1,33 @@
+# Issue #753: README 릴리스 경계의 단일 출처
+
+## 맥락
+
+루트 영문·한글 README는 안정 버전과 현재 개발선을 함께 안내한다. 이 값이
+각 문서에 직접 고정되면 릴리스 후에도 이전 안정 버전이나 과거 개발선이 남아
+사용자가 배포된 API와 미배포 API의 경계를 잘못 이해할 수 있다.
+
+## 결정
+
+안정 버전은 `docs/manual/manifest.yaml`의 `releaseRef`, 현재 개발선은
+`gradle.properties`의 `baseVersion`을 기준으로 삼는다. 기존
+`ReadmeJvm25Contract`가 두 README의 안정 버전, 버전 매뉴얼 링크,
+`baseVersion-SNAPSHOT`, 개발 API 표기를 함께 검증하도록 범위를 확장한다.
+
+## 결과
+
+영문·한글 README가 안정 버전 `0.5.0`과 개발 버전
+`1.0.0-SNAPSHOT`을 같은 경계로 안내한다. 과거 `0.4.0` 안정 버전과
+`0.6.0+` 개발선 표기는 제거했다.
+
+## 검증
+
+- 테스트 fixture에서 안정 버전, 매뉴얼 링크, 개발 버전, 개발 API 표기를
+  각각 어긋나게 했을 때 영문·한글 README 오류를 모두 검출했다.
+- 실제 README 수정 전 contract가 8개 drift를 보고했고, 수정 후 통과했다.
+- 전체 manual contract와 한글 용어 감사를 최종 검증에 포함한다.
+
+## 향후 지침
+
+릴리스나 다음 개발선 준비로 `releaseRef` 또는 `baseVersion`을 바꿀 때는
+README에 별도의 버전 상수를 추가하지 않는다. 두 metadata 파일을 기준으로
+영문·한글 README를 함께 갱신하고 `ReadmeJvm25Contract`를 통과시킨다.

--- a/scripts/manual/readme_jvm25_contract.rb
+++ b/scripts/manual/readme_jvm25_contract.rb
@@ -12,6 +12,7 @@ module ReadmeJvm25Contract
   OVERVIEW_SVG = "docs/images/readme-diagrams/root-readme-overview-01.svg"
   OVERVIEW_PNG = "docs/images/readme-diagrams/root-readme-overview-01.png"
   OVERVIEW_REFERENCE = "docs/images/readme-diagrams/root-readme-overview-01.png"
+  GRADLE_PROPERTIES = "gradle.properties"
 
   module_function
 
@@ -104,6 +105,9 @@ module ReadmeJvm25Contract
         return
       end
 
+      base_version = read_base_version(failures)
+      check_readme_release_boundary(failures, release_ref, base_version) if base_version
+
       MANUAL_PAGES.each do |relative|
         path = resolve(relative)
         unless path.file?
@@ -119,6 +123,49 @@ module ReadmeJvm25Contract
       end
     rescue Psych::SyntaxError => error
       failures << "manual manifest YAML is invalid: #{error.message.lines.first.to_s.strip}"
+    end
+
+    def read_base_version(failures)
+      path = resolve(GRADLE_PROPERTIES)
+      unless path.file?
+        failures << "Gradle properties are missing: #{GRADLE_PROPERTIES}"
+        return nil
+      end
+
+      match = path.read.match(/^baseVersion=(\S+)$/)
+      unless match
+        failures << "#{GRADLE_PROPERTIES} must define baseVersion"
+        return nil
+      end
+      match[1]
+    end
+
+    def check_readme_release_boundary(failures, release_ref, base_version)
+      expectations = {
+        "README.md" => {
+          stable: "Current stable version: `#{release_ref}`",
+          manual: "[Leader #{release_ref} manual](docs/manual/en/index.md)",
+          development: "Current development line: `#{base_version}-SNAPSHOT`",
+          api: "`#{base_version}+` development line",
+        },
+        "README.ko.md" => {
+          stable: "현재 안정 버전: `#{release_ref}`",
+          manual: "[Leader #{release_ref} 매뉴얼](docs/manual/ko/index.md)",
+          development: "현재 개발 버전: `#{base_version}-SNAPSHOT`",
+          api: "`#{base_version}+` 개발선",
+        },
+      }
+
+      expectations.each do |relative, expected|
+        path = resolve(relative)
+        next unless path.file?
+
+        content = path.read
+        failures << "#{relative} must advertise stable version #{release_ref}" unless content.include?(expected[:stable])
+        failures << "#{relative} must link the Leader #{release_ref} manual" unless content.include?(expected[:manual])
+        failures << "#{relative} must identify development line #{base_version}-SNAPSHOT" unless content.include?(expected[:development])
+        failures << "#{relative} must describe development APIs as #{base_version}+" unless content.include?(expected[:api])
+      end
     end
 
     def resolve(relative)

--- a/scripts/manual/readme_jvm25_contract_test.rb
+++ b/scripts/manual/readme_jvm25_contract_test.rb
@@ -10,6 +10,7 @@ require_relative "readme_jvm25_contract"
 class ReadmeJvm25ContractTest < Minitest::Test
   RELEASE_REF = "0.5.0"
   RELEASE_COMMIT = "a" * 40
+  BASE_VERSION = "1.0.0"
 
   def test_accepts_aligned_readmes_diagram_pair_and_pinned_manual_pages
     with_repository do |root|
@@ -45,6 +46,38 @@ class ReadmeJvm25ContractTest < Minitest::Test
     end
   end
 
+  def test_reports_readme_release_boundary_drift
+    with_repository do |root|
+      readme = root.join("README.md")
+      readme.write(
+        readme.read
+          .sub("Current stable version: `#{RELEASE_REF}`", "Current stable version: `0.4.0`")
+          .sub("Leader #{RELEASE_REF} manual", "Leader 0.4 manual")
+          .sub("Current development line: `#{BASE_VERSION}-SNAPSHOT`", "Current development line: `0.6.0-SNAPSHOT`")
+          .sub("`#{BASE_VERSION}+` development line", "`0.6.0+` development line"),
+      )
+      readme_ko = root.join("README.ko.md")
+      readme_ko.write(
+        readme_ko.read
+          .sub("현재 안정 버전: `#{RELEASE_REF}`", "현재 안정 버전: `0.4.0`")
+          .sub("Leader #{RELEASE_REF} 매뉴얼", "Leader 0.4 매뉴얼")
+          .sub("현재 개발 버전: `#{BASE_VERSION}-SNAPSHOT`", "현재 개발 버전: `0.6.0-SNAPSHOT`")
+          .sub("`#{BASE_VERSION}+` 개발선", "`0.6.0+` 개발선"),
+      )
+
+      errors = ReadmeJvm25Contract.errors(root: root)
+
+      assert_includes errors, "README.md must advertise stable version #{RELEASE_REF}"
+      assert_includes errors, "README.md must link the Leader #{RELEASE_REF} manual"
+      assert_includes errors, "README.md must identify development line #{BASE_VERSION}-SNAPSHOT"
+      assert_includes errors, "README.md must describe development APIs as #{BASE_VERSION}+"
+      assert_includes errors, "README.ko.md must advertise stable version #{RELEASE_REF}"
+      assert_includes errors, "README.ko.md must link the Leader #{RELEASE_REF} manual"
+      assert_includes errors, "README.ko.md must identify development line #{BASE_VERSION}-SNAPSHOT"
+      assert_includes errors, "README.ko.md must describe development APIs as #{BASE_VERSION}+"
+    end
+  end
+
   private
 
   def with_repository
@@ -55,11 +88,24 @@ class ReadmeJvm25ContractTest < Minitest::Test
       SVG
       write_png(root.join(ReadmeJvm25Contract::OVERVIEW_PNG))
       ReadmeJvm25Contract::README_FILES.each do |relative|
+        release_boundary = if relative == "README.md"
+                             "Current stable version: `#{RELEASE_REF}`\n" \
+                               "Current development line: `#{BASE_VERSION}-SNAPSHOT`\n" \
+                               "[Leader #{RELEASE_REF} manual](docs/manual/en/index.md)\n" \
+                               "Development APIs use the `#{BASE_VERSION}+` development line.\n"
+                           else
+                             "현재 안정 버전: `#{RELEASE_REF}`\n" \
+                               "현재 개발 버전: `#{BASE_VERSION}-SNAPSHOT`\n" \
+                               "[Leader #{RELEASE_REF} 매뉴얼](docs/manual/ko/index.md)\n" \
+                               "개발 API는 `#{BASE_VERSION}+` 개발선에서 제공합니다.\n"
+                           end
         write(
           root.join(relative),
-          "[![JVM](https://img.shields.io/badge/JVM-25-ED8B00)]\nJVM 25+\n#{ReadmeJvm25Contract::OVERVIEW_REFERENCE}\n",
+          "[![JVM](https://img.shields.io/badge/JVM-25-ED8B00)]\nJVM 25+\n" \
+            "#{ReadmeJvm25Contract::OVERVIEW_REFERENCE}\n#{release_boundary}",
         )
       end
+      write(root.join("gradle.properties"), "baseVersion=#{BASE_VERSION}\n")
       write(
         root.join("docs/manual/manifest.yaml"),
         YAML.dump("releaseRef" => RELEASE_REF, "releaseCommit" => RELEASE_COMMIT),


### PR DESCRIPTION
## Summary

Closes #753

루트 영문·한글 README가 공개 안정 버전과 현재 개발선을 서로 다른 계약으로 명확히 안내하도록 정렬합니다. 릴리스 후 같은 drift가 반복되지 않도록 기존 manual contract에 metadata 기반 회귀 가드를 추가합니다.

## Background

milestone `1.0.0` 개발선에서 README는 안정 버전을 `0.4.0`, 일부 개발 API를 `0.6.0+`로 안내하고 있었습니다. 반면 live latest release와 manual manifest는 `0.5.0`, `gradle.properties`의 현재 개발선은 `1.0.0`입니다.

## What This Solves

- 사용자가 배포된 `0.5.0` API와 미배포 `1.0.0-SNAPSHOT` API를 혼동하는 위험을 줄입니다.
- 영문·한글 README의 안정 버전, 버전 매뉴얼 링크, 개발선 표기가 release metadata에서 다시 벗어나는 것을 CI에서 검출합니다.

## Work Done

- EN/KO root README: 안정 버전 `0.5.0`, 현재 개발 버전 `1.0.0-SNAPSHOT`, 개발 API `1.0.0+` 경계를 source-equivalent하게 정렬했습니다.
- `ReadmeJvm25Contract`: `docs/manual/manifest.yaml`의 `releaseRef`와 `gradle.properties`의 `baseVersion`을 기준으로 두 README의 버전·링크 parity를 검증합니다.
- 회귀 테스트: EN/KO 각각 안정 버전, 매뉴얼 링크, 개발 버전, 개발 API 표기 drift를 검출합니다.
- lesson: 버전 안내의 단일 출처와 향후 갱신 절차를 기록했습니다.

## Validation

- `ruby -I scripts/manual scripts/manual/readme_jvm25_contract_test.rb`: PASS (`4 runs`, `30 assertions`, failures/errors/skips `0`)
- `ruby scripts/manual/readme_jvm25_contract.rb`: PASS
- `python3 scripts/ci/validate_manual_contract.py`: PASS (manual refs `446`, Ruby `38 runs`/`408 assertions`, failures/errors/skips `0`, diagram `5` pairs)
- `node /Users/debop/.codex/skills/bluetape-writer/scripts/audit-korean-terms.mjs README.ko.md docs/lessons/2026-08-29-issue-753-readme-release-boundary.md`: PASS (`findings=0`)
- `git diff --check`: PASS

## Review Notes

- P0/P1: `0`
- P2/P3: `0`
- Review evidence: 독립 `code-reviewer` verdict `APPROVE`; Ruby syntax와 문서 contract를 별도 재검증했습니다.

## Metadata

- Issue: #753, milestone `1.0.0`, assignee `debop`
- PR: #838, head `692c728f4b367285fe6a270d96bcd200c58fc99d`, rebase merge `7d35f285cf47c0de85e4b21d9434ecde1020cc2f`, milestone `1.0.0`, assignee `debop`
- CI: exact-head [CI run 33258649662](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33258649662), [README run 33258649631](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33258649631); post-merge [CI run 33259582596](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33259582596), [README run 33259582661](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33259582661), [Dependency Submission run 33259582594](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33259582594)

## DoD Status

Required checks: 19/19; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-01 - Authority | 현재 AGENTS 계층과 승인 범위 확인 | PASS | Type E, repo `bluetape4k-leader`, base `develop`, head `docs/issue-753-readme-release-boundary` | 없음 |
| CG-02 - Evidence | 이전 기록과 live Issue/Release 조회 | PASS | Issue #753 OPEN, latest release `0.5.0`, milestone `1.0.0` | 없음 |
| CG-03 - Boundaries | 격리 worktree와 5개 변경 경로 확인 | PASS | base `04e0cfe3`, feature branch, unrelated work 보존 | 없음 |
| CG-04 - Policy | 한국어 공개 prose와 EN/KO source-equivalence 적용 | PASS | governing AGENTS 및 writer 규칙 | 없음 |
| CG-05 - Patterns | 기존 `ReadmeJvm25Contract` 재사용 | PASS | 새 abstraction/dependency 없음 | 없음 |
| CG-06 - Contracts | README 공개 버전·매뉴얼·개발선 parity 검증 | PASS | EN/KO `0.5.0`, `1.0.0-SNAPSHOT`, `1.0.0+` | 없음 |
| CG-07 - Targeted proof | RED/GREEN 회귀 가드와 targeted proof 실행 | PASS | RED 8 drift, GREEN 4 tests/30 assertions | 없음 |
| CG-08 - Heavy checks | backend·Testcontainers 적용 여부 판정 | PASS | documentation-only scope; heavyweight check 불필요 | 없음 |
| CG-09 - Lesson | 재발 방지 lesson 작성·감사 | PASS | `docs/lessons/2026-08-29-issue-753-readme-release-boundary.md`, findings=0 | 없음 |
| CG-10 - Pre-PR proof | 전체 manual contract와 독립 리뷰 수렴 | PASS | 38 tests/408 assertions, P0/P1/P2/P3=0 | 없음 |
| CG-11 - PR authority | 승인된 repository/base/head와 PR 생성 범위 확인 | PASS | `bluetape4k/bluetape4k-leader`, `develop`, authorized head | 없음 |
| CG-12 - Exact head push | force 없이 원격 head 게시 및 SHA 대조 | PASS | local/remote `692c728f4b367285fe6a270d96bcd200c58fc99d` | 없음 |
| CG-12A - Guidance refresh | AGENTS 계층, Type E leaf, common gates, PR template, Issue #753 재조회 | PASS | 최종 본문 갱신 직전 current content hash와 Issue #753 `CLOSED`, PR #838 `MERGED` metadata 재확인, 적용 규칙 drift 없음 | 없음 |
| CG-13 - PR create/read-back | 한국어 PR 생성과 metadata/body 검증 | PASS | PR #838, exact head, assignee/labels/milestone 일치, final heading `## DoD Status` | 없음 |
| CG-14 - Exact-head CI/review | exact-head checks와 review/thread 확인 | PASS | run 33258649662: 9 success/38 intended skip; run 33258649631: 1 success; failure/pending 0; reviews/comments/threads 0; 독립 review P0/P1/P2/P3=0 | human review subgate `N/A (single-developer lane: owner/assignee debop, 추가 reviewer 요청 없음)` |
| CG-15 - Merge-ready | exact PR/head 기준 최종 DoD 보고 | PASS | PR #838 OPEN/MERGEABLE, exact head `692c728f4b367285fe6a270d96bcd200c58fc99d`, unchecked 없음 | fresh 명시적 병합 승인 전 정지 |
| CG-16 - Fresh merge approval | merge-ready 보고 후 exact-head 병합 승인 확인 | PASS | 사용자 승인, PR #838 head `692c728f4b367285fe6a270d96bcd200c58fc99d` hold 유지 | 없음 |
| CG-17 - Merge verification | 승인된 rebase strategy로 병합하고 live 상태 확인 | PASS | PR #838 `MERGED`, merge `7d35f285cf47c0de85e4b21d9434ecde1020cc2f`, Issue #753 `CLOSED`, auto-merge 미사용; post-merge CI 9 success/38 intended skip, README 1 success, Dependency Submission 1 success, failure/pending 0 | 없음 |
| CG-18 - Sync and cleanup | canonical 동기화와 보수적 worktree cleanup | PASS | `develop == origin/develop == 7d35f285`; patch-id/tree/5개 경로 동등; clean target worktree만 제거; local/remote feature ref 보존 | 없음 |

Final status: DONE — exact-head 검증, rebase merge, Issue close, canonical sync, integration proof, 보수적 cleanup 완료

Unchecked required items: 없음
