### PR TITLE
fix(leader-core): 없는 후보의 refresh 부활을 막는다

### DIFF
--- a/docs/lessons/2026-08-31-issue-847-refresh-no-resurrection.md
+++ b/docs/lessons/2026-08-31-issue-847-refresh-no-resurrection.md
@@ -1,0 +1,24 @@
+# refresh는 등록이 아니라 존재하는 후보의 갱신이다
+
+## 맥락
+
+Issue [#847](https://github.com/bluetape4k/bluetape4k-leader/issues/847)는 네 strategic interface의 기본 `refreshCandidate`가 없는 후보를 다시 등록해 heartbeat가 zombie 후보를 부활시키는 문제를 확인했다.
+
+## 놓친 가정과 근거
+
+후보가 없을 때 전달받은 `info`를 등록해도 된다는 기본 구현의 가정이 `registerCandidate`와 `refreshCandidate`의 책임을 섞었다. blocking/suspend, single/group custom fixture 네 개가 missing 후보를 재등록하는 동작을 RED로 재현했다.
+
+## 결정
+
+- missing 또는 expired 후보의 refresh는 no-op으로 종료한다.
+- 존재하는 후보만 갱신하며 `registeredAt`, 실행 시각, 성공/실패 횟수를 보존한다.
+- metadata와 요청 TTL만 변경한다.
+- 구체 backend는 가능하면 원자적 refresh를 제공하고, 기본 구현은 semantic fallback으로 유지한다.
+
+## 결과와 검증
+
+커밋 `655c1253`에서 네 기본 구현과 custom fixture를 같은 계약으로 맞췄다. core 전체 1,000개 테스트와 `detekt`, binary compatibility 검사가 통과했다.
+
+## 재발 방지
+
+등록, refresh, heartbeat API를 검토할 때 missing 상태의 의미를 수용 기준에 명시한다. 기본 메서드와 backend override를 함께 비교하고, missing, expired, existing 상태에서 등록 여부와 상태 보존을 각각 테스트한다. list 후 register로 구현한 기본 경로는 원자성을 보장하지 않으므로 backend override의 동시성 계약을 별도로 검증한다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderElector.kt
@@ -35,12 +35,14 @@ interface StrategicLeaderElector {
      * `info.metadata`와 TTL만 갱신합니다.
      *
      * Redis와 Local 구현은 이 연산을 backend 원자 경계로 처리합니다. 다른 구현은
-     * 호환성을 위해 `listCandidates`와 `registerCandidate` 조합을 기본 동작으로
-     * 사용할 수 있으므로, 동시 결과 갱신이 필요하면 backend 원자 구현을 제공해야 합니다.
+     * 호환성을 위해 `listCandidates`와 `registerCandidate` 조합으로 기존 후보를
+     * 갱신할 수 있습니다. 후보가 조회되지 않으면 새로 등록하지 않고 no-op으로
+     * 종료하며, 최초 등록은 `registerCandidate`가 담당합니다. 동시 결과 갱신이
+     * 필요하면 backend 원자 구현을 제공해야 합니다.
      */
     fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO) {
         val current = listCandidates(lockName).firstOrNull { it.nodeId == info.nodeId }
-        registerCandidate(lockName, current?.copy(metadata = info.metadata) ?: info, ttl)
+        current?.let { registerCandidate(lockName, it.copy(metadata = info.metadata), ttl) }
     }
 
     /**

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/StrategicLeaderGroupElector.kt
@@ -26,12 +26,14 @@ interface StrategicLeaderGroupElector {
      * heartbeat용 후보 갱신입니다. 기존 결과 카운터와 실행 시각은 보존하고
      * `info.metadata`와 TTL만 갱신합니다.
      * Redis와 Local 구현은 이 연산을 backend 원자 경계로 처리합니다. 다른 구현은
-     * 호환성을 위해 `listCandidates`와 `registerCandidate` 조합을 기본 동작으로
-     * 사용할 수 있으므로, 동시 결과 갱신이 필요하면 backend 원자 구현을 제공해야 합니다.
+     * 호환성을 위해 `listCandidates`와 `registerCandidate` 조합으로 기존 후보를
+     * 갱신할 수 있습니다. 후보가 조회되지 않으면 새로 등록하지 않고 no-op으로
+     * 종료하며, 최초 등록은 `registerCandidate`가 담당합니다. 동시 결과 갱신이
+     * 필요하면 backend 원자 구현을 제공해야 합니다.
      */
     fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO) {
         val current = listCandidates(lockName).firstOrNull { it.nodeId == info.nodeId }
-        registerCandidate(lockName, current?.copy(metadata = info.metadata) ?: info, ttl)
+        current?.let { registerCandidate(lockName, it.copy(metadata = info.metadata), ttl) }
     }
 
     /** 후보를 등록 해제합니다. */

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderElector.kt
@@ -36,12 +36,14 @@ interface StrategicSuspendLeaderElector {
      * `info.metadata`와 TTL만 갱신합니다.
      *
      * Redis와 Local 구현은 이 연산을 backend 원자 경계로 처리합니다. 다른 구현은
-     * 호환성을 위해 `listCandidates`와 `registerCandidate` 조합을 기본 동작으로
-     * 사용할 수 있으므로, 동시 결과 갱신이 필요하면 backend 원자 구현을 제공해야 합니다.
+     * 호환성을 위해 `listCandidates`와 `registerCandidate` 조합으로 기존 후보를
+     * 갱신할 수 있습니다. 후보가 조회되지 않으면 새로 등록하지 않고 no-op으로
+     * 종료하며, 최초 등록은 `registerCandidate`가 담당합니다. 동시 결과 갱신이
+     * 필요하면 backend 원자 구현을 제공해야 합니다.
      */
     suspend fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO) {
         val current = listCandidates(lockName).firstOrNull { it.nodeId == info.nodeId }
-        registerCandidate(lockName, current?.copy(metadata = info.metadata) ?: info, ttl)
+        current?.let { registerCandidate(lockName, it.copy(metadata = info.metadata), ttl) }
     }
 
     /**

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/coroutines/StrategicSuspendLeaderGroupElector.kt
@@ -26,12 +26,14 @@ interface StrategicSuspendLeaderGroupElector {
      * heartbeat용 후보 갱신입니다. 기존 결과 카운터와 실행 시각은 보존하고
      * `info.metadata`와 TTL만 갱신합니다.
      * Redis와 Local 구현은 이 연산을 backend 원자 경계로 처리합니다. 다른 구현은
-     * 호환성을 위해 `listCandidates`와 `registerCandidate` 조합을 기본 동작으로
-     * 사용할 수 있으므로, 동시 결과 갱신이 필요하면 backend 원자 구현을 제공해야 합니다.
+     * 호환성을 위해 `listCandidates`와 `registerCandidate` 조합으로 기존 후보를
+     * 갱신할 수 있습니다. 후보가 조회되지 않으면 새로 등록하지 않고 no-op으로
+     * 종료하며, 최초 등록은 `registerCandidate`가 담당합니다. 동시 결과 갱신이
+     * 필요하면 backend 원자 구현을 제공해야 합니다.
      */
     suspend fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration = Duration.ZERO) {
         val current = listCandidates(lockName).firstOrNull { it.nodeId == info.nodeId }
-        registerCandidate(lockName, current?.copy(metadata = info.metadata) ?: info, ttl)
+        current?.let { registerCandidate(lockName, it.copy(metadata = info.metadata), ttl) }
     }
 
     /** 후보를 등록 해제합니다. */

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/StrategicRefreshCandidateDefaultTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/StrategicRefreshCandidateDefaultTest.kt
@@ -1,0 +1,374 @@
+package io.bluetape4k.leader
+
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.leader.coroutines.StrategicSuspendLeaderElector
+import io.bluetape4k.leader.coroutines.StrategicSuspendLeaderGroupElector
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.ElectionStrategy
+import io.bluetape4k.leader.strategy.GroupElectionStrategy
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+class StrategicRefreshCandidateDefaultTest {
+
+    @Test
+    fun `blocking single default refresh는 missing expired 후보를 부활시키지 않고 기존 상태를 보존한다`() {
+        val fixture = BlockingSingleFixture()
+        assertBlockingRefreshContract(
+            fixture = fixture,
+            register = { lockName, info, ttl -> fixture.registerCandidate(lockName, info, ttl) },
+            refresh = { lockName, info, ttl -> fixture.refreshCandidate(lockName, info, ttl) },
+            list = { lockName -> fixture.listCandidates(lockName) },
+        )
+    }
+
+    @Test
+    fun `blocking group default refresh는 missing expired 후보를 부활시키지 않고 기존 상태를 보존한다`() {
+        val fixture = BlockingGroupFixture()
+        assertBlockingRefreshContract(
+            fixture = fixture,
+            register = { lockName, info, ttl -> fixture.registerCandidate(lockName, info, ttl) },
+            refresh = { lockName, info, ttl -> fixture.refreshCandidate(lockName, info, ttl) },
+            list = { lockName -> fixture.listCandidates(lockName) },
+        )
+    }
+
+    @Test
+    fun `suspend single default refresh는 missing expired 후보를 부활시키지 않고 기존 상태를 보존한다`() = runTest {
+        val fixture = SuspendSingleFixture()
+        assertSuspendRefreshContract(
+            fixture = fixture,
+            register = { lockName, info, ttl -> fixture.registerCandidate(lockName, info, ttl) },
+            refresh = { lockName, info, ttl -> fixture.refreshCandidate(lockName, info, ttl) },
+            list = { lockName -> fixture.listCandidates(lockName) },
+        )
+    }
+
+    @Test
+    fun `suspend group default refresh는 missing expired 후보를 부활시키지 않고 기존 상태를 보존한다`() = runTest {
+        val fixture = SuspendGroupFixture()
+        assertSuspendRefreshContract(
+            fixture = fixture,
+            register = { lockName, info, ttl -> fixture.registerCandidate(lockName, info, ttl) },
+            refresh = { lockName, info, ttl -> fixture.refreshCandidate(lockName, info, ttl) },
+            list = { lockName -> fixture.listCandidates(lockName) },
+        )
+    }
+
+    private fun assertBlockingRefreshContract(
+        fixture: BlockingFixture,
+        register: (String, CandidateInfo, Duration) -> Unit,
+        refresh: (String, CandidateInfo, Duration) -> Unit,
+        list: (String) -> List<CandidateInfo>,
+    ) {
+        refresh(
+            MISSING_LOCK,
+            CandidateInfo("missing", metadata = mapOf("heartbeat" to "missing")),
+            REFRESH_TTL,
+        )
+        list(MISSING_LOCK).shouldBeEmpty()
+        fixture.registrationCount shouldBeEqualTo 0
+
+        register(EXPIRED_LOCK, CandidateInfo("expired"), INITIAL_TTL)
+        fixture.expireCandidate(EXPIRED_LOCK, "expired")
+        list(EXPIRED_LOCK).shouldBeEmpty()
+        val registrationsBeforeRefresh = fixture.registrationCount
+
+        refresh(
+            EXPIRED_LOCK,
+            CandidateInfo("expired", metadata = mapOf("heartbeat" to "expired")),
+            REFRESH_TTL,
+        )
+
+        list(EXPIRED_LOCK).shouldBeEmpty()
+        fixture.registrationCount shouldBeEqualTo registrationsBeforeRefresh
+
+        val original = candidateInfo(fixture.nodeId)
+        register(PRESERVE_LOCK, original, INITIAL_TTL)
+
+        refresh(
+            PRESERVE_LOCK,
+            CandidateInfo(fixture.nodeId, metadata = NEW_METADATA),
+            REFRESH_TTL,
+        )
+
+        val refreshed = list(PRESERVE_LOCK).single()
+        refreshed.registeredAt shouldBeEqualTo original.registeredAt
+        refreshed.lastStartTime shouldBeEqualTo original.lastStartTime
+        refreshed.lastCompletionTime shouldBeEqualTo original.lastCompletionTime
+        refreshed.successCount shouldBeEqualTo original.successCount
+        refreshed.failureCount shouldBeEqualTo original.failureCount
+        refreshed.metadata shouldBeEqualTo NEW_METADATA
+        fixture.ttlFor(PRESERVE_LOCK, fixture.nodeId) shouldBeEqualTo REFRESH_TTL
+    }
+
+    private suspend fun assertSuspendRefreshContract(
+        fixture: SuspendFixture,
+        register: suspend (String, CandidateInfo, Duration) -> Unit,
+        refresh: suspend (String, CandidateInfo, Duration) -> Unit,
+        list: suspend (String) -> List<CandidateInfo>,
+    ) {
+        refresh(
+            MISSING_LOCK,
+            CandidateInfo("missing", metadata = mapOf("heartbeat" to "missing")),
+            REFRESH_TTL,
+        )
+        list(MISSING_LOCK).shouldBeEmpty()
+        fixture.registrationCount shouldBeEqualTo 0
+
+        register(EXPIRED_LOCK, CandidateInfo("expired"), INITIAL_TTL)
+        fixture.expireCandidate(EXPIRED_LOCK, "expired")
+        list(EXPIRED_LOCK).shouldBeEmpty()
+        val registrationsBeforeRefresh = fixture.registrationCount
+
+        refresh(
+            EXPIRED_LOCK,
+            CandidateInfo("expired", metadata = mapOf("heartbeat" to "expired")),
+            REFRESH_TTL,
+        )
+
+        list(EXPIRED_LOCK).shouldBeEmpty()
+        fixture.registrationCount shouldBeEqualTo registrationsBeforeRefresh
+
+        val original = candidateInfo(fixture.nodeId)
+        register(PRESERVE_LOCK, original, INITIAL_TTL)
+
+        refresh(
+            PRESERVE_LOCK,
+            CandidateInfo(fixture.nodeId, metadata = NEW_METADATA),
+            REFRESH_TTL,
+        )
+
+        val refreshed = list(PRESERVE_LOCK).single()
+        refreshed.registeredAt shouldBeEqualTo original.registeredAt
+        refreshed.lastStartTime shouldBeEqualTo original.lastStartTime
+        refreshed.lastCompletionTime shouldBeEqualTo original.lastCompletionTime
+        refreshed.successCount shouldBeEqualTo original.successCount
+        refreshed.failureCount shouldBeEqualTo original.failureCount
+        refreshed.metadata shouldBeEqualTo NEW_METADATA
+        fixture.ttlFor(PRESERVE_LOCK, fixture.nodeId) shouldBeEqualTo REFRESH_TTL
+    }
+
+    private fun candidateInfo(nodeId: String) = CandidateInfo(
+        nodeId = nodeId,
+        registeredAt = Instant.parse("2026-01-01T00:00:00Z"),
+        lastStartTime = Instant.parse("2026-01-01T00:01:00Z"),
+        lastCompletionTime = Instant.parse("2026-01-01T00:02:00Z"),
+        successCount = 7,
+        failureCount = 2,
+        metadata = mapOf("version" to "old"),
+    )
+
+    private interface FixtureState {
+        val nodeId: String
+        val registrationCount: Int
+
+        fun expireCandidate(lockName: String, nodeId: String)
+
+        fun ttlFor(lockName: String, nodeId: String): Duration?
+    }
+
+    private interface BlockingFixture : FixtureState
+
+    private interface SuspendFixture : FixtureState
+
+    private abstract class BlockingSingleFixtureBase : StrategicLeaderElector, BlockingFixture {
+        private val store = CandidateStore()
+
+        override val nodeId: String = "fixture-node"
+        override val registrationCount: Int get() = store.registrationCount
+
+        override fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+            store.register(lockName, info, ttl)
+        }
+
+        override fun unregisterCandidate(lockName: String, nodeId: String) {
+            store.unregister(lockName, nodeId)
+        }
+
+        override fun listCandidates(lockName: String): List<CandidateInfo> = store.list(lockName)
+
+        override fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
+            store.updateResult(lockName, nodeId, result)
+        }
+
+        override fun <T> runIfLeader(
+            lockName: String,
+            strategy: ElectionStrategy,
+            options: LeaderElectionOptions,
+            action: () -> T,
+        ): T? = error("runIfLeader is not used by this fixture")
+
+        override fun expireCandidate(lockName: String, nodeId: String) {
+            store.expire(lockName, nodeId)
+        }
+
+        override fun ttlFor(lockName: String, nodeId: String): Duration? = store.ttl(lockName, nodeId)
+    }
+
+    private class BlockingSingleFixture : BlockingSingleFixtureBase()
+
+    private abstract class BlockingGroupFixtureBase : StrategicLeaderGroupElector, BlockingFixture {
+        private val store = CandidateStore()
+
+        override val nodeId: String = "fixture-node"
+        override val registrationCount: Int get() = store.registrationCount
+
+        override fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+            store.register(lockName, info, ttl)
+        }
+
+        override fun unregisterCandidate(lockName: String, nodeId: String) {
+            store.unregister(lockName, nodeId)
+        }
+
+        override fun listCandidates(lockName: String): List<CandidateInfo> = store.list(lockName)
+
+        override fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
+            store.updateResult(lockName, nodeId, result)
+        }
+
+        override fun <T> runIfLeader(
+            lockName: String,
+            strategy: GroupElectionStrategy,
+            maxLeaders: Int,
+            action: () -> T,
+        ): T? = error("runIfLeader is not used by this fixture")
+
+        override fun expireCandidate(lockName: String, nodeId: String) {
+            store.expire(lockName, nodeId)
+        }
+
+        override fun ttlFor(lockName: String, nodeId: String): Duration? = store.ttl(lockName, nodeId)
+    }
+
+    private class BlockingGroupFixture : BlockingGroupFixtureBase()
+
+    private abstract class SuspendSingleFixtureBase : StrategicSuspendLeaderElector, SuspendFixture {
+        private val store = CandidateStore()
+
+        override val nodeId: String = "fixture-node"
+        override val registrationCount: Int get() = store.registrationCount
+
+        override suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+            store.register(lockName, info, ttl)
+        }
+
+        override suspend fun unregisterCandidate(lockName: String, nodeId: String) {
+            store.unregister(lockName, nodeId)
+        }
+
+        override suspend fun listCandidates(lockName: String): List<CandidateInfo> = store.list(lockName)
+
+        override suspend fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
+            store.updateResult(lockName, nodeId, result)
+        }
+
+        override suspend fun <T> runIfLeader(
+            lockName: String,
+            strategy: ElectionStrategy,
+            options: LeaderElectionOptions,
+            action: suspend () -> T,
+        ): T? = error("runIfLeader is not used by this fixture")
+
+        override fun expireCandidate(lockName: String, nodeId: String) {
+            store.expire(lockName, nodeId)
+        }
+
+        override fun ttlFor(lockName: String, nodeId: String): Duration? = store.ttl(lockName, nodeId)
+    }
+
+    private class SuspendSingleFixture : SuspendSingleFixtureBase()
+
+    private abstract class SuspendGroupFixtureBase : StrategicSuspendLeaderGroupElector, SuspendFixture {
+        private val store = CandidateStore()
+
+        override val nodeId: String = "fixture-node"
+        override val registrationCount: Int get() = store.registrationCount
+
+        override suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
+            store.register(lockName, info, ttl)
+        }
+
+        override suspend fun unregisterCandidate(lockName: String, nodeId: String) {
+            store.unregister(lockName, nodeId)
+        }
+
+        override suspend fun listCandidates(lockName: String): List<CandidateInfo> = store.list(lockName)
+
+        override suspend fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
+            store.updateResult(lockName, nodeId, result)
+        }
+
+        override suspend fun <T> runIfLeader(
+            lockName: String,
+            strategy: GroupElectionStrategy,
+            maxLeaders: Int,
+            action: suspend () -> T,
+        ): T? = error("runIfLeader is not used by this fixture")
+
+        override fun expireCandidate(lockName: String, nodeId: String) {
+            store.expire(lockName, nodeId)
+        }
+
+        override fun ttlFor(lockName: String, nodeId: String): Duration? = store.ttl(lockName, nodeId)
+    }
+
+    private class SuspendGroupFixture : SuspendGroupFixtureBase()
+
+    private class CandidateStore {
+        private val entries = mutableMapOf<CandidateKey, CandidateEntry>()
+        var registrationCount: Int = 0
+            private set
+
+        fun register(lockName: String, info: CandidateInfo, ttl: Duration) {
+            entries[CandidateKey(lockName, info.nodeId)] = CandidateEntry(info, ttl)
+            registrationCount += 1
+        }
+
+        fun unregister(lockName: String, nodeId: String) {
+            entries.remove(CandidateKey(lockName, nodeId))
+        }
+
+        fun list(lockName: String): List<CandidateInfo> = entries
+            .filterKeys { it.lockName == lockName }
+            .values
+            .filterNot { it.expired }
+            .map { it.info }
+
+        fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
+            entries[CandidateKey(lockName, nodeId)]?.let { entry ->
+                entry.info = entry.info.withResult(result)
+            }
+        }
+
+        fun expire(lockName: String, nodeId: String) {
+            entries[CandidateKey(lockName, nodeId)]?.expired = true
+        }
+
+        fun ttl(lockName: String, nodeId: String): Duration? =
+            entries[CandidateKey(lockName, nodeId)]?.ttl
+    }
+
+    private data class CandidateKey(val lockName: String, val nodeId: String)
+
+    private data class CandidateEntry(
+        var info: CandidateInfo,
+        val ttl: Duration,
+        var expired: Boolean = false,
+    )
+
+    private companion object {
+        const val MISSING_LOCK = "strategic-refresh-missing"
+        const val EXPIRED_LOCK = "strategic-refresh-expired"
+        const val PRESERVE_LOCK = "strategic-refresh-preserve"
+        val INITIAL_TTL = 30.seconds
+        val REFRESH_TTL = 60.seconds
+        val NEW_METADATA = mapOf("version" to "new")
+    }
+}


### PR DESCRIPTION
## Summary

Closes #847

strategic interface의 기본 `refreshCandidate`가 없는 후보를 다시 등록하지 않도록 no-op 계약을 복원합니다.

## Background

milestone `1.0.0`의 Issue #847에서 네 기본 구현이 missing/expired 후보를 `info`로 재등록해 heartbeat가 zombie 후보를 부활시키는 P1 결함을 확인했습니다. 최초 등록은 `registerCandidate`가 담당해야 합니다.

## What This Solves

- missing 또는 expired 후보의 heartbeat가 후보를 다시 등록하지 못하게 합니다.
- 기존 후보를 갱신할 때 등록 시각과 실행 결과 카운터를 보존합니다.

## Work Done

- blocking/suspend, single/group 기본 `refreshCandidate`를 missing no-op으로 통일했습니다.
- existing 후보에서는 metadata와 요청 TTL만 변경합니다.
- 네 custom fixture로 missing과 상태 보존 계약을 검증합니다.
- lesson: 등록과 refresh 책임 및 상태별 검증 규칙을 기록했습니다.

## Validation

- `./gradlew :bluetape4k-leader-core:test`: PASS (`tests=1000`, `failures=0`, `errors=0`, `skipped=0`)
- `./gradlew :bluetape4k-leader-core:detekt`: PASS
- `./gradlew checkBinaryCompatibility`: PASS
- `git diff --check && git show --check HEAD`: PASS

## Review Notes

- P0/P1: 0
- P2/P3: 없음
- Review evidence: main-session exact diff review에서 missing no-op과 `registeredAt`/실행 카운터 보존을 확인했습니다.
- Independent review: PASS (exact head `70d9fcd42bb14c09105480c46ea6062448a29e97`, P0=0/P1=0)
- Remaining risk: 기본 list 후 register 경로는 원자적이지 않으며 외부 custom backend의 자체 동시성 구현은 별도 검증 대상입니다.

## Metadata

- Issue: #847, milestone `1.0.0`, assignee `debop`
- PR: #853, head `70d9fcd42bb14c09105480c46ea6062448a29e97`, milestone `1.0.0`, assignee `debop`
- CI: PASS (exact head에서 47 pass, 실패/대기/skip 0)

## DoD Status

Required checks: 15/19; N/A: 0; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-01 | 결함과 root cause 재현 | PASS | 네 기본 구현의 resurrection RED 테스트 | 없음 |
| C-02 | Issue 범위와 metadata 확인 | PASS | #847, `1.0.0`, `debop`, `bug/test` | 없음 |
| C-03 | 회귀 테스트 RED 고정 | PASS | blocking/suspend single/group fixture가 수정 전 실패 | 없음 |
| C-04 | 최소 수정 적용 | PASS | 네 public interface 기본 메서드와 KDoc | 없음 |
| C-05 | GREEN과 blast radius 검증 | PASS | core 1,000개, detekt, ABI 통과 | 없음 |
| C-06 | 재사용 가능한 lesson 기록 | PASS | `docs/lessons/2026-08-31-issue-847-refresh-no-resurrection.md` | merge 후 canonical GNO index 갱신 |
| CG-10 | pre-PR proof 수렴 | PASS | P0=0, P1=0, exact local head | 없음 |
| CG-11 | PR delivery 권한 확인 | PASS | `bluetape4k/bluetape4k-leader`, `develop`, 승인된 head | 없음 |
| CG-12 | exact head push | PASS | local/remote `70d9fcd42bb14c09105480c46ea6062448a29e97` | 없음 |
| CG-12A | guidance refresh | PASS | user/workspace/repository `AGENTS.md`, Type C leaf, common gates, PR template, #847 재확인 | 없음 |
| CG-13 | PR 생성과 metadata 검증 | PASS | PR #853 live-read | 없음 |
| CG-14 | exact-head CI와 review | PASS | CI 47 pass, 실패/대기/skip 0; independent review P0=0/P1=0 | 없음 |
| CG-15 | merge-ready 보고 | PASS | exact head `70d9fcd42bb14c09105480c46ea6062448a29e97`, `OPEN`, `MERGEABLE` | fresh merge 승인 전 대기 |
| CG-16 | fresh merge 승인 | PENDING | 별도 승인 필요 | merge-ready 이후 승인 대기 |
| CG-17 | merge 실행 | PENDING | 승인 전 실행 금지 | 별도 세션/승인 |
| CG-18 | sync와 cleanup | PENDING | merge 전 실행 금지 | merge 후 검증 |
| C-07 | PR CI/review 완료 | PASS | exact-head CI와 independent review 수렴 | 없음 |
| C-08 | Type C merge-ready 보고 | PASS | PR #853 exact-head 상태와 미완료 merge gate 명시 | 없음 |
| C-09 | Type C closeout | PENDING | CG-16~18 의존 | fresh merge 승인 필요 |

Final status: PENDING (CG-16 fresh merge 승인)

Unchecked required items: CG-16, CG-17, CG-18, C-09
