### PR TITLE
fix(leader-redis-lettuce): 후보 Redis 키 경계를 보존한다

### DIFF
--- a/docs/lessons/2026-08-31-issue-845-candidate-key-boundaries.md
+++ b/docs/lessons/2026-08-31-issue-845-candidate-key-boundaries.md
@@ -1,0 +1,24 @@
+# 후보 키는 문자열 연결이 아니라 경계를 인코딩해야 한다
+
+## 맥락
+
+Issue [#845](https://github.com/bluetape4k/bluetape4k-leader/issues/845)는 `lockName`과 `nodeId`를 `:`로 연결한 Redis 키가 서로 다른 후보를 같은 키로 만들 수 있음을 확인했다. `lockName`은 `:`를 허용하고 기본 `nodeId`도 `hostname:pid` 형식이므로 구분자만으로 두 필드의 경계를 복원할 수 없다.
+
+## 놓친 가정과 근거
+
+`keyPrefix:lockName:nodeId`가 충분히 구분된다는 가정이 잘못됐다. `(a, b:c)`와 `(a:b, c)`가 같은 키가 되는 회귀 테스트가 이를 재현했다. 기존 키를 그대로 읽으면 다른 lock의 값이나 Redis 자료형까지 후보로 해석할 수 있다는 점도 함께 드러났다.
+
+## 결정
+
+- 새 키는 version, record type, UTF-8 byte length를 포함해 각 필드의 경계를 보존한다.
+- 새 namespace는 유효한 `lockName`과 겹칠 수 없는 구분자로 legacy namespace와 분리한다.
+- legacy 후보는 exact `nodeId`와 Redis key type을 확인한 경우에만 TTL을 보존해 새 키로 이관한다.
+- blocking과 suspend registry에 같은 codec과 migration 규칙을 적용한다.
+
+## 결과와 검증
+
+커밋 `f692f1d5`에서 충돌 쌍, `hostname:pid`, `list`, `refresh`, `updateResult`, `unregister` 격리를 고정했다. Lettuce 전체 325개 테스트와 `detekt`, binary compatibility 검사가 통과했다.
+
+## 재발 방지
+
+두 개 이상의 사용자 입력을 저장 키로 조합할 때는 delimiter 문자열 연결을 사용하지 않는다. 설계 검토에서 injectivity, namespace 분리, legacy 자료형, TTL 보존을 먼저 확인하고 delimiter를 각 필드에 넣은 충돌 쌍을 RED 테스트로 작성한다.

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateIndexCleanupScript.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateIndexCleanupScript.kt
@@ -1,0 +1,24 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.leader.lettuce.script.RedisScript
+
+/**
+ * 현재 후보 key가 여전히 없는 경우에만 index member를 제거합니다.
+ *
+ * 후보 migration 또는 동시 등록이 stale snapshot과 index 정리 사이에 key를 만들 수
+ * 있으므로, 존재 확인과 SREM을 하나의 Redis 원자 실행으로 묶습니다.
+ */
+internal object LettuceCandidateIndexCleanupScript {
+
+    val REMOVE_MISSING = RedisScript(
+        """
+        local removed = 0
+        for index = 2, #KEYS do
+          if redis.call('EXISTS', KEYS[index]) == 0 then
+            removed = removed + redis.call('SREM', KEYS[1], ARGV[index - 1])
+          end
+        end
+        return removed
+        """.trimIndent()
+    )
+}

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateKeyCodec.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateKeyCodec.kt
@@ -1,0 +1,41 @@
+package io.bluetape4k.leader.lettuce
+
+import io.lettuce.core.RedisCommandExecutionException
+import java.nio.charset.StandardCharsets
+
+/**
+ * Lettuce strategic 후보 Redis key를 논리적 구성 요소별로 인코딩합니다.
+ *
+ * `lockName`과 `nodeId`를 raw delimiter로 연결하면 `:`를 포함하는 허용 값이
+ * 서로 다른 후보를 같은 key로 만들 수 있습니다. 새 key는 legacy `:` namespace와
+ * 구분되는 version/type marker와 UTF-8 byte length prefix를 사용합니다.
+ */
+internal object LettuceCandidateKeyCodec {
+
+    private const val VERSION = "v2"
+    private const val INDEX_TYPE = "i"
+    private const val CANDIDATE_TYPE = "c"
+    private const val NAMESPACE_SEPARATOR = "|"
+
+    fun indexKey(keyPrefix: String, lockName: String): String =
+        "$keyPrefix$NAMESPACE_SEPARATOR$VERSION$NAMESPACE_SEPARATOR$INDEX_TYPE$NAMESPACE_SEPARATOR" +
+            lengthDelimited(lockName)
+
+    fun candidateKey(keyPrefix: String, lockName: String, nodeId: String): String =
+        "$keyPrefix$NAMESPACE_SEPARATOR$VERSION$NAMESPACE_SEPARATOR$CANDIDATE_TYPE$NAMESPACE_SEPARATOR" +
+            lengthDelimited(lockName) + lengthDelimited(nodeId)
+
+    fun legacyIndexKey(keyPrefix: String, lockName: String): String =
+        "$keyPrefix:$lockName"
+
+    fun legacyCandidateKey(keyPrefix: String, lockName: String, nodeId: String): String =
+        "${legacyIndexKey(keyPrefix, lockName)}:$nodeId"
+
+    private fun lengthDelimited(value: String): String {
+        val byteLength = value.toByteArray(StandardCharsets.UTF_8).size
+        return "$byteLength:$value"
+    }
+}
+
+internal fun RedisCommandExecutionException.isWrongType(): Boolean =
+    message?.startsWith("WRONGTYPE") == true

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt
@@ -4,7 +4,9 @@ import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.leader.lettuce.script.RedisScriptRunner
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
+import io.lettuce.core.RedisCommandExecutionException
 import io.lettuce.core.ScriptOutputType
+import io.lettuce.core.SetArgs
 import io.lettuce.core.api.StatefulRedisConnection
 import java.time.Instant
 import kotlin.time.Duration
@@ -33,10 +35,10 @@ internal class LettuceCandidateRegistry(
     private val sync = connection.sync()
 
     private fun indexKey(lockName: String) =
-        "$keyPrefix:$lockName"
+        LettuceCandidateKeyCodec.indexKey(keyPrefix, lockName)
 
     private fun candidateKey(lockName: String, nodeId: String) =
-        "${indexKey(lockName)}:$nodeId"
+        LettuceCandidateKeyCodec.candidateKey(keyPrefix, lockName, nodeId)
 
     /**
      * `registerCandidate` 호출은 Redis Lettuce backend leader election 계약의 일부 동작을 수행합니다.
@@ -59,11 +61,15 @@ internal class LettuceCandidateRegistry(
     /** 기존 후보의 heartbeat를 원자적으로 갱신하고 결과 통계는 보존합니다. */
     fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
         validateLockName(lockName)
+        val key = candidateKey(lockName, info.nodeId)
+        if (sync.get(key) == null) {
+            migrateLegacyCandidate(lockName, info.nodeId)
+        }
         val reply = RedisScriptRunner.run<List<Any>>(
             sync,
             LettuceCandidateRefreshScript.REFRESH,
             ScriptOutputType.MULTI,
-            arrayOf(candidateKey(lockName, info.nodeId), indexKey(lockName)),
+            arrayOf(key, indexKey(lockName)),
             LettuceCandidateInfoCodec.encode(info),
             ttl.inWholeMilliseconds.toString(),
         )
@@ -79,6 +85,11 @@ internal class LettuceCandidateRegistry(
         validateLockName(lockName)
         sync.del(candidateKey(lockName, nodeId))
         sync.srem(indexKey(lockName), nodeId)
+        val legacyKey = LettuceCandidateKeyCodec.legacyCandidateKey(keyPrefix, lockName, nodeId)
+        if (readLegacyCandidate(legacyKey, nodeId) != null) {
+            sync.del(legacyKey)
+        }
+        removeLegacyIndexMembers(lockName, listOf(nodeId))
     }
 
     /**
@@ -88,24 +99,49 @@ internal class LettuceCandidateRegistry(
      */
     fun listCandidates(lockName: String): List<CandidateInfo> {
         validateLockName(lockName)
-        val nodeIds = sync.smembers(indexKey(lockName)).toList()
-        if (nodeIds.isEmpty()) return emptyList()
-        val staleNodeIds = mutableListOf<String>()
-        val keys = nodeIds.map { nodeId -> candidateKey(lockName, nodeId) }
-        return sync.mget(*keys.toTypedArray())
-            .mapNotNull { kv ->
+        val currentIndexKey = indexKey(lockName)
+        val currentNodeIds = sync.smembers(currentIndexKey).toList()
+        val legacyNodeIds = readLegacyNodeIds(lockName)
+        if (currentNodeIds.isEmpty() && legacyNodeIds.isEmpty()) return emptyList()
+
+        val candidates = linkedMapOf<String, CandidateInfo>()
+        val staleCurrentNodeIds = mutableListOf<String>()
+        val currentKeys = currentNodeIds.associateBy { nodeId -> candidateKey(lockName, nodeId) }
+        if (currentKeys.isNotEmpty()) {
+            sync.mget(*currentKeys.keys.toTypedArray()).forEach { kv ->
+                val nodeId = currentKeys[kv.key] ?: return@forEach
                 if (!kv.hasValue()) {
-                    kv.key.removePrefix("${indexKey(lockName)}:").takeIf { it.isNotBlank() }?.let(staleNodeIds::add)
-                    return@mapNotNull null
+                    staleCurrentNodeIds += nodeId
+                    return@forEach
                 }
-                val raw = kv.value
-                LettuceCandidateInfoCodec.decode(raw)
+                val candidate = LettuceCandidateInfoCodec.decode(kv.value)
+                if (candidate.nodeId == nodeId) candidates[nodeId] = candidate
+                else staleCurrentNodeIds += nodeId
             }
-            .also {
-                if (staleNodeIds.isNotEmpty()) {
-                    sync.srem(indexKey(lockName), *staleNodeIds.toTypedArray())
-                }
+        }
+
+        val staleLegacyNodeIds = mutableListOf<String>()
+        legacyNodeIds.forEach { nodeId ->
+            if (candidates.containsKey(nodeId)) return@forEach
+            val legacyCandidate = readLegacyCandidate(
+                LettuceCandidateKeyCodec.legacyCandidateKey(keyPrefix, lockName, nodeId),
+                nodeId,
+            )
+            if (legacyCandidate == null) {
+                staleLegacyNodeIds += nodeId
+                return@forEach
             }
+            migrateLegacyCandidate(lockName, nodeId)
+            candidates[nodeId] = legacyCandidate
+        }
+
+        if (staleCurrentNodeIds.isNotEmpty()) {
+            sync.srem(currentIndexKey, *staleCurrentNodeIds.toTypedArray())
+        }
+        if (staleLegacyNodeIds.isNotEmpty()) {
+            removeLegacyIndexMembers(lockName, staleLegacyNodeIds)
+        }
+        return candidates.values.toList()
     }
 
     /**
@@ -116,6 +152,9 @@ internal class LettuceCandidateRegistry(
     fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
         validateLockName(lockName)
         val key = candidateKey(lockName, nodeId)
+        if (sync.get(key) == null) {
+            migrateLegacyCandidate(lockName, nodeId)
+        }
         val reply = RedisScriptRunner.run<List<Any>>(
             sync,
             LettuceCandidateResultScript.UPDATE,
@@ -124,5 +163,47 @@ internal class LettuceCandidateRegistry(
             *LettuceCandidateResultScript.resultArgs(result, Instant.now().toEpochMilli()),
         )
         LettuceCandidateResultScript.rethrowMalformed(reply)
+    }
+
+    private fun readLegacyNodeIds(lockName: String): Set<String> = try {
+        sync.smembers(LettuceCandidateKeyCodec.legacyIndexKey(keyPrefix, lockName))
+    } catch (e: RedisCommandExecutionException) {
+        if (e.isWrongType()) emptySet() else throw e
+    }
+
+    private fun readLegacyCandidate(key: String, expectedNodeId: String): CandidateInfo? {
+        val raw = try {
+            sync.get(key)
+        } catch (e: RedisCommandExecutionException) {
+            if (!e.isWrongType()) throw e
+            null
+        }
+        return raw?.let(LettuceCandidateInfoCodec::decode)?.takeIf { it.nodeId == expectedNodeId }
+    }
+
+    private fun migrateLegacyCandidate(lockName: String, nodeId: String): Boolean {
+        val legacyKey = LettuceCandidateKeyCodec.legacyCandidateKey(keyPrefix, lockName, nodeId)
+        val candidate = readLegacyCandidate(legacyKey, nodeId) ?: return false
+        val raw = LettuceCandidateInfoCodec.encode(candidate)
+        val ttl = sync.pttl(legacyKey)
+        val migrated = when {
+            ttl == -2L -> false
+            ttl == -1L -> sync.setnx(candidateKey(lockName, nodeId), raw)
+            ttl > 0L -> sync.set(candidateKey(lockName, nodeId), raw, SetArgs.Builder.nx().px(ttl)) != null
+            else -> false
+        }
+        if (migrated) {
+            sync.sadd(indexKey(lockName), nodeId)
+            sync.persist(indexKey(lockName))
+        }
+        return migrated
+    }
+
+    private fun removeLegacyIndexMembers(lockName: String, nodeIds: List<String>) {
+        try {
+            sync.srem(LettuceCandidateKeyCodec.legacyIndexKey(keyPrefix, lockName), *nodeIds.toTypedArray())
+        } catch (e: RedisCommandExecutionException) {
+            if (!e.isWrongType()) throw e
+        }
     }
 }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt
@@ -17,6 +17,7 @@ import kotlin.time.Duration
  * 정상 lock contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.
  * @property connection Redis Lettuce backend 호출과 상태 계산에 사용하는 속성입니다.
  */
+@Suppress("TooManyFunctions")
 internal class LettuceCandidateRegistry(
     private val connection: StatefulRedisConnection<String, String>,
     private val keyPrefix: String = DEFAULT_KEY_PREFIX,
@@ -97,6 +98,7 @@ internal class LettuceCandidateRegistry(
      *
      * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
      */
+    @Suppress("CyclomaticComplexMethod")
     fun listCandidates(lockName: String): List<CandidateInfo> {
         validateLockName(lockName)
         val currentIndexKey = indexKey(lockName)
@@ -105,18 +107,19 @@ internal class LettuceCandidateRegistry(
         if (currentNodeIds.isEmpty() && legacyNodeIds.isEmpty()) return emptyList()
 
         val candidates = linkedMapOf<String, CandidateInfo>()
-        val staleCurrentNodeIds = mutableListOf<String>()
+        val missingCurrentNodeIds = mutableListOf<String>()
+        val mismatchedCurrentNodeIds = mutableListOf<String>()
         val currentKeys = currentNodeIds.associateBy { nodeId -> candidateKey(lockName, nodeId) }
         if (currentKeys.isNotEmpty()) {
             sync.mget(*currentKeys.keys.toTypedArray()).forEach { kv ->
                 val nodeId = currentKeys[kv.key] ?: return@forEach
                 if (!kv.hasValue()) {
-                    staleCurrentNodeIds += nodeId
+                    missingCurrentNodeIds += nodeId
                     return@forEach
                 }
                 val candidate = LettuceCandidateInfoCodec.decode(kv.value)
                 if (candidate.nodeId == nodeId) candidates[nodeId] = candidate
-                else staleCurrentNodeIds += nodeId
+                else mismatchedCurrentNodeIds += nodeId
             }
         }
 
@@ -132,11 +135,21 @@ internal class LettuceCandidateRegistry(
                 return@forEach
             }
             migrateLegacyCandidate(lockName, nodeId)
-            candidates[nodeId] = legacyCandidate
+            val currentCandidate = readCurrentCandidate(lockName, nodeId)
+            if (currentCandidate != null) {
+                sync.sadd(currentIndexKey, nodeId)
+                sync.persist(currentIndexKey)
+                candidates[nodeId] = currentCandidate
+            } else {
+                candidates[nodeId] = legacyCandidate
+            }
         }
 
-        if (staleCurrentNodeIds.isNotEmpty()) {
-            sync.srem(currentIndexKey, *staleCurrentNodeIds.toTypedArray())
+        if (mismatchedCurrentNodeIds.isNotEmpty()) {
+            sync.srem(currentIndexKey, *mismatchedCurrentNodeIds.toTypedArray())
+        }
+        if (missingCurrentNodeIds.isNotEmpty()) {
+            removeMissingCurrentIndexMembers(lockName, currentIndexKey, missingCurrentNodeIds)
         }
         if (staleLegacyNodeIds.isNotEmpty()) {
             removeLegacyIndexMembers(lockName, staleLegacyNodeIds)
@@ -181,6 +194,11 @@ internal class LettuceCandidateRegistry(
         return raw?.let(LettuceCandidateInfoCodec::decode)?.takeIf { it.nodeId == expectedNodeId }
     }
 
+    private fun readCurrentCandidate(lockName: String, expectedNodeId: String): CandidateInfo? {
+        val raw = sync.get(candidateKey(lockName, expectedNodeId)) ?: return null
+        return LettuceCandidateInfoCodec.decode(raw).takeIf { it.nodeId == expectedNodeId }
+    }
+
     private fun migrateLegacyCandidate(lockName: String, nodeId: String): Boolean {
         val legacyKey = LettuceCandidateKeyCodec.legacyCandidateKey(keyPrefix, lockName, nodeId)
         val candidate = readLegacyCandidate(legacyKey, nodeId) ?: return false
@@ -197,6 +215,17 @@ internal class LettuceCandidateRegistry(
             sync.persist(indexKey(lockName))
         }
         return migrated
+    }
+
+    private fun removeMissingCurrentIndexMembers(lockName: String, indexKey: String, nodeIds: List<String>) {
+        val keys = arrayOf(indexKey) + nodeIds.map { candidateKey(lockName, it) }
+        RedisScriptRunner.run<Long>(
+            sync,
+            LettuceCandidateIndexCleanupScript.REMOVE_MISSING,
+            ScriptOutputType.INTEGER,
+            keys,
+            *nodeIds.toTypedArray(),
+        )
     }
 
     private fun removeLegacyIndexMembers(lockName: String, nodeIds: List<String>) {

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt
@@ -22,6 +22,7 @@ import kotlin.time.Duration
  *
  * 정상 lock contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.
  */
+@Suppress("TooManyFunctions")
 internal class LettuceSuspendCandidateRegistry(
     connection: StatefulRedisConnection<String, String>,
     private val keyPrefix: String = DEFAULT_KEY_PREFIX,
@@ -103,6 +104,7 @@ internal class LettuceSuspendCandidateRegistry(
      *
      * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
      */
+    @Suppress("CyclomaticComplexMethod")
     suspend fun listCandidates(lockName: String): List<CandidateInfo> {
         validateLockName(lockName)
         val currentIndexKey = indexKey(lockName)
@@ -111,18 +113,19 @@ internal class LettuceSuspendCandidateRegistry(
         if (currentNodeIds.isEmpty() && legacyNodeIds.isEmpty()) return emptyList()
 
         val candidates = linkedMapOf<String, CandidateInfo>()
-        val staleCurrentNodeIds = mutableListOf<String>()
+        val missingCurrentNodeIds = mutableListOf<String>()
+        val mismatchedCurrentNodeIds = mutableListOf<String>()
         val currentKeys = currentNodeIds.associateBy { nodeId -> candidateKey(lockName, nodeId) }
         if (currentKeys.isNotEmpty()) {
             cmds.mget(*currentKeys.keys.toTypedArray()).toList().forEach { kv ->
                 val nodeId = currentKeys[kv.key] ?: return@forEach
                 if (!kv.hasValue()) {
-                    staleCurrentNodeIds += nodeId
+                    missingCurrentNodeIds += nodeId
                     return@forEach
                 }
                 val candidate = LettuceCandidateInfoCodec.decode(kv.getValue())
                 if (candidate.nodeId == nodeId) candidates[nodeId] = candidate
-                else staleCurrentNodeIds += nodeId
+                else mismatchedCurrentNodeIds += nodeId
             }
         }
 
@@ -138,11 +141,21 @@ internal class LettuceSuspendCandidateRegistry(
                 return@forEach
             }
             migrateLegacyCandidate(lockName, nodeId)
-            candidates[nodeId] = legacyCandidate
+            val currentCandidate = readCurrentCandidate(lockName, nodeId)
+            if (currentCandidate != null) {
+                cmds.sadd(currentIndexKey, nodeId)
+                cmds.persist(currentIndexKey)
+                candidates[nodeId] = currentCandidate
+            } else {
+                candidates[nodeId] = legacyCandidate
+            }
         }
 
-        if (staleCurrentNodeIds.isNotEmpty()) {
-            cmds.srem(currentIndexKey, *staleCurrentNodeIds.toTypedArray())
+        if (mismatchedCurrentNodeIds.isNotEmpty()) {
+            cmds.srem(currentIndexKey, *mismatchedCurrentNodeIds.toTypedArray())
+        }
+        if (missingCurrentNodeIds.isNotEmpty()) {
+            removeMissingCurrentIndexMembers(lockName, currentIndexKey, missingCurrentNodeIds)
         }
         if (staleLegacyNodeIds.isNotEmpty()) {
             removeLegacyIndexMembers(lockName, staleLegacyNodeIds)
@@ -187,6 +200,11 @@ internal class LettuceSuspendCandidateRegistry(
         return raw?.let(LettuceCandidateInfoCodec::decode)?.takeIf { it.nodeId == expectedNodeId }
     }
 
+    private suspend fun readCurrentCandidate(lockName: String, expectedNodeId: String): CandidateInfo? {
+        val raw = cmds.get(candidateKey(lockName, expectedNodeId)) ?: return null
+        return LettuceCandidateInfoCodec.decode(raw).takeIf { it.nodeId == expectedNodeId }
+    }
+
     private suspend fun migrateLegacyCandidate(lockName: String, nodeId: String): Boolean {
         val legacyKey = LettuceCandidateKeyCodec.legacyCandidateKey(keyPrefix, lockName, nodeId)
         val candidate = readLegacyCandidate(legacyKey, nodeId) ?: return false
@@ -203,6 +221,21 @@ internal class LettuceSuspendCandidateRegistry(
             cmds.persist(indexKey(lockName))
         }
         return migrated
+    }
+
+    private suspend fun removeMissingCurrentIndexMembers(
+        lockName: String,
+        indexKey: String,
+        nodeIds: List<String>,
+    ) {
+        val keys = arrayOf(indexKey) + nodeIds.map { candidateKey(lockName, it) }
+        RedisScriptRunner.runSuspending<Long>(
+            asyncCommands,
+            LettuceCandidateIndexCleanupScript.REMOVE_MISSING,
+            ScriptOutputType.INTEGER,
+            keys,
+            *nodeIds.toTypedArray(),
+        )
     }
 
     private suspend fun removeLegacyIndexMembers(lockName: String, nodeIds: List<String>) {

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt
@@ -7,11 +7,12 @@ import io.bluetape4k.leader.strategy.CandidateResult
 import io.bluetape4k.leader.lettuce.script.RedisScriptRunner
 import io.bluetape4k.leader.validateLockName
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
+import io.lettuce.core.RedisCommandExecutionException
 import io.lettuce.core.ScriptOutputType
+import io.lettuce.core.SetArgs
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.coroutines
 import io.lettuce.core.api.coroutines.RedisCoroutinesCommands
-import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.toList
 import java.time.Instant
 import kotlin.time.Duration
@@ -40,10 +41,10 @@ internal class LettuceSuspendCandidateRegistry(
     private val asyncCommands by lazy { connection.async() }
 
     private fun indexKey(lockName: String) =
-        "$keyPrefix:$lockName"
+        LettuceCandidateKeyCodec.indexKey(keyPrefix, lockName)
 
     private fun candidateKey(lockName: String, nodeId: String) =
-        "${indexKey(lockName)}:$nodeId"
+        LettuceCandidateKeyCodec.candidateKey(keyPrefix, lockName, nodeId)
 
     /**
      * `registerCandidate` 호출은 Redis Lettuce backend leader election 계약의 일부 동작을 수행합니다.
@@ -66,11 +67,15 @@ internal class LettuceSuspendCandidateRegistry(
     /** 기존 후보의 heartbeat를 원자적으로 갱신하고 결과 통계는 보존합니다. */
     suspend fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
         validateLockName(lockName)
+        val key = candidateKey(lockName, info.nodeId)
+        if (cmds.get(key) == null) {
+            migrateLegacyCandidate(lockName, info.nodeId)
+        }
         val reply = RedisScriptRunner.runSuspending<List<Any>>(
             asyncCommands,
             LettuceCandidateRefreshScript.REFRESH,
             ScriptOutputType.MULTI,
-            arrayOf(candidateKey(lockName, info.nodeId), indexKey(lockName)),
+            arrayOf(key, indexKey(lockName)),
             LettuceCandidateInfoCodec.encode(info),
             ttl.inWholeMilliseconds.toString(),
         )
@@ -86,6 +91,11 @@ internal class LettuceSuspendCandidateRegistry(
         validateLockName(lockName)
         cmds.del(candidateKey(lockName, nodeId))
         cmds.srem(indexKey(lockName), nodeId)
+        val legacyKey = LettuceCandidateKeyCodec.legacyCandidateKey(keyPrefix, lockName, nodeId)
+        if (readLegacyCandidate(legacyKey, nodeId) != null) {
+            cmds.del(legacyKey)
+        }
+        removeLegacyIndexMembers(lockName, listOf(nodeId))
     }
 
     /**
@@ -95,24 +105,49 @@ internal class LettuceSuspendCandidateRegistry(
      */
     suspend fun listCandidates(lockName: String): List<CandidateInfo> {
         validateLockName(lockName)
-        val nodeIds = cmds.smembers(indexKey(lockName)).toList()
-        if (nodeIds.isEmpty()) return emptyList()
-        val staleNodeIds = mutableListOf<String>()
-        val keys = nodeIds.map { nodeId -> candidateKey(lockName, nodeId) }
-        return cmds.mget(*keys.toTypedArray())
-            .mapNotNull { kv ->
+        val currentIndexKey = indexKey(lockName)
+        val currentNodeIds = cmds.smembers(currentIndexKey).toList()
+        val legacyNodeIds = readLegacyNodeIds(lockName)
+        if (currentNodeIds.isEmpty() && legacyNodeIds.isEmpty()) return emptyList()
+
+        val candidates = linkedMapOf<String, CandidateInfo>()
+        val staleCurrentNodeIds = mutableListOf<String>()
+        val currentKeys = currentNodeIds.associateBy { nodeId -> candidateKey(lockName, nodeId) }
+        if (currentKeys.isNotEmpty()) {
+            cmds.mget(*currentKeys.keys.toTypedArray()).toList().forEach { kv ->
+                val nodeId = currentKeys[kv.key] ?: return@forEach
                 if (!kv.hasValue()) {
-                    kv.key.removePrefix("${indexKey(lockName)}:").takeIf { it.isNotBlank() }?.let(staleNodeIds::add)
-                    return@mapNotNull null
+                    staleCurrentNodeIds += nodeId
+                    return@forEach
                 }
-                LettuceCandidateInfoCodec.decode(kv.getValue())
+                val candidate = LettuceCandidateInfoCodec.decode(kv.getValue())
+                if (candidate.nodeId == nodeId) candidates[nodeId] = candidate
+                else staleCurrentNodeIds += nodeId
             }
-            .toList()
-            .also {
-                if (staleNodeIds.isNotEmpty()) {
-                    cmds.srem(indexKey(lockName), *staleNodeIds.toTypedArray())
-                }
+        }
+
+        val staleLegacyNodeIds = mutableListOf<String>()
+        legacyNodeIds.forEach { nodeId ->
+            if (candidates.containsKey(nodeId)) return@forEach
+            val legacyCandidate = readLegacyCandidate(
+                LettuceCandidateKeyCodec.legacyCandidateKey(keyPrefix, lockName, nodeId),
+                nodeId,
+            )
+            if (legacyCandidate == null) {
+                staleLegacyNodeIds += nodeId
+                return@forEach
             }
+            migrateLegacyCandidate(lockName, nodeId)
+            candidates[nodeId] = legacyCandidate
+        }
+
+        if (staleCurrentNodeIds.isNotEmpty()) {
+            cmds.srem(currentIndexKey, *staleCurrentNodeIds.toTypedArray())
+        }
+        if (staleLegacyNodeIds.isNotEmpty()) {
+            removeLegacyIndexMembers(lockName, staleLegacyNodeIds)
+        }
+        return candidates.values.toList()
     }
 
     /**
@@ -123,6 +158,9 @@ internal class LettuceSuspendCandidateRegistry(
     suspend fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
         validateLockName(lockName)
         val key = candidateKey(lockName, nodeId)
+        if (cmds.get(key) == null) {
+            migrateLegacyCandidate(lockName, nodeId)
+        }
         val reply = RedisScriptRunner.runSuspending<List<Any>>(
             asyncCommands,
             LettuceCandidateResultScript.UPDATE,
@@ -131,5 +169,47 @@ internal class LettuceSuspendCandidateRegistry(
             *LettuceCandidateResultScript.resultArgs(result, Instant.now().toEpochMilli()),
         )
         LettuceCandidateResultScript.rethrowMalformed(reply)
+    }
+
+    private suspend fun readLegacyNodeIds(lockName: String): Set<String> = try {
+        cmds.smembers(LettuceCandidateKeyCodec.legacyIndexKey(keyPrefix, lockName)).toList().toSet()
+    } catch (e: RedisCommandExecutionException) {
+        if (e.isWrongType()) emptySet() else throw e
+    }
+
+    private suspend fun readLegacyCandidate(key: String, expectedNodeId: String): CandidateInfo? {
+        val raw = try {
+            cmds.get(key)
+        } catch (e: RedisCommandExecutionException) {
+            if (!e.isWrongType()) throw e
+            null
+        }
+        return raw?.let(LettuceCandidateInfoCodec::decode)?.takeIf { it.nodeId == expectedNodeId }
+    }
+
+    private suspend fun migrateLegacyCandidate(lockName: String, nodeId: String): Boolean {
+        val legacyKey = LettuceCandidateKeyCodec.legacyCandidateKey(keyPrefix, lockName, nodeId)
+        val candidate = readLegacyCandidate(legacyKey, nodeId) ?: return false
+        val raw = LettuceCandidateInfoCodec.encode(candidate)
+        val ttl = cmds.pttl(legacyKey) ?: -2L
+        val migrated = when {
+            ttl == -2L -> false
+            ttl == -1L -> cmds.setnx(candidateKey(lockName, nodeId), raw) == true
+            ttl > 0L -> cmds.set(candidateKey(lockName, nodeId), raw, SetArgs.Builder.nx().px(ttl)) != null
+            else -> false
+        }
+        if (migrated) {
+            cmds.sadd(indexKey(lockName), nodeId)
+            cmds.persist(indexKey(lockName))
+        }
+        return migrated
+    }
+
+    private suspend fun removeLegacyIndexMembers(lockName: String, nodeIds: List<String>) {
+        try {
+            cmds.srem(LettuceCandidateKeyCodec.legacyIndexKey(keyPrefix, lockName), *nodeIds.toTypedArray())
+        } catch (e: RedisCommandExecutionException) {
+            if (!e.isWrongType()) throw e
+        }
     }
 }

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateKeyIsolationTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateKeyIsolationTest.kt
@@ -176,6 +176,64 @@ class LettuceCandidateKeyIsolationTest : AbstractLettuceLeaderTest() {
         connection.sync().get(versionedCandidateKey(lockName, nodeId)).shouldNotBeNull()
     }
 
+    @Test
+    fun `blocking list keeps a migrated candidate in the v2 index after stale cleanup`() {
+        val lockName = "issue-845-stale-migration-${System.nanoTime()}"
+        val nodeId = "hostname:pid"
+        seedLegacy(lockName, CandidateInfo(nodeId, metadata = mapOf("source" to "legacy")))
+        connection.sync().sadd(versionedIndexKey(lockName), nodeId)
+
+        LettuceStrategicLeaderElector(connection, "observer").listCandidates(lockName)
+
+        connection.sync().smembers(versionedIndexKey(lockName)) shouldBeEqualTo setOf(nodeId)
+        connection.sync().get(versionedCandidateKey(lockName, nodeId)).shouldNotBeNull()
+    }
+
+    @Test
+    fun `suspend list keeps a migrated candidate in the v2 index after stale cleanup`() = runSuspendIO {
+        val lockName = "issue-845-suspend-stale-migration-${System.nanoTime()}"
+        val nodeId = "hostname:pid"
+        seedLegacy(lockName, CandidateInfo(nodeId, metadata = mapOf("source" to "legacy")))
+        connection.sync().sadd(versionedIndexKey(lockName), nodeId)
+
+        LettuceStrategicSuspendLeaderElector(connection, "observer").listCandidates(lockName)
+
+        connection.sync().smembers(versionedIndexKey(lockName)) shouldBeEqualTo setOf(nodeId)
+        connection.sync().get(versionedCandidateKey(lockName, nodeId)).shouldNotBeNull()
+    }
+
+    @Test
+    fun `blocking list prefers an existing v2 value when legacy migration cannot claim it`() {
+        val lockName = "issue-845-v2-precedence-${System.nanoTime()}"
+        val nodeId = "hostname:pid"
+        seedLegacy(lockName, CandidateInfo(nodeId, metadata = mapOf("source" to "legacy")))
+        connection.sync().set(
+            versionedCandidateKey(lockName, nodeId),
+            LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId, metadata = mapOf("source" to "v2"))),
+        )
+
+        val listed = LettuceStrategicLeaderElector(connection, "observer").listCandidates(lockName)
+
+        listed.single().metadata shouldBeEqualTo mapOf("source" to "v2")
+        connection.sync().smembers(versionedIndexKey(lockName)) shouldBeEqualTo setOf(nodeId)
+    }
+
+    @Test
+    fun `suspend list prefers an existing v2 value when legacy migration cannot claim it`() = runSuspendIO {
+        val lockName = "issue-845-suspend-v2-precedence-${System.nanoTime()}"
+        val nodeId = "hostname:pid"
+        seedLegacy(lockName, CandidateInfo(nodeId, metadata = mapOf("source" to "legacy")))
+        connection.sync().set(
+            versionedCandidateKey(lockName, nodeId),
+            LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId, metadata = mapOf("source" to "v2"))),
+        )
+
+        val listed = LettuceStrategicSuspendLeaderElector(connection, "observer").listCandidates(lockName)
+
+        listed.single().metadata shouldBeEqualTo mapOf("source" to "v2")
+        connection.sync().smembers(versionedIndexKey(lockName)) shouldBeEqualTo setOf(nodeId)
+    }
+
     private fun collisionPair(): CollisionPair {
         val suffix = System.nanoTime().toString()
         val lockName = "issue-845-$suffix"
@@ -206,6 +264,9 @@ class LettuceCandidateKeyIsolationTest : AbstractLettuceLeaderTest() {
         fun part(value: String) = "${value.toByteArray(Charsets.UTF_8).size}:$value"
         return "${LettuceCandidateRegistry.DEFAULT_KEY_PREFIX}|v2|c|${part(lockName)}${part(nodeId)}"
     }
+
+    private fun versionedIndexKey(lockName: String) =
+        "${LettuceCandidateRegistry.DEFAULT_KEY_PREFIX}|v2|i|${lockName.toByteArray(Charsets.UTF_8).size}:$lockName"
 
     private data class CollisionPair(
         val lockName: String,

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateKeyIsolationTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateKeyIsolationTest.kt
@@ -1,0 +1,216 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration
+
+class LettuceCandidateKeyIsolationTest : AbstractLettuceLeaderTest() {
+
+    @Test
+    fun `blocking candidate lifecycle preserves lock and node boundaries`() {
+        val (lockName, nodeId, collidingLockName, collidingNodeId) = collisionPair()
+        val elector = LettuceStrategicLeaderElector(connection, "observer")
+
+        elector.registerCandidate(lockName, CandidateInfo(nodeId, metadata = mapOf("owner" to "first")))
+        elector.registerCandidate(
+            collidingLockName,
+            CandidateInfo(collidingNodeId, metadata = mapOf("owner" to "second")),
+        )
+
+        elector.listCandidates(lockName).single().nodeId shouldBeEqualTo nodeId
+        elector.listCandidates(collidingLockName).single().nodeId shouldBeEqualTo collidingNodeId
+
+        elector.refreshCandidate(
+            lockName,
+            CandidateInfo(nodeId, metadata = mapOf("owner" to "first-refreshed")),
+            Duration.ZERO,
+        )
+        elector.listCandidates(lockName).single().metadata shouldBeEqualTo mapOf("owner" to "first-refreshed")
+        elector.listCandidates(collidingLockName).single().metadata shouldBeEqualTo mapOf("owner" to "second")
+
+        elector.updateResult(lockName, nodeId, CandidateResult.SUCCESS)
+        elector.listCandidates(lockName).single().successCount shouldBeEqualTo 1L
+        elector.listCandidates(collidingLockName).single().successCount shouldBeEqualTo 0L
+
+        elector.unregisterCandidate(lockName, nodeId)
+        elector.listCandidates(lockName).shouldBeEmpty()
+        elector.listCandidates(collidingLockName).single().nodeId shouldBeEqualTo collidingNodeId
+    }
+
+    @Test
+    fun `suspend candidate lifecycle preserves lock and node boundaries`() = runSuspendIO {
+        val (lockName, nodeId, collidingLockName, collidingNodeId) = collisionPair()
+        val elector = LettuceStrategicSuspendLeaderElector(connection, "observer")
+
+        elector.registerCandidate(lockName, CandidateInfo(nodeId, metadata = mapOf("owner" to "first")))
+        elector.registerCandidate(
+            collidingLockName,
+            CandidateInfo(collidingNodeId, metadata = mapOf("owner" to "second")),
+        )
+
+        elector.listCandidates(lockName).single().nodeId shouldBeEqualTo nodeId
+        elector.listCandidates(collidingLockName).single().nodeId shouldBeEqualTo collidingNodeId
+
+        elector.refreshCandidate(
+            lockName,
+            CandidateInfo(nodeId, metadata = mapOf("owner" to "first-refreshed")),
+            Duration.ZERO,
+        )
+        elector.listCandidates(lockName).single().metadata shouldBeEqualTo mapOf("owner" to "first-refreshed")
+        elector.listCandidates(collidingLockName).single().metadata shouldBeEqualTo mapOf("owner" to "second")
+
+        elector.updateResult(lockName, nodeId, CandidateResult.SUCCESS)
+        elector.listCandidates(lockName).single().successCount shouldBeEqualTo 1L
+        elector.listCandidates(collidingLockName).single().successCount shouldBeEqualTo 0L
+
+        elector.unregisterCandidate(lockName, nodeId)
+        elector.listCandidates(lockName).shouldBeEmpty()
+        elector.listCandidates(collidingLockName).single().nodeId shouldBeEqualTo collidingNodeId
+    }
+
+    @Test
+    fun `legacy candidate with exact node id is read through and migrated`() {
+        val lockName = "issue-845-legacy-${System.nanoTime()}"
+        val nodeId = "hostname:pid"
+        val candidate = CandidateInfo(nodeId, metadata = mapOf("source" to "legacy"))
+        val legacyIndexKey = legacyIndexKey(lockName)
+        val legacyCandidateKey = legacyCandidateKey(lockName, nodeId)
+
+        connection.sync().set(legacyCandidateKey, LettuceCandidateInfoCodec.encode(candidate))
+        connection.sync().sadd(legacyIndexKey, nodeId)
+
+        val listed = LettuceStrategicLeaderElector(connection, "observer").listCandidates(lockName)
+
+        listed.single().nodeId shouldBeEqualTo nodeId
+        connection.sync().get(versionedCandidateKey(lockName, nodeId)).shouldNotBeNull()
+    }
+
+    @Test
+    fun `legacy candidate with a different node id is never exposed`() {
+        val lockName = "issue-845-legacy-mismatch-${System.nanoTime()}"
+        val expectedNodeId = "hostname:pid"
+        val actualNodeId = "other-node"
+        val legacyIndexKey = legacyIndexKey(lockName)
+        val legacyCandidateKey = legacyCandidateKey(lockName, expectedNodeId)
+
+        connection.sync().set(
+            legacyCandidateKey,
+            LettuceCandidateInfoCodec.encode(CandidateInfo(actualNodeId)),
+        )
+        connection.sync().sadd(legacyIndexKey, expectedNodeId)
+
+        LettuceStrategicLeaderElector(connection, "observer")
+            .listCandidates(lockName)
+            .shouldBeEmpty()
+    }
+
+    @Test
+    fun `blocking lifecycle operations migrate an exact legacy candidate before mutation`() {
+        val nodeId = "hostname:pid"
+        val elector = LettuceStrategicLeaderElector(connection, "observer")
+
+        val refreshLock = "issue-845-legacy-refresh-${System.nanoTime()}"
+        seedLegacy(refreshLock, CandidateInfo(nodeId, metadata = mapOf("source" to "old")))
+        elector.refreshCandidate(
+            refreshLock,
+            CandidateInfo(nodeId, metadata = mapOf("source" to "fresh")),
+            Duration.ZERO,
+        )
+        elector.listCandidates(refreshLock).single().metadata shouldBeEqualTo mapOf("source" to "fresh")
+
+        val updateLock = "issue-845-legacy-update-${System.nanoTime()}"
+        seedLegacy(updateLock, CandidateInfo(nodeId))
+        elector.updateResult(updateLock, nodeId, CandidateResult.SUCCESS)
+        elector.listCandidates(updateLock).single().successCount shouldBeEqualTo 1L
+
+        val unregisterLock = "issue-845-legacy-unregister-${System.nanoTime()}"
+        seedLegacy(unregisterLock, CandidateInfo(nodeId))
+        elector.unregisterCandidate(unregisterLock, nodeId)
+        elector.listCandidates(unregisterLock).shouldBeEmpty()
+        connection.sync().get(legacyCandidateKey(unregisterLock, nodeId)).shouldBeNull()
+    }
+
+    @Test
+    fun `suspend lifecycle operations migrate an exact legacy candidate before mutation`() = runSuspendIO {
+        val nodeId = "hostname:pid"
+        val elector = LettuceStrategicSuspendLeaderElector(connection, "observer")
+
+        val refreshLock = "issue-845-suspend-legacy-refresh-${System.nanoTime()}"
+        seedLegacy(refreshLock, CandidateInfo(nodeId, metadata = mapOf("source" to "old")))
+        elector.refreshCandidate(
+            refreshLock,
+            CandidateInfo(nodeId, metadata = mapOf("source" to "fresh")),
+            Duration.ZERO,
+        )
+        elector.listCandidates(refreshLock).single().metadata shouldBeEqualTo mapOf("source" to "fresh")
+
+        val updateLock = "issue-845-suspend-legacy-update-${System.nanoTime()}"
+        seedLegacy(updateLock, CandidateInfo(nodeId))
+        elector.updateResult(updateLock, nodeId, CandidateResult.SUCCESS)
+        elector.listCandidates(updateLock).single().successCount shouldBeEqualTo 1L
+
+        val unregisterLock = "issue-845-suspend-legacy-unregister-${System.nanoTime()}"
+        seedLegacy(unregisterLock, CandidateInfo(nodeId))
+        elector.unregisterCandidate(unregisterLock, nodeId)
+        elector.listCandidates(unregisterLock).shouldBeEmpty()
+        connection.sync().get(legacyCandidateKey(unregisterLock, nodeId)).shouldBeNull()
+    }
+
+    @Test
+    fun `version-shaped lock name remains separate from the legacy namespace`() {
+        val lockName = "v2:c:1:a1:b"
+        val nodeId = "hostname:pid"
+        val elector = LettuceStrategicLeaderElector(connection, "observer")
+
+        connection.sync().sadd(legacyIndexKey(lockName), "legacy-node")
+        elector.registerCandidate(lockName, CandidateInfo(nodeId))
+
+        connection.sync().type(legacyIndexKey(lockName)) shouldBeEqualTo "set"
+        elector.listCandidates(lockName).single().nodeId shouldBeEqualTo nodeId
+        connection.sync().get(versionedCandidateKey(lockName, nodeId)).shouldNotBeNull()
+    }
+
+    private fun collisionPair(): CollisionPair {
+        val suffix = System.nanoTime().toString()
+        val lockName = "issue-845-$suffix"
+        val nodeId = "hostname:pid"
+        return CollisionPair(
+            lockName = lockName,
+            nodeId = nodeId,
+            collidingLockName = "$lockName:hostname",
+            collidingNodeId = "pid",
+        )
+    }
+
+    private fun legacyIndexKey(lockName: String) =
+        "${LettuceCandidateRegistry.DEFAULT_KEY_PREFIX}:$lockName"
+
+    private fun legacyCandidateKey(lockName: String, nodeId: String) =
+        "${legacyIndexKey(lockName)}:$nodeId"
+
+    private fun seedLegacy(lockName: String, candidate: CandidateInfo) {
+        connection.sync().set(
+            legacyCandidateKey(lockName, candidate.nodeId),
+            LettuceCandidateInfoCodec.encode(candidate),
+        )
+        connection.sync().sadd(legacyIndexKey(lockName), candidate.nodeId)
+    }
+
+    private fun versionedCandidateKey(lockName: String, nodeId: String): String {
+        fun part(value: String) = "${value.toByteArray(Charsets.UTF_8).size}:$value"
+        return "${LettuceCandidateRegistry.DEFAULT_KEY_PREFIX}|v2|c|${part(lockName)}${part(nodeId)}"
+    }
+
+    private data class CollisionPair(
+        val lockName: String,
+        val nodeId: String,
+        val collidingLockName: String,
+        val collidingNodeId: String,
+    )
+}

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicCandidateLookupFailureTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicCandidateLookupFailureTest.kt
@@ -174,7 +174,16 @@ class LettuceStrategicCandidateLookupFailureTest {
         val commands = mockk<RedisCommands<String, String>>()
         every { connection.sync() } returns commands
         every { commands.smembers(any()) } returns setOf("node-1")
-        every { commands.mget(any<String>()) } returns listOf(KeyValue.just("ignored", "malformed"))
+        every { commands.mget(any<String>()) } returns listOf(
+            KeyValue.just(
+                LettuceCandidateKeyCodec.candidateKey(
+                    LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                    "issue-785-codec",
+                    "node-1",
+                ),
+                "malformed",
+            ),
+        )
         return connection
     }
 
@@ -191,7 +200,16 @@ class LettuceStrategicCandidateLookupFailureTest {
         val reactive = mockk<RedisReactiveCommands<String, String>>()
         every { connection.reactive() } returns reactive
         every { reactive.smembers(any()) } returns Flux.just("node-1")
-        every { reactive.mget(any<String>()) } returns Flux.just(KeyValue.just("ignored", "malformed"))
+        every { reactive.mget(any<String>()) } returns Flux.just(
+            KeyValue.just(
+                LettuceCandidateKeyCodec.candidateKey(
+                    LettuceSuspendCandidateRegistry.GROUP_KEY_PREFIX,
+                    "issue-785-codec-group",
+                    "node-1",
+                ),
+                "malformed",
+            ),
+        )
         return connection
     }
 }

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicHeartbeatTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicHeartbeatTest.kt
@@ -145,7 +145,11 @@ class LettuceStrategicHeartbeatTest : AbstractLettuceLeaderTest() {
         val lockName = randomName()
         val elector = LettuceStrategicLeaderElector(connection, "node-1")
         val stale = candidate("node-1", successCount = 1, failureCount = 0, metadata = "stale")
-        val key = "${LettuceCandidateRegistry.DEFAULT_KEY_PREFIX}:$lockName:node-1"
+        val key = LettuceCandidateKeyCodec.candidateKey(
+            LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+            lockName,
+            "node-1",
+        )
 
         elector.registerCandidate(lockName, stale, ttl = 800.milliseconds)
         val beforeUpdate = connection.sync().pttl(key)

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElectorTest.kt
@@ -168,7 +168,11 @@ class LettuceStrategicLeaderElectorTest: AbstractLettuceLeaderTest() {
     fun `updateResult - codec가 거부하는 지수 표기 카운터는 기존 예외를 전파`() {
         val lockName = randomName()
         node1.registerCandidate(lockName, CandidateInfo("node-1"))
-        val key = "leader:strategy:candidates:$lockName:node-1"
+        val key = LettuceCandidateKeyCodec.candidateKey(
+            LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+            lockName,
+            "node-1",
+        )
         val raw = "node-1|${Instant.now().toEpochMilli()}|||1e3|0|"
         connection.sync().set(key, raw)
 
@@ -181,7 +185,11 @@ class LettuceStrategicLeaderElectorTest: AbstractLettuceLeaderTest() {
     fun `updateResult - 손상된 metadata는 기존 codec 예외를 전파`() {
         val lockName = randomName()
         node1.registerCandidate(lockName, CandidateInfo("node-1"))
-        val key = "leader:strategy:candidates:$lockName:node-1"
+        val key = LettuceCandidateKeyCodec.candidateKey(
+            LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+            lockName,
+            "node-1",
+        )
         val raw = "node-1|${Instant.now().toEpochMilli()}|||0|0|brokenpair"
         connection.sync().set(key, raw)
 

--- a/scripts/compatibility/check_binary_api.py
+++ b/scripts/compatibility/check_binary_api.py
@@ -89,6 +89,9 @@ KNOWN_SYNTHETIC_ACCESSORS: dict[str, frozenset[str]] = {
     ),
     "io.bluetape4k.leader.lettuce.LettuceSuspendCandidateRegistry": frozenset(
         {
+            "PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) java.lang.String "
+            + "access$indexKey(io.bluetape4k.leader.lettuce.LettuceSuspendCandidateRegistry, "
+            + "java.lang.String)",
             "PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) java.lang.Object "
             + "access$scanKeys(io.bluetape4k.leader.lettuce.LettuceSuspendCandidateRegistry, "
             + "java.lang.String, kotlin.coroutines.Continuation)"


### PR DESCRIPTION
## Summary

Closes #845

Lettuce strategic 후보 키가 `lockName`과 `nodeId`의 경계를 잃어 서로 다른 lock namespace를 공유하는 문제를 해결합니다.

## Background

milestone `1.0.0`의 Issue #845에서 `(lockName="a", nodeId="b:c")`와 `(lockName="a:b", nodeId="c")`가 같은 Redis 키로 직렬화되는 P1 결함을 확인했습니다. `:`를 금지하면 기존 lock name과 기본 `hostname:pid` node ID 계약을 깨므로 호환 가능한 인코딩과 migration이 필요했습니다.

## What This Solves

- 서로 다른 lock과 node 조합이 같은 후보 키를 사용하는 충돌을 제거합니다.
- legacy 후보를 읽을 때 다른 lock의 값이나 Redis 자료형을 잘못 해석하지 않도록 제한합니다.

## Work Done

- `LettuceCandidateKeyCodec`: version, record type, UTF-8 byte length로 필드 경계를 보존합니다.
- blocking/suspend registry: exact `nodeId`와 key type을 확인한 legacy 후보만 TTL을 보존해 새 namespace로 이관합니다.
- migration 경합: v2 후보를 재조회하고 `EXISTS`+`SREM` 원자 스크립트로 stale snapshot의 새 index 삭제를 막습니다.
- 회귀 테스트: 충돌 쌍, `hostname:pid`, `list`, `refresh`, `updateResult`, `unregister` 격리를 검증합니다.
- lesson: 복합 저장 키의 injectivity와 legacy migration 검토 순서를 기록했습니다.

## Validation

- `./gradlew :bluetape4k-leader-redis-lettuce:test`: PASS (`tests=329`, `failures=0`, `errors=0`, `skipped=0`)
- `./gradlew :bluetape4k-leader-redis-lettuce:detekt`: PASS
- `./gradlew checkBinaryCompatibility`: PASS (`unknown=0`)
- `git diff --check && git show --check HEAD`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 없음
- Review evidence: main-session exact diff review에서 namespace 구분자 충돌과 legacy `WRONGTYPE` 경로를 보완한 뒤 재검증했습니다.
- Independent review: PASS (exact head `1f6d7603672a32114590c2089e16fb663711d15e`, P0=0/P1=0; migration/index 경합 finding 폐쇄)
- Remaining risk: `0.5.x` writer와 `1.0.0` writer의 장시간 혼합 운영은 검증하지 않았습니다.

## Metadata

- Issue: #845, milestone `1.0.0`, assignee `debop`
- PR: #851, head `1f6d7603672a32114590c2089e16fb663711d15e`, milestone `1.0.0`, assignee `debop`
- CI: PASS (exact head에서 18 pass, 29 path-filter skip, 실패/대기 0)

## DoD Status

Required checks: 15/19; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-01 | 결함과 root cause 재현 | PASS | 경계 충돌 RED 테스트 | 없음 |
| C-02 | Issue 범위와 metadata 확인 | PASS | #845, `1.0.0`, `debop`, `bug/integration/test` | 없음 |
| C-03 | 회귀 테스트 RED 고정 | PASS | collision/migration 테스트가 수정 전 실패 | 없음 |
| C-04 | 최소 수정 적용 | PASS | key codec과 blocking/suspend registry | 없음 |
| C-05 | GREEN과 blast radius 검증 | PASS | Lettuce 329개, detekt, ABI 통과 | 없음 |
| C-06 | 재사용 가능한 lesson 기록 | PASS | `docs/lessons/2026-08-31-issue-845-candidate-key-boundaries.md` | merge 후 canonical GNO index 갱신 |
| CG-10 | pre-PR proof 수렴 | PASS | P0=0, P1=0, exact local head | 없음 |
| CG-11 | PR delivery 권한 확인 | PASS | `bluetape4k/bluetape4k-leader`, `develop`, 승인된 head | 없음 |
| CG-12 | exact head push | PASS | local/remote `1f6d7603672a32114590c2089e16fb663711d15e` | 없음 |
| CG-12A | guidance refresh | PASS | user/workspace/repository `AGENTS.md`, Type C leaf, common gates, PR template, #845 재확인 | 없음 |
| CG-13 | PR 생성과 metadata 검증 | PASS | PR #851 live-read | 없음 |
| CG-14 | exact-head CI와 review | PASS | CI 18 pass/29 path-filter skip, 실패/대기 0; independent review P0=0/P1=0 | 없음 |
| CG-15 | merge-ready 보고 | PASS | exact head `1f6d7603672a32114590c2089e16fb663711d15e`, `OPEN`, `MERGEABLE` | fresh merge 승인 전 대기 |
| CG-16 | fresh merge 승인 | PENDING | 별도 승인 필요 | merge-ready 이후 승인 대기 |
| CG-17 | merge 실행 | PENDING | 승인 전 실행 금지 | 별도 세션/승인 |
| CG-18 | sync와 cleanup | PENDING | merge 전 실행 금지 | merge 후 검증 |
| C-07 | PR CI/review 완료 | PASS | exact-head CI와 independent review 수렴 | 없음 |
| C-08 | Type C merge-ready 보고 | PASS | PR #851 exact-head 상태와 미완료 merge gate 명시 | 없음 |
| C-09 | Type C closeout | PENDING | CG-16~18 의존 | fresh merge 승인 필요 |

Final status: PENDING (CG-16 fresh merge 승인)

Unchecked required items: CG-16, CG-17, CG-18, C-09
