### PR TITLE
fix(leader-core): audit diagnostics poll과 observer reservation을 단일 gate로 선형화

### DIFF
--- a/docs/lessons/2026-08-20-issue-732-diagnostics-admission.md
+++ b/docs/lessons/2026-08-20-issue-732-diagnostics-admission.md
@@ -1,0 +1,81 @@
+# Issue #732 — audit diagnostics admission gate 선형화
+
+## 맥락
+
+OBS-03 AUD-01의 `BoundedLeaderAuditExporter`는 observer callback을 별도
+diagnostics queue와 virtual-thread worker로 전달합니다. 기존 worker는 queue에서
+항목을 꺼내고 `diagnosticsQueued` permit을 줄인 뒤에야
+`diagnosticsLock`을 잡아 slot의 `active` 상태와 callback reservation을
+확인했습니다. 그 사이 `close()` 또는 observer handle `close()`가 queue를
+drain하거나 slot을 비활성화하면 poll, permit 반환, reservation 순서가 서로 다른
+경계에 놓였습니다.
+
+## 원인과 결정
+
+poll 직후 lock을 획득하는 방식은 close가 queue를 비운 뒤 worker가 permit을
+감소시키는 경로를 허용합니다. 이 경로에서는 close가 반환된 시점의 callback
+admission 상태와 worker가 나중에 관찰하는 slot 상태가 일치하지 않습니다.
+
+다음 동작을 `diagnosticsAdmissionLock` 하나의 짧은 critical section으로
+선형화했습니다.
+
+- worker의 queue poll과 `diagnosticsQueued` permit 반환
+- gate 및 slot `active` 확인과 callback `running` reservation
+- observer handle close, 정상 close, observer `Error`의 queued diagnostics drain
+- callback `finally`의 slot `running` release
+
+submit-side observation enqueue는 기존처럼 `tryLock()`만 사용해 callback이나
+queue wait로 caller를 막지 않습니다. 이미 reservation된 callback은 close 이후에도
+현재 호출을 마칠 수 있지만, close 반환 뒤 새 callback은 시작하지 않습니다.
+
+## 결과
+
+worker가 queue item을 꺼내는 순간부터 callback reservation까지 동일한 admission
+gate 아래에서 처리합니다. 따라서 observer close는 poll과 reservation 사이를
+통과하지 못하고, inactive item과 normal/fatal drain은 `diagnosticsQueued`를
+정확히 한 번만 반환합니다. callback 완료 release도 같은 gate를 사용해 동시
+observation enqueue와 permit 상태가 교차하지 않습니다.
+
+## 검증
+
+- RED: blocking diagnostics queue barrier의 targeted test가 기존 구현에서
+  `0 passing, 1 failing`으로 실패했습니다. worker가 poll 중인 동안 observer
+  close가 먼저 반환되는 경계를 재현했습니다.
+- GREEN: `BoundedLeaderAuditExporterTest`가 `21 passing`으로 통과했습니다.
+- 회귀 범위에는 inactive/normal/fatal drain 뒤 `diagnosticsQueued == 0`, observer
+  replacement의 capacity 2 전량 re-admission, poll/reservation gate barrier가
+  포함됩니다.
+- `./gradlew :bluetape4k-leader-core:test --no-daemon --rerun-tasks`가
+  `996 passing`으로 통과했습니다.
+- `./gradlew :bluetape4k-leader-core:detekt --no-daemon --rerun-tasks`와
+  `git diff --check`가 통과했습니다.
+- Korean terminology audit가 `findings=0`으로 통과했습니다.
+
+## 놀라움과 복구
+
+첫 lifecycle 회귀 테스트에서 `observerDrops == 0`을 함께 요구했지만,
+submit-side `tryLock()`은 worker가 짧은 reservation 구간을 선점하면 계약에 따라
+관찰 항목을 drop할 수 있습니다. 해당 assertion을 제거하고 callback 시작 순서,
+diagnostics 종료 상태, fatal counter처럼 계약을 직접 검증하는 조건만 남겼습니다.
+같은 이유로 executor rejection 회귀 테스트도 best-effort observer callback을 완료
+신호로 사용하지 않고 `snapshot()`의 `admitted == 0`과
+`executorRejections == 1` 상태를 기다리도록 정리했습니다.
+
+## 향후 지침
+
+bounded diagnostics를 수정할 때 queue depth, slot active 상태, callback
+reservation을 서로 다른 lock 또는 CAS 단계로 분리하지 않습니다. queue poll을
+테스트에서 멈출 수 있는 deterministic barrier를 유지해 observer close가
+reservation 전후 어느 쪽으로 선형화되는지 검증하고, close/fatal/inactive 경로의
+permit 반환을 각각 한 번만 확인합니다.
+
+## Writer DoD
+
+- SPW-01: Issue #732, `BoundedLeaderAuditExporter`, diagnostics admission 계약과
+  현재 소스·회귀 테스트를 근거로 audience와 범위를 고정했습니다.
+- SPW-02: 맥락·원인·결정·결과·검증·놀라움·향후 지침을 모두 기록했습니다.
+- SPW-03: 한국어 기술 문체와 기존 `diagnostics`, `reservation`, `permit`,
+  `callback`, `gate` 용어를 유지하고 자연스러움 검토를 완료했습니다.
+- SPW-04: Issue acceptance와 source diff, RED/GREEN 출력의 식별자·수치를
+  대조했습니다.
+- SPW-05: 최종 Markdown을 다시 읽었고 headings와 code tokens를 확인했습니다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
@@ -64,7 +64,7 @@ internal class BoundedLeaderAuditExporter(
     )
 
     private val admissionLock = ReentrantLock()
-    private val diagnosticsLock = ReentrantLock()
+    private val diagnosticsAdmissionLock = ReentrantLock()
     private val closed = AtomicBoolean(false)
     private val diagnosticsClosed = AtomicBoolean(false)
     private val workerRunning = AtomicBoolean(false)
@@ -137,7 +137,7 @@ internal class BoundedLeaderAuditExporter(
     }
 
     override fun observe(observer: LeaderAuditExportObserver): AutoCloseable {
-        diagnosticsLock.lock()
+        diagnosticsAdmissionLock.lock()
         try {
             if (diagnosticsClosed.get() || observerSlots.size >= MAX_OBSERVERS) {
                 observerRegistrationDrops.incrementAndGet()
@@ -147,7 +147,7 @@ internal class BoundedLeaderAuditExporter(
             observerSlots += slot
             return AutoCloseable { closeObserver(slot) }
         } finally {
-            diagnosticsLock.unlock()
+            diagnosticsAdmissionLock.unlock()
         }
     }
 
@@ -195,12 +195,12 @@ internal class BoundedLeaderAuditExporter(
             admissionLock.unlock()
         }
 
-        diagnosticsLock.lock()
+        diagnosticsAdmissionLock.lock()
         try {
             diagnosticsClosed.set(true)
-            drainDiagnostics()
+            drainDiagnosticsLocked()
         } finally {
-            diagnosticsLock.unlock()
+            diagnosticsAdmissionLock.unlock()
         }
         diagnosticsWorker.get()?.let(LockSupport::unpark)
         tryStartWorker()
@@ -579,7 +579,7 @@ internal class BoundedLeaderAuditExporter(
 
     private fun publish(observation: LeaderAuditExportObservation) {
         if (diagnosticsClosed.get()) return
-        if (!diagnosticsLock.tryLock()) {
+        if (!diagnosticsAdmissionLock.tryLock()) {
             observerDrops.incrementAndGet()
             return
         }
@@ -601,7 +601,7 @@ internal class BoundedLeaderAuditExporter(
                 }
             }
         } finally {
-            diagnosticsLock.unlock()
+            diagnosticsAdmissionLock.unlock()
         }
     }
 
@@ -618,22 +618,29 @@ internal class BoundedLeaderAuditExporter(
     }
 
     private fun runDiagnostics() {
-        while (!diagnosticsClosed.get() || diagnostics.isNotEmpty()) {
-            val work = diagnostics.poll()
+        while (true) {
+            var skipped = false
+            val work = diagnosticsAdmissionLock.withLock {
+                val item = diagnostics.poll()
+                if (item == null) {
+                    null
+                } else {
+                    diagnosticsQueued.decrementAndGet()
+                    if (diagnosticsClosed.get() || !item.slot.active.get()) {
+                        skipped = true
+                        null
+                    } else {
+                        item.slot.running.incrementAndGet()
+                        item
+                    }
+                }
+            }
             if (work == null) {
+                if (skipped) continue
+                if (diagnosticsClosed.get() && diagnostics.isEmpty()) break
                 LockSupport.park()
                 continue
             }
-            diagnosticsQueued.decrementAndGet()
-            val reserved = diagnosticsLock.withLockIfAvailable {
-                if (!diagnosticsClosed.get() && work.slot.active.get()) {
-                    work.slot.running.incrementAndGet()
-                    true
-                } else {
-                    false
-                }
-            }
-            if (!reserved) continue
             try {
                 work.slot.observer.onObservation(work.observation)
             } catch (e: Exception) {
@@ -643,22 +650,24 @@ internal class BoundedLeaderAuditExporter(
                 }
             } catch (e: Error) {
                 diagnosticsFatalErrors.incrementAndGet()
-                diagnosticsLock.lock()
+                diagnosticsAdmissionLock.lock()
                 try {
                     diagnosticsClosed.set(true)
-                    drainDiagnostics()
+                    drainDiagnosticsLocked()
                 } finally {
-                    diagnosticsLock.unlock()
+                    diagnosticsAdmissionLock.unlock()
                 }
                 throw e
             } finally {
-                work.slot.running.decrementAndGet()
+                diagnosticsAdmissionLock.withLock {
+                    work.slot.running.decrementAndGet()
+                }
             }
         }
     }
 
     private fun closeObserver(slot: ObserverSlot) {
-        diagnosticsLock.lock()
+        diagnosticsAdmissionLock.lock()
         try {
             if (!slot.active.getAndSet(false)) return
             observerSlots.remove(slot)
@@ -668,11 +677,11 @@ internal class BoundedLeaderAuditExporter(
                 true
             }
         } finally {
-            diagnosticsLock.unlock()
+            diagnosticsAdmissionLock.unlock()
         }
     }
 
-    private fun drainDiagnostics() {
+    private fun drainDiagnosticsLocked() {
         while (diagnostics.poll() != null) diagnosticsQueued.decrementAndGet()
     }
 
@@ -773,7 +782,7 @@ private fun Duration.toBoundedPositiveNanos(name: String, maximum: Duration): Lo
     return nanos
 }
 
-private inline fun <T> ReentrantLock.withLockIfAvailable(block: () -> T): T {
+private inline fun <T> ReentrantLock.withLock(block: () -> T): T {
     lock()
     return try {
         block()

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.leader.audit
 
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.leader.LockIdentity
@@ -11,13 +12,13 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
-import java.util.concurrent.CancellationException
 import java.util.concurrent.RejectedExecutionException
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
@@ -288,7 +289,6 @@ class BoundedLeaderAuditExporterTest {
     @Test
     fun `executor rejection releases all permits and later submissions recover`() {
         val rejectFirst = AtomicBoolean(true)
-        val rejected = CountDownLatch(1)
         val recovered = CountDownLatch(1)
         val deliveryFuture = CompletableFuture<LeaderAuditDeliveryResult>()
         val executor = Executor { command ->
@@ -302,12 +302,12 @@ class BoundedLeaderAuditExporterTest {
                 deliveryFuture
             },
             executor = executor,
-            onObservation = { if (it == LeaderAuditExportObservation.EXECUTOR_REJECTED) rejected.countDown() },
         )
 
         exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
-        rejected.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        awaitAdmissionReleased(exporter)
         exporter.snapshot().admitted.shouldBeEqualTo(0)
+        exporter.snapshot().executorRejections.shouldBeEqualTo(1)
         exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
         recovered.await(5, TimeUnit.SECONDS).shouldBeTrue()
         deliveryFuture.complete(LeaderAuditDeliveryResult.SUCCESS).shouldBeTrue()
@@ -574,6 +574,144 @@ class BoundedLeaderAuditExporterTest {
         exporter.close()
     }
 
+    @Test
+    fun `closing observer drops queued callbacks and allows a replacement observer to re-admit`() {
+        val firstStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val originalCalls = AtomicInteger()
+        val replacementCalls = AtomicInteger()
+        val exporter = exporter(
+            queueCapacity = 2,
+            registerObserver = false,
+        )
+        val registration = exporter.observe(LeaderAuditExportObserver {
+            if (originalCalls.incrementAndGet() == 1) {
+                firstStarted.countDown()
+                releaseFirst.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            }
+        })
+
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        firstStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        registration.close()
+        diagnosticsQueued(exporter).shouldBeEqualTo(0)
+        releaseFirst.countDown()
+
+        val replacementStarted = CountDownLatch(1)
+        val releaseReplacement = CountDownLatch(1)
+        val replacement = exporter.observe(LeaderAuditExportObserver {
+            if (replacementCalls.incrementAndGet() == 1) {
+                replacementStarted.countDown()
+                releaseReplacement.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            }
+        })
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        replacementStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        releaseReplacement.countDown()
+        awaitValue(replacementCalls, 2)
+
+        originalCalls.get().shouldBeEqualTo(1)
+        replacement.close()
+        exporter.close()
+    }
+
+    @Test
+    fun `close prevents queued observer callback from starting after close returns`() {
+        val firstStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val calls = AtomicInteger()
+        val exporter = exporter(
+            queueCapacity = 2,
+            registerObserver = false,
+        )
+        exporter.observe(LeaderAuditExportObserver {
+            if (calls.incrementAndGet() == 1) {
+                firstStarted.countDown()
+                releaseFirst.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            }
+        })
+
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        firstStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        exporter.close()
+        diagnosticsQueued(exporter).shouldBeEqualTo(0)
+        releaseFirst.countDown()
+
+        awaitValue(calls, 1)
+        calls.get().shouldBeEqualTo(1)
+        exporter.snapshot().diagnosticsClosed.shouldBeTrue()
+    }
+
+    @Test
+    fun `observer Error closes diagnostics and drops queued callbacks`() {
+        val firstStarted = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val secondStarted = CountDownLatch(1)
+        val uncaught = CountDownLatch(1)
+        val calls = AtomicInteger()
+        val previous = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { _, error ->
+            if (error is AssertionError) uncaught.countDown()
+        }
+        try {
+            val exporter = exporter(
+                queueCapacity = 2,
+                registerObserver = false,
+            )
+            exporter.observe(LeaderAuditExportObserver {
+                if (calls.incrementAndGet() == 1) {
+                    firstStarted.countDown()
+                    releaseFirst.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                    throw AssertionError("observer-failed")
+                } else {
+                    secondStarted.countDown()
+                }
+            })
+
+            exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+            firstStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+            releaseFirst.countDown()
+
+            uncaught.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            diagnosticsQueued(exporter).shouldBeEqualTo(0)
+            secondStarted.await(200, TimeUnit.MILLISECONDS).shouldBeFalse()
+            exporter.snapshot().diagnosticsClosed.shouldBeTrue()
+            exporter.snapshot().diagnosticsFatalErrors.shouldBeEqualTo(1)
+            exporter.close()
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(previous)
+        }
+    }
+
+    @Test
+    fun `observer close waits for diagnostics poll and reservation gate`() {
+        val polled = CountDownLatch(1)
+        val releasePoll = CountDownLatch(1)
+        val closeReturned = CountDownLatch(1)
+        val exporter = exporter(
+            queueCapacity = 1,
+            registerObserver = false,
+        )
+        val registration = exporter.observe(LeaderAuditExportObserver { })
+        replaceDiagnosticsQueue(exporter, BlockingDiagnosticsQueue(polled, releasePoll))
+
+        exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        polled.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        Thread.ofVirtual().start {
+            registration.close()
+            closeReturned.countDown()
+        }
+
+        closeReturned.await(200, TimeUnit.MILLISECONDS).shouldBeFalse()
+        releasePoll.countDown()
+        closeReturned.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        exporter.close()
+    }
+
     private fun exporter(
         delivery: LeaderAuditDelivery = LeaderAuditDelivery {
             CompletableFuture.completedFuture(LeaderAuditDeliveryResult.SUCCESS)
@@ -626,5 +764,41 @@ class BoundedLeaderAuditExporterTest {
         while (exporter.snapshot().admitted != 0 && System.nanoTime() < deadline) {
             Thread.onSpinWait()
         }
+    }
+
+    private fun replaceDiagnosticsQueue(
+        exporter: BoundedLeaderAuditExporter,
+        queue: ConcurrentLinkedQueue<Any>,
+    ) {
+        exporter.javaClass.getDeclaredField("diagnostics").apply {
+            isAccessible = true
+            set(exporter, queue)
+        }
+    }
+
+    private fun diagnosticsQueued(exporter: BoundedLeaderAuditExporter): Int =
+        (exporter.javaClass.getDeclaredField("diagnosticsQueued").apply { isAccessible = true }
+            .get(exporter) as AtomicInteger).get()
+
+    private class BlockingDiagnosticsQueue(
+        private val polled: CountDownLatch,
+        private val release: CountDownLatch,
+    ) : ConcurrentLinkedQueue<Any>() {
+        override fun poll(): Any? {
+            val item = super.poll()
+            if (item != null) {
+                polled.countDown()
+                release.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            }
+            return item
+        }
+    }
+
+    private fun awaitValue(value: AtomicInteger, expected: Int) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (value.get() != expected && System.nanoTime() < deadline) {
+            Thread.onSpinWait()
+        }
+        value.get().shouldBeEqualTo(expected)
     }
 }


### PR DESCRIPTION
## 요약

Fixes #732

audit diagnostics worker의 queue poll, permit 반환, observer slot 확인, callback reservation을 하나의 `diagnosticsAdmissionLock` 아래에서 선형화합니다.

## 배경

기존 구현은 `diagnostics.poll()`과 `diagnosticsQueued` 감소를 lock 밖에서 수행한 뒤 callback reservation만 lock 안에서 처리했습니다. 이 경계에서 observer handle `close()`나 exporter `close()`가 먼저 반환하면 poll된 callback의 admission 상태와 permit 회수가 서로 다른 순서로 관찰될 수 있었습니다.

## 변경 내용

- diagnostics queue poll, permit 반환, slot active 확인, callback reservation을 단일 gate로 묶었습니다.
- inactive observer 제거, 정상 close, observer `Error` drain이 queued permit을 정확히 한 번 반환하도록 정렬했습니다.
- queue capacity 2 전체를 replacement observer가 다시 admission하는 회귀 테스트를 추가했습니다.
- best-effort observer callback을 executor rejection 완료 신호로 사용하던 기존 테스트를 exporter 상태 대기로 교체했습니다.
- RED/GREEN과 동시성 경계의 결정 근거를 lesson으로 기록했습니다.

## 검증

- current `develop` baseline targeted test: RED (`0 passing`, `1 failing`)
- focused capacity/permit tests: PASS (`2 passing`)
- `BoundedLeaderAuditExporterTest`: PASS (`21 passing`)
- `./gradlew :bluetape4k-leader-core:test --no-daemon --rerun-tasks`: PASS (`996 tests`, failures/errors/skipped `0`)
- `./gradlew :bluetape4k-leader-core:detekt --no-daemon --rerun-tasks`: PASS
- `./gradlew checkBinaryCompatibility --no-daemon --rerun-tasks`: PASS (`artifacts=16`, `unknown=0`)
- Korean terminology audit: PASS (`findings=0`)
- forbidden Kotlin assertion audit와 `git diff --check`: PASS

## 리뷰

- 최초 독립 리뷰: P0=0, P1=0, P2=1 — full-capacity/exact-once 증거 보강 요청
- 수정 후 독립 최종 검증: P0=0, P1=0, P2=0, P3=0 — `APPROVE`

## DoD Status

Required checks: 8/9; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-03 - RED/GREEN | baseline 결함 재현 후 수정 구현 검증 | PASS | RED 0/1, GREEN focused 2/0 및 class 21/0 | 없음 |
| C-05 - Type C verification | module test, detekt, ABI, diff, 용어 감사 | PASS | 996/0/skipped=0, detekt PASS, ABI unknown=0 | 없음 |
| CG-08 - Heavyweight backends | Docker/Testcontainers 적용 여부 판정 | N/A | `leader-core` in-memory diagnostics 3-file 변경 | 없음 |
| CG-10 - Preflight | base/head/scope/worktree/중복 PR 확인 | PASS | `7d35f285` → `d7f7e8b7`, clean 3-file diff, 중복 PR 없음 | 없음 |
| CG-12A - Guidance refresh | AGENTS/workflow/Type C/Kotlin checklist 재확인 | PASS | current guidance와 Issue #732 live metadata 확인 | 없음 |
| CG-13 - PR delivery | 승인된 base/head로 PR 생성 및 metadata read-back | PASS | PR #839 OPEN/MERGEABLE, `develop` ← `fix/issue-732-diagnostics-admission`, exact head `d7f7e8b7` | 없음 |
| CG-14 - Exact-head CI | PR head의 모든 check를 terminal 상태로 확인 | PASS | run 33263495035, exact head `d7f7e8b7`, 47/47 success, failure/cancelled/skipped/pending 0 | 없음 |
| CG-15 - Review convergence | 독립 리뷰와 unresolved thread 확인 | PASS | 독립 최종 P0/P1/P2/P3=0 `APPROVE`, GitHub threads/comments/reviews 0 | 없음 |
| CG-16 - Fresh merge approval | exact-head evidence 뒤 별도 merge 승인 확인 | PENDING | merge는 현재 요청 범위 밖 | 병합 전 fresh 승인 필요 |

Final status: DONE — PR #839 생성, exact-head CI와 리뷰 수렴 완료; 병합은 fresh 승인 대기

Unchecked required items: CG-16
