### PR TITLE
fix(leader-core): BoundedLeaderAuditExporter flaky 경로 수정

### DIFF
--- a/docs/lessons/2026-09-04-issue-868-bounded-audit-exporter.md
+++ b/docs/lessons/2026-09-04-issue-868-bounded-audit-exporter.md
@@ -1,0 +1,41 @@
+# Issue #868: BoundedLeaderAuditExporter flaky 경로
+
+## 맥락
+
+Milestone `1.1.0`의 [Issue #868](https://github.com/bluetape4k/bluetape4k-leader/issues/868)은 `leader-core` 전체 테스트에서 `BoundedLeaderAuditExporter`의 rejection counter 관측값과 observer 재등록 검증이 간헐적으로 실패하는 문제를 다룬다. 현재 `develop` exact head `e50dd883bb2e08961c1dd48c698d253605ce512e`에서 `leader-core` 전체 테스트를 새로 실행한 결과, 기존 관측값 불일치와 observer 수명주기 실패 외에 close 중 concurrent key-set 순회 예외와 worker handoff 재시작 손실도 재현했다.
+
+## 결정
+
+- `finishWork()`는 terminal observation counter를 `admitted` permit 해제보다 먼저 갱신한다. 따라서 `admitted == 0`을 읽은 관측값이 `EXECUTOR_REJECTED`, `SCHEDULER_REJECTED`, `CANCELLED`, `TERMINAL_FAILURE` counter를 뒤늦게 보는 창을 만들지 않는다.
+- `active`는 동시 축소가 가능한 `ConcurrentHashMap` key-set이다. `active.toList()`의 크기 추정과 iterator가 경합하면 `NoSuchElementException`이 발생하므로 close에서는 weakly-consistent `forEach`를 사용하고 `terminalized` CAS로 중복 취소를 막는다.
+- worker handoff가 실행 중일 때 새 dispatch를 중복 생성하지 않고, 기존 handoff가 `IDLE`로 돌아오는 시점에 큐를 다시 확인한다. 이 재확인으로 inline executor가 반환되는 순간 queued work를 놓치지 않는다.
+- observer 재등록 테스트는 callback이 막힌 동안 두 번째 work가 실제로 종료됐는지 기다린 뒤 queued diagnostics 항목을 확인한다. bounded admission 경합으로 발생한 정상적인 `DROPPED_QUEUE_FULL`을 observer 수명주기 실패로 오판하지 않도록 장벽을 명시한다.
+
+## 결과
+
+수정 범위는 `leader-core` 내부 구현과 해당 회귀 테스트로 제한했다. 공개 API나 ABI surface는 변경하지 않았다. observer close/replacement 테스트는 callback 큐가 남아 있는 상태와 replacement callback 시작을 각각 검증한다.
+
+## 검증
+
+다음 검증을 수행했다.
+
+```text
+BoundedLeaderAuditExporterTest: 21 tests, targeted run PASS
+serial stress: 5/5 PASS; parallel stress: 5/5 PASS
+executor rejection recovery: 20/20 isolated repetitions PASS
+leader-core full test: 1,018 tests, repeated runs 3/3 PASS
+detekt: PASS; checkBinaryCompatibility: PASS (`No changes` for all published artifacts)
+git diff --check: PASS; Korean terminology audit: PASS (0 findings)
+```
+
+정확한 CI exact-head run, 병합 후 downstream 모듈, publication은 이 로컬 수정 범위에서 실행하지 않았다. `gno update`는 실행했지만 등록 collection이 isolated `.worktrees`를 제외하므로 이 lesson은 기존 `bluetape4k-docs` index에 반영되지 않았다. 대신 임시 collection에서 index와 BM25 검색을 확인하고 embedding 257개 chunk를 생성한 뒤 collection을 제거해 격리 문서의 검색 가능성과 설정 정리를 검증했다.
+
+## 놓친 점
+
+기존 테스트는 `admitted` 해제와 observer callback 큐의 진행을 독립적으로 기다리지 않았다. 테스트가 정상적인 non-blocking admission drop과 실제 observer worker 결함을 같은 실패로 보고할 수 있었다. 또한 concurrent collection의 `toList()`가 원자적 순회처럼 보인다는 가정이 close 경로에 남아 있었다.
+
+## 앞으로의 guard
+
+- concurrent collection을 public lifecycle 경계에서 목록으로 materialize하지 말고 weakly-consistent iteration 또는 명시적인 동기화된 관측 목록을 사용한다.
+- 공개 관측값에서 한 필드의 해제가 다른 counter의 갱신을 앞서지 않도록 terminal counter와 permit release 순서를 회귀 테스트로 고정한다.
+- observer close/re-register 테스트는 work admission, diagnostics queue, callback running 상태를 각각 장벽으로 고정하고 단독·반복·전체 모듈 실행을 함께 기록한다.

--- a/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
+++ b/leader-core/src/main/kotlin/io/bluetape4k/leader/audit/internal/BoundedLeaderAuditExporter.kt
@@ -68,7 +68,6 @@ internal class BoundedLeaderAuditExporter(
     private val closed = AtomicBoolean(false)
     private val diagnosticsClosed = AtomicBoolean(false)
     private val workerRunning = AtomicBoolean(false)
-    private val workerRestartRequested = AtomicBoolean(false)
     private val workerHandoffState = AtomicReference(WorkerHandoffState.IDLE)
     private val worker = ConcurrentLinkedQueue<WorkItem>()
     private val active = ConcurrentHashMap.newKeySet<WorkItem>()
@@ -190,7 +189,11 @@ internal class BoundedLeaderAuditExporter(
         // already published CLOSED.
         admissionLock.lock()
         try {
-            active.toList().forEach(::cancelWork)
+            // ConcurrentHashMap key-set의 `toList()`는 크기 추정과 iterator 순회가
+            // 동시에 축소될 때 `NoSuchElementException`을 던질 수 있습니다. close와
+            // 완료 경합에서는 weakly-consistent 순회로 이미 종료된 항목만 건너뛰면
+            // terminalized CAS가 나머지 항목의 취소를 멱등하게 보장합니다.
+            active.forEach(::cancelWork)
         } finally {
             admissionLock.unlock()
         }
@@ -216,6 +219,9 @@ internal class BoundedLeaderAuditExporter(
 
     private fun tryStartWorker() {
         if (closed.get()) return
+        // 실행 중인 handoff가 끝난 뒤 같은 큐를 다시 확인하므로, 동일한 executor
+        // 호출에 대해 중복 dispatch를 만들지 않습니다.
+        if (workerHandoffState.get() != WorkerHandoffState.IDLE) return
         if (!workerRunning.compareAndSet(false, true)) return
         // An Executor is allowed to run inline. Invoke it from a dedicated virtual
         // thread so submit() remains an admission-only, non-blocking boundary even
@@ -225,7 +231,6 @@ internal class BoundedLeaderAuditExporter(
             .start {
                 if (!workerHandoffState.compareAndSet(WorkerHandoffState.IDLE, WorkerHandoffState.CLAIMED)) {
                     workerRunning.set(false)
-                    if (!closed.get()) workerRestartRequested.set(true)
                     return@start
                 }
                 if (!workerHandoffState.compareAndSet(WorkerHandoffState.CLAIMED, WorkerHandoffState.EXECUTING)) {
@@ -249,7 +254,7 @@ internal class BoundedLeaderAuditExporter(
                     if (!closed.get() &&
                         workerHandoffState.compareAndSet(WorkerHandoffState.EXECUTING, WorkerHandoffState.IDLE)
                     ) {
-                        if (workerRestartRequested.getAndSet(false)) tryStartWorker()
+                        if (worker.isNotEmpty()) tryStartWorker()
                     }
                 }
             }
@@ -551,8 +556,6 @@ internal class BoundedLeaderAuditExporter(
 
     private fun finishWork(item: WorkItem, observation: LeaderAuditExportObservation?) {
         if (!item.terminalized.compareAndSet(false, true)) return
-        active.remove(item)
-        admitted.decrementAndGet()
         if (observation != null) {
             when (observation) {
                 LeaderAuditExportObservation.TERMINAL_FAILURE -> terminalFailures.incrementAndGet()
@@ -561,8 +564,12 @@ internal class BoundedLeaderAuditExporter(
                 LeaderAuditExportObservation.SCHEDULER_REJECTED -> schedulerRejections.incrementAndGet()
                 else -> Unit
             }
-            publish(observation)
         }
+        active.remove(item)
+        // 공개 snapshot이 admitted=0을 관찰한 뒤 terminal counter를 놓치지 않도록
+        // observation counter를 permit release보다 먼저 갱신합니다.
+        admitted.decrementAndGet()
+        if (observation != null) publish(observation)
     }
 
     private fun drainQueued(observation: LeaderAuditExportObservation) {

--- a/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
+++ b/leader-core/src/test/kotlin/io/bluetape4k/leader/audit/BoundedLeaderAuditExporterTest.kt
@@ -593,7 +593,10 @@ class BoundedLeaderAuditExporterTest {
 
         exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
         firstStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+        awaitAdmissionReleased(exporter)
         exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
+        awaitAdmissionReleased(exporter)
+        diagnosticsQueued(exporter).shouldBeEqualTo(1)
         registration.close()
         diagnosticsQueued(exporter).shouldBeEqualTo(0)
         releaseFirst.countDown()
@@ -673,6 +676,7 @@ class BoundedLeaderAuditExporterTest {
 
             exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
             firstStarted.await(5, TimeUnit.SECONDS).shouldBeTrue()
+            awaitAdmissionReleased(exporter)
             exporter.submit(event()).shouldBeEqualTo(LeaderAuditSubmitResult.ACCEPTED)
             releaseFirst.countDown()
 
@@ -764,6 +768,7 @@ class BoundedLeaderAuditExporterTest {
         while (exporter.snapshot().admitted != 0 && System.nanoTime() < deadline) {
             Thread.onSpinWait()
         }
+        exporter.snapshot().admitted.shouldBeEqualTo(0)
     }
 
     private fun replaceDiagnosticsQueue(


### PR DESCRIPTION
## Summary

Closes #868

`BoundedLeaderAuditExporter`의 snapshot ordering, observer 재등록, worker handoff 경로에서 발생하던 flaky 테스트를 결정적으로 고정합니다. 구현 계약은 유지하면서 terminal counter와 active 작업 정리 순서, worker 재시작 경계를 수리했습니다.

## Background

Milestone `1.1.0`의 Issue #868은 `leader-core` audit exporter 테스트에서 admission/observer/worker lifecycle 관측이 간헐적으로 어긋나는 문제를 다룹니다. 변경은 `origin/develop` `e50dd883bb2e08961c1dd48c698d253605ce512e`에서 분리한 branch의 단일 커밋으로 제한했습니다.

## What This Solves

- terminal counter가 active 작업 제거보다 먼저 관측되어 rejection/close 결과가 안정적으로 보이도록 합니다.
- `close()` 중 concurrent key-set 순회와 observer replacement 사이의 race를 줄입니다.
- worker handoff가 실행 중인 동안 새 작업이 들어와도 handoff 종료 후 queue를 다시 확인해 worker가 유실되지 않도록 합니다.

## Work Done

- `BoundedLeaderAuditExporter.kt`: terminal accounting 순서, weakly-consistent close 순회, handoff 후 queue 재확인을 정리했습니다.
- `BoundedLeaderAuditExporterTest.kt`: admission release와 observer replacement 경계를 명시적으로 기다리는 회귀 검증을 추가했습니다.
- `docs/lessons/2026-09-04-issue-868-bounded-audit-exporter.md`: 재사용 가능한 lifecycle guard와 검증 결과를 기록했습니다.

## Validation

- `./gradlew :bluetape4k-leader-core:test --tests 'io.bluetape4k.leader.audit.BoundedLeaderAuditExporterTest' --no-daemon --no-configuration-cache --no-build-cache --rerun-tasks --console=plain`: PASS (21/21)
- `./gradlew :bluetape4k-leader-core:cleanTest :bluetape4k-leader-core:test --no-daemon --no-configuration-cache --no-build-cache --console=plain`: PASS (1,018 tests; failures=0, errors=0, skipped=0)
- `./gradlew detekt --no-daemon --no-configuration-cache --no-build-cache --console=plain`: PASS
- `./gradlew checkBinaryCompatibility --no-daemon --no-configuration-cache --no-build-cache --console=plain`: PASS (`No changes` for published artifacts)
- post-merge canonical `develop` targeted rerun: PASS (21/21, BUILD SUCCESSFUL)
- serial/parallel stress and isolated rejection recovery: PASS (5/5, 5/5, 20/20)
- `git diff --check HEAD^ HEAD` 및 Korean terminology audit: PASS (findings=0)

## Review Notes

- P0/P1: 0
- P2/P3: scoped diff에서 남은 항목 없음
- Review evidence: local exact-head diff review at `BoundedLeaderAuditExporter.kt:192-196,220-258,557-573`; no new `!!`, suspend `runCatching`, forbidden assertions, or `workerRestartRequested`

## Metadata

- Issue: #868, milestone `1.1.0`, assignee `debop`
- PR: #874, MERGED at `2026-09-04T11:22:13Z`, `https://github.com/bluetape4k/bluetape4k-leader/pull/874`
- Head: `fix/issue-868-audit-exporter-flaky` @ `3fb594adedcb38f4b2b4105186621b68f0e8b2d4`
- Base: `develop` @ `e50dd883bb2e08961c1dd48c698d253605ce512e`
- CI: exact-head run `33866093666`; 46/46 checks PASS, pending/failure 0; hosted review 없음(저장소 required approval count=0)
- Merge: squash commit `c47324bcff5738e5505cf733d838afd730bad226`; `origin/develop`와 canonical `develop` 동기화 완료

## DoD Status

Required checks: 75/75; N/A: 25; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| WF-00~CG-10 / C-01~C-06 / KT / SPW / KO | local workflow, bugfix, Kotlin, testing, writer, and repair gates | PASS | checklist ledger; targeted/full/static/ABI/docs evidence above | none |
| CG-11 - PR delivery authority | target repo/base/head and current user PR request | PASS | current request; `bluetape4k/bluetape4k-leader`, `develop`, `fix/issue-868-audit-exporter-flaky` | none |
| CG-12 - Exact head publish | push feature branch without force | PASS | `git ls-remote --heads origin fix/issue-868-audit-exporter-flaky` = `3fb594adedcb38f4b2b4105186621b68f0e8b2d4` | none |
| CG-12A - Guidance refresh | re-read current guidance, selected skills, common gates, PR template, and Issue #868 | PASS | refreshed before PR stage; exact target snapshot above | none |
| CG-13 - PR creation and verification | create PR and read back body/base/head/linkage | PASS | PR #874; `gh pr view` confirms base `develop`, head `3fb594adedcb38f4b2b4105186621b68f0e8b2d4`, `Closes #868`, final `## DoD Status` | none |
| CG-14 - Exact-head CI/review | inspect hosted checks and review state for PR head | PASS | exact-head run `33866093666`: `gh pr checks --json` reports 46/46 PASS, pending/failure 0; `reviewDecision` empty, `reviews=[]`; repository requires 0 approvals | none |
| CG-15 - Merge-ready report | report CI/review/DoD and remaining risk | PASS | current PR body/ledger refreshed with 46/46 CI, clean mergeability, no review blocker, and remaining post-merge gates | none |
| CG-16 - Fresh merge approval | obtain approval for this exact head after merge-ready report | PASS | current user message `승인` received after exact head `3fb594adedcb38f4b2b4105186621b68f0e8b2d4` and merge-ready refresh | proceed to merge, then verify |
| CG-17 - Merge execution and verification | merge exact head and verify target PR/develop | PASS | PR #874 `MERGED`; squash commit `c47324bcff5738e5505cf733d838afd730bad226`; `origin/develop` fast-forwarded to same SHA; canonical targeted rerun 21/21 PASS | none |
| CG-18 - Canonical sync and cleanup | sync canonical develop and remove proven merged targets | PASS | canonical `develop`=`origin/develop`=`c47324bcff5738e5505cf733d838afd730bad226`; feature worktree and local/remote feature refs absent; unrelated catalog worktree preserved | none |
| C-09 - Post-approval closeout | complete merge, canonical sync, and cleanup after fresh approval | PASS | current user `승인` preceded merge; merged PR, canonical sync, and cleanup proof completed | none |
| C-07 - Authorized PR delivery | push and create Issue #868 PR | PASS | remote branch and PR #874 created from exact head | none |
| C-08 - PR phase report | record current count, validation, CI/review state, and remaining gates | PASS | this body and delivery ledger updated after merge/cleanup; final count is 75/75 with no unchecked required item | none |
| C-10 - PR body DoD final section | keep `## DoD Status` as final section with current count | PASS | `gh pr view --json body` read-back; body ends with `Unchecked required items: none` | none |

Final status: DONE (exact-head CI, approval, merge, canonical sync, and cleanup verified)

Unchecked required items: none
