### PR TITLE
[release] 검증된 exact head로 Snapshot source를 고정한다

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -30,6 +30,12 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+      - name: Verify exact checkout
+        env:
+          EXPECTED_HEAD_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
       - uses: actions/setup-java@v6.0.0
         with:
           java-version: ${{ env.JAVA_VERSION }}


### PR DESCRIPTION
## Summary

Refs bluetape4k/bluetape4k-projects#1578

Full Nightly에서 검증한 commit의 exact `head_sha`를 Snapshot 배포 source로 고정합니다. 승인 대기 중 `develop`이 이동해도 검증되지 않은 source가 배포되지 않도록 합니다.

## Background

중앙 release 이슈 #1578 검증에서 자동 Snapshot workflow가 검증 run 이후 가변 `develop`을 checkout하는 경로를 확인했습니다. action pinning과 별개로 source identity를 고정해야 검증 결과와 배포 입력이 일치합니다.

## What This Solves

- 자동 Snapshot 배포가 trigger한 Full Nightly run의 exact commit을 사용합니다.
- checkout 직후 실제 `HEAD`가 기대 SHA와 같은지 검증해 source drift를 중단시킵니다.

## Work Done

- `.github/workflows/publish-snapshot.yml`: 검증 run의 `head_sha`로 checkout ref를 고정했습니다.
- exact checkout 검증 단계를 추가해 기대 SHA와 실제 `HEAD`가 다르면 배포 전에 실패하도록 했습니다.


## Validation

- `actionlint .github/workflows/publish-snapshot.yml`: PASS
- `git diff --check origin/develop...HEAD`: PASS
- source-pin fixed-string check: PASS

## Review Notes

- P0/P1: 0
- P2: 선행 action-pinning PR [PR #849](https://github.com/bluetape4k/bluetape4k-leader/pull/849)을 먼저 병합한 뒤 이 PR을 최신 `develop`에 rebase해야 합니다.
- P3: 0
- Review evidence: local inline review에서 자동·수동 dispatch source와 exact checkout 경계를 확인했습니다.
- 독립 리뷰: N/A — 단독 개발자 운영 범위이며 inline review와 exact-head 검증을 유지했습니다.

## Metadata

- Issue: bluetape4k/bluetape4k-projects#1578, milestone `2.0.0`, assignee `debop`
- PR: #850, head `06d4a1dcff1ea980bdd6cfa1f223c874deaaaae2`, milestone `1.0.0`, assignee `debop`
- CI: exact head terminal checks 47건 PASS

## DoD Status

Required checks: 7\/7; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| CG-04 - Isolated worktree | `fix/issue-1578-snapshot-source` worktree에서 변경 | PASS | clean worktree, semantic branch | none |
| CG-07 - Validation | actionlint, diff check, source-pin 검사 | PASS | 정적 검사 3종 PASS | none |
| CG-08 - Inline review | 자동·수동 source identity 경로 검토 | PASS | P0/P1 0, merge ordering P2 기록 | none |
| CG-12A - Guidance refresh | 현재 AGENTS hierarchy, maintenance skill, common gates, PR template, 이슈를 재확인 | PASS | PR 생성 직전 live 재검증 | none |
| CG-13 - PR metadata | base/head, assignee, milestone, 본문과 exact head 확인 | PASS | PR #850, `06d4a1dcff1ea980bdd6cfa1f223c874deaaaae2` | none |
| CG-14 - Hosted CI | exact PR head의 hosted checks 확인 | PASS | exact head terminal checks 47건, failure 0 | none |
| Independent review | 단독 개발자 운영 범위 | N/A | 사용자 지정 single-owner 정책 | inline review 유지 |

Final status: PENDING — exact head CI는 통과했으며 선행 action-pinning PR 병합 대기

Unchecked required items: 선행 action-pinning PR [PR #849](https://github.com/bluetape4k/bluetape4k-leader/pull/849)