### PR TITLE
fix(ci): Kover 실행과 release source provenance 고정

### DIFF
--- a/.github/scripts/aggregate-kover-coverage.py
+++ b/.github/scripts/aggregate-kover-coverage.py
@@ -3,25 +3,45 @@
 Kover XML 리포트를 집계해서 GitHub Step Summary에 모듈별 coverage 표를 출력합니다.
 
 Usage:
-    aggregate-kover-coverage.py <coverage-root>
+    aggregate-kover-coverage.py [coverage-root] [--expected-artifact NAME ...]
 """
+import argparse
+import glob
 import os
 import sys
-import glob
 import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+class CoverageReportError(ValueError):
+    """Kover report가 집계에 사용할 수 없을 때 발생하는 오류."""
 
 
 def parse_report(path: str) -> tuple[int, int]:
     try:
         root = ET.parse(path).getroot()
-        missed = covered = 0
-        for c in root.findall("counter"):
-            if c.get("type") == "INSTRUCTION":
-                missed += int(c.get("missed", "0"))
-                covered += int(c.get("covered", "0"))
-        return covered, missed
-    except Exception:
-        return 0, 0
+    except (ET.ParseError, OSError) as error:
+        raise CoverageReportError(f"{path}: malformed Kover XML ({error})") from error
+
+    counters = [
+        counter for counter in root.findall("counter") if counter.get("type") == "INSTRUCTION"
+    ]
+    if len(counters) != 1:
+        raise CoverageReportError(
+            f"{path}: exactly one INSTRUCTION counter is required (found {len(counters)})"
+        )
+
+    counter = counters[0]
+    try:
+        covered = int(counter.get("covered", ""))
+        missed = int(counter.get("missed", ""))
+    except (TypeError, ValueError) as error:
+        raise CoverageReportError(f"{path}: INSTRUCTION counter values must be integers") from error
+    if covered < 0 or missed < 0:
+        raise CoverageReportError(f"{path}: INSTRUCTION counter values must be non-negative")
+    if covered + missed == 0:
+        raise CoverageReportError(f"{path}: INSTRUCTION counter is empty")
+    return covered, missed
 
 
 def module_from_path(root_dir: str, path: str) -> str:
@@ -33,33 +53,59 @@ def module_from_path(root_dir: str, path: str) -> str:
     return os.path.basename(os.path.dirname(os.path.dirname(path)))
 
 
-def main() -> int:
-    root_dir = sys.argv[1] if len(sys.argv) > 1 else "coverage-artifacts"
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root_dir", nargs="?", default="coverage-artifacts")
+    parser.add_argument("--expected-artifact", action="append", default=[])
+    args = parser.parse_args(argv)
+    root_dir = args.root_dir
+    expected_artifacts = args.expected_artifact
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
 
     patterns = [f"{root_dir}/**/report.xml", f"{root_dir}/**/reportJvm.xml"]
     rows: list[tuple[str, int, int, float]] = []
     total_covered = total_missed = 0
-    seen: set[tuple[str, str]] = set()
+    errors: list[str] = []
 
     for pattern in patterns:
         for xml_path in sorted(glob.glob(pattern, recursive=True)):
             module = module_from_path(root_dir, xml_path)
-            key = (module, os.path.basename(xml_path))
-            if key in seen:
+            try:
+                covered, missed = parse_report(xml_path)
+            except CoverageReportError as error:
+                errors.append(str(error))
                 continue
-            seen.add(key)
-            covered, missed = parse_report(xml_path)
             total = covered + missed
             pct = (covered * 100.0 / total) if total else 0.0
             rows.append((module, covered, missed, pct))
             total_covered += covered
             total_missed += missed
 
+    artifact_root = Path(root_dir)
+    artifact_dirs = (
+        sorted(path for path in artifact_root.glob("coverage-*") if path.is_dir())
+        if artifact_root.is_dir()
+        else []
+    )
+    for artifact_dir in artifact_dirs:
+        if not any(artifact_dir.glob("**/report.xml")) and not any(
+            artifact_dir.glob("**/reportJvm.xml")
+        ):
+            errors.append(f"{artifact_dir}: no Kover XML report found")
+    for expected_artifact in expected_artifacts:
+        expected_path = artifact_root / expected_artifact
+        if not expected_path.is_dir():
+            errors.append(f"{expected_path}: expected coverage artifact is missing")
+        elif not any(expected_path.glob("**/report.xml")) and not any(
+            expected_path.glob("**/reportJvm.xml")
+        ):
+            errors.append(f"{expected_path}: expected Kover XML report is missing")
+
+    if not rows and not errors:
+        errors.append(f"{root_dir}: No coverage reports found")
+
     lines: list[str] = ["## Kover Coverage Summary", ""]
-    if not rows:
-        lines.append("_No coverage reports found._")
-    else:
+    if rows:
         lines += [
             "| Module | Instruction Covered | Instruction Missed | Coverage |",
             "|--------|--------------------:|-------------------:|---------:|",
@@ -69,13 +115,16 @@ def main() -> int:
         grand_total = total_covered + total_missed
         grand_pct = (total_covered * 100.0 / grand_total) if grand_total else 0.0
         lines.append(f"| **TOTAL** | **{total_covered}** | **{total_missed}** | **{grand_pct:.2f}%** |")
+    if errors:
+        lines += ["", "### Coverage validation errors", ""]
+        lines.extend(f"- {error}" for error in errors)
 
     output = "\n".join(lines) + "\n"
     if summary_path:
         with open(summary_path, "a", encoding="utf-8") as fp:
             fp.write(output)
     print(output)
-    return 0
+    return 1 if errors else 0
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1952,6 +1952,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
+      - changes
       - test-core
       - test-micrometer
       - test-redis-lettuce
@@ -1988,7 +1989,22 @@ jobs:
       - test-examples-tenant-aggregator
       - test-examples-ktor-app
       - test-examples-prometheus-dashboard
-    if: always()
+    if: >-
+      always() && (
+        github.event_name == 'workflow_dispatch' ||
+        needs.changes.outputs['dependency-graph'] == 'true' ||
+        needs.changes.outputs['leader-core'] == 'true' ||
+        needs.changes.outputs['leader-redis'] == 'true' ||
+        needs.changes.outputs['leader-exposed'] == 'true' ||
+        needs.changes.outputs['leader-spring-boot'] == 'true' ||
+        needs.changes.outputs['leader-ktor'] == 'true' ||
+        needs.changes.outputs['leader-mongodb'] == 'true' ||
+        needs.changes.outputs['leader-dynamodb'] == 'true' ||
+        needs.changes.outputs['leader-etcd'] == 'true' ||
+        needs.changes.outputs['leader-consul'] == 'true' ||
+        needs.changes.outputs['leader-hazelcast'] == 'true' ||
+        needs.changes.outputs['leader-zookeeper'] == 'true'
+      )
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,10 @@ jobs:
           python3 scripts/ci/validate_detekt_configuration_cache_test.py
           python3 scripts/ci/validate_provider_artifacts.py --workflow-contract .github/workflows/ci.yml .github/workflows/nightly-tests.yml
           python3 scripts/ci/validate_provider_artifacts.py --self-test
+          python3 scripts/ci/validate_kover_contract.py --static
+          python3 scripts/ci/validate_kover_contract_test.py
+          python3 scripts/ci/validate_release_provenance.py
+          python3 scripts/ci/validate_release_provenance_test.py
           python3 scripts/compatibility/check_binary_api_test.py
 
   # ── 2-B. 매뉴얼/릴리스 provenance 계약 검증 ─────────────────────────────
@@ -457,17 +461,12 @@ jobs:
       - name: Test leader-core
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-core:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-core:test :bluetape4k-leader-core:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
-
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-core:koverXmlReport --no-configuration-cache --no-daemon -x test
-        continue-on-error: true
 
       - name: Upload test results
         if: always()
@@ -481,6 +480,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-core
           path: '**/build/reports/kover/'
           retention-days: 7
@@ -505,16 +505,12 @@ jobs:
       - name: Test leader-micrometer
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-micrometer:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-micrometer:test :bluetape4k-leader-micrometer:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-micrometer:koverXmlReport --no-configuration-cache --no-daemon -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -526,6 +522,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-micrometer
           path: '**/build/reports/kover/'
           retention-days: 7
@@ -553,7 +550,7 @@ jobs:
       - name: Test leader-redis-lettuce
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-redis-lettuce:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-redis-lettuce:test :bluetape4k-leader-redis-lettuce:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -561,11 +558,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-redis-lettuce:koverXmlReport --no-configuration-cache --no-daemon -x test
-        continue-on-error: true
 
       - name: Upload test results
         if: always()
@@ -579,6 +571,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-redis-lettuce
           path: '**/build/reports/kover/'
           retention-days: 7
@@ -606,7 +599,7 @@ jobs:
       - name: Test leader-redis-redisson
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-redis-redisson:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-redis-redisson:test :bluetape4k-leader-redis-redisson:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -614,11 +607,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-redis-redisson:koverXmlReport --no-configuration-cache --no-daemon -x test
-        continue-on-error: true
 
       - name: Upload test results
         if: always()
@@ -632,6 +620,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-redis-redisson
           path: '**/build/reports/kover/'
           retention-days: 7
@@ -659,20 +648,13 @@ jobs:
       - name: Test leader-exposed-jdbc (H2)
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-exposed-jdbc:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-exposed-jdbc:test :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           LEADER_TEST_DB: "H2"
-
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-configuration-cache --no-daemon -x test
-        env:
-          LEADER_TEST_DB: "H2"
-        continue-on-error: true
 
       - name: Verify provider artifact provenance
         if: always()
@@ -692,6 +674,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-exposed-jdbc-h2
           path: |
             **/build/reports/kover/
@@ -721,7 +704,7 @@ jobs:
       - name: Test leader-exposed-jdbc (PostgreSQL)
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-exposed-jdbc:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-exposed-jdbc:test :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -730,13 +713,6 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
           LEADER_TEST_DB: "POSTGRESQL"
-
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-configuration-cache --no-daemon -x test
-        env:
-          LEADER_TEST_DB: "POSTGRESQL"
-        continue-on-error: true
 
       - name: Verify provider artifact provenance
         if: always()
@@ -756,6 +732,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-exposed-jdbc-postgresql
           path: |
             **/build/reports/kover/
@@ -785,7 +762,7 @@ jobs:
       - name: Test leader-exposed-jdbc (MySQL 8)
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-exposed-jdbc:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-exposed-jdbc:test :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -794,13 +771,6 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
           LEADER_TEST_DB: "MYSQL_V8"
-
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-configuration-cache --no-daemon -x test
-        env:
-          LEADER_TEST_DB: "MYSQL_V8"
-        continue-on-error: true
 
       - name: Verify provider artifact provenance
         if: always()
@@ -820,6 +790,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-exposed-jdbc-mysql
           path: |
             **/build/reports/kover/
@@ -847,19 +818,13 @@ jobs:
       - name: Test leader-exposed-r2dbc (H2)
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-exposed-r2dbc:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-exposed-r2dbc:test :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           LEADER_TEST_DB: "H2"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-configuration-cache --no-daemon -x test
-        env:
-          LEADER_TEST_DB: "H2"
-        continue-on-error: true
       - name: Verify provider artifact provenance
         if: always()
         run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-r2dbc --provider H2
@@ -876,6 +841,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-exposed-r2dbc-h2
           path: |
             **/build/reports/kover/
@@ -902,7 +868,7 @@ jobs:
       - name: Test leader-exposed-r2dbc (PostgreSQL)
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-exposed-r2dbc:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-exposed-r2dbc:test :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -911,12 +877,6 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
           LEADER_TEST_DB: "POSTGRESQL"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-configuration-cache --no-daemon -x test
-        env:
-          LEADER_TEST_DB: "POSTGRESQL"
-        continue-on-error: true
       - name: Verify provider artifact provenance
         if: always()
         run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-r2dbc --provider POSTGRESQL
@@ -933,6 +893,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-exposed-r2dbc-postgresql
           path: |
             **/build/reports/kover/
@@ -959,7 +920,7 @@ jobs:
       - name: Test leader-exposed-r2dbc (MySQL 8)
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-exposed-r2dbc:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-exposed-r2dbc:test :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -968,12 +929,6 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
           LEADER_TEST_DB: "MYSQL_V8"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-configuration-cache --no-daemon -x test
-        env:
-          LEADER_TEST_DB: "MYSQL_V8"
-        continue-on-error: true
       - name: Verify provider artifact provenance
         if: always()
         run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-r2dbc --provider MYSQL_V8
@@ -990,6 +945,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-exposed-r2dbc-mysql
           path: |
             **/build/reports/kover/
@@ -1620,7 +1576,7 @@ jobs:
       - name: Test leader-spring-boot
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-spring-boot:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-spring-boot:test :bluetape4k-leader-spring-boot:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -1628,10 +1584,6 @@ jobs:
           GRADLE_OPTS: '-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false'
           TESTCONTAINERS_RYUK_DISABLED: 'true'
           DOCKER_HOST: 'unix:///var/run/docker.sock'
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-spring-boot:koverXmlReport --no-configuration-cache --no-daemon -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -1643,6 +1595,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-spring-boot
           path: '**/build/reports/kover/'
           retention-days: 7
@@ -1667,7 +1620,7 @@ jobs:
       - name: Test leader-ktor
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-ktor:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-ktor:test :bluetape4k-leader-ktor:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -1675,10 +1628,6 @@ jobs:
           GRADLE_OPTS: '-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false'
           TESTCONTAINERS_RYUK_DISABLED: 'true'
           DOCKER_HOST: 'unix:///var/run/docker.sock'
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-ktor:koverXmlReport --no-configuration-cache --no-daemon -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -1690,6 +1639,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-leader-ktor
           path: '**/build/reports/kover/'
           retention-days: 7
@@ -1714,7 +1664,7 @@ jobs:
       - name: Test leader-mongodb
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-mongodb:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-mongodb:test :bluetape4k-leader-mongodb:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -1722,10 +1672,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-mongodb:koverXmlReport --no-configuration-cache --no-daemon -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -1737,6 +1683,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-mongodb
           path: '**/build/reports/kover/'
           retention-days: 7
@@ -1761,7 +1708,7 @@ jobs:
       - name: Test leader-dynamodb
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-dynamodb:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-dynamodb:test :bluetape4k-leader-dynamodb:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -1769,10 +1716,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-dynamodb:koverXmlReport --no-configuration-cache --no-daemon -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -1784,6 +1727,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-leader-dynamodb
           path: '**/build/reports/kover/'
           retention-days: 7
@@ -1808,7 +1752,7 @@ jobs:
       - name: Test leader-etcd
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-etcd:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-etcd:test :bluetape4k-leader-etcd:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -1816,10 +1760,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-etcd:koverXmlReport --no-configuration-cache --no-daemon -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -1831,6 +1771,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-leader-etcd
           path: '**/build/reports/kover/'
           retention-days: 7
@@ -1855,7 +1796,7 @@ jobs:
       - name: Test leader-consul
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-consul:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-consul:test :bluetape4k-leader-consul:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -1863,10 +1804,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-consul:koverXmlReport --no-configuration-cache --no-daemon -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -1878,6 +1815,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-leader-consul
           path: '**/build/reports/kover/'
           retention-days: 7
@@ -1940,7 +1878,7 @@ jobs:
       - name: Test leader-hazelcast
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-hazelcast:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-hazelcast:test :bluetape4k-leader-hazelcast:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -1948,10 +1886,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-hazelcast:koverXmlReport --no-configuration-cache --no-daemon -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -1963,6 +1897,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-hazelcast
           path: '**/build/reports/kover/'
           retention-days: 7
@@ -1987,7 +1922,7 @@ jobs:
       - name: Test leader-zookeeper
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-zookeeper:test --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-zookeeper:test :bluetape4k-leader-zookeeper:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -1995,10 +1930,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-zookeeper:koverXmlReport --no-configuration-cache --no-daemon -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -2010,6 +1941,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-zookeeper
           path: '**/build/reports/kover/'
           retention-days: 7
@@ -2068,7 +2000,6 @@ jobs:
           pattern: coverage-*
           path: coverage-artifacts
           merge-multiple: false
-        continue-on-error: true
       - name: Aggregate Kover coverage summary
         if: always()
         run: python3 .github/scripts/aggregate-kover-coverage.py coverage-artifacts

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -132,16 +132,12 @@ jobs:
       - name: Test leader-core
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-core:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-core:test :bluetape4k-leader-core:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-core:koverXmlReport --no-daemon --no-configuration-cache -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -153,6 +149,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-core
           path: '**/build/reports/kover/'
           retention-days: 14
@@ -178,7 +175,7 @@ jobs:
       - name: Test leader-redis-lettuce
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-redis-lettuce:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-redis-lettuce:test :bluetape4k-leader-redis-lettuce:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -186,10 +183,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-redis-lettuce:koverXmlReport --no-daemon --no-configuration-cache -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -201,6 +194,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-redis-lettuce
           path: '**/build/reports/kover/'
           retention-days: 14
@@ -226,7 +220,7 @@ jobs:
       - name: Test leader-redis-redisson
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-redis-redisson:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-redis-redisson:test :bluetape4k-leader-redis-redisson:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -234,10 +228,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-redis-redisson:koverXmlReport --no-daemon --no-configuration-cache -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -249,6 +239,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-redis-redisson
           path: '**/build/reports/kover/'
           retention-days: 14
@@ -272,17 +263,13 @@ jobs:
       - name: Test leader-exposed-core (H2)
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-exposed-core:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-exposed-core:test :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           LEADER_TEST_DB: "H2"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon --no-configuration-cache -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -294,6 +281,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-exposed-core-h2
           path: '**/build/reports/kover/'
           retention-days: 14
@@ -319,7 +307,7 @@ jobs:
       - name: Test leader-exposed-core (PostgreSQL)
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-exposed-core:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-exposed-core:test :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -328,10 +316,6 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
           LEADER_TEST_DB: "POSTGRESQL"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon --no-configuration-cache -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -343,6 +327,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-exposed-core-postgresql
           path: '**/build/reports/kover/'
           retention-days: 14
@@ -368,7 +353,7 @@ jobs:
       - name: Test leader-exposed-core (MySQL 8)
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-exposed-core:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-exposed-core:test :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -377,10 +362,6 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
           LEADER_TEST_DB: "MYSQL_V8"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-core:koverXmlReport --no-daemon --no-configuration-cache -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -392,6 +373,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-exposed-core-mysql
           path: '**/build/reports/kover/'
           retention-days: 14
@@ -415,19 +397,13 @@ jobs:
       - name: Test leader-exposed-jdbc (H2)
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-exposed-jdbc:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-exposed-jdbc:test :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           LEADER_TEST_DB: "H2"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon --no-configuration-cache -x test
-        env:
-          LEADER_TEST_DB: "H2"
-        continue-on-error: true
       - name: Verify provider artifact provenance
         if: always()
         run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-jdbc --provider H2
@@ -444,6 +420,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-exposed-jdbc-h2
           path: |
             **/build/reports/kover/
@@ -471,7 +448,7 @@ jobs:
       - name: Test leader-exposed-jdbc (PostgreSQL)
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-exposed-jdbc:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-exposed-jdbc:test :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -480,12 +457,6 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
           LEADER_TEST_DB: "POSTGRESQL"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon --no-configuration-cache -x test
-        env:
-          LEADER_TEST_DB: "POSTGRESQL"
-        continue-on-error: true
       - name: Verify provider artifact provenance
         if: always()
         run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-jdbc --provider POSTGRESQL
@@ -502,6 +473,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-exposed-jdbc-postgresql
           path: |
             **/build/reports/kover/
@@ -529,7 +501,7 @@ jobs:
       - name: Test leader-exposed-jdbc (MySQL 8)
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-exposed-jdbc:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-exposed-jdbc:test :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -538,12 +510,6 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
           LEADER_TEST_DB: "MYSQL_V8"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-jdbc:koverXmlReport --no-daemon --no-configuration-cache -x test
-        env:
-          LEADER_TEST_DB: "MYSQL_V8"
-        continue-on-error: true
       - name: Verify provider artifact provenance
         if: always()
         run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-jdbc --provider MYSQL_V8
@@ -560,6 +526,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-exposed-jdbc-mysql
           path: |
             **/build/reports/kover/
@@ -585,19 +552,13 @@ jobs:
       - name: Test leader-exposed-r2dbc (H2)
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-exposed-r2dbc:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-exposed-r2dbc:test :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
           LEADER_TEST_DB: "H2"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon --no-configuration-cache -x test
-        env:
-          LEADER_TEST_DB: "H2"
-        continue-on-error: true
       - name: Verify provider artifact provenance
         if: always()
         run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-r2dbc --provider H2
@@ -614,6 +575,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-exposed-r2dbc-h2
           path: |
             **/build/reports/kover/
@@ -640,7 +602,7 @@ jobs:
       - name: Test leader-exposed-r2dbc (PostgreSQL)
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-exposed-r2dbc:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-exposed-r2dbc:test :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -649,12 +611,6 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
           LEADER_TEST_DB: "POSTGRESQL"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon --no-configuration-cache -x test
-        env:
-          LEADER_TEST_DB: "POSTGRESQL"
-        continue-on-error: true
       - name: Verify provider artifact provenance
         if: always()
         run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-r2dbc --provider POSTGRESQL
@@ -671,6 +627,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-exposed-r2dbc-postgresql
           path: |
             **/build/reports/kover/
@@ -697,7 +654,7 @@ jobs:
       - name: Test leader-exposed-r2dbc (MySQL 8)
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-exposed-r2dbc:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-exposed-r2dbc:test :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -706,12 +663,6 @@ jobs:
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
           LEADER_TEST_DB: "MYSQL_V8"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-exposed-r2dbc:koverXmlReport --no-daemon --no-configuration-cache -x test
-        env:
-          LEADER_TEST_DB: "MYSQL_V8"
-        continue-on-error: true
       - name: Verify provider artifact provenance
         if: always()
         run: python3 scripts/ci/validate_provider_artifacts.py --root . --module leader-exposed-r2dbc --provider MYSQL_V8
@@ -728,6 +679,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-exposed-r2dbc-mysql
           path: |
             **/build/reports/kover/
@@ -755,7 +707,7 @@ jobs:
       - name: Test leader-mongodb
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-mongodb:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-mongodb:test :bluetape4k-leader-mongodb:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -763,10 +715,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-mongodb:koverXmlReport --no-daemon --no-configuration-cache -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -778,6 +726,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-mongodb
           path: '**/build/reports/kover/'
           retention-days: 14
@@ -803,7 +752,7 @@ jobs:
       - name: Test leader-dynamodb
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-dynamodb:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-dynamodb:test :bluetape4k-leader-dynamodb:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -811,10 +760,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-dynamodb:koverXmlReport --no-daemon --no-configuration-cache -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -826,6 +771,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-leader-dynamodb
           path: '**/build/reports/kover/'
           retention-days: 14
@@ -851,7 +797,7 @@ jobs:
       - name: Test leader-etcd
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-etcd:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-etcd:test :bluetape4k-leader-etcd:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -859,10 +805,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-etcd:koverXmlReport --no-daemon --no-configuration-cache -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -874,6 +816,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-leader-etcd
           path: '**/build/reports/kover/'
           retention-days: 14
@@ -897,7 +840,7 @@ jobs:
       - name: Test leader-consul
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-consul:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-consul:test :bluetape4k-leader-consul:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -905,10 +848,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-consul:koverXmlReport --no-daemon --no-configuration-cache -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -920,6 +859,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-leader-consul
           path: '**/build/reports/kover/'
           retention-days: 14
@@ -945,7 +885,7 @@ jobs:
       - name: Test leader-k8s unit and K3s group slots
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-k8s:test :bluetape4k-leader-k8s:k8sTest --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-k8s:test :bluetape4k-leader-k8s:k8sTest :bluetape4k-leader-k8s:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -953,10 +893,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-k8s:koverXmlReport --no-daemon --no-configuration-cache -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -968,6 +904,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-leader-k8s
           path: '**/build/reports/kover/'
           retention-days: 14
@@ -993,7 +930,7 @@ jobs:
       - name: Test leader-hazelcast
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-hazelcast:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-hazelcast:test :bluetape4k-leader-hazelcast:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -1001,10 +938,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-hazelcast:koverXmlReport --no-daemon --no-configuration-cache -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -1016,6 +949,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-hazelcast
           path: '**/build/reports/kover/'
           retention-days: 14
@@ -1041,7 +975,7 @@ jobs:
       - name: Test leader-zookeeper
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-zookeeper:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-zookeeper:test :bluetape4k-leader-zookeeper:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -1049,10 +983,6 @@ jobs:
           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
           TESTCONTAINERS_RYUK_DISABLED: "true"
           DOCKER_HOST: "unix:///var/run/docker.sock"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-zookeeper:koverXmlReport --no-daemon --no-configuration-cache -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -1064,6 +994,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-zookeeper
           path: '**/build/reports/kover/'
           retention-days: 14
@@ -1087,16 +1018,12 @@ jobs:
       - name: Test leader-micrometer
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-micrometer:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-micrometer:test :bluetape4k-leader-micrometer:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
         env:
           GRADLE_OPTS: "-Dorg.gradle.daemon=false"
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-micrometer:koverXmlReport --no-daemon --no-configuration-cache -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -1108,6 +1035,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-micrometer
           path: "**/build/reports/kover/"
           retention-days: 14
@@ -1133,7 +1061,7 @@ jobs:
       - name: Test leader-spring-boot
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-spring-boot:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-spring-boot:test :bluetape4k-leader-spring-boot:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -1141,10 +1069,6 @@ jobs:
           GRADLE_OPTS: '-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false'
           TESTCONTAINERS_RYUK_DISABLED: 'true'
           DOCKER_HOST: 'unix:///var/run/docker.sock'
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-spring-boot:koverXmlReport --no-daemon --no-configuration-cache -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -1156,6 +1080,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-spring-boot
           path: '**/build/reports/kover/'
           retention-days: 14
@@ -1181,7 +1106,7 @@ jobs:
       - name: Test leader-ktor
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-ktor:test --no-daemon --no-configuration-cache && break
+            ./gradlew :bluetape4k-leader-ktor:test :bluetape4k-leader-ktor:koverXmlReport --no-daemon --no-configuration-cache && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -1189,10 +1114,6 @@ jobs:
           GRADLE_OPTS: '-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false'
           TESTCONTAINERS_RYUK_DISABLED: 'true'
           DOCKER_HOST: 'unix:///var/run/docker.sock'
-      - name: Generate Kover XML report
-        if: always()
-        run: ./gradlew :bluetape4k-leader-ktor:koverXmlReport --no-daemon --no-configuration-cache -x test
-        continue-on-error: true
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v7
@@ -1204,6 +1125,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
+          if-no-files-found: error
           name: coverage-leader-ktor
           path: '**/build/reports/kover/'
           retention-days: 14
@@ -1248,7 +1170,6 @@ jobs:
           pattern: coverage-*
           path: coverage-artifacts
           merge-multiple: false
-        continue-on-error: true
       - name: Aggregate Kover coverage summary
         if: always()
         run: python3 .github/scripts/aggregate-kover-coverage.py coverage-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,16 @@ jobs:
       contents: read
     outputs:
       version: ${{ steps.resolve.outputs.version }}
-      ref: ${{ steps.resolve.outputs.ref }}
+      source_sha: ${{ steps.resolve.outputs.source_sha }}
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
       - id: resolve
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
+          GITHUB_SHA: ${{ github.sha }}
           TAG_NAME: ${{ github.ref_name }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
@@ -58,9 +62,17 @@ jobs:
             echo "::error::Invalid version format: $VERSION"
             exit 1
           fi
+          if ! SOURCE_SHA="$(git rev-parse --verify "refs/tags/$VERSION^{commit}")"; then
+            echo "::error::Release tag does not exist: $VERSION"
+            exit 1
+          fi
+          if [[ "$EVENT_NAME" == "push" && "$SOURCE_SHA" != "$GITHUB_SHA" ]]; then
+            echo "::error::Tag commit ($SOURCE_SHA) does not match the triggering commit ($GITHUB_SHA)"
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "ref=refs/tags/$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Resolved version=$VERSION"
+          echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+          echo "Resolved version=$VERSION source_sha=$SOURCE_SHA"
 
   publish:
     name: Publish RELEASE to Maven Central Portal
@@ -72,8 +84,27 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ needs.resolve-version.outputs.ref }}
+          ref: ${{ needs.resolve-version.outputs.source_sha }}
           fetch-depth: 0
+
+      - name: Verify immutable release source
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ needs.resolve-version.outputs.source_sha }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          ACTUAL_SHA="$(git rev-parse HEAD)"
+          TAG_SHA="$(git rev-parse --verify "refs/tags/$VERSION^{commit}")"
+          if [[ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Checked out HEAD ($ACTUAL_SHA) does not match resolved source SHA ($EXPECTED_SHA)"
+            exit 1
+          fi
+          if [[ "$TAG_SHA" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Tag $VERSION resolves to $TAG_SHA, expected $EXPECTED_SHA"
+            exit 1
+          fi
+          echo "Verified immutable release source: version=$VERSION sha=$EXPECTED_SHA"
 
       - name: Resolve dependencies catalog ref
         id: catalog
@@ -259,8 +290,27 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ needs.resolve-version.outputs.ref }}
+          ref: ${{ needs.resolve-version.outputs.source_sha }}
           fetch-depth: 0
+
+      - name: Verify immutable release source
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ needs.resolve-version.outputs.source_sha }}
+          VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          ACTUAL_SHA="$(git rev-parse HEAD)"
+          TAG_SHA="$(git rev-parse --verify "refs/tags/$VERSION^{commit}")"
+          if [[ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Checked out HEAD ($ACTUAL_SHA) does not match resolved source SHA ($EXPECTED_SHA)"
+            exit 1
+          fi
+          if [[ "$TAG_SHA" != "$EXPECTED_SHA" ]]; then
+            echo "::error::Tag $VERSION resolves to $TAG_SHA, expected $EXPECTED_SHA"
+            exit 1
+          fi
+          echo "Verified immutable release source: version=$VERSION sha=$EXPECTED_SHA"
 
       - name: Resolve previous tag
         id: prev_tag

--- a/scripts/ci/validate_kover_contract.py
+++ b/scripts/ci/validate_kover_contract.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""CI/Nightly Kover 실행 그래프와 fail-closed 집계 계약을 검증한다."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_WORKFLOWS = (
+    ROOT / ".github/workflows/ci.yml",
+    ROOT / ".github/workflows/nightly-tests.yml",
+)
+
+
+def _job_block(source: str, job_id: str) -> str | None:
+    marker = f"  {job_id}:"
+    start = source.find(marker)
+    if start < 0 or (start and source[start - 1] != "\n"):
+        return None
+    next_job = re.search(
+        r"^  [A-Za-z0-9][A-Za-z0-9_-]*:\s*$",
+        source[start + len(marker) :],
+        flags=re.MULTILINE,
+    )
+    if next_job is None:
+        return source[start:]
+    return source[start : start + len(marker) + next_job.start()]
+
+
+def _step_block(block: str, step_name: str) -> str | None:
+    marker = f"- name: {step_name}"
+    start = block.find(marker)
+    if start < 0:
+        return None
+    step_start = block.rfind("\n", 0, start) + 1
+    next_step = re.search(r"^      - name:", block[start + len(marker) :], flags=re.MULTILINE)
+    if next_step is None:
+        return block[step_start:]
+    return block[step_start : start + len(marker) + next_step.start()]
+
+
+def _gradle_kover_commands(source: str) -> list[str]:
+    return [
+        line.strip()
+        for line in source.splitlines()
+        if "./gradlew" in line and "koverXmlReport" in line
+    ]
+
+
+def validate_workflow(path: Path) -> list[str]:
+    if path.is_symlink() or not path.is_file():
+        return [f"{path}: workflow 파일이 없습니다"]
+
+    source = path.read_text(encoding="utf-8")
+    violations: list[str] = []
+    commands = _gradle_kover_commands(source)
+    if not commands:
+        violations.append(f"{path}: koverXmlReport 실행이 없습니다")
+
+    for command in commands:
+        modules = re.findall(r"(:[A-Za-z0-9_-]+):koverXmlReport\b", command)
+        if not modules:
+            violations.append(f"{path}: Kover 명령에서 모듈을 찾을 수 없습니다: {command}")
+            continue
+        if re.search(r"(?:^|\s)-x\s+test(?:\s|$)", command):
+            violations.append(f"{path}: Kover 명령이 test를 건너뜁니다: {command}")
+        for module in modules:
+            if f"{module}:test" not in command:
+                violations.append(
+                    f"{path}: {module}:test와 koverXmlReport는 same Gradle invocation이어야 합니다"
+                )
+
+    if "Generate Kover XML report" in source:
+        violations.append(f"{path}: 독립적인 Generate Kover XML report step이 남아 있습니다")
+
+    coverage_steps = [
+        block
+        for job in re.finditer(r"^  [A-Za-z0-9][A-Za-z0-9_-]*:\s*$", source, re.MULTILINE)
+        for block in [_job_block(source, job.group(0).strip().rstrip(":"))]
+        if block and "Upload coverage report" in block
+    ]
+    for block in coverage_steps:
+        step = _step_block(block, "Upload coverage report")
+        if step is None or "if-no-files-found: error" not in step:
+            violations.append(f"{path}: coverage upload은 if-no-files-found: error여야 합니다")
+
+    coverage_report = _job_block(source, "coverage-report")
+    if coverage_report is not None:
+        download = _step_block(coverage_report, "Download all coverage artifacts")
+        if download is None:
+            violations.append(f"{path}: coverage-report에 artifact download step이 없습니다")
+        elif "continue-on-error: true" in download:
+            violations.append(f"{path}: coverage artifact download가 continue-on-error로 fail-open입니다")
+        aggregate = _step_block(coverage_report, "Aggregate Kover coverage summary")
+        if aggregate is None or "aggregate-kover-coverage.py" not in aggregate:
+            violations.append(f"{path}: coverage-report에 Kover 집계 step이 없습니다")
+
+    return violations
+
+
+def validate_workflows(workflows: tuple[Path, ...]) -> list[str]:
+    if not workflows:
+        return ["검증할 workflow가 없습니다"]
+    violations: list[str] = []
+    for workflow in workflows:
+        violations.extend(validate_workflow(workflow))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workflow-contract", nargs="+", type=Path)
+    parser.add_argument("--static", action="store_true", help="기본 CI/Nightly workflow를 검증")
+    args = parser.parse_args(argv)
+    workflows = tuple(args.workflow_contract or DEFAULT_WORKFLOWS)
+    violations = validate_workflows(workflows)
+    if violations:
+        for violation in violations:
+            print(f"Kover contract FAILED: {violation}", file=sys.stderr)
+        return 1
+    print("Kover contract OK: test and report share one Gradle graph; aggregation fails closed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/validate_kover_contract.py
+++ b/scripts/ci/validate_kover_contract.py
@@ -89,6 +89,13 @@ def validate_workflow(path: Path) -> list[str]:
 
     coverage_report = _job_block(source, "coverage-report")
     if coverage_report is not None:
+        if _job_block(source, "changes") is not None:
+            if "- changes" not in coverage_report:
+                violations.append(f"{path}: coverage-report는 changes job에 의존해야 합니다")
+            if "needs.changes.outputs" not in coverage_report or "workflow_dispatch" not in coverage_report:
+                violations.append(
+                    f"{path}: coverage-report는 영향받은 coverage job 또는 workflow_dispatch일 때만 실행되어야 합니다"
+                )
         download = _step_block(coverage_report, "Download all coverage artifacts")
         if download is None:
             violations.append(f"{path}: coverage-report에 artifact download step이 없습니다")

--- a/scripts/ci/validate_kover_contract_test.py
+++ b/scripts/ci/validate_kover_contract_test.py
@@ -86,6 +86,37 @@ jobs:
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("continue-on-error", result.stdout + result.stderr)
 
+    def test_validator_requires_coverage_job_to_follow_impact_filters(self) -> None:
+        workflow = """
+jobs:
+  changes:
+    outputs:
+      leader-core: ${{ steps.filter.outputs.leader-core }}
+  test-core:
+    needs: [changes]
+    if: ${{ needs.changes.outputs['leader-core'] == 'true' }}
+    steps:
+      - run: ./gradlew :bluetape4k-leader-core:test :bluetape4k-leader-core:koverXmlReport
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          if-no-files-found: error
+  coverage-report:
+    needs: [test-core]
+    if: always()
+    steps:
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@v8
+      - name: Aggregate Kover coverage summary
+        run: python3 .github/scripts/aggregate-kover-coverage.py coverage-artifacts
+"""
+
+        path = self._write_workflow(workflow)
+        result = run_validator("--workflow-contract", str(path))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("changes job", result.stdout + result.stderr)
+
     def test_aggregator_fails_when_no_reports_are_present(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             result = run_aggregator(Path(directory))

--- a/scripts/ci/validate_kover_contract_test.py
+++ b/scripts/ci/validate_kover_contract_test.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Kover test/report execution and fail-closed aggregation 계약 테스트."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/ci/validate_kover_contract.py"
+AGGREGATOR = ROOT / ".github/scripts/aggregate-kover-coverage.py"
+WORKFLOWS = (
+    ROOT / ".github/workflows/ci.yml",
+    ROOT / ".github/workflows/nightly-tests.yml",
+)
+
+
+def run_validator(*arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *arguments],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def run_aggregator(root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(AGGREGATOR), str(root)],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+class KoverContractTest(unittest.TestCase):
+    def test_current_workflows_use_one_gradle_graph_for_tests_and_kover(self) -> None:
+        result = run_validator(
+            "--workflow-contract",
+            *(str(workflow) for workflow in WORKFLOWS),
+        )
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_validator_rejects_a_report_command_that_skips_tests(self) -> None:
+        workflow = """
+jobs:
+  test-core:
+    steps:
+      - run: ./gradlew :bluetape4k-leader-core:test
+      - name: Generate Kover XML report
+        run: ./gradlew :bluetape4k-leader-core:koverXmlReport -x test
+"""
+
+        path = self._write_workflow(workflow)
+        result = run_validator("--workflow-contract", str(path))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("same Gradle invocation", result.stdout + result.stderr)
+
+    def test_validator_requires_fail_on_missing_coverage_files(self) -> None:
+        workflow = """
+jobs:
+  test-core:
+    steps:
+      - run: ./gradlew :bluetape4k-leader-core:test :bluetape4k-leader-core:koverXmlReport
+  coverage-report:
+    steps:
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: coverage-*
+        continue-on-error: true
+      - name: Aggregate Kover coverage summary
+        run: python3 .github/scripts/aggregate-kover-coverage.py coverage-artifacts
+"""
+
+        path = self._write_workflow(workflow)
+        result = run_validator("--workflow-contract", str(path))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("continue-on-error", result.stdout + result.stderr)
+
+    def test_aggregator_fails_when_no_reports_are_present(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            result = run_aggregator(Path(directory))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("No coverage reports found", result.stdout + result.stderr)
+
+    def test_aggregator_fails_when_a_report_is_malformed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = Path(directory) / "coverage-core/build/reports/kover/report.xml"
+            report.parent.mkdir(parents=True)
+            report.write_text("<report>", encoding="utf-8")
+
+            result = run_aggregator(Path(directory))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("malformed", result.stdout + result.stderr)
+
+    def test_aggregator_accepts_a_valid_instruction_report(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = Path(directory) / "coverage-core/build/reports/kover/report.xml"
+            report.parent.mkdir(parents=True)
+            report.write_text(
+                '<report><counter type="INSTRUCTION" missed="2" covered="8"/></report>',
+                encoding="utf-8",
+            )
+
+            result = run_aggregator(Path(directory))
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("80.00%", result.stdout)
+
+    def test_aggregator_fails_when_an_expected_artifact_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = Path(directory) / "coverage-core/build/reports/kover/report.xml"
+            report.parent.mkdir(parents=True)
+            report.write_text(
+                '<report><counter type="INSTRUCTION" missed="1" covered="1"/></report>',
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(AGGREGATOR),
+                    directory,
+                    "--expected-artifact",
+                    "coverage-core",
+                    "--expected-artifact",
+                    "coverage-micrometer",
+                ],
+                cwd=ROOT,
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("expected coverage artifact is missing", result.stdout + result.stderr)
+
+    def _write_workflow(self, source: str) -> Path:
+        directory_handle = tempfile.TemporaryDirectory()
+        self.addCleanup(directory_handle.cleanup)
+        directory = Path(directory_handle.name)
+        path = directory / "workflow.yml"
+        path.write_text(source, encoding="utf-8")
+        return path
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/validate_provider_artifacts.py
+++ b/scripts/ci/validate_provider_artifacts.py
@@ -162,7 +162,8 @@ def validate_workflow(path: Path) -> list[str]:
 
         kover = _step_block(block, "Generate Kover XML report")
         if kover is None:
-            violations.append(f"{path}: {job_id}에 Kover report step이 없습니다")
+            if test_step is None or "koverXmlReport" not in test_step:
+                violations.append(f"{path}: {job_id} test step에 Kover report task가 없습니다")
         elif not _has_env_provider(kover, provider):
             violations.append(
                 f"{path}: {job_id} Kover report env에 LEADER_TEST_DB={provider}가 없습니다"

--- a/scripts/ci/validate_provider_artifacts_test.py
+++ b/scripts/ci/validate_provider_artifacts_test.py
@@ -104,8 +104,8 @@ class ProviderArtifactContractTest(unittest.TestCase):
     def test_rejects_provider_removed_from_test_step(self) -> None:
         source = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
         source = source.replace(
-            '          LEADER_TEST_DB: "H2"\n\n      - name: Generate Kover XML report',
-            '          LEADER_TEST_DB: "BROKEN"\n\n      - name: Generate Kover XML report',
+            '          LEADER_TEST_DB: "H2"\n\n      - name: Verify provider artifact provenance',
+            '          LEADER_TEST_DB: "BROKEN"\n\n      - name: Verify provider artifact provenance',
             1,
         )
 
@@ -131,8 +131,8 @@ class ProviderArtifactContractTest(unittest.TestCase):
             1,
         )
         job = job.replace(
-            '          LEADER_TEST_DB: "H2"\n\n      - name: Generate Kover XML report',
-            '\n      - name: Generate Kover XML report',
+            '          LEADER_TEST_DB: "H2"\n\n      - name: Verify provider artifact provenance',
+            '\n      - name: Verify provider artifact provenance',
             1,
         )
         source = source[:job_start] + job + source[job_end:]

--- a/scripts/ci/validate_release_provenance.py
+++ b/scripts/ci/validate_release_provenance.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""release workflow의 immutable source SHA provenance 계약을 검증한다."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_WORKFLOW = ROOT / ".github/workflows/release.yml"
+
+
+def validate_workflow(path: Path) -> list[str]:
+    if path.is_symlink() or not path.is_file():
+        return [f"{path}: workflow 파일이 없습니다"]
+
+    source = path.read_text(encoding="utf-8")
+    violations: list[str] = []
+    required_fragments = {
+        "resolve-version source_sha output": "source_sha: ${{ steps.resolve.outputs.source_sha }}",
+        "tag commit resolution": 'git rev-parse --verify "refs/tags/$VERSION^{commit}"',
+        "publish SHA checkout": "ref: ${{ needs.resolve-version.outputs.source_sha }}",
+        "head equality guard": 'ACTUAL_SHA="$(git rev-parse HEAD)"',
+        "tag equality guard": 'TAG_SHA="$(git rev-parse --verify "refs/tags/$VERSION^{commit}")"',
+        "expected SHA comparison": '"$ACTUAL_SHA" != "$EXPECTED_SHA"',
+        "tag SHA comparison": '"$TAG_SHA" != "$EXPECTED_SHA"',
+    }
+    for description, fragment in required_fragments.items():
+        if fragment not in source:
+            violations.append(f"{path}: {description}가 없습니다 ({fragment})")
+
+    if "ref: ${{ steps.resolve.outputs.ref }}" in source:
+        violations.append(f"{path}: resolve-version이 mutable ref output을 노출합니다")
+    if "needs.resolve-version.outputs.ref" in source:
+        violations.append(f"{path}: release checkout이 mutable tag ref를 사용합니다")
+
+    if source.count("Verify immutable release source") < 2:
+        violations.append(f"{path}: publish와 github-release 양쪽에 immutable source guard가 필요합니다")
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--workflow", type=Path, default=DEFAULT_WORKFLOW)
+    args = parser.parse_args(argv)
+    violations = validate_workflow(args.workflow)
+    if violations:
+        for violation in violations:
+            print(f"Release provenance contract FAILED: {violation}", file=sys.stderr)
+        return 1
+    print("Release provenance contract OK: source SHA, checked-out HEAD, and tag commit are bound")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/validate_release_provenance_test.py
+++ b/scripts/ci/validate_release_provenance_test.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""release source SHA/tag equality 계약 테스트."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/ci/validate_release_provenance.py"
+WORKFLOW = ROOT / ".github/workflows/release.yml"
+
+
+def run_validator(*arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *arguments],
+        cwd=ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+class ReleaseProvenanceContractTest(unittest.TestCase):
+    def test_release_workflow_resolves_and_checks_an_immutable_source_sha(self) -> None:
+        result = run_validator("--workflow", str(WORKFLOW))
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_validator_rejects_mutable_tag_checkout(self) -> None:
+        source = """
+jobs:
+  resolve-version:
+    outputs:
+      ref: ${{ steps.resolve.outputs.ref }}
+  publish:
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve-version.outputs.ref }}
+"""
+
+        path = self._write_workflow(source)
+        result = run_validator("--workflow", str(path))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("source_sha", result.stdout + result.stderr)
+
+    def test_validator_requires_tag_and_head_equality_guard(self) -> None:
+        source = """
+jobs:
+  resolve-version:
+    outputs:
+      source_sha: ${{ steps.resolve.outputs.source_sha }}
+    steps:
+      - uses: actions/checkout@v7
+      - id: resolve
+        run: |
+          TAG_SHA=$(git rev-parse --verify "refs/tags/$VERSION^{commit}")
+          echo "source_sha=$TAG_SHA" >> "$GITHUB_OUTPUT"
+  publish:
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve-version.outputs.source_sha }}
+"""
+
+        path = self._write_workflow(source)
+        result = run_validator("--workflow", str(path))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("equality", result.stdout + result.stderr)
+
+    def _write_workflow(self, source: str) -> Path:
+        directory_handle = tempfile.TemporaryDirectory()
+        self.addCleanup(directory_handle.cleanup)
+        directory = Path(directory_handle.name)
+        path = directory / "release.yml"
+        path.write_text(source, encoding="utf-8")
+        return path
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

- [#867](https://github.com/bluetape4k/bluetape4k-leader/issues/867)의 Kover 실행·집계를 실제 테스트 산출물에 결속하도록 수정했습니다.
- [#859](https://github.com/bluetape4k/bluetape4k-leader/issues/859)의 release source provenance를 immutable commit SHA와 tag equality guard로 고정했습니다.

## 변경 사항

- CI/Nightly의 각 Kover job을 `test`와 `koverXmlReport` 단일 Gradle invocation으로 통합했습니다.
- coverage artifact 업로드 누락을 실패로 처리하고, aggregate script가 empty/malformed/missing report를 fail-closed로 처리하도록 강화했습니다.
- path-filter로 모든 coverage job이 의도적으로 skip되는 CI에서는 aggregate job을 skip하도록 조건과 계약 테스트를 추가했습니다.
- Kover/release provenance 계약 validator와 회귀 테스트를 추가했습니다.
- release workflow가 tag commit을 `source_sha`로 해석하고 publish/github-release checkout 및 HEAD/tag를 검증하도록 변경했습니다.

## 검증

- 로컬: `actionlint`, `ruff`, `git diff --check`, Kover/release/provider 및 기존 CI 계약 테스트 통과
- 로컬 combined Gradle: leader-core, micrometer, exposed-jdbc H2 coverage 실행 통과
- PR CI [33763493146](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33763493146): head `5ac0cb26c0538a84dfd14b78e129e838a853c290`, 성공
- Nightly full [33763530701](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33763530701): 동일 head, 28/28 job 성공

Closes #867
Closes #859

## DoD Status

- [x] 구현 및 로컬 검증 완료
- [x] Lore commit 및 branch push 완료
- [x] exact-head GitHub CI 확인
- [x] Nightly dispatch 및 결과 확인
- [x] merge 전 최신 head, CI, reviews, threads, mergeability 재확인
- [x] merge 완료: `e037ef4e6c7487272edfbc00fc9d783678286682`