### PR TITLE
2.0.0 BOM catalog 기준을 정식 SHA로 전환한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ env:
   JAVA_VERSION: '25'
   JAVA_DISTRIBUTION: 'temurin'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-  BLUETAPE4K_DEPENDENCIES_CATALOG_REF: '8efed120b91c4e1b1cfbfe1269321df325b08aef'
+  BLUETAPE4K_DEPENDENCIES_CATALOG_REF: '3c203aa9f8ba80685aac766c5fb8f24e23d0058e'
 
 jobs:
   # ── 0. 시크릿 스캔 ────────────────────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,6 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           INPUT_CATALOG_REF: ${{ github.event.inputs.catalogRef || '' }}
-          REPOSITORY_CATALOG_REF: ${{ vars.BLUETAPE4K_DEPENDENCIES_CATALOG_REF || '' }}
         run: |
           set -euo pipefail
           DEFAULT_CATALOG_REF=$(sed -nE 's/^[[:space:]]*\.orElse\("([^"]+)"\).*/\1/p' settings.gradle.kts | head -1)
@@ -94,16 +93,14 @@ jobs:
           if [[ "$EVENT_NAME" == "workflow_dispatch" && -n "$INPUT_CATALOG_REF" ]]; then
             SELECTED_CATALOG_REF="$INPUT_CATALOG_REF"
             CATALOG_SOURCE="workflow_dispatch input catalogRef"
-          elif [[ "$EVENT_NAME" == "workflow_dispatch" && -n "$REPOSITORY_CATALOG_REF" ]]; then
-            SELECTED_CATALOG_REF="$REPOSITORY_CATALOG_REF"
-            CATALOG_SOURCE="repository variable BLUETAPE4K_DEPENDENCIES_CATALOG_REF"
           else
             SELECTED_CATALOG_REF="$DEFAULT_CATALOG_REF"
             CATALOG_SOURCE="checked-in settings.gradle.kts default"
           fi
 
-          if [[ "$EVENT_NAME" == "push" && -n "$REPOSITORY_CATALOG_REF" && "$REPOSITORY_CATALOG_REF" != "$DEFAULT_CATALOG_REF" ]]; then
-            echo "::notice::Ignoring repository catalog variable '$REPOSITORY_CATALOG_REF' for tag-triggered release. Using checked-in default '$DEFAULT_CATALOG_REF'."
+          if [[ ! "$SELECTED_CATALOG_REF" =~ ^([0-9a-f]{40}|[0-9a-f]{64})$ ]]; then
+            echo "::error::Catalog ref must be an immutable Git commit SHA: $SELECTED_CATALOG_REF"
+            exit 1
           fi
 
           echo "BLUETAPE4K_DEPENDENCIES_CATALOG_REF=$SELECTED_CATALOG_REF" >> "$GITHUB_ENV"
@@ -115,7 +112,6 @@ jobs:
           echo "catalogRef=$SELECTED_CATALOG_REF"
           echo "catalogSource=$CATALOG_SOURCE"
           echo "checkedInDefault=$DEFAULT_CATALOG_REF"
-          echo "repositoryVariable=${REPOSITORY_CATALOG_REF:-<unset>}"
 
       - name: Verify dependencies catalog aliases
         shell: bash

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,8 +2,6 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k = "2.0.0-SNAPSHOT"  # https://central.sonatype.com/artifact/io.github.bluetape4k/bluetape4k-bom
-bluetape4k-exposed = "2.0.0-SNAPSHOT"  # https://mvnrepository.com/artifact/io.github.bluetape4k.exposed/bluetape4k-exposed-bom
 
 kotlinx-benchmark = "0.4.17"  # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-benchmark-runtime
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-        .orElse("8efed120b91c4e1b1cfbfe1269321df325b08aef")
+        .orElse("3c203aa9f8ba80685aac766c5fb8f24e23d0058e")
     .get()
 require(bluetape4kDependenciesCatalogRef.matches(Regex("[0-9a-f]{40}|[0-9a-f]{64}"))) {
     "bluetape4k-dependencies catalog ref must be an immutable Git commit SHA: " +


### PR DESCRIPTION
## 배경

`bluetape4k-dependencies:2.0.0` 정식 배포가 완료되어 소비자 build catalog 기준을 검증된 immutable commit으로 전환합니다. release workflow의 repository variable 이중 관리를 제거하고 checked-in 기본값을 단일 기준으로 사용합니다.

## 변경

- `settings.gradle.kts`와 CI catalog ref를 `3c203aa9f8ba80685aac766c5fb8f24e23d0058e`로 고정
- release workflow는 수동 입력 또는 checked-in 기본값만 사용
- 사용되지 않는 local `2.0.0-SNAPSHOT` version alias 제거
- 적용 repo에서는 CodeQL build cache 중복을 비활성화

## 검증

- `actionlint` 통과
- `git diff --check` 통과
- `./gradlew help --no-daemon --no-configuration-cache --no-build-cache` 성공

관련: https://github.com/bluetape4k/bluetape4k-projects/issues/1451
관련: https://github.com/bluetape4k/bluetape4k-projects/issues/1605

## DoD Status

- [x] catalog SHA 단일화
- [x] 로컬 workflow/Gradle 검증
- [ ] exact-head PR CI 통과
- [ ] develop 병합