### PR TITLE
docs: Leader 1.0 안정 매뉴얼 경계를 반영한다

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@
 
 ### 변경
 
-- Kotlin 2.4, JDK 25, Gradle 9.7 기준의 1.0.0 개발선을 완료하고, 중앙 catalog ref를
-  `8efed120b91c4e1b1cfbfe1269321df325b08aef`로 고정해 Projects/Exposed 안정
-  버전을 사용하는 배포 경계를 확정했습니다([Issue #666](https://github.com/bluetape4k/bluetape4k-leader/issues/666), [Issue #753](https://github.com/bluetape4k/bluetape4k-leader/issues/753), [Issue #860](https://github.com/bluetape4k/bluetape4k-leader/issues/860), [PR #838](https://github.com/bluetape4k/bluetape4k-leader/pull/838)).
+- Kotlin 2.4, JDK 25, Gradle 9.7 기준의 1.0.0 개발선을 완료하고, 배포 후 중앙 catalog ref를
+  `3c203aa9f8ba80685aac766c5fb8f24e23d0058e`로 수렴해 전체 stable BOM 경계를
+  사용하도록 정리했습니다([Issue #666](https://github.com/bluetape4k/bluetape4k-leader/issues/666), [Issue #753](https://github.com/bluetape4k/bluetape4k-leader/issues/753), [Issue #860](https://github.com/bluetape4k/bluetape4k-leader/issues/860), [PR #838](https://github.com/bluetape4k/bluetape4k-leader/pull/838), [PR #862](https://github.com/bluetape4k/bluetape4k-leader/pull/862)).
 - `UNKNOWN` reason, active probe, Micrometer counter, Spring health, Ktor route, Prometheus alert/runbook을 운영 해석이 가능한 bounded contract로 연결했습니다([PR #819](https://github.com/bluetape4k/bluetape4k-leader/pull/819), [PR #820](https://github.com/bluetape4k/bluetape4k-leader/pull/820), [PR #822](https://github.com/bluetape4k/bluetape4k-leader/pull/822), [PR #823](https://github.com/bluetape4k/bluetape4k-leader/pull/823)).
 - Spring lease-extension 관측 범위를 `ObservationRegistry` identity별 execution scope로 격리해 여러 application context의 telemetry가 섞이지 않도록 했습니다([PR #835](https://github.com/bluetape4k/bluetape4k-leader/pull/835)).
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,9 +7,9 @@
 [![JVM](https://img.shields.io/badge/JVM-25-ED8B00?logo=openjdk)](https://openjdk.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-현재 안정 버전: `0.5.0`
+현재 안정 버전: `1.0.0`
 
-현재 개발 버전: `1.0.0-SNAPSHOT`
+현재 개발선: `develop`의 1.0.0 배포 후 유지보수
 
 ![bluetape4k 리더 선출 작업대 일러스트](./docs/assets/leader-election-workbench.png)
 
@@ -41,16 +41,14 @@ Spring Boot 4 자동 구성과 Ktor 3.x 통합을 1급으로 지원합니다.
 
 ## 매뉴얼
 
-[Leader 0.5.0 매뉴얼](https://bluetape4k.github.io/ko/manual/bluetape4k-leader/0.5/)은 안정판 동작을 설명하는 기준 문서입니다. 선출 모델과 백엔드 선택, 실행 결과와 취소 규칙, Spring Boot·Ktor 연동, 운영 방법, 17개 실행 예제를 따라가는 학습 경로를 함께 다룹니다. README는 빠른 안내만 맡고, 상세한 사용법은 `central manual`에서 관리합니다.
+[Leader 1.0.0 매뉴얼](https://bluetape4k.github.io/ko/manual/bluetape4k-leader/1.0/)은 안정판 동작을 설명하는 기준 문서입니다. 선출 모델과 백엔드 선택, 실행 결과와 취소 규칙, Spring Boot·Ktor 연동, 운영 방법, 실행 예제를 따라가는 학습 경로를 함께 다룹니다. README는 빠른 안내만 맡고, 상세한 사용법은 중앙 매뉴얼에서 관리합니다.
 
 ## 개발 상태
 
-`0.5.0`이 최신 안정 릴리스이며 `develop`은 아직 배포하지 않은
-`1.0.0-SNAPSHOT` 개발선을 추적합니다. [`WIP.md`](./WIP.md)에서 기준일의
-프로젝트 상태와 milestone·release 경계를 확인하고, [`CHANGELOG.md`](./CHANGELOG.md)에서
-미배포 변경을 확인하세요. 버전 매뉴얼은 `0.5.0` release commit에 계속
-고정되어 있으므로, 개발선 전용 diagnostics·observability 안내는 해당
-release train이 승격될 때까지 `central manual drafts/`에서 관리합니다.
+`1.0.0`이 최신 안정 릴리스이며 `develop`은 배포 후 유지보수를 추적합니다.
+[`WIP.md`](./WIP.md)에서 기준일의 프로젝트 상태와 release 경계를 확인하고,
+[`CHANGELOG.md`](./CHANGELOG.md)에서 배포 내역과 다음 변경을 확인하세요. 버전
+매뉴얼은 exact `1.0.0` release commit에 고정되어 있습니다.
 
 ## 벤치마크
 
@@ -154,13 +152,13 @@ Connectivity 결과에는 제한된 `LeaderBackendConnectivityReason` 값도 포
 않습니다. `UNKNOWN`은 dashboard와 warning 신호로만 사용하고 자동으로 `DOWN`이나
 page로 승격하지 마세요.
 
-운영 decision table과 timeout/bypass 런북은 [미배포 observability manual
-초안](https://github.com/bluetape4k/bluetape4k.github.io/blob/develop/docs/manual/bluetape4k-leader/drafts/2026-08-28-issue-774-observability.ko.md)에서 확인하세요.
+운영 decision table과 timeout/bypass 런북은 [backend connectivity 관측성
+가이드](https://bluetape4k.github.io/ko/manual/bluetape4k-leader/1.0/guides/backend-connectivity-observability/)에서 확인하세요.
 <!-- LEADER_BACKEND_DIAGNOSTICS:END -->
 
 `@LeaderGroupElection`은 scalar, suspend, `Mono` 결과를 지원하지만 slot별 stream lease extension이 정의되지 않아 `Flux`와 Kotlin `Flow`를 거부합니다. 길거나 무한에 가까운 단일 리더 stream에는 `@LeaderElection(autoExtend = true)`를 사용하세요.
 
-선택 기준은 [백엔드 선택](https://bluetape4k.github.io/ko/manual/bluetape4k-leader/0.5/guides/backend-selection/), [실행 모델 선택](https://bluetape4k.github.io/ko/manual/bluetape4k-leader/0.5/guides/execution-model-selection/), [lease 연장](https://bluetape4k.github.io/ko/manual/bluetape4k-leader/0.5/core/lease-extension/)을 참고하세요. 실행 경로는 [예제](#예제-examples)에서 확인할 수 있습니다.
+선택 기준은 [백엔드 선택](https://bluetape4k.github.io/ko/manual/bluetape4k-leader/1.0/guides/backend-selection/), [실행 모델 선택](https://bluetape4k.github.io/ko/manual/bluetape4k-leader/1.0/guides/execution-model-selection/), [lease 연장](https://bluetape4k.github.io/ko/manual/bluetape4k-leader/1.0/core/lease-extension/)을 참고하세요. 실행 경로는 [예제](#예제-examples)에서 확인할 수 있습니다.
 
 ## 예제 (Examples)
 
@@ -243,7 +241,7 @@ import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderGroupElector
 val options = ExposedJdbcLeaderGroupElectionOptions(
     leaderGroupOptions = LeaderGroupElectionOptions(
         maxLeaders = 3,
-        useDbTime = true, // 1.0.0+ develop: 그룹 소유권 판정에 DB server time 사용
+        useDbTime = true, // 그룹 소유권 판정에 DB server time 사용
     ),
 )
 val groupElection = ExposedJdbcLeaderGroupElector(db, options)
@@ -259,10 +257,10 @@ val result = groupElection.runIfLeader("parallel-batch") {
 DB time을 사용할 수 없으면 그룹 상태를 보수적으로 보고하고
 `runIfLeader`는 소유권을 주장하지 않고 건너뜁니다.
 
-이 옵션은 `1.0.0+` 개발선에서 제공됩니다. 버전 매뉴얼은 `0.5.0`
-release provenance에 계속 고정되어 있습니다.
+이 옵션은 `1.0.0`에 포함되었습니다. 버전 매뉴얼은 해당 release provenance에
+고정되어 있습니다.
 
-### Exposed R2DBC 그룹 (coroutine-native, 1.0.0+ develop)
+### Exposed R2DBC 그룹 (coroutine-native, 1.0.0+)
 
 ```kotlin
 import io.bluetape4k.leader.LeaderGroupElectionOptions
@@ -336,7 +334,7 @@ val election = RedissonLeaderElector(client, options)
 
 `minLeaseTime`은 ShedLock `lockAtLeastFor` 대응 옵션입니다. 로컬 elector는 release 전 대기하고, 지원되는 분산 backend는 남은 최소 lease를 storage TTL에 위임하므로 caller는 즉시 반환됩니다.
 
-`autoExtend` 의미는 백엔드마다 다릅니다. [백엔드 capability matrix](#백엔드-capability-matrix)와 [lease 연장 가이드](https://bluetape4k.github.io/ko/manual/bluetape4k-leader/0.5/core/lease-extension/)를 기준으로 확인하세요. `@LeaderGroupElection`은 auto-extension을 지원하지 않습니다.
+`autoExtend` 의미는 백엔드마다 다릅니다. [백엔드 capability matrix](#백엔드-capability-matrix)와 [lease 연장 가이드](https://bluetape4k.github.io/ko/manual/bluetape4k-leader/1.0/core/lease-extension/)를 기준으로 확인하세요. `@LeaderGroupElection`은 auto-extension을 지원하지 않습니다.
 
 ### 상태 기준 정보
 
@@ -702,9 +700,8 @@ contract를 새로 만들지 말고 이 core event stream을 adapter로 사용�
 
 ### Lease-extension 관찰
 
-> **미배포 API:** 이 절은 현재 `develop` 구현을 설명합니다. 이 README의 의존성 예제는 배포된 `0.5.0`을 대상으로
-> 하며, 같은 release에 고정한 매뉴얼에는 이 hook이 없습니다. 초안의 promotion gate가 끝날 때까지는 일치하는
-> `develop` 브랜치 또는 일치하는 미배포 빌드에서만 이 연동을 사용하세요.
+이 API는 `1.0.0`에 포함되었습니다. 전체 계약과 adapter 안내는 release에 고정된
+매뉴얼을 사용하세요.
 
 `LockExtender`와 `LeaderLeaseAutoExtender`는 같은 framework-neutral terminal event 계약을 발생시킵니다. lease
 extension 진단이 필요할 때만 observer를 등록하세요.
@@ -758,7 +755,7 @@ Callback 예외는 extension 결과를 바꾸지 않습니다. extension 경로�
 `LeaderLeaseExtensionContext.toString()`은 redaction하므로 애플리케이션도 raw `lockName`이나
 `auditLeaderId`를 로그에 남기지 않아야 합니다. Fail-open `NotHeld` event에는 `context`의 lock name이 남고
 `auditLeaderId = null`입니다. Scope 밖이나 named mismatch event의 `context`는 `null`입니다. 전체 계약과 Micrometer/Spring adapter는
-[미배포 lease-extension 관찰 초안](https://github.com/bluetape4k/bluetape4k.github.io/blob/develop/docs/manual/bluetape4k-leader/drafts/2026-08-27-issue-559-lease-extension-observation.ko.md)에서 확인할 수 있습니다.
+[lease 연장 가이드](https://bluetape4k.github.io/ko/manual/bluetape4k-leader/1.0/core/lease-extension/)에서 확인할 수 있습니다.
 
 ### HTTP/webhook sink로 audit export
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ English | [한국어](README.ko.md)
 [![JVM](https://img.shields.io/badge/JVM-25-ED8B00?logo=openjdk)](https://openjdk.org)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Current stable version: `0.5.0`
+Current stable version: `1.0.0`
 
-Current development line: `1.0.0-SNAPSHOT`
+Current development line: post-`1.0.0` maintenance on `develop`
 
 ![Bluetape4k leader election workbench](./docs/assets/leader-election-workbench.png)
 
@@ -42,16 +42,14 @@ Spring Boot 4 auto-configuration and Ktor 3.x integration are first-class.
 
 ## Manual
 
-The [Leader 0.5.0 manual](https://bluetape4k.github.io/manual/bluetape4k-leader/0.5/) is the source of truth for release behavior. It covers model and backend selection, result and cancellation semantics, Spring Boot and Ktor integration, operations, and a progressive path through all 17 runnable examples. README files remain concise entry points; detailed guidance belongs in `central manual`.
+The [Leader 1.0.0 manual](https://bluetape4k.github.io/manual/bluetape4k-leader/1.0/) is the source of truth for release behavior. It covers model and backend selection, result and cancellation semantics, Spring Boot and Ktor integration, operations, and a progressive path through all runnable examples. README files remain concise entry points; detailed guidance belongs in the central manual.
 
 ## Development status
 
-`0.5.0` is the latest stable release, while `develop` tracks the unreleased
-`1.0.0-SNAPSHOT` development line. [`WIP.md`](./WIP.md) records the dated
-project snapshot, milestone, and release boundary; [`CHANGELOG.md`](./CHANGELOG.md) lists the
-unreleased changes. The versioned manual remains pinned to the `0.5.0` release
-commit, so development-only diagnostics and observability guidance stays in
-`central manual drafts/` until the corresponding release train is promoted.
+`1.0.0` is the latest stable release, while `develop` tracks post-release
+maintenance. [`WIP.md`](./WIP.md) records the dated project snapshot and
+release boundary; [`CHANGELOG.md`](./CHANGELOG.md) lists released and upcoming
+changes. The versioned manual is pinned to the exact `1.0.0` release commit.
 
 ## Benchmarks
 
@@ -155,12 +153,12 @@ exported. `UNKNOWN` is a dashboard and warning signal, not an automatic
 `DOWN` or page condition.
 
 For the operational decision table and timeout/bypass runbook, see the
-[unreleased observability manual draft](https://github.com/bluetape4k/bluetape4k.github.io/blob/develop/docs/manual/bluetape4k-leader/drafts/2026-08-28-issue-774-observability.en.md).
+[backend connectivity observability guide](https://bluetape4k.github.io/manual/bluetape4k-leader/1.0/guides/backend-connectivity-observability/).
 <!-- LEADER_BACKEND_DIAGNOSTICS:END -->
 
 `@LeaderGroupElection` supports scalar, suspend, and `Mono` results, but rejects `Flux` and Kotlin `Flow` because per-slot stream lease extension is undefined. For long-running or unbounded single-leader streams, use `@LeaderElection(autoExtend = true)`.
 
-For selection guidance, see [backend selection](https://bluetape4k.github.io/manual/bluetape4k-leader/0.5/guides/backend-selection/), [execution model selection](https://bluetape4k.github.io/manual/bluetape4k-leader/0.5/guides/execution-model-selection/), and [lease extension](https://bluetape4k.github.io/manual/bluetape4k-leader/0.5/core/lease-extension/). The runnable paths are indexed in [Examples](#examples).
+For selection guidance, see [backend selection](https://bluetape4k.github.io/manual/bluetape4k-leader/1.0/guides/backend-selection/), [execution model selection](https://bluetape4k.github.io/manual/bluetape4k-leader/1.0/guides/execution-model-selection/), and [lease extension](https://bluetape4k.github.io/manual/bluetape4k-leader/1.0/core/lease-extension/). The runnable paths are indexed in [Examples](#examples).
 
 ## Examples
 
@@ -244,7 +242,7 @@ import io.bluetape4k.leader.exposed.jdbc.ExposedJdbcLeaderGroupElector
 val options = ExposedJdbcLeaderGroupElectionOptions(
     leaderGroupOptions = LeaderGroupElectionOptions(
         maxLeaders = 3,
-        useDbTime = true, // 1.0.0+ develop: use database server time for group ownership
+        useDbTime = true, // use database server time for group ownership
     ),
 )
 val groupElection = ExposedJdbcLeaderGroupElector(db, options)
@@ -260,10 +258,10 @@ transaction, so JVM clock skew does not change the lease boundary. It defaults
 to `false`; when database time is unavailable, group state is reported
 conservatively and `runIfLeader` skips rather than claiming ownership.
 
-The option is available on the `1.0.0+` development line. The versioned manual
-pages remain pinned to the `0.5.0` release provenance.
+The option is available in `1.0.0`. The versioned manual pages are pinned to
+that release provenance.
 
-### Exposed R2DBC group (coroutine-native, 1.0.0+ develop)
+### Exposed R2DBC group (coroutine-native, 1.0.0+)
 
 ```kotlin
 import io.bluetape4k.leader.LeaderGroupElectionOptions
@@ -337,7 +335,7 @@ val election = RedissonLeaderElector(client, options)
 
 `minLeaseTime` is the `lockAtLeastFor` equivalent. Local electors wait before releasing; supported distributed backends delegate the remaining minimum lease to storage TTL so callers can return immediately.
 
-`autoExtend` semantics vary by backend. Use the [backend capability matrix](#backend-capability-matrix) and [lease extension guide](https://bluetape4k.github.io/manual/bluetape4k-leader/0.5/core/lease-extension/) as the source of truth. `@LeaderGroupElection` does not support auto-extension.
+`autoExtend` semantics vary by backend. Use the [backend capability matrix](#backend-capability-matrix) and [lease extension guide](https://bluetape4k.github.io/manual/bluetape4k-leader/1.0/core/lease-extension/) as the source of truth. `@LeaderGroupElection` does not support auto-extension.
 
 ### State snapshots
 
@@ -701,9 +699,8 @@ introducing framework-specific event contracts.
 
 ### Lease-extension observation
 
-> **Unreleased API:** This section describes the current `develop` implementation. The dependency examples in this
-> README target released `0.5.0`, and the manual pinned to that release does not include this hook. Keep this integration on a
-> matching develop/snapshot build until the promotion gate in the draft is complete.
+This API is included in `1.0.0`; use the release-pinned manual for the complete
+contract and adapter guidance.
 
 `LockExtender` and `LeaderLeaseAutoExtender` publish the same framework-neutral terminal event contract. Register an
 observer only when the application needs lease-extension diagnostics:
@@ -756,8 +753,8 @@ Callback exceptions do not change the extension result. `CancellationException` 
 are not flattened into an outcome or published as events. `BackendError.cause` remains the original backend `Exception`;
 core does not redact it, so custom observers must sanitise the cause before logging or exporting. `LeaderLeaseExtensionContext.toString()` is redacted, so applications should still
 avoid logging raw `lockName` or `auditLeaderId`. A fail-open `NotHeld` event still carries its lock name in `context` with
-`auditLeaderId = null`; scope-free and named-mismatch events have `context = null`. The [unreleased lease-extension observation draft](https://github.com/bluetape4k/bluetape4k.github.io/blob/develop/docs/manual/bluetape4k-leader/drafts/2026-08-27-issue-559-lease-extension-observation.en.md)
-contains the complete contract and the Micrometer/Spring adapters.
+`auditLeaderId = null`; scope-free and named-mismatch events have `context = null`. The [lease extension guide](https://bluetape4k.github.io/manual/bluetape4k-leader/1.0/core/lease-extension/)
+contains the complete contract and adapter guidance.
 
 ### Audit export to an HTTP/webhook sink
 

--- a/WIP.md
+++ b/WIP.md
@@ -1,53 +1,42 @@
 # WIP - bluetape4k-leader
 
-기준일: 2026-09-02 KST. `0.5.0`은 tag, GitHub Release, Maven Central publication이
-완료된 최신 안정 릴리스이며, 현재 `develop`은 1.0.0 release-prep #860을 수행합니다.
-중앙 catalog는 Projects/Exposed 안정 버전이 승격된 immutable SHA
-`8efed120b91c4e1b1cfbfe1269321df325b08aef`를 사용합니다. release-pinned manual은
-1.0.0 배포 이후 #774에서 별도로 승격합니다.
+기준일: 2026-09-02 KST. `1.0.0` tag, GitHub Release, Maven Central publication이
+완료되었고 `develop`은 배포 후 유지보수를 진행합니다. 중앙 catalog는 전체
+stable BOM을 포함한 immutable SHA
+`3c203aa9f8ba80685aac766c5fb8f24e23d0058e`로 수렴했습니다.
 
 ## 현재 방향
 
-`1.0.0` milestone은 open 상태이며 release-prep #860 한 건이 열려 있고 200건이
-닫혔습니다. PR 생성 전 열린 PR은 0개입니다. `1.0.0-post` milestone의 유일한 열린
-이슈인 [#774](https://github.com/bluetape4k/bluetape4k-leader/issues/774)의
-observability 운영 정책·경보·runbook은 완료되었고, `1.0.0` release train 이후
-새 API를 포함한 versioned manual을 승격하는 작업만 남았습니다. 따라서 현재
-manual pin은 변경하지 않습니다.
-
-`1.1.0` milestone은 생성되어 있지만 열린 이슈가 없습니다. `1.0.0` release/tag,
-Maven publication, versioned manual 승격은 별도 release 승인과 candidate 검증이
-필요합니다.
+`1.0.0` 정식 배포와 catalog 후속 반영은 완료되었습니다. `1.0.0-post`의
+[#774](https://github.com/bluetape4k/bluetape4k-leader/issues/774)는 중앙 EN/KO
+1.0 versioned manual을 exact release commit에 게시하고 README 링크를 안정 경로로
+전환하면서 닫습니다. 이후 `develop` 변경은 다음 명시적인 release train에서
+별도로 버전 승격합니다.
 
 ## 최근 반영
 
 | 영역 | 현재 증거 |
 |---|---|
-| Backend diagnostics | [Issue #766](https://github.com/bluetape4k/bluetape4k-leader/issues/766)의 공통 probe 계약과 built-in backend·Ktor·Spring 적용이 [PR #812](https://github.com/bluetape4k/bluetape4k-leader/pull/812), [PR #813](https://github.com/bluetape4k/bluetape4k-leader/pull/813), [PR #814](https://github.com/bluetape4k/bluetape4k-leader/pull/814), [PR #816](https://github.com/bluetape4k/bluetape4k-leader/pull/816), [PR #817](https://github.com/bluetape4k/bluetape4k-leader/pull/817)로 반영되었습니다. |
-| Observability policy | `UNKNOWN` bounded reason, active probe, Micrometer·Spring health 연결, Ktor route, Prometheus alert/runbook을 [PR #819](https://github.com/bluetape4k/bluetape4k-leader/pull/819), [PR #820](https://github.com/bluetape4k/bluetape4k-leader/pull/820), [PR #822](https://github.com/bluetape4k/bluetape4k-leader/pull/822), [PR #823](https://github.com/bluetape4k/bluetape4k-leader/pull/823)로 고정했습니다. 운영 정책은 완료되었고 versioned manual 승격은 [#774](https://github.com/bluetape4k/bluetape4k-leader/issues/774)가 소유합니다. |
-| Strategic election | Redis 후보 heartbeat 재등록과 결과 카운터·취소·interrupt 경계를 [Issue #804](https://github.com/bluetape4k/bluetape4k-leader/issues/804), [PR #802](https://github.com/bluetape4k/bluetape4k-leader/pull/802), [PR #830](https://github.com/bluetape4k/bluetape4k-leader/pull/830)으로 닫았습니다. |
-| Prometheus example | [Issue #724](https://github.com/bluetape4k/bluetape4k-leader/issues/724)의 scheduler 시작 순서와 scrape readiness 분리를 [PR #840](https://github.com/bluetape4k/bluetape4k-leader/pull/840)으로 병합했습니다. HTTP status/body와 누락 metric 이름을 readiness 진단에 보존합니다. |
-| Release-facing README | [Issue #753](https://github.com/bluetape4k/bluetape4k-leader/issues/753)와 [PR #838](https://github.com/bluetape4k/bluetape4k-leader/pull/838)에서 `0.5.0` stable·`1.0.0-SNAPSHOT` development·manual pin 경계를 정렬했습니다. |
+| 1.0.0 release | [PR #861](https://github.com/bluetape4k/bluetape4k-leader/pull/861), tag/release commit `e70146330302758f563a46b7286e3ce25f1bac49`, GitHub Release와 Maven Central publication을 완료했습니다. |
+| Stable catalog handoff | [PR #862](https://github.com/bluetape4k/bluetape4k-leader/pull/862)에서 CI와 settings의 catalog ref를 최종 Dependencies 2.0.0 SHA로 수렴했습니다. |
+| Backend diagnostics | [Issue #766](https://github.com/bluetape4k/bluetape4k-leader/issues/766)의 공통 probe 계약과 built-in backend·Ktor·Spring 적용을 PR #812, #813, #814, #816, #817로 반영했습니다. |
+| Observability policy | `UNKNOWN` bounded reason, active probe, Micrometer·Spring health, Ktor route, Prometheus alert/runbook을 PR #819, #820, #822, #823으로 고정하고 [#774](https://github.com/bluetape4k/bluetape4k-leader/issues/774)의 1.0 manual에 승격했습니다. |
 
 ## 현재 Release boundary
 
-- 최신 안정 버전은 `0.5.0`이며 release commit은
-  `721a9a3808f67489d2bdb8177734325981c24977`입니다.
-- [GitHub Release 0.5.0](https://github.com/bluetape4k/bluetape4k-leader/releases/tag/0.5.0)은
-  2026-08-06에 게시되었습니다.
-- [Maven Central BOM 0.5.0](https://central.sonatype.com/artifact/io.github.bluetape4k.leader/bluetape4k-leader-bom/0.5.0)
-  및 publishable module POM이 확인되었습니다.
-- `docs/manual/manifest.yaml`은 `releaseRef: 0.5.0`과 위 release commit에
-  고정되어 있습니다. 현재 `develop` 전용 diagnostics·observability 내용은
-  `docs/manual/drafts/`에서 관리합니다.
-- 1.0.0 release-prep #860은 `baseVersion=1.0.0`, 빈 `snapshotVersion`, 중앙
-  catalog exact SHA `8efed120b91c4e1b1cfbfe1269321df325b08aef`를 사용합니다.
-- `1.0.0` tag/release/publication은 아직 없으며, `1.0.0-post`의 [#774](https://github.com/bluetape4k/bluetape4k-leader/issues/774)는
-  새 API를 포함하는 versioned release train에서 manual pin을 갱신한 뒤 닫습니다.
+- 최신 안정 버전은 `1.0.0`이며 release commit은
+  `e70146330302758f563a46b7286e3ce25f1bac49`입니다.
+- [GitHub Release 1.0.0](https://github.com/bluetape4k/bluetape4k-leader/releases/tag/1.0.0)과
+  [Maven Central BOM 1.0.0](https://central.sonatype.com/artifact/io.github.bluetape4k.leader/bluetape4k-leader-bom/1.0.0)을 게시했습니다.
+- 중앙 [Leader 1.0 EN manual](https://bluetape4k.github.io/manual/bluetape4k-leader/1.0/)과
+  [Leader 1.0 KO manual](https://bluetape4k.github.io/ko/manual/bluetape4k-leader/1.0/)은
+  위 exact release commit에 고정됩니다.
+- 현재 build catalog ref는
+  `3c203aa9f8ba80685aac766c5fb8f24e23d0058e`입니다.
 
-## 이전 기준일 (2026-08-15 KST)
+## 이전 기준일 (2026-09-02 release-prep)
 
-- 당시 `develop` head는 `4b99338a1079ccf5d792b930238cf2f56f8f1929`였고,
-  `0.5.0` release-readiness와 localization train이 완료된 상태였습니다.
-- 당시 문서가 다음 개발선으로 기록한 `0.6.0`은 현재 milestone 정책으로
-  대체되었습니다. 현재 개발선은 `1.0.0-SNAPSHOT`입니다.
+- 당시 최신 안정판은 `0.5.0`이었고 `1.0.0` release-prep #860과 중앙 catalog
+  promotion을 진행했습니다.
+- 당시 중앙 매뉴얼의 release pin은 `0.5.0`을 보존했으며, #774의 관측성
+  runbook은 1.0.0 배포 후 승격하도록 명시했습니다.


### PR DESCRIPTION
## 변경 사항

- README EN/KO의 stable version과 중앙 매뉴얼 링크를 1.0.0/1.0으로 갱신했습니다.
- 이미 배포된 diagnostics·lease-extension API의 미배포/초안 안내를 안정 매뉴얼 경로로 교체했습니다.
- WIP를 1.0.0 GitHub Release, Maven Central, exact release commit, 최종 catalog SHA에 맞췄습니다.
- CHANGELOG의 배포 후 catalog handoff를 PR #862와 최종 SHA로 기록했습니다.

## 검증

- README language switch: 37 groups, 74 files, failures=0
- release manual compatibility: 35 modules, 0 missing
- Leader manual tooling: 39 runs, 410 assertions, 0 failures
- release diagrams: 103 entries, failures=0
- full manual/release/diagram contract: OK
- `git diff --check`: PASS

Closes #774
Refs bluetape4k/bluetape4k.github.io#401
Refs bluetape4k/bluetape4k.github.io#403

## DoD Status

- [x] README EN/KO 1.0 안정 경계
- [x] WIP/CHANGELOG 배포 후 상태
- [x] exact release manual contract
- [ ] site fix 재배포와 PR CI 확인
