### PR TITLE
fix: async leader lifecycle 정리 누락을 막는다

### DIFF
--- a/docs/lessons/2026-09-04-async-leader-lifecycle-cleanup.md
+++ b/docs/lessons/2026-09-04-async-leader-lifecycle-cleanup.md
@@ -1,0 +1,54 @@
+# 비동기 leader lifecycle의 취소와 executor 거부 정리
+
+## 맥락
+
+Issue #857과 #858은 `runAsyncIfLeaderResult`가 반환한 future를 취소하거나,
+lock을 획득한 직후 executor가 작업 제출을 거부할 때 실제 action과 lease의
+lifecycle이 끝나지 않는 문제를 다룹니다. 반환 future의 terminal 상태만 바뀌고
+내부 action이 계속 실행되면 lock 재획득이 지연됩니다. Redis backend에서는
+획득과 action 제출 사이의 실패 때문에 이미 얻은 lease나 group permit이 남을 수
+있습니다.
+
+## 원인
+
+- 결과 future의 취소 대상이 바깥쪽 source future에만 연결되어 실제 action
+  future까지 전달되지 않았습니다.
+- `thenComposeAsync` 계열 pipeline은 lock 획득 뒤 executor 제출이 실패하면 action
+  callback에 진입하지 않으므로 callback 내부의 release 경로도 실행하지 않습니다.
+- 취소와 정상 완료가 경쟁할 때 여러 callback이 cleanup을 시작할 수 있으므로,
+  cleanup owner를 하나로 고정하지 않으면 중복 release 위험이 생깁니다.
+
+## 결정
+
+- 결과 변환과 backend pipeline 사이에 cancellation relay를 두고, 실제 action
+  future가 정해지는 즉시 취소 대상을 연결합니다.
+- lock 획득 이후에는 action 실행 여부와 관계없이 terminal 경로가 lease cleanup을
+  소유합니다. executor rejection도 cleanup이 끝난 뒤 원래 예외로 완료합니다.
+- cancellation, action 완료, 제출 실패가 경쟁해도 원자적 owner가 cleanup을 정확히
+  한 번만 시작하도록 합니다.
+
+## 결과와 검증
+
+반환 future를 취소하면 실제 action future도 취소되고, cleanup 완료 뒤 같은 lock을
+다시 획득할 수 있습니다. Lettuce, Redisson, MongoDB의 단일/group 경로는 두 번째
+executor 제출을 의도적으로 거부하는 회귀 테스트로 lease와 permit 회수를
+검증했습니다.
+
+- RED: 실제 action이 취소되지 않고 재획득이 `null`이 되는 동작을 재현했습니다.
+- GREEN: 영향 모듈 9개의 전체 suite 2,571개가 한 차례 통과했고, 최종 CAS 수정 뒤
+  core/MongoDB/Lettuce/Redisson lifecycle 회귀 16개가 다시 통과했습니다.
+- `./gradlew detekt --no-daemon --console=plain`이 통과했습니다.
+- `git diff --cached --check`가 통과했습니다.
+- 최종 core 전체 재실행은 기존 Issue #868의
+  `BoundedLeaderAuditExporterTest` flake 1건을 두 번 재현했습니다. 해당 테스트의
+  격리 재실행은 통과했으며 이번 lifecycle 변경과 겹치는 source는 없습니다.
+
+## 놓친 가정과 향후 지침
+
+`CompletableFuture.cancel()`은 연결된 비동기 작업 전체를 자동으로 취소하지
+않습니다. future adapter를 추가하거나 수정할 때는 반환 future, acquire future,
+실제 action future, watchdog, lease cleanup의 ownership을 각각 확인해야 합니다.
+회귀 테스트는 `isCancelled`만 검사하지 말고 action 취소와 동일 lock/slot 재획득을
+함께 검증합니다. acquire 뒤 비동기 제출이 있는 backend는 executor rejection을
+별도 terminal 경로로 취급하고, 원래 실패가 관찰되기 전에 cleanup이 끝나는지도
+검증합니다.

--- a/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElector.kt
+++ b/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElector.kt
@@ -120,10 +120,11 @@ class ConsulLeaderElector private constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         var elected = false
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
         return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected = true
-            action()
-        }) { value, failure ->
+            cancellationRelay.invoke(action)
+        }, cancellationRelay) { value, failure ->
             val cause = failure.unwrapCompletionException()
             when {
                 cause is CancellationException -> throw cause
@@ -207,9 +208,8 @@ class ConsulLeaderElector private constructor(
                 if (handle == null) {
                     CompletableFuture.completedFuture(null)
                 } else {
-                    val actionFuture = runAcquiredAsync(handle, executor, action)
                     lifecycleStarted.set(true)
-                    actionFuture
+                    runAcquiredAsync(handle, executor, action)
                 }
             }, executor)
         } catch (error: Throwable) {
@@ -220,6 +220,9 @@ class ConsulLeaderElector private constructor(
         }
         pipelineFuture.whenComplete { _, failure ->
             if (failure != null) releaseIfUnclaimed()
+        }
+        acquisitionFuture.whenComplete { handle, _ ->
+            if (handle != null && pipelineFuture.isCancelled) releaseIfUnclaimed()
         }
         return pipelineFuture
     }

--- a/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElector.kt
+++ b/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElector.kt
@@ -23,6 +23,7 @@ import io.bluetape4k.leader.consul.internal.ConsulSessionTtl
 import io.bluetape4k.leader.consul.internal.JavaHttpConsulLockClient
 import io.bluetape4k.leader.consul.internal.getWithinRequestTimeout
 import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import io.bluetape4k.leader.remainingMinLeaseTime
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
@@ -32,6 +33,8 @@ import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -117,10 +120,10 @@ class ConsulLeaderElector private constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         var elected = false
-        return runAsyncIfLeader(slot, executor) {
+        return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected = true
             action()
-        }.handle { value, failure ->
+        }) { value, failure ->
             val cause = failure.unwrapCompletionException()
             when {
                 cause is CancellationException -> throw cause
@@ -178,36 +181,70 @@ class ConsulLeaderElector private constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun <T> runAsyncWithLock(
         lockName: String,
         auditLeaderId: String?,
         executor: Executor,
         action: () -> CompletableFuture<T>,
-    ): CompletableFuture<T?> =
-        CompletableFuture.supplyAsync({ acquire(lockName, auditLeaderId) }, executor)
-            .thenComposeAsync({ handle ->
+    ): CompletableFuture<T?> {
+        val acquiredRef = AtomicReference<ConsulLeaseHandle?>()
+        val lifecycleStarted = AtomicBoolean()
+        val rejectionCleanupClaimed = AtomicBoolean()
+        val releaseIfUnclaimed: () -> Unit = {
+            val handle = acquiredRef.get()
+            if (handle != null && !lifecycleStarted.get() && rejectionCleanupClaimed.compareAndSet(false, true)) {
+                release(handle)
+            }
+        }
+        val acquisitionFuture = CompletableFuture.supplyAsync({
+            acquire(lockName, auditLeaderId).also { handle ->
+                if (handle != null) acquiredRef.set(handle)
+            }
+        }, executor)
+        val pipelineFuture: CompletableFuture<T?> = try {
+            acquisitionFuture.thenComposeAsync({ handle ->
                 if (handle == null) {
                     CompletableFuture.completedFuture(null)
                 } else {
-                    runAcquiredAsync(handle, executor, action)
+                    val actionFuture = runAcquiredAsync(handle, executor, action)
+                    lifecycleStarted.set(true)
+                    actionFuture
                 }
             }, executor)
+        } catch (error: Throwable) {
+            acquisitionFuture.whenComplete { handle, _ ->
+                if (handle != null) releaseIfUnclaimed()
+            }
+            CompletableFuture.failedFuture(error)
+        }
+        pipelineFuture.whenComplete { _, failure ->
+            if (failure != null) releaseIfUnclaimed()
+        }
+        return pipelineFuture
+    }
 
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
     private fun <T> runAcquiredAsync(
         handle: ConsulLeaseHandle,
         executor: Executor,
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
         val delegate = ConsulLockExtendDelegate(lockClient, handle)
-        val watchdog = LeaderLeaseAutoExtender.start(
-            options.leaderOptions.autoExtend,
-            options.leaderOptions.leaseTime,
-            delegate,
-            ERROR_CLASSIFIER,
-        )
+        val watchdog = try {
+            LeaderLeaseAutoExtender.start(
+                options.leaderOptions.autoExtend,
+                options.leaderOptions.leaseTime,
+                delegate,
+                ERROR_CLASSIFIER,
+            )
+        } catch (e: Throwable) {
+            release(handle)
+            return CompletableFuture.failedFuture(e)
+        }
         val actionFuture = try {
             action()
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             watchdog.close()
             release(handle)
             return CompletableFuture.failedFuture(e)

--- a/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderGroupElector.kt
+++ b/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderGroupElector.kt
@@ -21,6 +21,7 @@ import io.bluetape4k.leader.consul.internal.ConsulSessionId
 import io.bluetape4k.leader.consul.internal.ConsulSessionTtl
 import io.bluetape4k.leader.consul.internal.JavaHttpConsulLockClient
 import io.bluetape4k.leader.consul.internal.getWithinRequestTimeout
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import io.bluetape4k.leader.remainingMinLeaseTime
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
@@ -31,6 +32,8 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * `ConsulLeaderGroupElector`는 Consul backend의 lease, ownership 확인, session/TTL 정리를 담당합니다.
@@ -122,10 +125,10 @@ class ConsulLeaderGroupElector private constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         var elected = false
-        return runAsyncIfLeader(slot, executor) {
+        return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected = true
             action()
-        }.handle { value, failure ->
+        }) { value, failure ->
             val cause = failure.unwrapCompletionException()
             when {
                 cause is CancellationException -> throw cause
@@ -176,37 +179,71 @@ class ConsulLeaderGroupElector private constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun <T> runAsyncWithSlot(
         lockName: String,
         auditLeaderId: String?,
         executor: Executor,
         action: () -> CompletableFuture<T>,
-    ): CompletableFuture<T?> =
-        CompletableFuture.supplyAsync({ acquire(lockName, auditLeaderId) }, executor)
-            .thenComposeAsync({ handle ->
+    ): CompletableFuture<T?> {
+        val acquiredRef = AtomicReference<ConsulLeaseHandle?>()
+        val lifecycleStarted = AtomicBoolean()
+        val rejectionCleanupClaimed = AtomicBoolean()
+        val releaseIfUnclaimed: () -> Unit = {
+            val handle = acquiredRef.get()
+            if (handle != null && !lifecycleStarted.get() && rejectionCleanupClaimed.compareAndSet(false, true)) {
+                release(handle)
+            }
+        }
+        val acquisitionFuture = CompletableFuture.supplyAsync({
+            acquire(lockName, auditLeaderId).also { handle ->
+                if (handle != null) acquiredRef.set(handle)
+            }
+        }, executor)
+        val pipelineFuture: CompletableFuture<T?> = try {
+            acquisitionFuture.thenComposeAsync({ handle ->
                 if (handle == null) {
                     CompletableFuture.completedFuture(null)
                 } else {
-                    runAcquiredAsync(handle, executor, action)
+                    val actionFuture = runAcquiredAsync(handle, executor, action)
+                    lifecycleStarted.set(true)
+                    actionFuture
                 }
             }, executor)
+        } catch (error: Throwable) {
+            acquisitionFuture.whenComplete { handle, _ ->
+                if (handle != null) releaseIfUnclaimed()
+            }
+            CompletableFuture.failedFuture(error)
+        }
+        pipelineFuture.whenComplete { _, failure ->
+            if (failure != null) releaseIfUnclaimed()
+        }
+        return pipelineFuture
+    }
 
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
     private fun <T> runAcquiredAsync(
         handle: ConsulLeaseHandle,
         executor: Executor,
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
         val delegate = ConsulLockExtendDelegate(lockClient, handle)
-        val watchdog = LeaderLeaseAutoExtender.start(
-            // Group auto-extension is disabled; explicit LockExtender renews the Consul session.
-            enabled = false,
-            leaseTime = options.leaderGroupOptions.leaseTime,
-            delegate = delegate,
-            classifier = ConsulLeaderElector.ERROR_CLASSIFIER,
-        )
+        val watchdog = try {
+            LeaderLeaseAutoExtender.start(
+                // Group auto-extension is disabled; explicit LockExtender renews the Consul session.
+                enabled = false,
+                leaseTime = options.leaderGroupOptions.leaseTime,
+                delegate = delegate,
+                classifier = ConsulLeaderElector.ERROR_CLASSIFIER,
+            )
+        } catch (e: Throwable) {
+            release(handle)
+            return CompletableFuture.failedFuture(e)
+        }
         val actionFuture = try {
             action()
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             watchdog.close()
             release(handle)
             return CompletableFuture.failedFuture(e)

--- a/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderGroupElector.kt
+++ b/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderGroupElector.kt
@@ -125,10 +125,11 @@ class ConsulLeaderGroupElector private constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         var elected = false
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
         return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected = true
-            action()
-        }) { value, failure ->
+            cancellationRelay.invoke(action)
+        }, cancellationRelay) { value, failure ->
             val cause = failure.unwrapCompletionException()
             when {
                 cause is CancellationException -> throw cause
@@ -205,9 +206,8 @@ class ConsulLeaderGroupElector private constructor(
                 if (handle == null) {
                     CompletableFuture.completedFuture(null)
                 } else {
-                    val actionFuture = runAcquiredAsync(handle, executor, action)
                     lifecycleStarted.set(true)
-                    actionFuture
+                    runAcquiredAsync(handle, executor, action)
                 }
             }, executor)
         } catch (error: Throwable) {
@@ -218,6 +218,9 @@ class ConsulLeaderGroupElector private constructor(
         }
         pipelineFuture.whenComplete { _, failure ->
             if (failure != null) releaseIfUnclaimed()
+        }
+        acquisitionFuture.whenComplete { handle, _ ->
+            if (handle != null && pipelineFuture.isCancelled) releaseIfUnclaimed()
         }
         return pipelineFuture
     }

--- a/leader-consul/src/test/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElectorDelegationTest.kt
+++ b/leader-consul/src/test/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElectorDelegationTest.kt
@@ -30,6 +30,7 @@ import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -291,6 +292,77 @@ class ConsulLeaderElectorDelegationTest {
     }
 
     @Test
+    fun `runAsyncIfLeaderResult 취소 후 늦게 획득한 single lease를 정리한다`() {
+        val acquisition = CompletableFuture<Boolean>()
+        val acquireStarted = CountDownLatch(1)
+        val releaseObserved = CountDownLatch(1)
+        val client = FakeConsulLockClient(
+            acquireFuture = acquisition,
+            acquireStarted = acquireStarted,
+            releaseObserved = releaseObserved,
+        )
+        val elector = ConsulLeaderElector.create(client)
+        val executor = Executors.newFixedThreadPool(2)
+        val actionInvoked = AtomicBoolean()
+
+        try {
+            val result = elector.runAsyncIfLeaderResult(LeaderSlot("lock-late-single", "audit-a"), executor) {
+                actionInvoked.set(true)
+                CompletableFuture.completedFuture("실행되면 안 됨")
+            }
+
+            acquireStarted.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            result.cancel(false).shouldBeTrue()
+            acquisition.complete(true)
+
+            releaseObserved.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            actionInvoked.get() shouldBeEqualTo false
+            client.releaseCalls shouldBeEqualTo 1
+            client.destroyCalls shouldBeEqualTo 1
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult 취소 후 늦게 획득한 group lease를 정리한다`() {
+        val acquisition = CompletableFuture<Boolean>()
+        val acquireStarted = CountDownLatch(1)
+        val releaseObserved = CountDownLatch(1)
+        val client = FakeConsulLockClient(
+            acquireFuture = acquisition,
+            acquireStarted = acquireStarted,
+            releaseObserved = releaseObserved,
+        )
+        val elector = ConsulLeaderGroupElector.create(
+            client,
+            ConsulLeaderGroupElectionOptions(
+                leaderGroupOptions = LeaderGroupElectionOptions(maxLeaders = 1, leaseTime = 10.seconds),
+            ),
+        )
+        val executor = Executors.newFixedThreadPool(2)
+        val actionInvoked = AtomicBoolean()
+
+        try {
+            val result = elector.runAsyncIfLeaderResult(LeaderSlot("lock-late-group", "audit-a"), executor) {
+                actionInvoked.set(true)
+                CompletableFuture.completedFuture("실행되면 안 됨")
+            }
+
+            acquireStarted.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            result.cancel(false).shouldBeTrue()
+            acquisition.complete(true)
+
+            releaseObserved.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            actionInvoked.get() shouldBeEqualTo false
+            client.releaseCalls shouldBeEqualTo 1
+            client.destroyCalls shouldBeEqualTo 1
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
     fun `runAsyncIfLeader cleanup runs after caller executor shutdown`() {
         val client = FakeConsulLockClient()
         val elector = ConsulLeaderElector.create(
@@ -463,6 +535,9 @@ class ConsulLeaderElectorDelegationTest {
         override val requestTimeout: Duration = 5.seconds,
         private val readFuture: CompletableFuture<ConsulKvEntry?>? = null,
         private val interruptAcquire: Boolean = false,
+        private val acquireFuture: CompletableFuture<Boolean>? = null,
+        private val acquireStarted: CountDownLatch? = null,
+        private val releaseObserved: CountDownLatch? = null,
     ) : ConsulLockClient {
 
         private var currentEntry: ConsulKvEntry? = entry
@@ -501,9 +576,11 @@ class ConsulLeaderElectorDelegationTest {
             ownerPayload: String,
         ): CompletableFuture<Boolean> {
             acquireCalls++
+            acquireStarted?.countDown()
             if (interruptAcquire) {
                 return InterruptingFuture()
             }
+            acquireFuture?.let { return it }
             if (acquireResult) {
                 currentEntry = ConsulKvEntry(
                     key = key,
@@ -518,6 +595,7 @@ class ConsulLeaderElectorDelegationTest {
 
         override fun release(key: String, sessionId: ConsulSessionId): CompletableFuture<Boolean> {
             releaseCalls++
+            releaseObserved?.countDown()
             return CompletableFuture.completedFuture(true)
         }
 

--- a/leader-consul/src/test/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElectorDelegationTest.kt
+++ b/leader-consul/src/test/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElectorDelegationTest.kt
@@ -26,8 +26,11 @@ import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
 import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -320,6 +323,73 @@ class ConsulLeaderElectorDelegationTest {
             client.destroyCalls shouldBeEqualTo 2
         } finally {
             executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `runAsyncIfLeader releases acquired single lease when second executor submission is rejected`() {
+        val client = FakeConsulLockClient()
+        val elector = ConsulLeaderElector.create(client)
+        val worker = Executors.newSingleThreadExecutor()
+        val submissions = AtomicInteger()
+        val executor = Executor { command ->
+            if (submissions.incrementAndGet() == 1) {
+                worker.execute(command)
+            } else {
+                throw RejectedExecutionException("second submission rejected")
+            }
+        }
+
+        try {
+            val resultFuture = runCatching {
+                elector.runAsyncIfLeader("lock-a", executor) {
+                    CompletableFuture.completedFuture("should-not-run")
+                }
+            }.getOrElse { CompletableFuture.failedFuture(it) }
+
+            val failure = assertFailsWith<CompletionException> { resultFuture.join() }
+            failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            elector.runIfLeader("lock-a") { "reacquired" } shouldBeEqualTo "reacquired"
+            client.releaseCalls shouldBeEqualTo 2
+            client.destroyCalls shouldBeEqualTo 2
+        } finally {
+            worker.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `runAsyncIfLeader releases acquired group slot when second executor submission is rejected`() {
+        val client = FakeConsulLockClient()
+        val elector = ConsulLeaderGroupElector.create(
+            client,
+            ConsulLeaderGroupElectionOptions(
+                leaderGroupOptions = LeaderGroupElectionOptions(maxLeaders = 1, leaseTime = 10.seconds),
+            ),
+        )
+        val worker = Executors.newSingleThreadExecutor()
+        val submissions = AtomicInteger()
+        val executor = Executor { command ->
+            if (submissions.incrementAndGet() == 1) {
+                worker.execute(command)
+            } else {
+                throw RejectedExecutionException("second submission rejected")
+            }
+        }
+
+        try {
+            val resultFuture = runCatching {
+                elector.runAsyncIfLeader("lock-a", executor) {
+                    CompletableFuture.completedFuture("should-not-run")
+                }
+            }.getOrElse { CompletableFuture.failedFuture(it) }
+
+            val failure = assertFailsWith<CompletionException> { resultFuture.join() }
+            failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            elector.runIfLeader("lock-a") { "reacquired" } shouldBeEqualTo "reacquired"
+            client.releaseCalls shouldBeEqualTo 2
+            client.destroyCalls shouldBeEqualTo 2
+        } finally {
+            worker.shutdownNow()
         }
     }
 

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderElector.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader
 
 import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
 import io.bluetape4k.leader.identity.LeaderElectorBridgeLog
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
@@ -64,10 +65,10 @@ interface AsyncLeaderElector: LeaderElectionState {
     ): CompletableFuture<LeaderRunResult<T>> {
         LeaderElectorBridgeLog.global().warnOnResultBridgeUse(this::class, slot)
         val elected = AtomicBoolean(false)
-        return runAsyncIfLeader(slot.lockName, executor) {
+        return LeaderFutureBridge.map(runAsyncIfLeader(slot.lockName, executor) {
             elected.set(true)
             action()
-        }.handle { value, failure ->
+        }) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderElector.kt
@@ -65,10 +65,11 @@ interface AsyncLeaderElector: LeaderElectionState {
     ): CompletableFuture<LeaderRunResult<T>> {
         LeaderElectorBridgeLog.global().warnOnResultBridgeUse(this::class, slot)
         val elected = AtomicBoolean(false)
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
         return LeaderFutureBridge.map(runAsyncIfLeader(slot.lockName, executor) {
             elected.set(true)
-            action()
-        }) { value, failure ->
+            cancellationRelay.invoke(action)
+        }, cancellationRelay) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderGroupElector.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader
 
 import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
 import io.bluetape4k.leader.identity.LeaderElectorBridgeLog
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
@@ -64,10 +65,10 @@ interface AsyncLeaderGroupElector: LeaderGroupElectionState {
     ): CompletableFuture<LeaderRunResult<T>> {
         LeaderElectorBridgeLog.global().warnOnResultBridgeUse(this::class, slot)
         val elected = AtomicBoolean(false)
-        return runAsyncIfLeader(slot.lockName, executor) {
+        return LeaderFutureBridge.map(runAsyncIfLeader(slot.lockName, executor) {
             elected.set(true)
             action()
-        }.handle { value, failure ->
+        }) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderGroupElector.kt
@@ -65,10 +65,11 @@ interface AsyncLeaderGroupElector: LeaderGroupElectionState {
     ): CompletableFuture<LeaderRunResult<T>> {
         LeaderElectorBridgeLog.global().warnOnResultBridgeUse(this::class, slot)
         val elected = AtomicBoolean(false)
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
         return LeaderFutureBridge.map(runAsyncIfLeader(slot.lockName, executor) {
             elected.set(true)
-            action()
-        }) { value, failure ->
+            cancellationRelay.invoke(action)
+        }, cancellationRelay) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/ListeningLeaderElectors.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/ListeningLeaderElectors.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.support.requireNotNull
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsAware
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
 import io.bluetape4k.leader.diagnostics.resolveLeaderBackendDiagnosticsProvider
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -188,7 +189,7 @@ class ListeningLeaderElector(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
-        return delegate.runAsyncIfLeaderResult(slot, executor) {
+        val source = delegate.runAsyncIfLeaderResult(slot, executor) {
             elected.set(true)
             val leader = delegate.state(slot.lockName).leader
             listeners.notifyElected(slot.lockName, leader)
@@ -203,7 +204,8 @@ class ListeningLeaderElector(
                 eventSubject.tryEmit(LeaderElectionEvent.Revoked(slot.lockName))
                 CompletableFuture.failedFuture(e)
             }
-        }.whenComplete { result, failure ->
+        }
+        return LeaderFutureBridge.observe(source) { result, failure ->
             if (!elected.get() && failure == null && result is LeaderRunResult.Skipped) {
                 listeners.notifySkipped(slot.lockName)
                 eventSubject.tryEmit(LeaderElectionEvent.Skipped(slot.lockName))

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/ListeningLeaderElectors.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/ListeningLeaderElectors.kt
@@ -131,13 +131,13 @@ class ListeningLeaderElector(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
         val elected = AtomicBoolean(false)
-        return delegate.runAsyncIfLeader(lockName, executor) {
+        val source = delegate.runAsyncIfLeader(lockName, executor) {
             elected.set(true)
             val leader = delegate.state(lockName).leader
             listeners.notifyElected(lockName, leader)
             eventSubject.tryEmit(LeaderElectionEvent.Elected.fromLease(lockName, leader))
             try {
-                action().whenComplete { _, _ ->
+                LeaderFutureBridge.observe(action()) { _, _ ->
                     listeners.notifyRevoked(lockName)
                     eventSubject.tryEmit(LeaderElectionEvent.Revoked(lockName))
                 }
@@ -146,7 +146,8 @@ class ListeningLeaderElector(
                 eventSubject.tryEmit(LeaderElectionEvent.Revoked(lockName))
                 CompletableFuture.failedFuture(e)
             }
-        }.whenComplete { value, failure ->
+        }
+        return LeaderFutureBridge.observe(source) { value, failure ->
             if (!elected.get() && failure == null && value == null) {
                 listeners.notifySkipped(lockName)
                 eventSubject.tryEmit(LeaderElectionEvent.Skipped(lockName))
@@ -160,13 +161,13 @@ class ListeningLeaderElector(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
         val elected = AtomicBoolean(false)
-        return delegate.runAsyncIfLeader(slot, executor) {
+        val source = delegate.runAsyncIfLeader(slot, executor) {
             elected.set(true)
             val leader = delegate.state(slot.lockName).leader
             listeners.notifyElected(slot.lockName, leader)
             eventSubject.tryEmit(LeaderElectionEvent.Elected.fromLease(slot.lockName, leader))
             try {
-                action().whenComplete { _, _ ->
+                LeaderFutureBridge.observe(action()) { _, _ ->
                     listeners.notifyRevoked(slot.lockName)
                     eventSubject.tryEmit(LeaderElectionEvent.Revoked(slot.lockName))
                 }
@@ -175,7 +176,8 @@ class ListeningLeaderElector(
                 eventSubject.tryEmit(LeaderElectionEvent.Revoked(slot.lockName))
                 CompletableFuture.failedFuture(e)
             }
-        }.whenComplete { value, failure ->
+        }
+        return LeaderFutureBridge.observe(source) { value, failure ->
             if (!elected.get() && failure == null && value == null) {
                 listeners.notifySkipped(slot.lockName)
                 eventSubject.tryEmit(LeaderElectionEvent.Skipped(slot.lockName))
@@ -195,7 +197,7 @@ class ListeningLeaderElector(
             listeners.notifyElected(slot.lockName, leader)
             eventSubject.tryEmit(LeaderElectionEvent.Elected.fromLease(slot.lockName, leader))
             try {
-                action().whenComplete { _, _ ->
+                LeaderFutureBridge.observe(action()) { _, _ ->
                     listeners.notifyRevoked(slot.lockName)
                     eventSubject.tryEmit(LeaderElectionEvent.Revoked(slot.lockName))
                 }
@@ -281,12 +283,12 @@ class ListeningLeaderGroupElector(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
         val elected = AtomicBoolean(false)
-        return delegate.runAsyncIfLeader(lockName, executor) {
+        val source = delegate.runAsyncIfLeader(lockName, executor) {
             elected.set(true)
             listeners.notifyElected(lockName, null)
             eventSubject.tryEmit(LeaderElectionEvent.Elected.fromLease(lockName, null))
             try {
-                action().whenComplete { _, _ ->
+                LeaderFutureBridge.observe(action()) { _, _ ->
                     listeners.notifyRevoked(lockName)
                     eventSubject.tryEmit(LeaderElectionEvent.Revoked(lockName))
                 }
@@ -295,7 +297,8 @@ class ListeningLeaderGroupElector(
                 eventSubject.tryEmit(LeaderElectionEvent.Revoked(lockName))
                 CompletableFuture.failedFuture(e)
             }
-        }.whenComplete { value, failure ->
+        }
+        return LeaderFutureBridge.observe(source) { value, failure ->
             if (!elected.get() && failure == null && value == null) {
                 listeners.notifySkipped(lockName)
                 eventSubject.tryEmit(LeaderElectionEvent.Skipped(lockName))

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/VirtualThreadLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/VirtualThreadLeaderElector.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader
 
 import io.bluetape4k.concurrent.virtualthread.VirtualFuture
 import io.bluetape4k.leader.identity.LeaderElectorBridgeLog
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletionException
 import java.util.concurrent.atomic.AtomicBoolean
@@ -60,16 +61,14 @@ interface VirtualThreadLeaderElector: LeaderElectionState {
             elected.set(true)
             action()
         }
-        val mapped: java.util.concurrent.CompletableFuture<LeaderRunResult<T>> =
-            source.toCompletableFuture().handle { value, failure ->
-                when {
-                    failure != null && elected.get() -> failure.toActionFailedResult()
-                    failure != null -> throw failure.asCompletionException()
-                    elected.get() -> LeaderRunResult.Elected(value) as LeaderRunResult<T>
-                    else -> LeaderRunResult.Skipped as LeaderRunResult<T>
-                }
+        return LeaderFutureBridge.map(source) { value, failure ->
+            when {
+                failure != null && elected.get() -> failure.toActionFailedResult()
+                failure != null -> throw failure.asCompletionException()
+                elected.get() -> LeaderRunResult.Elected(value) as LeaderRunResult<T>
+                else -> LeaderRunResult.Skipped as LeaderRunResult<T>
             }
-        return VirtualFuture(mapped)
+        }
     }
 
     private fun Throwable.unwrapCompletionCause(): Throwable =

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/VirtualThreadLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/VirtualThreadLeaderGroupElector.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader
 
 import io.bluetape4k.concurrent.virtualthread.VirtualFuture
 import io.bluetape4k.leader.identity.LeaderElectorBridgeLog
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletionException
 import java.util.concurrent.atomic.AtomicBoolean
@@ -60,16 +61,14 @@ interface VirtualThreadLeaderGroupElector: LeaderGroupElectionState {
             elected.set(true)
             action()
         }
-        val mapped: java.util.concurrent.CompletableFuture<LeaderRunResult<T>> =
-            source.toCompletableFuture().handle { value, failure ->
-                when {
-                    failure != null && elected.get() -> failure.toActionFailedResult()
-                    failure != null -> throw failure.asCompletionException()
-                    elected.get() -> LeaderRunResult.Elected(value) as LeaderRunResult<T>
-                    else -> LeaderRunResult.Skipped as LeaderRunResult<T>
-                }
+        return LeaderFutureBridge.map(source) { value, failure ->
+            when {
+                failure != null && elected.get() -> failure.toActionFailedResult()
+                failure != null -> throw failure.asCompletionException()
+                elected.get() -> LeaderRunResult.Elected(value) as LeaderRunResult<T>
+                else -> LeaderRunResult.Skipped as LeaderRunResult<T>
             }
-        return VirtualFuture(mapped)
+        }
     }
 
     private fun Throwable.unwrapCompletionCause(): Throwable =

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderFutureBridge.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderFutureBridge.kt
@@ -1,7 +1,9 @@
 package io.bluetape4k.leader.internal
 
 import io.bluetape4k.concurrent.virtualthread.VirtualFuture
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * 결과 bridge가 반환한 future의 취소를 원본 lifecycle future로 전달하는 내부 adapter입니다.
@@ -22,6 +24,34 @@ object LeaderFutureBridge {
         val transformed = source.handle { value, failure -> mapper(value, failure) }
         return mirror(transformed, source)
     }
+
+    /**
+     * 원본 future의 terminal state를 비동기 cleanup stage로 변환하면서 caller cancellation을 원본에 전달합니다.
+     */
+    fun <T, R> flatMap(
+        source: CompletableFuture<T>,
+        mapper: (T, Throwable?) -> CompletableFuture<R>,
+    ): CompletableFuture<R> {
+        val transformed = source.handle { value, failure -> mapper(value, failure) }.thenCompose { it }
+        return mirror(transformed, source)
+    }
+
+    /**
+     * 원본 future 변환과 함께 caller cancellation을 실제 action future까지 전달합니다.
+     */
+    fun <T, R> map(
+        source: CompletableFuture<T>,
+        cancellationRelay: CancellationRelay,
+        mapper: (T, Throwable?) -> R,
+    ): CompletableFuture<R> {
+        val transformed = source.handle { value, failure -> mapper(value, failure) }
+        return mirror(transformed, source, cancellationRelay::cancel)
+    }
+
+    /**
+     * Result adapter가 아직 생성되지 않았거나 실행 중인 action future를 추적하는 relay를 만듭니다.
+     */
+    fun cancellationRelay(): CancellationRelay = CancellationRelay()
 
     /**
      * 원본 future를 관찰하면서 반환 future의 취소를 원본으로 전파합니다.
@@ -53,8 +83,9 @@ object LeaderFutureBridge {
     private fun <T> mirror(
         source: CompletableFuture<T>,
         cancellationTarget: CompletableFuture<*>,
+        onCancellation: (Boolean) -> Unit = {},
     ): CompletableFuture<T> {
-        val mirrored = CancellationPropagatingFuture<T>(cancellationTarget)
+        val mirrored = CancellationPropagatingFuture<T>(cancellationTarget, onCancellation)
         source.whenComplete { value, failure ->
             if (failure == null) {
                 mirrored.complete(value)
@@ -67,14 +98,48 @@ object LeaderFutureBridge {
 
     private class CancellationPropagatingFuture<T>(
         private val cancellationTarget: CompletableFuture<*>,
+        private val onCancellation: (Boolean) -> Unit,
     ) : CompletableFuture<T>() {
 
         override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
             val cancelled = super.cancel(mayInterruptIfRunning)
             if (cancelled) {
                 cancellationTarget.cancel(mayInterruptIfRunning)
+                onCancellation(mayInterruptIfRunning)
             }
             return cancelled
+        }
+    }
+
+    /**
+     * caller cancellation과 action future 생성 사이의 race를 닫는 내부 lifecycle relay입니다.
+     */
+    class CancellationRelay internal constructor() {
+        private val state = AtomicReference(State.READY)
+        private val actionFuture = AtomicReference<CompletableFuture<*>?>()
+
+        /**
+         * action을 실행하고 그 future를 현재 cancellation lifecycle에 연결합니다.
+         */
+        fun <T> invoke(action: () -> CompletableFuture<T>): CompletableFuture<T> {
+            if (!state.compareAndSet(State.READY, State.INVOKED)) {
+                return CompletableFuture.failedFuture(CancellationException("leader result future was cancelled"))
+            }
+            return action().also { future ->
+                actionFuture.set(future)
+                if (state.get() == State.CANCELLED) future.cancel(false)
+            }
+        }
+
+        internal fun cancel(mayInterruptIfRunning: Boolean) {
+            state.set(State.CANCELLED)
+            actionFuture.get()?.cancel(mayInterruptIfRunning)
+        }
+
+        private enum class State {
+            READY,
+            INVOKED,
+            CANCELLED,
         }
     }
 }

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderFutureBridge.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderFutureBridge.kt
@@ -1,0 +1,80 @@
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.concurrent.virtualthread.VirtualFuture
+import java.util.concurrent.CompletableFuture
+
+/**
+ * 결과 bridge가 반환한 future의 취소를 원본 lifecycle future로 전달하는 내부 adapter입니다.
+ *
+ * `CompletableFuture.handle`와 `whenComplete`가 만드는 dependent future는 취소가 원본으로
+ * 자동 전파되지 않으므로, leader lease와 action lifecycle이 caller 취소 뒤에도 남지 않도록
+ * 명시적으로 연결합니다.
+ */
+object LeaderFutureBridge {
+
+    /**
+     * 원본 future를 변환하면서 반환 future의 취소를 원본으로 전파합니다.
+     */
+    fun <T, R> map(
+        source: CompletableFuture<T>,
+        mapper: (T, Throwable?) -> R,
+    ): CompletableFuture<R> {
+        val transformed = source.handle { value, failure -> mapper(value, failure) }
+        return mirror(transformed, source)
+    }
+
+    /**
+     * 원본 future를 관찰하면서 반환 future의 취소를 원본으로 전파합니다.
+     */
+    fun <T> observe(
+        source: CompletableFuture<T>,
+        observer: (T?, Throwable?) -> Unit,
+    ): CompletableFuture<T> {
+        val observed = source.whenComplete { value, failure -> observer(value, failure) }
+        return mirror(observed, source)
+    }
+
+    /**
+     * [VirtualFuture] 결과 bridge에도 동일한 cancellation propagation을 적용합니다.
+     */
+    fun <T, R> map(
+        source: VirtualFuture<T>,
+        mapper: (T, Throwable?) -> R,
+    ): VirtualFuture<R> = VirtualFuture(map(source.toCompletableFuture(), mapper))
+
+    /**
+     * [VirtualFuture]의 성공·실패 결과는 변경하지 않고 반환 future의 취소만 원본으로 전파합니다.
+     */
+    fun <T> propagateCancellation(source: VirtualFuture<T>): VirtualFuture<T> {
+        val completable = source.toCompletableFuture()
+        return VirtualFuture(mirror(completable, completable))
+    }
+
+    private fun <T> mirror(
+        source: CompletableFuture<T>,
+        cancellationTarget: CompletableFuture<*>,
+    ): CompletableFuture<T> {
+        val mirrored = CancellationPropagatingFuture<T>(cancellationTarget)
+        source.whenComplete { value, failure ->
+            if (failure == null) {
+                mirrored.complete(value)
+            } else {
+                mirrored.completeExceptionally(failure)
+            }
+        }
+        return mirrored
+    }
+
+    private class CancellationPropagatingFuture<T>(
+        private val cancellationTarget: CompletableFuture<*>,
+    ) : CompletableFuture<T>() {
+
+        override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+            val cancelled = super.cancel(mayInterruptIfRunning)
+            if (cancelled) {
+                cancellationTarget.cancel(mayInterruptIfRunning)
+            }
+            return cancelled
+        }
+    }
+}

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalAsyncLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalAsyncLeaderElector.kt
@@ -82,6 +82,7 @@ class LocalAsyncLeaderElector(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
         return LeaderFutureBridge.map(CompletableFuture.supplyAsync(
             {
                 tryWithLeaderLock(
@@ -91,11 +92,11 @@ class LocalAsyncLeaderElector(
                     waitTime = options.waitTime,
                 ) {
                     elected.set(true)
-                    action().join()
+                    cancellationRelay.invoke(action).join()
                 }
             },
             executor
-        )) { value, failure ->
+        ), cancellationRelay) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalAsyncLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalAsyncLeaderElector.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.leader.AsyncLeaderElector
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
@@ -81,7 +82,7 @@ class LocalAsyncLeaderElector(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
-        return CompletableFuture.supplyAsync(
+        return LeaderFutureBridge.map(CompletableFuture.supplyAsync(
             {
                 tryWithLeaderLock(
                     lockName = slot.lockName,
@@ -94,7 +95,7 @@ class LocalAsyncLeaderElector(
                 }
             },
             executor
-        ).handle { value, failure ->
+        )) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalAsyncLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalAsyncLeaderGroupElector.kt
@@ -99,6 +99,7 @@ class LocalAsyncLeaderGroupElector private constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
         return LeaderFutureBridge.map(CompletableFuture.supplyAsync(
             {
                 tryWithPermit(
@@ -107,11 +108,11 @@ class LocalAsyncLeaderGroupElector private constructor(
                     nodeId = options.nodeId,
                 ) {
                     elected.set(true)
-                    action().join()
+                    cancellationRelay.invoke(action).join()
                 }
             },
             executor
-        )) { value, failure ->
+        ), cancellationRelay) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalAsyncLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalAsyncLeaderGroupElector.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.leader.AsyncLeaderGroupElector
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.requirePositiveNumber
 import java.util.concurrent.CancellationException
@@ -98,7 +99,7 @@ class LocalAsyncLeaderGroupElector private constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
-        return CompletableFuture.supplyAsync(
+        return LeaderFutureBridge.map(CompletableFuture.supplyAsync(
             {
                 tryWithPermit(
                     lockName = slot.lockName,
@@ -110,7 +111,7 @@ class LocalAsyncLeaderGroupElector private constructor(
                 }
             },
             executor
-        ).handle { value, failure ->
+        )) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderElector.kt
@@ -68,10 +68,11 @@ class LocalLeaderElector(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
         return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected.set(true)
-            action()
-        }) { value, failure ->
+            cancellationRelay.invoke(action)
+        }, cancellationRelay) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalLeaderElector.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.leader.LeaderElector
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
@@ -67,10 +68,10 @@ class LocalLeaderElector(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
-        return runAsyncIfLeader(slot, executor) {
+        return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected.set(true)
             action()
-        }.handle { value, failure ->
+        }) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalVirtualThreadLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalVirtualThreadLeaderElector.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.VirtualThreadLeaderElector
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletionException
 import java.util.concurrent.atomic.AtomicBoolean
@@ -77,16 +78,14 @@ class LocalVirtualThreadLeaderElector(
                 action()
             }
         }
-        val mapped: java.util.concurrent.CompletableFuture<LeaderRunResult<T>> =
-            source.toCompletableFuture().handle { value, failure ->
-                when {
-                    failure != null && elected.get() -> failure.toActionFailedResult()
-                    failure != null -> throw failure.asCompletionException()
-                    elected.get() -> LeaderRunResult.Elected(value, leaderId = slot.leaderId) as LeaderRunResult<T>
-                    else -> LeaderRunResult.Skipped as LeaderRunResult<T>
-                }
+        return LeaderFutureBridge.map(source) { value, failure ->
+            when {
+                failure != null && elected.get() -> failure.toActionFailedResult()
+                failure != null -> throw failure.asCompletionException()
+                elected.get() -> LeaderRunResult.Elected(value, leaderId = slot.leaderId) as LeaderRunResult<T>
+                else -> LeaderRunResult.Skipped as LeaderRunResult<T>
             }
-        return VirtualFuture(mapped)
+        }
     }
 
     private fun Throwable.unwrapCompletionCause(): Throwable =

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalVirtualThreadLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/local/LocalVirtualThreadLeaderGroupElector.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.VirtualThreadLeaderGroupElector
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.requirePositiveNumber
 import java.util.concurrent.CancellationException
@@ -93,16 +94,14 @@ class LocalVirtualThreadLeaderGroupElector private constructor(
                 action()
             }
         }
-        val mapped: java.util.concurrent.CompletableFuture<LeaderRunResult<T>> =
-            source.toCompletableFuture().handle { value, failure ->
-                when {
-                    failure != null && elected.get() -> failure.toActionFailedResult()
-                    failure != null -> throw failure.asCompletionException()
-                    elected.get() -> LeaderRunResult.Elected(value, leaderId = slot.leaderId) as LeaderRunResult<T>
-                    else -> LeaderRunResult.Skipped as LeaderRunResult<T>
-                }
+        return LeaderFutureBridge.map(source) { value, failure ->
+            when {
+                failure != null && elected.get() -> failure.toActionFailedResult()
+                failure != null -> throw failure.asCompletionException()
+                elected.get() -> LeaderRunResult.Elected(value, leaderId = slot.leaderId) as LeaderRunResult<T>
+                else -> LeaderRunResult.Skipped as LeaderRunResult<T>
             }
-        return VirtualFuture(mapped)
+        }
     }
 
     private fun Throwable.unwrapCompletionCause(): Throwable =

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/AsyncLeaderElectorContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/AsyncLeaderElectorContractTest.kt
@@ -141,6 +141,44 @@ class AsyncLeaderElectorContractTest {
     }
 
     @Test
+    fun `runAsyncIfLeaderResult - 반환 future 취소가 원본 future 로 전파된다`() {
+        val source = CompletableFuture<Any?>()
+        val election = object : AsyncLeaderElector {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T> runAsyncIfLeader(
+                lockName: String,
+                executor: java.util.concurrent.Executor,
+                action: () -> CompletableFuture<T>,
+            ): CompletableFuture<T?> = source as CompletableFuture<T?>
+        }
+
+        val result = election.runAsyncIfLeaderResult(LeaderSlot(randomLockName(), "bridge-cancel-node")) {
+            CompletableFuture.completedFuture("unused")
+        }
+
+        result.cancel(false).shouldBeTrue()
+        source.isCancelled.shouldBeTrue()
+    }
+
+    @Test
+    fun `VirtualThreadLeaderElector result bridge 도 반환 future 취소를 원본으로 전파한다`() {
+        val source = CompletableFuture<Any?>()
+        val election = object : VirtualThreadLeaderElector {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T> runAsyncIfLeader(
+                lockName: String,
+                action: () -> T,
+            ): io.bluetape4k.concurrent.virtualthread.VirtualFuture<T?> =
+                io.bluetape4k.concurrent.virtualthread.VirtualFuture(source as java.util.concurrent.Future<T?>)
+        }
+
+        val result = election.runAsyncIfLeaderResult(LeaderSlot(randomLockName(), "virtual-bridge-cancel-node")) { "unused" }
+
+        result.cancel(false).shouldBeTrue()
+        source.isCancelled.shouldBeTrue()
+    }
+
+    @Test
     fun `runAsyncIfLeader - action 실패 시 CompletionException 을 전파한다`() {
         val election: AsyncLeaderElector = LocalAsyncLeaderElector()
         assertFailsWith<CompletionException> {

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/AsyncLeaderElectorContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/AsyncLeaderElectorContractTest.kt
@@ -8,12 +8,18 @@ import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * [AsyncLeaderElector] 인터페이스 계약을 검증하는 테스트입니다.
@@ -158,6 +164,64 @@ class AsyncLeaderElectorContractTest {
 
         result.cancel(false).shouldBeTrue()
         source.isCancelled.shouldBeTrue()
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult - 반환 future 취소가 action future와 lease lifecycle로 전파된다`() {
+        val election: AsyncLeaderElector = LocalAsyncLeaderElector()
+        val lockName = randomLockName()
+        val executor = Executors.newVirtualThreadPerTaskExecutor()
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>()
+
+        try {
+            val result = election.runAsyncIfLeaderResult(LeaderSlot(lockName, "async-cancel-node"), executor) {
+                actionStarted.countDown()
+                actionFuture
+            }
+
+            actionStarted.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            result.cancel(false).shouldBeTrue()
+            await.atMost(2.seconds).untilAsserted {
+                actionFuture.isCancelled.shouldBeTrue()
+            }
+            await.atMost(2.seconds).untilAsserted {
+                election.runAsyncIfLeader(lockName, executor) {
+                    CompletableFuture.completedFuture("reacquired")
+                }.get(1, TimeUnit.SECONDS) shouldBeEqualTo "reacquired"
+            }
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult - listener decorator도 반환 future 취소를 action future로 전파한다`() {
+        val election = LocalLeaderElector().withListeners()
+        val lockName = randomLockName()
+        val executor = Executors.newVirtualThreadPerTaskExecutor()
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>()
+
+        try {
+            val result = election.runAsyncIfLeaderResult(LeaderSlot(lockName, "listener-cancel-node"), executor) {
+                actionStarted.countDown()
+                actionFuture
+            }
+
+            actionStarted.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            result.cancel(false).shouldBeTrue()
+            await.atMost(2.seconds).untilAsserted {
+                actionFuture.isCancelled.shouldBeTrue()
+            }
+            await.atMost(2.seconds).untilAsserted {
+                election.runAsyncIfLeader(lockName, executor) {
+                    CompletableFuture.completedFuture("reacquired")
+                }.get(1, TimeUnit.SECONDS) shouldBeEqualTo "reacquired"
+            }
+        } finally {
+            executor.shutdownNow()
+        }
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/AsyncLeaderGroupElectorContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/AsyncLeaderGroupElectorContractTest.kt
@@ -197,4 +197,58 @@ class AsyncLeaderGroupElectorContractTest {
         (result is LeaderRunResult.ActionFailed).shouldBeTrue()
         (result as LeaderRunResult.ActionFailed).cause shouldBeEqualTo failure
     }
+
+    @Test
+    fun `runAsyncIfLeaderResult - group 반환 future 취소가 원본 future 로 전파된다`() {
+        val source = CompletableFuture<Any?>()
+        val election = object : AsyncLeaderGroupElector {
+            override val maxLeaders: Int = 1
+
+            override fun activeCount(lockName: String): Int = 0
+
+            override fun availableSlots(lockName: String): Int = 1
+
+            override fun state(lockName: String): LeaderGroupState = LeaderGroupState(lockName, maxLeaders, 0)
+
+            @Suppress("UNCHECKED_CAST")
+            override fun <T> runAsyncIfLeader(
+                lockName: String,
+                executor: java.util.concurrent.Executor,
+                action: () -> CompletableFuture<T>,
+            ): CompletableFuture<T?> = source as CompletableFuture<T?>
+        }
+
+        val result = election.runAsyncIfLeaderResult(LeaderSlot(randomLockName(), "group-bridge-cancel-node")) {
+            CompletableFuture.completedFuture("unused")
+        }
+
+        result.cancel(false).shouldBeTrue()
+        source.isCancelled.shouldBeTrue()
+    }
+
+    @Test
+    fun `VirtualThreadLeaderGroupElector result bridge 도 반환 future 취소를 원본으로 전파한다`() {
+        val source = CompletableFuture<Any?>()
+        val election = object : VirtualThreadLeaderGroupElector {
+            override val maxLeaders: Int = 1
+
+            override fun activeCount(lockName: String): Int = 0
+
+            override fun availableSlots(lockName: String): Int = 1
+
+            override fun state(lockName: String): LeaderGroupState = LeaderGroupState(lockName, maxLeaders, 0)
+
+            @Suppress("UNCHECKED_CAST")
+            override fun <T> runAsyncIfLeader(
+                lockName: String,
+                action: () -> T,
+            ): io.bluetape4k.concurrent.virtualthread.VirtualFuture<T?> =
+                io.bluetape4k.concurrent.virtualthread.VirtualFuture(source as java.util.concurrent.Future<T?>)
+        }
+
+        val result = election.runAsyncIfLeaderResult(LeaderSlot(randomLockName(), "virtual-group-cancel-node")) { "unused" }
+
+        result.cancel(false).shouldBeTrue()
+        source.isCancelled.shouldBeTrue()
+    }
 }

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/AsyncLeaderGroupElectorContractTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/AsyncLeaderGroupElectorContractTest.kt
@@ -10,6 +10,9 @@ import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeLessOrEqualTo
 import io.bluetape4k.assertions.shouldBeTrue
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.concurrent.CancellationException
@@ -21,6 +24,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.max
 import kotlin.random.Random
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * [AsyncLeaderGroupElector] 인터페이스 계약을 검증하는 테스트입니다.
@@ -224,6 +228,64 @@ class AsyncLeaderGroupElectorContractTest {
 
         result.cancel(false).shouldBeTrue()
         source.isCancelled.shouldBeTrue()
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult - group 반환 future 취소가 action future와 lease lifecycle로 전파된다`() {
+        val election: AsyncLeaderGroupElector = LocalAsyncLeaderGroupElector(LeaderGroupElectionOptions(maxLeaders = 1))
+        val lockName = randomLockName()
+        val executor = Executors.newVirtualThreadPerTaskExecutor()
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>()
+
+        try {
+            val result = election.runAsyncIfLeaderResult(LeaderSlot(lockName, "async-group-cancel-node"), executor) {
+                actionStarted.countDown()
+                actionFuture
+            }
+
+            actionStarted.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            result.cancel(false).shouldBeTrue()
+            await.atMost(2.seconds).untilAsserted {
+                actionFuture.isCancelled.shouldBeTrue()
+            }
+            await.atMost(2.seconds).untilAsserted {
+                election.runAsyncIfLeader(lockName, executor) {
+                    CompletableFuture.completedFuture("reacquired")
+                }.get(1, TimeUnit.SECONDS) shouldBeEqualTo "reacquired"
+            }
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult - group listener decorator도 반환 future 취소를 action future로 전파한다`() {
+        val election = LocalLeaderGroupElector(LeaderGroupElectionOptions(maxLeaders = 1)).withListeners()
+        val lockName = randomLockName()
+        val executor = Executors.newVirtualThreadPerTaskExecutor()
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>()
+
+        try {
+            val result = election.runAsyncIfLeaderResult(LeaderSlot(lockName, "group-listener-cancel-node"), executor) {
+                actionStarted.countDown()
+                actionFuture
+            }
+
+            actionStarted.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            result.cancel(false).shouldBeTrue()
+            await.atMost(2.seconds).untilAsserted {
+                actionFuture.isCancelled.shouldBeTrue()
+            }
+            await.atMost(2.seconds).untilAsserted {
+                election.runAsyncIfLeader(lockName, executor) {
+                    CompletableFuture.completedFuture("reacquired")
+                }.get(1, TimeUnit.SECONDS) shouldBeEqualTo "reacquired"
+            }
+        } finally {
+            executor.shutdownNow()
+        }
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LeaderFutureBridgeTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LeaderFutureBridgeTest.kt
@@ -2,11 +2,13 @@ package io.bluetape4k.leader.internal
 
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.concurrent.virtualthread.VirtualFuture
 import org.junit.jupiter.api.Test
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
+import java.util.concurrent.atomic.AtomicBoolean
 
 class LeaderFutureBridgeTest {
 
@@ -29,6 +31,47 @@ class LeaderFutureBridgeTest {
         }
 
         assertFailsWith<CompletionException> { observed.join() }.cause shouldBeEqualTo failure
+    }
+
+    @Test
+    fun `flatMap 반환 future 취소를 원본 future 로 전파한다`() {
+        val source = CompletableFuture<String>()
+
+        val bridged = LeaderFutureBridge.flatMap(source) { value, _ ->
+            CompletableFuture.completedFuture(value)
+        }
+
+        bridged.cancel(false).shouldBeTrue()
+        source.isCancelled.shouldBeTrue()
+    }
+
+    @Test
+    fun `flatMap은 cleanup stage 완료 후 terminal state를 반환한다`() {
+        val source = CompletableFuture.failedFuture<String>(IllegalStateException("failed"))
+        val cleanup = CompletableFuture<String>()
+
+        val bridged = LeaderFutureBridge.flatMap(source) { _, _ -> cleanup }
+
+        bridged.isDone.shouldBeFalse()
+        cleanup.complete("cleaned")
+        bridged.join() shouldBeEqualTo "cleaned"
+    }
+
+    @Test
+    fun `action 실행 전 취소는 action을 시작하지 않는다`() {
+        val source = CompletableFuture<String>()
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
+        val bridged = LeaderFutureBridge.map(source, cancellationRelay) { value, _ -> value }
+        val invoked = AtomicBoolean()
+
+        bridged.cancel(false).shouldBeTrue()
+        val actionFuture = cancellationRelay.invoke {
+            invoked.set(true)
+            CompletableFuture.completedFuture("started")
+        }
+
+        invoked.get().shouldBeFalse()
+        actionFuture.isCompletedExceptionally.shouldBeTrue()
     }
 
     @Test

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LeaderFutureBridgeTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LeaderFutureBridgeTest.kt
@@ -1,0 +1,44 @@
+package io.bluetape4k.leader.internal
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.concurrent.virtualthread.VirtualFuture
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+
+class LeaderFutureBridgeTest {
+
+    @Test
+    fun `observe 반환 future 취소를 원본 future 로 전파한다`() {
+        val source = CompletableFuture<String>()
+
+        val observed = LeaderFutureBridge.observe(source) { _, _ -> }
+
+        observed.cancel(false).shouldBeTrue()
+        source.isCancelled.shouldBeTrue()
+    }
+
+    @Test
+    fun `observe callback 실패를 반환 future 로 전파한다`() {
+        val failure = IllegalStateException("observer failed")
+
+        val observed = LeaderFutureBridge.observe(CompletableFuture.completedFuture("done")) { _, _ ->
+            throw failure
+        }
+
+        assertFailsWith<CompletionException> { observed.join() }.cause shouldBeEqualTo failure
+    }
+
+    @Test
+    fun `VirtualFuture cancellation bridge 는 반환 future 취소를 원본으로 전파한다`() {
+        val source = CompletableFuture<String>()
+        val virtual = VirtualFuture(source as java.util.concurrent.Future<String>)
+
+        val bridged = LeaderFutureBridge.propagateCancellation(virtual)
+
+        bridged.cancel(false).shouldBeTrue()
+        source.isCancelled.shouldBeTrue()
+    }
+}

--- a/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbLeaderElector.kt
+++ b/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbLeaderElector.kt
@@ -152,10 +152,11 @@ class DynamoDbLeaderElector(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
         return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected.set(true)
-            action()
-        }) { value, failure ->
+            cancellationRelay.invoke(action)
+        }, cancellationRelay) { value, failure ->
             val cause = (failure as? CompletionException)?.cause ?: failure
             when {
                 cause is CancellationException -> throw cause

--- a/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbLeaderElector.kt
+++ b/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbLeaderElector.kt
@@ -15,6 +15,7 @@ import io.bluetape4k.leader.dynamodb.internal.DynamoDbKeys
 import io.bluetape4k.leader.dynamodb.internal.DynamoDbLockClient
 import io.bluetape4k.leader.dynamodb.internal.DynamoDbLockExtendDelegate
 import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
@@ -151,10 +152,10 @@ class DynamoDbLeaderElector(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
-        return runAsyncIfLeader(slot, executor) {
+        return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected.set(true)
             action()
-        }.handle { value, failure ->
+        }) { value, failure ->
             val cause = (failure as? CompletionException)?.cause ?: failure
             when {
                 cause is CancellationException -> throw cause

--- a/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbLeaderGroupElector.kt
+++ b/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbLeaderGroupElector.kt
@@ -169,10 +169,11 @@ class DynamoDbLeaderGroupElector(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
         return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected.set(true)
-            action()
-        }) { value, failure ->
+            cancellationRelay.invoke(action)
+        }, cancellationRelay) { value, failure ->
             val cause = (failure as? CompletionException)?.cause ?: failure
             when {
                 cause is CancellationException -> throw cause

--- a/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbLeaderGroupElector.kt
+++ b/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbLeaderGroupElector.kt
@@ -13,6 +13,7 @@ import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
 import io.bluetape4k.leader.dynamodb.internal.DynamoDbKeys
 import io.bluetape4k.leader.dynamodb.internal.DynamoDbLockClient
 import io.bluetape4k.leader.dynamodb.internal.DynamoDbLockExtendDelegate
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
@@ -168,10 +169,10 @@ class DynamoDbLeaderGroupElector(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
-        return runAsyncIfLeader(slot, executor) {
+        return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected.set(true)
             action()
-        }.handle { value, failure ->
+        }) { value, failure ->
             val cause = (failure as? CompletionException)?.cause ?: failure
             when {
                 cause is CancellationException -> throw cause

--- a/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbVirtualThreadLeaderElector.kt
+++ b/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbVirtualThreadLeaderElector.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.VirtualThreadLeaderElector
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 /**
@@ -33,9 +34,9 @@ class DynamoDbVirtualThreadLeaderElector(
         slot: LeaderSlot,
         action: () -> T,
     ): VirtualFuture<LeaderRunResult<T>> =
-        virtualFuture {
+        LeaderFutureBridge.propagateCancellation(virtualFuture {
             delegate.runIfLeaderResult(slot, action)
-    }
+        })
 }
 
 /**

--- a/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbVirtualThreadLeaderGroupElector.kt
+++ b/leader-dynamodb/src/main/kotlin/io/bluetape4k/leader/dynamodb/DynamoDbVirtualThreadLeaderGroupElector.kt
@@ -7,6 +7,7 @@ import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.VirtualThreadLeaderGroupElector
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 
 /**
@@ -45,9 +46,9 @@ class DynamoDbVirtualThreadLeaderGroupElector(
         slot: LeaderSlot,
         action: () -> T,
     ): VirtualFuture<LeaderRunResult<T>> =
-        virtualFuture {
+        LeaderFutureBridge.propagateCancellation(virtualFuture {
             delegate.runIfLeaderResult(slot, action)
-    }
+        })
 }
 
 /**

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElector.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElector.kt
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -181,20 +182,38 @@ class ExposedJdbcLeaderElector private constructor(
 
         val resultFuture = CompletableFuture<T?>()
         val actionFutureRef = AtomicReference<CompletableFuture<*>?>()
-        val pipelineFuture = CompletableFuture
+        val lockAcquired = AtomicBoolean()
+        val acquiredAtNanosRef = AtomicLong()
+        val lifecycleStarted = AtomicBoolean()
+        val rejectionCleanupClaimed = AtomicBoolean()
+        val releaseIfUnclaimed: () -> Unit = {
+            if (lockAcquired.get() && !lifecycleStarted.get() && rejectionCleanupClaimed.compareAndSet(false, true)) {
+                runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanosRef.get()) }
+                    .onSuccess { log.debug { "executor 거부 후 비동기 락을 반납했습니다. lockName=$lockName" } }
+                    .onFailure { e -> log.warn(e) { "executor 거부 후 비동기 락 해제 실패. lockName=$lockName" } }
+            }
+        }
+        val acquisitionFuture = CompletableFuture
             .supplyAsync(
                 {
                     lock.tryLock(options.leaderOptions.waitTime, options.leaderOptions.leaseTime) {
                         resultFuture.isCancelled
+                    }.also { acquired ->
+                        if (acquired) {
+                            acquiredAtNanosRef.set(System.nanoTime())
+                            lockAcquired.set(true)
+                        }
                     }
                 },
                 executor,
             )
-            .thenComposeAsync({ acquired ->
+        val pipelineFuture: CompletableFuture<T?> = try {
+            acquisitionFuture.thenComposeAsync({ acquired ->
                 if (!acquired) {
                     log.debug { "리더 승격 실패 (비동기). lockName=$lockName" }
                     CompletableFuture.completedFuture(null)
                 } else {
+                    lifecycleStarted.set(true)
                     val startedAt = Instant.now()
                     val acquiredAtNanos = System.nanoTime()
                     val terminal = AtomicBoolean()
@@ -306,11 +325,18 @@ class ExposedJdbcLeaderElector private constructor(
                     terminalFuture
                 }
             }, executor)
+        } catch (e: Throwable) {
+            acquisitionFuture.whenComplete { acquired, _ ->
+                if (acquired == true) releaseIfUnclaimed()
+            }
+            CompletableFuture.failedFuture(e)
+        }
 
         resultFuture.whenComplete { _, _ ->
             if (resultFuture.isCancelled) actionFutureRef.get()?.cancel(false)
         }
         pipelineFuture.whenComplete { value, throwable ->
+            if (throwable != null) releaseIfUnclaimed()
             if (throwable == null) {
                 resultFuture.complete(value)
             } else {

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElector.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElector.kt
@@ -320,53 +320,97 @@ class ExposedJdbcLeaderGroupElector private constructor(
 
                 val startedAt = Instant.now()
                 val acquiredAtNanos = System.nanoTime()
-                val record = historyRecorder?.let {
-                    LeaderLockHistoryRecord(
-                        lockName = lockName,
-                        token = lock.token,
-                        kind = LockIdentity.AnnotationKind.GROUP,
-                        acquiredAt = startedAt,
-                        lockedUntil = startedAt.plusMillis(leaseTime.inWholeMilliseconds),
-                        nodeId = options.lockOwner,
-                        slotId = slot.toString(),
-                    )
-                }
-                val hKey = record?.let { historyRecorder.recordAcquired(it) }
-                val effectiveKey: LeaderHistoryKey? =
-                    hKey ?: record?.let { LeaderHistoryKey(lockName = lockName, token = lock.token, slotId = slot.toString()) }
-
-                // T10 PR 5: async path 도 sync path 와 동일하게 watchdog/delegate 등록 (split-brain 방지)
-                // Group elector: autoExtend 옵션 부재 — caller 가 LockExtender 로 명시적 연장. watchdog disabled.
-                val delegate = ExposedJdbcSlotExtendDelegate(lock)
-                val watchdog = LeaderLeaseAutoExtender.start(
-                    false,
-                    options.leaderGroupOptions.leaseTime,
-                    delegate,
-                    ERROR_CLASSIFIER,
-                )
+                var watchdog: AutoCloseable? = null
+                var effectiveKey: LeaderHistoryKey? = null
                 val terminal = AtomicBoolean()
-                val finishAction: (Throwable?) -> Unit = { throwable ->
-                    if (terminal.compareAndSet(false, true)) {
-                        watchdog.close()
-                        val finishedAt = Instant.now()
-                        val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
-                        when {
-                            throwable == null -> effectiveKey?.let {
-                                historyRecorder?.recordCompleted(it, finishedAt, durationMs)
+                val finishAction: (Throwable?) -> Throwable? = { throwable ->
+                    if (!terminal.compareAndSet(false, true)) {
+                        null
+                    } else {
+                        var cleanupFailure: Throwable? = null
+
+                        runCatching { watchdog?.close() }
+                            .onFailure { e ->
+                                cleanupFailure = e
+                                log.warn(e) { "비동기 그룹 watchdog 종료 실패. lockName=$lockName, slot=$slot" }
                             }
-                            else -> effectiveKey?.let {
-                                historyRecorder?.recordFailed(it, finishedAt, durationMs, throwable)
+
+                        runCatching {
+                            val finishedAt = Instant.now()
+                            val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
+                            when {
+                                throwable == null -> effectiveKey?.let {
+                                    historyRecorder?.recordCompleted(it, finishedAt, durationMs)
+                                }
+                                else -> effectiveKey?.let {
+                                    historyRecorder?.recordFailed(it, finishedAt, durationMs, throwable)
+                                }
                             }
+                        }.onFailure { e ->
+                            cleanupFailure = cleanupFailure?.also { it.addSuppressed(e) } ?: e
+                            log.warn(e) { "비동기 그룹 history 기록 실패. lockName=$lockName, slot=$slot" }
                         }
-                        when (lock.unlockAndReport(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos)) {
-                            ExposedJdbcUnlockOutcome.RELEASED ->
-                                log.debug { "비동기 그룹 슬롯 반납. lockName=$lockName, slot=$slot" }
-                            ExposedJdbcUnlockOutcome.NOT_HELD ->
-                                log.warn { "비동기 그룹 슬롯 반납 대상이 없습니다. lockName=$lockName, slot=$slot" }
-                            ExposedJdbcUnlockOutcome.FAILED ->
-                                log.warn { "비동기 그룹 슬롯 해제 실패(DB 오류). lockName=$lockName, slot=$slot" }
+
+                        runCatching {
+                            when (lock.unlockAndReport(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos)) {
+                                ExposedJdbcUnlockOutcome.RELEASED ->
+                                    log.debug { "비동기 그룹 슬롯 반납. lockName=$lockName, slot=$slot" }
+                                ExposedJdbcUnlockOutcome.NOT_HELD ->
+                                    log.warn { "비동기 그룹 슬롯 반납 대상이 없습니다. lockName=$lockName, slot=$slot" }
+                                ExposedJdbcUnlockOutcome.FAILED ->
+                                    log.warn { "비동기 그룹 슬롯 해제 실패(DB 오류). lockName=$lockName, slot=$slot" }
+                            }
+                        }.onFailure { e ->
+                            cleanupFailure = cleanupFailure?.also { it.addSuppressed(e) } ?: e
+                            log.warn(e) { "비동기 그룹 슬롯 해제 실패. lockName=$lockName, slot=$slot" }
+                        }
+
+                        if (throwable != null) {
+                            cleanupFailure?.let { throwable.addSuppressed(it) }
+                            null
+                        } else {
+                            cleanupFailure
                         }
                     }
+                }
+
+                try {
+                    val record = historyRecorder?.let {
+                        LeaderLockHistoryRecord(
+                            lockName = lockName,
+                            token = lock.token,
+                            kind = LockIdentity.AnnotationKind.GROUP,
+                            acquiredAt = startedAt,
+                            lockedUntil = startedAt.plusMillis(leaseTime.inWholeMilliseconds),
+                            nodeId = options.lockOwner,
+                            slotId = slot.toString(),
+                        )
+                    }
+                    val fallbackKey = record?.let {
+                        LeaderHistoryKey(lockName = lockName, token = lock.token, slotId = slot.toString())
+                    }
+                    effectiveKey = fallbackKey
+                    val key = record?.let { historyRecorder.recordAcquired(it) }
+                    effectiveKey = key ?: fallbackKey
+
+                    // Group elector에는 autoExtend 옵션이 없으므로 명시적 LockExtender만 사용합니다.
+                    watchdog = LeaderLeaseAutoExtender.start(
+                        false,
+                        options.leaderGroupOptions.leaseTime,
+                        ExposedJdbcSlotExtendDelegate(lock),
+                        ERROR_CLASSIFIER,
+                    )
+                } catch (e: Throwable) {
+                    finishAction(e)
+                    return@thenComposeAsync CompletableFuture.failedFuture(e)
+                }
+
+                if (resultFuture.isCancelled) {
+                    val cancellation = java.util.concurrent.CancellationException(
+                        "runAsyncIfLeader result was cancelled before action",
+                    )
+                    finishAction(cancellation)
+                    return@thenComposeAsync CompletableFuture.failedFuture(cancellation)
                 }
 
                 val actionFuture = runCatching { action() }
@@ -376,7 +420,10 @@ class ExposedJdbcLeaderGroupElector private constructor(
                     }
 
                 val terminalFuture = actionFuture.whenComplete { _, throwable ->
-                    finishAction(throwable)
+                    val cleanupFailure = finishAction(throwable)
+                    if (throwable == null && cleanupFailure != null) {
+                        throw cleanupFailure
+                    }
                 }
                 actionFutureRef.set(actionFuture)
                 if (resultFuture.isCancelled) actionFuture.cancel(false)

--- a/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElector.kt
+++ b/leader-exposed-jdbc/src/main/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElector.kt
@@ -254,7 +254,23 @@ class ExposedJdbcLeaderGroupElector private constructor(
 
         val resultFuture = CompletableFuture<T?>()
         val actionFutureRef = AtomicReference<CompletableFuture<*>?>()
-        val pipelineFuture = CompletableFuture.supplyAsync({
+        val acquiredSlotRef = AtomicReference<Pair<ExposedJdbcGroupLock, Int>?>(null)
+        val lifecycleStarted = AtomicBoolean()
+        val rejectionCleanupClaimed = AtomicBoolean()
+        val releaseIfUnclaimed: () -> Unit = {
+            val acquired = acquiredSlotRef.get()
+            if (acquired != null && !lifecycleStarted.get() && rejectionCleanupClaimed.compareAndSet(false, true)) {
+                when (acquired.first.unlockAndReport()) {
+                    ExposedJdbcUnlockOutcome.RELEASED ->
+                        log.debug { "executor 거부 후 비동기 그룹 슬롯을 반납했습니다. lockName=$lockName, slot=${acquired.second}" }
+                    ExposedJdbcUnlockOutcome.NOT_HELD ->
+                        log.warn { "executor 거부 후 반납할 그룹 슬롯이 없습니다. lockName=$lockName, slot=${acquired.second}" }
+                    ExposedJdbcUnlockOutcome.FAILED ->
+                        log.warn { "executor 거부 후 그룹 슬롯 해제에 실패했습니다. lockName=$lockName, slot=${acquired.second}" }
+                }
+            }
+        }
+        val acquisitionFuture = CompletableFuture.supplyAsync({
             var acquired: Pair<ExposedJdbcGroupLock, Int>? = null
             for (i in 0 until maxLeaders) {
                 if (resultFuture.isCancelled) return@supplyAsync null
@@ -276,12 +292,16 @@ class ExposedJdbcLeaderGroupElector private constructor(
                     }
                 }
             }
+            acquired?.also { acquiredSlotRef.set(it) }
             acquired
-        }, executor).thenComposeAsync({ acquired ->
+        }, executor)
+        val pipelineFuture: CompletableFuture<T?> = try {
+            acquisitionFuture.thenComposeAsync({ acquired ->
             if (acquired == null) {
                 log.debug { "그룹 슬롯 획득 실패 (비동기). lockName=$lockName" }
                 CompletableFuture.completedFuture(null)
             } else {
+                lifecycleStarted.set(true)
                 val (lock, slot) = acquired
                 if (resultFuture.isCancelled) {
                     when (lock.unlockAndReport()) {
@@ -362,12 +382,19 @@ class ExposedJdbcLeaderGroupElector private constructor(
                 if (resultFuture.isCancelled) actionFuture.cancel(false)
                 terminalFuture
             }
-        }, executor)
+            }, executor)
+        } catch (e: Throwable) {
+            acquisitionFuture.whenComplete { acquired, _ ->
+                if (acquired != null) releaseIfUnclaimed()
+            }
+            CompletableFuture.failedFuture(e)
+        }
 
         resultFuture.whenComplete { _, _ ->
             if (resultFuture.isCancelled) actionFutureRef.get()?.cancel(false)
         }
         pipelineFuture.whenComplete { value, throwable ->
+            if (throwable != null) releaseIfUnclaimed()
             if (throwable == null) {
                 resultFuture.complete(value)
             } else {

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElectionTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElectionTest.kt
@@ -42,6 +42,7 @@ import java.util.concurrent.CompletionException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.CancellationException as FutureCancellationException
 import java.util.concurrent.atomic.AtomicInteger
@@ -340,6 +341,45 @@ class ExposedJdbcLeaderElectionTest: AbstractExposedJdbcLeaderTest() {
 
     @ParameterizedTest
     @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - 두 번째 executor 제출 거부 후 획득한 락을 정리한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val election = ExposedJdbcLeaderElector(
+            db,
+            ExposedJdbcLeaderElectionOptions(
+                leaderOptions = LeaderElectionOptions(
+                    waitTime = 100.milliseconds,
+                    leaseTime = 30.seconds,
+                ),
+            ),
+        )
+        val worker = Executors.newSingleThreadExecutor()
+        val submissions = AtomicInteger()
+        val executor = Executor { command ->
+            if (submissions.incrementAndGet() == 1) {
+                worker.execute(command)
+            } else {
+                throw RejectedExecutionException("second submission rejected")
+            }
+        }
+
+        try {
+            val resultFuture = runCatching {
+                election.runAsyncIfLeader(lockName, executor) {
+                    CompletableFuture.completedFuture("실행되면 안 됨")
+                }
+            }.getOrElse { CompletableFuture.failedFuture(it) }
+
+            assertFailsWith<CompletionException> { resultFuture.join() }
+            election.runIfLeader(lockName) { "executor 거부 후 복구" } shouldBeEqualTo "executor 거부 후 복구"
+        } finally {
+            worker.shutdownNow()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
     fun `runAsyncIfLeader - 반환 future 취소 시 락 획득 대기를 중단한다`(testDB: TestDB) {
         val db = connectDb(testDB)
         cleanTables(db)
@@ -597,6 +637,10 @@ class ExposedJdbcLeaderElectionTest: AbstractExposedJdbcLeaderTest() {
         actionStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
         resultFuture.cancel(false).shouldBeTrue()
         assertFailsWith<FutureCancellationException> { resultFuture.join() }
+        val cancellationDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (!actionFuture.isCancelled && System.nanoTime() < cancellationDeadline) {
+            Thread.sleep(10)
+        }
         actionFuture.isCancelled.shouldBeTrue()
 
         val history = transaction(db) {
@@ -606,6 +650,45 @@ class ExposedJdbcLeaderElectionTest: AbstractExposedJdbcLeaderTest() {
         }
         history[LeaderLockHistoryTable.status] shouldBeEqualTo LeaderHistoryStatus.FAILED.name
         election.runIfLeader(lockName) { "반환 취소 후 복구" } shouldBeEqualTo "반환 취소 후 복구"
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runAsyncIfLeaderResult - 반환 future 취소를 action에 전파하고 FAILED 이력과 락 반환을 보장한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val recorder = SafeLeaderHistoryRecorder(ExposedLeaderHistorySink(db))
+        val election = ExposedJdbcLeaderElector(db, historyRecorder = recorder)
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>()
+
+        val resultFuture = election.runAsyncIfLeaderResult(LeaderSlot(lockName, "result-cancel-node"), VirtualThreadExecutor) {
+            actionStarted.countDown()
+            actionFuture
+        }
+
+        actionStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        resultFuture.cancel(false).shouldBeTrue()
+        assertFailsWith<FutureCancellationException> { resultFuture.join() }
+        val cancellationDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (!actionFuture.isCancelled && System.nanoTime() < cancellationDeadline) {
+            Thread.sleep(10)
+        }
+        actionFuture.isCancelled.shouldBeTrue()
+
+        var historyStatus: String? = null
+        val historyDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (historyStatus != LeaderHistoryStatus.FAILED.name && System.nanoTime() < historyDeadline) {
+            historyStatus = transaction(db) {
+                LeaderLockHistoryTable.selectAll()
+                    .where { LeaderLockHistoryTable.lockName eq lockName }
+                    .single()[LeaderLockHistoryTable.status]
+            }
+            if (historyStatus != LeaderHistoryStatus.FAILED.name) Thread.sleep(10)
+        }
+        historyStatus shouldBeEqualTo LeaderHistoryStatus.FAILED.name
+        election.runIfLeader(lockName) { "result 취소 후 복구" } shouldBeEqualTo "result 취소 후 복구"
     }
 
     @ParameterizedTest

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElectionTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElectionTest.kt
@@ -15,6 +15,7 @@ import io.bluetape4k.leader.exposed.jdbc.history.ExposedLeaderHistorySink
 import io.bluetape4k.leader.history.LeaderHistoryStatus
 import io.bluetape4k.leader.exposed.tables.LeaderLockHistoryTable
 import io.bluetape4k.leader.history.LeaderHistoryKey
+import io.bluetape4k.leader.history.LeaderLockHistoryRecord
 import io.bluetape4k.leader.history.SafeLeaderHistoryRecorder
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
@@ -22,6 +23,7 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeGreaterOrEqualTo
 import io.bluetape4k.assertions.shouldBeLessOrEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldNotBeNull
@@ -497,6 +499,32 @@ class ExposedJdbcLeaderGroupElectionTest: AbstractExposedJdbcLeaderTest() {
         history[LeaderLockHistoryTable.finishedAt].shouldNotBeNull()
         history[LeaderLockHistoryTable.durationMs].shouldNotBeNull() shouldBeGreaterOrEqualTo 0L
         election.runIfLeader(lockName) { "async-group-recovered-after-cancel" } shouldBeEqualTo "async-group-recovered-after-cancel"
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - recordAcquired 인터럽트 후 슬롯을 정리한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val recorder = object : SafeLeaderHistoryRecorder(ExposedLeaderHistorySink(db)) {
+            override fun recordAcquired(record: LeaderLockHistoryRecord): LeaderHistoryKey? {
+                throw InterruptedException("group acquire history interrupted")
+            }
+        }
+        val options = makeOptions(maxLeaders = 1, waitSec = 1, leaseSec = 30)
+        val election = ExposedJdbcLeaderGroupElector(db, options, recorder)
+        val actionInvocations = AtomicInteger()
+
+        val resultFuture = election.runAsyncIfLeader(lockName, VirtualThreadExecutor) {
+            actionInvocations.incrementAndGet()
+            CompletableFuture.completedFuture("실행되면 안 됨")
+        }
+
+        val failure = assertFailsWith<CompletionException> { resultFuture.join() }
+        failure.cause.shouldBeInstanceOf(InterruptedException::class)
+        actionInvocations.get() shouldBeEqualTo 0
+        ExposedJdbcLeaderGroupElector(db, options).runIfLeader(lockName) { "복구 성공" } shouldBeEqualTo "복구 성공"
     }
 
     @ParameterizedTest

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElectionTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElectionTest.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.exposed.tests.TestDB
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.leader.LeaderElectionException
 import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.exposed.jdbc.lock.ExposedJdbcGroupLock
 import io.bluetape4k.leader.exposed.jdbc.lock.ExposedJdbcSchemaInitializer
 import io.bluetape4k.leader.exposed.retry.RetryStrategy
@@ -35,10 +36,13 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import java.time.Instant
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.CancellationException as FutureCancellationException
+import java.util.concurrent.Executor
 import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.max
@@ -429,6 +433,37 @@ class ExposedJdbcLeaderGroupElectionTest: AbstractExposedJdbcLeaderTest() {
 
     @ParameterizedTest
     @MethodSource("enableDialects")
+    fun `runAsyncIfLeader - 두 번째 executor 제출 거부 후 획득한 슬롯을 정리한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val election = ExposedJdbcLeaderGroupElector(db, makeOptions(maxLeaders = 1, waitSec = 1))
+        val worker = Executors.newSingleThreadExecutor()
+        val submissions = AtomicInteger()
+        val executor = Executor { command ->
+            if (submissions.incrementAndGet() == 1) {
+                worker.execute(command)
+            } else {
+                throw RejectedExecutionException("second submission rejected")
+            }
+        }
+
+        try {
+            val resultFuture = runCatching {
+                election.runAsyncIfLeader(lockName, executor) {
+                    CompletableFuture.completedFuture("실행되면 안 됨")
+                }
+            }.getOrElse { CompletableFuture.failedFuture(it) }
+
+            assertFailsWith<CompletionException> { resultFuture.join() }
+            election.runIfLeader(lockName) { "executor 거부 후 슬롯 복구" } shouldBeEqualTo "executor 거부 후 슬롯 복구"
+        } finally {
+            worker.shutdownNow()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
     fun `runAsyncIfLeader - action future 취소 후 FAILED 이력을 기록하고 슬롯을 반환한다`(testDB: TestDB) {
         val db = connectDb(testDB)
         cleanTables(db)
@@ -487,6 +522,10 @@ class ExposedJdbcLeaderGroupElectionTest: AbstractExposedJdbcLeaderTest() {
         actionStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
         resultFuture.cancel(false).shouldBeTrue()
         assertFailsWith<FutureCancellationException> { resultFuture.join() }
+        val cancellationDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (!actionFuture.isCancelled && System.nanoTime() < cancellationDeadline) {
+            Thread.sleep(10)
+        }
         actionFuture.isCancelled.shouldBeTrue()
 
         val history = transaction(db) {
@@ -499,6 +538,52 @@ class ExposedJdbcLeaderGroupElectionTest: AbstractExposedJdbcLeaderTest() {
         history[LeaderLockHistoryTable.durationMs].shouldNotBeNull() shouldBeGreaterOrEqualTo 0L
         election.runIfLeader(lockName) { "async-group-recovered-after-result-cancel" } shouldBeEqualTo
             "async-group-recovered-after-result-cancel"
+    }
+
+    @ParameterizedTest
+    @MethodSource("enableDialects")
+    fun `runAsyncIfLeaderResult - 반환 future 취소를 action에 전파하고 FAILED 이력과 슬롯 반환을 보장한다`(testDB: TestDB) {
+        val db = connectDb(testDB)
+        cleanTables(db)
+        val lockName = randomName()
+        val recorder = SafeLeaderHistoryRecorder(ExposedLeaderHistorySink(db))
+        val election = ExposedJdbcLeaderGroupElector(
+            db,
+            makeOptions(maxLeaders = 1),
+            recorder,
+        )
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>()
+
+        val resultFuture = election.runAsyncIfLeaderResult(
+            LeaderSlot(lockName, "group-result-cancel-node"),
+            VirtualThreadExecutor,
+        ) {
+            actionStarted.countDown()
+            actionFuture
+        }
+
+        actionStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        resultFuture.cancel(false).shouldBeTrue()
+        assertFailsWith<FutureCancellationException> { resultFuture.join() }
+        val cancellationDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (!actionFuture.isCancelled && System.nanoTime() < cancellationDeadline) {
+            Thread.sleep(10)
+        }
+        actionFuture.isCancelled.shouldBeTrue()
+
+        var historyStatus: String? = null
+        val historyDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (historyStatus != LeaderHistoryStatus.FAILED.name && System.nanoTime() < historyDeadline) {
+            historyStatus = transaction(db) {
+                LeaderLockHistoryTable.selectAll()
+                    .where { LeaderLockHistoryTable.lockName eq lockName }
+                    .single()[LeaderLockHistoryTable.status]
+            }
+            if (historyStatus != LeaderHistoryStatus.FAILED.name) Thread.sleep(10)
+        }
+        historyStatus shouldBeEqualTo LeaderHistoryStatus.FAILED.name
+        election.runIfLeader(lockName) { "group result 취소 후 복구" } shouldBeEqualTo "group result 취소 후 복구"
     }
 
     @ParameterizedTest

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElector.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElector.kt
@@ -19,6 +19,8 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.error
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * `HazelcastLeaderElector`는 Hazelcast backend의 leader election, lock lease, ownership 확인을 담당합니다.
@@ -99,6 +101,7 @@ class HazelcastLeaderElector private constructor(
      *
      * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
      */
+    @Suppress("LongMethod", "TooGenericExceptionCaught")
     override fun <T> runAsyncIfLeader(
         lockName: String,
         executor: Executor,
@@ -108,38 +111,71 @@ class HazelcastLeaderElector private constructor(
 
         val lock = HazelcastLock(lockMap, lockName, LOCK_MAP_NAME, hazelcast::newTransactionContext)
 
-        return CompletableFuture
-            .supplyAsync({ lock.tryLock(options.waitTime, options.leaseTime) }, executor)
-            .thenComposeAsync({ acquired ->
+        val lockAcquired = AtomicBoolean()
+        val acquiredAtNanosRef = AtomicLong()
+        val lifecycleStarted = AtomicBoolean()
+        val rejectionCleanupClaimed = AtomicBoolean()
+        val releaseIfUnclaimed: () -> Unit = {
+            if (lockAcquired.get() && !lifecycleStarted.get() && rejectionCleanupClaimed.compareAndSet(false, true)) {
+                runCatching { lock.unlock(options.minLeaseTime, acquiredAtNanosRef.get()) }
+                    .onSuccess { log.debug { "executor 거부 후 비동기 락을 반납했습니다. lockName=$lockName" } }
+                    .onFailure { e -> log.error(e) { "Fail to release lock after executor rejection. lockName=$lockName" } }
+            }
+        }
+        val acquisitionFuture = CompletableFuture.supplyAsync({
+            lock.tryLock(options.waitTime, options.leaseTime).also { acquired ->
+                if (acquired) {
+                    acquiredAtNanosRef.set(System.nanoTime())
+                    lockAcquired.set(true)
+                }
+            }
+        }, executor)
+        val pipelineFuture: CompletableFuture<T?> = try {
+            acquisitionFuture.thenComposeAsync({ acquired ->
                 if (!acquired) {
                     log.debug { "Leader 승격 실패 (슬롯 없음, 비동기). lockName=$lockName" }
                     CompletableFuture.completedFuture(null)
                 } else {
-                    val acquiredAtNanos = System.nanoTime()
+                    val acquiredAtNanos = acquiredAtNanosRef.get()
                     val delegate = HazelcastLockExtendDelegate(lock)
-                    val watchdog = LeaderLeaseAutoExtender.start(
-                        options.autoExtend,
-                        options.leaseTime,
-                        delegate,
-                        ERROR_CLASSIFIER,
-                    )
+                    val watchdog = try {
+                        LeaderLeaseAutoExtender.start(
+                            options.autoExtend,
+                            options.leaseTime,
+                            delegate,
+                            ERROR_CLASSIFIER,
+                        )
+                    } catch (error: Throwable) {
+                        return@thenComposeAsync CompletableFuture.failedFuture(error)
+                    }
                     log.debug { "Leader로 승격하여 비동기 작업을 수행합니다. lockName=$lockName" }
                     // async path 는 handle push 미수행 (AOP scope sync/suspend 만 지원)
                     val actionFuture = runCatching { action() }
                         .getOrElse { error ->
                             watchdog.close()
-                            runCatching { lock.unlock(options.minLeaseTime, acquiredAtNanos) }
-                                .onFailure { e -> log.error(e) { "Fail to release lock on action error (async). lockName=$lockName" } }
+                            releaseIfUnclaimed()
                             return@thenComposeAsync CompletableFuture.failedFuture(error)
                         }
+                    lifecycleStarted.set(true)
                     actionFuture.whenComplete { _, _ ->
                         watchdog.close()
                         runCatching { lock.unlock(options.minLeaseTime, acquiredAtNanos) }
                             .onSuccess { log.debug { "비동기 Leader 권한을 반납했습니다. lockName=$lockName" } }
                             .onFailure { e -> log.error(e) { "Fail to release lock (async). lockName=$lockName" } }
                     }
+                    actionFuture
                 }
             }, executor)
+        } catch (error: Throwable) {
+            acquisitionFuture.whenComplete { acquired, _ ->
+                if (acquired == true) releaseIfUnclaimed()
+            }
+            CompletableFuture.failedFuture(error)
+        }
+        pipelineFuture.whenComplete { _, failure ->
+            if (failure != null) releaseIfUnclaimed()
+        }
+        return pipelineFuture
     }
 }
 

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElector.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElector.kt
@@ -138,6 +138,7 @@ class HazelcastLeaderElector private constructor(
                 } else {
                     val acquiredAtNanos = acquiredAtNanosRef.get()
                     val delegate = HazelcastLockExtendDelegate(lock)
+                    lifecycleStarted.set(true)
                     val watchdog = try {
                         LeaderLeaseAutoExtender.start(
                             options.autoExtend,
@@ -146,6 +147,8 @@ class HazelcastLeaderElector private constructor(
                             ERROR_CLASSIFIER,
                         )
                     } catch (error: Throwable) {
+                        runCatching { lock.unlock(options.minLeaseTime, acquiredAtNanos) }
+                            .onFailure { error.addSuppressed(it) }
                         return@thenComposeAsync CompletableFuture.failedFuture(error)
                     }
                     log.debug { "Leader로 승격하여 비동기 작업을 수행합니다. lockName=$lockName" }
@@ -153,10 +156,10 @@ class HazelcastLeaderElector private constructor(
                     val actionFuture = runCatching { action() }
                         .getOrElse { error ->
                             watchdog.close()
-                            releaseIfUnclaimed()
+                            runCatching { lock.unlock(options.minLeaseTime, acquiredAtNanos) }
+                                .onFailure { error.addSuppressed(it) }
                             return@thenComposeAsync CompletableFuture.failedFuture(error)
                         }
-                    lifecycleStarted.set(true)
                     actionFuture.whenComplete { _, _ ->
                         watchdog.close()
                         runCatching { lock.unlock(options.minLeaseTime, acquiredAtNanos) }
@@ -174,6 +177,9 @@ class HazelcastLeaderElector private constructor(
         }
         pipelineFuture.whenComplete { _, failure ->
             if (failure != null) releaseIfUnclaimed()
+        }
+        acquisitionFuture.whenComplete { acquired, _ ->
+            if (acquired == true && pipelineFuture.isCancelled) releaseIfUnclaimed()
         }
         return pipelineFuture
     }

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElector.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElector.kt
@@ -182,20 +182,23 @@ class HazelcastLeaderGroupElector private constructor(
                     val acquiredAtNanos = acquiredAtNanosRef.get()
                     log.debug { "리더 그룹 슬롯을 획득하여 비동기 작업을 수행합니다. lockName=$lockName, slot=$slot" }
                     val delegate = HazelcastSlotExtendDelegate(lock)
+                    lifecycleStarted.set(true)
                     // Group elector: watchdog disabled (autoExtend 옵션 부재)
                     val watchdog = try {
                         LeaderLeaseAutoExtender.start(false, leaseTime, delegate, ERROR_CLASSIFIER)
                     } catch (error: Throwable) {
+                        runCatching { lock.unlock(minLeaseTime, acquiredAtNanos) }
+                            .onFailure { error.addSuppressed(it) }
                         return@thenComposeAsync CompletableFuture.failedFuture(error)
                     }
                     // async path 는 handle push 미수행 (AOP scope sync/suspend 만 지원)
                     val actionFuture = runCatching { action() }
                         .getOrElse { error ->
                             watchdog.close()
-                            releaseIfUnclaimed()
+                            runCatching { lock.unlock(minLeaseTime, acquiredAtNanos) }
+                                .onFailure { error.addSuppressed(it) }
                             return@thenComposeAsync CompletableFuture.failedFuture(error)
                         }
-                    lifecycleStarted.set(true)
                     actionFuture.whenComplete { _, _ ->
                         watchdog.close()
                         runCatching { lock.unlock(minLeaseTime, acquiredAtNanos) }
@@ -213,6 +216,9 @@ class HazelcastLeaderGroupElector private constructor(
         }
         pipelineFuture.whenComplete { _, failure ->
             if (failure != null) releaseIfUnclaimed()
+        }
+        acquisitionFuture.whenComplete { acquired, _ ->
+            if (acquired != null && pipelineFuture.isCancelled) releaseIfUnclaimed()
         }
         return pipelineFuture
     }

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElector.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElector.kt
@@ -21,6 +21,9 @@ import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requirePositiveNumber
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * `HazelcastLeaderGroupElector`는 Hazelcast backend의 leader election, lock lease, ownership 확인을 담당합니다.
@@ -132,6 +135,7 @@ class HazelcastLeaderGroupElector private constructor(
         }
     }
 
+    @Suppress("LongMethod", "TooGenericExceptionCaught")
     override fun <T> runAsyncIfLeader(
         lockName: String,
         executor: Executor,
@@ -141,40 +145,76 @@ class HazelcastLeaderGroupElector private constructor(
 
         val slotWaitTime = waitTime / maxLeaders
 
-        return CompletableFuture.supplyAsync({
+        val acquiredRef = AtomicReference<Pair<HazelcastLock, Int>?>(null)
+        val acquiredAtNanosRef = AtomicLong()
+        val lifecycleStarted = AtomicBoolean()
+        val rejectionCleanupClaimed = AtomicBoolean()
+        val releaseIfUnclaimed: () -> Unit = {
+            val acquired = acquiredRef.get()
+            if (acquired != null && !lifecycleStarted.get() && rejectionCleanupClaimed.compareAndSet(false, true)) {
+                runCatching { acquired.first.unlock(minLeaseTime, acquiredAtNanosRef.get()) }
+                    .onSuccess { log.debug { "executor 거부 후 비동기 그룹 슬롯을 반납했습니다. lockName=$lockName, slot=${acquired.second}" } }
+                    .onFailure { e -> log.error(e) { "Fail to release group slot after executor rejection. lockName=$lockName, slot=${acquired.second}" } }
+            }
+        }
+        val acquisitionFuture = CompletableFuture.supplyAsync({
             (0 until maxLeaders)
                 .asSequence()
                 .map { slot ->
                     HazelcastLock(lockMap, slotKey(lockName, slot), LOCK_MAP_NAME, hazelcast::newTransactionContext) to slot
                 }
-                .firstOrNull { (lock, _) -> lock.tryLock(slotWaitTime, leaseTime) }
-        }, executor).thenComposeAsync({ acquired ->
-            if (acquired == null) {
-                log.debug { "리더 그룹 슬롯 획득 실패 (비동기). lockName=$lockName" }
-                CompletableFuture.completedFuture(null)
-            } else {
-                val (lock, slot) = acquired
-                val acquiredAtNanos = System.nanoTime()
-                log.debug { "리더 그룹 슬롯을 획득하여 비동기 작업을 수행합니다. lockName=$lockName, slot=$slot" }
-                val delegate = HazelcastSlotExtendDelegate(lock)
-                // Group elector: watchdog disabled (autoExtend 옵션 부재)
-                val watchdog = LeaderLeaseAutoExtender.start(false, leaseTime, delegate, ERROR_CLASSIFIER)
-                // async path 는 handle push 미수행 (AOP scope sync/suspend 만 지원)
-                val actionFuture = runCatching { action() }
-                    .getOrElse { e ->
+                .firstOrNull { (lock, slot) ->
+                    lock.tryLock(slotWaitTime, leaseTime).also { acquired ->
+                        if (acquired) {
+                            acquiredAtNanosRef.set(System.nanoTime())
+                            acquiredRef.set(lock to slot)
+                        }
+                    }
+                }
+        }, executor)
+        val pipelineFuture: CompletableFuture<T?> = try {
+            acquisitionFuture.thenComposeAsync({ acquired ->
+                if (acquired == null) {
+                    log.debug { "리더 그룹 슬롯 획득 실패 (비동기). lockName=$lockName" }
+                    CompletableFuture.completedFuture(null)
+                } else {
+                    val (lock, slot) = acquired
+                    val acquiredAtNanos = acquiredAtNanosRef.get()
+                    log.debug { "리더 그룹 슬롯을 획득하여 비동기 작업을 수행합니다. lockName=$lockName, slot=$slot" }
+                    val delegate = HazelcastSlotExtendDelegate(lock)
+                    // Group elector: watchdog disabled (autoExtend 옵션 부재)
+                    val watchdog = try {
+                        LeaderLeaseAutoExtender.start(false, leaseTime, delegate, ERROR_CLASSIFIER)
+                    } catch (error: Throwable) {
+                        return@thenComposeAsync CompletableFuture.failedFuture(error)
+                    }
+                    // async path 는 handle push 미수행 (AOP scope sync/suspend 만 지원)
+                    val actionFuture = runCatching { action() }
+                        .getOrElse { error ->
+                            watchdog.close()
+                            releaseIfUnclaimed()
+                            return@thenComposeAsync CompletableFuture.failedFuture(error)
+                        }
+                    lifecycleStarted.set(true)
+                    actionFuture.whenComplete { _, _ ->
                         watchdog.close()
                         runCatching { lock.unlock(minLeaseTime, acquiredAtNanos) }
-                            .onFailure { ex -> log.error(ex) { "Fail to release group slot on action error (async). lockName=$lockName, slot=$slot" } }
-                        return@thenComposeAsync CompletableFuture.failedFuture(e)
+                            .onSuccess { log.debug { "비동기 리더 그룹 슬롯을 반납했습니다. lockName=$lockName, slot=$slot" } }
+                            .onFailure { e -> log.error(e) { "Fail to release group slot (async). lockName=$lockName, slot=$slot" } }
                     }
-                actionFuture.whenComplete { _, _ ->
-                    watchdog.close()
-                    runCatching { lock.unlock(minLeaseTime, acquiredAtNanos) }
-                        .onSuccess { log.debug { "비동기 리더 그룹 슬롯을 반납했습니다. lockName=$lockName, slot=$slot" } }
-                        .onFailure { e -> log.error(e) { "Fail to release group slot (async). lockName=$lockName, slot=$slot" } }
+                    actionFuture
                 }
+            }, executor)
+        } catch (error: Throwable) {
+            acquisitionFuture.whenComplete { acquired, _ ->
+                if (acquired != null) releaseIfUnclaimed()
             }
-        }, executor)
+            CompletableFuture.failedFuture(error)
+        }
+        pipelineFuture.whenComplete { _, failure ->
+            if (failure != null) releaseIfUnclaimed()
+        }
+        return pipelineFuture
     }
 }
 

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElectionTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElectionTest.kt
@@ -11,6 +11,7 @@ import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
 import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import org.junit.jupiter.api.Test
@@ -233,6 +234,31 @@ class HazelcastLeaderElectionTest: AbstractHazelcastLeaderTest() {
         } finally {
             executor.shutdownNow()
         }
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult - caller 취소를 action과 lock cleanup에 전파한다`() {
+        val lockName = randomName()
+        val election = HazelcastLeaderElector(
+            hazelcastClient,
+            LeaderElectionOptions(waitTime = 2.seconds, leaseTime = 10.seconds, autoExtend = true),
+        )
+        val actionStarted = CountDownLatch(1)
+        val actionTerminal = CountDownLatch(1)
+        val actionFuture = CompletableFuture<Int>().also { future ->
+            future.whenComplete { _, _ -> actionTerminal.countDown() }
+        }
+
+        val result = election.runAsyncIfLeaderResult(LeaderSlot(lockName, "hazelcast-single-cancel")) {
+            actionStarted.countDown()
+            actionFuture
+        }
+
+        actionStarted.await(3, TimeUnit.SECONDS).shouldBeTrue()
+        result.cancel(false).shouldBeTrue()
+        actionTerminal.await(3, TimeUnit.SECONDS).shouldBeTrue()
+        actionFuture.isCancelled.shouldBeTrue()
+        election.runIfLeader(lockName) { "reacquired" } shouldBeEqualTo "reacquired"
     }
 
     @Test

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElectionTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElectionTest.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
@@ -16,8 +17,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
 import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.random.Random
@@ -228,6 +232,38 @@ class HazelcastLeaderElectionTest: AbstractHazelcastLeaderTest() {
             election.runIfLeader(lockName) { "reacquired" } shouldBeEqualTo "reacquired"
         } finally {
             executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `runAsyncIfLeader - 두 번째 executor 제출 거부 후 획득한 락을 정리한다`() {
+        val lockName = randomName()
+        val election = HazelcastLeaderElector(
+            hazelcastClient,
+            LeaderElectionOptions(waitTime = 2.seconds, leaseTime = 10.seconds),
+        )
+        val worker = Executors.newSingleThreadExecutor()
+        val submissions = AtomicInteger()
+        val executor = Executor { command ->
+            if (submissions.incrementAndGet() == 1) {
+                worker.execute(command)
+            } else {
+                throw RejectedExecutionException("second submission rejected")
+            }
+        }
+
+        try {
+            val resultFuture = runCatching {
+                election.runAsyncIfLeader(lockName, executor) {
+                    CompletableFuture.completedFuture("실행되면 안 됨")
+                }
+            }.getOrElse { CompletableFuture.failedFuture(it) }
+
+            val failure = assertFailsWith<CompletionException> { resultFuture.join() }
+            failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            election.runIfLeader(lockName) { "executor 거부 후 복구" } shouldBeEqualTo "executor 거부 후 복구"
+        } finally {
+            worker.shutdownNow()
         }
     }
 

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElectionTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElectionTest.kt
@@ -13,6 +13,7 @@ import io.bluetape4k.junit5.concurrency.MultithreadingTester
 import io.bluetape4k.junit5.concurrency.StructuredTaskScopeTester
 import io.bluetape4k.leader.LeaderGroupElectionException
 import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import org.junit.jupiter.api.Test
@@ -212,6 +213,31 @@ class HazelcastLeaderGroupElectionTest: AbstractHazelcastLeaderTest() {
         } finally {
             executor.shutdownNow()
         }
+    }
+
+    @Test
+    fun `runAsyncIfLeaderResult - caller 취소를 action과 그룹 슬롯 cleanup에 전파한다`() {
+        val lockName = randomName()
+        val singleElection = HazelcastLeaderGroupElector(
+            hazelcastClient,
+            LeaderGroupElectionOptions(maxLeaders = 1, waitTime = 2.seconds, leaseTime = 10.seconds),
+        )
+        val actionStarted = CountDownLatch(1)
+        val actionTerminal = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>().also { future ->
+            future.whenComplete { _, _ -> actionTerminal.countDown() }
+        }
+
+        val result = singleElection.runAsyncIfLeaderResult(LeaderSlot(lockName, "hazelcast-group-cancel")) {
+            actionStarted.countDown()
+            actionFuture
+        }
+
+        actionStarted.await(3, TimeUnit.SECONDS).shouldBeTrue()
+        result.cancel(false).shouldBeTrue()
+        actionTerminal.await(3, TimeUnit.SECONDS).shouldBeTrue()
+        actionFuture.isCancelled.shouldBeTrue()
+        singleElection.runIfLeader(lockName) { "reacquired" } shouldBeEqualTo "reacquired"
     }
 
     @Test

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElectionTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElectionTest.kt
@@ -4,7 +4,9 @@ import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeLessOrEqualTo
 import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.concurrent.futureOf
 import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
 import io.bluetape4k.junit5.concurrency.MultithreadingTester
@@ -17,8 +19,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.JRE
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
 import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.max
@@ -206,6 +211,39 @@ class HazelcastLeaderGroupElectionTest: AbstractHazelcastLeaderTest() {
             singleElection.runIfLeader(lockName) { "reacquired" } shouldBeEqualTo "reacquired"
         } finally {
             executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `runAsyncIfLeader - 두 번째 executor 제출 거부 후 획득한 슬롯을 정리한다`() {
+        val lockName = randomName()
+        val singleElection = HazelcastLeaderGroupElector(
+            hazelcastClient,
+            LeaderGroupElectionOptions(maxLeaders = 1, waitTime = 2.seconds, leaseTime = 10.seconds),
+        )
+        val worker = Executors.newSingleThreadExecutor()
+        val submissions = AtomicInteger()
+        val executor = Executor { command ->
+            if (submissions.incrementAndGet() == 1) {
+                worker.execute(command)
+            } else {
+                throw RejectedExecutionException("second submission rejected")
+            }
+        }
+
+        try {
+            val resultFuture = runCatching {
+                singleElection.runAsyncIfLeader(lockName, executor) {
+                    CompletableFuture.completedFuture("실행되면 안 됨")
+                }
+            }.getOrElse { CompletableFuture.failedFuture(it) }
+
+            val failure = assertFailsWith<CompletionException> { resultFuture.join() }
+            failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            singleElection.runIfLeader(lockName) { "executor 거부 후 슬롯 복구" } shouldBeEqualTo
+                    "executor 거부 후 슬롯 복구"
+        } finally {
+            worker.shutdownNow()
         }
     }
 

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderElector.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderElector.kt
@@ -100,10 +100,11 @@ class KubernetesLeaseLeaderElector @JvmOverloads constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         var elected = false
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
         return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected = true
-            action()
-        }) { value, failure ->
+            cancellationRelay.invoke(action)
+        }, cancellationRelay) { value, failure ->
             val cause = failure.unwrapCompletionException()
             when {
                 cause is CancellationException -> throw cause
@@ -206,6 +207,9 @@ class KubernetesLeaseLeaderElector @JvmOverloads constructor(
         }
         pipelineFuture.whenComplete { _, failure ->
             if (failure != null) releaseIfUnclaimed()
+        }
+        acquisitionFuture.whenComplete { acquired, _ ->
+            if (acquired == true && pipelineFuture.isCancelled) releaseIfUnclaimed()
         }
         return pipelineFuture
     }

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderElector.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderElector.kt
@@ -10,6 +10,7 @@ import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
 import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import io.bluetape4k.leader.k8s.internal.KubernetesBackendErrorClassifier
 import io.bluetape4k.leader.k8s.internal.KubernetesLeaseLock
 import io.bluetape4k.leader.k8s.internal.KubernetesLeaseLockExtendDelegate
@@ -22,6 +23,8 @@ import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * `KubernetesLeaseLeaderElector`는 Kubernetes Lease backend의 lease, ownership 확인, session/TTL 정리를 담당합니다.
@@ -97,10 +100,10 @@ class KubernetesLeaseLeaderElector @JvmOverloads constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         var elected = false
-        return runAsyncIfLeader(slot, executor) {
+        return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected = true
             action()
-        }.handle { value, failure ->
+        }) { value, failure ->
             val cause = failure.unwrapCompletionException()
             when {
                 cause is CancellationException -> throw cause
@@ -154,6 +157,7 @@ class KubernetesLeaseLeaderElector @JvmOverloads constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun <T> runAsyncWithLock(
         lockName: String,
         auditLeaderId: String?,
@@ -162,34 +166,73 @@ class KubernetesLeaseLeaderElector @JvmOverloads constructor(
     ): CompletableFuture<T?> {
         val lock = newLock(lockName, auditLeaderId)
 
-        return CompletableFuture.supplyAsync({
-            lock.tryLock(options.leaderOptions.waitTime, options.leaderOptions.leaseTime)
-        }, executor).thenComposeAsync({ acquired ->
-            if (!acquired) {
-                CompletableFuture.completedFuture(null)
-            } else {
-                runAcquiredAsync(lockName, lock, executor, action)
+        val lockAcquired = AtomicBoolean()
+        val acquiredAtNanosRef = AtomicLong()
+        val lifecycleStarted = AtomicBoolean()
+        val rejectionCleanupClaimed = AtomicBoolean()
+        val releaseIfUnclaimed: () -> Unit = {
+            if (lockAcquired.get() && !lifecycleStarted.get() && rejectionCleanupClaimed.compareAndSet(false, true)) {
+                release(lock, acquiredAtNanosRef.get(), lockName)
+            }
+        }
+        val acquisitionFuture = CompletableFuture.supplyAsync({
+            lock.tryLock(options.leaderOptions.waitTime, options.leaderOptions.leaseTime).also { acquired ->
+                if (acquired) {
+                    acquiredAtNanosRef.set(System.nanoTime())
+                    lockAcquired.set(true)
+                }
             }
         }, executor)
+        val pipelineFuture: CompletableFuture<T?> = try {
+            acquisitionFuture.thenComposeAsync({ acquired ->
+                if (!acquired) {
+                    CompletableFuture.completedFuture(null)
+                } else {
+                    lifecycleStarted.set(true)
+                    try {
+                        runAcquiredAsync(lockName, lock, acquiredAtNanosRef.get(), executor, action)
+                    } catch (error: Throwable) {
+                        lifecycleStarted.set(false)
+                        releaseIfUnclaimed()
+                        CompletableFuture.failedFuture(error)
+                    }
+                }
+            }, executor)
+        } catch (error: Throwable) {
+            acquisitionFuture.whenComplete { acquired, _ ->
+                if (acquired == true) releaseIfUnclaimed()
+            }
+            CompletableFuture.failedFuture(error)
+        }
+        pipelineFuture.whenComplete { _, failure ->
+            if (failure != null) releaseIfUnclaimed()
+        }
+        return pipelineFuture
     }
 
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
     private fun <T> runAcquiredAsync(
         lockName: String,
         lock: KubernetesLeaseLock,
+        acquiredAtNanos: Long,
         executor: Executor,
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
-        val acquiredAtNanos = System.nanoTime()
         val delegate = KubernetesLeaseLockExtendDelegate(lock)
-        val watchdog = LeaderLeaseAutoExtender.start(
-            options.leaderOptions.autoExtend,
-            options.leaderOptions.leaseTime,
-            delegate,
-            ERROR_CLASSIFIER,
-        )
+        val watchdog = try {
+            LeaderLeaseAutoExtender.start(
+                options.leaderOptions.autoExtend,
+                options.leaderOptions.leaseTime,
+                delegate,
+                ERROR_CLASSIFIER,
+            )
+        } catch (e: Throwable) {
+            release(lock, acquiredAtNanos, lockName)
+            return CompletableFuture.failedFuture(e)
+        }
         val actionFuture = try {
             action()
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             watchdog.close()
             release(lock, acquiredAtNanos, lockName)
             return CompletableFuture.failedFuture(e)

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderGroupElector.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderGroupElector.kt
@@ -11,6 +11,7 @@ import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import io.bluetape4k.leader.k8s.internal.KubernetesLeaseLock
 import io.bluetape4k.leader.k8s.internal.KubernetesLeaseLockExtendDelegate
 import io.bluetape4k.leader.k8s.internal.KubernetesLeaseGroupAcquisitionDeadline
@@ -25,6 +26,8 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -109,10 +112,10 @@ class KubernetesLeaseLeaderGroupElector @JvmOverloads constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         var elected = false
-        return runAsyncWithGroupSlot(slot.lockName, slot.leaderId, executor) {
+        return LeaderFutureBridge.map(runAsyncWithGroupSlot(slot.lockName, slot.leaderId, executor) {
             elected = true
             action()
-        }.handle { value, failure ->
+        }) { value, failure ->
             val cause = failure.unwrapCompletionException()
             when {
                 cause is CancellationException -> throw cause
@@ -151,21 +154,55 @@ class KubernetesLeaseLeaderGroupElector @JvmOverloads constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun <T> runAsyncWithGroupSlot(
         lockName: String,
         auditLeaderId: String?,
         executor: Executor,
         action: () -> CompletableFuture<T>,
-    ): CompletableFuture<T?> =
-        CompletableFuture.supplyAsync({ acquire(lockName, auditLeaderId) }, executor)
-            .thenComposeAsync({ acquired ->
+    ): CompletableFuture<T?> {
+        val acquiredRef = AtomicReference<AcquiredSlot?>()
+        val lifecycleStarted = AtomicBoolean()
+        val rejectionCleanupClaimed = AtomicBoolean()
+        val releaseIfUnclaimed: () -> Unit = {
+            val acquired = acquiredRef.get()
+            if (acquired != null && !lifecycleStarted.get() && rejectionCleanupClaimed.compareAndSet(false, true)) {
+                release(acquired.lock, acquired.acquiredAtNanos, lockName, acquired.slot)
+            }
+        }
+        val acquisitionFuture = CompletableFuture.supplyAsync({
+            acquire(lockName, auditLeaderId).also { acquired ->
+                if (acquired != null) acquiredRef.set(acquired)
+            }
+        }, executor)
+        val pipelineFuture: CompletableFuture<T?> = try {
+            acquisitionFuture.thenComposeAsync({ acquired ->
                 if (acquired == null) {
                     CompletableFuture.completedFuture(null)
                 } else {
-                    runAcquiredAsync(lockName, acquired, auditLeaderId, executor, action)
+                    lifecycleStarted.set(true)
+                    try {
+                        runAcquiredAsync(lockName, acquired, auditLeaderId, executor, action)
+                    } catch (error: Throwable) {
+                        lifecycleStarted.set(false)
+                        releaseIfUnclaimed()
+                        CompletableFuture.failedFuture(error)
+                    }
                 }
             }, executor)
+        } catch (error: Throwable) {
+            acquisitionFuture.whenComplete { acquired, _ ->
+                if (acquired != null) releaseIfUnclaimed()
+            }
+            CompletableFuture.failedFuture(error)
+        }
+        pipelineFuture.whenComplete { _, failure ->
+            if (failure != null) releaseIfUnclaimed()
+        }
+        return pipelineFuture
+    }
 
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
     private fun <T> runAcquiredAsync(
         lockName: String,
         acquired: AcquiredSlot,
@@ -175,16 +212,21 @@ class KubernetesLeaseLeaderGroupElector @JvmOverloads constructor(
     ): CompletableFuture<T?> {
         val lock = acquired.lock
         val delegate = KubernetesLeaseLockExtendDelegate(lock)
-        val watchdog = LeaderLeaseAutoExtender.start(
-            enabled = false,
-            leaseTime = options.leaderGroupOptions.leaseTime,
-            delegate = delegate,
-            classifier = KubernetesLeaseLeaderElector.ERROR_CLASSIFIER,
-        )
+        val watchdog = try {
+            LeaderLeaseAutoExtender.start(
+                enabled = false,
+                leaseTime = options.leaderGroupOptions.leaseTime,
+                delegate = delegate,
+                classifier = KubernetesLeaseLeaderElector.ERROR_CLASSIFIER,
+            )
+        } catch (e: Throwable) {
+            release(lock, acquired.acquiredAtNanos, lockName, acquired.slot)
+            return CompletableFuture.failedFuture(e)
+        }
         val actionFuture = try {
             val handle = handle(lockName, lock, acquired.slot, acquired.acquiredAtNanos, delegate, auditLeaderId)
             AopScopeAccess.withPushedSync(handle) { action() }
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             watchdog.close()
             release(lock, acquired.acquiredAtNanos, lockName, acquired.slot)
             return CompletableFuture.failedFuture(e)

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderGroupElector.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderGroupElector.kt
@@ -112,10 +112,11 @@ class KubernetesLeaseLeaderGroupElector @JvmOverloads constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         var elected = false
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
         return LeaderFutureBridge.map(runAsyncWithGroupSlot(slot.lockName, slot.leaderId, executor) {
             elected = true
-            action()
-        }) { value, failure ->
+            cancellationRelay.invoke(action)
+        }, cancellationRelay) { value, failure ->
             val cause = failure.unwrapCompletionException()
             when {
                 cause is CancellationException -> throw cause
@@ -198,6 +199,9 @@ class KubernetesLeaseLeaderGroupElector @JvmOverloads constructor(
         }
         pipelineFuture.whenComplete { _, failure ->
             if (failure != null) releaseIfUnclaimed()
+        }
+        acquisitionFuture.whenComplete { acquired, _ ->
+            if (acquired != null && pipelineFuture.isCancelled) releaseIfUnclaimed()
         }
         return pipelineFuture
     }

--- a/leader-k8s/src/test/kotlin/io/bluetape4k/leader/k8s/contract/KubernetesLeaseExecutorOverloadContractTest.kt
+++ b/leader-k8s/src/test/kotlin/io/bluetape4k/leader/k8s/contract/KubernetesLeaseExecutorOverloadContractTest.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.leader.k8s.contract
 
-import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.leader.LeaderElectionOptions
@@ -17,6 +17,11 @@ import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -28,7 +33,7 @@ class KubernetesLeaseExecutorOverloadContractTest {
     private val client: KubernetesClient = KubernetesContractSupport.newClient()
 
     @Test
-    fun singleExecutorOverloadPropagatesLeaderIdAndReleases() {
+    fun singleExecutorRejectsSecondSubmissionAndReleases() {
         val elector = KubernetesLeaseLeaderElector(
             client,
             KubernetesLeaseOptions(
@@ -41,32 +46,39 @@ class KubernetesLeaseExecutorOverloadContractTest {
             ),
         )
         val lockName = "k8s-executor-single-contract"
+        val worker = Executors.newSingleThreadExecutor()
+        val submissions = AtomicInteger()
+        val executor = Executor { command ->
+            if (submissions.incrementAndGet() == 1) {
+                worker.execute(command)
+            } else {
+                throw RejectedExecutionException("second submission rejected")
+            }
+        }
 
-        val first = elector.runAsyncIfLeaderResult(
-            LeaderSlot(lockName, "k8s-single-a"),
-            VirtualThreadExecutor,
-        ) {
-            CompletableFuture.completedFuture("single-ok")
-        }.join()
+        try {
+            val resultFuture = runCatching {
+                elector.runAsyncIfLeader(lockName, executor) {
+                    CompletableFuture.completedFuture("should-not-run")
+                }
+            }.getOrElse { CompletableFuture.failedFuture(it) }
 
-        first shouldBeInstanceOf LeaderRunResult.Elected::class
-        (first as LeaderRunResult.Elected).value shouldBeEqualTo "single-ok"
-        first.leaderId shouldBeEqualTo "k8s-single-a"
+            val failure = assertFailsWith<CompletionException> { resultFuture.join() }
+            failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
 
-        val second = elector.runAsyncIfLeaderResult(
-            LeaderSlot(lockName, "k8s-single-b"),
-            VirtualThreadExecutor,
-        ) {
-            CompletableFuture.completedFuture("single-reacquired")
-        }.join()
-
-        second shouldBeInstanceOf LeaderRunResult.Elected::class
-        (second as LeaderRunResult.Elected).value shouldBeEqualTo "single-reacquired"
-        second.leaderId shouldBeEqualTo "k8s-single-b"
+            val result = elector.runAsyncIfLeaderResult(LeaderSlot(lockName, "k8s-single-b")) {
+                CompletableFuture.completedFuture("single-reacquired")
+            }.join()
+            result shouldBeInstanceOf LeaderRunResult.Elected::class
+            (result as LeaderRunResult.Elected).value shouldBeEqualTo "single-reacquired"
+            result.leaderId shouldBeEqualTo "k8s-single-b"
+        } finally {
+            worker.shutdownNow()
+        }
     }
 
     @Test
-    fun groupExecutorOverloadPropagatesLeaderIdAndReleases() {
+    fun groupExecutorRejectsSecondSubmissionAndReleases() {
         val elector = KubernetesLeaseLeaderGroupElector(
             client,
             KubernetesLeaseGroupOptions(
@@ -80,28 +92,35 @@ class KubernetesLeaseExecutorOverloadContractTest {
             ),
         )
         val lockName = "k8s-executor-group-contract"
+        val worker = Executors.newSingleThreadExecutor()
+        val submissions = AtomicInteger()
+        val executor = Executor { command ->
+            if (submissions.incrementAndGet() == 1) {
+                worker.execute(command)
+            } else {
+                throw RejectedExecutionException("second submission rejected")
+            }
+        }
 
-        val first = elector.runAsyncIfLeaderResult(
-            LeaderSlot(lockName, "k8s-group-a"),
-            VirtualThreadExecutor,
-        ) {
-            CompletableFuture.completedFuture("group-ok")
-        }.join()
+        try {
+            val resultFuture = runCatching {
+                elector.runAsyncIfLeader(lockName, executor) {
+                    CompletableFuture.completedFuture("should-not-run")
+                }
+            }.getOrElse { CompletableFuture.failedFuture(it) }
 
-        first shouldBeInstanceOf LeaderRunResult.Elected::class
-        (first as LeaderRunResult.Elected).value shouldBeEqualTo "group-ok"
-        first.leaderId shouldBeEqualTo "k8s-group-a"
+            val failure = assertFailsWith<CompletionException> { resultFuture.join() }
+            failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
 
-        val second = elector.runAsyncIfLeaderResult(
-            LeaderSlot(lockName, "k8s-group-b"),
-            VirtualThreadExecutor,
-        ) {
-            CompletableFuture.completedFuture("group-reacquired")
-        }.join()
-
-        second shouldBeInstanceOf LeaderRunResult.Elected::class
-        (second as LeaderRunResult.Elected).value shouldBeEqualTo "group-reacquired"
-        second.leaderId shouldBeEqualTo "k8s-group-b"
+            val result = elector.runAsyncIfLeaderResult(LeaderSlot(lockName, "k8s-group-b")) {
+                CompletableFuture.completedFuture("group-reacquired")
+            }.join()
+            result shouldBeInstanceOf LeaderRunResult.Elected::class
+            (result as LeaderRunResult.Elected).value shouldBeEqualTo "group-reacquired"
+            result.leaderId shouldBeEqualTo "k8s-group-b"
+        } finally {
+            worker.shutdownNow()
+        }
     }
 
     @AfterAll

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElector.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderElector.kt
@@ -12,6 +12,7 @@ import io.bluetape4k.leader.history.LeaderHistoryKey
 import io.bluetape4k.leader.history.LeaderLockHistoryRecord
 import io.bluetape4k.leader.history.SafeLeaderHistoryRecorder
 import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import io.bluetape4k.leader.mongodb.internal.MongoBackendErrorClassifier
 import io.bluetape4k.leader.mongodb.internal.MongoLockExtendDelegate
 import io.bluetape4k.leader.mongodb.lock.MongoLock
@@ -22,8 +23,13 @@ import io.bluetape4k.logging.warn
 import org.bson.Document
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * `MongoLeaderElector`는 MongoDB backend의 leader election, lock lease, ownership 확인을 담당합니다.
@@ -130,6 +136,7 @@ class MongoLeaderElector private constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     override fun <T> runAsyncIfLeader(
         lockName: String,
         executor: Executor,
@@ -138,66 +145,139 @@ class MongoLeaderElector private constructor(
         validateMongoLockName(lockName)
         val lock = MongoLock(collection, lockName, options.retryDelay)
 
-        return lock
+        val rejectionCleanup = AsyncLockRejectionCleanup(lock, lockName)
+        val acquisitionFuture = lock
             .tryLockAsync(options.leaderOptions.waitTime, options.leaderOptions.leaseTime)
-            .thenComposeAsync({ acquired ->
-                if (!acquired) {
-                    log.debug { "리더 승격 실패 (슬롯 없음, 비동기). lockName=$lockName" }
-                    CompletableFuture.completedFuture(null)
-                } else {
-                    val startedAt = Instant.now()
-                    val acquiredAtNanos = System.nanoTime()
-                    val delegate = MongoLockExtendDelegate(lock)
-                    val watchdog = LeaderLeaseAutoExtender.start(
-                        options.leaderOptions.autoExtend,
-                        options.leaderOptions.leaseTime,
-                        delegate,
-                        ERROR_CLASSIFIER,
-                    )
-
-                    val record = historyRecorder?.let {
-                        LeaderLockHistoryRecord(
-                            lockName = lockName,
-                            token = lock.token,
-                            kind = LockIdentity.AnnotationKind.SINGLE,
-                            acquiredAt = startedAt,
-                            lockedUntil = startedAt.plusMillis(options.leaderOptions.leaseTime.inWholeMilliseconds),
-                        )
-                    }
-                    val key = record?.let { historyRecorder.recordAcquired(it) }
-                    val effectiveKey: LeaderHistoryKey? =
-                        key ?: record?.let { LeaderHistoryKey(lockName = lockName, token = lock.token) }
-
-                    log.debug { "리더로 승격하여 비동기 작업을 수행합니다. lockName=$lockName" }
-                    val actionFuture = runCatching { action() }
-                        .getOrElse { e ->
-                            watchdog.close()
-                            val finishedAt = Instant.now()
-                            val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
-                            effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, e) }
-                            runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos) }
-                                .onFailure { ex -> log.warn(ex) { "락 해제 실패 (action 오류 경로). lockName=$lockName" } }
-                            return@thenComposeAsync CompletableFuture.failedFuture(e)
-                        }
-                    actionFuture.whenComplete { _, throwable ->
-                        watchdog.close()
-                        val finishedAt = Instant.now()
-                        val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
-                        when {
-                            throwable == null -> effectiveKey?.let {
-                                historyRecorder?.recordCompleted(it, finishedAt, durationMs)
-                            }
-                            throwable is java.util.concurrent.CancellationException -> { /* cancelled — no audit */ }
-                            else -> effectiveKey?.let {
-                                historyRecorder?.recordFailed(it, finishedAt, durationMs, throwable)
-                            }
-                        }
-                        runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos) }
-                            .onSuccess { log.debug { "비동기 리더 권한을 반납했습니다. lockName=$lockName" } }
-                            .onFailure { e -> log.warn(e) { "비동기 락 해제 실패. lockName=$lockName" } }
-                    }
+            .thenApply { acquired ->
+                if (acquired) rejectionCleanup.markAcquired()
+                acquired
+            }
+        val pipelineFuture = acquisitionFuture.thenComposeAsync({ acquired ->
+            if (!acquired) {
+                log.debug { "리더 승격 실패 (슬롯 없음, 비동기). lockName=$lockName" }
+                CompletableFuture.completedFuture(null)
+            } else {
+                if (!rejectionCleanup.markLifecycleStarted()) {
+                    CompletableFuture.failedFuture(CancellationException("leader action was cancelled before start"))
+                } else try {
+                    runAcquiredAsync(lock, lockName, rejectionCleanup.acquiredAtNanos, action)
+                } catch (error: Throwable) {
+                    releaseAcquiredLock(lock, lockName, rejectionCleanup.acquiredAtNanos, error)
                 }
-            }, executor)
+            }
+        }, executor)
+        acquisitionFuture.whenComplete { acquired, _ ->
+            if (acquired == true && pipelineFuture.isCancelled) {
+                rejectionCleanup.release<Any?>(
+                    CancellationException("leader result future was cancelled before action"),
+                )
+            }
+        }
+        return LeaderFutureBridge.flatMap(pipelineFuture) { value, failure ->
+            if (failure != null) {
+                rejectionCleanup.release(failure.unwrapCompletionCause())
+            } else {
+                CompletableFuture.completedFuture(value)
+            }
+        }
+    }
+
+    private fun <T> runAcquiredAsync(
+        lock: MongoLock,
+        lockName: String,
+        acquiredAtNanos: Long,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> {
+        val startedAt = Instant.now()
+        val delegate = MongoLockExtendDelegate(lock)
+        val watchdog = LeaderLeaseAutoExtender.start(
+            options.leaderOptions.autoExtend,
+            options.leaderOptions.leaseTime,
+            delegate,
+            ERROR_CLASSIFIER,
+        )
+        val record = historyRecorder?.let {
+            LeaderLockHistoryRecord(
+                lockName = lockName,
+                token = lock.token,
+                kind = LockIdentity.AnnotationKind.SINGLE,
+                acquiredAt = startedAt,
+                lockedUntil = startedAt.plusMillis(options.leaderOptions.leaseTime.inWholeMilliseconds),
+            )
+        }
+        val key = record?.let { historyRecorder.recordAcquired(it) }
+        val effectiveKey = key ?: record?.let { LeaderHistoryKey(lockName = lockName, token = lock.token) }
+
+        log.debug { "리더로 승격하여 비동기 작업을 수행합니다. lockName=$lockName" }
+        val actionFuture = runCatching { action() }.getOrElse { error ->
+            watchdog.close()
+            val finishedAt = Instant.now()
+            val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
+            effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, error) }
+            return releaseAcquiredLock(lock, lockName, acquiredAtNanos, error)
+        }
+        return actionFuture.whenComplete { _, failure ->
+            watchdog.close()
+            val finishedAt = Instant.now()
+            val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
+            when {
+                failure == null -> effectiveKey?.let { historyRecorder?.recordCompleted(it, finishedAt, durationMs) }
+                failure is CancellationException -> Unit
+                else -> effectiveKey?.let { historyRecorder?.recordFailed(it, finishedAt, durationMs, failure) }
+            }
+            runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos) }
+                .onSuccess { log.debug { "비동기 리더 권한을 반납했습니다. lockName=$lockName" } }
+                .onFailure { error -> log.warn(error) { "비동기 락 해제 실패. lockName=$lockName" } }
+        }.thenApply<T?> { it }
+    }
+
+    private fun <T> releaseAcquiredLock(
+        lock: MongoLock,
+        lockName: String,
+        acquiredAtNanos: Long,
+        failure: Throwable,
+    ): CompletableFuture<T?> {
+        runCatching { lock.unlock(options.leaderOptions.minLeaseTime, acquiredAtNanos) }
+            .onFailure { error ->
+                failure.addSuppressed(error)
+                log.warn(error) { "비동기 락 해제 실패. lockName=$lockName" }
+            }
+        return CompletableFuture.failedFuture(failure)
+    }
+
+    private inner class AsyncLockRejectionCleanup(
+        private val lock: MongoLock,
+        private val lockName: String,
+    ) {
+        private val acquired = AtomicBoolean()
+        private val lifecycle = AtomicReference(AsyncLifecycle.WAITING)
+        private val acquiredAtNanosRef = AtomicLong()
+
+        val acquiredAtNanos: Long get() = acquiredAtNanosRef.get()
+
+        fun markAcquired() {
+            acquiredAtNanosRef.set(System.nanoTime())
+            acquired.set(true)
+        }
+
+        fun markLifecycleStarted(): Boolean =
+            lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.STARTED)
+
+        fun <T> release(failure: Throwable): CompletableFuture<T?> =
+            if (acquired.get() && lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.CLEANUP)) {
+                releaseAcquiredLock(lock, lockName, acquiredAtNanos, failure)
+            } else {
+                CompletableFuture.failedFuture(failure)
+            }
+    }
+
+    private fun Throwable.unwrapCompletionCause(): Throwable =
+        if (this is CompletionException) cause ?: this else this
+
+    private enum class AsyncLifecycle {
+        WAITING,
+        STARTED,
+        CLEANUP,
     }
 }
 

--- a/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderGroupElector.kt
+++ b/leader-mongodb/src/main/kotlin/io/bluetape4k/leader/mongodb/MongoLeaderGroupElector.kt
@@ -14,6 +14,7 @@ import io.bluetape4k.leader.history.LeaderHistoryKey
 import io.bluetape4k.leader.history.LeaderLockHistoryRecord
 import io.bluetape4k.leader.history.SafeLeaderHistoryRecorder
 import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import io.bluetape4k.leader.mongodb.internal.MongoBackendErrorClassifier
 import io.bluetape4k.leader.mongodb.internal.MongoSlotExtendDelegate
 import io.bluetape4k.leader.mongodb.lock.MongoLock
@@ -25,8 +26,12 @@ import org.bson.Document
 import java.time.Instant
 import java.util.Date
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.random.Random
 import kotlin.time.Duration
 
@@ -38,6 +43,7 @@ import kotlin.time.Duration
  * @property options MongoDB backend 호출과 상태 계산에 사용하는 속성입니다.
  * @property historyRecorder MongoDB backend 호출과 상태 계산에 사용하는 속성입니다.
  */
+@Suppress("TooManyFunctions")
 class MongoLeaderGroupElector private constructor(
     private val groupCollection: MongoCollection<Document>,
     val options: MongoLeaderGroupElectionOptions,
@@ -162,6 +168,7 @@ class MongoLeaderGroupElector private constructor(
         return null
     }
 
+    @Suppress("TooGenericExceptionCaught")
     override fun <T> runAsyncIfLeader(
         lockName: String,
         executor: Executor,
@@ -173,45 +180,134 @@ class MongoLeaderGroupElector private constructor(
         val perSlotWait = options.leaderGroupOptions.waitTime / maxLeaders
         val start = Random.nextInt(maxLeaders)
 
-        return acquireSlotAsync(lockName, start, perSlotWait, leaseTime).thenComposeAsync({ acquired ->
+        val rejectionCleanup = AsyncSlotRejectionCleanup(lockName)
+        val acquisitionFuture = acquireSlotAsync(lockName, start, perSlotWait, leaseTime).thenApply { acquired ->
+            if (acquired != null) rejectionCleanup.markAcquired(acquired)
+            acquired
+        }
+        val pipelineFuture = acquisitionFuture.thenComposeAsync({ acquired ->
             if (acquired == null) {
                 log.debug { "리더 그룹 슬롯 획득 실패 (비동기). lockName=$lockName" }
                 CompletableFuture.completedFuture(null)
             } else {
                 val (lock, slot) = acquired
-                val acquiredAtNanos = System.nanoTime()
-                val startedAt = Instant.now()
-                log.debug { "리더 그룹 슬롯을 획득하여 비동기 작업을 수행합니다. lockName=$lockName, slot=$slot" }
-                val delegate = MongoSlotExtendDelegate(lock)
-                val historyKey = recordAcquired(lockName, lock.token, slot, startedAt, leaseTime)
-                // Group elector: watchdog disabled (autoExtend 옵션 부재)
-                val watchdog = LeaderLeaseAutoExtender.start(false, leaseTime, delegate, ERROR_CLASSIFIER)
-                // async path 는 handle push 미수행 (AOP scope sync/suspend 만 지원)
-                val actionFuture = runCatching { action() }
-                    .getOrElse { e ->
-                        val finishedAt = Instant.now()
-                        val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
-                        recordFailed(historyKey, finishedAt, durationMs, e)
-                        watchdog.close()
-                        runCatching { lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos) }
-                            .onFailure { ex -> log.warn(ex) { "그룹 슬롯 해제 실패 (action 오류 경로). lockName=$lockName, slot=$slot" } }
-                        return@thenComposeAsync CompletableFuture.failedFuture(e)
-                    }
-                actionFuture.whenComplete { _, throwable ->
-                    val finishedAt = Instant.now()
-                    val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
-                    if (throwable == null) {
-                        recordCompleted(historyKey, finishedAt, durationMs)
-                    } else {
-                        recordFailed(historyKey, finishedAt, durationMs, throwable)
-                    }
-                    watchdog.close()
-                    runCatching { lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos) }
-                        .onSuccess { log.debug { "비동기 그룹 슬롯을 반납했습니다. lockName=$lockName, slot=$slot" } }
-                        .onFailure { e -> log.warn(e) { "비동기 그룹 슬롯 해제 실패. lockName=$lockName, slot=$slot" } }
+                val acquiredAtNanos = rejectionCleanup.acquiredAtNanos
+                if (!rejectionCleanup.markLifecycleStarted()) {
+                    CompletableFuture.failedFuture(
+                        CancellationException("leader group action was cancelled before start"),
+                    )
+                } else try {
+                    runAcquiredAsync(lock, lockName, slot, acquiredAtNanos, leaseTime, action)
+                } catch (error: Throwable) {
+                    releaseAcquiredSlot(lock, lockName, slot, acquiredAtNanos, error)
                 }
             }
         }, executor)
+        acquisitionFuture.whenComplete { acquired, _ ->
+            if (acquired != null && pipelineFuture.isCancelled) {
+                rejectionCleanup.release<Any?>(
+                    CancellationException("leader group result future was cancelled before action"),
+                )
+            }
+        }
+        return LeaderFutureBridge.flatMap(pipelineFuture) { value, failure ->
+            if (failure != null) {
+                rejectionCleanup.release(failure.unwrapCompletionCause())
+            } else {
+                CompletableFuture.completedFuture(value)
+            }
+        }
+    }
+
+    private fun <T> runAcquiredAsync(
+        lock: MongoLock,
+        lockName: String,
+        slot: Int,
+        acquiredAtNanos: Long,
+        leaseTime: Duration,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> {
+        val startedAt = Instant.now()
+        log.debug { "리더 그룹 슬롯을 획득하여 비동기 작업을 수행합니다. lockName=$lockName, slot=$slot" }
+        val delegate = MongoSlotExtendDelegate(lock)
+        val historyKey = recordAcquired(lockName, lock.token, slot, startedAt, leaseTime)
+        val watchdog = LeaderLeaseAutoExtender.start(false, leaseTime, delegate, ERROR_CLASSIFIER)
+        val actionFuture = runCatching { action() }.getOrElse { error ->
+            val finishedAt = Instant.now()
+            val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
+            recordFailed(historyKey, finishedAt, durationMs, error)
+            watchdog.close()
+            return releaseAcquiredSlot(lock, lockName, slot, acquiredAtNanos, error)
+        }
+        return actionFuture.whenComplete { _, failure ->
+            val finishedAt = Instant.now()
+            val durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - acquiredAtNanos)
+            if (failure == null) {
+                recordCompleted(historyKey, finishedAt, durationMs)
+            } else {
+                recordFailed(historyKey, finishedAt, durationMs, failure)
+            }
+            watchdog.close()
+            runCatching { lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos) }
+                .onSuccess { log.debug { "비동기 그룹 슬롯을 반납했습니다. lockName=$lockName, slot=$slot" } }
+                .onFailure { error ->
+                    log.warn(error) { "비동기 그룹 슬롯 해제 실패. lockName=$lockName, slot=$slot" }
+                }
+        }.thenApply<T?> { it }
+    }
+
+    private fun <T> releaseAcquiredSlot(
+        lock: MongoLock,
+        lockName: String,
+        slot: Int,
+        acquiredAtNanos: Long,
+        failure: Throwable,
+    ): CompletableFuture<T?> {
+        runCatching { lock.unlock(options.leaderGroupOptions.minLeaseTime, acquiredAtNanos) }
+            .onFailure { error ->
+                failure.addSuppressed(error)
+                log.warn(error) { "비동기 그룹 슬롯 해제 실패. lockName=$lockName, slot=$slot" }
+            }
+        return CompletableFuture.failedFuture(failure)
+    }
+
+    private inner class AsyncSlotRejectionCleanup(
+        private val lockName: String,
+    ) {
+        private val acquired = AtomicReference<Pair<MongoLock, Int>?>()
+        private val acquiredAtNanosRef = AtomicLong()
+        private val lifecycle = AtomicReference(AsyncLifecycle.WAITING)
+
+        val acquiredAtNanos: Long get() = acquiredAtNanosRef.get()
+
+        fun markAcquired(acquiredSlot: Pair<MongoLock, Int>) {
+            acquiredAtNanosRef.set(System.nanoTime())
+            acquired.set(acquiredSlot)
+        }
+
+        fun markLifecycleStarted(): Boolean =
+            lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.STARTED)
+
+        fun <T> release(failure: Throwable): CompletableFuture<T?> {
+            val acquiredSlot = acquired.get()
+            if (
+                acquiredSlot != null &&
+                lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.CLEANUP)
+            ) {
+                val (lock, slot) = acquiredSlot
+                return releaseAcquiredSlot(lock, lockName, slot, acquiredAtNanos, failure)
+            }
+            return CompletableFuture.failedFuture(failure)
+        }
+    }
+
+    private fun Throwable.unwrapCompletionCause(): Throwable =
+        if (this is CompletionException) cause ?: this else this
+
+    private enum class AsyncLifecycle {
+        WAITING,
+        STARTED,
+        CLEANUP,
     }
 
     private fun acquireSlotAsync(

--- a/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoExecutorRejectionLifecycleTest.kt
+++ b/leader-mongodb/src/test/kotlin/io/bluetape4k/leader/mongodb/MongoExecutorRejectionLifecycleTest.kt
@@ -1,0 +1,116 @@
+package io.bluetape4k.leader.mongodb
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class MongoExecutorRejectionLifecycleTest: AbstractMongoLeaderTest() {
+
+    @Test
+    fun `single async executor 거부 후 획득한 lock을 정리한다`() {
+        val lockName = randomName()
+        val election = MongoLeaderElector(
+            lockCollection,
+            MongoLeaderElectionOptions(
+                leaderOptions = LeaderElectionOptions(waitTime = 100.milliseconds, leaseTime = 10.seconds),
+            ),
+        )
+        val actionInvoked = AtomicBoolean()
+        val rejectingExecutor = rejectingSecondSubmissionExecutor()
+
+        try {
+            rejectingExecutor.prime()
+
+            val rejected = election.runAsyncIfLeader(lockName, rejectingExecutor.executor) {
+                actionInvoked.set(true)
+                CompletableFuture.completedFuture("must-not-run")
+            }
+            val failure = assertFailsWith<CompletionException> { rejected.join() }
+
+            failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            rejectingExecutor.submissions.get() shouldBeEqualTo 2
+            actionInvoked.get() shouldBeEqualTo false
+            election.runIfLeader(lockName) { "recovered" } shouldBeEqualTo "recovered"
+        } finally {
+            rejectingExecutor.close()
+        }
+    }
+
+    @Test
+    fun `group async executor 거부 후 획득한 slot을 정리한다`() {
+        val lockName = randomName()
+        val election = MongoLeaderGroupElector(
+            groupLockCollection,
+            MongoLeaderGroupElectionOptions(
+                leaderGroupOptions = LeaderGroupElectionOptions(
+                    maxLeaders = 1,
+                    waitTime = 100.milliseconds,
+                    leaseTime = 10.seconds,
+                ),
+            ),
+        )
+        val actionInvoked = AtomicBoolean()
+        val rejectingExecutor = rejectingSecondSubmissionExecutor()
+
+        try {
+            rejectingExecutor.prime()
+
+            val rejected = election.runAsyncIfLeader(lockName, rejectingExecutor.executor) {
+                actionInvoked.set(true)
+                CompletableFuture.completedFuture("must-not-run")
+            }
+            val failure = assertFailsWith<CompletionException> { rejected.join() }
+
+            failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            rejectingExecutor.submissions.get() shouldBeEqualTo 2
+            actionInvoked.get() shouldBeEqualTo false
+            election.runIfLeader(lockName) { "recovered" } shouldBeEqualTo "recovered"
+        } finally {
+            rejectingExecutor.close()
+        }
+    }
+
+    private fun rejectingSecondSubmissionExecutor(): RejectingExecutor {
+        val worker = Executors.newSingleThreadExecutor()
+        val submissions = AtomicInteger()
+        val executor = Executor { command ->
+            if (submissions.incrementAndGet() == 1) {
+                worker.execute(command)
+            } else {
+                throw RejectedExecutionException("second submission rejected")
+            }
+        }
+        return RejectingExecutor(executor, worker, submissions)
+    }
+
+    private class RejectingExecutor(
+        val executor: Executor,
+        private val worker: java.util.concurrent.ExecutorService,
+        val submissions: AtomicInteger,
+    ) : AutoCloseable {
+
+        fun prime() {
+            val primed = CountDownLatch(1)
+            executor.execute { primed.countDown() }
+            primed.await(2, TimeUnit.SECONDS) shouldBeEqualTo true
+        }
+
+        override fun close() {
+            worker.shutdownNow()
+        }
+    }
+}

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElector.kt
@@ -29,6 +29,8 @@ import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * `StatefulRedisConnection` 호출은 Redis Lettuce backend leader election 계약의 일부 동작을 수행합니다.
@@ -180,10 +182,11 @@ class LettuceLeaderElector @JvmOverloads constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
         return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected.set(true)
-            action()
-        }) { value, failure ->
+            cancellationRelay.invoke(action)
+        }, cancellationRelay) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()
@@ -193,6 +196,7 @@ class LettuceLeaderElector @JvmOverloads constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun <T> runAsyncImpl(
         lockName: String,
         auditLeaderId: String?,
@@ -202,59 +206,102 @@ class LettuceLeaderElector @JvmOverloads constructor(
         lockName.requireNotBlank("lockName")
 
         val lock = LettuceLock(connection, lockName, options.leaseTime)
-        return lock.tryLockAsync(options.waitTime, options.leaseTime).thenComposeAsync({ acquired ->
+        val acquiredAtNanos = AtomicLong()
+        val lockAcquired = AtomicBoolean()
+        val lifecycle = AtomicReference(AsyncLifecycle.WAITING)
+        val releaseAfterRejection: (Throwable) -> CompletableFuture<T?> = { failure ->
+            if (
+                lockAcquired.get() &&
+                lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.CLEANUP)
+            ) {
+                lock.unlockAsync(options.minLeaseTime, acquiredAtNanos.get())
+                    .exceptionally { releaseError ->
+                        log.warn(releaseError) { "executor 거부 후 비동기 락 해제 실패. lockName=$lockName" }
+                    }
+                    .thenCompose { CompletableFuture.failedFuture(failure) }
+            } else {
+                CompletableFuture.failedFuture(failure)
+            }
+        }
+        val acquisitionFuture = lock.tryLockAsync(options.waitTime, options.leaseTime).thenApply { acquired ->
+            if (acquired) {
+                acquiredAtNanos.set(System.nanoTime())
+                lockAcquired.set(true)
+            }
+            acquired
+        }
+        val pipelineFuture = acquisitionFuture.thenComposeAsync({ acquired ->
             if (!acquired) {
                 log.debug { "리더 선출 실패 (슬롯 없음, async): lockName=$lockName" }
                 CompletableFuture.completedFuture(null)
             } else {
-                val startedAt = Instant.now()
-                val acquiredAtNanos = System.nanoTime()
-                val token = lock.currentToken() ?: error("token missing after tryLock — lockName=$lockName")
-                val delegate = LettuceLockExtendDelegate(lock)
-                val watchdog =
-                    LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime, delegate, ERROR_CLASSIFIER)
-                val identity = LockIdentity(
-                    lockName = lockName,
-                    kind = LockIdentity.AnnotationKind.SINGLE,
-                    factoryBeanName = LETTUCE_FACTORY_BEAN_NAME,
-                )
-                val handle = LeaderLockHandle.real(
-                    identity = identity,
-                    token = token,
-                    acquiredAtNanos = acquiredAtNanos,
-                    extendDelegate = delegate,
-                    auditLeaderId = auditLeaderId,
-                )
-
-                val record = historyRecorder?.let {
-                    LeaderLockHistoryRecord(
-                        lockName = lockName,
-                        token = token,
-                        kind = LockIdentity.AnnotationKind.SINGLE,
-                        acquiredAt = startedAt,
-                        lockedUntil = startedAt.plusMillis(options.leaseTime.inWholeMilliseconds),
-                    )
-                }
-                val key = record?.let { historyRecorder.recordAcquired(it) }
-                val effectiveKey: LeaderHistoryKey? =
-                    key ?: record?.let { LeaderHistoryKey(lockName = lockName, token = token) }
-
-                log.debug { "리더 선출 성공 (async): lockName=$lockName" }
-                val actionFuture: CompletableFuture<T> = try {
-                    AopScopeAccess.withPushedSync(handle) { action() }
-                } catch (e: Throwable) {
-                    return@thenComposeAsync releaseAndPropagate<T>(
-                        lock, lockName, watchdog, acquiredAtNanos, effectiveKey, e, null
-                    )
-                }
-
-                actionFuture.handle<Pair<T?, Throwable?>> { value, error ->
-                    Pair(value, error)
-                }.thenCompose { (value, error) ->
-                    releaseAndPropagate(lock, lockName, watchdog, acquiredAtNanos, effectiveKey, error, value)
+                val acquiredAt = acquiredAtNanos.get()
+                if (!lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.STARTED)) {
+                    CompletableFuture.failedFuture(CancellationException("leader action was cancelled before start"))
+                } else try {
+                    runAcquiredAsync(lock, lockName, auditLeaderId, acquiredAt, action)
+                } catch (error: Throwable) {
+                    lock.unlockAsync(options.minLeaseTime, acquiredAt)
+                        .exceptionally { releaseError ->
+                            error.addSuppressed(releaseError.unwrapCompletionCause())
+                        }
+                        .thenCompose { CompletableFuture.failedFuture(error) }
                 }
             }
         }, executor)
+        acquisitionFuture.whenComplete { acquired, _ ->
+            if (acquired == true && pipelineFuture.isCancelled) {
+                releaseAfterRejection(CancellationException("leader result future was cancelled before action"))
+            }
+        }
+        return LeaderFutureBridge.flatMap(pipelineFuture) { value, failure ->
+            if (failure != null) {
+                releaseAfterRejection(failure.unwrapCompletionCause())
+            } else {
+                CompletableFuture.completedFuture(value)
+            }
+        }
+    }
+
+    private fun <T> runAcquiredAsync(
+        lock: LettuceLock,
+        lockName: String,
+        auditLeaderId: String?,
+        acquiredAtNanos: Long,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> {
+        val startedAt = Instant.now()
+        val token = lock.currentToken() ?: error("token missing after tryLock — lockName=$lockName")
+        val delegate = LettuceLockExtendDelegate(lock)
+        val handle = LeaderLockHandle.real(
+            identity = LockIdentity(lockName, LockIdentity.AnnotationKind.SINGLE, LETTUCE_FACTORY_BEAN_NAME),
+            token = token,
+            acquiredAtNanos = acquiredAtNanos,
+            extendDelegate = delegate,
+            auditLeaderId = auditLeaderId,
+        )
+        val record = historyRecorder?.let {
+            LeaderLockHistoryRecord(
+                lockName = lockName,
+                token = token,
+                kind = LockIdentity.AnnotationKind.SINGLE,
+                acquiredAt = startedAt,
+                lockedUntil = startedAt.plusMillis(options.leaseTime.inWholeMilliseconds),
+            )
+        }
+        val key = record?.let { historyRecorder.recordAcquired(it) }
+        val effectiveKey = key ?: record?.let { LeaderHistoryKey(lockName = lockName, token = token) }
+        val watchdog = LeaderLeaseAutoExtender.start(options.autoExtend, options.leaseTime, delegate, ERROR_CLASSIFIER)
+
+        log.debug { "리더 선출 성공 (async): lockName=$lockName" }
+        val actionFuture = runCatching { AopScopeAccess.withPushedSync(handle) { action() } }
+            .getOrElse { error ->
+                return releaseAndPropagate(lock, lockName, watchdog, acquiredAtNanos, effectiveKey, error, null)
+            }
+        return actionFuture.handle<Pair<T?, Throwable?>> { value, error -> Pair(value, error) }
+            .thenCompose { (value, error) ->
+                releaseAndPropagate(lock, lockName, watchdog, acquiredAtNanos, effectiveKey, error, value)
+            }
     }
 
     private fun Throwable.unwrapCompletionCause(): Throwable =
@@ -317,5 +364,11 @@ class LettuceLeaderElector @JvmOverloads constructor(
                     CompletableFuture.completedFuture<T?>(value)
                 }
             }
+    }
+
+    private enum class AsyncLifecycle {
+        WAITING,
+        STARTED,
+        CLEANUP,
     }
 }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderElector.kt
@@ -12,6 +12,7 @@ import io.bluetape4k.leader.history.LeaderHistoryKey
 import io.bluetape4k.leader.history.LeaderLockHistoryRecord
 import io.bluetape4k.leader.history.SafeLeaderHistoryRecorder
 import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import io.bluetape4k.leader.lettuce.internal.LettuceBackendErrorClassifier
 import io.bluetape4k.leader.lettuce.internal.LettuceLockExtendDelegate
 import io.bluetape4k.leader.lettuce.lock.LettuceLock
@@ -179,10 +180,10 @@ class LettuceLeaderElector @JvmOverloads constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
-        return runAsyncIfLeader(slot, executor) {
+        return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected.set(true)
             action()
-        }.handle { value, failure ->
+        }) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElector.kt
@@ -10,6 +10,7 @@ import io.bluetape4k.leader.LeaderRunResult
 import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import io.bluetape4k.leader.lettuce.internal.LettuceBackendErrorClassifier
 import io.bluetape4k.leader.lettuce.internal.LettuceSlotExtendDelegate
 import io.bluetape4k.leader.lettuce.semaphore.LettuceSlotTokenGroup
@@ -171,10 +172,10 @@ class LettuceLeaderGroupElector(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
-        return runAsyncIfLeader(slot, executor) {
+        return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected.set(true)
             action()
-        }.handle { value, failure ->
+        }) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceLeaderGroupElector.kt
@@ -27,6 +27,8 @@ import java.util.concurrent.CompletionException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * `StatefulRedisConnection` 호출은 Redis Lettuce backend leader election 계약의 일부 동작을 수행합니다.
@@ -172,10 +174,11 @@ class LettuceLeaderGroupElector(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
         return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected.set(true)
-            action()
-        }) { value, failure ->
+            cancellationRelay.invoke(action)
+        }, cancellationRelay) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()
@@ -185,6 +188,7 @@ class LettuceLeaderGroupElector(
         }
     }
 
+    @Suppress("LongMethod", "TooGenericExceptionCaught")
     private fun <T> runAsyncImpl(
         lockName: String,
         auditLeaderId: String?,
@@ -193,51 +197,107 @@ class LettuceLeaderGroupElector(
     ): CompletableFuture<T?> {
         val slotGroup = getSlotGroup(lockName)
 
-        return slotGroup.tryAcquireAsync(options.waitTime, options.leaseTime, auditLeaderId ?: "").thenComposeAsync({ token ->
+        val acquiredToken = AtomicReference<String?>()
+        val acquiredAtNanos = AtomicLong()
+        val lifecycle = AtomicReference(AsyncLifecycle.WAITING)
+        val releaseAfterRejection: (Throwable) -> CompletableFuture<T?> = { failure ->
+            val token = acquiredToken.get()
+            if (
+                token != null &&
+                lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.CLEANUP)
+            ) {
+                releaseAndPropagate(slotGroup, lockName, token, acquiredAtNanos.get(), failure, null)
+            } else {
+                CompletableFuture.failedFuture(failure)
+            }
+        }
+        val acquisitionFuture = slotGroup
+            .tryAcquireAsync(options.waitTime, options.leaseTime, auditLeaderId ?: "")
+            .thenApply { token ->
+                if (token != null) {
+                    acquiredAtNanos.set(System.nanoTime())
+                    acquiredToken.set(token)
+                }
+                token
+            }
+        val pipelineFuture = acquisitionFuture.thenComposeAsync({ token ->
             if (token == null) {
                 log.debug { "리더 선출 실패 (슬롯 없음, async): lockName=$lockName" }
                 CompletableFuture.completedFuture<T?>(null)
             } else {
-                // Codex P2: acquire 성공 후 startedAtNanos 캡처
-                val startedAtNanos = System.nanoTime()
-                val delegate = LettuceSlotExtendDelegate(slotGroup, token)
-                val identity = LockIdentity(
-                    lockName = lockName,
-                    kind = LockIdentity.AnnotationKind.GROUP,
-                    factoryBeanName = LETTUCE_GROUP_FACTORY_BEAN_NAME,
-                    groupParams = LockIdentity.GroupParams(maxLeaders),
-                )
-                val handle = LeaderLockHandle.real(
-                    identity = identity,
-                    token = token,
-                    acquiredAtNanos = startedAtNanos,
-                    slotId = token,
-                    extendDelegate = delegate,
-                    auditLeaderId = auditLeaderId,
-                )
-                log.debug { "리더 선출 성공 (async): lockName=$lockName, token=$token" }
-
-                // Codex P2-2: action 결과(성공/실패)와 무관하게 release 완료까지 대기한 뒤 outer future 를 complete.
-                val actionFuture: CompletableFuture<T> = try {
-                    AopScopeAccess.withPushedSync(handle) {
-                        AopScopeAccess.setCapture(handle)
-                        try {
-                            action()
-                        } finally {
-                            AopScopeAccess.clearCapture()
-                        }
-                    }
-                } catch (e: Throwable) {
-                    return@thenComposeAsync releaseAndPropagate<T>(slotGroup, lockName, token, startedAtNanos, e, null)
-                }
-
-                actionFuture.handle<Pair<T?, Throwable?>> { value, error ->
-                    Pair(value, error)
-                }.thenCompose { (value, error) ->
-                    releaseAndPropagate<T>(slotGroup, lockName, token, startedAtNanos, error, value)
+                val startedAtNanos = acquiredAtNanos.get()
+                if (!lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.STARTED)) {
+                    CompletableFuture.failedFuture(
+                        CancellationException("leader group action was cancelled before start"),
+                    )
+                } else try {
+                    runAcquiredAsync(
+                        slotGroup,
+                        lockName,
+                        token,
+                        auditLeaderId,
+                        startedAtNanos,
+                        action,
+                    )
+                } catch (error: Throwable) {
+                    releaseAndPropagate(slotGroup, lockName, token, startedAtNanos, error, null)
                 }
             }
         }, executor)
+        acquisitionFuture.whenComplete { token, _ ->
+            if (token != null && pipelineFuture.isCancelled) {
+                releaseAfterRejection(CancellationException("leader group result future was cancelled before action"))
+            }
+        }
+        return LeaderFutureBridge.flatMap(pipelineFuture) { value, failure ->
+            if (failure != null) {
+                releaseAfterRejection(failure.unwrapCompletionCause())
+            } else {
+                CompletableFuture.completedFuture(value)
+            }
+        }
+    }
+
+    private fun <T> runAcquiredAsync(
+        slotGroup: LettuceSlotTokenGroup,
+        lockName: String,
+        token: String,
+        auditLeaderId: String?,
+        startedAtNanos: Long,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> {
+        val delegate = LettuceSlotExtendDelegate(slotGroup, token)
+        val identity = LockIdentity(
+            lockName = lockName,
+            kind = LockIdentity.AnnotationKind.GROUP,
+            factoryBeanName = LETTUCE_GROUP_FACTORY_BEAN_NAME,
+            groupParams = LockIdentity.GroupParams(maxLeaders),
+        )
+        val handle = LeaderLockHandle.real(
+            identity = identity,
+            token = token,
+            acquiredAtNanos = startedAtNanos,
+            slotId = token,
+            extendDelegate = delegate,
+            auditLeaderId = auditLeaderId,
+        )
+        log.debug { "리더 선출 성공 (async): lockName=$lockName, token=$token" }
+        val actionFuture = runCatching {
+            AopScopeAccess.withPushedSync(handle) {
+                AopScopeAccess.setCapture(handle)
+                try {
+                    action()
+                } finally {
+                    AopScopeAccess.clearCapture()
+                }
+            }
+        }.getOrElse { error ->
+            return releaseAndPropagate(slotGroup, lockName, token, startedAtNanos, error, null)
+        }
+        return actionFuture.handle<Pair<T?, Throwable?>> { value, error -> Pair(value, error) }
+            .thenCompose { (value, error) ->
+                releaseAndPropagate(slotGroup, lockName, token, startedAtNanos, error, value)
+            }
     }
 
     private fun Throwable.unwrapCompletionCause(): Throwable =
@@ -274,5 +334,11 @@ class LettuceLeaderGroupElector(
                     CompletableFuture.completedFuture<T?>(value)
                 }
             }
+    }
+
+    private enum class AsyncLifecycle {
+        WAITING,
+        STARTED,
+        CLEANUP,
     }
 }

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceExecutorRejectionLifecycleTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceExecutorRejectionLifecycleTest.kt
@@ -1,0 +1,159 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderSlot
+import org.junit.jupiter.api.Test
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class LettuceExecutorRejectionLifecycleTest: AbstractLettuceLeaderTest() {
+
+    @Test
+    fun `single result 취소를 action과 lock lifecycle에 전파한다`() {
+        val lockName = randomName()
+        val election = LettuceLeaderElector(connection)
+        val executor = Executors.newVirtualThreadPerTaskExecutor()
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>()
+
+        try {
+            val result = election.runAsyncIfLeaderResult(LeaderSlot(lockName, "lettuce-cancel"), executor) {
+                actionStarted.countDown()
+                actionFuture
+            }
+
+            actionStarted.await(2, TimeUnit.SECONDS) shouldBeEqualTo true
+            result.cancel(false) shouldBeEqualTo true
+            actionFuture.isCancelled shouldBeEqualTo true
+            await.atMost(2.seconds).untilAsserted {
+                election.runIfLeader(lockName) { "recovered" } shouldBeEqualTo "recovered"
+            }
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `group result 취소를 action과 permit lifecycle에 전파한다`() {
+        val lockName = randomName()
+        val election = LettuceLeaderGroupElector(
+            connection,
+            LeaderGroupElectionOptions(maxLeaders = 1),
+        )
+        val executor = Executors.newVirtualThreadPerTaskExecutor()
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>()
+
+        try {
+            val result = election.runAsyncIfLeaderResult(LeaderSlot(lockName, "lettuce-group-cancel"), executor) {
+                actionStarted.countDown()
+                actionFuture
+            }
+
+            actionStarted.await(2, TimeUnit.SECONDS) shouldBeEqualTo true
+            result.cancel(false) shouldBeEqualTo true
+            actionFuture.isCancelled shouldBeEqualTo true
+            await.atMost(2.seconds).untilAsserted {
+                election.runIfLeader(lockName) { "recovered" } shouldBeEqualTo "recovered"
+            }
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `single async executor 거부 후 획득한 lock을 정리한다`() {
+        val lockName = randomName()
+        val election = LettuceLeaderElector(
+            connection,
+            LeaderElectionOptions(waitTime = 100.milliseconds, leaseTime = 10.seconds),
+        )
+        val worker = Executors.newSingleThreadExecutor()
+        val submissions = AtomicInteger()
+        val actionInvoked = AtomicBoolean()
+        val executor = Executor { command ->
+            if (submissions.incrementAndGet() == 1) {
+                worker.execute(command)
+            } else {
+                throw RejectedExecutionException("second submission rejected")
+            }
+        }
+
+        try {
+            val primed = CountDownLatch(1)
+            executor.execute { primed.countDown() }
+            primed.await(2, TimeUnit.SECONDS) shouldBeEqualTo true
+
+            val rejected = election.runAsyncIfLeader(lockName, executor) {
+                actionInvoked.set(true)
+                CompletableFuture.completedFuture("must-not-run")
+            }
+            val failure = assertFailsWith<CompletionException> { rejected.join() }
+
+            failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            submissions.get() shouldBeEqualTo 2
+            actionInvoked.get() shouldBeEqualTo false
+            election.runIfLeader(lockName) { "recovered" } shouldBeEqualTo "recovered"
+        } finally {
+            worker.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `group async executor 거부 후 획득한 permit을 정리한다`() {
+        val lockName = randomName()
+        val election = LettuceLeaderGroupElector(
+            connection,
+            LeaderGroupElectionOptions(
+                maxLeaders = 1,
+                waitTime = 100.milliseconds,
+                leaseTime = 10.seconds,
+            ),
+        )
+        val worker = Executors.newSingleThreadExecutor()
+        val submissions = AtomicInteger()
+        val actionInvoked = AtomicBoolean()
+        val executor = Executor { command ->
+            if (submissions.incrementAndGet() == 1) {
+                worker.execute(command)
+            } else {
+                throw RejectedExecutionException("second submission rejected")
+            }
+        }
+
+        try {
+            val primed = CountDownLatch(1)
+            executor.execute { primed.countDown() }
+            primed.await(2, TimeUnit.SECONDS) shouldBeEqualTo true
+
+            val rejected = election.runAsyncIfLeader(lockName, executor) {
+                actionInvoked.set(true)
+                CompletableFuture.completedFuture("must-not-run")
+            }
+            val failure = assertFailsWith<CompletionException> { rejected.join() }
+
+            failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            submissions.get() shouldBeEqualTo 2
+            actionInvoked.get() shouldBeEqualTo false
+            election.runIfLeader(lockName) { "recovered" } shouldBeEqualTo "recovered"
+        } finally {
+            worker.shutdownNow()
+        }
+    }
+}

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElector.kt
@@ -29,6 +29,8 @@ import java.util.concurrent.Executor
 import java.util.concurrent.ForkJoinPool
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * `RedissonLeaderElector`는 Redis Redisson backend의 leader election, lock lease, ownership 확인을 담당합니다.
@@ -187,10 +189,11 @@ class RedissonLeaderElector private constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
         return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected.set(true)
-            action()
-        }) { value, failure ->
+            cancellationRelay.invoke(action)
+        }, cancellationRelay) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()
@@ -200,6 +203,7 @@ class RedissonLeaderElector private constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun <T> runAsyncImpl(
         lockName: String,
         auditLeaderId: String?,
@@ -212,24 +216,94 @@ class RedissonLeaderElector private constructor(
 
         try {
             val currentThreadId = Thread.currentThread().threadId()
+            val rejectionCleanup = AsyncLockRejectionCleanup(lock, currentThreadId)
             log.debug { "Leader 승격을 요청합니다 ... lock=$lockName, currentThreadId=$currentThreadId" }
 
             // T8: 항상 명시적 leaseTime — Redisson 내장 watchdog 비활성화.
-            return lock
+            val acquisitionFuture = lock
                 .tryLockAsync(waitTimeMills, leaseTimeMills, TimeUnit.MILLISECONDS, currentThreadId)
+                .toCompletableFuture()
+                .thenApply { acquired ->
+                    if (acquired) rejectionCleanup.markAcquired()
+                    acquired
+                }
+            val pipelineFuture = acquisitionFuture
                 .thenComposeAsync({ acquired ->
                     if (acquired) {
-                        executeActionAsync(lock, auditLeaderId, currentThreadId, executor, System.nanoTime(), action)
+                        if (!rejectionCleanup.markLifecycleStarted()) {
+                            CompletableFuture.failedFuture(
+                                CancellationException("leader action was cancelled before start"),
+                            )
+                        } else try {
+                            executeActionAsync(
+                                lock,
+                                auditLeaderId,
+                                currentThreadId,
+                                rejectionCleanup.acquiredAtNanos,
+                                action,
+                            )
+                        } catch (error: Throwable) {
+                            releaseAcquiredLockAsync(lock, currentThreadId, rejectionCleanup.acquiredAtNanos)
+                                .handle { _, releaseError ->
+                                    if (releaseError != null) error.addSuppressed(releaseError.unwrapCompletionCause())
+                                }
+                                .thenCompose { CompletableFuture.failedFuture(error) }
+                        }
                     } else {
                         log.debug { "Leader 승격 실패 (슬롯 없음). lock=$lockName" }
                         CompletableFuture.completedFuture(null)
                     }
                 }, executor)
-                .toCompletableFuture()
+            acquisitionFuture.whenComplete { acquired, _ ->
+                if (acquired == true && pipelineFuture.isCancelled) {
+                    rejectionCleanup.release<Any?>(
+                        CancellationException("leader result future was cancelled before action"),
+                    )
+                }
+            }
+            return LeaderFutureBridge.flatMap(pipelineFuture) { value, failure ->
+                if (failure != null) {
+                    rejectionCleanup.release(failure.unwrapCompletionCause())
+                } else {
+                    CompletableFuture.completedFuture(value)
+                }
+            }
 
         } catch (e: Throwable) {
             log.error(e) { "Fail to runAsync as Leader" }
             return failedCompletableFutureOf(e)
+        }
+    }
+
+    private inner class AsyncLockRejectionCleanup(
+        private val lock: RLock,
+        private val currentThreadId: Long,
+    ) {
+        private val acquired = AtomicBoolean()
+        private val lifecycle = AtomicReference(AsyncLifecycle.WAITING)
+        private val acquiredAtNanosRef = AtomicLong()
+
+        val acquiredAtNanos: Long get() = acquiredAtNanosRef.get()
+
+        fun markAcquired() {
+            acquiredAtNanosRef.set(System.nanoTime())
+            acquired.set(true)
+        }
+
+        fun markLifecycleStarted(): Boolean =
+            lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.STARTED)
+
+        fun <T> release(failure: Throwable): CompletableFuture<T?> {
+            if (!acquired.get() || !lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.CLEANUP)) {
+                return CompletableFuture.failedFuture(failure)
+            }
+            return releaseAcquiredLockAsync(lock, currentThreadId, acquiredAtNanos)
+                .exceptionally { releaseError ->
+                    log.error(releaseError) {
+                        "Fail to release lock after executor rejection. lock=${lock.name}, threadId=$currentThreadId"
+                    }
+                }
+                .thenCompose { CompletableFuture.failedFuture(failure) }
         }
     }
 
@@ -242,7 +316,6 @@ class RedissonLeaderElector private constructor(
         lock: RLock,
         auditLeaderId: String?,
         currentThreadId: Long,
-        executor: Executor,
         acquiredAtNanos: Long,
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
@@ -277,7 +350,7 @@ class RedissonLeaderElector private constructor(
             }
 
         return actionFuture
-            .handleAsync<Pair<T?, Throwable?>>({ value, error -> Pair(value, error) }, executor)
+            .handle<Pair<T?, Throwable?>> { value, error -> Pair(value, error) }
             .thenCompose { (value, error) ->
                 releaseAndPropagate(lock, currentThreadId, acquiredAtNanos, watchdog, error, value)
             }
@@ -353,8 +426,38 @@ class RedissonLeaderElector private constructor(
         }
     }
 
+    private fun releaseAcquiredLockAsync(
+        lock: RLock,
+        currentThreadId: Long,
+        acquiredAtNanos: Long,
+    ): CompletableFuture<Unit> {
+        val lockName = lock.name
+        return try {
+            val remaining = remainingMinLeaseTime(acquiredAtNanos, options.minLeaseTime)
+            val releaseFuture: CompletableFuture<*> = if (remaining > kotlin.time.Duration.ZERO) {
+                CompletableFuture.supplyAsync {
+                    redissonClient.keys.expire(remaining.toJavaDuration(), lockName)
+                }
+            } else {
+                lock.unlockAsync(currentThreadId).toCompletableFuture()
+            }
+            releaseFuture.thenApply {
+                log.debug { "executor 거부 후 Leader 권한을 반납했습니다. lock=$lockName, threadId=$currentThreadId" }
+                Unit
+            }
+        } catch (e: Throwable) {
+            failedCompletableFutureOf(e)
+        }
+    }
+
     private fun kotlin.time.Duration.toJavaDuration(): java.time.Duration =
         java.time.Duration.ofNanos(inWholeNanoseconds)
+
+    private enum class AsyncLifecycle {
+        WAITING,
+        STARTED,
+        CLEANUP,
+    }
 }
 
 

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderElector.kt
@@ -11,6 +11,7 @@ import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
 import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import io.bluetape4k.leader.redisson.internal.RedissonBackendErrorClassifier
 import io.bluetape4k.leader.redisson.internal.RedissonLockExtendDelegate
 import io.bluetape4k.leader.remainingMinLeaseTime
@@ -186,10 +187,10 @@ class RedissonLeaderElector private constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
-        return runAsyncIfLeader(slot, executor) {
+        return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected.set(true)
             action()
-        }.handle { value, failure ->
+        }) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElector.kt
@@ -12,6 +12,7 @@ import io.bluetape4k.leader.LeaderSlot
 import io.bluetape4k.leader.LockIdentity
 import io.bluetape4k.leader.diagnostics.LeaderBackendDiagnosticsProvider
 import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import io.bluetape4k.leader.redisson.internal.RedissonBackendErrorClassifier
 import io.bluetape4k.leader.redisson.internal.RedissonSemaphoreExtendDelegate
 import io.bluetape4k.leader.remainingMinLeaseTime
@@ -226,10 +227,10 @@ class RedissonLeaderGroupElector private constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
-        return runAsyncIfLeader(slot, executor) {
+        return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected.set(true)
             action()
-        }.handle { value, failure ->
+        }) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()

--- a/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElector.kt
+++ b/leader-redis-redisson/src/main/kotlin/io/bluetape4k/leader/redisson/RedissonLeaderGroupElector.kt
@@ -32,6 +32,8 @@ import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 
 /**
@@ -227,10 +229,11 @@ class RedissonLeaderGroupElector private constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<LeaderRunResult<T>> {
         val elected = AtomicBoolean(false)
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
         return LeaderFutureBridge.map(runAsyncIfLeader(slot, executor) {
             elected.set(true)
-            action()
-        }) { value, failure ->
+            cancellationRelay.invoke(action)
+        }, cancellationRelay) { value, failure ->
             when {
                 failure != null && elected.get() -> failure.toActionFailedResult()
                 failure != null -> throw failure.asCompletionException()
@@ -240,6 +243,7 @@ class RedissonLeaderGroupElector private constructor(
         }
     }
 
+    @Suppress("TooGenericExceptionCaught")
     private fun <T> runAsyncImpl(
         lockName: String,
         auditLeaderId: String?,
@@ -249,28 +253,93 @@ class RedissonLeaderGroupElector private constructor(
         return try {
             lockName.requireNotBlank("lockName")
             val semaphore = getPermitSemaphore(lockName)
+            val rejectionCleanup = AsyncPermitRejectionCleanup(semaphore, lockName)
             log.debug { "리더 그룹 슬롯 획득 요청 (async). lockName=$lockName" }
 
-            semaphore
+            val acquisitionFuture = semaphore
                 .tryAcquireAsync(
                     waitTime.inWholeMilliseconds,
                     leaseTime.inWholeMilliseconds,
                     TimeUnit.MILLISECONDS,
                 )
                 .toCompletableFuture()
+                .thenApply { permitId ->
+                    if (permitId != null) rejectionCleanup.markAcquired(permitId)
+                    permitId
+                }
+            val pipelineFuture = acquisitionFuture
                 .thenComposeAsync({ permitId ->
                     if (permitId == null) {
                         log.debug { "슬롯 획득 실패 (async). lockName=$lockName" }
                         CompletableFuture.completedFuture<T?>(null)
                     } else {
                         // Codex P2: acquire 성공 후 startedAtNanos 캡처
-                        val startedAtNanos = System.nanoTime()
-                        executeAsync(semaphore, lockName, permitId, auditLeaderId, startedAtNanos, action)
+                        val startedAtNanos = rejectionCleanup.acquiredAtNanos
+                        if (!rejectionCleanup.markLifecycleStarted()) {
+                            CompletableFuture.failedFuture(
+                                CancellationException("leader group action was cancelled before start"),
+                            )
+                        } else try {
+                            executeAsync(semaphore, lockName, permitId, auditLeaderId, startedAtNanos, action)
+                        } catch (error: Throwable) {
+                            releaseAndPropagate(semaphore, permitId, startedAtNanos, lockName, error, null)
+                        }
                     }
                 }, executor)
+            acquisitionFuture.whenComplete { permitId, _ ->
+                if (permitId != null && pipelineFuture.isCancelled) {
+                    rejectionCleanup.release<Any?>(
+                        CancellationException("leader group result future was cancelled before action"),
+                    )
+                }
+            }
+            LeaderFutureBridge.flatMap(pipelineFuture) { value, failure ->
+                if (failure != null) {
+                    rejectionCleanup.release(failure.unwrapCompletionCause())
+                } else {
+                    CompletableFuture.completedFuture(value)
+                }
+            }
         } catch (e: Throwable) {
             log.error(e) { "Fail to runAsync as Leader Group. lockName=$lockName" }
             failedCompletableFutureOf(e)
+        }
+    }
+
+    private inner class AsyncPermitRejectionCleanup(
+        private val semaphore: RPermitExpirableSemaphore,
+        private val lockName: String,
+    ) {
+        private val permitId = AtomicReference<String?>()
+        private val acquiredAtNanosRef = AtomicLong()
+        private val lifecycle = AtomicReference(AsyncLifecycle.WAITING)
+
+        val acquiredAtNanos: Long get() = acquiredAtNanosRef.get()
+
+        fun markAcquired(acquiredPermitId: String) {
+            acquiredAtNanosRef.set(System.nanoTime())
+            permitId.set(acquiredPermitId)
+        }
+
+        fun markLifecycleStarted(): Boolean =
+            lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.STARTED)
+
+        fun <T> release(failure: Throwable): CompletableFuture<T?> {
+            val acquiredPermitId = permitId.get()
+            if (
+                acquiredPermitId == null ||
+                !lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.CLEANUP)
+            ) {
+                return CompletableFuture.failedFuture(failure)
+            }
+            return releaseAndPropagate(
+                semaphore,
+                acquiredPermitId,
+                acquiredAtNanos,
+                lockName,
+                failure,
+                null,
+            )
         }
     }
 
@@ -413,6 +482,12 @@ class RedissonLeaderGroupElector private constructor(
         } else {
             semaphore.releaseAsync(permitId).toCompletableFuture()
         }
+    }
+
+    private enum class AsyncLifecycle {
+        WAITING,
+        STARTED,
+        CLEANUP,
     }
 }
 

--- a/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonExecutorRejectionLifecycleTest.kt
+++ b/leader-redis-redisson/src/test/kotlin/io/bluetape4k/leader/redisson/RedissonExecutorRejectionLifecycleTest.kt
@@ -1,0 +1,161 @@
+package io.bluetape4k.leader.redisson
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LeaderSlot
+import org.junit.jupiter.api.Test
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class RedissonExecutorRejectionLifecycleTest: AbstractRedissonLeaderTest() {
+
+    @Test
+    fun `single result 취소를 action과 lock lifecycle에 전파한다`() {
+        val lockName = randomName()
+        val election = RedissonLeaderElector(redissonClient)
+        val executor = Executors.newVirtualThreadPerTaskExecutor()
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>()
+
+        try {
+            val result = election.runAsyncIfLeaderResult(LeaderSlot(lockName, "redisson-cancel"), executor) {
+                actionStarted.countDown()
+                actionFuture
+            }
+
+            actionStarted.await(2, TimeUnit.SECONDS) shouldBeEqualTo true
+            result.cancel(false) shouldBeEqualTo true
+            actionFuture.isCancelled shouldBeEqualTo true
+            await.atMost(2.seconds).untilAsserted {
+                election.runIfLeader(lockName) { "recovered" } shouldBeEqualTo "recovered"
+            }
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `group result 취소를 action과 permit lifecycle에 전파한다`() {
+        val lockName = randomName()
+        val election = RedissonLeaderGroupElector(
+            redissonClient,
+            LeaderGroupElectionOptions(maxLeaders = 1),
+        )
+        val executor = Executors.newVirtualThreadPerTaskExecutor()
+        val actionStarted = CountDownLatch(1)
+        val actionFuture = CompletableFuture<String>()
+
+        try {
+            val result = election.runAsyncIfLeaderResult(LeaderSlot(lockName, "redisson-group-cancel"), executor) {
+                actionStarted.countDown()
+                actionFuture
+            }
+
+            actionStarted.await(2, TimeUnit.SECONDS) shouldBeEqualTo true
+            result.cancel(false) shouldBeEqualTo true
+            actionFuture.isCancelled shouldBeEqualTo true
+            await.atMost(2.seconds).untilAsserted {
+                election.runIfLeader(lockName) { "recovered" } shouldBeEqualTo "recovered"
+            }
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `single async executor 거부 후 획득한 lock을 정리한다`() {
+        val lockName = randomName()
+        val election = RedissonLeaderElector(
+            redissonClient,
+            LeaderElectionOptions(waitTime = 100.milliseconds, leaseTime = 10.seconds),
+        )
+        val worker = Executors.newSingleThreadExecutor()
+        val submissions = AtomicInteger()
+        val actionInvoked = AtomicBoolean()
+        val executor = Executor { command ->
+            if (submissions.incrementAndGet() == 1) {
+                worker.execute(command)
+            } else {
+                throw RejectedExecutionException("second submission rejected")
+            }
+        }
+
+        try {
+            val primed = CountDownLatch(1)
+            executor.execute { primed.countDown() }
+            primed.await(2, TimeUnit.SECONDS) shouldBeEqualTo true
+
+            val rejected = election.runAsyncIfLeader(lockName, executor) {
+                actionInvoked.set(true)
+                CompletableFuture.completedFuture("must-not-run")
+            }
+            val failure = assertFailsWith<CompletionException> { rejected.join() }
+
+            failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            submissions.get() shouldBeEqualTo 2
+            actionInvoked.get() shouldBeEqualTo false
+            CompletableFuture.supplyAsync {
+                election.runIfLeader(lockName) { "recovered" }
+            }.get(2, TimeUnit.SECONDS) shouldBeEqualTo "recovered"
+        } finally {
+            worker.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `group async executor 거부 후 획득한 permit을 정리한다`() {
+        val lockName = randomName()
+        val election = RedissonLeaderGroupElector(
+            redissonClient,
+            LeaderGroupElectionOptions(
+                maxLeaders = 1,
+                waitTime = 100.milliseconds,
+                leaseTime = 10.seconds,
+            ),
+        )
+        val worker = Executors.newSingleThreadExecutor()
+        val submissions = AtomicInteger()
+        val actionInvoked = AtomicBoolean()
+        val executor = Executor { command ->
+            if (submissions.incrementAndGet() == 1) {
+                worker.execute(command)
+            } else {
+                throw RejectedExecutionException("second submission rejected")
+            }
+        }
+
+        try {
+            val primed = CountDownLatch(1)
+            executor.execute { primed.countDown() }
+            primed.await(2, TimeUnit.SECONDS) shouldBeEqualTo true
+
+            val rejected = election.runAsyncIfLeader(lockName, executor) {
+                actionInvoked.set(true)
+                CompletableFuture.completedFuture("must-not-run")
+            }
+            val failure = assertFailsWith<CompletionException> { rejected.join() }
+
+            failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            submissions.get() shouldBeEqualTo 2
+            actionInvoked.get() shouldBeEqualTo false
+            election.runIfLeader(lockName) { "recovered" } shouldBeEqualTo "recovered"
+        } finally {
+            worker.shutdownNow()
+        }
+    }
+}


### PR DESCRIPTION
## 요약

Closes #857
Closes #858

`runAsyncIfLeaderResult` 취소가 실제 action과 lease lifecycle까지 전달되도록 고치고,
lock/slot 획득 직후 executor가 작업을 거부해도 cleanup이 정확히 한 번 완료되도록 합니다.

## 배경

milestone `1.1.0` 점검에서 결과 future만 취소되고 실제 action은 계속 실행되는 경로와,
Lettuce·Redisson·MongoDB의 acquire→executor submission 사이에서 lease/permit이 남는
경로를 재현했습니다. callback 시작과 cancellation cleanup도 단일 상태 전이가 아니어서
release 뒤 action이 시작될 수 있었습니다.

## 해결 내용

- 결과 future 취소를 실제 action future까지 전달합니다.
- `WAITING → STARTED`와 `WAITING → CLEANUP`을 단일 CAS로 선형화합니다.
- executor rejection과 cancel-before-action에서 원래 실패를 보존하면서 cleanup 완료를 기다립니다.
- single/group, local/listener, Consul, DynamoDB, Exposed JDBC, Hazelcast, Kubernetes,
  Lettuce, Redisson, MongoDB adapter의 lifecycle 계약을 맞춥니다.

## 작업 내역

- `LeaderFutureBridge`: cancellation relay, cleanup-aware `flatMap`, 원자적 action 시작 상태를 추가했습니다.
- backend adapter: acquisition, action, cancellation, rejection의 cleanup owner를 명확히 했습니다.
- 회귀 테스트: 실제 action 취소·동일 lock/slot 재획득·두 번째 executor 제출 거부를 검증합니다.
- 재발 방지 기록: `docs/lessons/2026-09-04-async-leader-lifecycle-cleanup.md`를 추가했습니다.

## 검증

- lifecycle 회귀: PASS (`core 6`, `MongoDB 2`, `Lettuce 4`, `Redisson 4`)
- 영향 모듈 전체 suite: 누적 PASS (`9 modules`, `2,571 tests`)
- `./gradlew detekt --no-daemon --console=plain`: PASS
- `git diff --cached --check`: PASS
- Korean terminology audit 및 GNO `bluetape4k-docs` read-back: PASS
- hosted exact-head CI: PASS (`46/46`, run `33841932481`)
- core 전체 재실행: hosted exact-head PASS. 로컬에서는 기존 #868
  `BoundedLeaderAuditExporterTest` flake가 1/1,014로 두 번 재현됐고,
  해당 테스트 격리 재실행은 1/1 PASS였습니다.

## 리뷰 참고

- P0/P1/P2: `0/0/0`
- 독립 리뷰에서 MongoDB rejection 누락과 cancellation/lifecycle TOCTOU를 발견해 수정했습니다.
- 이번 변경과 #868 실패 source는 겹치지 않으며 hosted exact-head core job은 PASS했습니다.

## 메타데이터

- Issues: #857, #858 / milestone `1.1.0` / assignee `debop`
- PR: #872 / head `0192b2a476da16708b83314caf8f661e2ef68994`
- CI: exact-head run `33841932481` (`46/46` PASS)

## DoD Status

Required checks: 15/15; N/A: 1; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| C-01~C-04 | 재현·원인 규명·RED·수정 | PASS | action cancellation, executor rejection, cleanup owner race 재현 및 CAS 수정 | 없음 |
| C-05 | GREEN과 영향 범위 검증 | PASS | final lifecycle 16/16, 영향 suite 누적 2,571, detekt PASS, hosted core PASS | 로컬 #868 flake는 별도 이슈로 유지 |
| C-06 | 재사용 가능한 교훈 기록 | PASS | lesson audit/GNO read-back PASS | 없음 |
| CG-10 | 최종 pre-PR 리뷰 수렴 | PASS | 독립 리뷰 P0/P1/P2=0/0/0 | 없음 |
| CG-12 | exact head 게시 | PASS | local/remote `0192b2a476da16708b83314caf8f661e2ef68994` 일치 | 없음 |
| CG-12A | guidance refresh | PASS | AGENTS/leaf/common/template hash 및 #857/#858 metadata 재확인 | 없음 |
| CG-13 | PR 생성·metadata read-back | PASS | PR #872, base `develop`, exact head, assignee/labels/milestone 일치 | 없음 |
| CG-14 | exact-head CI·review/thread 확인 | PASS | run `33841932481`, head `0192b2a4`, 46/46 PASS, unresolved thread 0, P0/P1=0/0 | human-review subgate: N/A (single-developer lane, direct collaborator 0) |
| CG-15 | merge-ready 보고 | PASS | PR #872 / `0192b2a4`, `CLEAN`·`MERGEABLE`, CI·review·lesson evidence 보고 | 없음 |
| CG-16 | fresh merge 승인 | PASS | merge-ready 보고 후 exact PR #872 / head `0192b2a4`에 대한 사용자 승인 | rebase merge 실행 |
| CG-17 | merge 실행·검증 | PASS | rebase merge, PR `MERGED`, `develop` `54abae2e627fae653730ac1a6952395b9b74c190`, #857/#858 CLOSED | 없음 |
| CG-18 | 로컬 동기화·정리 | PASS | local/remote `develop` 일치, clean patch-equivalent 보조 worktree/branch 제거 | dirty root feature branch와 범위 밖 변경 보존 |

Final status: DONE

Unchecked required items: 없음
