### PR TITLE
build(deps): 다음 minor catalog commit을 고정한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ env:
   JAVA_VERSION: '25'
   JAVA_DISTRIBUTION: 'temurin'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-  BLUETAPE4K_DEPENDENCIES_CATALOG_REF: '3c203aa9f8ba80685aac766c5fb8f24e23d0058e'
+  BLUETAPE4K_DEPENDENCIES_CATALOG_REF: '850959d0ea5f76ac7e2c442400f47653d5f95eed'
 
 jobs:
   # ── 0. 시크릿 스캔 ────────────────────────────────────────────────────────

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-        .orElse("3c203aa9f8ba80685aac766c5fb8f24e23d0058e")
+        .orElse("850959d0ea5f76ac7e2c442400f47653d5f95eed")
     .get()
 require(bluetape4kDependenciesCatalogRef.matches(Regex("[0-9a-f]{40}|[0-9a-f]{64}"))) {
     "bluetape4k-dependencies catalog ref must be an immutable Git commit SHA: " +


### PR DESCRIPTION
## 변경 내용

- `settings.gradle.kts`와 CI의 catalog ref를 동일한 immutable commit `850959d0ea5f76ac7e2c442400f47653d5f95eed`로 전환합니다.
- 다음 release train 전까지 두 진입점이 같은 catalog source를 사용하도록 유지합니다.

Refs bluetape4k/bluetape4k-dependencies#235

## 검증

- `git diff --check` 통과
- settings/CI exact SHA 일치 확인
- 중앙 post-publish consumer guard 통과

## DoD Status

DONE — exact head `b511fdc64dc7478947d833686b0e0d77687607c2`에서 필수 PR CI가 모두 통과했고 mergeable 상태를 확인했습니다.
