### PR TITLE
[release] SNAPSHOT source와 배포 action을 정리한다

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -30,6 +30,17 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Verify source commit
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+
       - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: ${{ env.JAVA_VERSION }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -29,12 +29,12 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-java@v6.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
-      - uses: gradle/actions/setup-gradle@v6.3.0
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           gradle-version: wrapper
           cache-read-only: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.resolve-version.outputs.ref }}
           fetch-depth: 0
@@ -165,12 +165,12 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/setup-java@v6.0.0
+      - uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
-      - uses: gradle/actions/setup-gradle@v6.3.0
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           gradle-version: wrapper
           cache-read-only: true
@@ -261,7 +261,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ needs.resolve-version.outputs.ref }}
           fetch-depth: 0


### PR DESCRIPTION
## 요약

Refs bluetape4k/bluetape4k-projects#1578

routine SNAPSHOT 배포의 source 선택을 단순화하고, privileged publication action은 immutable commit SHA로 유지합니다.

## 변경

- 자동 `workflow_run` 배포는 `github.event.workflow_run.head_sha`를 사용합니다.
- 수동 `workflow_dispatch` 배포는 현재 `develop`의 `github.sha`를 사용합니다.
- checkout 결과와 기대 SHA를 비교해 다른 commit 배포를 차단합니다.
- `maven-central-release` 환경의 required reviewer를 제거했습니다.
- `develop` branch policy, `can_admins_bypass=false`, 기존 secret 5개는 유지했습니다.

## 검증

- `actionlint`: PASS
- workflow source assertion 및 `git diff --check`: PASS
- exact-head hosted CI: PASS
- 통합 검토: 지적 사항 없음

## DoD Status

- 구현 및 로컬 검증: **PASS**
- 환경 정책 read-back: **PASS**
- exact-head hosted CI: **PASS**
- merge: **PENDING** — 현재 head에 대한 별도 승인 필요
