### PR TITLE
fix(leader-exposed-jdbc): async 취소를 락 생명주기에 전파한다

### DIFF
--- a/docs/lessons/2026-08-31-issue-846-async-cancellation-lifecycle.md
+++ b/docs/lessons/2026-08-31-issue-846-async-cancellation-lifecycle.md
@@ -1,0 +1,24 @@
+# 반환 future의 취소는 내부 락 생명주기까지 연결해야 한다
+
+## 맥락
+
+Issue [#846](https://github.com/bluetape4k/bluetape4k-leader/issues/846)는 Exposed JDBC single async 경로가 dependent future를 그대로 반환해 호출자 취소를 획득 작업과 action future에 전달하지 못하는 문제를 다뤘다.
+
+## 놓친 가정과 근거
+
+`thenComposeAsync`로 만든 결과 future를 취소하면 upstream 작업도 함께 취소된다는 가정이 잘못됐다. 획득 대기, compose callback 직전, history 기록 직후, action 실행 중에 결과를 취소하는 회귀 테스트에서 action 또는 unlock이 남거나 취소가 내부 future에 전달되지 않았다.
+
+## 결정
+
+- 호출자에게 반환하는 `resultFuture`와 내부 `actionFuture`를 명시적으로 연결한다.
+- 획득 재시도와 action 경계마다 취소 상태를 확인한다.
+- terminal guard 하나가 watchdog, history, unlock, 결과 완료를 정확히 한 번만 처리한다.
+- 취소 history는 group async 경로와 같은 `FAILED` 계약을 사용한다.
+
+## 결과와 검증
+
+커밋 `7677a4f9`에서 취소 경계와 락 재획득을 검증했다. Exposed JDBC 전체 334개 테스트가 H2, PostgreSQL, MySQL에서 통과했고 `detekt`와 binary compatibility 검사도 통과했다.
+
+## 재발 방지
+
+새 async backend를 검토할 때 반환 future만 확인하지 않는다. acquisition, acquired-before-action, action, terminal cleanup 상태를 나누고 각 상태에서 caller cancellation을 주입해 내부 작업 취소와 exactly-once cleanup을 함께 검증한다. 이미 실행 중인 JDBC transaction의 강제 중단은 별도 driver 계약으로 취급한다.

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElector.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElector.kt
@@ -24,6 +24,8 @@ import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * `ExposedJdbcLeaderElector`는 Exposed database backend의 leader election, lock lease, ownership 확인을 담당합니다.
@@ -161,6 +163,7 @@ class ExposedJdbcLeaderElector private constructor(
      *
      * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
      */
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     override fun <T> runAsyncIfLeader(
         lockName: String,
         executor: Executor,
@@ -176,13 +179,29 @@ class ExposedJdbcLeaderElector private constructor(
             useDbTime = options.leaderOptions.useDbTime,
         )
 
-        return CompletableFuture
-            .supplyAsync({ lock.tryLock(options.leaderOptions.waitTime, options.leaderOptions.leaseTime) }, executor)
+        val resultFuture = CompletableFuture<T?>()
+        val actionFutureRef = AtomicReference<CompletableFuture<*>?>()
+        val pipelineFuture = CompletableFuture
+            .supplyAsync(
+                {
+                    lock.tryLock(options.leaderOptions.waitTime, options.leaderOptions.leaseTime) {
+                        resultFuture.isCancelled
+                    }
+                },
+                executor,
+            )
             .thenComposeAsync({ acquired ->
                 if (!acquired) {
                     log.debug { "리더 승격 실패 (비동기). lockName=$lockName" }
                     CompletableFuture.completedFuture(null)
                 } else {
+                    if (resultFuture.isCancelled) {
+                        lock.unlock()
+                        return@thenComposeAsync CompletableFuture.failedFuture<T?>(
+                            java.util.concurrent.CancellationException("runAsyncIfLeader result was cancelled"),
+                        )
+                    }
+
                     log.debug { "리더로 승격하여 비동기 작업을 수행합니다. lockName=$lockName" }
                     val startedAt = Instant.now()
                     val acquiredAtNanos = System.nanoTime()
@@ -208,36 +227,59 @@ class ExposedJdbcLeaderElector private constructor(
                     val effectiveKey: LeaderHistoryKey? =
                         key ?: record?.let { LeaderHistoryKey(lockName = lockName, token = lock.token) }
 
-                    val actionFuture = runCatching { action() }
-                        .getOrElse { e ->
+                    val terminal = AtomicBoolean()
+                    val finishAction: (Throwable?) -> Unit = { throwable ->
+                        if (terminal.compareAndSet(false, true)) {
                             watchdog.close()
                             val finishedAt = Instant.now()
                             val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
-                            effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, e) }
+                            when {
+                                throwable == null -> effectiveKey?.let {
+                                    historyRecorder?.recordCompleted(it, finishedAt, durationMs)
+                                }
+                                else -> effectiveKey?.let {
+                                    historyRecorder?.recordFailed(it, finishedAt, durationMs, throwable)
+                                }
+                            }
                             runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos) }
-                                .onFailure { ex -> log.warn(ex) { "락 해제 실패 (action 오류 경로). lockName=$lockName" } }
+                                .onSuccess { log.debug { "비동기 리더 권한을 반납했습니다. lockName=$lockName" } }
+                                .onFailure { e -> log.warn(e) { "비동기 락 해제 실패. lockName=$lockName" } }
+                        }
+                    }
+
+                    if (resultFuture.isCancelled) {
+                        val cancellation = java.util.concurrent.CancellationException(
+                            "runAsyncIfLeader result was cancelled before action",
+                        )
+                        finishAction(cancellation)
+                        return@thenComposeAsync CompletableFuture.failedFuture(cancellation)
+                    }
+
+                    val actionFuture = runCatching { action() }
+                        .getOrElse { e ->
+                            finishAction(e)
                             return@thenComposeAsync CompletableFuture.failedFuture(e)
                         }
 
-                    actionFuture.whenComplete { _, throwable ->
-                        watchdog.close()
-                        val finishedAt = Instant.now()
-                        val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
-                        when {
-                            throwable == null -> effectiveKey?.let {
-                                historyRecorder?.recordCompleted(it, finishedAt, durationMs)
-                            }
-                            throwable is java.util.concurrent.CancellationException -> { /* cancelled — no audit */ }
-                            throwable is CancellationException -> { /* cancelled — no audit */ }
-                            else -> effectiveKey?.let {
-                                historyRecorder?.recordFailed(it, finishedAt, durationMs, throwable)
-                            }
-                        }
-                        runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos) }
-                            .onSuccess { log.debug { "비동기 리더 권한을 반납했습니다. lockName=$lockName" } }
-                            .onFailure { e -> log.warn(e) { "비동기 락 해제 실패. lockName=$lockName" } }
+                    val terminalFuture = actionFuture.whenComplete { _, throwable ->
+                        finishAction(throwable)
                     }
+                    actionFutureRef.set(actionFuture)
+                    if (resultFuture.isCancelled) actionFuture.cancel(false)
+                    terminalFuture
                 }
             }, executor)
+
+        resultFuture.whenComplete { _, _ ->
+            if (resultFuture.isCancelled) actionFutureRef.get()?.cancel(false)
+        }
+        pipelineFuture.whenComplete { value, throwable ->
+            if (throwable == null) {
+                resultFuture.complete(value)
+            } else {
+                resultFuture.completeExceptionally(throwable)
+            }
+        }
+        return resultFuture
     }
 }

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElector.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElector.kt
@@ -163,7 +163,7 @@ class ExposedJdbcLeaderElector private constructor(
      *
      * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
      */
-    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    @Suppress("CyclomaticComplexMethod", "LongMethod", "TooGenericExceptionCaught")
     override fun <T> runAsyncIfLeader(
         lockName: String,
         executor: Executor,
@@ -195,56 +195,90 @@ class ExposedJdbcLeaderElector private constructor(
                     log.debug { "리더 승격 실패 (비동기). lockName=$lockName" }
                     CompletableFuture.completedFuture(null)
                 } else {
+                    val startedAt = Instant.now()
+                    val acquiredAtNanos = System.nanoTime()
+                    val terminal = AtomicBoolean()
+                    var watchdog: AutoCloseable = AutoCloseable { }
+                    var effectiveKey: LeaderHistoryKey? = null
+                    val finishAction: (Throwable?) -> Throwable? = { throwable ->
+                        if (!terminal.compareAndSet(false, true)) {
+                            null
+                        } else {
+                            var cleanupFailure: Throwable? = null
+
+                            runCatching { watchdog.close() }
+                                .onFailure { e ->
+                                    cleanupFailure = e
+                                    log.warn(e) { "비동기 watchdog 종료 실패. lockName=$lockName" }
+                                }
+
+                            runCatching {
+                                val finishedAt = Instant.now()
+                                val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
+                                when {
+                                    throwable == null -> effectiveKey?.let {
+                                        historyRecorder?.recordCompleted(it, finishedAt, durationMs)
+                                    }
+                                    else -> effectiveKey?.let {
+                                        historyRecorder?.recordFailed(it, finishedAt, durationMs, throwable)
+                                    }
+                                }
+                            }.onFailure { e ->
+                                cleanupFailure = cleanupFailure?.also { it.addSuppressed(e) } ?: e
+                                log.warn(e) { "비동기 history 기록 실패. lockName=$lockName" }
+                            }
+
+                            runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos) }
+                                .onSuccess { log.debug { "비동기 리더 권한을 반납했습니다. lockName=$lockName" } }
+                                .onFailure { e ->
+                                    cleanupFailure = cleanupFailure?.also { it.addSuppressed(e) } ?: e
+                                    log.warn(e) { "비동기 락 해제 실패. lockName=$lockName" }
+                                }
+
+                            if (throwable != null) {
+                                cleanupFailure?.let { throwable.addSuppressed(it) }
+                                null
+                            } else {
+                                cleanupFailure
+                            }
+                        }
+                    }
+
                     if (resultFuture.isCancelled) {
-                        lock.unlock()
-                        return@thenComposeAsync CompletableFuture.failedFuture<T?>(
-                            java.util.concurrent.CancellationException("runAsyncIfLeader result was cancelled"),
+                        val cancellation = java.util.concurrent.CancellationException(
+                            "runAsyncIfLeader result was cancelled",
                         )
+                        finishAction(cancellation)
+                        return@thenComposeAsync CompletableFuture.failedFuture(cancellation)
                     }
 
                     log.debug { "리더로 승격하여 비동기 작업을 수행합니다. lockName=$lockName" }
-                    val startedAt = Instant.now()
-                    val acquiredAtNanos = System.nanoTime()
                     val delegate = ExposedJdbcLockExtendDelegate(lock)
-                    val watchdog = LeaderLeaseAutoExtender.start(
-                        options.leaderOptions.autoExtend,
-                        options.leaderOptions.leaseTime,
-                        delegate,
-                        ERROR_CLASSIFIER,
-                    )
 
-                    val record = historyRecorder?.let {
-                        LeaderLockHistoryRecord(
-                            lockName = lockName,
-                            token = lock.token,
-                            kind = LockIdentity.AnnotationKind.SINGLE,
-                            acquiredAt = startedAt,
-                            lockedUntil = startedAt.plusMillis(options.leaderOptions.leaseTime.inWholeMilliseconds),
-                            nodeId = options.lockOwner,
+                    try {
+                        watchdog = LeaderLeaseAutoExtender.start(
+                            options.leaderOptions.autoExtend,
+                            options.leaderOptions.leaseTime,
+                            delegate,
+                            ERROR_CLASSIFIER,
                         )
-                    }
-                    val key = record?.let { historyRecorder.recordAcquired(it) }
-                    val effectiveKey: LeaderHistoryKey? =
-                        key ?: record?.let { LeaderHistoryKey(lockName = lockName, token = lock.token) }
-
-                    val terminal = AtomicBoolean()
-                    val finishAction: (Throwable?) -> Unit = { throwable ->
-                        if (terminal.compareAndSet(false, true)) {
-                            watchdog.close()
-                            val finishedAt = Instant.now()
-                            val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
-                            when {
-                                throwable == null -> effectiveKey?.let {
-                                    historyRecorder?.recordCompleted(it, finishedAt, durationMs)
-                                }
-                                else -> effectiveKey?.let {
-                                    historyRecorder?.recordFailed(it, finishedAt, durationMs, throwable)
-                                }
-                            }
-                            runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos) }
-                                .onSuccess { log.debug { "비동기 리더 권한을 반납했습니다. lockName=$lockName" } }
-                                .onFailure { e -> log.warn(e) { "비동기 락 해제 실패. lockName=$lockName" } }
+                        val record = historyRecorder?.let {
+                            LeaderLockHistoryRecord(
+                                lockName = lockName,
+                                token = lock.token,
+                                kind = LockIdentity.AnnotationKind.SINGLE,
+                                acquiredAt = startedAt,
+                                lockedUntil = startedAt.plusMillis(options.leaderOptions.leaseTime.inWholeMilliseconds),
+                                nodeId = options.lockOwner,
+                            )
                         }
+                        val fallbackKey = record?.let { LeaderHistoryKey(lockName = lockName, token = lock.token) }
+                        effectiveKey = fallbackKey
+                        val key = record?.let { historyRecorder.recordAcquired(it) }
+                        effectiveKey = key ?: fallbackKey
+                    } catch (e: Throwable) {
+                        finishAction(e)
+                        return@thenComposeAsync CompletableFuture.failedFuture(e)
                     }
 
                     if (resultFuture.isCancelled) {
@@ -262,7 +296,10 @@ class ExposedJdbcLeaderElector private constructor(
                         }
 
                     val terminalFuture = actionFuture.whenComplete { _, throwable ->
-                        finishAction(throwable)
+                        val cleanupFailure = finishAction(throwable)
+                        if (throwable == null && cleanupFailure != null) {
+                            throw cleanupFailure
+                        }
                     }
                     actionFutureRef.set(actionFuture)
                     if (resultFuture.isCancelled) actionFuture.cancel(false)

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcLock.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/lock/ExposedJdbcLock.kt
@@ -63,12 +63,23 @@ internal class ExposedJdbcLock internal constructor(
      */
     // The retry loop must distinguish cancellation, interruption, transient database errors,
     // and the sleep interruption path to preserve the blocking API contract.
-    @Suppress("ThrowsCount")
-    fun tryLock(waitTime: Duration, leaseTime: Duration): Boolean {
+    fun tryLock(waitTime: Duration, leaseTime: Duration): Boolean =
+        tryLock(waitTime, leaseTime) { false }
+
+    @Suppress("ThrowsCount", "ReturnCount")
+    internal fun tryLock(
+        waitTime: Duration,
+        leaseTime: Duration,
+        isCancelled: () -> Boolean,
+    ): Boolean {
         val deadline = MonotonicDeadline.fromNow(waitTime)
         var attempt = 0
 
         do {
+            if (isCancelled()) {
+                log.debug { "락 획득 취소: lockName=$lockName" }
+                return false
+            }
             val acquired = try {
                 tryAcquireOnce(leaseTime)
             } catch (e: CancellationException) {
@@ -84,6 +95,11 @@ internal class ExposedJdbcLock internal constructor(
             if (acquired) {
                 log.debug { "락 획득 성공: lockName=$lockName, token=${token.take(8)}" }
                 return true
+            }
+
+            if (isCancelled()) {
+                log.debug { "락 재시도 취소: lockName=$lockName" }
+                return false
             }
 
             val remaining = deadline.remainingMillisForSleep()

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElectionTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElectionTest.kt
@@ -33,6 +33,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import io.bluetape4k.assertions.assertFailsWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import java.time.Instant
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -468,6 +469,82 @@ class ExposedJdbcLeaderElectionTest: AbstractExposedJdbcLeaderTest() {
             recordAllowed.countDown()
             worker.shutdownNow()
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - recordAcquired 인터럽트 후 watchdog과 락을 정리한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val recorder = object : SafeLeaderHistoryRecorder(ExposedLeaderHistorySink(db)) {
+            override fun recordAcquired(record: LeaderLockHistoryRecord): LeaderHistoryKey? {
+                throw InterruptedException("acquire history interrupted")
+            }
+        }
+        val options = ExposedJdbcLeaderElectionOptions(
+            leaderOptions = LeaderElectionOptions(
+                waitTime = 100.milliseconds,
+                leaseTime = 30.seconds,
+                autoExtend = true,
+            ),
+        )
+        val election = ExposedJdbcLeaderElector(db, options, recorder)
+
+        val resultFuture = election.runAsyncIfLeader(lockName, VirtualThreadExecutor) {
+            CompletableFuture.completedFuture("실행되면 안 됨")
+        }
+
+        val failure = assertFailsWith<CompletionException> { resultFuture.join() }
+        failure.cause.shouldBeInstanceOf(InterruptedException::class)
+        ExposedJdbcLeaderElector(db, options).runIfLeader(lockName) { "복구 성공" } shouldBeEqualTo "복구 성공"
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - finishAction history 예외 후 원 결과와 락 정리를 보장한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val options = ExposedJdbcLeaderElectionOptions(
+            leaderOptions = LeaderElectionOptions(
+                waitTime = 100.milliseconds,
+                leaseTime = 30.seconds,
+                autoExtend = true,
+            ),
+        )
+        val actionFailure = IllegalStateException("action 실패")
+        val recorder = object : SafeLeaderHistoryRecorder(ExposedLeaderHistorySink(db)) {
+            override fun recordCompleted(key: LeaderHistoryKey, finishedAt: Instant, durationMs: Long) {
+                throw InterruptedException("completed history interrupted")
+            }
+
+            override fun recordFailed(
+                key: LeaderHistoryKey,
+                finishedAt: Instant,
+                durationMs: Long,
+                error: Throwable?,
+            ) {
+                throw InterruptedException("failed history interrupted")
+            }
+        }
+        val election = ExposedJdbcLeaderElector(db, options, recorder)
+
+        val completedLockName = randomName()
+        val completedFuture = election.runAsyncIfLeader(completedLockName, VirtualThreadExecutor) {
+            CompletableFuture.completedFuture("완료")
+        }
+        val completedFailure = assertFailsWith<CompletionException> { completedFuture.join() }
+        completedFailure.cause.shouldBeInstanceOf(InterruptedException::class)
+        ExposedJdbcLeaderElector(db, options).runIfLeader(completedLockName) { "완료 복구" } shouldBeEqualTo "완료 복구"
+
+        val failedLockName = randomName()
+        val failedFuture = election.runAsyncIfLeader<Int>(failedLockName, VirtualThreadExecutor) {
+            CompletableFuture.failedFuture(actionFailure)
+        }
+
+        val failedCompletion = assertFailsWith<CompletionException> { failedFuture.join() }
+        failedCompletion.cause shouldBeEqualTo actionFailure
+        ExposedJdbcLeaderElector(db, options).runIfLeader(failedLockName) { "실패 복구" } shouldBeEqualTo "실패 복구"
     }
 
     @ParameterizedTest

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElectionTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElectionTest.kt
@@ -11,6 +11,8 @@ import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.exposed.jdbc.history.ExposedLeaderHistorySink
 import io.bluetape4k.leader.exposed.jdbc.lock.ExposedJdbcLock
 import io.bluetape4k.leader.exposed.retry.RetryStrategy
+import io.bluetape4k.leader.history.LeaderHistoryKey
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
 import io.bluetape4k.leader.history.LeaderHistoryStatus
 import io.bluetape4k.leader.exposed.tables.LeaderLockHistoryTable
 import io.bluetape4k.leader.exposed.tables.LeaderLockTable
@@ -37,8 +39,10 @@ import kotlin.time.Duration.Companion.seconds
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.CancellationException as FutureCancellationException
 import java.util.concurrent.atomic.AtomicInteger
 
 class ExposedJdbcLeaderElectionTest: AbstractExposedJdbcLeaderTest() {
@@ -331,6 +335,200 @@ class ExposedJdbcLeaderElectionTest: AbstractExposedJdbcLeaderTest() {
         }.get(5, TimeUnit.SECONDS)
 
         result shouldBeEqualTo "async 성공"
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - 반환 future 취소 시 락 획득 대기를 중단한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val holder = ExposedJdbcLock(db, lockName, RetryStrategy.Fixed(10L))
+        holder.tryLock(Duration.ZERO, 30.seconds).shouldBeTrue()
+        val election = ExposedJdbcLeaderElector(
+            db,
+            ExposedJdbcLeaderElectionOptions(
+                leaderOptions = LeaderElectionOptions(
+                    waitTime = 10.seconds,
+                    leaseTime = 30.seconds,
+                ),
+                retryStrategy = RetryStrategy.Fixed(10L),
+            ),
+        )
+        val executor = Executors.newSingleThreadExecutor()
+        val actionInvocations = AtomicInteger()
+
+        try {
+            val resultFuture = election.runAsyncIfLeader(lockName, executor) {
+                actionInvocations.incrementAndGet()
+                CompletableFuture.completedFuture("실행되면 안 됨")
+            }
+
+            resultFuture.cancel(false).shouldBeTrue()
+            assertFailsWith<FutureCancellationException> { resultFuture.join() }
+            executor.submit { }.get(3, TimeUnit.SECONDS)
+            actionInvocations.get() shouldBeEqualTo 0
+        } finally {
+            executor.shutdownNow()
+            holder.unlock()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - 획득 후 composition callback 전에 취소되면 action 없이 락을 반납한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val election = ExposedJdbcLeaderElector(
+            db,
+            ExposedJdbcLeaderElectionOptions(
+                leaderOptions = LeaderElectionOptions(
+                    waitTime = 2.seconds,
+                    leaseTime = 30.seconds,
+                ),
+            ),
+        )
+        val worker = Executors.newSingleThreadExecutor()
+        val taskNumber = AtomicInteger()
+        val composeReady = CountDownLatch(1)
+        val composeAllowed = CountDownLatch(1)
+        val actionInvocations = AtomicInteger()
+        val executor = Executor { command ->
+            worker.execute {
+                if (taskNumber.incrementAndGet() == 2) {
+                    composeReady.countDown()
+                    check(composeAllowed.await(5, TimeUnit.SECONDS)) { "composition callback 대기 시간이 초과되었습니다." }
+                }
+                command.run()
+            }
+        }
+
+        try {
+            val resultFuture = election.runAsyncIfLeader(lockName, executor) {
+                actionInvocations.incrementAndGet()
+                CompletableFuture.completedFuture("실행되면 안 됨")
+            }
+
+            composeReady.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            resultFuture.cancel(false).shouldBeTrue()
+            composeAllowed.countDown()
+            assertFailsWith<FutureCancellationException> { resultFuture.join() }
+            worker.submit { }.get(3, TimeUnit.SECONDS)
+            actionInvocations.get() shouldBeEqualTo 0
+
+            election.runIfLeader(lockName) { "compose 경계 복구" } shouldBeEqualTo "compose 경계 복구"
+        } finally {
+            composeAllowed.countDown()
+            worker.shutdownNow()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - history 기록 중 취소되면 action 없이 FAILED 이력과 락 반납을 완료한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val recordStarted = CountDownLatch(1)
+        val recordAllowed = CountDownLatch(1)
+        val recorder = object : SafeLeaderHistoryRecorder(ExposedLeaderHistorySink(db)) {
+            override fun recordAcquired(record: LeaderLockHistoryRecord): LeaderHistoryKey? {
+                recordStarted.countDown()
+                check(recordAllowed.await(5, TimeUnit.SECONDS)) { "history 기록 대기 시간이 초과되었습니다." }
+                return super.recordAcquired(record)
+            }
+        }
+        val election = ExposedJdbcLeaderElector(db, historyRecorder = recorder)
+        val actionInvocations = AtomicInteger()
+        val worker = Executors.newSingleThreadExecutor()
+        val executor = Executor { command -> worker.execute(command) }
+
+        try {
+            val resultFuture = election.runAsyncIfLeader(lockName, executor) {
+                actionInvocations.incrementAndGet()
+                CompletableFuture.completedFuture("실행되면 안 됨")
+            }
+
+            recordStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            resultFuture.cancel(false).shouldBeTrue()
+            recordAllowed.countDown()
+            assertFailsWith<FutureCancellationException> { resultFuture.join() }
+            worker.submit { }.get(3, TimeUnit.SECONDS)
+            actionInvocations.get() shouldBeEqualTo 0
+
+            val history = transaction(db) {
+                LeaderLockHistoryTable.selectAll()
+                    .where { LeaderLockHistoryTable.lockName eq lockName }
+                    .single()
+            }
+            history[LeaderLockHistoryTable.status] shouldBeEqualTo LeaderHistoryStatus.FAILED.name
+            election.runIfLeader(lockName) { "history 경계 복구" } shouldBeEqualTo "history 경계 복구"
+        } finally {
+            recordAllowed.countDown()
+            worker.shutdownNow()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - action future 취소 후 FAILED 이력을 기록하고 락을 반환한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val recorder = SafeLeaderHistoryRecorder(ExposedLeaderHistorySink(db))
+        val election = ExposedJdbcLeaderElector(db, historyRecorder = recorder)
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>()
+
+        val resultFuture = election.runAsyncIfLeader(lockName, VirtualThreadExecutor) {
+            actionStarted.countDown()
+            actionFuture
+        }
+
+        actionStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        actionFuture.cancel(false).shouldBeTrue()
+
+        val thrown = assertFailsWith<CompletionException> { resultFuture.join() }
+        thrown.cause.shouldNotBeNull()
+        (thrown.cause is FutureCancellationException).shouldBeTrue()
+        val history = transaction(db) {
+            LeaderLockHistoryTable.selectAll()
+                .where { LeaderLockHistoryTable.lockName eq lockName }
+                .single()
+        }
+        history[LeaderLockHistoryTable.status] shouldBeEqualTo LeaderHistoryStatus.FAILED.name
+        election.runIfLeader(lockName) { "action 취소 후 복구" } shouldBeEqualTo "action 취소 후 복구"
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - 반환 future 취소를 action에 전파하고 FAILED 이력과 락 반환을 보장한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val recorder = SafeLeaderHistoryRecorder(ExposedLeaderHistorySink(db))
+        val election = ExposedJdbcLeaderElector(db, historyRecorder = recorder)
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>()
+
+        val resultFuture = election.runAsyncIfLeader(lockName, VirtualThreadExecutor) {
+            actionStarted.countDown()
+            actionFuture
+        }
+
+        actionStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        resultFuture.cancel(false).shouldBeTrue()
+        assertFailsWith<FutureCancellationException> { resultFuture.join() }
+        actionFuture.isCancelled.shouldBeTrue()
+
+        val history = transaction(db) {
+            LeaderLockHistoryTable.selectAll()
+                .where { LeaderLockHistoryTable.lockName eq lockName }
+                .single()
+        }
+        history[LeaderLockHistoryTable.status] shouldBeEqualTo LeaderHistoryStatus.FAILED.name
+        election.runIfLeader(lockName) { "반환 취소 후 복구" } shouldBeEqualTo "반환 취소 후 복구"
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Summary

Closes #846

Exposed JDBC single async 실행의 반환 future 취소를 lock acquisition, action, cleanup 전체 생명주기에 전파합니다.

## Background

milestone `1.0.0`의 Issue #846에서 dependent future 취소가 upstream `tryLock` 작업과 action future에 전달되지 않아 취소된 실행이 lease 만료까지 lock을 남길 수 있는 P1 결함을 확인했습니다.

## What This Solves

- 획득 대기부터 action 실행까지 caller cancellation을 내부 future에 전달합니다.
- watchdog, history, unlock, 결과 완료가 취소 경계에서도 정확히 한 번 실행되도록 보장합니다.

## Work Done

- `resultFuture`, `actionFutureRef`, terminal guard로 async lifecycle을 명시했습니다.
- 획득 재시도, 획득 직후, history 기록 직후, action 게시 직후에 취소 상태를 확인합니다.
- `recordAcquired`와 terminal history 예외가 발생해도 watchdog 중지와 unlock을 exactly-once 실행합니다.
- acquisition/action/result 취소와 lock 재획득을 deterministic 테스트로 고정했습니다.
- lesson: 반환 future와 내부 resource lifecycle을 함께 검증하는 규칙을 기록했습니다.

## Validation

- `./gradlew :bluetape4k-leader-exposed-jdbc:test`: PASS (`tests=340`, `failures=0`, `errors=0`, `skipped=0`; H2/PostgreSQL/MySQL)
- `./gradlew :bluetape4k-leader-exposed-jdbc:detekt`: PASS
- `./gradlew checkBinaryCompatibility`: PASS
- `git diff --check && git show --check HEAD`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 없음
- Review evidence: main-session exact diff review에서 action dispatch 직전 cancellation check를 추가하고 exactly-once cleanup을 재검증했습니다.
- Independent review: PASS (exact head `28be31f6fef1ca6136e943c8b5f6ccb229655abf`, P0=0/P1=0; history/unlock findings 폐쇄)
- Remaining risk: 이미 JVM에서 실행 중인 JDBC transaction을 driver 수준에서 강제 중단하지는 않습니다.

## Metadata

- Issue: #846, milestone `1.0.0`, assignee `debop`
- PR: #852, head `28be31f6fef1ca6136e943c8b5f6ccb229655abf`, milestone `1.0.0`, assignee `debop`
- CI: PASS (exact head에서 19 pass, 28 path-filter skip, 실패/대기 0)

## DoD Status

Required checks: 15/19; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-01 | 결함과 root cause 재현 | PASS | dependent future cancellation RED 테스트 | 없음 |
| C-02 | Issue 범위와 metadata 확인 | PASS | #846, `1.0.0`, `debop`, `bug/integration/test` | 없음 |
| C-03 | 회귀 테스트 RED 고정 | PASS | lifecycle 경계별 취소 테스트가 수정 전 실패 | 없음 |
| C-04 | 최소 수정 적용 | PASS | single JDBC async lifecycle과 lock retry callback | 없음 |
| C-05 | GREEN과 blast radius 검증 | PASS | JDBC 340개, detekt, ABI 통과 | 없음 |
| C-06 | 재사용 가능한 lesson 기록 | PASS | `docs/lessons/2026-08-31-issue-846-async-cancellation-lifecycle.md` | merge 후 canonical GNO index 갱신 |
| CG-10 | pre-PR proof 수렴 | PASS | P0=0, P1=0, exact local head | 없음 |
| CG-11 | PR delivery 권한 확인 | PASS | `bluetape4k/bluetape4k-leader`, `develop`, 승인된 head | 없음 |
| CG-12 | exact head push | PASS | local/remote `28be31f6fef1ca6136e943c8b5f6ccb229655abf` | 없음 |
| CG-12A | guidance refresh | PASS | user/workspace/repository `AGENTS.md`, Type C leaf, common gates, PR template, #846 재확인 | 없음 |
| CG-13 | PR 생성과 metadata 검증 | PASS | PR #852 live-read | 없음 |
| CG-14 | exact-head CI와 review | PASS | CI 19 pass/28 path-filter skip, 실패/대기 0; independent review P0=0/P1=0 | 없음 |
| CG-15 | merge-ready 보고 | PASS | exact head `28be31f6fef1ca6136e943c8b5f6ccb229655abf`, `OPEN`, `MERGEABLE` | fresh merge 승인 전 대기 |
| CG-16 | fresh merge 승인 | PENDING | 별도 승인 필요 | merge-ready 이후 승인 대기 |
| CG-17 | merge 실행 | PENDING | 승인 전 실행 금지 | 별도 세션/승인 |
| CG-18 | sync와 cleanup | PENDING | merge 전 실행 금지 | merge 후 검증 |
| C-07 | PR CI/review 완료 | PASS | exact-head CI와 independent review 수렴 | 없음 |
| C-08 | Type C merge-ready 보고 | PASS | PR #852 exact-head 상태와 미완료 merge gate 명시 | 없음 |
| C-09 | Type C closeout | PENDING | CG-16~18 의존 | fresh merge 승인 필요 |

Final status: PENDING (CG-16 fresh merge 승인)

Unchecked required items: CG-16, CG-17, CG-18, C-09
