### PR TITLE
fix: async lifecycle 후속 검증을 닫는다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1840,7 +1840,7 @@ jobs:
       - name: Test leader-k8s
         run: |
           for attempt in 1 2 3 4 5; do
-            ./gradlew :bluetape4k-leader-k8s:test :bluetape4k-leader-k8s:k8sTest --no-configuration-cache --no-daemon && break
+            ./gradlew :bluetape4k-leader-k8s:test :bluetape4k-leader-k8s:k8sTest :bluetape4k-leader-k8s:koverXmlReport --no-configuration-cache --no-daemon && break
             echo "Attempt $attempt failed"
             [ $attempt -lt 5 ] && sleep 30 || exit 1
           done
@@ -1856,6 +1856,14 @@ jobs:
           path: |
             **/build/test-results/test/*.xml
             **/build/test-results/k8sTest/*.xml
+          retention-days: 7
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          if-no-files-found: error
+          name: coverage-leader-k8s
+          path: '**/build/reports/kover/'
           retention-days: 7
 
   # ── leader-hazelcast 테스트 (Testcontainers: Hazelcast) ──────────────────
@@ -2002,6 +2010,7 @@ jobs:
         needs.changes.outputs['leader-dynamodb'] == 'true' ||
         needs.changes.outputs['leader-etcd'] == 'true' ||
         needs.changes.outputs['leader-consul'] == 'true' ||
+        needs.changes.outputs['leader-k8s'] == 'true' ||
         needs.changes.outputs['leader-hazelcast'] == 'true' ||
         needs.changes.outputs['leader-zookeeper'] == 'true'
       )

--- a/README.ko.md
+++ b/README.ko.md
@@ -471,6 +471,8 @@ when (val r = election.runIfLeaderResult("daily-job") { compute() }) {
 
 동기 elector는 `runIfLeaderResult`, 코루틴 elector는 `runIfLeaderResultSuspend`, `CompletableFuture`/가상 스레드 elector는 `runAsyncIfLeaderResult`를 제공합니다. `CancellationException`은 `ActionFailed`로 감싸지 않습니다. 동기/코루틴 API는 재전파하고, async/가상 스레드 API는 예외 완료됩니다(`join()`에서는 cancellation을 감싼 `CompletionException`을 기대하세요. `isCancelled()` 보장은 아닙니다). 동기 API는 `InterruptedException`도 interrupt flag를 복원한 뒤 재전파합니다.
 
+async 선출이 반환한 `CompletableFuture`를 취소하면 acquisition과 실행 중인 action에 취소를 전달하고 lease 또는 slot 정리를 시작합니다. 취소는 협력적으로 동작하며 정리는 비동기로 끝날 수 있습니다. `mayInterruptIfRunning=true`도 사용자 코드의 강제 중단을 보장하지 않습니다.
+
 ### 옵션 클래스
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -472,6 +472,8 @@ when (val r = election.runIfLeaderResult("daily-job") { compute() }) {
 
 `runIfLeaderResult` is available for blocking electors, `runIfLeaderResultSuspend` for coroutine electors, and `runAsyncIfLeaderResult` for `CompletableFuture` / virtual-thread electors. `CancellationException` is not wrapped as `ActionFailed`: blocking and suspend APIs rethrow it, while async and virtual-thread APIs complete exceptionally (for `join()`, expect `CompletionException` wrapping the cancellation; `isCancelled()` is not guaranteed). Blocking APIs also rethrow `InterruptedException` after restoring the interrupt flag.
 
+Cancelling the `CompletableFuture` returned by an async election propagates the cancellation request to acquisition and any in-flight action, then starts lease or slot cleanup. Cancellation is cooperative and cleanup may finish asynchronously; `mayInterruptIfRunning=true` does not guarantee that user code is forcibly interrupted.
+
 ### Options
 
 ```kotlin

--- a/docs/lessons/2026-09-04-async-leader-lifecycle-cleanup.md
+++ b/docs/lessons/2026-09-04-async-leader-lifecycle-cleanup.md
@@ -17,6 +17,11 @@ lifecycle이 끝나지 않는 문제를 다룹니다. 반환 future의 terminal 
   callback에 진입하지 않으므로 callback 내부의 release 경로도 실행하지 않습니다.
 - 취소와 정상 완료가 경쟁할 때 여러 callback이 cleanup을 시작할 수 있으므로,
   cleanup owner를 하나로 고정하지 않으면 중복 release 위험이 생깁니다.
+- action 시작 여부와 cleanup 여부를 서로 다른 원자 값으로 관리하면 cancellation과
+  action 제출이 모두 성공했다고 판단하는 TOCTOU 경쟁이 생깁니다.
+- `CompletableFuture.handle`은 실패 시 value를 `null`로 전달합니다. terminal
+  mapper가 value를 non-null `T`로 선언하면 lambda 진입 전에 Kotlin NPE가 발생해
+  원래 cancellation이나 backend 예외를 가립니다.
 
 ## 결정
 
@@ -26,22 +31,29 @@ lifecycle이 끝나지 않는 문제를 다룹니다. 반환 future의 terminal 
   소유합니다. executor rejection도 cleanup이 끝난 뒤 원래 예외로 완료합니다.
 - cancellation, action 완료, 제출 실패가 경쟁해도 원자적 owner가 cleanup을 정확히
   한 번만 시작하도록 합니다.
+- Consul, Hazelcast, Kubernetes 단일/group 경로는 `WAITING -> STARTED`와
+  `WAITING -> CLEANUP`을 하나의 CAS 상태 전이로 통합합니다. action과 cleanup 중
+  하나만 lifecycle 소유권을 얻습니다.
+- `LeaderFutureBridge.map`과 `flatMap`의 terminal value 계약을 `T?`로 바꿔
+  `value == null && failure != null`인 표준 `CompletableFuture` 실패를 보존합니다.
 
 ## 결과와 검증
 
 반환 future를 취소하면 실제 action future도 취소되고, cleanup 완료 뒤 같은 lock을
-다시 획득할 수 있습니다. Lettuce, Redisson, MongoDB의 단일/group 경로는 두 번째
-executor 제출을 의도적으로 거부하는 회귀 테스트로 lease와 permit 회수를
-검증했습니다.
+다시 획득할 수 있습니다. backend별 회귀 테스트는 action 미실행, 원래
+`RejectedExecutionException`, lease/permit 회수까지 검증합니다.
 
 - RED: 실제 action이 취소되지 않고 재획득이 `null`이 되는 동작을 재현했습니다.
-- GREEN: 영향 모듈 9개의 전체 suite 2,571개가 한 차례 통과했고, 최종 CAS 수정 뒤
-  core/MongoDB/Lettuce/Redisson lifecycle 회귀 16개가 다시 통과했습니다.
-- `./gradlew detekt --no-daemon --console=plain`이 통과했습니다.
-- `git diff --cached --check`가 통과했습니다.
-- 최종 core 전체 재실행은 기존 Issue #868의
-  `BoundedLeaderAuditExporterTest` flake 1건을 두 번 재현했습니다. 해당 테스트의
-  격리 재실행은 통과했으며 이번 lifecycle 변경과 겹치는 source는 없습니다.
+- GREEN: 최종 source 기준 targeted test 275개가 통과했습니다. 구성은 core 39,
+  Exposed JDBC 174, Consul 20, Hazelcast 28, Kubernetes executor contract 4,
+  MongoDB 2, Lettuce 4, Redisson 4입니다.
+- Kubernetes PR task graph에서 unit 16개와 K3s 103개가 통과했고,
+  `leader-k8s/build/reports/kover/report.xml`을 같은 invocation에서 생성했습니다.
+- 영향 모듈 9개의 `compileTestKotlin`, 전체 `detekt`, binary compatibility 검사가
+  통과했습니다. ABI inventory는 artifacts 16, ignored 0, unknown 0이며 분류되지
+  않은 public incompatibility가 없습니다.
+- Kover 정적 계약 validator와 단위 테스트 9개, `actionlint`, diff whitespace 검사를
+  통과했습니다. hosted exact-head CI는 PR push 뒤 별도로 확인합니다.
 
 ## 놓친 가정과 향후 지침
 
@@ -52,3 +64,9 @@ executor 제출을 의도적으로 거부하는 회귀 테스트로 lease와 per
 함께 검증합니다. acquire 뒤 비동기 제출이 있는 backend는 executor rejection을
 별도 terminal 경로로 취급하고, 원래 실패가 관찰되기 전에 cleanup이 끝나는지도
 검증합니다.
+
+리뷰 운영에서도 P1 발견을 issue-only closeout으로 넘기지 않습니다. P0/P1은 현재
+delivery를 막고 먼저 수정하며, 독립 review lane이 응답 없이 멈추거나 실행되지
+않으면 lane을 회수해 inline으로 동일 범위를 검토하고 증거를 다시 실행합니다.
+이번 재검토에서는 이 규칙으로 lifecycle TOCTOU와 terminal mapper NPE를 추가로
+찾아 수정했습니다.

--- a/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElector.kt
+++ b/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElector.kt
@@ -33,7 +33,6 @@ import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -71,6 +70,12 @@ class ConsulLeaderElector private constructor(
             options: ConsulLeaderElectionOptions = ConsulLeaderElectionOptions.Default,
         ): ConsulLeaderElector =
             ConsulLeaderElector(lockClient, options)
+    }
+
+    private enum class AsyncLifecycle {
+        WAITING,
+        STARTED,
+        CLEANUP,
     }
 
     override fun <T> runIfLeader(lockName: String, action: () -> T): T? =
@@ -190,11 +195,10 @@ class ConsulLeaderElector private constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
         val acquiredRef = AtomicReference<ConsulLeaseHandle?>()
-        val lifecycleStarted = AtomicBoolean()
-        val rejectionCleanupClaimed = AtomicBoolean()
+        val lifecycle = AtomicReference(AsyncLifecycle.WAITING)
         val releaseIfUnclaimed: () -> Unit = {
             val handle = acquiredRef.get()
-            if (handle != null && !lifecycleStarted.get() && rejectionCleanupClaimed.compareAndSet(false, true)) {
+            if (handle != null && lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.CLEANUP)) {
                 release(handle)
             }
         }
@@ -207,8 +211,11 @@ class ConsulLeaderElector private constructor(
             acquisitionFuture.thenComposeAsync({ handle ->
                 if (handle == null) {
                     CompletableFuture.completedFuture(null)
+                } else if (!lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.STARTED)) {
+                    CompletableFuture.failedFuture(
+                        CancellationException("leader result future was cancelled before action"),
+                    )
                 } else {
-                    lifecycleStarted.set(true)
                     runAcquiredAsync(handle, executor, action)
                 }
             }, executor)

--- a/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderGroupElector.kt
+++ b/leader-consul/src/main/kotlin/io/bluetape4k/leader/consul/ConsulLeaderGroupElector.kt
@@ -32,7 +32,6 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.ThreadLocalRandom
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -63,6 +62,12 @@ class ConsulLeaderGroupElector private constructor(
             options: ConsulLeaderGroupElectionOptions = ConsulLeaderGroupElectionOptions.Default,
         ): ConsulLeaderGroupElector =
             ConsulLeaderGroupElector(lockClient, options)
+    }
+
+    private enum class AsyncLifecycle {
+        WAITING,
+        STARTED,
+        CLEANUP,
     }
 
     override val maxLeaders: Int = options.maxLeaders
@@ -188,11 +193,10 @@ class ConsulLeaderGroupElector private constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
         val acquiredRef = AtomicReference<ConsulLeaseHandle?>()
-        val lifecycleStarted = AtomicBoolean()
-        val rejectionCleanupClaimed = AtomicBoolean()
+        val lifecycle = AtomicReference(AsyncLifecycle.WAITING)
         val releaseIfUnclaimed: () -> Unit = {
             val handle = acquiredRef.get()
-            if (handle != null && !lifecycleStarted.get() && rejectionCleanupClaimed.compareAndSet(false, true)) {
+            if (handle != null && lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.CLEANUP)) {
                 release(handle)
             }
         }
@@ -205,8 +209,11 @@ class ConsulLeaderGroupElector private constructor(
             acquisitionFuture.thenComposeAsync({ handle ->
                 if (handle == null) {
                     CompletableFuture.completedFuture(null)
+                } else if (!lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.STARTED)) {
+                    CompletableFuture.failedFuture(
+                        CancellationException("leader result future was cancelled before action"),
+                    )
                 } else {
-                    lifecycleStarted.set(true)
                     runAcquiredAsync(handle, executor, action)
                 }
             }, executor)

--- a/leader-consul/src/test/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElectorDelegationTest.kt
+++ b/leader-consul/src/test/kotlin/io/bluetape4k/leader/consul/ConsulLeaderElectorDelegationTest.kt
@@ -404,6 +404,7 @@ class ConsulLeaderElectorDelegationTest {
         val elector = ConsulLeaderElector.create(client)
         val worker = Executors.newSingleThreadExecutor()
         val submissions = AtomicInteger()
+        val actionInvoked = AtomicBoolean()
         val executor = Executor { command ->
             if (submissions.incrementAndGet() == 1) {
                 worker.execute(command)
@@ -415,12 +416,14 @@ class ConsulLeaderElectorDelegationTest {
         try {
             val resultFuture = runCatching {
                 elector.runAsyncIfLeader("lock-a", executor) {
+                    actionInvoked.set(true)
                     CompletableFuture.completedFuture("should-not-run")
                 }
             }.getOrElse { CompletableFuture.failedFuture(it) }
 
             val failure = assertFailsWith<CompletionException> { resultFuture.join() }
             failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            actionInvoked.get() shouldBeEqualTo false
             elector.runIfLeader("lock-a") { "reacquired" } shouldBeEqualTo "reacquired"
             client.releaseCalls shouldBeEqualTo 2
             client.destroyCalls shouldBeEqualTo 2
@@ -440,6 +443,7 @@ class ConsulLeaderElectorDelegationTest {
         )
         val worker = Executors.newSingleThreadExecutor()
         val submissions = AtomicInteger()
+        val actionInvoked = AtomicBoolean()
         val executor = Executor { command ->
             if (submissions.incrementAndGet() == 1) {
                 worker.execute(command)
@@ -451,12 +455,14 @@ class ConsulLeaderElectorDelegationTest {
         try {
             val resultFuture = runCatching {
                 elector.runAsyncIfLeader("lock-a", executor) {
+                    actionInvoked.set(true)
                     CompletableFuture.completedFuture("should-not-run")
                 }
             }.getOrElse { CompletableFuture.failedFuture(it) }
 
             val failure = assertFailsWith<CompletionException> { resultFuture.join() }
             failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            actionInvoked.get() shouldBeEqualTo false
             elector.runIfLeader("lock-a") { "reacquired" } shouldBeEqualTo "reacquired"
             client.releaseCalls shouldBeEqualTo 2
             client.destroyCalls shouldBeEqualTo 2

--- a/leader-core/README.ko.md
+++ b/leader-core/README.ko.md
@@ -46,6 +46,10 @@ Result API는 `CancellationException`을 `ActionFailed`로 변환하지 않습�
 async/가상 스레드 API는 예외 완료됩니다(`join()`에서는 cancellation을 감싼 `CompletionException`을
 기대하세요. `isCancelled()` 보장은 아닙니다). 동기 API는 `InterruptedException`도 interrupt flag를 복원한 뒤 재전파합니다.
 
+async 선출이 반환한 `CompletableFuture`를 취소하면 acquisition과 실행 중인 action에 취소를 전달하고 lease 또는
+slot 정리를 시작합니다. 취소는 협력적으로 동작하며 정리는 비동기로 끝날 수 있습니다.
+`mayInterruptIfRunning=true`도 사용자 코드의 강제 중단을 보장하지 않습니다.
+
 ### 선출 생명주기 listener
 
 `LeaderElectionListenerRegistry` 구현체는 `addListener`, `removeListener`로 생명주기 callback을 등록할 수 있습니다.

--- a/leader-core/README.md
+++ b/leader-core/README.md
@@ -48,6 +48,10 @@ async and virtual-thread APIs complete exceptionally instead (for `join()`, expe
 wrapping the cancellation; `isCancelled()` is not guaranteed). Blocking APIs also rethrow
 `InterruptedException` after restoring the interrupt flag.
 
+Cancelling the `CompletableFuture` returned by an async election propagates the cancellation request to acquisition
+and any in-flight action, then starts lease or slot cleanup. Cancellation is cooperative and cleanup may finish
+asynchronously; `mayInterruptIfRunning=true` does not guarantee that user code is forcibly interrupted.
+
 ### Election lifecycle listeners
 
 `LeaderElectionListenerRegistry` implementations support `addListener` and `removeListener` for lifecycle callbacks:

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderElector.kt
@@ -20,6 +20,8 @@ interface AsyncLeaderElector: LeaderElectionState {
      * `runAsyncIfLeader`는 leadership을 획득한 경우에만 async action을 실행하고, 획득하지 못하면 null 결과를 완료합니다.
      *
      * 정상 contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.
+     * 반환된 future를 취소하면 acquisition과 실행 중인 action에 취소를 전달하고 lease 정리를 시작합니다.
+     * 취소는 협력적이며 `mayInterruptIfRunning=true`가 사용자 코드를 강제로 중단하거나 정리가 동기적으로 끝남을 보장하지 않습니다.
      * @param lockName leader election에 사용할 lock 이름입니다. backend별 검증 규칙을 통과해야 하며 상태 조회와 audit의 기준 키가 됩니다.
      * @param executor `executor` 호출 또는 상태 계산에 필요한 값입니다.
      * @param action leadership을 획득한 경우에만 실행되는 사용자 작업입니다.
@@ -35,6 +37,8 @@ interface AsyncLeaderElector: LeaderElectionState {
      * `runAsyncIfLeader`는 leadership을 획득한 경우에만 async action을 실행하고, 획득하지 못하면 null 결과를 완료합니다.
      *
      * 정상 contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.
+     * 반환된 future를 취소하면 acquisition과 실행 중인 action에 취소를 전달하고 lease 정리를 시작합니다.
+     * 취소는 협력적이며 `mayInterruptIfRunning=true`가 사용자 코드를 강제로 중단하거나 정리가 동기적으로 끝남을 보장하지 않습니다.
      * @param slot group election slot과 audit leader id를 함께 전달하는 값입니다.
      * @param executor `executor` 호출 또는 상태 계산에 필요한 값입니다.
      * @param action leadership을 획득한 경우에만 실행되는 사용자 작업입니다.
@@ -53,6 +57,8 @@ interface AsyncLeaderElector: LeaderElectionState {
      * `runAsyncIfLeaderResult`는 async leadership 획득, skip, action 실패를 명시적인 LeaderRunResult로 반환합니다.
      *
      * 정상 contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.
+     * 반환된 future를 취소하면 acquisition과 실행 중인 action에 취소를 전달하고 lease 정리를 시작합니다.
+     * 취소는 협력적이며 `mayInterruptIfRunning=true`가 사용자 코드를 강제로 중단하거나 정리가 동기적으로 끝남을 보장하지 않습니다.
      * @param slot group election slot과 audit leader id를 함께 전달하는 값입니다.
      * @param executor `executor` 호출 또는 상태 계산에 필요한 값입니다.
      * @param action leadership을 획득한 경우에만 실행되는 사용자 작업입니다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderGroupElector.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/AsyncLeaderGroupElector.kt
@@ -20,6 +20,8 @@ interface AsyncLeaderGroupElector: LeaderGroupElectionState {
      * `runAsyncIfLeader`는 leadership을 획득한 경우에만 async action을 실행하고, 획득하지 못하면 null 결과를 완료합니다.
      *
      * 정상 contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.
+     * 반환된 future를 취소하면 acquisition과 실행 중인 action에 취소를 전달하고 slot 정리를 시작합니다.
+     * 취소는 협력적이며 `mayInterruptIfRunning=true`가 사용자 코드를 강제로 중단하거나 정리가 동기적으로 끝남을 보장하지 않습니다.
      * @param lockName leader election에 사용할 lock 이름입니다. backend별 검증 규칙을 통과해야 하며 상태 조회와 audit의 기준 키가 됩니다.
      * @param executor `executor` 호출 또는 상태 계산에 필요한 값입니다.
      * @param action leadership을 획득한 경우에만 실행되는 사용자 작업입니다.
@@ -35,6 +37,8 @@ interface AsyncLeaderGroupElector: LeaderGroupElectionState {
      * `runAsyncIfLeader`는 leadership을 획득한 경우에만 async action을 실행하고, 획득하지 못하면 null 결과를 완료합니다.
      *
      * 정상 contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.
+     * 반환된 future를 취소하면 acquisition과 실행 중인 action에 취소를 전달하고 slot 정리를 시작합니다.
+     * 취소는 협력적이며 `mayInterruptIfRunning=true`가 사용자 코드를 강제로 중단하거나 정리가 동기적으로 끝남을 보장하지 않습니다.
      * @param slot group election slot과 audit leader id를 함께 전달하는 값입니다.
      * @param executor `executor` 호출 또는 상태 계산에 필요한 값입니다.
      * @param action leadership을 획득한 경우에만 실행되는 사용자 작업입니다.
@@ -53,6 +57,8 @@ interface AsyncLeaderGroupElector: LeaderGroupElectionState {
      * `runAsyncIfLeaderResult`는 async leadership 획득, skip, action 실패를 명시적인 LeaderRunResult로 반환합니다.
      *
      * 정상 contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.
+     * 반환된 future를 취소하면 acquisition과 실행 중인 action에 취소를 전달하고 slot 정리를 시작합니다.
+     * 취소는 협력적이며 `mayInterruptIfRunning=true`가 사용자 코드를 강제로 중단하거나 정리가 동기적으로 끝남을 보장하지 않습니다.
      * @param slot group election slot과 audit leader id를 함께 전달하는 값입니다.
      * @param executor `executor` 호출 또는 상태 계산에 필요한 값입니다.
      * @param action leadership을 획득한 경우에만 실행되는 사용자 작업입니다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderFutureBridge.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/internal/LeaderFutureBridge.kt
@@ -19,7 +19,7 @@ object LeaderFutureBridge {
      */
     fun <T, R> map(
         source: CompletableFuture<T>,
-        mapper: (T, Throwable?) -> R,
+        mapper: (T?, Throwable?) -> R,
     ): CompletableFuture<R> {
         val transformed = source.handle { value, failure -> mapper(value, failure) }
         return mirror(transformed, source)
@@ -30,7 +30,7 @@ object LeaderFutureBridge {
      */
     fun <T, R> flatMap(
         source: CompletableFuture<T>,
-        mapper: (T, Throwable?) -> CompletableFuture<R>,
+        mapper: (T?, Throwable?) -> CompletableFuture<R>,
     ): CompletableFuture<R> {
         val transformed = source.handle { value, failure -> mapper(value, failure) }.thenCompose { it }
         return mirror(transformed, source)
@@ -42,7 +42,7 @@ object LeaderFutureBridge {
     fun <T, R> map(
         source: CompletableFuture<T>,
         cancellationRelay: CancellationRelay,
-        mapper: (T, Throwable?) -> R,
+        mapper: (T?, Throwable?) -> R,
     ): CompletableFuture<R> {
         val transformed = source.handle { value, failure -> mapper(value, failure) }
         return mirror(transformed, source, cancellationRelay::cancel)
@@ -69,7 +69,7 @@ object LeaderFutureBridge {
      */
     fun <T, R> map(
         source: VirtualFuture<T>,
-        mapper: (T, Throwable?) -> R,
+        mapper: (T?, Throwable?) -> R,
     ): VirtualFuture<R> = VirtualFuture(map(source.toCompletableFuture(), mapper))
 
     /**

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LeaderFutureBridgeTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/internal/LeaderFutureBridgeTest.kt
@@ -3,14 +3,60 @@ package io.bluetape4k.leader.internal
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.concurrent.virtualthread.VirtualFuture
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.atomic.AtomicBoolean
 
 class LeaderFutureBridgeTest {
+
+    @Test
+    fun `map은 성공 값을 변환한다`() {
+        val mapped = LeaderFutureBridge.map(CompletableFuture.completedFuture("done")) { value, failure ->
+            failure shouldBeEqualTo null
+            requireNotNull(value).length
+        }
+
+        mapped.join() shouldBeEqualTo 4
+    }
+
+    @Test
+    fun `map은 source 실패를 mapper에 전달한다`() {
+        val failure = IllegalStateException("source failed")
+        val mapped = LeaderFutureBridge.map(CompletableFuture.failedFuture<String>(failure)) { _, observed ->
+            val observedFailure = requireNotNull(observed)
+            observedFailure shouldBeEqualTo failure
+            throw observedFailure
+        }
+
+        assertFailsWith<CompletionException> { mapped.join() }.cause shouldBeEqualTo failure
+    }
+
+    @Test
+    fun `map은 source cancellation을 보존한다`() {
+        val source = CompletableFuture<String>()
+        val mapped = LeaderFutureBridge.map(source) { _, failure ->
+            throw requireNotNull(failure)
+        }
+
+        source.cancel(false).shouldBeTrue()
+
+        assertFailsWith<CompletionException> { mapped.join() }.cause shouldBeInstanceOf CancellationException::class
+    }
+
+    @Test
+    fun `map 완료 후 cancel은 source 상태를 바꾸지 않는다`() {
+        val source = CompletableFuture.completedFuture("done")
+        val mapped = LeaderFutureBridge.map(source) { value, _ -> value }
+
+        mapped.join() shouldBeEqualTo "done"
+        mapped.cancel(false).shouldBeFalse()
+        source.isCancelled.shouldBeFalse()
+    }
 
     @Test
     fun `observe 반환 future 취소를 원본 future 로 전파한다`() {

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElectionTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderElectionTest.kt
@@ -31,6 +31,9 @@ import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import io.bluetape4k.assertions.assertFailsWith
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.time.Instant
@@ -45,6 +48,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.CancellationException as FutureCancellationException
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 class ExposedJdbcLeaderElectionTest: AbstractExposedJdbcLeaderTest() {
@@ -356,6 +360,7 @@ class ExposedJdbcLeaderElectionTest: AbstractExposedJdbcLeaderTest() {
         )
         val worker = Executors.newSingleThreadExecutor()
         val submissions = AtomicInteger()
+        val actionInvoked = AtomicBoolean()
         val executor = Executor { command ->
             if (submissions.incrementAndGet() == 1) {
                 worker.execute(command)
@@ -367,11 +372,14 @@ class ExposedJdbcLeaderElectionTest: AbstractExposedJdbcLeaderTest() {
         try {
             val resultFuture = runCatching {
                 election.runAsyncIfLeader(lockName, executor) {
+                    actionInvoked.set(true)
                     CompletableFuture.completedFuture("실행되면 안 됨")
                 }
             }.getOrElse { CompletableFuture.failedFuture(it) }
 
-            assertFailsWith<CompletionException> { resultFuture.join() }
+            val failure = assertFailsWith<CompletionException> { resultFuture.join() }
+            failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            actionInvoked.get() shouldBeEqualTo false
             election.runIfLeader(lockName) { "executor 거부 후 복구" } shouldBeEqualTo "executor 거부 후 복구"
         } finally {
             worker.shutdownNow()
@@ -637,18 +645,18 @@ class ExposedJdbcLeaderElectionTest: AbstractExposedJdbcLeaderTest() {
         actionStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
         resultFuture.cancel(false).shouldBeTrue()
         assertFailsWith<FutureCancellationException> { resultFuture.join() }
-        val cancellationDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
-        while (!actionFuture.isCancelled && System.nanoTime() < cancellationDeadline) {
-            Thread.sleep(10)
+        await atMost 5.seconds untilAsserted {
+            actionFuture.isCancelled.shouldBeTrue()
         }
-        actionFuture.isCancelled.shouldBeTrue()
 
-        val history = transaction(db) {
-            LeaderLockHistoryTable.selectAll()
-                .where { LeaderLockHistoryTable.lockName eq lockName }
-                .single()
+        await atMost 5.seconds untilAsserted {
+            val history = transaction(db) {
+                LeaderLockHistoryTable.selectAll()
+                    .where { LeaderLockHistoryTable.lockName eq lockName }
+                    .single()
+            }
+            history[LeaderLockHistoryTable.status] shouldBeEqualTo LeaderHistoryStatus.FAILED.name
         }
-        history[LeaderLockHistoryTable.status] shouldBeEqualTo LeaderHistoryStatus.FAILED.name
         election.runIfLeader(lockName) { "반환 취소 후 복구" } shouldBeEqualTo "반환 취소 후 복구"
     }
 
@@ -671,23 +679,18 @@ class ExposedJdbcLeaderElectionTest: AbstractExposedJdbcLeaderTest() {
         actionStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
         resultFuture.cancel(false).shouldBeTrue()
         assertFailsWith<FutureCancellationException> { resultFuture.join() }
-        val cancellationDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
-        while (!actionFuture.isCancelled && System.nanoTime() < cancellationDeadline) {
-            Thread.sleep(10)
+        await atMost 5.seconds untilAsserted {
+            actionFuture.isCancelled.shouldBeTrue()
         }
-        actionFuture.isCancelled.shouldBeTrue()
 
-        var historyStatus: String? = null
-        val historyDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
-        while (historyStatus != LeaderHistoryStatus.FAILED.name && System.nanoTime() < historyDeadline) {
-            historyStatus = transaction(db) {
+        await atMost 5.seconds untilAsserted {
+            val historyStatus = transaction(db) {
                 LeaderLockHistoryTable.selectAll()
                     .where { LeaderLockHistoryTable.lockName eq lockName }
                     .single()[LeaderLockHistoryTable.status]
             }
-            if (historyStatus != LeaderHistoryStatus.FAILED.name) Thread.sleep(10)
+            historyStatus shouldBeEqualTo LeaderHistoryStatus.FAILED.name
         }
-        historyStatus shouldBeEqualTo LeaderHistoryStatus.FAILED.name
         election.runIfLeader(lockName) { "result 취소 후 복구" } shouldBeEqualTo "result 취소 후 복구"
     }
 

--- a/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElectionTest.kt
+++ b/leader-exposed-jdbc/src/test/kotlin/io/bluetape4k/leader/exposed/jdbc/ExposedJdbcLeaderGroupElectionTest.kt
@@ -32,6 +32,9 @@ import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import io.bluetape4k.assertions.assertFailsWith
 import kotlinx.coroutines.CancellationException
+import org.awaitility.kotlin.atMost
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import kotlin.time.Duration
@@ -46,6 +49,7 @@ import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.max
 
@@ -442,6 +446,7 @@ class ExposedJdbcLeaderGroupElectionTest: AbstractExposedJdbcLeaderTest() {
         val election = ExposedJdbcLeaderGroupElector(db, makeOptions(maxLeaders = 1, waitSec = 1))
         val worker = Executors.newSingleThreadExecutor()
         val submissions = AtomicInteger()
+        val actionInvoked = AtomicBoolean()
         val executor = Executor { command ->
             if (submissions.incrementAndGet() == 1) {
                 worker.execute(command)
@@ -453,11 +458,14 @@ class ExposedJdbcLeaderGroupElectionTest: AbstractExposedJdbcLeaderTest() {
         try {
             val resultFuture = runCatching {
                 election.runAsyncIfLeader(lockName, executor) {
+                    actionInvoked.set(true)
                     CompletableFuture.completedFuture("실행되면 안 됨")
                 }
             }.getOrElse { CompletableFuture.failedFuture(it) }
 
-            assertFailsWith<CompletionException> { resultFuture.join() }
+            val failure = assertFailsWith<CompletionException> { resultFuture.join() }
+            failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            actionInvoked.get() shouldBeEqualTo false
             election.runIfLeader(lockName) { "executor 거부 후 슬롯 복구" } shouldBeEqualTo "executor 거부 후 슬롯 복구"
         } finally {
             worker.shutdownNow()
@@ -550,20 +558,20 @@ class ExposedJdbcLeaderGroupElectionTest: AbstractExposedJdbcLeaderTest() {
         actionStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
         resultFuture.cancel(false).shouldBeTrue()
         assertFailsWith<FutureCancellationException> { resultFuture.join() }
-        val cancellationDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
-        while (!actionFuture.isCancelled && System.nanoTime() < cancellationDeadline) {
-            Thread.sleep(10)
+        await atMost 5.seconds untilAsserted {
+            actionFuture.isCancelled.shouldBeTrue()
         }
-        actionFuture.isCancelled.shouldBeTrue()
 
-        val history = transaction(db) {
-            LeaderLockHistoryTable.selectAll()
-                .where { LeaderLockHistoryTable.lockName eq lockName }
-                .single()
+        await atMost 5.seconds untilAsserted {
+            val history = transaction(db) {
+                LeaderLockHistoryTable.selectAll()
+                    .where { LeaderLockHistoryTable.lockName eq lockName }
+                    .single()
+            }
+            history[LeaderLockHistoryTable.status] shouldBeEqualTo LeaderHistoryStatus.FAILED.name
+            history[LeaderLockHistoryTable.finishedAt].shouldNotBeNull()
+            history[LeaderLockHistoryTable.durationMs].shouldNotBeNull() shouldBeGreaterOrEqualTo 0L
         }
-        history[LeaderLockHistoryTable.status] shouldBeEqualTo LeaderHistoryStatus.FAILED.name
-        history[LeaderLockHistoryTable.finishedAt].shouldNotBeNull()
-        history[LeaderLockHistoryTable.durationMs].shouldNotBeNull() shouldBeGreaterOrEqualTo 0L
         election.runIfLeader(lockName) { "async-group-recovered-after-result-cancel" } shouldBeEqualTo
             "async-group-recovered-after-result-cancel"
     }
@@ -594,23 +602,18 @@ class ExposedJdbcLeaderGroupElectionTest: AbstractExposedJdbcLeaderTest() {
         actionStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
         resultFuture.cancel(false).shouldBeTrue()
         assertFailsWith<FutureCancellationException> { resultFuture.join() }
-        val cancellationDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
-        while (!actionFuture.isCancelled && System.nanoTime() < cancellationDeadline) {
-            Thread.sleep(10)
+        await atMost 5.seconds untilAsserted {
+            actionFuture.isCancelled.shouldBeTrue()
         }
-        actionFuture.isCancelled.shouldBeTrue()
 
-        var historyStatus: String? = null
-        val historyDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
-        while (historyStatus != LeaderHistoryStatus.FAILED.name && System.nanoTime() < historyDeadline) {
-            historyStatus = transaction(db) {
+        await atMost 5.seconds untilAsserted {
+            val historyStatus = transaction(db) {
                 LeaderLockHistoryTable.selectAll()
                     .where { LeaderLockHistoryTable.lockName eq lockName }
                     .single()[LeaderLockHistoryTable.status]
             }
-            if (historyStatus != LeaderHistoryStatus.FAILED.name) Thread.sleep(10)
+            historyStatus shouldBeEqualTo LeaderHistoryStatus.FAILED.name
         }
-        historyStatus shouldBeEqualTo LeaderHistoryStatus.FAILED.name
         election.runIfLeader(lockName) { "group result 취소 후 복구" } shouldBeEqualTo "group result 취소 후 복구"
     }
 

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElector.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElector.kt
@@ -17,10 +17,12 @@ import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.error
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * `HazelcastLeaderElector`는 Hazelcast backend의 leader election, lock lease, ownership 확인을 담당합니다.
@@ -50,6 +52,12 @@ class HazelcastLeaderElector private constructor(
             hazelcast: HazelcastInstance,
             options: LeaderElectionOptions = LeaderElectionOptions.Default,
         ): HazelcastLeaderElector = HazelcastLeaderElector(hazelcast, options)
+    }
+
+    private enum class AsyncLifecycle {
+        WAITING,
+        STARTED,
+        CLEANUP,
     }
 
     private val lockMap: IMap<String, String> = hazelcast.getMap(LOCK_MAP_NAME)
@@ -113,13 +121,16 @@ class HazelcastLeaderElector private constructor(
 
         val lockAcquired = AtomicBoolean()
         val acquiredAtNanosRef = AtomicLong()
-        val lifecycleStarted = AtomicBoolean()
-        val rejectionCleanupClaimed = AtomicBoolean()
+        val lifecycle = AtomicReference(AsyncLifecycle.WAITING)
         val releaseIfUnclaimed: () -> Unit = {
-            if (lockAcquired.get() && !lifecycleStarted.get() && rejectionCleanupClaimed.compareAndSet(false, true)) {
+            if (lockAcquired.get() && lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.CLEANUP)) {
                 runCatching { lock.unlock(options.minLeaseTime, acquiredAtNanosRef.get()) }
-                    .onSuccess { log.debug { "executor 거부 후 비동기 락을 반납했습니다. lockName=$lockName" } }
-                    .onFailure { e -> log.error(e) { "Fail to release lock after executor rejection. lockName=$lockName" } }
+                    .onSuccess {
+                        log.debug { "executor 거부 후 비동기 락을 반납했습니다. lockName=$lockName" }
+                    }
+                    .onFailure { e ->
+                        log.error(e) { "Fail to release lock after executor rejection. lockName=$lockName" }
+                    }
             }
         }
         val acquisitionFuture = CompletableFuture.supplyAsync({
@@ -135,10 +146,13 @@ class HazelcastLeaderElector private constructor(
                 if (!acquired) {
                     log.debug { "Leader 승격 실패 (슬롯 없음, 비동기). lockName=$lockName" }
                     CompletableFuture.completedFuture(null)
+                } else if (!lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.STARTED)) {
+                    CompletableFuture.failedFuture(
+                        CancellationException("leader result future was cancelled before action"),
+                    )
                 } else {
                     val acquiredAtNanos = acquiredAtNanosRef.get()
                     val delegate = HazelcastLockExtendDelegate(lock)
-                    lifecycleStarted.set(true)
                     val watchdog = try {
                         LeaderLeaseAutoExtender.start(
                             options.autoExtend,

--- a/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElector.kt
+++ b/leader-hazelcast/src/main/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElector.kt
@@ -19,9 +19,9 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.error
 import io.bluetape4k.support.requireNotBlank
 import io.bluetape4k.support.requirePositiveNumber
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executor
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
@@ -50,6 +50,12 @@ class HazelcastLeaderGroupElector private constructor(
             options.maxLeaders.requirePositiveNumber("maxLeaders")
             return HazelcastLeaderGroupElector(hazelcast, options)
         }
+    }
+
+    private enum class AsyncLifecycle {
+        WAITING,
+        STARTED,
+        CLEANUP,
     }
 
     override val maxLeaders: Int = options.maxLeaders
@@ -147,14 +153,23 @@ class HazelcastLeaderGroupElector private constructor(
 
         val acquiredRef = AtomicReference<Pair<HazelcastLock, Int>?>(null)
         val acquiredAtNanosRef = AtomicLong()
-        val lifecycleStarted = AtomicBoolean()
-        val rejectionCleanupClaimed = AtomicBoolean()
+        val lifecycle = AtomicReference(AsyncLifecycle.WAITING)
         val releaseIfUnclaimed: () -> Unit = {
             val acquired = acquiredRef.get()
-            if (acquired != null && !lifecycleStarted.get() && rejectionCleanupClaimed.compareAndSet(false, true)) {
+            if (acquired != null && lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.CLEANUP)) {
                 runCatching { acquired.first.unlock(minLeaseTime, acquiredAtNanosRef.get()) }
-                    .onSuccess { log.debug { "executor 거부 후 비동기 그룹 슬롯을 반납했습니다. lockName=$lockName, slot=${acquired.second}" } }
-                    .onFailure { e -> log.error(e) { "Fail to release group slot after executor rejection. lockName=$lockName, slot=${acquired.second}" } }
+                    .onSuccess {
+                        log.debug {
+                            "executor 거부 후 비동기 그룹 슬롯을 반납했습니다. " +
+                                "lockName=$lockName, slot=${acquired.second}"
+                        }
+                    }
+                    .onFailure { e ->
+                        log.error(e) {
+                            "Fail to release group slot after executor rejection. " +
+                                "lockName=$lockName, slot=${acquired.second}"
+                        }
+                    }
             }
         }
         val acquisitionFuture = CompletableFuture.supplyAsync({
@@ -177,12 +192,15 @@ class HazelcastLeaderGroupElector private constructor(
                 if (acquired == null) {
                     log.debug { "리더 그룹 슬롯 획득 실패 (비동기). lockName=$lockName" }
                     CompletableFuture.completedFuture(null)
+                } else if (!lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.STARTED)) {
+                    CompletableFuture.failedFuture(
+                        CancellationException("leader result future was cancelled before action"),
+                    )
                 } else {
                     val (lock, slot) = acquired
                     val acquiredAtNanos = acquiredAtNanosRef.get()
                     log.debug { "리더 그룹 슬롯을 획득하여 비동기 작업을 수행합니다. lockName=$lockName, slot=$slot" }
                     val delegate = HazelcastSlotExtendDelegate(lock)
-                    lifecycleStarted.set(true)
                     // Group elector: watchdog disabled (autoExtend 옵션 부재)
                     val watchdog = try {
                         LeaderLeaseAutoExtender.start(false, leaseTime, delegate, ERROR_CLASSIFIER)
@@ -202,8 +220,16 @@ class HazelcastLeaderGroupElector private constructor(
                     actionFuture.whenComplete { _, _ ->
                         watchdog.close()
                         runCatching { lock.unlock(minLeaseTime, acquiredAtNanos) }
-                            .onSuccess { log.debug { "비동기 리더 그룹 슬롯을 반납했습니다. lockName=$lockName, slot=$slot" } }
-                            .onFailure { e -> log.error(e) { "Fail to release group slot (async). lockName=$lockName, slot=$slot" } }
+                            .onSuccess {
+                                log.debug {
+                                    "비동기 리더 그룹 슬롯을 반납했습니다. lockName=$lockName, slot=$slot"
+                                }
+                            }
+                            .onFailure { e ->
+                                log.error(e) {
+                                    "Fail to release group slot (async). lockName=$lockName, slot=$slot"
+                                }
+                            }
                     }
                     actionFuture
                 }

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElectionTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderElectionTest.kt
@@ -24,6 +24,7 @@ import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.milliseconds
@@ -270,6 +271,7 @@ class HazelcastLeaderElectionTest: AbstractHazelcastLeaderTest() {
         )
         val worker = Executors.newSingleThreadExecutor()
         val submissions = AtomicInteger()
+        val actionInvoked = AtomicBoolean()
         val executor = Executor { command ->
             if (submissions.incrementAndGet() == 1) {
                 worker.execute(command)
@@ -281,12 +283,14 @@ class HazelcastLeaderElectionTest: AbstractHazelcastLeaderTest() {
         try {
             val resultFuture = runCatching {
                 election.runAsyncIfLeader(lockName, executor) {
+                    actionInvoked.set(true)
                     CompletableFuture.completedFuture("실행되면 안 됨")
                 }
             }.getOrElse { CompletableFuture.failedFuture(it) }
 
             val failure = assertFailsWith<CompletionException> { resultFuture.join() }
             failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            actionInvoked.get() shouldBeEqualTo false
             election.runIfLeader(lockName) { "executor 거부 후 복구" } shouldBeEqualTo "executor 거부 후 복구"
         } finally {
             worker.shutdownNow()

--- a/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElectionTest.kt
+++ b/leader-hazelcast/src/test/kotlin/io/bluetape4k/leader/hazelcast/HazelcastLeaderGroupElectionTest.kt
@@ -26,6 +26,7 @@ import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.math.max
 import kotlin.random.Random
@@ -249,6 +250,7 @@ class HazelcastLeaderGroupElectionTest: AbstractHazelcastLeaderTest() {
         )
         val worker = Executors.newSingleThreadExecutor()
         val submissions = AtomicInteger()
+        val actionInvoked = AtomicBoolean()
         val executor = Executor { command ->
             if (submissions.incrementAndGet() == 1) {
                 worker.execute(command)
@@ -260,12 +262,14 @@ class HazelcastLeaderGroupElectionTest: AbstractHazelcastLeaderTest() {
         try {
             val resultFuture = runCatching {
                 singleElection.runAsyncIfLeader(lockName, executor) {
+                    actionInvoked.set(true)
                     CompletableFuture.completedFuture("실행되면 안 됨")
                 }
             }.getOrElse { CompletableFuture.failedFuture(it) }
 
             val failure = assertFailsWith<CompletionException> { resultFuture.join() }
             failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            actionInvoked.get() shouldBeEqualTo false
             singleElection.runIfLeader(lockName) { "executor 거부 후 슬롯 복구" } shouldBeEqualTo
                     "executor 거부 후 슬롯 복구"
         } finally {

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderElector.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderElector.kt
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * `KubernetesLeaseLeaderElector`는 Kubernetes Lease backend의 lease, ownership 확인, session/TTL 정리를 담당합니다.
@@ -51,6 +52,12 @@ class KubernetesLeaseLeaderElector @JvmOverloads constructor(
     companion object : KLogging() {
         internal const val K8S_FACTORY_BEAN_NAME = "kubernetes-lease-leader-elector"
         internal val ERROR_CLASSIFIER = CompositeBackendErrorClassifier(KubernetesBackendErrorClassifier)
+    }
+
+    private enum class AsyncLifecycle {
+        WAITING,
+        STARTED,
+        CLEANUP,
     }
 
     override fun <T> runIfLeader(lockName: String, action: () -> T): T? =
@@ -169,10 +176,9 @@ class KubernetesLeaseLeaderElector @JvmOverloads constructor(
 
         val lockAcquired = AtomicBoolean()
         val acquiredAtNanosRef = AtomicLong()
-        val lifecycleStarted = AtomicBoolean()
-        val rejectionCleanupClaimed = AtomicBoolean()
+        val lifecycle = AtomicReference(AsyncLifecycle.WAITING)
         val releaseIfUnclaimed: () -> Unit = {
-            if (lockAcquired.get() && !lifecycleStarted.get() && rejectionCleanupClaimed.compareAndSet(false, true)) {
+            if (lockAcquired.get() && lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.CLEANUP)) {
                 release(lock, acquiredAtNanosRef.get(), lockName)
             }
         }
@@ -188,13 +194,15 @@ class KubernetesLeaseLeaderElector @JvmOverloads constructor(
             acquisitionFuture.thenComposeAsync({ acquired ->
                 if (!acquired) {
                     CompletableFuture.completedFuture(null)
+                } else if (!lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.STARTED)) {
+                    CompletableFuture.failedFuture(
+                        CancellationException("leader result future was cancelled before action"),
+                    )
                 } else {
-                    lifecycleStarted.set(true)
                     try {
                         runAcquiredAsync(lockName, lock, acquiredAtNanosRef.get(), executor, action)
                     } catch (error: Throwable) {
-                        lifecycleStarted.set(false)
-                        releaseIfUnclaimed()
+                        release(lock, acquiredAtNanosRef.get(), lockName)
                         CompletableFuture.failedFuture(error)
                     }
                 }

--- a/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderGroupElector.kt
+++ b/leader-k8s/src/main/kotlin/io/bluetape4k/leader/k8s/KubernetesLeaseLeaderGroupElector.kt
@@ -26,7 +26,6 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.ThreadLocalRandom
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -50,6 +49,12 @@ class KubernetesLeaseLeaderGroupElector @JvmOverloads constructor(
 
     companion object : KLogging() {
         internal const val K8S_GROUP_FACTORY_BEAN_NAME = "kubernetes-lease-leader-group-elector"
+    }
+
+    private enum class AsyncLifecycle {
+        WAITING,
+        STARTED,
+        CLEANUP,
     }
 
     override val maxLeaders: Int = options.maxLeaders
@@ -163,11 +168,10 @@ class KubernetesLeaseLeaderGroupElector @JvmOverloads constructor(
         action: () -> CompletableFuture<T>,
     ): CompletableFuture<T?> {
         val acquiredRef = AtomicReference<AcquiredSlot?>()
-        val lifecycleStarted = AtomicBoolean()
-        val rejectionCleanupClaimed = AtomicBoolean()
+        val lifecycle = AtomicReference(AsyncLifecycle.WAITING)
         val releaseIfUnclaimed: () -> Unit = {
             val acquired = acquiredRef.get()
-            if (acquired != null && !lifecycleStarted.get() && rejectionCleanupClaimed.compareAndSet(false, true)) {
+            if (acquired != null && lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.CLEANUP)) {
                 release(acquired.lock, acquired.acquiredAtNanos, lockName, acquired.slot)
             }
         }
@@ -180,13 +184,15 @@ class KubernetesLeaseLeaderGroupElector @JvmOverloads constructor(
             acquisitionFuture.thenComposeAsync({ acquired ->
                 if (acquired == null) {
                     CompletableFuture.completedFuture(null)
+                } else if (!lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.STARTED)) {
+                    CompletableFuture.failedFuture(
+                        CancellationException("leader result future was cancelled before action"),
+                    )
                 } else {
-                    lifecycleStarted.set(true)
                     try {
                         runAcquiredAsync(lockName, acquired, auditLeaderId, executor, action)
                     } catch (error: Throwable) {
-                        lifecycleStarted.set(false)
-                        releaseIfUnclaimed()
+                        release(acquired.lock, acquired.acquiredAtNanos, lockName, acquired.slot)
                         CompletableFuture.failedFuture(error)
                     }
                 }

--- a/leader-k8s/src/test/kotlin/io/bluetape4k/leader/k8s/contract/KubernetesLeaseExecutorOverloadContractTest.kt
+++ b/leader-k8s/src/test/kotlin/io/bluetape4k/leader/k8s/contract/KubernetesLeaseExecutorOverloadContractTest.kt
@@ -3,6 +3,7 @@ package io.bluetape4k.leader.k8s.contract
 import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.LeaderRunResult
@@ -21,6 +22,7 @@ import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.seconds
 
@@ -31,6 +33,83 @@ import kotlin.time.Duration.Companion.seconds
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class KubernetesLeaseExecutorOverloadContractTest {
     private val client: KubernetesClient = KubernetesContractSupport.newClient()
+
+    @Test
+    fun singleExecutorOverloadPropagatesLeaderIdAndReleases() {
+        val elector = KubernetesLeaseLeaderElector(
+            client,
+            KubernetesLeaseOptions(
+                leaderOptions = LeaderElectionOptions(
+                    waitTime = 1.seconds,
+                    leaseTime = 5.seconds,
+                    nodeId = "k8s-contract-single",
+                ),
+                namespace = "default",
+            ),
+        )
+        val lockName = "k8s-executor-single-success-contract"
+
+        val first = elector.runAsyncIfLeaderResult(
+            LeaderSlot(lockName, "k8s-single-a"),
+            VirtualThreadExecutor,
+        ) {
+            CompletableFuture.completedFuture("single-ok")
+        }.join()
+
+        first shouldBeInstanceOf LeaderRunResult.Elected::class
+        (first as LeaderRunResult.Elected).value shouldBeEqualTo "single-ok"
+        first.leaderId shouldBeEqualTo "k8s-single-a"
+
+        val second = elector.runAsyncIfLeaderResult(
+            LeaderSlot(lockName, "k8s-single-b"),
+            VirtualThreadExecutor,
+        ) {
+            CompletableFuture.completedFuture("single-reacquired")
+        }.join()
+
+        second shouldBeInstanceOf LeaderRunResult.Elected::class
+        (second as LeaderRunResult.Elected).value shouldBeEqualTo "single-reacquired"
+        second.leaderId shouldBeEqualTo "k8s-single-b"
+    }
+
+    @Test
+    fun groupExecutorOverloadPropagatesLeaderIdAndReleases() {
+        val elector = KubernetesLeaseLeaderGroupElector(
+            client,
+            KubernetesLeaseGroupOptions(
+                leaderGroupOptions = LeaderGroupElectionOptions(
+                    maxLeaders = 2,
+                    waitTime = 1.seconds,
+                    leaseTime = 5.seconds,
+                    nodeId = "k8s-contract-group",
+                ),
+                namespace = "default",
+            ),
+        )
+        val lockName = "k8s-executor-group-success-contract"
+
+        val first = elector.runAsyncIfLeaderResult(
+            LeaderSlot(lockName, "k8s-group-a"),
+            VirtualThreadExecutor,
+        ) {
+            CompletableFuture.completedFuture("group-ok")
+        }.join()
+
+        first shouldBeInstanceOf LeaderRunResult.Elected::class
+        (first as LeaderRunResult.Elected).value shouldBeEqualTo "group-ok"
+        first.leaderId shouldBeEqualTo "k8s-group-a"
+
+        val second = elector.runAsyncIfLeaderResult(
+            LeaderSlot(lockName, "k8s-group-b"),
+            VirtualThreadExecutor,
+        ) {
+            CompletableFuture.completedFuture("group-reacquired")
+        }.join()
+
+        second shouldBeInstanceOf LeaderRunResult.Elected::class
+        (second as LeaderRunResult.Elected).value shouldBeEqualTo "group-reacquired"
+        second.leaderId shouldBeEqualTo "k8s-group-b"
+    }
 
     @Test
     fun singleExecutorRejectsSecondSubmissionAndReleases() {
@@ -48,6 +127,7 @@ class KubernetesLeaseExecutorOverloadContractTest {
         val lockName = "k8s-executor-single-contract"
         val worker = Executors.newSingleThreadExecutor()
         val submissions = AtomicInteger()
+        val actionInvoked = AtomicBoolean()
         val executor = Executor { command ->
             if (submissions.incrementAndGet() == 1) {
                 worker.execute(command)
@@ -59,12 +139,14 @@ class KubernetesLeaseExecutorOverloadContractTest {
         try {
             val resultFuture = runCatching {
                 elector.runAsyncIfLeader(lockName, executor) {
+                    actionInvoked.set(true)
                     CompletableFuture.completedFuture("should-not-run")
                 }
             }.getOrElse { CompletableFuture.failedFuture(it) }
 
             val failure = assertFailsWith<CompletionException> { resultFuture.join() }
             failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            actionInvoked.get() shouldBeEqualTo false
 
             val result = elector.runAsyncIfLeaderResult(LeaderSlot(lockName, "k8s-single-b")) {
                 CompletableFuture.completedFuture("single-reacquired")
@@ -94,6 +176,7 @@ class KubernetesLeaseExecutorOverloadContractTest {
         val lockName = "k8s-executor-group-contract"
         val worker = Executors.newSingleThreadExecutor()
         val submissions = AtomicInteger()
+        val actionInvoked = AtomicBoolean()
         val executor = Executor { command ->
             if (submissions.incrementAndGet() == 1) {
                 worker.execute(command)
@@ -105,12 +188,14 @@ class KubernetesLeaseExecutorOverloadContractTest {
         try {
             val resultFuture = runCatching {
                 elector.runAsyncIfLeader(lockName, executor) {
+                    actionInvoked.set(true)
                     CompletableFuture.completedFuture("should-not-run")
                 }
             }.getOrElse { CompletableFuture.failedFuture(it) }
 
             val failure = assertFailsWith<CompletionException> { resultFuture.join() }
             failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            actionInvoked.get() shouldBeEqualTo false
 
             val result = elector.runAsyncIfLeaderResult(LeaderSlot(lockName, "k8s-group-b")) {
                 CompletableFuture.completedFuture("group-reacquired")

--- a/scripts/ci/validate_kover_contract.py
+++ b/scripts/ci/validate_kover_contract.py
@@ -50,6 +50,44 @@ def _gradle_kover_commands(source: str) -> list[str]:
     ]
 
 
+def _validate_k8s_coverage_contract(source: str, path: Path) -> list[str]:
+    coverage_report = _job_block(source, "coverage-report")
+    if coverage_report is None or "test-leader-k8s" not in coverage_report:
+        return []
+
+    violations: list[str] = []
+    k8s_job = _job_block(source, "test-leader-k8s")
+    if k8s_job is None:
+        return [f"{path}: coverage-report가 의존하는 test-leader-k8s job이 없습니다"]
+
+    k8s_commands = [line.strip() for line in k8s_job.splitlines() if "./gradlew" in line]
+    if not any(
+        all(
+            task in command
+            for task in (
+                ":bluetape4k-leader-k8s:test",
+                ":bluetape4k-leader-k8s:k8sTest",
+                ":bluetape4k-leader-k8s:koverXmlReport",
+            )
+        )
+        for command in k8s_commands
+    ):
+        violations.append(
+            f"{path}: test-leader-k8s는 test, k8sTest, koverXmlReport를 same Gradle invocation으로 실행해야 합니다"
+        )
+
+    upload = _step_block(k8s_job, "Upload coverage report")
+    if upload is None:
+        violations.append(f"{path}: test-leader-k8s에 coverage artifact upload step이 없습니다")
+    elif "if-no-files-found: error" not in upload:
+        violations.append(f"{path}: test-leader-k8s coverage upload은 if-no-files-found: error여야 합니다")
+
+    if _job_block(source, "changes") is not None and "needs.changes.outputs['leader-k8s']" not in coverage_report:
+        violations.append(f"{path}: coverage-report의 영향 필터에 leader-k8s가 없습니다")
+
+    return violations
+
+
 def validate_workflow(path: Path) -> list[str]:
     if path.is_symlink() or not path.is_file():
         return [f"{path}: workflow 파일이 없습니다"]
@@ -104,6 +142,8 @@ def validate_workflow(path: Path) -> list[str]:
         aggregate = _step_block(coverage_report, "Aggregate Kover coverage summary")
         if aggregate is None or "aggregate-kover-coverage.py" not in aggregate:
             violations.append(f"{path}: coverage-report에 Kover 집계 step이 없습니다")
+
+    violations.extend(_validate_k8s_coverage_contract(source, path))
 
     return violations
 

--- a/scripts/ci/validate_kover_contract_test.py
+++ b/scripts/ci/validate_kover_contract_test.py
@@ -117,6 +117,44 @@ jobs:
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("changes job", result.stdout + result.stderr)
 
+    def test_validator_requires_k8s_pr_job_to_publish_aggregated_coverage(self) -> None:
+        workflow = """
+jobs:
+  changes:
+    outputs:
+      leader-k8s: ${{ steps.filter.outputs.leader-k8s }}
+  test-core:
+    steps:
+      - run: ./gradlew :bluetape4k-leader-core:test :bluetape4k-leader-core:koverXmlReport
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          if-no-files-found: error
+  test-leader-k8s:
+    needs: [changes]
+    if: ${{ needs.changes.outputs['leader-k8s'] == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Test leader-k8s
+        run: ./gradlew :bluetape4k-leader-k8s:test :bluetape4k-leader-k8s:k8sTest
+  coverage-report:
+    needs:
+      - changes
+      - test-core
+      - test-leader-k8s
+    if: ${{ needs.changes.outputs['leader-k8s'] == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@v8
+      - name: Aggregate Kover coverage summary
+        run: python3 .github/scripts/aggregate-kover-coverage.py coverage-artifacts
+"""
+
+        path = self._write_workflow(workflow)
+        result = run_validator("--workflow-contract", str(path))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("test-leader-k8s", result.stdout + result.stderr)
+
     def test_aggregator_fails_when_no_reports_are_present(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             result = run_aggregator(Path(directory))


### PR DESCRIPTION
## 요약

Closes #857
Closes #858
Closes #870
Closes #871

PR #872 병합 뒤 inline 7-Tier 재검토에서 확인한 async lifecycle 경쟁과 실패 보존 문제를 수정하고, Kubernetes PR coverage 계약을 fail-closed로 고정합니다.

## 주요 수정

- Consul, Hazelcast, Kubernetes 단일/group 경로에서 `WAITING -> STARTED`와 `WAITING -> CLEANUP`을 하나의 CAS로 통합해 action 시작과 cleanup의 이중 소유를 막습니다.
- `LeaderFutureBridge.map`과 `flatMap`이 실패 시 nullable terminal value를 받도록 해 원래 cancellation/backend 예외가 Kotlin NPE로 바뀌지 않게 합니다.
- executor rejection 테스트가 action 미실행, 원래 `RejectedExecutionException`, 동일 lock/slot 재획득을 함께 검증합니다.
- Exposed JDBC 취소/history 검증을 bounded Awaitility assertion으로 바꿉니다.
- `leader-k8s` PR job이 `test`, `k8sTest`, `koverXmlReport`를 같은 Gradle invocation에서 실행하고 coverage artifact 누락 시 실패하도록 합니다.

## 7-Tier 재검토

1. Correctness: cancellation과 executor rejection 뒤 lease/slot cleanup을 확인했습니다.
2. Concurrency: action/cleanup 소유권을 단일 CAS로 선형화했습니다.
3. Failure semantics: terminal `null + failure`를 보존하고 원래 예외를 검증했습니다.
4. Backend parity: core, Consul, Exposed JDBC, Hazelcast, Kubernetes, MongoDB, Lettuce, Redisson 경로를 확인했습니다.
5. Tests: targeted 275개와 Kubernetes unit 16개/K3s 103개가 통과했습니다.
6. CI/coverage: Kover contract validator 9개, `actionlint`, same-task-graph Kover XML 생성을 확인했습니다.
7. API/ABI/docs: ABI artifacts 16, ignored 0, unknown 0이며 공개 incompatibility가 없습니다. EN/KO cancellation 계약과 lesson을 동기화했습니다.

수정 후 판정은 P0/P1/P2/P3 `0/0/0/0`입니다. 응답 없는 독립 review lane은 workflow liveness 계약에 따라 회수하고 같은 범위를 inline으로 재검토했습니다.

## 검증

- targeted regression: PASS (`275/275`)
- Kubernetes same task graph: PASS (`test 16/16`, `k8sTest 103/103`, Kover XML 91,337 bytes)
- 영향 모듈 9개 `compileTestKotlin`: PASS
- `detekt`: PASS
- binary compatibility: PASS (`artifacts 16`, `ignored 0`, `unknown 0`)
- Kover validator/unit: PASS (`9/9`)
- assertion/timing/leader matrix validator, `actionlint`, Korean terminology audit, `git diff --check`: PASS
- hosted exact-head CI: PASS (`47/47`; CI `46/46` + README `1/1`, run `33845615253`)
- Kubernetes artifacts: PASS (`coverage-leader-k8s` 7,757 bytes, `test-results-leader-k8s` 18,243 bytes, aggregate `coverage-all` 278,122 bytes)
- post-merge develop CI: PASS (`46/46`, run `33847729263`, head `e50dd883bb2e08961c1dd48c698d253605ce512e`)

## 메타데이터

- Base: `develop`
- Head: `fix/milestone-1-1-0-review-followups`
- Exact head: `0d59d7a87d0ef49c3627d0b82cb3c71c0e31655f`
- Milestone: `1.1.0`
- Merge commit: `e50dd883bb2e08961c1dd48c698d253605ce512e`

## DoD Status

Required checks: 14/14; N/A: 1; Blocked: 0

| Check | Status | Evidence / Next Action |
|---|---|---|
| C-01~C-06 | PASS | 재현, P1 수정, targeted/K3s/Kover/ABI 검증, lesson 기록 완료 |
| CG-10 | PASS | inline 7-Tier review P0/P1/P2/P3 `0/0/0/0` |
| CG-12 | PASS | local/remote `0d59d7a87d0ef49c3627d0b82cb3c71c0e31655f` 일치, force 없이 push |
| CG-13 | PASS | PR #873 MERGED, base/head, assignee, milestone, labels, final DoD section read-back |
| CG-14 | PASS | exact-head run `33845615253`의 CI `46/46`와 README `1/1` 성공, K8s test/coverage artifacts 확인, review/thread `0/0` |
| CG-15 | PASS | PR #873 MERGED with exact-head merge commit, auto-merge 없음, P0/P1/P2/P3 `0/0/0/0` |
| CG-16 | PASS | fresh approval 후 exact-head merge 완료, merge commit `e50dd883bb2e08961c1dd48c698d253605ce512e`, post-merge develop CI `46/46` |

Final status: DONE — exact-head merge와 post-merge develop CI가 완료되었습니다.

Unchecked required items: 없음
