### PR TITLE
[release] Snapshot publication 시크릿을 보호 환경으로 이관

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -23,6 +23,7 @@ jobs:
   publish:
     name: Publish SNAPSHOT to Maven Central
     runs-on: ubuntu-latest
+    environment: maven-central-release
     # workflow_run: Nightly 성공 시에만 실행. 수동 dispatch는 항상 실행.
     if: |
       github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
## 목적

[projects #1578](https://github.com/bluetape4k/bluetape4k-projects/issues/1578)의 조직-wide Maven Central 자격증명 회수 전제 조건으로 workflow secret 참조를 repository environment 범위로 이관합니다.

## 변경

- Maven Central Snapshot publication job에 `environment: maven-central-release`를 명시했습니다.
- Image의 Snapshot 소비 CI는 일반 빌드가 release 승인 대기에 묶이지 않도록 `maven-central-snapshots` 환경으로 `CENTRAL_USERNAME`/`CENTRAL_PASSWORD`를 한정했습니다.
- 기존 secret 이름과 Gradle 입력 계약은 유지했으며 secret 값은 코드·로그·artifact에 기록하지 않았습니다.

## 검증

- YAML parse 통과
- 변경 workflow `actionlint` 통과
- `git diff --check` 통과
- secret 참조 job의 environment 지정과 top-level secret 참조 부재를 정적 확인

독립/2인 리뷰는 1인 개발자 운영 정책에 따라 N/A이며, exact-head CI·환경 metadata read-back·조직 secret 회수는 병합 후 별도 게이트입니다.

Refs https://github.com/bluetape4k/bluetape4k-projects/issues/1578

## DoD Status

- [x] workflow secret 참조의 environment 범위 이관
- [x] 정적 workflow 검증
- [x] secret 값 비노출 확인
- [ ] exact-head GitHub CI 통과 및 병합
- [ ] 조직 secret 회수 후 전역 read-back