### PR TITLE
1.0.0 정식 배포 경계를 준비한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ env:
   JAVA_VERSION: '25'
   JAVA_DISTRIBUTION: 'temurin'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-  BLUETAPE4K_DEPENDENCIES_CATALOG_REF: '91f9ea9336b5ea991f5675323a1cf25ccfd6f5ed'
+  BLUETAPE4K_DEPENDENCIES_CATALOG_REF: '8efed120b91c4e1b1cfbfe1269321df325b08aef'
 
 jobs:
   # ── 0. 시크릿 스캔 ────────────────────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ## [미공개]
 
+## [1.0.0] — 2026-09-02
+
 ### 추가
 
 - `LeaderBackendDiagnosticsProbe` 공통 계약과 `UNKNOWN` 원인(`CLIENT_STATE_UNCONFIRMED`, `PROVIDER_UNSUPPORTED`, `PROVIDER_EXCEPTION`)을 built-in backend, Ktor, Spring, Micrometer 경로에 연결했습니다([Issue #766](https://github.com/bluetape4k/bluetape4k-leader/issues/766), [PR #812](https://github.com/bluetape4k/bluetape4k-leader/pull/812), [PR #813](https://github.com/bluetape4k/bluetape4k-leader/pull/813), [PR #814](https://github.com/bluetape4k/bluetape4k-leader/pull/814), [PR #816](https://github.com/bluetape4k/bluetape4k-leader/pull/816), [PR #819](https://github.com/bluetape4k/bluetape4k-leader/pull/819), [PR #820](https://github.com/bluetape4k/bluetape4k-leader/pull/820)).
@@ -15,7 +17,9 @@
 
 ### 변경
 
-- Kotlin 2.4, JDK 25, Gradle 9.7 기준의 `1.0.0-SNAPSHOT` 개발선을 유지하고, 공개 README의 `0.5.0` stable·`1.0.0-SNAPSHOT` development·manual pin 경계를 정렬했습니다([Issue #666](https://github.com/bluetape4k/bluetape4k-leader/issues/666), [Issue #753](https://github.com/bluetape4k/bluetape4k-leader/issues/753), [PR #838](https://github.com/bluetape4k/bluetape4k-leader/pull/838)).
+- Kotlin 2.4, JDK 25, Gradle 9.7 기준의 1.0.0 개발선을 완료하고, 중앙 catalog ref를
+  `8efed120b91c4e1b1cfbfe1269321df325b08aef`로 고정해 Projects/Exposed 안정
+  버전을 사용하는 배포 경계를 확정했습니다([Issue #666](https://github.com/bluetape4k/bluetape4k-leader/issues/666), [Issue #753](https://github.com/bluetape4k/bluetape4k-leader/issues/753), [Issue #860](https://github.com/bluetape4k/bluetape4k-leader/issues/860), [PR #838](https://github.com/bluetape4k/bluetape4k-leader/pull/838)).
 - `UNKNOWN` reason, active probe, Micrometer counter, Spring health, Ktor route, Prometheus alert/runbook을 운영 해석이 가능한 bounded contract로 연결했습니다([PR #819](https://github.com/bluetape4k/bluetape4k-leader/pull/819), [PR #820](https://github.com/bluetape4k/bluetape4k-leader/pull/820), [PR #822](https://github.com/bluetape4k/bluetape4k-leader/pull/822), [PR #823](https://github.com/bluetape4k/bluetape4k-leader/pull/823)).
 - Spring lease-extension 관측 범위를 `ObservationRegistry` identity별 execution scope로 격리해 여러 application context의 telemetry가 섞이지 않도록 했습니다([PR #835](https://github.com/bluetape4k/bluetape4k-leader/pull/835)).
 

--- a/WIP.md
+++ b/WIP.md
@@ -1,17 +1,15 @@
 # WIP - bluetape4k-leader
 
-기준일: 2026-08-30 KST. 이 문서는 [PR #841](https://github.com/bluetape4k/bluetape4k-leader/pull/841)의
-merge commit `e46216f5e2a4bcd8103310d1493245f9f3e2e7c7` 직후 확인한
-`develop` 상태를 기록하며, Prometheus scrape readiness 테스트의 간헐 timeout과
-실행 순서 의존성을 다룬 [PR #840](https://github.com/bluetape4k/bluetape4k-leader/pull/840)이
-병합되었습니다. `0.5.0`은 tag, GitHub Release, Maven Central publication이
-완료된 안정 릴리스이고, `1.0.0-SNAPSHOT`은 아직 배포하지 않은 개발선입니다.
-이 문서는 기준일의 GitHub 상태와 release-pinned manual의 범위를 분리해 기록합니다.
+기준일: 2026-09-02 KST. `0.5.0`은 tag, GitHub Release, Maven Central publication이
+완료된 최신 안정 릴리스이며, 현재 `develop`은 1.0.0 release-prep #860을 수행합니다.
+중앙 catalog는 Projects/Exposed 안정 버전이 승격된 immutable SHA
+`8efed120b91c4e1b1cfbfe1269321df325b08aef`를 사용합니다. release-pinned manual은
+1.0.0 배포 이후 #774에서 별도로 승격합니다.
 
 ## 현재 방향
 
-`1.0.0` milestone은 open 상태지만 열린 이슈 0개, 닫힌 이슈 190개입니다.
-현재 열린 PR도 0개입니다. `1.0.0-post` milestone의 유일한 열린
+`1.0.0` milestone은 open 상태이며 release-prep #860 한 건이 열려 있고 200건이
+닫혔습니다. PR 생성 전 열린 PR은 0개입니다. `1.0.0-post` milestone의 유일한 열린
 이슈인 [#774](https://github.com/bluetape4k/bluetape4k-leader/issues/774)의
 observability 운영 정책·경보·runbook은 완료되었고, `1.0.0` release train 이후
 새 API를 포함한 versioned manual을 승격하는 작업만 남았습니다. 따라서 현재
@@ -42,6 +40,8 @@ Maven publication, versioned manual 승격은 별도 release 승인과 candidate
 - `docs/manual/manifest.yaml`은 `releaseRef: 0.5.0`과 위 release commit에
   고정되어 있습니다. 현재 `develop` 전용 diagnostics·observability 내용은
   `docs/manual/drafts/`에서 관리합니다.
+- 1.0.0 release-prep #860은 `baseVersion=1.0.0`, 빈 `snapshotVersion`, 중앙
+  catalog exact SHA `8efed120b91c4e1b1cfbfe1269321df325b08aef`를 사용합니다.
 - `1.0.0` tag/release/publication은 아직 없으며, `1.0.0-post`의 [#774](https://github.com/bluetape4k/bluetape4k-leader/issues/774)는
   새 API를 포함하는 versioned release train에서 manual pin을 갱신한 뒤 닫습니다.
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-        .orElse("91f9ea9336b5ea991f5675323a1cf25ccfd6f5ed")
+        .orElse("8efed120b91c4e1b1cfbfe1269321df325b08aef")
     .get()
 require(bluetape4kDependenciesCatalogRef.matches(Regex("[0-9a-f]{40}|[0-9a-f]{64}"))) {
     "bluetape4k-dependencies catalog ref must be an immutable Git commit SHA: " +


### PR DESCRIPTION
## 변경 내용

- 중앙 catalog ref를 `8efed120b91c4e1b1cfbfe1269321df325b08aef`로 고정해 Projects/Exposed 안정 버전을 사용합니다.
- CI 기본값과 저장소 변수도 같은 SHA로 통일합니다.
- `CHANGELOG.md`에 1.0.0 경계를 만들고 `WIP.md`의 release-prep 상태를 최신화합니다.
- 1.0.0 이후 manual 승격 #774는 기존 post-release 경계로 유지합니다.

Closes #860

## DoD Status

- [x] catalog ref·CI 기본값·저장소 변수를 exact SHA로 통일
- [x] CHANGELOG/WIP release boundary 갱신
- [x] #774 post-release 경계 유지
- [x] `git diff --check`
- [x] `actionlint`
- [x] `./gradlew help --no-daemon`
- [x] exact-head PR CI 성공 (run 33600086255)
- [x] merge exact-head Full Nightly 성공 (run 33602672509, SHA `e70146330302758f563a46b7286e3ce25f1bac49`)
- [x] 1.0.0 서명 태그·GitHub Release·Maven Central 공개 검증 (run 33604184809, BOM + 16 modules)