### PR TITLE
feat(leader-redis-lettuce): Redis Cluster same-slot 상태 전이 지원

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -199,6 +199,104 @@ jobs:
           path: '**/build/reports/kover/'
           retention-days: 14
 
+  # ── leader-redis-lettuce Redis Cluster (전용 Nightly/manual full) ─────────
+  test-redis-lettuce-cluster:
+    name: Test / leader-redis-lettuce (Redis Cluster)
+    if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v6.0.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+      - uses: gradle/actions/setup-gradle@v6.3.0
+        with:
+          gradle-version: wrapper
+          cache-read-only: true
+      - name: Prepare Redis Cluster diagnostics
+        run: mkdir -p leader-redis-lettuce/build/redis-cluster-diagnostics
+      - name: Test Redis Cluster
+        run: ./gradlew :bluetape4k-leader-redis-lettuce:clusterTest --no-daemon --no-configuration-cache --console=plain
+        env:
+          GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+          TESTCONTAINERS_RYUK_DISABLED: "true"
+          DOCKER_HOST: "unix:///var/run/docker.sock"
+      - name: Verify Redis Cluster test scope
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          reports=(leader-redis-lettuce/build/test-results/clusterTest/*.xml)
+          test "${#reports[@]}" -gt 0 || { echo "No clusterTest JUnit XML" >&2; exit 1; }
+          python3 - "${reports[@]}" <<'PY'
+          import sys
+          from pathlib import Path
+          import xml.etree.ElementTree as ET
+
+          matrix_path = Path("leader-redis-lettuce/src/test/resources/redis-cluster-test-matrix.txt")
+          expected_names = {
+              line.strip()
+              for line in matrix_path.read_text().splitlines()
+              if line.strip()
+          }
+          tests = skipped = failures = errors = 0
+          observed_names = set()
+          for path in sys.argv[1:]:
+              root = ET.parse(path).getroot()
+              tests += int(root.attrib.get("tests", 0))
+              skipped += int(root.attrib.get("skipped", 0))
+              failures += int(root.attrib.get("failures", 0))
+              errors += int(root.attrib.get("errors", 0))
+              for testcase in root.findall(".//testcase"):
+                  observed_names.add(testcase.attrib.get("name", "").removesuffix("()"))
+          missing_names = sorted(expected_names - observed_names)
+          print({"tests": tests, "skipped": skipped, "failures": failures, "errors": errors})
+          print({"expected_matrix": len(expected_names), "missing_names": missing_names})
+          if tests < len(expected_names) or missing_names or skipped != 0 or failures != 0 or errors != 0:
+              print(f"Redis Cluster test matrix is incomplete; expected={len(expected_names)} missing={missing_names}")
+              raise SystemExit(1)
+
+          provenance = Path("leader-redis-lettuce/build/redis-cluster-diagnostics/cluster-runtime.txt")
+          if not provenance.is_file():
+              print(f"Missing Redis Cluster runtime provenance: {provenance}")
+              raise SystemExit(1)
+          fields = {}
+          for line in provenance.read_text().splitlines():
+              key, separator, value = line.partition("=")
+              if separator:
+                  fields[key] = value
+          endpoints = [endpoint for endpoint in fields.get("endpoints", "").split(",") if endpoint]
+          if "@sha256:" not in fields.get("image_digest", "") or fields.get("cluster_state") != "ok" or len(endpoints) < 6:
+              print(f"Incomplete Redis Cluster runtime provenance: {fields}")
+              raise SystemExit(1)
+          PY
+      - name: Capture Redis Cluster failure diagnostics
+        if: failure()
+        shell: bash
+        run: |
+          set +e
+          docker ps -a > leader-redis-lettuce/build/redis-cluster-diagnostics/docker-ps.txt
+          docker ps -aq | xargs -r -n1 docker inspect > leader-redis-lettuce/build/redis-cluster-diagnostics/docker-inspect.json
+          docker ps -aq | xargs -r -n1 docker logs > leader-redis-lettuce/build/redis-cluster-diagnostics/docker-logs.txt
+          docker events --since 10m --until "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > leader-redis-lettuce/build/redis-cluster-diagnostics/docker-events.txt
+          if command -v redis-cli >/dev/null 2>&1; then
+            redis-cli -c cluster info > leader-redis-lettuce/build/redis-cluster-diagnostics/cluster-info.txt 2>&1
+          fi
+      - name: Upload Redis Cluster diagnostics
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: redis-lettuce-cluster-diagnostics
+          path: |
+            **/build/test-results/clusterTest/*.xml
+            **/build/reports/tests/clusterTest/**
+            **/build/redis-cluster-diagnostics/**
+          retention-days: 14
+
   # ── leader-redis-redisson (Testcontainers: Redis) ───────────────────────────
   test-redis-redisson:
     name: Test / leader-redis-redisson (Testcontainers)
@@ -1138,6 +1236,7 @@ jobs:
     needs:
       - test-core
       - test-redis-lettuce
+      - test-redis-lettuce-cluster
       - test-redis-redisson
       - test-exposed-core-h2
       - test-exposed-core-postgresql
@@ -1228,6 +1327,7 @@ jobs:
       - snapshot-warmup
       - test-core
       - test-redis-lettuce
+      - test-redis-lettuce-cluster
       - test-redis-redisson
       - test-exposed-core-h2
       - test-exposed-core-postgresql
@@ -1255,10 +1355,16 @@ jobs:
       - name: Check all jobs
         env:
           RESULTS: ${{ join(needs.*.result, ',') }}
+          CLUSTER_RESULT: ${{ needs.test-redis-lettuce-cluster.result }}
+          FULL_SCOPE: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
         run: |
           echo "Nightly results: $RESULTS"
           if echo "$RESULTS" | grep -qE "failure|cancelled"; then
             echo "Nightly failed"
+            exit 1
+          fi
+          if [ "$FULL_SCOPE" = "true" ] && [ "$CLUSTER_RESULT" != "success" ]; then
+            echo "Redis Cluster Nightly gate is $CLUSTER_RESULT, expected success"
             exit 1
           fi
           echo "Nightly passed"

--- a/docs/lessons/2026-09-04-issue-854-redis-cluster.md
+++ b/docs/lessons/2026-09-04-issue-854-redis-cluster.md
@@ -1,0 +1,66 @@
+# Redis Cluster strategic candidate 지원 lesson
+
+Issue #854의 `leader-redis-lettuce` 구현에서 재사용할 규칙을 정리한다. 기준은 `origin/develop` `c47324bcff5738e5505cf733d838afd730bad226`이며 Lettuce는 immutable catalog ref `850959d0ea5f76ac7e2c442400f47653d5f95eed`가 resolve하는 `7.6.0.RELEASE`다.
+
+## Key와 slot
+
+- 새 v3 index/candidate/tombstone/migration-token key는 모두 `{lengthDelimited(lockName)}`를 공통 hash tag로 사용한다. node ID는 tag 밖에 둔다.
+- `lockName`과 `nodeId`를 raw `:` delimiter로 이어 붙이지 않는다. UTF-8 byte length prefix가 경계와 다국어 값을 보존한다.
+- `{`와 `}`가 들어간 lock name은 기존 validation에서 거부한다. 사용자가 만든 hash-tag 경계를 다시 해석하지 않도록 하는 안전장치다.
+- `DEFAULT`와 `GROUP` prefix는 서로 다른 namespace를 유지한다. 같은 lock name이라도 후보가 섞이지 않아야 한다.
+
+근거: `LettuceCandidateKeyCodec.kt:23-58`, `LettuceCandidateKeyCodecTest`, `LettuceCandidateKeyIsolationTest`.
+
+## Legacy migration
+
+- v2와 colon legacy source는 호환 읽기·이행 전용이다. source `GET`/`PTTL`은 각각 단일 key로 수행하며 source key를 multi-key Lua `KEYS`에 넣지 않는다.
+- v3 destination은 `SET NX`와 same-slot `SADD`/`PERSIST`로 기록한다. 이미 destination이 있으면 값을 덮어쓰지 않고 index만 repair한다.
+- source는 migration 중 삭제하지 않는다. unregister의 명시적 cleanup에서만 nodeId payload를 확인한 뒤 candidate를 삭제하고 index member를 제거한다.
+- `GET`과 `PTTL` 사이의 만료는 cross-slot 원자화가 불가능하므로 bounded race로 기록한다. post-copy 재확인에서 source가 사라진 경우에만 destination을 best-effort 정리한다.
+- `PTTL=-1`은 persistent source이며 만료가 아니다. `-2` 또는 관찰 후 실제 0ms 만료만 expired로 취급한다.
+- public TTL 입력은 Redis 쓰기 전에 검증한다. 음수와 1ms 미만 양수는 거부하고 `Duration.ZERO`는 persistent 후보로 허용한다. Lua도 정수·비음수 TTL만 받아 직접 호출의 우회를 막는다.
+- destination payload가 malformed이면 legacy source로 조용히 대체하지 않고 기존 codec 예외를 표면화한다. 유효한 다른 node ID가 있으면 해당 v3 destination/index를 정리한 뒤 migration을 재시도한다.
+
+근거: `LettuceCandidateRegistry.kt:244-314`, `LettuceSuspendCandidateRegistry.kt:249-319`, `LettuceCandidateWriteScriptTest`의 persistent-source/TTL 테스트, 실제 Cluster migration 테스트.
+
+## Lifecycle fence와 ownership
+
+- `UNREGISTER`는 candidate/token 삭제와 index `SREM`보다 먼저 persistent tombstone을 세운다. 그 뒤 실행되는 migration은 tombstone을 보고 아무것도 되살리지 않는다.
+- 새 `REGISTER`만 tombstone과 stale migration token을 지우고 새 generation을 시작한다.
+- migration이 성공한 호출만 unique token을 보유한다. cleanup은 destination raw value와 token이 모두 일치할 때에만 candidate/index/token을 삭제한다.
+- regular `refresh`, `updateResult`, `register`가 token을 지워 늦은 migration cleanup이 현재 writer를 삭제하지 못하게 한다.
+
+근거: `LettuceCandidateWriteScript.kt:31-101`, `LettuceCandidateRefreshScript.kt:77-80`, `LettuceCandidateResultScript.kt:184-188`, write-script barrier/token 테스트.
+
+## Capability와 coroutine parity
+
+- direct command, script command, batch value reader를 하나의 concrete API cast로 묶지 않는다. standalone은 `RedisCommands`/`RedisCoroutinesCommands` native `MGET`, Cluster는 `RedisAdvancedClusterCommands`/coroutine common `MGET`을 사용한다.
+- `RedisScriptRunner` overload는 기존 standalone descriptor를 삭제하지 않고 Cluster/common scripting capability를 추가한다. `NOSCRIPT`는 원문 fallback, 다른 예외와 `CancellationException`은 원인/취소 semantics를 보존한다.
+- connection, client, container는 caller/fixture가 소유한다. registry/elector가 닫거나 shutdown하지 않는다.
+
+근거: `LettuceCandidateCommands.kt:15-92`, `LettuceSuspendCandidateCommands.kt:15-90`, `script/RedisScript.kt:47-194`, suspend Cluster tests.
+
+## Fixture·CI gate
+
+- actual Cluster 검증은 기존 `RedisClusterServer.Launcher.redisCluster`를 사용한다. raw container를 새로 만들지 않는다.
+- `clusterTest`는 regular `test`에서 `redis-cluster` tag를 제외하고, test classes/classpath, `failOnNoDiscoveredTests`, checked-in 17개 manifest exact-name, XML `tests>=manifest`, `skipped=0`, 직렬 실행을 강제한다. 테스트 범위가 축소되거나 전부 skip된 경우에도 성공하지 않도록 Gradle과 CI 양쪽에서 이름·count를 검사한다.
+- CI success/failure 시 image reference와 실제 `@sha256:` digest, `cluster_state`, 6개 endpoint, mapped ports, Docker inspect/logs/events를 남긴다. local 성공은 hosted Nightly 성공으로 간주하지 않는다.
+- fixture의 `awaitClusterReady()`가 첫 시작에서 일시적인 node ping `Invalid first byte`/`Connection reset by peer`를 낼 수 있다. 이를 제품 테스트 통과로 오인하지 말고 동일 SHA에서 즉시 재실행하며, 재현되면 launcher/image/daemon diagnostics와 함께 hosted 환경성 flake로 분리한다.
+- `MOVED`/`ASK` topology 수렴과 failover performance는 이슈 범위 밖이다. 이 경계를 넘으려면 별도 benchmark/운영 이슈가 필요하다.
+
+근거: `leader-redis-lettuce/build.gradle.kts:35-76`, `.github/workflows/nightly-tests.yml:203-269,1294-1345`, `LettuceStrategicRedisClusterTest.kt:1-576` (17개 lifecycle/migration/cancellation 테스트와 runtime provenance helper).
+
+## ABI·문서·전달
+
+- Kotlin default parameter를 public constructor에서 제거하지 않는다. standalone `@JvmOverloads`와 compiler synthetic bridge를 기준 artifact의 `javap -p -s`와 precompiled Kotlin consumer로 확인한다.
+- Cluster constructor는 additive public descriptor로 추가한다. Java fixture가 explicit two-arg call을 compile해야 한다.
+- README 양국어에는 지원 버전, key/migration/rollback 경계, caller-owned connection, `clusterTest`/Nightly 위치를 같이 적는다.
+- v3 write 후 old binary rollback이나 v3→v2 parity 변환은 지원하지 않는다. writers 정지 → 상태·diagnostics 보존 → forward fix 순서로 대응한다.
+- 기존 Issue #854가 milestone `1.1.0`에 있으므로 중복 issue를 만들지 않는다. PR/push/merge/Nightly dispatch는 fresh exact-head 승인 게이트다.
+
+## 이번 실행의 검증 표본
+
+- regular module test: 352 tests, failures/skipped/errors 모두 0.
+- `clusterTest`: manifest의 17 tests, failures/skipped/errors 모두 0; exact names와 runtime provenance guard 통과.
+- `koverXmlReport`, root `detekt`, Gradle/custom ABI, `dependencyInsight`, static validators, `actionlint`, YAML parser, old Kotlin/new Java consumer compile 통과.
+- hosted Nightly와 PR은 실행하지 않았으므로 최종 전달 상태는 `PENDING`이다. `tommy351/redis-cluster:6.2`는 mutable tag이므로 digest pinning과 failover stress는 후속 hosted/fixture 이슈로 남긴다.

--- a/docs/review/2026-09-04-issue-854-redis-cluster-review.md
+++ b/docs/review/2026-09-04-issue-854-redis-cluster-review.md
@@ -1,0 +1,79 @@
+# Issue #854 Redis Cluster 지원 7-Tier 코드 리뷰
+
+## DoD 판정
+
+- 대상: `origin/develop` `c47324bcff5738e5505cf733d838afd730bad226`
+- 변경 branch/worktree: `feat/issue-854-redis-cluster`
+- 이슈: [#854](https://github.com/bluetape4k/bluetape4k-leader/issues/854), milestone `1.1.0`
+- 리뷰 모델: `gpt-5.6-luna`, effort `max`
+- 로컬 판정: **P0=0, P1=0, P2=4, P3=1**
+- 전달 판정: **PENDING** — hosted Nightly/PR/remote CI와 merge는 이 실행에서 권한을 사용하지 않았다.
+
+P1은 모두 구현 또는 검증으로 수렴했다. 독립 최종 재검토에서 지적된 stale legacy-index 정리,
+하위 우선순위 malformed source 표면화, Cluster matrix 범위, no-test guard는 이번 inline
+수정과 회귀 테스트로 해소했다. 다만 로컬 Testcontainers가 hosted Nightly를 대신하지 않으며,
+failover 성능 benchmark는 이슈의 비범위다.
+
+## 7-Tier 결과
+
+| Tier | 판단 및 근거 | 상태 |
+|---|---|---|
+| 1. Intent/Contract | Issue #854의 Cluster 지원, same-slot, migration/TTL, blocking/suspend parity 범위를 유지했다. 정상 contention은 기존 `null`/skip 계약을 바꾸지 않는다. | PASS |
+| 2. Architecture/API | `LettuceCandidateCommands.kt:15-92`, `LettuceSuspendCandidateCommands.kt:15-90`이 direct/script capability와 standalone/Cluster value reader를 분리한다. 네 elector의 `@JvmOverloads` standalone constructor와 additive Cluster constructor를 `...Strategic*Elector.kt:27-48`에서 확인했다. | PASS |
+| 3. Data/Redis | `LettuceCandidateKeyCodec.kt:23-58`의 v3 `{lengthDelimited(lockName)}` tag가 index/candidate/tombstone/token을 한 slot으로 묶는다. `LettuceCandidateWriteScript.kt:31-101`은 v3 key만 Lua `KEYS`에 받고 legacy source는 ARGV로만 전달한다. 실제 Cluster에서 `MGET`·Lua가 `CROSSSLOT` 없이 완료됐다. | PASS |
+| 4. Concurrency/Lifecycle | `LettuceCandidateRegistry.kt:121-137, 262-314`와 suspend 대응 코드가 persistent tombstone, `SET NX` migration token, raw+token compare cleanup을 적용한다. write-script barrier/token 테스트와 persistent source `PTTL=-1` 회귀 테스트가 통과했다. | PASS |
+| 5. Tests/CI | `build.gradle.kts:35-132`의 `clusterTest`는 test classes/classpath, tag 격리, `failOnNoDiscoveredTests`, 직렬 실행, checked-in 17개 manifest exact-name·XML·provenance guard를 갖는다. Nightly job/aggregator는 `.github/workflows/nightly-tests.yml:203-276,1294-1345`에 연결됐다. | 로컬 PASS; hosted PENDING |
+| 6. Security/Operations | `{}` lock-name 거부, caller-owned connection, `MOVED`/`ASK` topology 경계, v3 write 이후 old binary rollback 금지와 forward-fix 절차를 README/spec에 명시했다. connection/client/container를 registry가 닫지 않는다. | PASS |
+| 7. Docs/ABI/Release | README 양국어가 `7.6.0.RELEASE`, v3 migration, rollback 경계를 반영한다. custom ABI checker는 `artifacts=16 ignored=1 unknown=0`; Gradle `checkBinaryCompatibility`와 Kotlin/Java consumer compile이 통과했다. PR/push/merge/release는 실행하지 않았다. | 로컬 PASS; 전달 PENDING |
+
+## 주요 findings와 disposition
+
+| Severity | finding | disposition/evidence |
+|---|---|---|
+| P1 → 해소 | catalog가 7.7 주장과 실제 7.6 resolve가 어긋날 위험 | plan/spec/README를 `7.6.0.RELEASE`와 immutable ref `850959d0ea5f76ac7e2c442400f47653d5f95eed`로 고정하고 `dependencyInsight`로 재검증했다. |
+| P1 → 해소 | Kotlin default constructor synthetic ABI 삭제 위험 | 기존 `(StatefulRedisConnection,String,int,DefaultConstructorMarker)` descriptor를 `@JvmOverloads`로 보존했다. old Kotlin fixture가 synthetic call을 compile했고, new Java fixture가 Cluster two-arg constructor를 compile했다. |
+| P1 → 해소 | unregister와 migration resurrection race | same-slot persistent tombstone을 먼저 세우는 `UNREGISTER`, tombstone을 거부하는 `MIGRATE`, barrier 테스트로 순서를 고정했다. |
+| P1 → 해소 | 같은 raw payload의 destructive cleanup race | migration 성공 때 unique token을 기록하고 `REMOVE_IF_VALUE`가 raw와 token을 모두 비교한다. refresh/result/register는 token을 지운다. |
+| P1 → 해소 | Cluster task/CI false green | regular `test`에서 tag를 제외하고 `clusterTest`에 classpath/no-test/XML/skip guard 및 Nightly full-scope 판정을 추가했다. |
+| P2 → 해소 | v3 index에 남은 stale legacy version member가 다른 source를 가렸다. | blocking/suspend `listCandidates`가 v2·colon payload를 모두 preflight하고, stale member가 속한 index만 정리한다. `LettuceCandidateKeyIsolationTest`에서 current v3와 stale legacy index 조합을 각각 검증했다. |
+| P2 → 해소 | v3 payload가 유효해도 하위 우선순위 legacy source의 malformed payload가 short-circuit로 숨겨질 수 있었다. | 두 legacy version key를 모두 decode하고 malformed 예외를 표면화하도록 blocking/suspend lookup을 보정했다. 동일 회귀 테스트가 malformed lower-priority source를 고정한다. |
+| P2 | source `GET`/`PTTL`은 서로 다른 slot의 legacy key를 원자적으로 snapshot하지 못한다. | 설계상 bounded race로 명시했다. source는 script에서 삭제하지 않고 post-copy 재확인+v3 token cleanup만 수행한다. 실제 Cluster race/failover stress는 별도 후속 검증이다. |
+| P2 | `PTTL` 1ms/0/-2 및 runtime topology failover의 모든 조합은 hosted 환경에서 확인하지 않았다. | 코드가 `-1` persistent, `-2`/0 이하 만료 경계를 구분하고 positive TTL을 검증한다. hosted Nightly에서 확장 matrix를 실행해야 한다. |
+| P2 → 해소 | Cluster integration이 public elector lifecycle을 충분히 실행하지 않을 위험 | `LettuceStrategicRedisClusterTest`를 blocking/suspend single/group의 register·refresh·result·unregister, v2/colon migration·positive TTL, group cancellation, direct script cancellation까지 **17개** 독립 test로 확장했다. `redis-cluster-test-matrix.txt` manifest의 exact method names를 Gradle/CI가 모두 확인한다. |
+| P2 → 해소 | Cluster test scope가 count-only guard로 축소될 위험 | Gradle/Nightly가 checked-in manifest의 모든 testcase 이름 누락을 거부하고 `tests >= manifest`, `skipped=0`, `failures=0`, `errors=0`을 함께 단정한다. |
+| P2 → 해소 | Cluster fixture provenance가 image/tag와 runtime topology를 충분히 남기지 않을 위험 | 성공 artifact에 image reference와 실제 `@sha256:` digest, fixture/helper, `cluster_state=ok`, 6개 endpoint, mapped ports를 기록하고 Gradle/Nightly가 필수 provenance를 검증한다. mutable tag pinning은 upstream fixture/hosted Nightly 후속 범위로 남긴다. |
+| P2 | Cluster fixture provenance가 mutable `tommy351/redis-cluster:6.2` tag에만 의존한다. | 현재 실행은 실제 digest를 read-back해 증거화했지만 dependency/image reference 자체의 immutable pinning은 upstream fixture/hosted Nightly 후속 범위이므로 local PASS로 승격하지 않는다. |
+| P2 | `MOVED`/`ASK` failover 수렴은 의도적으로 성능 benchmark 범위 밖이다. | caller-owned topology refresh와 외부 장애 경계를 문서화했다. 별도 benchmark 이슈가 필요하다. |
+| P3 | test helper의 `!!`/reflection 의존 가능성은 운영 코드가 아닌 검증 보조 경로에 남아 있다. | 동작·ABI 검증을 막지 않는 low-risk 품질 항목으로 기록했다. production path에는 새 `!!`를 추가하지 않았다. |
+
+## 검증 증거
+
+| Check | 결과 |
+|---|---|
+| `:bluetape4k-leader-redis-lettuce:test` | 36 XML files, **352 tests, failures=0, skipped=0, errors=0** |
+| `:bluetape4k-leader-redis-lettuce:clusterTest` | **17 tests, failures=0, skipped=0, errors=0**; manifest exact names 모두 관찰, image `tommy351/redis-cluster:6.2`, 실제 `@sha256:78eb164a6e3380b733cb3cfb91f7c54f50cba42292bcdc21b969450161af9e89`, `cluster_state=ok`, 6개 endpoint, fixture/helper·Colima Docker socket provenance 기록 |
+| `koverXmlReport` | 생성 성공; INSTRUCTION `covered=11662/missed=2284`, BRANCH `covered=419/missed=239`, LINE `covered=1446/missed=246`, METHOD `covered=338/missed=67`, CLASS `covered=60/missed=10` |
+| `detekt` | root task `BUILD SUCCESSFUL`; module adapter의 기존 18건을 수리 후 clean |
+| ABI | `checkBinaryCompatibility` exit 0; custom `ABI inventory: artifacts=16 ignored=1 unknown=0` |
+| Consumer fixture | old Kotlin one-arg/default call compile, new Java Cluster two-arg call compile; `javap`에서 old synthetic 및 new Cluster descriptors 확인 |
+| Dependency | `io.lettuce:lettuce-core:7.6.0.RELEASE`, `dependencyInsight` exit 0 |
+| Static contracts | CI fan-out, Kover fail-closed, assertion, Exposed provider validators 모두 exit 0; `check_binary_api_test.py` 16 tests OK; `actionlint`와 YAML parser OK |
+| Regression | `LettuceCandidateLookupFailureTest` 8/8, `LettuceCandidateWriteScriptTest` 8/8, 전체 module 352/352 |
+
+첫 combined module→Cluster 실행에서는 fixture의 `awaitClusterReady()`가 node ping 중
+일시적인 `Invalid first byte`/`Connection reset by peer`로 2건을 실패시켰다. 실패 stack은
+제품 코드가 아닌 Testcontainers launcher 초기화 경계였고, 같은 SHA에서 즉시 단독 재실행한
+Cluster 17/17와 최종 순차 게이트 352/352 + 17/17가 모두 통과했다. 이 환경성 flake는
+hosted Nightly에서 재확인할 PENDING 위험으로 유지한다.
+
+## 운영·전달 경계
+
+- registry/elector는 connection, client, Testcontainers fixture를 소유하거나 닫지 않는다.
+- v3 write가 관찰된 뒤에는 old binary rollback이나 v3→v2 변환을 시도하지 않는다. writers를 멈추고 v2/colon/v3 상태와 diagnostics를 보존한 뒤 forward fix를 배포한다.
+- `clusterTest`는 local/수동 Nightly 전용이다. 일반 `test`와 benchmark로 대체할 수 없다.
+- 이슈 #854가 이미 존재하므로 중복 milestone issue는 만들지 않았다.
+- PR, push, merge, tag/release, hosted Nightly dispatch는 이 리뷰의 로컬 DoD를 넘어서는 별도 승인 게이트다.
+
+## 최종 판정
+
+로컬 구현·테스트·정적 분석·ABI·문서 검토에서 P0/P1은 0이다. 그러나 hosted Nightly/PR/remote CI가 실행되지 않았으므로 이 결과는 **DONE (local implementation)** 이 아니라 **PENDING (delivery gate)** 로 인계한다.

--- a/docs/superpowers/plans/2026-09-04-issue-854-redis-cluster-plan.md
+++ b/docs/superpowers/plans/2026-09-04-issue-854-redis-cluster-plan.md
@@ -1,0 +1,736 @@
+# Issue #854 Redis Cluster 공식 지원 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `leader-redis-lettuce`의 네 가지 strategic elector가 standalone Redis와 Redis Cluster를 동일한 후보·TTL·결과 계약으로 지원하도록 하고, hash-slot-safe key layout, v2/colon legacy migration, 실제 Cluster/Testcontainers 검증, ABI/API 및 양국어 문서를 완성한다.
+
+**Architecture:** 후보 key는 v3에서 lockName을 공통 hash tag로 감싸 index와 candidate multi-key 연산을 한 slot에 고정한다. blocking/suspend registry는 호출자가 소유한 standalone/Cluster connection을 각각의 Lettuce capability adapter로 감싸고, v3 후보만 batch read와 same-slot Lua를 사용한다. v2와 colon legacy source는 단일 key GET/PTTL로 읽어 CROSSSLOT을 피하고, v3 destination의 `SET NX`·index repair·lifecycle fence·migration token을 same-slot Lua로 원자화한다. unregister는 persistent tombstone으로 source resurrection을 차단하고, cleanup은 raw value와 unique token을 함께 비교한다. 네 public elector에는 기존 standalone JVM descriptor를 보존하는 명시적 Cluster secondary constructor를 추가한다.
+
+**Tech Stack:** Kotlin/JVM, Lettuce `7.6.0.RELEASE` (현재 catalog resolved version), Redis Cluster, JUnit 5, bluetape assertions, kotlinx-coroutines, Testcontainers `RedisClusterServer.Launcher.redisCluster`, Gradle `clusterTest`, Kover, detekt, binary API checker.
+
+---
+
+## 실행 상태 체크박스
+
+- [x] Task 1 — key codec와 slot 불변식
+- [x] Task 2 — scripting capability와 same-slot write Lua
+- [x] Task 3 — blocking registry capability adapter와 versioned precedence
+- [x] Task 4 — suspend registry parity와 cancellation
+- [x] Task 5 — 네 public elector의 additive Cluster API와 ABI
+- [x] Task 6 — 실제 Redis Cluster fixture와 전용 `clusterTest`
+- [x] Task 7 — README locale과 Nightly/manual CI gate
+- [x] Task 8 — review artifact, lesson, full verification
+
+## 0. 고정 전제와 실행 경계
+
+- 기준은 `origin/develop` `c47324bcff5738e5505cf733d838afd730bad226`이며 작업 branch/worktree는 `feat/issue-854-redis-cluster` / `.worktrees/feat/issue-854-redis-cluster`다.
+- 이 계획은 revised 설계를 실행 단위로 분해한다. resolved version·standalone ABI·lifecycle fence·migration token·Cluster CI guard 보정은 material design change이므로 이전 spec/plan 승인을 재사용하지 않고 fresh 사용자 승인을 받은 뒤에만 Task 1 구현을 시작한다.
+- `StatefulRedisConnection` 및 `StatefulRedisClusterConnection`은 호출자 소유다. registry/elector가 connection, client, container를 닫지 않는다.
+- 기존 `indexKey`/`candidateKey` 호출자는 v3를 사용한다. 기존 v2 및 colon key는 읽기·등록 migration source로만 유지하며 v3 write 이후 구버전 writer rollback은 지원하지 않는다. v3에는 node별 persistent tombstone/fence와 migration token key를 추가해 unregister→migration resurrection과 동일 payload cleanup race를 막는다.
+- 현재 dependency catalog immutable ref `850959d0ea5f76ac7e2c442400f47653d5f95eed`가 Lettuce `7.6.0.RELEASE`를 resolve한다. 이 이슈는 전역 catalog나 7.7 dependency upgrade를 포함하지 않으며, 구현 후 `dependencyInsight` 결과를 evidence로 남긴다.
+- `lockName` validation은 기존 `validateLockName`을 그대로 사용한다. `{}`는 hash-tag 경계 모호성을 없애기 위해 계속 거부한다.
+- Redis Cluster failover 성능 최적화와 별도 benchmark는 범위 밖이다. MOVED/ASK/topology refresh가 수렴하지 않는 외부 장애는 지원 계약의 성공으로 간주하지 않는다.
+- PR, push, merge, tag, release, branch/worktree 삭제와 Nightly dispatch는 구현·검증과 분리한다. 이 계획의 끝은 merge-ready 증거를 갖춘 로컬 상태다.
+
+## 1. 파일 소유와 변경 지도
+
+| 경로 | 작업 | 책임 |
+|---|---|---|
+| `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateKeyCodec.kt` | 수정 | v3 hash-tag key와 v2/legacy source codec |
+| `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/script/RedisScript.kt` | 수정 | sync/async scripting capability 공통 overload와 `NOSCRIPT` 계약 |
+| `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateWriteScript.kt` | 신규 | register 및 same-slot migration write Lua |
+| `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRefreshScript.kt` | 수정 | v3 same-slot refresh 결과와 TTL 상태 |
+| `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateIndexCleanupScript.kt` | 수정 | v3 candidate 존재 확인 후 stale index 정리 |
+| `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateCommands.kt` | 신규 | blocking direct/script capability와 standalone/Cluster value reader |
+| `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt` | 수정 | blocking capability adapter, v3 read/migration/precedence |
+| `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateCommands.kt` | 신규 | suspend direct/script capability와 standalone/Cluster coroutine value reader |
+| `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt` | 수정 | suspend capability adapter와 blocking parity |
+| `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElector.kt` | 수정 | standalone descriptor 보존 및 Cluster constructor |
+| `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElector.kt` | 수정 | group standalone descriptor 보존 및 Cluster constructor |
+| `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElector.kt` | 수정 | suspend standalone descriptor 보존 및 Cluster constructor |
+| `leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElector.kt` | 수정 | suspend group standalone descriptor 보존 및 Cluster constructor |
+| `leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateKeyCodecTest.kt` | 신규 | v3/v2 key, UTF-8 length, slot 불변식, brace validation |
+| `leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateKeyIsolationTest.kt` | 수정 | v2/legacy migration과 v3 precedence 회귀 |
+| `leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateWriteScriptTest.kt` | 신규 | write Lua 반환 상태와 TTL 경계 |
+| `leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicRedisClusterTest.kt` | 신규 | 기존 Launcher 기반 Cluster fixture, 네 elector lifecycle, MGET/Lua/CROSSSLOT/migration matrix |
+| `leader-redis-lettuce/build.gradle.kts` | 수정 | `clusterTest` tagged Test task |
+| `.github/workflows/nightly-tests.yml` | 수정 | Cluster 전용 Nightly job, artifact, aggregator needs |
+| `leader-redis-lettuce/README.md` | 수정 | English Cluster constructor/운영 경계 |
+| `leader-redis-lettuce/README.ko.md` | 수정 | Korean Cluster constructor/운영 경계 |
+| `docs/review/2026-09-04-issue-854-redis-cluster-review.md` | 신규 | 7-Tier pre-PR review와 P0/P1 수렴 |
+| `docs/lessons/2026-09-04-issue-854-redis-cluster.md` | 신규 | 재사용 가능한 key/migration/fixture lesson |
+| `.flow-inputs/issue-854-workflow/2026-09-04-checklist.md` | 갱신 | 각 gate의 fresh command/count/evidence |
+
+소유권은 main lane에 고정한다. 독립 subagent는 계획·최종 diff의 read-only 검토만 수행하며 위 파일을 수정하지 않는다.
+
+## 2. Acceptance traceability
+
+| 승인된 acceptance | 구현 작업 | 검증 증거 |
+|---|---|---|
+| 네 strategic elector가 standalone/Cluster를 지원하고 기존 descriptor가 유지됨 | Task 5 | `javap`, binary API checker, Kotlin/Java consumer compile, Cluster matrix |
+| v3 index/candidate가 동일 slot이고 v2/colon key collision이 없음 | Task 1, 3 | codec unit, `SlotHash`, 실제 Cluster multi-key/MGET, `CROSSSLOT` 부재 |
+| v3 register/refresh/result/index cleanup이 same-slot 원자 경계를 지킴 | Task 2, 3 | Lua unit/Cluster 실행, concurrent reader, stale-cleanup |
+| v2와 colon source가 v3보다 낮은 precedence로 migration됨 | Task 3, 4 | source precedence, concurrent migration race, destination repair, old source 보존 |
+| unregister가 source migration으로 되살아나지 않고 cleanup이 다른 writer를 삭제하지 않음 | Task 2, 3, 6 | persistent tombstone barrier, migration token+raw compare, deterministic race/ownership tests |
+| TTL 0/positive/expired 경계와 결과 통계 보존 | Task 2–4 | PTTL/SET NX tests, heartbeat tests, post-copy expiry race |
+| blocking/suspend가 command/cancellation 의미를 보존함 | Task 3, 4 | 네 elector lifecycle 및 cancellation tests |
+| 실제 Cluster fixture가 Nightly/manual 전용으로 실행됨 | Task 6, 7 | `clusterTest`, fixture image/ref/digest, cluster_state/endpoints/logs artifact |
+| 문서·호환성·운영 rollout 경계가 코드와 일치함 | Task 7, 8 | README locale diff, review artifact, `git diff --check` |
+| P0/P1이 0이고 release/PR 경계가 분리됨 | Task 8 | 7-Tier review, checklist counts, no push/PR evidence |
+
+## 3. Task 1 — key codec와 slot 불변식 (RED → GREEN)
+
+**Files:** `LettuceCandidateKeyCodec.kt`, 신규 `LettuceCandidateKeyCodecTest.kt`, 기존 `LettuceCandidateKeyIsolationTest.kt`.
+
+1. `[ ]` RED: 다음 테스트를 먼저 추가한다. `io.bluetape4k.assertions`와 기존 프로젝트 test idiom을 사용하고, 테스트 이름은 동작을 명시한다.
+
+   ```kotlin
+   class LettuceCandidateKeyCodecTest {
+       @Test
+       fun `v3 index and candidate keys share the lock hash slot`() {
+           val prefix = "leader:strategy:candidates"
+           val lockName = "결정:lock"
+           val nodeId = "node:1"
+           val index = LettuceCandidateKeyCodec.indexKey(prefix, lockName)
+           val candidate = LettuceCandidateKeyCodec.candidateKey(prefix, lockName, nodeId)
+
+           index shouldBe "leader:strategy:candidates|v3|i|{11:결정:lock}"
+           candidate shouldBe "leader:strategy:candidates|v3|c|{11:결정:lock}6:node:1"
+           SlotHash.getSlot(StringCodec.UTF8.encodeKey(index)) shouldBe
+               SlotHash.getSlot(StringCodec.UTF8.encodeKey(candidate))
+       }
+
+       @Test
+       fun `v2 and colon source keys remain addressable without sharing v3 namespace`() {
+           val prefix = "leader:strategy:candidates"
+           val lockName = "a:b"
+           val nodeId = "n:1"
+
+           LettuceCandidateKeyCodec.v2IndexKey(prefix, lockName) shouldBe
+               "leader:strategy:candidates|v2|i|3:a:b"
+           LettuceCandidateKeyCodec.v2CandidateKey(prefix, lockName, nodeId) shouldBe
+               "leader:strategy:candidates|v2|c|3:a:b3:n:1"
+           LettuceCandidateKeyCodec.legacyCandidateKey(prefix, lockName, nodeId) shouldBe
+               "leader:strategy:candidates:a:b:n:1"
+       }
+
+       @Test
+       fun `lock names containing braces remain rejected`() {
+           assertFailsWith<IllegalArgumentException> { validateLockName("a{b") }
+           assertFailsWith<IllegalArgumentException> { validateLockName("a}b") }
+       }
+   }
+   ```
+
+2. `[ ]` RED 검증: `./gradlew :bluetape4k-leader-redis-lettuce:test --tests '*LettuceCandidateKeyCodecTest*' --no-daemon --no-configuration-cache --no-build-cache --console=plain`을 실행한다. 구현 전에는 v2 문자열/누락된 helper 때문에 실패해야 하며, compile 환경 실패는 RED 증거로 인정하지 않는다.
+3. `[ ]` GREEN 구현: codec의 버전을 `v3`으로 전환하고 다음 API를 유지한다. `lengthDelimited`는 UTF-8 byte length를 사용한다.
+
+   ```kotlin
+   internal object LettuceCandidateKeyCodec {
+       private const val CURRENT_VERSION = "v3"
+       private const val PREVIOUS_VERSION = "v2"
+       private const val INDEX_TYPE = "i"
+       private const val CANDIDATE_TYPE = "c"
+       private const val NAMESPACE_SEPARATOR = "|"
+
+       fun indexKey(keyPrefix: String, lockName: String): String =
+           "$keyPrefix|$CURRENT_VERSION|$INDEX_TYPE|{" + lengthDelimited(lockName) + "}"
+
+       fun candidateKey(keyPrefix: String, lockName: String, nodeId: String): String =
+           "$keyPrefix|$CURRENT_VERSION|$CANDIDATE_TYPE|{" +
+               lengthDelimited(lockName) + "}" + lengthDelimited(nodeId)
+
+       fun tombstoneKey(keyPrefix: String, lockName: String, nodeId: String): String =
+           "$keyPrefix|$CURRENT_VERSION|t|{" +
+               lengthDelimited(lockName) + "}" + lengthDelimited(nodeId)
+
+       fun migrationTokenKey(keyPrefix: String, lockName: String, nodeId: String): String =
+           "$keyPrefix|$CURRENT_VERSION|m|{" +
+               lengthDelimited(lockName) + "}" + lengthDelimited(nodeId)
+
+       internal fun v2IndexKey(keyPrefix: String, lockName: String): String =
+           "$keyPrefix|$PREVIOUS_VERSION|$INDEX_TYPE|" + lengthDelimited(lockName)
+
+       internal fun v2CandidateKey(keyPrefix: String, lockName: String, nodeId: String): String =
+           "$keyPrefix|$PREVIOUS_VERSION|$CANDIDATE_TYPE|" +
+               lengthDelimited(lockName) + lengthDelimited(nodeId)
+
+       fun legacyIndexKey(keyPrefix: String, lockName: String): String = "$keyPrefix:$lockName"
+
+       fun legacyCandidateKey(keyPrefix: String, lockName: String, nodeId: String): String =
+           "${legacyIndexKey(keyPrefix, lockName)}:$nodeId"
+
+       private fun lengthDelimited(value: String): String {
+           val byteLength = value.toByteArray(StandardCharsets.UTF_8).size
+           return "$byteLength:$value"
+       }
+   }
+   ```
+
+   `NAMESPACE_SEPARATOR`는 기존 코드 가독성을 위해 유지하되 key 조합은 exact string으로 검증한다. `{lengthDelimited(lockName)}`만 hash tag이며 nodeId는 tag 밖이다. tombstone/token helper도 같은 tag를 공유하고, v2/legacy helper는 migration fixture 전용으로 유지한다.
+4. `[ ]` GREEN 검증: 위 targeted test가 `BUILD SUCCESSFUL` 및 모든 assertion pass를 출력해야 한다. 기존 key-isolation tests의 v2 fixture helper를 `v2IndexKey`/`v2CandidateKey`로 바꾸고 전체 isolation test도 pass시킨다.
+5. `[ ]` 커밋 시점에는 Korean Lore intent/trailers를 사용하고, plan/checklist의 evidence를 즉시 갱신한다. 커밋은 별도 사용자 PR/merge 승인으로 간주하지 않는다.
+
+## 4. Task 2 — scripting capability와 same-slot write Lua (RED → GREEN)
+
+**Files:** `RedisScript.kt`, 신규 `LettuceCandidateWriteScript.kt`, 신규 `LettuceCandidateWriteScriptTest.kt`, `LettuceCandidateRefreshScript.kt`, `LettuceCandidateIndexCleanupScript.kt`.
+
+1. `[ ]` RED: script runner의 standalone/Cluster capability compile surface와 `NOSCRIPT` fallback을 고정한다. 공통 overload의 외부 계약은 다음과 같다.
+
+   ```kotlin
+   fun <T> run(
+       commands: RedisScriptingCommands<String, String>,
+       script: RedisScript,
+       outputType: ScriptOutputType,
+       keys: Array<String>,
+       vararg args: String,
+   ): T
+
+   fun <T> runAsync(
+       commands: RedisScriptingAsyncCommands<String, String>,
+       script: RedisScript,
+       outputType: ScriptOutputType,
+       keys: Array<String>,
+       vararg args: String,
+   ): CompletableFuture<T>
+
+   suspend fun <T> runSuspending(
+       commands: RedisScriptingAsyncCommands<String, String>,
+       script: RedisScript,
+       outputType: ScriptOutputType,
+       keys: Array<String>,
+       vararg args: String,
+   ): T
+   ```
+
+   기존 `RedisCommands`/`RedisAsyncCommands` overload와 `evalsha` 우선, `RedisNoScriptException`일 때 원문 fallback, 그 외 예외 cause 보존, suspend cancellation 전파를 유지한다. 공통 구현은 private helper로 수렴하고 public overload descriptor는 삭제하지 않는다.
+
+2. `[ ]` RED 검증: 신규 runner test 또는 compile-only contract test가 overload 부재로 실패하는지 확인한다. 가짜 `CROSSSLOT` 예외를 성공으로 처리하지 말고 실제 Cluster test에서 재검증한다.
+3. `[ ]` GREEN 구현: `LettuceCandidateWriteScript`에 register, migrate, unregister, token-guarded cleanup script를 정의한다. 모든 multi-key script는 v3 candidate/index/tombstone/token만 `KEYS`로 받고 호출자는 네 key가 같은 tag임을 먼저 보장한다. v2/colon source는 어떤 script에도 전달하지 않는다.
+
+   ```kotlin
+   internal object LettuceCandidateWriteScript {
+       const val ABSENT = 0L
+       const val WRITTEN = 1L
+       const val EXISTING_REPAIRED = 2L
+
+       val REGISTER = RedisScript(
+           """
+           local ttl = tonumber(ARGV[2])
+           if ttl and ttl < 0 then
+             return redis.error_reply('ERR invalid candidate TTL')
+           end
+           redis.call('DEL', KEYS[3], KEYS[4])
+           if ttl and ttl > 0 then
+             redis.call('PSETEX', KEYS[1], ttl, ARGV[1])
+           else
+             redis.call('SET', KEYS[1], ARGV[1])
+           end
+           redis.call('SADD', KEYS[2], ARGV[3])
+           redis.call('PERSIST', KEYS[2])
+           return { $WRITTEN }
+           """.trimIndent(),
+       )
+
+       val MIGRATE = RedisScript(
+           """
+           if redis.call('EXISTS', KEYS[3]) == 1 then
+             return { $ABSENT }
+           end
+           local ttl = tonumber(ARGV[2])
+           if not ttl or ttl == -2 or ttl <= 0 and ttl ~= -1 then
+             return { $ABSENT }
+           end
+           local written
+           if ttl == -1 then
+             written = redis.call('SET', KEYS[1], ARGV[1], 'NX')
+           else
+             written = redis.call('SET', KEYS[1], ARGV[1], 'NX', 'PX', ttl)
+           end
+           if not written then
+             if redis.call('EXISTS', KEYS[1]) == 1 then
+               redis.call('SADD', KEYS[2], ARGV[3])
+               redis.call('PERSIST', KEYS[2])
+               return { $EXISTING_REPAIRED }
+             end
+             return { $ABSENT }
+           end
+           redis.call('SADD', KEYS[2], ARGV[3])
+           redis.call('PERSIST', KEYS[2])
+           redis.call('SET', KEYS[4], ARGV[4])
+           return { $WRITTEN }
+           """.trimIndent(),
+       )
+
+       val UNREGISTER = RedisScript(
+           """
+           redis.call('SET', KEYS[3], ARGV[1])
+           redis.call('DEL', KEYS[1], KEYS[4])
+           redis.call('SREM', KEYS[2], ARGV[2])
+           return 1
+           """.trimIndent(),
+       )
+
+       val REMOVE_IF_VALUE = RedisScript(
+           """
+           if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+             return 0
+           end
+           if redis.call('GET', KEYS[3]) ~= ARGV[3] then
+             return 0
+           end
+           local removed = redis.call('DEL', KEYS[1], KEYS[3])
+           redis.call('SREM', KEYS[2], ARGV[2])
+           return removed
+           """.trimIndent(),
+       )
+   }
+   ```
+
+   `MIGRATE`는 candidate/index/tombstone/token 순서로, `REMOVE_IF_VALUE`는 candidate/index/token 순서로 key를 전달한다. 성공적인 `SET NX` 때만 `ARGV[4]` unique token을 persistent하게 기록하고, destination이 이미 있으면 token을 탈취하지 않고 index를 `SADD`/`PERSIST`로 repair한 뒤 `EXISTING_REPAIRED`를 반환한다. `UNREGISTER`는 tombstone을 먼저 persistent하게 세워 migration을 차단한 뒤 candidate/token/index를 정리한다. `ttl == 0`은 migration에서는 source 부재/만료로 취급하며, register의 `ttl == 0`만 persistent다. negative TTL은 호출자 validation과 기존 예외 계약을 유지한다.
+   Migration source key는 Lua `KEYS`에 넣지 않는다. source GET/PTTL은 single-key command로 수행하고, 복사 대상 v3 key만 same-slot Lua에 넣는다. source read 직후 unregister가 실행되는 barrier race에서는 Redis script 원자 순서에 따라 tombstone이 migration을 거부하거나 unregister가 destination을 제거한다. raw value만 비교해 삭제하지 않고 token과 함께 비교해 동일 payload를 다시 쓴 writer를 보호한다.
+4. `[ ]` GREEN 구현: refresh/result/cleanup script 호출은 v3 key만 받도록 정리한다. refresh는 candidate/index/token, result는 candidate/token을 same-slot `KEYS`로 받아 regular writer가 migration token을 해제한다. malformed payload는 기존 `LettuceCandidateInfoCodec` 예외를 그대로 다시 던지고, absent candidate를 새로 생성하지 않는다. register는 tombstone/token을 먼저 지우고, migration은 tombstone 존재 시 `ABSENT`, 성공 시 unique token, 기존 destination 시 `EXISTING_REPAIRED`를 반환하며, unregister는 persistent tombstone을 세운다.
+5. `[ ]` GREEN 검증: write script unit/fixture test에서 persistent, positive PTTL, `-1`, `-2`, non-positive 경계, tombstone refusal, unregister ordering, token+raw compare cleanup 및 same-payload writer 보호를 확인한다. `git diff --check`를 실행하고 script return status와 exception cause를 checklist에 기록한다.
+
+## 5. Task 3 — blocking registry capability adapter와 versioned precedence
+
+**Files:** `LettuceCandidateRegistry.kt`, `LettuceCandidateKeyIsolationTest.kt`, `LettuceStrategicHeartbeatTest.kt`.
+
+1. `[ ]` RED: standalone/Cluster constructor compile surface와 다음 precedence를 검증하는 테스트를 먼저 추가한다.
+
+   ```kotlin
+   // v3 값이 있으면 v2/colon 값이 달라도 v3만 반환한다.
+   registry.registerCandidate(lockName, v3Info, Duration.ZERO)
+   standalone.sync().set(v2Key, encodedV2)
+   standalone.sync().set(legacyKey, encodedLegacy)
+   registry.listCandidates(lockName).single() shouldBe v3Info
+
+   // v3가 없으면 v2가 colon legacy보다 우선하고, destination/index를 repair한다.
+   standalone.sync().del(v3Key, v3Index)
+   registry.listCandidates(lockName).single() shouldBe v2Info
+   standalone.sync().smembers(v3Index) shouldContain nodeId
+   ```
+
+2. `[ ]` RED 검증: 기존 registry가 standalone connection만 수용하므로 Cluster constructor test가 compile 실패하거나 v3 precedence assertion이 실패해야 한다.
+3. `[ ]` GREEN 설계: blocking registry는 caller-facing constructor 두 개와 private narrow adapter를 사용한다. adapter는 single-key/set/script를 `RedisCommands`/`RedisClusterCommands`의 실제 capability에 위임하고, batch reader만 별도로 둔다.
+
+   ```kotlin
+   internal class LettuceCandidateRegistry private constructor(
+       private val commands: BlockingCandidateCommands,
+       private val readMany: CandidateValueReader,
+       private val keyPrefix: String,
+   ) {
+       // 기존 internal one-argument call site/fixture를 위한 compatibility bridge
+       internal constructor(
+           commands: BlockingCandidateCommands,
+           keyPrefix: String = DEFAULT_KEY_PREFIX,
+       ) : this(
+           commands,
+           CandidateValueReader { keys -> keys.associateWith { commands.get(it) } },
+           keyPrefix,
+       )
+
+       constructor(
+           connection: StatefulRedisConnection<String, String>,
+           keyPrefix: String = DEFAULT_KEY_PREFIX,
+       ) : this(
+           StandaloneBlockingCandidateCommands(connection.sync()),
+           StandaloneCandidateValueReader(connection.sync()),
+           keyPrefix,
+       )
+
+       constructor(
+           connection: StatefulRedisClusterConnection<String, String>,
+           keyPrefix: String = DEFAULT_KEY_PREFIX,
+       ) : this(
+           ClusterBlockingCandidateCommands(connection.sync()),
+           ClusterCandidateValueReader(connection.sync()),
+           keyPrefix,
+       )
+   }
+
+   private fun interface CandidateValueReader {
+       fun read(keys: List<String>): Map<String, String?>
+   }
+
+   private class StandaloneCandidateValueReader(
+       private val commands: RedisCommands<String, String>,
+   ) : CandidateValueReader {
+       override fun read(keys: List<String>): Map<String, String?> =
+           keys.associateWith { commands.get(it) }
+   }
+
+   private class ClusterCandidateValueReader(
+       private val commands: RedisAdvancedClusterCommands<String, String>,
+   ) : CandidateValueReader {
+       override fun read(keys: List<String>): Map<String, String?> =
+           commands.mget(*keys.toTypedArray()).associate { value ->
+               value.key to value.value
+           }
+   }
+   ```
+
+   실제 Lettuce 타입이 제공하는 공통 parent가 다르면 adapter 내부에서만 concrete type을 조정한다. public constructor와 script runner overload는 변경하지 않는다. standalone과 Cluster `MGET`은 v3 candidate keys만 호출하며, Cluster key는 모두 동일 lockName tag를 가진다. v2/colon source는 단건 `GET`/`PTTL`로만 읽는다. 기존 internal one-argument registry 호출자는 compatibility bridge를 통해 같은 command/read capability를 유지한다.
+
+4. `[ ]` GREEN 구현 세부:
+   - `registerCandidate`: v3 candidate/index를 `REGISTER` Lua로 기록한다. index TTL은 항상 `PERSIST`한다.
+   - `listCandidates`: v3 index `SMEMBERS` → `CandidateValueReader.read` → decode/expected nodeId 확인 → stale/mismatch cleanup 순서로 실행한다. v3가 없거나 node가 빠졌을 때 v2 index/candidate를 single-key로 읽고, 마지막으로 colon index/candidate를 읽는다. node별 tombstone이 있으면 해당 source candidate를 숨기고 migration하지 않는다.
+   - source precedence는 `v3 > v2 > colon legacy`이며 malformed payload는 다음 source로 조용히 fall through하지 않는다. mismatch는 기존 stale-index 정리 계약을 따른다.
+   - migration은 source candidate의 `GET` 및 `PTTL`을 각각 single-key로 관찰한 뒤 destination candidate/index/tombstone/token만 `MIGRATE` Lua에 전달한다. tombstone이 생기면 `ABSENT`, `ttl == -1`은 `SET NX`, positive는 관찰 PTTL 이하의 `SET NX PX`, `-2`/`<=0`은 skip한다. 성공한 호출만 unique token을 저장한다.
+   - copy 후 source를 다시 `GET`/`PTTL`하여 만료가 확인되고 destination write가 이 호출에서 성공한 경우에만 destination raw value와 migration token이 모두 일치할 때 same-slot `REMOVE_IF_VALUE`로 best-effort cleanup을 수행한다. 다른 writer가 같은 payload를 다시 썼거나 token을 지웠다면 삭제하지 않는다. source key는 절대 삭제하지 않으며 bounded stale window를 문서화한다.
+   - `refreshCandidate`와 `updateResult`는 v3 destination이 없을 때 node tombstone을 확인한 뒤 v2 → colon 순서로 migration을 시도하고 v3 same-slot script를 호출한다. v3 destination을 갱신할 때는 migration token을 함께 지워 stale cleanup ownership을 해제한다. `unregisterCandidate`는 v3 `UNREGISTER` Lua로 tombstone 설정·v3 candidate/token/index 정리를 원자화한 후 v2/colon source와 각 index member를 single-key로 정리한다.
+   - deterministic barrier test는 source GET/PTTL 이후 `unregisterCandidate`를 실행하고 migration을 재개한다. 결과는 tombstone 유지, v3 destination/index 부재, source 비노출이며, 이후 `registerCandidate`가 tombstone을 지우고 새 generation을 시작하는 것도 확인한다.
+
+5. `[ ]` GREEN 검증:
+   - `./gradlew :bluetape4k-leader-redis-lettuce:test --tests '*LettuceCandidateKeyIsolationTest*' --tests '*LettuceStrategicHeartbeatTest*' --no-daemon --no-configuration-cache --no-build-cache --console=plain`이 pass한다.
+   - 테스트에서 v3/v2/colon collision, v2 TTL 보존, concurrent `SET NX` winner 하나, stale index cleanup, result counter 보존을 확인한다.
+   - source와 destination이 같은 raw payload인 상태에서 새 register/refresh가 token을 교체한 뒤 이전 cleanup을 호출해도 destination/index가 보존되는지 확인한다. migration Lua의 `KEYS`에 source key가 없고 실제 Cluster에서 `CROSSSLOT`이 발생하지 않는지도 검증한다.
+
+## 6. Task 4 — suspend registry parity와 cancellation
+
+**Files:** `LettuceSuspendCandidateRegistry.kt`, `LettuceStrategicSuspendLeaderElector.kt`, `LettuceStrategicSuspendLeaderGroupElector.kt`, suspend lifecycle tests.
+
+1. `[ ]` RED: `StatefulRedisClusterConnection.coroutines()`와 `async()`를 사용하는 suspend constructor/matrix test 및 cancellation test를 추가한다. cancellation 중 direct command와 script future가 각각 취소되고 `CancellationException`이 삼켜지지 않아야 한다. in-flight migration, refresh, result update, `runIfLeader` action cancellation을 별도 test method로 고정한다.
+2. `[ ]` GREEN 구현: blocking adapter와 동일한 key/precedence/migration 알고리즘을 suspend command로 구현한다. tombstone refusal, token-guarded cleanup, source preservation을 blocking path와 동일하게 유지한다.
+
+   ```kotlin
+   @file:OptIn(ExperimentalLettuceCoroutinesApi::class)
+
+   private constructor(
+       private val commands: SuspendCandidateCommands,
+       private val readMany: SuspendCandidateValueReader,
+       private val keyPrefix: String,
+   )
+
+   constructor(
+       connection: StatefulRedisConnection<String, String>,
+       keyPrefix: String = DEFAULT_KEY_PREFIX,
+   ) : this(
+       StandaloneSuspendCandidateCommands(connection.coroutines(), connection.async()),
+       StandaloneSuspendCandidateValueReader(connection.coroutines()),
+       keyPrefix,
+   )
+
+   constructor(
+       connection: StatefulRedisClusterConnection<String, String>,
+       keyPrefix: String = DEFAULT_KEY_PREFIX,
+   ) : this(
+       ClusterSuspendCandidateCommands(connection.coroutines(), connection.async()),
+       ClusterSuspendCandidateValueReader(connection.coroutines()),
+       keyPrefix,
+   )
+   ```
+
+   direct command는 `RedisClusterCoroutinesCommands`, script는 `RedisScriptingAsyncCommands`로 분리한다. standalone `RedisCoroutinesCommands`는 adapter에서 직접 위임한다. script는 `RedisScriptRunner.runSuspending`와 `await()`를 사용하고, `CancellationException`은 기존 `updateStrategicResultPreservingCancellation` 경계를 통해 재전파한다.
+3. `[ ]` GREEN 검증: blocking과 동일한 fixture에 대해 suspend single/group register, list, refresh, updateResult, migration, stale cleanup을 실행한다. `runIfLeader` action cancellation, direct command cancellation, script future cancellation을 별도 assertion으로 확인하고 cause가 `CancellationException`인지 검증한다. unregister/migration barrier와 same-payload token ownership도 suspend에서 확인한다.
+4. `[ ]` 정적 검증: 새 `!!`, `runBlocking` production 사용, cancellation catch 후 무시, caller connection close가 없는지 `rg`와 detekt로 확인한다.
+
+## 7. Task 5 — 네 public elector의 additive Cluster API와 ABI
+
+**Files:** 네 `LettuceStrategic*Elector.kt`, 관련 contract tests, consumer compile fixture.
+
+1. `[ ]` RED: 기준 develop artifact에서 네 클래스의 `javap -p -s` descriptor set을 저장하고, precompiled Kotlin one-argument consumer와 Java two-argument consumer가 현재 standalone constructor를 호출하는지 확인한다. 네 클래스 각각에 Cluster one-/two-argument constructor reflection/compile test를 추가한다. 기존 standalone descriptor와 default nodeId 동작도 함께 고정한다.
+2. `[ ]` GREEN 구현: primary constructor를 private registry/nodeId 형태로 바꾸고 다음 명시적 public overload를 네 클래스에 각각 적용한다. Group 클래스는 `GROUP_KEY_PREFIX`를 계속 사용한다.
+
+   ```kotlin
+   class LettuceStrategicLeaderElector private constructor(
+       private val registry: LettuceCandidateRegistry,
+       override val nodeId: String,
+   ) : StrategicLeaderElector {
+       @JvmOverloads
+       constructor(
+           connection: StatefulRedisConnection<String, String>,
+           nodeId: String = Uuid.V7.nextBase62(),
+       ) : this(LettuceCandidateRegistry(connection), nodeId)
+
+       @JvmOverloads
+       constructor(
+           connection: StatefulRedisClusterConnection<String, String>,
+           nodeId: String = Uuid.V7.nextBase62(),
+       ) : this(LettuceCandidateRegistry(connection), nodeId)
+   }
+   ```
+
+   Group/suspend/suspend-group도 registry 종류와 interface만 바꾼 동일한 descriptor 집합을 갖는다. standalone secondary constructor의 `@JvmOverloads`와 Kotlin default synthetic bridge를 의도적으로 유지하고, Cluster overload는 명시적 새 descriptor로 추가한다. `javap -p -s` 결과는 기준과 after를 diff하며, compatibility checker가 synthetic descriptor를 생략해도 precompiled Kotlin consumer compile을 별도 필수 증거로 삼는다. `RedisScriptRunner`의 기존 overload도 standalone/Cluster capability 각각에 대해 descriptor와 consumer compile을 별도로 확인한다.
+3. `[ ]` GREEN 검증:
+   - `./gradlew :bluetape4k-leader-redis-lettuce:compileKotlin :bluetape4k-leader-redis-lettuce:compileTestKotlin --no-daemon --no-configuration-cache --no-build-cache --console=plain`
+   - `./gradlew checkBinaryCompatibility --no-daemon --no-configuration-cache --no-build-cache --console=plain`
+   - `python3 scripts/compatibility/check_binary_api.py`
+   - 기준/after artifact에 `javap -p -s`를 실행해 네 elector와 `RedisScriptRunner`의 old/new descriptor를 비교한다.
+   - precompiled Kotlin fixture가 standalone one-/two-arg 및 Cluster one-/two-arg constructor를 compile하고, Java fixture가 명시적 public descriptor를 compile한다.
+4. `[ ]` ABI 결과를 이전 develop baseline과 비교한다. 삭제/변경 descriptor가 있거나 Kotlin fixture가 synthetic bridge를 호출하지 못하면 Task 5를 멈추고 compatibility repair 후 같은 명령을 다시 실행한다.
+
+## 8. Task 6 — 실제 Redis Cluster fixture와 전용 `clusterTest`
+
+**Files:** 신규 `LettuceStrategicRedisClusterTest.kt`, `leader-redis-lettuce/build.gradle.kts`.
+
+1. `[ ]` RED: `@Tag("redis-cluster")` 테스트와 전용 task를 먼저 추가한다. regular `test`가 이 tag를 실행하지 않는지 확인한다.
+2. `[ ]` GREEN fixture는 `bluetape4k-testcontainers:2.1.0-SNAPSHOT`의 기존 Testcontainers helper와 기본 image `tommy351/redis-cluster:6.2`를 재사용한다. 새 raw container를 만들지 않는다. 테스트 task가 시작할 때 `build/redis-cluster-diagnostics/`를 먼저 만들고 fixture는 provenance를 즉시 기록하므로, startup failure에서도 artifact 경로가 사라지지 않는다.
+
+   ```kotlin
+   abstract class AbstractLettuceClusterTest {
+       companion object {
+           @JvmStatic
+           protected val redisCluster = RedisClusterServer.Launcher.redisCluster
+
+           @JvmStatic
+           protected val clusterClient by lazy {
+               RedisClusterServer.Launcher.LettuceLib.getClusterClient(redisCluster)
+           }
+
+           @JvmStatic
+           protected val clusterConnection by lazy {
+               clusterClient.connect(StringCodec.UTF8).also { connection ->
+                   ShutdownQueue.register { connection.closeSafe() }
+               }
+           }
+       }
+   }
+   ```
+
+   fixture image/ref/digest, cluster state, node endpoints, topology refresh, container logs/events는 startup 후 provenance 파일과 CI failure hook에서 수집한다. 현재 테스트는 `LettuceStrategicRedisClusterTest` 내부 helper로 기존 Launcher를 감싸며, task/CI가 provenance·JUnit XML·failure diagnostics를 검증한다. 테스트 시작 시 실제 image reference와 digest를 read-back하고 `CLUSTER INFO`의 `cluster_state:ok`, `CLUSTER NODES` endpoint를 기록한다. registry/elector는 connection을 닫지 않고, helper의 `use` 정리만 사용한다.
+3. `[x]` 테스트 matrix를 다음 순서로 구현한다.
+   - blocking single elector: `DEFAULT_KEY_PREFIX`, register/list/refresh/result/unregister.
+   - blocking group elector: `GROUP_KEY_PREFIX`, top-N list와 same-slot index/candidate.
+   - suspend single/group: 동일 동작 및 cancellation.
+   - standalone과 실제 Cluster `MGET`은 v3 candidate만 대상으로 실행하고, v2/colon source는 per-key `GET`/`PTTL`만 실행한다.
+   - refresh/register/migration/stale-cleanup Lua를 실제 Cluster에서 실행하고 `CROSSSLOT` 문자열이 없어야 한다.
+   - write-script unit test에서 concurrent migration의 하나의 destination winner, index repair, source expiry race, malformed payload 경계를 고정하고, `NOSCRIPT` fallback은 기존 runner contract로 검증한다.
+   - `LettuceCandidateWriteScriptTest`의 barrier test에서 source GET/PTTL 뒤 unregister가 migration을 거부하고, 이후 register가 tombstone을 지우는지 확인한다.
+   - migration token과 raw value가 모두 일치할 때만 cleanup되고, 동일 payload를 다시 쓴 writer의 destination은 보존되는지 확인한다.
+   - 실제 Cluster matrix는 `LettuceStrategicRedisClusterTest`의 17개 독립 test method로 추적하고, 필수 이름은 `src/test/resources/redis-cluster-test-matrix.txt` manifest에 고정한다. JUnit XML에서 `tests >= 17`, manifest 이름 누락 없음, `skipped == 0`, `failures == 0`, `errors == 0`을 확인하고, no-test/축소된 scope는 `failOnNoDiscoveredTests`와 별도 XML guard로 실패시킨다.
+4. `[x]` Gradle task를 다음처럼 등록한다.
+
+   ```kotlin
+   import org.gradle.api.tasks.testing.Test
+
+   tasks.register<Test>("clusterTest") {
+       group = "verification"
+       description = "Runs Redis Cluster integration tests."
+       dependsOn(tasks.named("testClasses"))
+       testClassesDirs = sourceSets.test.get().output.classesDirs
+       classpath = sourceSets.test.get().runtimeClasspath
+       failOnNoDiscoveredTests = true
+       useJUnitPlatform {
+           includeTags("redis-cluster")
+       }
+       mustRunAfter(tasks.named("test"))
+       systemProperty("junit.jupiter.execution.parallel.enabled", "false")
+       maxParallelForks = 1
+       doLast {
+           // CI와 local 모두 빈 또는 skip-only Cluster task를 성공으로 남기지 않는다.
+           require(fileTree(binaryResultsDirectory).matching { include("**/*.xml") }.files.isNotEmpty()) {
+               "Redis Cluster test produced no JUnit XML"
+           }
+       }
+   }
+
+   tasks.named<Test>("test") {
+       useJUnitPlatform { excludeTags("redis-cluster") }
+   }
+   ```
+
+5. `[ ]` RED/GREEN 검증 순서:
+   - `./gradlew :bluetape4k-leader-redis-lettuce:test --no-daemon --no-configuration-cache --no-build-cache --console=plain`은 Cluster tag를 실행하지 않고 기존 standalone suite만 pass한다.
+   - `./gradlew :bluetape4k-leader-redis-lettuce:clusterTest --no-daemon --no-configuration-cache --no-build-cache --console=plain`은 실제 container를 시작해 manifest의 모든 tagged test를 pass한다. JUnit XML은 `tests >= 17`, manifest 누락 0, `skipped = 0`, `failures = 0`, `errors = 0`이어야 하며 성공 provenance에 image digest, `cluster_state=ok`, 6개 endpoint가 있어야 한다.
+   - failure/startup failure 시 image/ref/digest, `cluster_state:ok`, endpoints, `docker inspect`, logs, events를 `build/redis-cluster-diagnostics/`와 CI artifact에 남기고 환경 skip을 pass로 보고하지 않는다. report/artifact가 없으면 별도 guard가 실패한다.
+
+## 9. Task 7 — README locale과 Nightly/manual CI gate
+
+**Files:** `leader-redis-lettuce/README.md`, `leader-redis-lettuce/README.ko.md`, `.github/workflows/nightly-tests.yml`.
+
+1. `[ ]` README 두 locale에 다음 사실을 동일 의미로 추가한다. English 문서는 기존 locale 계약을 유지하고 Korean 문서는 native technical prose로 작성한다.
+   - standalone/Cluster constructor의 네 클래스 예제와 caller-owned connection.
+   - v3 hash tag와 동일 slot, v2/colon migration precedence, mixed-version cutover.
+   - v3 write 이후 old binary rollback 금지와 forward-fix 경계.
+   - 현재 catalog가 resolve하는 Lettuce `7.6.0.RELEASE`에서 검증한 지원 범위, MOVED/ASK topology 및 failover 경계. 7.7 upgrade는 이 이슈 범위가 아니다.
+   - `clusterTest`는 regular PR test가 아닌 Nightly/manual verification 전용이며 benchmark가 아님.
+2. `[ ]` Nightly에 기존 `test-redis-lettuce`와 별도로 `test-redis-lettuce-cluster` job을 추가한다. schedule/manual full 조건, `needs: build`, `clusterTest`, `TESTCONTAINERS_RYUK_DISABLED`, `DOCKER_HOST`, test-result/diagnostic artifact를 명시한다. `coverage-report` 및 `nightly-status`의 needs에 새 job을 추가하고, full Nightly 조건에서는 cluster job 결과가 `success`가 아니면 aggregator가 실패하도록 한다. non-full/manual scope에서 의도된 `skipped`는 별도 N/A로 요약한다. `nightly-status`에는 `if: always()`와 full-scope guard를 적용해 headline green이나 unrelated job success만으로 Cluster coverage를 통과시키지 않는다.
+
+   ```yaml
+   test-redis-lettuce-cluster:
+     name: Test / leader-redis-lettuce (Redis Cluster)
+     if: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+     runs-on: ubuntu-latest
+     timeout-minutes: 15
+     needs: build
+     steps:
+       - uses: actions/checkout@v7
+       - uses: actions/setup-java@v6.0.0
+         with:
+           java-version: ${{ env.JAVA_VERSION }}
+           distribution: ${{ env.JAVA_DISTRIBUTION }}
+       - uses: gradle/actions/setup-gradle@v6.3.0
+         with:
+           gradle-version: wrapper
+           cache-read-only: true
+       - name: Prepare Redis Cluster diagnostics
+         run: mkdir -p leader-redis-lettuce/build/redis-cluster-diagnostics
+       - name: Test Redis Cluster
+         run: ./gradlew :bluetape4k-leader-redis-lettuce:clusterTest --no-daemon --no-configuration-cache --console=plain
+         env:
+           GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false"
+           TESTCONTAINERS_RYUK_DISABLED: "true"
+           DOCKER_HOST: "unix:///var/run/docker.sock"
+       - name: Verify Redis Cluster test scope
+         if: always()
+         shell: bash
+         run: |
+           set -euo pipefail
+           shopt -s nullglob
+           reports=(leader-redis-lettuce/build/test-results/clusterTest/*.xml)
+           test "${#reports[@]}" -gt 0 || { echo "No clusterTest JUnit XML" >&2; exit 1; }
+           python3 - "${reports[@]}" <<'PY'
+           import sys
+           from pathlib import Path
+           import xml.etree.ElementTree as ET
+
+           matrix_path = Path("leader-redis-lettuce/src/test/resources/redis-cluster-test-matrix.txt")
+           expected_names = {
+               line.strip() for line in matrix_path.read_text().splitlines() if line.strip()
+           }
+           tests = skipped = failures = errors = 0
+           observed_names = set()
+           for path in sys.argv[1:]:
+               root = ET.parse(path).getroot()
+               tests += int(root.attrib.get("tests", 0))
+               skipped += int(root.attrib.get("skipped", 0))
+               failures += int(root.attrib.get("failures", 0))
+               errors += int(root.attrib.get("errors", 0))
+               observed_names.update(
+                   testcase.attrib.get("name", "").removesuffix("()")
+                   for testcase in root.findall(".//testcase")
+               )
+           missing_names = sorted(expected_names - observed_names)
+           print({"tests": tests, "skipped": skipped, "failures": failures, "errors": errors})
+           print({"expected_matrix": len(expected_names), "missing_names": missing_names})
+           if tests < len(expected_names) or missing_names or skipped != 0 or failures != 0 or errors != 0:
+               raise SystemExit(1)
+
+           provenance = Path("leader-redis-lettuce/build/redis-cluster-diagnostics/cluster-runtime.txt")
+           if not provenance.is_file():
+               raise SystemExit(1)
+           fields = {
+               key: value
+               for line in provenance.read_text().splitlines()
+               for key, separator, value in [line.partition("=")]
+               if separator
+           }
+           endpoints = [endpoint for endpoint in fields.get("endpoints", "").split(",") if endpoint]
+           if "@sha256:" not in fields.get("image_digest", "") or fields.get("cluster_state") != "ok" or len(endpoints) < 6:
+               raise SystemExit(1)
+           PY
+       - name: Capture Redis Cluster failure diagnostics
+         if: failure()
+         shell: bash
+         run: |
+           set +e
+           docker ps -a > leader-redis-lettuce/build/redis-cluster-diagnostics/docker-ps.txt
+           docker ps -aq | xargs -r -n1 docker inspect > leader-redis-lettuce/build/redis-cluster-diagnostics/docker-inspect.json
+           docker ps -aq | xargs -r -n1 docker logs > leader-redis-lettuce/build/redis-cluster-diagnostics/docker-logs.txt
+           docker events --since 10m --until "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > leader-redis-lettuce/build/redis-cluster-diagnostics/docker-events.txt
+           if command -v redis-cli >/dev/null 2>&1; then redis-cli -c cluster info > leader-redis-lettuce/build/redis-cluster-diagnostics/cluster-info.txt 2>&1; fi
+       - name: Upload Redis Cluster diagnostics
+         if: always()
+         uses: actions/upload-artifact@v7
+         with:
+           name: redis-lettuce-cluster-diagnostics
+           path: |
+             **/build/test-results/clusterTest/*.xml
+             **/build/reports/tests/clusterTest/**
+             **/build/redis-cluster-diagnostics/**
+           retention-days: 14
+   ```
+
+3. `[ ]` `nightly-status`의 결과 검사는 다음 의미를 갖도록 갱신한다.
+
+   ```yaml
+   - name: Check all jobs
+     if: always()
+     env:
+       RESULTS: ${{ join(needs.*.result, ',') }}
+       CLUSTER_RESULT: ${{ needs.test-redis-lettuce-cluster.result }}
+       FULL_SCOPE: ${{ (github.event_name == 'schedule' && github.event.schedule == '19 19 * * 0') || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}
+     run: |
+       echo "Nightly results: $RESULTS"
+       if echo "$RESULTS" | grep -qE "failure|cancelled"; then
+         echo "Nightly failed"
+         exit 1
+       fi
+       if [ "$FULL_SCOPE" = "true" ] && [ "$CLUSTER_RESULT" != "success" ]; then
+         echo "Redis Cluster Nightly gate is $CLUSTER_RESULT, expected success"
+         exit 1
+       fi
+       echo "Nightly passed"
+   ```
+
+   YAML validation과 `git diff --check`를 실행한다. `.github/workflows/nightly-tests.yml` 변경 후에는 repository guard에 따라 Nightly를 명시적으로 dispatch하고, exact workflow run의 Cluster job terminal result와 artifact를 fresh read-back해야 한다. 현재 사용자는 local implementation/verification만 승인했으므로 dispatch는 별도 외부 권한 gate이며, 실행하지 않은 동안 DoD는 `PENDING`이다.
+
+## 10. Task 8 — review artifact, lesson, full verification
+
+**Files:** 신규 `docs/review/2026-09-04-issue-854-redis-cluster-review.md`, 신규 `docs/lessons/2026-09-04-issue-854-redis-cluster.md`, checklist.
+
+1. `[x]` 7-Tier review를 수행한다. 각 finding에 file/line, severity, reproduction, disposition를 기록하고 P0/P1은 0이 될 때까지 수리한다. `$bluetape-kotlin-patterns`의 null-safety/immutability/structured cancellation/assertion/resource ownership 규칙을 Kotlin tier의 근거로 인용한다.
+
+   | Tier | 검토 범위 | 필수 증거 |
+   |---|---|---|
+   | 1. Intent/Contract | Issue #854 범위, contention/null/error, non-goals | issue/spec/acceptance traceability |
+   | 2. Architecture/API | capability adapter, four elector constructors, ABI bridge | source/consumer compile, `javap`, binary checker |
+   | 3. Data/Redis | v3 hash tag, tombstone/token, Lua `KEYS`, `CROSSSLOT` | codec/slot tests, actual Cluster script output |
+   | 4. Concurrency/Lifecycle | unregister↔migration ordering, TTL/source expiry, ownership | deterministic barrier and token race tests |
+   | 5. Tests/CI | regular vs `clusterTest`, no-test/skip guard, fixture diagnostics, Nightly aggregation | JUnit XML counts, CI static validators, artifact paths |
+   | 6. Security/Operations | brace validation, caller-owned resources, MOVED/ASK/failover and rollback boundary | negative tests, diagnostics, forward-fix runbook wording |
+   | 7. Docs/ABI/Release | README parity, resolved version, consumer compatibility, delivery gates | Korean lesson/review, `dependencyInsight`, exact-head/PR-N/A proof |
+
+2. `[x]` Korean lesson에 다음 재사용 규칙을 기록한다: 공통 hash tag, old source single-key migration, persistent lifecycle tombstone, migration token ownership, bounded TTL cleanup, same-slot destination Lua, capability adapter, actual Cluster fixture diagnostics, tag/manual gate. source/spec anchor와 실제 command/test/CI result를 함께 기록하고, 미실행 Nightly/PR/merge는 `PENDING`으로 명시한다.
+3. `[x]` 검증을 heavy command 순서로 직렬 실행한다. module test 352건, manifest 기반 `clusterTest` 17건, Kover, root detekt, Gradle/custom ABI, dependencyInsight, static validators, YAML/actionlint, consumer fixture를 순차 확인했다. hosted Nightly/PR은 실행하지 않았다.
+
+   ```bash
+   ./gradlew :bluetape4k-leader-redis-lettuce:test --tests '*LettuceCandidateKeyCodecTest*' --tests '*LettuceCandidateKeyIsolationTest*' --no-daemon --no-configuration-cache --no-build-cache --console=plain
+   ./gradlew :bluetape4k-leader-redis-lettuce:clusterTest --no-daemon --no-configuration-cache --no-build-cache --console=plain
+   ./gradlew :bluetape4k-leader-redis-lettuce:test :bluetape4k-leader-redis-lettuce:koverXmlReport --no-daemon --no-configuration-cache --no-build-cache --console=plain
+   ./gradlew detekt --no-daemon --no-configuration-cache --no-build-cache --console=plain
+   ./gradlew checkBinaryCompatibility --no-daemon --no-configuration-cache --no-build-cache --console=plain
+   ./gradlew :bluetape4k-leader-redis-lettuce:dependencyInsight --dependency io.lettuce:lettuce-core --configuration testRuntimeClasspath --no-daemon --no-configuration-cache --no-build-cache --console=plain
+   python3 scripts/compatibility/check_binary_api_test.py
+   ABI_BASE_DIR="$PWD/build/abi-base-develop" ABI_CURRENT_DIR="$PWD" python3 scripts/compatibility/check_binary_api.py
+   python3 scripts/ci/validate_ci_fanout.py --static
+   python3 scripts/ci/validate_kover_contract.py --static
+   python3 scripts/ci/validate_test_assertion_contract.py
+   python3 -c 'import pathlib, yaml; yaml.safe_load(pathlib.Path(".github/workflows/nightly-tests.yml").read_text())'
+   git diff --check
+   git diff --no-index --check /dev/null docs/review/2026-09-04-issue-854-redis-cluster-review.md || test $? -eq 1
+   git diff --no-index --check /dev/null docs/lessons/2026-09-04-issue-854-redis-cluster.md || test $? -eq 1
+   ```
+
+   `build/abi-base-develop`는 기준 커밋 `c47324bcff5738e5505cf733d838afd730bad226`에서 수집한 정확한 baseline artifact directory로 먼저 채우고, ABI 출력의 resolved base/current version과 `unknown=0`을 확인한다. Python YAML parser가 없는 환경에서는 repository의 기존 YAML validator나 `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly-tests.yml")'`을 사용하고 N/A 사유를 기록한다. 각 명령은 exit 0, 기대 test count, report 생성, P0/P1 zero를 기록한다. context-mode가 Gradle 실행을 가로채면 nested `mcp__context_mode__ctx_execute` 결과를 동일한 command/evidence로 보존한다. report-only Kover가 빈 report를 exit 0으로 끝내면 coverage pass가 아니라 BLOCKED/FAIL로 기록한다. untracked review/lesson도 no-index diff-check로 whitespace 오류를 검증한다.
+4. `[x]` source-to-doc·ABI·checklist 대조 후 main workflow evidence를 갱신한다. `Required checks: X/Y; N/A: N; Blocked: N`을 실제 leaf rows에서 계산하고 unchecked IDs를 숨기지 않는다.
+5. `[ ]` implementation commit과 lesson/review commit은 각각 Korean Lore intent/trailers를 사용한다. PR/merge/publish는 이 계획의 완료 조건이 아니다.
+
+## 11. Revised plan review disposition
+
+초기 read-only plan review 세 lane의 판정은 `REQUEST CHANGES`였다. 다음 보정을 반영하고 fresh 사용자 승인 뒤 구현·로컬 검증을 완료했다. 호스팅 Nightly와 PR은 별도 외부 게이트이므로 여기서는 실행하지 않았다.
+
+| finding | revised 대응 | 상태 |
+|---|---|---|
+| catalog/API version mismatch | 현재 immutable catalog의 Lettuce `7.6.0.RELEASE`로 고정, 7.7 upgrade 제거, `dependencyInsight` 증거 추가 | 검증 완료 |
+| standalone Kotlin ABI bridge | `@JvmOverloads` secondary constructor, baseline/after `javap`, precompiled Kotlin consumer, `RedisScriptRunner` 별도 descriptor 검사 | 검증 완료 |
+| unregister→migration resurrection | same-slot persistent tombstone/fence, source 숨김, deterministic barrier test | 검증 완료 |
+| same-payload destructive cleanup | migration unique token + raw value compare, candidate/index/token만 cleanup, source key는 script에서 제외 | 검증 완료 |
+| clusterTest/CI false green | `testClassesDirs`/`classpath`/`dependsOn`/`failOnNoDiscoveredTests`, regular tag exclusion, JUnit XML count/skip guard, full-scope Nightly aggregator와 diagnostics artifact | 로컬 검증 완료; hosted Nightly PENDING |
+| stale legacy index / source precedence | v2·colon key를 모두 preflight하고 stale member가 속한 index만 제거하며, 하위 우선순위 malformed source도 표면화 | 검증 완료; blocking/suspend isolation 회귀 |
+| Cluster matrix scope | public blocking/suspend single/group lifecycle·migration·TTL·cancellation을 17개 독립 test와 checked-in manifest로 고정하고 Gradle/CI가 필수 이름을 exact 검증 | 로컬 검증 완료; hosted Nightly PENDING |
+| mutable fixture image tag | image tag와 실제 image digest, helper, `cluster_state`, 6개 endpoint, Docker host provenance를 성공 artifact에 기록하고 tag pinning은 upstream fixture 후속 범위로 명시 | provenance 로컬 검증 완료; immutable pull P2 후속 |
+| rollback claim overreach | 별도 recovery tool/parity 변환을 비범위로 명시하고 v3 write 뒤 stop·보존·forward fix만 허용 | 검증 완료 |
+
+초기 구현 전에는 이 표의 P0/P1 항목과 `A-04` 승인 상태가 수렴되기 전 source code mutation, Nightly dispatch, PR 생성 또는 merge를 실행하지 않는 stop condition을 적용했다. 현재 구현은 로컬 증거를 갱신했지만, mutable fixture pinning·hosted Nightly·PR은 별도 PENDING 범위로 남긴다.
+
+구현 후 확인 결과: catalog는 `7.6.0.RELEASE`로 고정되었고 네 elector의 standalone descriptor·Kotlin synthetic bridge·Cluster constructor가 보존/추가되었다. v3 same-slot write와 tombstone/token fence, standalone·Cluster native `MGET`, v2/colon single-key migration, persistent-source TTL 경계를 코드와 테스트로 검증했다. TTL 입력 사전 검증과 malformed/mismatched destination 처리도 blocking/suspend 및 Cluster 회귀 테스트로 고정했다. stale legacy index와 하위 우선순위 malformed source 회귀를 추가해 lookup precedence를 고정했고, `test` 352건과 manifest 기반 `clusterTest` 17건은 모두 성공했다. Cluster 성공 provenance에는 `tommy351/redis-cluster:6.2`의 실제 image digest, `cluster_state=ok`, 6개 mapped endpoint와 fixture/helper가 기록되며 Gradle/Nightly가 manifest 이름 누락도 거부한다. root `detekt`, Gradle/custom ABI, dependencyInsight, static validators, YAML/actionlint, Kotlin/Java consumer fixture도 통과했다. hosted Nightly dispatch와 PR/CI는 권한 경계 때문에 `PENDING`이다.
+
+## 12. Stop, rollback, and handoff conditions
+
+- P0/P1 finding, actual `CROSSSLOT`, destination TTL이 observed source TTL보다 길어지는 증거, malformed payload의 silent fallback, cancellation swallow, public descriptor 삭제, fixture diagnostics 누락이 있으면 다음 task로 진행하지 않고 해당 task를 RED 상태로 되돌린다.
+- Cluster image pull/daemon/topology 환경이 준비되지 않으면 test를 skip하지 않는다. failure diagnostics를 남기고 `Blocked: 1`로 보고하며 환경 복구 후 동일 SHA에서 재실행한다.
+- v3 write가 한 번이라도 관찰된 뒤에는 old binary rollback을 수행하지 않는다. 별도 parity/recovery tool은 이 이슈에 포함하지 않으며, emergency stop → 상태 보존·진단 → forward fix 순서만 허용한다.
+- 구현·검증 완료 후에도 Nightly dispatch, push, PR, merge, tag/release, branch/worktree cleanup은 각각 fresh exact-head 승인 gate를 기다린다.
+- 최종 handoff는 변경 파일 목록, exact HEAD, test/static/ABI/Cluster evidence, review/lesson 경로, `Required checks` count, 남은 N/A/Blocked 및 사용자의 다음 승인 지점을 포함한다.

--- a/docs/superpowers/specs/2026-09-04-issue-854-redis-cluster-design.md
+++ b/docs/superpowers/specs/2026-09-04-issue-854-redis-cluster-design.md
@@ -1,0 +1,450 @@
+# Issue #854 Redis Cluster 공식 지원 설계
+
+## 문서 상태
+
+- 상태: 독립 검토 결과와 안전 보정을 반영한 승인 완료 설계 — 로컬 구현·검증 완료, hosted delivery gate 대기
+- 작성일: 2026-09-04
+- 대상 저장소: `bluetape4k/bluetape4k-leader`
+- 대상 모듈: `leader-redis-lettuce`
+- 이슈: [#854](https://github.com/bluetape4k/bluetape4k-leader/issues/854)
+- 기준 커밋: `c47324bcff5738e5505cf733d838afd730bad226` (`origin/develop`)
+- 작업 branch: `feat/issue-854-redis-cluster`
+- 승인 범위: Redis Cluster를 사용하는 strategic candidate registry의 공식 지원
+- 제외 범위: Cluster failover 성능 benchmark, 일반 lock/group primitive의 추가 재설계, publish/release/tag, PR·merge
+
+## SPW-01 — 독자·목적·근거 고정
+
+### 독자
+
+`leader-redis-lettuce`의 API 사용자, Redis 운영자, 구현자와 리뷰어를 대상으로 한다. 사용자는 standalone Redis 연결을 이미 알고 있다고 가정하되, Redis Cluster의 same-slot 제약과 Lettuce 연결 타입은 설명한다.
+
+### 목적
+
+다음 질문에 구현 전에 답한다.
+
+1. 어떤 public API로 `StatefulRedisClusterConnection`을 받는가?
+2. candidate index와 candidate value가 왜 항상 한 hash slot에 놓이는가?
+3. 기존 v2·colon legacy 자료를 어떻게 잃지 않고 v3으로 읽고 이행하는가?
+4. blocking/suspend 경로와 Lua cleanup이 실제 Cluster에서 `CROSSSLOT` 없이 동작하는가?
+5. 문서·ABI·테스트가 공식 지원 주장을 어떻게 입증하는가?
+
+### 근거 계층
+
+| 근거 | 역할 |
+|---|---|
+| [Redis Cluster specification](https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/) | CRC16 hash slot, `{...}` hash tag, multi-key same-slot 계약 |
+| [Redis multi-key operations](https://redis.io/docs/latest/develop/using-commands/multi-key-operations/) | `MGET`·transaction·Lua의 same-slot 및 `CROSSSLOT` 동작 |
+| [Redis scripting API](https://redis.io/docs/latest/develop/programmability/lua-api/) | Lua에 전달하는 declared keys의 Cluster 제약 |
+| [Lettuce architecture](https://github.com/redis/lettuce/blob/main/.agents/docs/architecture.md) | `RedisClusterClient`와 `StatefulRedisClusterConnection` 연결 모델 |
+| local source | 현재 v2/legacy codec, registry script, strategic elector와 테스트 계약 |
+| sibling `infra/lettuce` | 공통 `RedisScriptingCommands`/`RedisScriptingAsyncCommands`와 Cluster overload 패턴 |
+
+Redis 공식 문서의 핵심 제약은 하나의 command, transaction 또는 Lua script에 전달되는 여러 key가 같은 hash slot에 있어야 한다는 것이다. hash tag의 `{...}` 안쪽 substring만 slot 계산에 사용되며, 기본 slot 수는 16384이다. 이는 설계의 외부 계약이고 로컬 테스트보다 우선한다.
+
+## SPW-02 — 산출물 계약
+
+이 문서는 다음 항목을 반드시 포함한다.
+
+- 선택한 접근과 거부한 대안
+- public API 및 ABI 호환성
+- v3 key layout과 slot 불변식
+- v2·colon legacy 읽기/이행·TTL·우선순위
+- blocking/suspend 명령 및 취소 경계
+- 오류·동시성·mixed-version 동작
+- 테스트와 정적/ABI/문서 검증 매트릭스
+- rollout, rollback, non-goals 및 acceptance criteria
+
+## 1. 현재 구현과 문제
+
+현재 `LettuceCandidateKeyCodec`은 다음 v2/legacy 키를 만든다.
+
+```text
+v2 index:     <prefix>|v2|i|<lengthDelimited(lockName)>
+v2 candidate: <prefix>|v2|c|<lengthDelimited(lockName)><lengthDelimited(nodeId)>
+legacy index: <prefix>:<lockName>
+legacy value: <prefix>:<lockName>:<nodeId>
+```
+
+`LettuceCandidateRegistry`의 `refreshCandidate`와 stale-index cleanup은 index와 candidate를 함께 Lua에 전달하고, `listCandidates`는 candidate 여러 개를 `MGET`한다. v2/legacy 키에는 hash tag가 없으므로 Redis Cluster에서 이 다중 키 호출은 서로 다른 slot으로 라우팅될 수 있다. 따라서 단순히 `StatefulRedisClusterConnection` overload만 추가하면 공식 지원이 아니다.
+
+현재 호출 경로는 다음과 같다.
+
+| 계층 | blocking | suspend |
+|---|---|---|
+| public strategic elector | `LettuceStrategicLeaderElector`, `LettuceStrategicLeaderGroupElector` | `LettuceStrategicSuspendLeaderElector`, `LettuceStrategicSuspendLeaderGroupElector` |
+| registry | `LettuceCandidateRegistry` | `LettuceSuspendCandidateRegistry` |
+| script | `RedisScriptRunner.run` | `runSuspending` |
+| 기존 검증 | `LettuceCandidateKeyIsolationTest`, `LettuceStrategicHeartbeatTest` | 동일 테스트의 suspend 경로 |
+
+일반 `LettuceLock`, `LettuceSlotTokenGroup` 등은 이번 이슈의 대상이 아니다. 특히 `LettuceSlotTokenGroup`은 이미 `lg:{lockName}` 형식의 same-slot key 계약을 갖고 있으므로 중복 재설계하지 않는다.
+
+## 2. 대안과 선택
+
+### 대안 A — Cluster 전용 registry/elector 추가
+
+Cluster용 클래스를 별도로 만들고 기존 standalone 구현은 유지한다.
+
+- 장점: 기존 코드의 변경 범위가 작다.
+- 단점: blocking/suspend와 migration 로직이 이중화되고, bug fix와 테스트 parity가 쉽게 어긋난다.
+- 판정: 거부. public API는 늘지만 공통 계약을 보장하지 못한다.
+
+### 대안 B — 모든 Redis primitive를 Cluster-aware로 재설계
+
+일반 lock, semaphore, group primitive까지 하나의 공통 추상화로 바꾼다.
+
+- 장점: 장기적으로 공통화된 facade를 만들 수 있다.
+- 단점: Issue #854 범위를 크게 넘고, 이미 Cluster key 계약을 가진 primitive까지 ABI·운영 위험을 만든다.
+- 판정: 거부. 별도 이슈와 migration plan이 필요한 broad refactor다.
+
+### 대안 C — 공통 command adapter + v3 hash-tag key + 기존 constructor 보존 (선택)
+
+Lettuce가 제공하는 common sync/async Cluster command interface로 registry를 일반화하고, 기존 standalone constructor는 유지한다. 새 v3 key에서 lock name을 hash tag로 묶고 v2/legacy를 읽어 v3으로 이행한다. 단일 키·set·script 명령은 공통 interface를 사용하고, v3 후보 일괄 조회는 private reader capability로 분리한다. standalone은 `RedisCommands.mget`, Cluster는 `RedisAdvancedClusterCommands.mget`을 사용해 기존 결과 계약을 유지한다.
+
+- 장점: 기존 ABI를 보존하고, 실제 Cluster와 standalone이 같은 registry·script·테스트 경로를 공유한다.
+- 단점: v3 rollout 동안 이전 버전과의 동시 쓰기와 cutover 이후 rollback은 지원하지 않으며, 별도 운영 절차가 필요하다.
+- 판정: 선택. 변경 범위가 strategic registry로 한정되고 same-slot 불변식을 코드·테스트·문서에서 직접 입증한다.
+
+## 3. 설계
+
+### 3.1 Public API와 ABI
+
+네 개 public class에 `StatefulRedisClusterConnection<String, String>` 생성자를 추가한다.
+
+```kotlin
+class LettuceStrategicLeaderElector private constructor(
+    private val registry: LettuceCandidateRegistry,
+    override val nodeId: String,
+) : StrategicLeaderElector {
+    @JvmOverloads
+    constructor(
+        connection: StatefulRedisConnection<String, String>,
+        nodeId: String = Uuid.V7.nextBase62(),
+    ) : this(LettuceCandidateRegistry(connection), nodeId)
+
+    @JvmOverloads
+    constructor(
+        connection: StatefulRedisClusterConnection<String, String>,
+        nodeId: String = Uuid.V7.nextBase62(),
+    ) : this(LettuceCandidateRegistry(connection), nodeId)
+}
+```
+
+동일한 형태를 다음 클래스에 적용한다.
+
+- `LettuceStrategicLeaderGroupElector`
+- `LettuceStrategicSuspendLeaderElector`
+- `LettuceStrategicSuspendLeaderGroupElector`
+
+기존 `StatefulRedisConnection` 생성자의 one-/two-argument JVM descriptor와 Kotlin default constructor synthetic bridge는 유지한다. 구현 전 develop 산출물에서 `javap -p -s`로 현재 descriptor set을 저장하고, 구현 후 동일 명령과 precompiled Kotlin one-argument consumer fixture로 `(StatefulRedisConnection, String)`, `(StatefulRedisConnection)`, 그리고 기존 synthetic `(StatefulRedisConnection, String, int, DefaultConstructorMarker)` 호출이 모두 유지되는지 확인한다. `@JvmOverloads`는 standalone secondary constructor에 적용해 Java/Kotlin 호출 surface를 명시적으로 보존하고, Cluster overload는 새 descriptor로 추가한다. caller-owned connection은 닫거나 shutdown하지 않는다. core interface와 nodeId·result·contention 계약은 변경하지 않는다.
+
+registry의 internal command adapter는 다음 capability를 분리한다.
+
+- blocking 단일 키·set·script 명령: `io.lettuce.core.cluster.api.sync.RedisClusterCommands<String, String>`.
+- blocking v3 일괄 조회: `RedisAdvancedClusterCommands.mget`를 노출하는 private `CandidateValueReader` adapter. Cluster connection은 이 capability를 사용하고, standalone `RedisCommands.mget` connection은 같은 reader 계약을 사용한다. 따라서 `mget`을 mutation 공통 타입에 억지로 선언하지 않는다.
+- suspend direct 명령: `io.lettuce.core.cluster.api.coroutines.RedisClusterCoroutinesCommands<String, String>`. `RedisCoroutinesCommands`는 이 Cluster 공통 interface의 subtype이고, Cluster connection은 `StatefulRedisClusterConnection.coroutines()` extension을 사용한다. `mget`을 포함한 coroutine 명령과 nullable reply semantics를 그대로 보존한다.
+- suspend script 명령: `io.lettuce.core.api.async.RedisScriptingAsyncCommands<String, String>`. standalone의 `RedisAsyncCommands`와 Cluster의 `RedisAdvancedClusterAsyncCommands` 모두 이 script capability를 제공하며, `await()` cancellation 경계를 유지한다.
+
+이 타입 분리는 현재 dependency catalog가 실제로 resolve하는 Lettuce `7.6.0.RELEASE` API hierarchy를 기준으로 한다. 저장소의 immutable catalog ref `850959d0ea5f76ac7e2c442400f47653d5f95eed`와 sibling `bluetape4k-dependencies/gradle/libs.versions.toml`의 `lettuce = "7.6.0.RELEASE"`를 기준 증거로 삼으며, 이 이슈에서는 7.7 upgrade나 전역 catalog 변경을 수행하지 않는다. Cluster 공통 `RedisClusterCommands`/`RedisClusterAsyncCommands`에는 `mget`이 없고 Cluster 전용 `RedisAdvancedClusterCommands`/`RedisAdvancedClusterAsyncCommands`에만 있으므로, Cluster value reader는 Advanced capability를 사용한다. standalone `RedisCommands`/`RedisCoroutinesCommands`는 자체 `mget`을 사용한다. 구현 전에 해당 public API와 `StatefulRedisClusterConnection.sync()/async()/coroutines()`의 실제 컴파일을 acceptance에 포함한다. 실제 resolved version은 `dependencyInsight`로 다시 기록한다.
+
+### 3.2 Script runner 공통화
+
+`RedisScriptRunner`는 기존 overload를 삭제하지 않고 다음 overload를 추가한다.
+
+```kotlin
+fun <T> run(
+    commands: RedisScriptingCommands<String, String>,
+    script: RedisScript,
+    outputType: ScriptOutputType,
+    keys: Array<String>,
+    vararg args: String,
+): T
+
+fun <T> runAsync(
+    commands: RedisScriptingAsyncCommands<String, String>,
+    script: RedisScript,
+    outputType: ScriptOutputType,
+    keys: Array<String>,
+    vararg args: String,
+): CompletableFuture<T>
+
+suspend fun <T> runSuspending(
+    commands: RedisScriptingAsyncCommands<String, String>,
+    script: RedisScript,
+    outputType: ScriptOutputType,
+    keys: Array<String>,
+    vararg args: String,
+): T
+```
+
+기존 standalone overload는 호환성을 위해 유지하고 공통 private 실행 함수로 위임한다. `NOSCRIPT` fallback과 예외 원인, suspend cancellation semantics를 바꾸지 않는다.
+
+### 3.3 v3 key layout과 slot 불변식
+
+현재 key 생성 함수는 v3을 반환하도록 바꾸고, v2 생성 함수는 migration/test용으로 보존한다.
+
+```text
+v3 index:     <prefix>|v3|i|{<lengthDelimited(lockName)>}
+v3 candidate: <prefix>|v3|c|{<lengthDelimited(lockName)>}<lengthDelimited(nodeId)>
+v3 tombstone: <prefix>|v3|t|{<lengthDelimited(lockName)>}<lengthDelimited(nodeId)>
+v3 mig token: <prefix>|v3|m|{<lengthDelimited(lockName)>}<lengthDelimited(nodeId)>
+v2 index:     <prefix>|v2|i|<lengthDelimited(lockName)>
+v2 candidate: <prefix>|v2|c|<lengthDelimited(lockName)><lengthDelimited(nodeId)>
+colon legacy: <prefix>:<lockName>[:<nodeId>]
+```
+
+`lengthDelimited`는 기존처럼 lock name의 UTF-8 byte length와 원문을 함께 보존한다. v3 index, candidate, lifecycle tombstone/fence, migration token은 동일한 `{<lengthDelimited(lockName)>}` substring을 가지므로 `StringCodec.UTF8` wire key 기준 `SlotHash.getSlot` 결과가 같다. `keyPrefix`는 `DEFAULT_KEY_PREFIX`와 `GROUP_KEY_PREFIX`로 달라지므로 namespace key는 서로 다른 Redis key이고, 같은 lock name에 대해 같은 slot을 사용한다.
+
+`validateLockName`의 `{`/`}` 거부를 유지한다. 이 검증은 사용자가 hash tag를 닫거나 추가해 다른 key를 같은 logical operation에 끼워 넣는 hashtag injection을 막는다. nodeId는 closing brace 뒤에 있으므로 nodeId의 brace는 slot 경계를 바꾸지 않는다.
+
+필수 invariant:
+
+1. 하나의 lock name에 대한 v3 index와 v3 candidate는 같은 slot이다.
+2. `refresh` Lua의 `KEYS[1]`/`KEYS[2]`는 v3 candidate/index이고 `KEYS[3]`은 migration token이며, token이 있으면 같은 원자 경계에서 지운다. `updateResult`도 v3 candidate/token을 함께 받아 regular writer가 migration ownership을 해제한다.
+3. stale cleanup Lua의 첫 index key와 모든 candidate key는 v3만 전달한다.
+4. v3 `MGET`은 candidate reader가 제공하는 v3 key에만 사용한다. Cluster에서는 모든 key가 같은 lockName hash tag를 가지며, standalone은 `RedisCommands.mget`을 사용한다.
+5. v2/legacy migration과 cleanup은 multi-key 명령을 사용하지 않는다.
+6. lifecycle tombstone/fence와 migration token도 candidate/index와 같은 slot이며, source(v2/colon) key는 multi-key script에 전달하지 않는다.
+7. 서로 다른 lock name의 candidate pool은 key가 분리되고, 서로 다른 namespace도 key가 분리된다.
+
+standalone `RedisCommands`는 `RedisStringCommands`를 통해 `mget`을 제공하므로 기존 일괄 조회 계약을 유지한다. Cluster adapter는 `RedisAdvancedClusterCommands.mget`을 사용한다. 두 경로 모두 v3 candidate key만 전달하며, v2/colon source는 단건 `GET`/`PTTL` 경계를 유지한다.
+
+### 3.4 읽기 우선순위와 migration
+
+읽기 우선순위는 `v3 > v2 > colon legacy`다.
+
+#### list
+
+1. v3 index를 `SMEMBERS`로 읽고 v3 candidate key만 조회한다. standalone과 Cluster adapter 모두 실제 `MGET`을 사용하며, Cluster에서는 same-slot capability로 라우팅한다.
+2. v2 index와 colon index는 각각 `SMEMBERS`로 읽는다.
+3. v2 candidate와 legacy candidate는 각 key를 단건 `GET`한다. 이 경로에서는 v2/legacy key가 서로 다른 slot이어도 `MGET`하지 않는다.
+4. candidate payload의 `nodeId`가 index member와 다르면 노출하지 않고 해당 index member를 제거한다.
+5. source를 migration하기 전에 같은 node의 v3 lifecycle tombstone/fence를 확인한다. tombstone이 있으면 source candidate를 노출하거나 migration하지 않는다.
+6. v2 또는 legacy candidate가 유효하면 TTL을 읽고 v3 migration script를 호출한다. script는 v3 candidate `SET NX`, migration token 기록, v3 index `SADD`/`PERSIST`를 한 same-slot 원자 경계로 수행하며, destination이 이미 있으면 값을 덮어쓰지 않고 index만 repair한다.
+7. v3가 이미 있으면 v3 값을 우선하고 source를 덮어쓰지 않는다.
+8. legacy/v2 source key는 migration 직후 삭제하지 않는다. source 보존은 진단과 forward-fix에 필요하며, `unregisterCandidate`가 exact node에 대해 세 버전을 정리한다.
+9. v3 stale candidate cleanup script는 v3 index/candidate/token만 처리한다. v2/legacy index 정리는 단일 `SREM`으로 처리한다.
+
+동일 node의 source가 여러 버전에 동시에 존재할 때는 다음 표를 적용한다.
+
+| v3 | v2 | colon legacy | 선택 결과 | 정리/이행 |
+|---|---|---|---|---|
+| 유효 | 임의 | 임의 | v3 | source는 보존하고 index 누락만 repair |
+| 없음/불일치 | 유효 | 임의 | v2 | v3로 `SET NX` migration, v2 source 보존 |
+| 없음/불일치 | 없음/불일치 | 유효 | legacy | v3로 `SET NX` migration, legacy source 보존 |
+| 없음/만료 | 없음/만료 | 없음/만료 | 없음 | index member만 version별 제거, candidate 부활 금지 |
+
+payload decode 오류는 더 낮은 우선순위 source로 조용히 숨기지 않고 기존 malformed 예외 계약을 따른다. index member와 payload의 nodeId가 다르면 해당 version의 member만 제거한다.
+
+#### refresh/updateResult
+
+1. v3 candidate를 먼저 확인한다.
+2. 없으면 v2, 그 다음 legacy exact node candidate를 단건 조회·이행한다.
+3. destination이 이미 있으면 destination 값을 우선한다.
+4. v3 candidate가 확보된 뒤 `refresh`는 v3 index/token과 함께 same-slot Lua를 실행하고, `updateResult`는 v3 candidate/token을 함께 받는 same-slot Lua를 실행한다. 두 regular writer 모두 migration token을 지워 이후 expiry cleanup이 자신이 만든 최신 값을 삭제하지 못하게 한다.
+5. source가 만료되었거나 없으면 새 candidate를 만들지 않는다. `refresh`는 `ABSENT`를 반환하고 `updateResult`는 no-op 상태를 유지한다.
+
+#### unregister
+
+먼저 v3 same-slot `UNREGISTER` Lua가 persistent lifecycle tombstone/fence를 설정하고 v3 candidate·migration token을 `DEL`, v3 index member를 `SREM`한다. tombstone은 이후 source migration이 unregister를 되살리지 못하게 하는 분산 lifecycle 경계다. 그 다음 v2 candidate, colon candidate와 각 legacy index member를 서로 독립적인 single-key `DEL`/`SREM`으로 정리한다. source key는 이 cleanup 단계에서만 삭제하며 migration Lua의 `KEYS`에는 절대 넣지 않는다. 여러 slot의 key를 한 command 또는 Lua call에 묶지 않으므로 Cluster에서 `CROSSSLOT`을 발생시키지 않는다. legacy candidate payload의 nodeId가 요청 nodeId와 다르면 삭제하지 않는다. 이후 새 `REGISTER`는 같은 slot의 script에서 tombstone과 stale token을 먼저 지운 뒤 candidate/index를 기록한다.
+
+#### TTL
+
+- `Duration.ZERO`: destination을 persistent `SET`/`SETNX`로 만든다.
+- 양수 TTL: source `PTTL`을 읽고 `SET ... NX PX <remaining>`으로 복사한다.
+- `PTTL == -1`: persistent source로 간주한다.
+- `PTTL == -2` 또는 0 이하의 만료 경쟁: source를 없는 것으로 간주한다.
+
+TTL은 candidate value에만 둔다. index set은 `PERSIST`하여 한 finite candidate가 같은 lock name의 persistent candidate를 가리지 않게 한다. `updateResult`는 Lua `KEEPTTL`로 기존 TTL을 보존하고, `refresh`는 요청 TTL로 교체한다.
+
+`GET`과 `PTTL` 사이의 source 만료는 서로 다른 slot의 key를 원자적으로 검사할 수 없으므로 bounded race로 정의한다. 관찰한 `PTTL > 0`을 destination TTL의 상한으로 사용하고 migration script 직후 source를 재확인한다. 재확인에서 source가 만료되면 migration script가 발급한 unique token과 raw value를 함께 비교하는 same-slot `REMOVE_IF_VALUE`로 destination candidate/index/token을 best-effort 정리한다. 다른 writer가 같은 payload를 다시 썼거나 token을 지웠다면 삭제하지 않는다. source key 자체는 절대 이 script로 삭제하지 않으며, persistent zombie가 발생할 수 있는 bounded window와 그 진단 방법을 문서화한다. 이 경계와 `PTTL` 1ms/0/-1/-2 결과를 결정론적 테스트로 고정한다.
+
+### 3.5 오류·동시성·취소
+
+- Redis `WRONGTYPE` 처리와 malformed `CandidateInfo` 예외는 기존 계약을 유지한다.
+- Cluster가 `MOVED`를 반환하는 경우 topology-aware Lettuce connection에 위임한다. 본 변경은 topology refresh policy나 failover 성능 보장을 추가하지 않는다.
+- resharding 중 Redis가 `TRYAGAIN` 또는 연결 오류를 반환하면 호출자에게 전파한다. 자동 재시도 정책은 Lettuce client 설정의 책임이다.
+- `refresh`와 stale cleanup의 atomicity는 기존 Lua 경계를 유지한다. key layout만 v3 same-slot으로 바꾼다.
+- suspend direct command는 standalone/Cluster 모두 `RedisClusterCoroutinesCommands`를 사용하고, script만 `RedisScriptingAsyncCommands`의 `RedisFuture`를 `await()`한다. coroutine direct command와 script의 cancellation/error/null semantics를 각각 기존 경계와 대조하고, `CancellationException`을 일반 backend failure로 삼키지 않는다.
+- caller-owned connection과 Testcontainers singleton lifecycle은 registry/elector가 소유하지 않는다.
+- `REGISTER`는 v3 candidate, index, tombstone, migration token을 같은 slot의 Lua `KEYS`로 받아 tombstone과 이전 token을 먼저 지운 뒤 candidate write/index repair를 수행한다. negative TTL은 기존 caller validation/error contract를 유지하고, persistent는 `Duration.ZERO`에서만 허용한다.
+- `MIGRATE`는 v3 candidate, index, tombstone, migration token 네 key만 받는다. tombstone이 존재하면 `ABSENT`를 반환하고 아무것도 만들지 않는다. source raw value/observed PTTL은 single-key command로 읽어 `ARGV`로만 전달하며, 성공적인 `SET NX` 뒤에는 이 호출을 식별하는 unique token을 token key에 persistent하게 기록한다. destination이 이미 있으면 token을 탈취하지 않고 index만 repair한다.
+- `REMOVE_IF_VALUE`는 v3 candidate/index/token 세 key와 raw value/member/token 세 argument를 비교한다. candidate raw value와 token이 모두 일치할 때만 candidate를 삭제하고 index member와 token을 정리한다. source(v2/colon) key는 이 script의 `KEYS`에 포함하지 않으며 source 삭제는 unregister의 별도 single-key cleanup에서만 수행한다. candidate/index/token 조작을 한 same-slot Lua 경계로 묶어 중간 crash와 동일 payload writer 삭제를 방지한다.
+- unregister와 migration의 경쟁은 두 script 중 Redis가 먼저 실행한 하나의 원자 순서로 결정된다. unregister가 먼저면 persistent tombstone이 migration을 거부하고, migration이 먼저면 unregister가 tombstone을 세운 뒤 destination을 제거한다. source read 이후 unregister가 끼어드는 결정론적 barrier 테스트로 이 순서를 입증한다.
+
+v3와 v2를 동시에 쓰는 이전 바이너리와의 실시간 양방향 동기화는 제공하지 않는다. 따라서 mixed-version writer 운용과 cutover 이후 rollback은 지원하지 않는 명시적 안전 경계로 둔다.
+
+| 단계 | 허용 writer/reader | migration | rollback 판정 |
+|---|---|---|---|
+| 준비 | 기존 v2/legacy writer만 | 새 binary를 기동하지 않으므로 없음 | 허용 |
+| cutover | 모든 strategic writer를 일시 정지한 뒤 새 binary로 교체 | 모든 writer 교체 확인 후에만 허용 | v3 write 전까지만 허용 |
+| 안정 | 새 v3 writer/reader만 | 허용, v2/legacy source 보존 | 구버전 binary rollback 금지, forward fix만 허용 |
+| 비상 복구 | 모든 writer 정지 | 중단 | v3 key가 한 번이라도 쓰였으면 old binary 재기동 금지; source를 진단용으로 보존하고 forward fix만 수행 |
+
+구버전 writer가 v2를 갱신한 뒤 새 reader가 stale v3를 우선하는 시나리오는 지원 계약 밖이며, integration test는 이를 감지 가능한 진단 상태로 고정한다. cutover 이후 장애에는 이 이슈가 별도 recovery tool이나 v3→v2 parity 변환을 제공하지 않는다. 모든 writer를 정지하고 v2/colon source와 v3 상태를 보존·조사한 뒤 forward fix를 배포하며, destructive conversion은 별도 승인된 migration 이슈로 분리한다. 이 절차를 지키지 않으면 leader safety와 중복 실행 방지를 보장하지 않는다.
+
+## 4. 테스트 설계
+
+### 4.1 단위/계약 테스트
+
+| 대상 | 검증 |
+|---|---|
+| codec | v3 index/candidate가 같은 slot인지 `SlotHash.getSlot(StringCodec.UTF8.encodeKey(key))`로 확인 |
+| codec | 서로 다른 lock name은 보통 다른 slot일 수 있지만 각 lock 내부 key는 항상 동일 slot인지 확인 |
+| codec | `DEFAULT`와 `GROUP` prefix key가 서로 다르고 같은 lock name에서 same-slot인지 확인 |
+| validation | lock name에 `{` 또는 `}`가 있으면 기존 validation 예외가 유지되는지 확인 |
+| migration | v2 persistent/finite TTL과 colon legacy가 v3으로 복사되고 TTL이 보존되는지 확인 |
+| precedence | v3 값이 v2/legacy와 다를 때 v3이 노출되는지 확인 |
+| cleanup | v3 stale index cleanup이 유효 candidate를 지우지 않고, missing candidate만 제거하는지 확인 |
+| API | 네 strategic elector의 standalone constructor와 Cluster constructor가 모두 노출되는지 ABI/API 검사로 확인 |
+| migration race | 동시 reader가 하나의 destination만 만들고 source를 삭제하지 않는지, destination 기존 값과 index 누락을 repair하는지 확인 |
+| lifecycle fence | source read와 migration 사이 unregister barrier에서 persistent tombstone이 resurrection을 막고, 이후 list/refresh/update가 source를 숨기는지 확인 |
+| migration ownership | migration token과 raw value가 모두 일치할 때만 destination cleanup이 일어나고, 같은 payload를 다시 쓴 writer의 값은 보존되는지 확인 |
+| migration TTL | `PTTL` 1ms/0/-1/-2, `GET` 직후 만료, expired source 비부활 및 bounded stale window를 확인 |
+| script failure | `WRONGTYPE`, `NOSCRIPT` fallback, `MOVED`/`TRYAGAIN` 전파와 sync/async/suspend 반환·취소 semantics를 확인 |
+
+### 4.2 실제 Redis Cluster 통합 테스트
+
+기존 `RedisClusterServer.Launcher.redisCluster`와 `RedisClusterServer.Launcher.LettuceLib.getClusterClient`를 재사용한다. 테스트는 heavyweight fixture이므로 순차 실행하고, active Colima/Docker context를 먼저 확인한다.
+
+`StatefulRedisClusterConnection` 하나에서 다음을 blocking과 suspend 각각 검증한다. 테스트 fixture는 `bluetape4k-testcontainers:2.1.0-SNAPSHOT`의 `RedisClusterServer`와 `tommy351/redis-cluster:6.2` image reference를 고정된 provenance로 기록하고, 실패 시 image reference/digest, Redis `cluster_state`, mapped endpoints, Docker inspect/logs/events를 출력한다. image digest 또는 fixture artifact가 바뀌면 acceptance 증거를 갱신한다.
+
+1. `registerCandidate` 후 v3 index/value 존재와 `listCandidates` 결과
+2. 여러 node의 `listCandidates`가 standalone과 Cluster 모두 v3 `MGET`으로 동작
+3. `refreshCandidate` metadata/TTL 갱신 및 결과 counter 보존
+4. `updateResult` success/failure counter와 TTL 보존
+5. `unregisterCandidate`가 v3 index/value를 정리
+6. v2와 colon legacy seed를 `list`/`refresh`/`update`에서 읽고 v3으로 이행
+7. finite candidate 만료 후 stale index가 정리되고 zombie candidate가 생성되지 않음
+8. v3 index와 candidate keys의 실제 wire slot이 동일함
+9. index cleanup/refresh Lua 호출이 `CROSSSLOT` 없이 완료됨
+10. `DEFAULT`와 `GROUP` strategic elector가 동일 lock name에서 서로의 후보를 노출하지 않음
+11. source read 직후 unregister와 migration을 barrier로 교차시켜 destination 재생성과 source 노출이 발생하지 않음
+12. migration token을 보유한 호출보다 늦은 동일 payload writer가 destination을 갱신해도 이전 cleanup이 값을 삭제하지 않음
+
+공개 elector별 최소 matrix는 다음과 같다.
+
+| elector | namespace | 필수 lifecycle |
+|---|---|---|
+| `LettuceStrategicLeaderElector` | `DEFAULT` | register/list/refresh/updateResult/unregister/migration/TTL |
+| `LettuceStrategicLeaderGroupElector` | `GROUP` | register/list/refresh/updateResult/unregister/migration/TTL |
+| `LettuceStrategicSuspendLeaderElector` | `DEFAULT` | register/list/refresh/updateResult/unregister/migration/TTL/cancellation |
+| `LettuceStrategicSuspendLeaderGroupElector` | `GROUP` | register/list/refresh/updateResult/unregister/migration/TTL/cancellation |
+
+각 matrix 행은 별도 test method 또는 parameterized case로 추적하고, 네 elector 모두에 대해 실제 Cluster `MGET`, refresh Lua, stale-cleanup Lua가 `CROSSSLOT` 없이 완료되는지 단정한다. v3 stale value와 변경된 v2 source를 함께 심는 case는 mixed-version drift가 지원 범위 밖임을 명시적으로 진단한다. 필수 method 이름은 `leader-redis-lettuce/src/test/resources/redis-cluster-test-matrix.txt`에 한 줄씩 고정하며, 현재 17개 항목을 Gradle과 Nightly XML guard가 모두 확인한다. suspend matrix에는 group cancellation과 직접 script capability의 취소 전파·caller connection 보존도 포함한다.
+
+테스트가 단순 compile이나 mock 성공만으로 통과하지 않도록 실제 Cluster 응답, `SlotHash`, TTL 범위, persisted index, candidate payload를 함께 단정한다. `CROSSSLOT` 예외가 한 번이라도 발생하면 실패로 처리하고, Docker/Colima 또는 fixture를 사용할 수 없으면 skip을 PASS로 세지 않고 `PENDING`/`BLOCKED`로 보고한다. failover performance benchmark는 추가하지 않는다.
+
+### 4.3 기존 회귀와 정적 검증
+
+- 기존 standalone `leader-redis-lettuce` 테스트 전체를 fresh `--rerun-tasks`로 실행한다.
+- 변경된 테스트를 먼저 targeted 실행한 뒤 모듈 전체 테스트를 실행한다.
+- `@Tag("redis-cluster")`가 붙은 테스트는 `:bluetape4k-leader-redis-lettuce:clusterTest` 전용 task로 순차 실행하고, 일반 `test`에는 자동으로 섞지 않는다. Nightly/수동 verification lane에서 같은 task를 실행하며 fixture diagnostics를 보존한다.
+- `detekt`와 binary API/ABI 검사를 실행한다. 정확한 명령은 `./gradlew checkBinaryCompatibility --no-daemon --no-configuration-cache --no-build-cache`와 repository static contract의 `check_binary_api.py`를 사용하고, 기존 standalone descriptor 및 네 Cluster overload의 `javap`/Kotlin·Java consumer compile 결과를 함께 기록한다.
+- `git diff --check`와 README 양쪽 언어 source-to-doc 대조를 실행한다.
+- Kover report는 결과를 관찰하되, report 누락을 성공으로 해석하지 않는다.
+
+실행 순서와 판정 기준은 다음과 같다. (1) codec/migration/slot/script 단위 테스트가 0 failure/error여야 한다. (2) Cluster task가 실제 6-node fixture에서 0 `CROSSSLOT`/failure/error여야 한다. (3) 모듈 전체 test와 `koverXmlReport`, `detekt`, ABI/API, docs check가 각각 성공해야 한다. required task가 실행되지 않거나 fixture가 unavailable이면 해당 항목은 `N/A` 또는 `BLOCKED`로 남기고 전체 DoD를 `PENDING`으로 유지한다.
+
+## 5. 문서와 사용 예
+
+`leader-redis-lettuce/README.md`와 `README.ko.md`에 다음을 같은 의미로 추가한다.
+
+- standalone과 Redis OSS Cluster 모두 지원한다는 범위
+- Cluster 연결은 `RedisClusterClient.connect()`가 반환한 `StatefulRedisClusterConnection`을 strategic elector 생성자에 전달한다는 예
+- 하나의 lock name에 속한 index/candidate key가 hash tag로 same-slot이 된다는 설명
+- Lettuce가 `MOVED`/topology refresh를 담당하며 이 라이브러리가 failover latency/performance를 보장하지 않는다는 경계
+- v2/colon legacy는 읽기·TTL 보존 migration 대상이며, mixed-version writer 동시 운용은 지원하지 않으므로 rolling deployment 순서를 지킨다는 주의
+- failover benchmark가 공식 지원 범위가 아니라는 설명
+
+지원 범위는 현재 catalog의 Lettuce `7.6.0.RELEASE` API hierarchy에서 검증하며, 이 이슈에서는 Lettuce 6.x 예시를 새 Cluster API의 최소 지원 버전으로 승격하지 않는다. 구현 시 `libs.lettuce.core`의 실제 resolved version을 `dependencyInsight`로 기록하고, `RedisClusterCommands`/`RedisAdvancedClusterCommands`/coroutine extension이 모두 컴파일되는 범위를 문서와 ABI check에 고정한다. Redis OSS Cluster topology refresh와 `MOVED` 처리는 Lettuce 설정에 위임하고, managed Redis vendor별 failover 차이는 지원 보장에 포함하지 않는다.
+
+문서 parity check는 다음 항목을 양쪽 README에서 같은 순서와 의미로 확인한다: (1) 네 elector의 standalone/Cluster constructor 예제, (2) caller-owned connection close 책임, (3) v3 same-slot 및 v2/legacy migration, (4) mixed-version cutover/rollback 금지, (5) Lettuce resolved version과 failover 경계. README는 central manual을 복제하지 않고 모듈 진입점 역할만 한다.
+
+## 6. 위험과 대응
+
+| 위험 | 신호 | 대응/rollback |
+|---|---|---|
+| v2/legacy key를 다중 key command에 전달 | 실제 Cluster `CROSSSLOT` | migration 경로를 단건 command로 되돌리고 v3 key만 Lua/MGET에 허용 |
+| hash tag injection | brace lock name에서 slot mismatch | `validateLockName` 유지, 거부 테스트 고정 |
+| source TTL 복사 중 만료 | `PTTL == -2`, empty list | source를 absent로 처리하고 새 candidate를 만들지 않음 |
+| v3/v2 precedence 오류 | 서로 다른 payload가 노출됨 | v3 > v2 > legacy 순서와 exact node 검증 강화 |
+| suspend async 호출이 common interface와 맞지 않음 | compile 또는 cancellation test 실패 | direct는 `RedisClusterCoroutinesCommands`, script는 `RedisScriptingAsyncCommands` + `await()` 경로로 고정 |
+| migration/register crash window | candidate/index 불일치 또는 unregister resurrection | v3 candidate/index SET·SADD·PERSIST와 tombstone/token fence를 same-slot Lua로 묶고 index repair·barrier race를 검증 |
+| mixed-version writer drift | v2만 갱신되고 v3가 stale | cutover 전 writer quiesce, cutover 후 old binary rollback 금지, 상태 보존 후 forward fix |
+| Cluster fixture 환경 실패 | Docker bind/포트/cluster_state 오류 | Colima/context/fixture 진단과 image/ref/digest를 보존 후 테스트를 `PENDING`/`BLOCKED`로 보고; skip을 PASS로 취급하지 않음 |
+| ABI/API surface drift | descriptor·consumer compile 불일치 | release baseline dump, `checkBinaryCompatibility`, `javap`, Kotlin/Java consumer compile을 모두 통과시킴 |
+
+rollback은 v3 write 전의 branch/commit 되돌리기만 허용한다. cutover 이후에는 모든 writer를 정지하고 이전 binary를 재기동하지 않는다. 이 이슈는 별도 복구 도구나 v3→v2 parity 변환을 제공하지 않으므로, v2/legacy source와 v3 상태를 보존해 진단한 뒤 forward fix를 배포한다. 검증되지 않은 destructive cleanup은 수행하지 않으며, 변환이 필요하면 별도 승인된 migration 이슈로 분리한다.
+
+## 7. Acceptance criteria와 DoD
+
+### Acceptance criteria
+
+- [ ] four strategic electors에 Cluster connection overload가 있고 기존 standalone API/ABI가 유지된다.
+- [ ] v3 index/candidate key가 lock name hash tag로 same-slot이 된다.
+- [ ] v2와 colon legacy를 단건 명령으로 읽고 TTL을 보존하며 v3으로 이행한다. source는 migration 중 삭제하지 않는다.
+- [ ] blocking/suspend register/list/refresh/updateResult/unregister가 실제 Redis Cluster에서 동작한다.
+- [ ] standalone/Cluster adapter의 실제 `MGET`과 multi-key Lua가 v3 candidate key만 사용하고 `CROSSSLOT`이 재현되지 않는다.
+- [ ] stale cleanup, malformed payload, exact node mismatch, migration concurrent reader, PTTL 1ms/0/-1/-2, source-expiry race 회귀가 테스트된다.
+- [ ] unregister/migration lifecycle tombstone race와 migration token ownership race가 결정론적으로 테스트된다.
+- [ ] 네 public elector 각각의 DEFAULT/GROUP lifecycle·TTL·migration·cancellation matrix가 실행된다.
+- [ ] `@Tag("redis-cluster")` 전용 task, fixture provenance/diagnostics, resolved Lettuce version이 fresh evidence로 기록된다.
+- [ ] README와 `README.ko.md`가 동일한 Cluster/mixed-version/failover 경계를 설명하고 parity check가 통과한다. resolved Lettuce는 `7.6.0.RELEASE`로 기록한다.
+- [ ] `checkBinaryCompatibility`, static `check_binary_api.py`, `javap`, Kotlin/Java consumer compile에서 기존 standalone과 새 Cluster descriptor가 유지된다.
+- [ ] module tests, `clusterTest`, detekt, ABI/API, diff-check가 fresh evidence로 수렴하고 P0/P1 finding이 없다. 실행 불가 항목은 PASS가 아니라 `N/A`/`BLOCKED`로 보고한다.
+
+### DoD 보고 필드
+
+최종 보고에는 다음을 포함한다.
+
+- 변경 파일과 public API descriptor
+- targeted/cluster/module/static/ABI/docs 검증 명령과 실제 결과
+- 테스트 수(성공/실패/error/skip)와 Cluster fixture 상태
+- 남은 gap: hosted CI, PR, merge, failover benchmark는 별도 gate로 `PENDING`
+- `Required checks: X/Y; N/A: N; Blocked: N`
+- unchecked checklist ID와 rollback/운영 주의사항
+- spec review severity와 해소 근거: P0/P1/P2/P3 개수, 각 P1의 설계·테스트 대응, 미해소 항목
+
+## 8. 독립 검토 결과와 해소
+
+사용자 설계 승인 뒤 세 개의 read-only lane이 기준 커밋과 현재 Lettuce API/source를 대조했다. 모든 lane은 소스·문서 변경 없이 완료했다. 아래 REQUEST CHANGES 결과를 반영해 이 문서를 보정했으며, 버전·ABI·lifecycle fence·token·CI guard를 추가한 material revision에 대해 사용자가 fresh `승인`을 재확인했다. 구현·로컬 검증은 완료했고 hosted delivery gate는 별도로 남긴다.
+
+| lane | 판정 | P0 | P1 | P2 | 핵심 대응 |
+|---|---|---:|---:|---:|---|
+| `spec-architecture` | REQUEST CHANGES | 0 | 2 | 4 | command capability, suspend cancellation, rollout/rollback, TTL/crash/source precedence를 본문과 acceptance에 추가 |
+| `spec-test-risk` | REQUEST CHANGES | 0 | 0 | 6 | `clusterTest`, fixture diagnostics/provenance, 네 elector matrix, 실제 `CROSSSLOT`, ABI/API 명령을 추가 |
+| `spec-compatibility` | REQUEST CHANGES | 0 | 2 | 3 | command capability 분리, mixed-version rollback 금지 경계, README parity와 resolved Lettuce version을 추가 |
+
+초기 P1은 다음과 같이 revised 설계와 구현에 반영했다. 아래 로컬 증거로 해소를 확인하며, hosted Nightly/PR/merge는 별도 승인 게이트다.
+
+1. `mget`을 mutation 공통 타입에 선언하지 않고, standalone `RedisCommands`와 Cluster `RedisAdvancedClusterCommands`를 private `CandidateValueReader`로 분리했다. suspend direct는 `RedisClusterCoroutinesCommands`, script는 `RedisScriptingAsyncCommands`로 분리했다.
+2. v3 우선순위와 양방향 동기화 부재를 숨기지 않고 mixed-version writer와 cutover 이후 rollback을 지원 범위 밖으로 확정했다. 모든 writer quiesce → 새 binary 전환 → migration 허용 순서를 운영 계약으로 고정하고, v3 write 뒤에는 old binary 재기동을 금지한다. 별도 recovery tool/parity 변환은 범위에서 제거하고 상태 보존 후 forward fix만 허용한다.
+3. 현재 catalog의 resolved Lettuce를 `7.6.0.RELEASE`로 고정하고, 7.7 upgrade를 이슈 범위에서 제거했다. 기존 standalone default constructor의 synthetic JVM descriptor는 `@JvmOverloads`, `javap`, precompiled Kotlin consumer로 별도 보존 검증한다.
+4. unregister→migration resurrection은 persistent v3 tombstone/fence와 source 숨김 규칙으로 차단한다. migration 성공 소유권은 unique token으로 기록하고 raw value와 token을 모두 비교할 때만 destination cleanup을 허용한다. v2/colon source는 multi-key script에 전달하지 않는다.
+5. clusterTest no-test/skip guard, full-scope Nightly aggregator, fixture diagnostics artifact, actual resolved-version 및 static validator evidence를 implementation plan의 executable gate로 고정한다.
+
+P2는 implementation plan의 executable task와 acceptance test로 추적한다. source-expiry race는 cross-slot 원자성의 한계를 반영해 bounded stale window로 계약을 조정했고, migration/register는 v3 candidate/index same-slot Lua로 crash window를 줄인다. 실제 fixture·ABI/API·Kover 로컬 증거는 확보했으며 hosted CI/PR/merge는 `PENDING`이다.
+
+## 9. SPW-03~05 문서 품질 기록
+
+### SPW-03 — 한국어 기술 문체
+
+- 독자에게 직접 필요한 계약과 제한을 먼저 적고, 영어는 API·명령·URL·식별자에만 남긴다.
+- `CROSSSLOT`, `MOVED`, `TRYAGAIN`, `PTTL`, `MGET`, `Lua`, `ABI/API` 등 기계 토큰은 번역하지 않는다.
+- 문장을 짧게 유지하고 “지원한다”와 “보장하지 않는다”를 구분한다.
+- 구현자가 바로 파일·심볼·테스트를 찾을 수 있도록 local anchor와 acceptance를 함께 둔다.
+
+### SPW-04 — 사실·출처·추적성
+
+주요 주장마다 위의 Redis/Lettuce primary link 또는 local source anchor를 연결했다. 독립 review lane의 지적은 §8과 acceptance에 연결했으며, source-to-test-to-doc 추적은 implementation plan에서 파일별로 다시 펼친다. 실제 Cluster의 topology/failover 결과는 로컬 테스트 출력과 hosted CI를 분리해 보고한다.
+
+### SPW-05 — 읽기 되돌림 기록
+
+작성 후 다음을 재확인했다.
+
+- 범위: strategic candidate registry와 docs/test로 제한
+- 비범위: 일반 primitive, failover benchmark, release/PR/merge
+- migration: v3 우선, v2 다음, colon legacy 마지막; source 보존
+- same-slot: v3 keys만 `MGET`/Lua에 전달
+- parity: blocking/suspend 네 API 모두 Cluster overload와 실제 통합 테스트 대상
+- 승인: 초기 사용자 설계 승인을 바탕으로 작성했고 독립 review 결과를 반영했다. resolved version·lifecycle fence·ABI·CI guard를 추가한 revised 문서는 fresh 사용자 승인 후에만 plan·code mutation을 진행한다.

--- a/leader-redis-lettuce/README.ko.md
+++ b/leader-redis-lettuce/README.ko.md
@@ -52,6 +52,46 @@ val redisClient = RedisClient.create("redis://localhost:6379")
 val connection = redisClient.connect()
 ```
 
+### Redis Cluster 전략적 elector
+
+네 `LettuceStrategic*Elector` 클래스는 standalone용
+`StatefulRedisConnection`과 Redis Cluster용
+`StatefulRedisClusterConnection`을 모두 받습니다. connection과 client의
+생명주기는 caller가 소유하며 elector가 닫지 않습니다.
+
+```kotlin
+val clusterClient = RedisClusterClient.create("redis://localhost:7000")
+val clusterConnection = clusterClient.connect()
+val elector = LettuceStrategicLeaderElector(clusterConnection, nodeId = "node-a")
+
+val result = elector.runIfLeader("daily-report", FifoElectionStrategy) {
+    generateReport()
+}
+```
+
+Cluster 후보는 v3 hash-tag key layout을 사용하므로 하나의 lock에 속한
+index, candidate, tombstone, migration token이 같은 Redis slot에 배치됩니다.
+기존 v2와 colon layout key는 single-key 연산으로 읽고 source를 삭제하지 않은
+채 승격합니다. persistent tombstone은 unregister와 migration의 race에서
+부활을 막으며, 만료 cleanup은 migration token과 raw value가 모두 일치할 때만
+destination을 삭제합니다.
+
+`lockName`에 Redis hash-tag brace가 들어가면 거부합니다. v3 write가 한 번이라도
+발생한 뒤에는 구버전 binary로 rollback하지 마십시오. writer를 중지하고
+v2/colon 및 v3 상태를 보존·진단한 뒤 forward fix를 배포해야 합니다. Redis의
+`MOVED`/`ASK` 처리와 failover 수렴은 Lettuce topology refresh에 위임되며,
+정상 Cluster 자체를 대신하지 않습니다.
+
+Migration은 한 방향으로만 진행합니다. 구버전과 신버전 writer를 동시에
+운영하지 말고, 구버전 writer를 quiesce한 뒤 v3를 지원하는 reader/writer를
+배포하고 v2 또는 colon source 승격을 완료한 후 정상 스케줄링을 재개합니다.
+v3 write가 관찰된 이후 장애가 발생하면 새 binary를 유지한 채
+중지·상태 보존·진단·forward fix 순서로 복구합니다.
+
+저장소는 Lettuce `7.6.0.RELEASE`를 resolve하고 검증합니다. `clusterTest`
+Gradle task는 일반 PR test와 분리된 Nightly/manual 통합 검증 게이트이며
+benchmark가 아닙니다.
+
 ### 블로킹 단일 리더
 
 ```kotlin
@@ -197,5 +237,5 @@ release 시 `HDEL`로 삭제됩니다. `leaderId`가 빈 문자열이면 기록�
 implementation("io.github.bluetape4k.leader:bluetape4k-leader-redis-lettuce:0.4.0")
 
 // Lettuce가 클래스패스에 있어야 합니다
-implementation("io.lettuce:lettuce-core:6.x.x")
+implementation("io.lettuce:lettuce-core:7.6.0.RELEASE")
 ```

--- a/leader-redis-lettuce/README.md
+++ b/leader-redis-lettuce/README.md
@@ -52,6 +52,45 @@ val redisClient = RedisClient.create("redis://localhost:6379")
 val connection = redisClient.connect()
 ```
 
+### Redis Cluster strategic electors
+
+The four `LettuceStrategic*Elector` classes accept either a standalone
+`StatefulRedisConnection` or a `StatefulRedisClusterConnection`. The connection
+and client remain caller-owned; the elector never closes them.
+
+```kotlin
+val clusterClient = RedisClusterClient.create("redis://localhost:7000")
+val clusterConnection = clusterClient.connect()
+val elector = LettuceStrategicLeaderElector(clusterConnection, nodeId = "node-a")
+
+val result = elector.runIfLeader("daily-report", FifoElectionStrategy) {
+    generateReport()
+}
+```
+
+Cluster candidates use a v3 hash-tagged key layout so an index, candidate,
+tombstone, and migration token for one lock are on the same Redis slot. Existing
+v2 and colon-layout keys are read with single-key operations and promoted without
+deleting the source. A persistent tombstone prevents an unregister/migration race;
+the migration token and raw value must both match before expiry cleanup can remove
+a destination.
+
+`lockName` values containing Redis hash-tag braces are rejected. After any v3
+write, do not roll back to an older binary: stop writers, preserve the v2/colon
+and v3 state, collect diagnostics, and forward-fix the deployment. Redis
+`MOVED`/`ASK` handling and failover convergence remain delegated to Lettuce's
+topology refresh and are not a substitute for a healthy Cluster.
+
+The migration is one-way. Do not run old and new writers concurrently: quiesce
+the old writers, deploy the v3-capable readers/writers, allow the bounded v2 or
+colon source promotion to complete, and only then resume normal scheduling.
+Once a v3 write is observed, keep the deployment on the new binary and use the
+stop-preserve-diagnose-forward-fix procedure for recovery.
+
+The repository resolves and verifies Lettuce `7.6.0.RELEASE`. The
+`clusterTest` Gradle task is a Nightly/manual integration gate, separate from the
+regular PR test task, and is not a benchmark.
+
 ### Blocking single-leader
 
 ```kotlin
@@ -200,5 +239,5 @@ removed with `HDEL` on release. An empty `leaderId` skips the write entirely.
 implementation("io.github.bluetape4k.leader:bluetape4k-leader-redis-lettuce:0.4.0")
 
 // Lettuce must be on the classpath
-implementation("io.lettuce:lettuce-core:6.x.x")
+implementation("io.lettuce:lettuce-core:7.6.0.RELEASE")
 ```

--- a/leader-redis-lettuce/build.gradle.kts
+++ b/leader-redis-lettuce/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.tasks.testing.Test
+import java.time.Instant
+
 configurations {
     testImplementation.get().extendsFrom(compileOnly.get(), runtimeOnly.get())
 }
@@ -21,4 +24,110 @@ dependencies {
 
     // T7 PR 2 — Abstract*ContractTest 사용
     testImplementation(testFixtures(project(":bluetape4k-leader-core")))
+}
+
+tasks.named<Test>("test") {
+    useJUnitPlatform {
+        excludeTags("redis-cluster")
+    }
+}
+
+val clusterTestMatrixFile = layout.projectDirectory.file("src/test/resources/redis-cluster-test-matrix.txt").asFile
+val expectedClusterTestNames = clusterTestMatrixFile.readLines()
+    .map(String::trim)
+    .filter(String::isNotEmpty)
+    .also { names ->
+        require(names.size == names.toSet().size) {
+            "Redis Cluster test matrix contains duplicate names"
+        }
+    }
+
+val clusterTest = tasks.register<Test>("clusterTest") {
+    val expectedClusterTestCount = expectedClusterTestNames.size
+    group = "verification"
+    description = "Runs Redis Cluster integration tests."
+    dependsOn(tasks.named("testClasses"))
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    failOnNoDiscoveredTests = true
+    useJUnitPlatform {
+        includeTags("redis-cluster")
+    }
+    mustRunAfter(tasks.named("test"))
+    systemProperty("junit.jupiter.execution.parallel.enabled", "false")
+    maxParallelForks = 1
+    binaryResultsDirectory.set(layout.buildDirectory.dir("test-results/clusterTest/binary"))
+    reports.junitXml.required.set(true)
+    reports.junitXml.outputLocation.set(layout.buildDirectory.dir("test-results/clusterTest"))
+    reports.junitXml.includeSystemOutLog.set(false)
+    reports.junitXml.includeSystemErrLog.set(false)
+    reports.html.required.set(false)
+
+    val diagnosticsDirectory = layout.buildDirectory.dir("redis-cluster-diagnostics")
+    systemProperty("redis.cluster.diagnostics.dir", diagnosticsDirectory.get().asFile.absolutePath)
+    doFirst {
+        val directory = diagnosticsDirectory.get().asFile
+        directory.mkdirs()
+        directory.resolve("task-provenance.txt").writeText(
+            buildString {
+                appendLine("image=tommy351/redis-cluster:6.2")
+                appendLine("fixture=io.bluetape4k.testcontainers.storage.RedisClusterServer.Launcher.redisCluster")
+                appendLine("task=clusterTest")
+                appendLine("expectedTests=$expectedClusterTestCount")
+                appendLine("dockerHost=${System.getenv("DOCKER_HOST") ?: "default"}")
+                appendLine("startedAt=${Instant.now()}")
+            },
+        )
+    }
+    doLast {
+        val xmlReports = reports.junitXml.outputLocation.get().asFile.walkTopDown()
+            .filter { it.isFile && it.extension == "xml" }
+            .toList()
+        require(xmlReports.isNotEmpty()) {
+            "Redis Cluster test produced no JUnit XML"
+        }
+
+        var tests = 0
+        var skipped = 0
+        var failures = 0
+        var errors = 0
+        val observedTestNames = mutableSetOf<String>()
+        xmlReports.forEach { report ->
+            val document = javax.xml.parsers.DocumentBuilderFactory.newInstance()
+                .apply { isNamespaceAware = false }
+                .newDocumentBuilder()
+                .parse(report)
+            val suite = document.documentElement
+            tests += suite.getAttribute("tests").toIntOrNull() ?: 0
+            skipped += suite.getAttribute("skipped").toIntOrNull() ?: 0
+            failures += suite.getAttribute("failures").toIntOrNull() ?: 0
+            errors += suite.getAttribute("errors").toIntOrNull() ?: 0
+            val testCases = suite.getElementsByTagName("testcase")
+            for (index in 0 until testCases.length) {
+                val testCase = testCases.item(index) as org.w3c.dom.Element
+                observedTestNames += testCase.getAttribute("name").removeSuffix("()")
+            }
+        }
+        val missingTestNames = expectedClusterTestNames.filterNot(observedTestNames::contains)
+        require(tests >= expectedClusterTestCount && missingTestNames.isEmpty() &&
+            skipped == 0 && failures == 0 && errors == 0) {
+            "Redis Cluster test scope invalid: expected at least $expectedClusterTestCount tests and " +
+                "all matrix names, actual=$tests, missing=$missingTestNames, skipped=$skipped, " +
+                "failures=$failures, errors=$errors"
+        }
+
+        val runtimeProvenance = diagnosticsDirectory.get().asFile.resolve("cluster-runtime.txt")
+        require(runtimeProvenance.isFile) {
+            "Redis Cluster runtime provenance is missing: ${runtimeProvenance.absolutePath}"
+        }
+        val provenanceLines = runtimeProvenance.readLines()
+        val imageDigest = provenanceLines.firstOrNull { it.startsWith("image_digest=") }
+        val clusterState = provenanceLines.firstOrNull { it.startsWith("cluster_state=") }
+        val endpoints = provenanceLines.firstOrNull { it.startsWith("endpoints=") }
+        val endpointCount = endpoints?.substringAfter('=')?.split(',')?.count { it.isNotBlank() } ?: 0
+        require(imageDigest?.contains("@sha256:") == true && clusterState == "cluster_state=ok" &&
+            endpointCount >= 6) {
+            "Redis Cluster runtime provenance is incomplete: $provenanceLines"
+        }
+    }
 }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateCommands.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateCommands.kt
@@ -1,0 +1,103 @@
+@file:Suppress("TooManyFunctions")
+
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.leader.lettuce.script.RedisScript
+import io.lettuce.core.ScriptOutputType
+import io.lettuce.core.SetArgs
+import io.lettuce.core.api.sync.RedisCommands
+import io.lettuce.core.cluster.api.sync.RedisClusterCommands
+
+/**
+ * blocking registry가 사용하는 단일 key/set/script capability입니다.
+ * `RedisCommands`는 `RedisClusterCommands`의 subtype이므로 standalone과 Cluster가
+ * 동일한 mutation 경계를 공유하고, 일괄 조회만 별도 reader capability로 분리합니다.
+ */
+internal interface BlockingCandidateCommands {
+    fun get(key: String): String?
+    fun set(key: String, value: String): String?
+    fun set(key: String, value: String, args: SetArgs): String?
+    fun setnx(key: String, value: String): Boolean
+    fun psetex(key: String, ttlMillis: Long, value: String): String?
+    fun sadd(key: String, nodeId: String): Long
+    fun persist(key: String): Boolean
+    fun smembers(key: String): Set<String>
+    fun srem(key: String, nodeIds: Array<String>): Long
+    fun del(key: String): Long
+    fun pttl(key: String): Long
+
+    fun <T> runScript(
+        script: RedisScript,
+        outputType: ScriptOutputType,
+        keys: Array<String>,
+        vararg args: String,
+    ): T
+}
+
+/** standalone/Cluster sync API의 공통 command adapter입니다. */
+internal class LettuceBlockingCandidateCommands(
+    private val commands: RedisClusterCommands<String, String>,
+) : BlockingCandidateCommands {
+
+    override fun get(key: String): String? = commands.get(key)
+
+    override fun set(key: String, value: String): String? = commands.set(key, value)
+
+    override fun set(key: String, value: String, args: SetArgs): String? = commands.set(key, value, args)
+
+    override fun setnx(key: String, value: String): Boolean = commands.setnx(key, value)
+
+    override fun psetex(key: String, ttlMillis: Long, value: String): String? = commands.psetex(key, ttlMillis, value)
+
+    override fun sadd(key: String, nodeId: String): Long = commands.sadd(key, nodeId)
+
+    override fun persist(key: String): Boolean = commands.persist(key)
+
+    override fun smembers(key: String): Set<String> = commands.smembers(key)
+
+    override fun srem(key: String, nodeIds: Array<String>): Long = commands.srem(key, *nodeIds)
+
+    override fun del(key: String): Long = commands.del(key)
+
+    override fun pttl(key: String): Long = commands.pttl(key)
+
+    override fun <T> runScript(
+        script: RedisScript,
+        outputType: ScriptOutputType,
+        keys: Array<String>,
+        vararg args: String,
+    ): T = io.bluetape4k.leader.lettuce.script.RedisScriptRunner.run(
+        commands,
+        script,
+        outputType,
+        keys,
+        *args,
+    )
+}
+
+/** v3 일괄 candidate 조회에 필요한 Cluster 전용 capability입니다. */
+internal fun interface BlockingCandidateValueReader {
+    fun read(keys: List<String>): Map<String, String?>
+}
+
+/** standalone에서도 Lettuce sync API가 제공하는 MGET으로 후보를 일괄 조회합니다. */
+internal class StandaloneBlockingCandidateValueReader(
+    private val commands: RedisCommands<String, String>,
+) : BlockingCandidateValueReader {
+    override fun read(keys: List<String>): Map<String, String?> =
+        commands.mget(*keys.toTypedArray()).associate { value ->
+            value.key to if (value.hasValue()) value.value else null
+        }
+}
+
+/** Cluster에서는 같은 lock hash-tag를 가진 v3 key만 MGET합니다. */
+internal class ClusterBlockingCandidateValueReader(
+    private val commands: io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands<String, String>,
+) : BlockingCandidateValueReader {
+    override fun read(keys: List<String>): Map<String, String?> =
+        commands.mget(*keys.toTypedArray()).associate { value ->
+            value.key to if (value.hasValue()) value.value else null
+        }
+}
+
+private const val REDIS_KEY_ABSENT_TTL = -2L

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateIndexCleanupScript.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateIndexCleanupScript.kt
@@ -6,17 +6,22 @@ import io.bluetape4k.leader.lettuce.script.RedisScript
  * 현재 후보 key가 여전히 없는 경우에만 index member를 제거합니다.
  *
  * 후보 migration 또는 동시 등록이 stale snapshot과 index 정리 사이에 key를 만들 수
- * 있으므로, 존재 확인과 SREM을 하나의 Redis 원자 실행으로 묶습니다.
+ * 있으므로, 존재 확인과 SREM/token 정리를 하나의 Redis 원자 실행으로 묶습니다.
  */
 internal object LettuceCandidateIndexCleanupScript {
 
     val REMOVE_MISSING = RedisScript(
         """
         local removed = 0
-        for index = 2, #KEYS do
-          if redis.call('EXISTS', KEYS[index]) == 0 then
-            removed = removed + redis.call('SREM', KEYS[1], ARGV[index - 1])
+        local candidateIndex = 2
+        local memberIndex = 1
+        while candidateIndex <= #KEYS do
+          if redis.call('EXISTS', KEYS[candidateIndex]) == 0 then
+            removed = removed + redis.call('SREM', KEYS[1], ARGV[memberIndex])
+            redis.call('DEL', KEYS[candidateIndex + 1])
           end
+          candidateIndex = candidateIndex + 2
+          memberIndex = memberIndex + 1
         end
         return removed
         """.trimIndent()

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateKeyCodec.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateKeyCodec.kt
@@ -12,17 +12,36 @@ import java.nio.charset.StandardCharsets
  */
 internal object LettuceCandidateKeyCodec {
 
-    private const val VERSION = "v2"
+    private const val V2_VERSION = "v2"
+    private const val V3_VERSION = "v3"
     private const val INDEX_TYPE = "i"
     private const val CANDIDATE_TYPE = "c"
+    private const val TOMBSTONE_TYPE = "t"
+    private const val MIGRATION_TOKEN_TYPE = "m"
     private const val NAMESPACE_SEPARATOR = "|"
 
     fun indexKey(keyPrefix: String, lockName: String): String =
-        "$keyPrefix$NAMESPACE_SEPARATOR$VERSION$NAMESPACE_SEPARATOR$INDEX_TYPE$NAMESPACE_SEPARATOR" +
-            lengthDelimited(lockName)
+        "$keyPrefix$NAMESPACE_SEPARATOR$V3_VERSION$NAMESPACE_SEPARATOR$INDEX_TYPE$NAMESPACE_SEPARATOR" +
+            hashTag(lockName)
 
     fun candidateKey(keyPrefix: String, lockName: String, nodeId: String): String =
-        "$keyPrefix$NAMESPACE_SEPARATOR$VERSION$NAMESPACE_SEPARATOR$CANDIDATE_TYPE$NAMESPACE_SEPARATOR" +
+        "$keyPrefix$NAMESPACE_SEPARATOR$V3_VERSION$NAMESPACE_SEPARATOR$CANDIDATE_TYPE$NAMESPACE_SEPARATOR" +
+            hashTag(lockName) + lengthDelimited(nodeId)
+
+    fun tombstoneKey(keyPrefix: String, lockName: String, nodeId: String): String =
+        "$keyPrefix$NAMESPACE_SEPARATOR$V3_VERSION$NAMESPACE_SEPARATOR$TOMBSTONE_TYPE$NAMESPACE_SEPARATOR" +
+            hashTag(lockName) + lengthDelimited(nodeId)
+
+    fun migrationTokenKey(keyPrefix: String, lockName: String, nodeId: String): String =
+        "$keyPrefix$NAMESPACE_SEPARATOR$V3_VERSION$NAMESPACE_SEPARATOR$MIGRATION_TOKEN_TYPE$NAMESPACE_SEPARATOR" +
+            hashTag(lockName) + lengthDelimited(nodeId)
+
+    fun v2IndexKey(keyPrefix: String, lockName: String): String =
+        "$keyPrefix$NAMESPACE_SEPARATOR$V2_VERSION$NAMESPACE_SEPARATOR$INDEX_TYPE$NAMESPACE_SEPARATOR" +
+            lengthDelimited(lockName)
+
+    fun v2CandidateKey(keyPrefix: String, lockName: String, nodeId: String): String =
+        "$keyPrefix$NAMESPACE_SEPARATOR$V2_VERSION$NAMESPACE_SEPARATOR$CANDIDATE_TYPE$NAMESPACE_SEPARATOR" +
             lengthDelimited(lockName) + lengthDelimited(nodeId)
 
     fun legacyIndexKey(keyPrefix: String, lockName: String): String =
@@ -35,6 +54,8 @@ internal object LettuceCandidateKeyCodec {
         val byteLength = value.toByteArray(StandardCharsets.UTF_8).size
         return "$byteLength:$value"
     }
+
+    private fun hashTag(lockName: String): String = "{${lengthDelimited(lockName)}}"
 }
 
 internal fun RedisCommandExecutionException.isWrongType(): Boolean =

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRefreshScript.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRefreshScript.kt
@@ -16,6 +16,11 @@ internal object LettuceCandidateRefreshScript {
 
     val REFRESH = RedisScript(
         """
+        local ttl = tonumber(ARGV[2])
+        if not ttl or ttl < 0 or ttl % 1 ~= 0 then
+          return redis.error_reply('candidate TTL must be a non-negative integer')
+        end
+
         local current = redis.call('GET', KEYS[1])
         if not current then
           return { $ABSENT }
@@ -68,7 +73,6 @@ internal object LettuceCandidateRefreshScript {
           nodeId, registeredAt, lastStartTime, lastCompletionTime, successCount,
           failureCount, incomingMetadata
         }, '|')
-        local ttl = tonumber(ARGV[2])
         if ttl and ttl > 0 then
           redis.call('PSETEX', KEYS[1], ttl, updated)
         else
@@ -76,6 +80,7 @@ internal object LettuceCandidateRefreshScript {
         end
         redis.call('SADD', KEYS[2], nodeId)
         redis.call('PERSIST', KEYS[2])
+        redis.call('DEL', KEYS[3])
         return { $UPDATED }
         """.trimIndent()
     )

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateRegistry.kt
@@ -1,31 +1,55 @@
 package io.bluetape4k.leader.lettuce
 
-import io.bluetape4k.leader.validateLockName
 import io.bluetape4k.leader.lettuce.script.RedisScriptRunner
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.validateLockName
 import io.lettuce.core.RedisCommandExecutionException
 import io.lettuce.core.ScriptOutputType
-import io.lettuce.core.SetArgs
 import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
 import java.time.Instant
+import java.util.UUID
 import kotlin.time.Duration
 
 /**
- * `LettuceCandidateRegistry`는 Redis Lettuce backend의 leader election, lock lease, ownership 확인을 담당합니다.
+ * `LettuceCandidateRegistry`는 blocking Lettuce strategic 후보의 lifecycle과
+ * legacy migration을 담당합니다.
  *
- * 정상 lock contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.
- * @property connection Redis Lettuce backend 호출과 상태 계산에 사용하는 속성입니다.
+ * v3 mutation은 candidate/index/tombstone/token을 같은 hash slot의 Lua 경계로
+ * 묶고, v2/colon source는 single-key 관찰과 cleanup만 허용합니다.
  */
 @Suppress("TooManyFunctions")
-internal class LettuceCandidateRegistry(
-    private val connection: StatefulRedisConnection<String, String>,
-    private val keyPrefix: String = DEFAULT_KEY_PREFIX,
+internal class LettuceCandidateRegistry private constructor(
+    private val commands: BlockingCandidateCommands,
+    private val readMany: BlockingCandidateValueReader,
+    private val keyPrefix: String,
 ) {
-    /** 기존 internal JVM constructor descriptor를 보존합니다. */
+
+    /** 기존 standalone internal JVM constructor descriptor를 보존합니다. */
+    internal constructor(
+        connection: StatefulRedisConnection<String, String>,
+        keyPrefix: String = DEFAULT_KEY_PREFIX,
+    ) : this(
+        LettuceBlockingCandidateCommands(connection.sync()),
+        StandaloneBlockingCandidateValueReader(connection.sync()),
+        keyPrefix,
+    )
+
+    /** 기존 one-argument internal 호출 surface를 보존합니다. */
     internal constructor(connection: StatefulRedisConnection<String, String>) : this(
         connection,
         DEFAULT_KEY_PREFIX,
+    )
+
+    /** Redis Cluster connection을 위한 additive internal constructor입니다. */
+    internal constructor(
+        connection: StatefulRedisClusterConnection<String, String>,
+        keyPrefix: String = DEFAULT_KEY_PREFIX,
+    ) : this(
+        LettuceBlockingCandidateCommands(connection.sync()),
+        ClusterBlockingCandidateValueReader(connection.sync()),
+        keyPrefix,
     )
 
     companion object {
@@ -33,160 +57,240 @@ internal class LettuceCandidateRegistry(
         internal const val GROUP_KEY_PREFIX = "leader:strategy:group-candidates:lettuce:v1"
     }
 
-    private val sync = connection.sync()
-
-    private fun indexKey(lockName: String) =
+    private fun indexKey(lockName: String): String =
         LettuceCandidateKeyCodec.indexKey(keyPrefix, lockName)
 
-    private fun candidateKey(lockName: String, nodeId: String) =
+    private fun candidateKey(lockName: String, nodeId: String): String =
         LettuceCandidateKeyCodec.candidateKey(keyPrefix, lockName, nodeId)
 
-    /**
-     * `registerCandidate` 호출은 Redis Lettuce backend leader election 계약의 일부 동작을 수행합니다.
-     *
-     * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
-     */
+    private fun tombstoneKey(lockName: String, nodeId: String): String =
+        LettuceCandidateKeyCodec.tombstoneKey(keyPrefix, lockName, nodeId)
+
+    private fun migrationTokenKey(lockName: String, nodeId: String): String =
+        LettuceCandidateKeyCodec.migrationTokenKey(keyPrefix, lockName, nodeId)
+
+    private fun v2IndexKey(lockName: String): String =
+        LettuceCandidateKeyCodec.v2IndexKey(keyPrefix, lockName)
+
+    private fun v2CandidateKey(lockName: String, nodeId: String): String =
+        LettuceCandidateKeyCodec.v2CandidateKey(keyPrefix, lockName, nodeId)
+
+    private fun legacyIndexKey(lockName: String): String =
+        LettuceCandidateKeyCodec.legacyIndexKey(keyPrefix, lockName)
+
+    private fun legacyCandidateKey(lockName: String, nodeId: String): String =
+        LettuceCandidateKeyCodec.legacyCandidateKey(keyPrefix, lockName, nodeId)
+
     fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
         validateLockName(lockName)
-        val key = candidateKey(lockName, info.nodeId)
-        val indexKey = indexKey(lockName)
-        val value = LettuceCandidateInfoCodec.encode(info)
-        if (ttl == Duration.ZERO) sync.set(key, value)
-        else sync.psetex(key, ttl.inWholeMilliseconds, value)
-        sync.sadd(indexKey, info.nodeId)
-        // 후보별 TTL은 candidate key에만 적용한다. index set까지 만료시키면
-        // 유한 TTL 후보가 영구 후보를 같은 lockName에서 가릴 수 있다.
-        sync.persist(indexKey)
+        val ttlMillis = candidateTtlMillis(ttl)
+        val reply = runWriteScript(
+            operation = LettuceCandidateWriteScript.REGISTER,
+            keys = arrayOf(
+                candidateKey(lockName, info.nodeId),
+                indexKey(lockName),
+                tombstoneKey(lockName, info.nodeId),
+                migrationTokenKey(lockName, info.nodeId),
+            ),
+            args = arrayOf(
+                LettuceCandidateInfoCodec.encode(info),
+                ttlMillis.toString(),
+                info.nodeId,
+            ),
+        )
+        requireStatus(reply, LettuceCandidateWriteScript.REGISTERED)
     }
 
-    /** 기존 후보의 heartbeat를 원자적으로 갱신하고 결과 통계는 보존합니다. */
     fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
         validateLockName(lockName)
-        val key = candidateKey(lockName, info.nodeId)
-        if (sync.get(key) == null) {
-            migrateLegacyCandidate(lockName, info.nodeId)
-        }
-        val reply = RedisScriptRunner.run<List<Any>>(
-            sync,
+        val ttlMillis = candidateTtlMillis(ttl)
+        if (commands.get(tombstoneKey(lockName, info.nodeId)) != null) return
+        ensureCurrentCandidate(lockName, info.nodeId)
+        val reply = commands.runScript<List<Any>>(
             LettuceCandidateRefreshScript.REFRESH,
             ScriptOutputType.MULTI,
-            arrayOf(key, indexKey(lockName)),
+            arrayOf(
+                candidateKey(lockName, info.nodeId),
+                indexKey(lockName),
+                migrationTokenKey(lockName, info.nodeId),
+            ),
             LettuceCandidateInfoCodec.encode(info),
-            ttl.inWholeMilliseconds.toString(),
+            ttlMillis.toString(),
         )
         LettuceCandidateRefreshScript.rethrowMalformed(reply)
     }
 
-    /**
-     * `unregisterCandidate` 호출은 Redis Lettuce backend leader election 계약의 일부 동작을 수행합니다.
-     *
-     * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
-     */
     fun unregisterCandidate(lockName: String, nodeId: String) {
         validateLockName(lockName)
-        sync.del(candidateKey(lockName, nodeId))
-        sync.srem(indexKey(lockName), nodeId)
-        val legacyKey = LettuceCandidateKeyCodec.legacyCandidateKey(keyPrefix, lockName, nodeId)
-        if (readLegacyCandidate(legacyKey, nodeId) != null) {
-            sync.del(legacyKey)
-        }
-        removeLegacyIndexMembers(lockName, listOf(nodeId))
+        val reply = runWriteScript(
+            operation = LettuceCandidateWriteScript.UNREGISTER,
+            keys = arrayOf(
+                candidateKey(lockName, nodeId),
+                indexKey(lockName),
+                tombstoneKey(lockName, nodeId),
+                migrationTokenKey(lockName, nodeId),
+            ),
+            args = arrayOf(nodeId),
+        )
+        requireStatus(reply, LettuceCandidateWriteScript.UNREGISTERED)
+
+        cleanupLegacyCandidate(nodeId, v2CandidateKey(lockName, nodeId), v2IndexKey(lockName))
+        cleanupLegacyCandidate(nodeId, legacyCandidateKey(lockName, nodeId), legacyIndexKey(lockName))
     }
 
-    /**
-     * `listCandidates` 호출은 Redis Lettuce backend leader election 계약의 일부 동작을 수행합니다.
-     *
-     * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
-     */
     @Suppress("CyclomaticComplexMethod")
     fun listCandidates(lockName: String): List<CandidateInfo> {
         validateLockName(lockName)
-        val currentIndexKey = indexKey(lockName)
-        val currentNodeIds = sync.smembers(currentIndexKey).toList()
-        val legacyNodeIds = readLegacyNodeIds(lockName)
-        if (currentNodeIds.isEmpty() && legacyNodeIds.isEmpty()) return emptyList()
-
+        val currentIndex = indexKey(lockName)
+        val currentNodeIds = commands.smembers(currentIndex).toList()
         val candidates = linkedMapOf<String, CandidateInfo>()
         val missingCurrentNodeIds = mutableListOf<String>()
         val mismatchedCurrentNodeIds = mutableListOf<String>()
-        val currentKeys = currentNodeIds.associateBy { nodeId -> candidateKey(lockName, nodeId) }
-        if (currentKeys.isNotEmpty()) {
-            sync.mget(*currentKeys.keys.toTypedArray()).forEach { kv ->
-                val nodeId = currentKeys[kv.key] ?: return@forEach
-                if (!kv.hasValue()) {
+
+        if (currentNodeIds.isNotEmpty()) {
+            val keys = currentNodeIds.map { candidateKey(lockName, it) }
+            val values = readMany.read(keys)
+            currentNodeIds.forEach { nodeId ->
+                if (commands.get(tombstoneKey(lockName, nodeId)) != null) {
+                    mismatchedCurrentNodeIds += nodeId
+                    return@forEach
+                }
+                val raw = values[candidateKey(lockName, nodeId)]
+                if (raw == null) {
                     missingCurrentNodeIds += nodeId
                     return@forEach
                 }
-                val candidate = LettuceCandidateInfoCodec.decode(kv.value)
+                val candidate = LettuceCandidateInfoCodec.decode(raw)
                 if (candidate.nodeId == nodeId) candidates[nodeId] = candidate
                 else mismatchedCurrentNodeIds += nodeId
             }
         }
 
-        val staleLegacyNodeIds = mutableListOf<String>()
-        legacyNodeIds.forEach { nodeId ->
+        val v2Index = v2IndexKey(lockName)
+        val legacyIndex = legacyIndexKey(lockName)
+        val v2NodeIds = readIndexMembers(v2Index)
+        val legacyNodeIds = readIndexMembers(legacyIndex)
+        val sourceNodeIds = (v2NodeIds + legacyNodeIds).distinct()
+        val legacySources = sourceNodeIds.associateWith { nodeId ->
+            readLegacySources(lockName, nodeId, nodeId in v2NodeIds, nodeId in legacyNodeIds)
+        }
+        sourceNodeIds.forEach { nodeId ->
             if (candidates.containsKey(nodeId)) return@forEach
-            val legacyCandidate = readLegacyCandidate(
-                LettuceCandidateKeyCodec.legacyCandidateKey(keyPrefix, lockName, nodeId),
-                nodeId,
-            )
-            if (legacyCandidate == null) {
-                staleLegacyNodeIds += nodeId
-                return@forEach
-            }
-            migrateLegacyCandidate(lockName, nodeId)
-            val currentCandidate = readCurrentCandidate(lockName, nodeId)
-            if (currentCandidate != null) {
-                sync.sadd(currentIndexKey, nodeId)
-                sync.persist(currentIndexKey)
-                candidates[nodeId] = currentCandidate
-            } else {
-                candidates[nodeId] = legacyCandidate
-            }
+            if (commands.get(tombstoneKey(lockName, nodeId)) != null) return@forEach
+
+            val source = legacySources[nodeId]?.firstOrNull() ?: return@forEach
+
+            val migrated = migrateLegacyCandidate(lockName, nodeId, source)
+            if (!migrated) return@forEach
+
+            mismatchedCurrentNodeIds.remove(nodeId)
+            val currentRaw = commands.get(candidateKey(lockName, nodeId)) ?: return@forEach
+            val currentCandidate = LettuceCandidateInfoCodec.decode(currentRaw)
+            if (currentCandidate.nodeId == nodeId) candidates[nodeId] = currentCandidate
         }
 
         if (mismatchedCurrentNodeIds.isNotEmpty()) {
-            sync.srem(currentIndexKey, *mismatchedCurrentNodeIds.toTypedArray())
+            commands.srem(currentIndex, mismatchedCurrentNodeIds.toTypedArray())
         }
         if (missingCurrentNodeIds.isNotEmpty()) {
-            removeMissingCurrentIndexMembers(lockName, currentIndexKey, missingCurrentNodeIds)
-        }
-        if (staleLegacyNodeIds.isNotEmpty()) {
-            removeLegacyIndexMembers(lockName, staleLegacyNodeIds)
+            removeMissingCurrentIndexMembers(lockName, currentIndex, missingCurrentNodeIds)
         }
         return candidates.values.toList()
     }
 
-    /**
-     * `updateResult` 호출은 Redis Lettuce backend leader election 계약의 일부 동작을 수행합니다.
-     *
-     * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
-     */
     fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
         validateLockName(lockName)
-        val key = candidateKey(lockName, nodeId)
-        if (sync.get(key) == null) {
-            migrateLegacyCandidate(lockName, nodeId)
-        }
-        val reply = RedisScriptRunner.run<List<Any>>(
-            sync,
+        if (commands.get(tombstoneKey(lockName, nodeId)) != null) return
+        ensureCurrentCandidate(lockName, nodeId)
+        val reply = commands.runScript<List<Any>>(
             LettuceCandidateResultScript.UPDATE,
             ScriptOutputType.MULTI,
-            arrayOf(key),
+            arrayOf(candidateKey(lockName, nodeId), migrationTokenKey(lockName, nodeId)),
             *LettuceCandidateResultScript.resultArgs(result, Instant.now().toEpochMilli()),
         )
         LettuceCandidateResultScript.rethrowMalformed(reply)
     }
 
-    private fun readLegacyNodeIds(lockName: String): Set<String> = try {
-        sync.smembers(LettuceCandidateKeyCodec.legacyIndexKey(keyPrefix, lockName))
+    private fun runWriteScript(operation: String, keys: Array<String>, args: Array<String>): List<Any> =
+        commands.runScript(
+            LettuceCandidateWriteScript.WRITE,
+            ScriptOutputType.MULTI,
+            keys,
+            operation,
+            *args,
+        )
+
+    private fun requireStatus(reply: List<Any>, expected: Long) {
+        val actual = reply.firstOrNull()?.toString()?.toLongOrNull()
+        require(actual == expected) {
+            "Unexpected candidate write status: expected=$expected actual=$actual"
+        }
+    }
+
+    private fun ensureCurrentCandidate(lockName: String, nodeId: String): Boolean {
+        if (commands.get(candidateKey(lockName, nodeId)) != null) return true
+        val source = readSourceCandidate(lockName, nodeId)
+        return if (source == null) {
+            false
+        } else {
+            migrateLegacyCandidate(lockName, nodeId, source)
+            commands.get(candidateKey(lockName, nodeId)) != null
+        }
+    }
+
+    private fun readIndexMembers(indexKey: String): Set<String> = try {
+        commands.smembers(indexKey)
     } catch (e: RedisCommandExecutionException) {
         if (e.isWrongType()) emptySet() else throw e
     }
 
+    private fun readSourceCandidate(lockName: String, nodeId: String): LegacyCandidate? {
+        val v2Key = v2CandidateKey(lockName, nodeId)
+        val legacyKey = legacyCandidateKey(lockName, nodeId)
+        val v2Candidate = readLegacyCandidate(v2Key, nodeId)
+        val legacyCandidate = readLegacyCandidate(legacyKey, nodeId)
+        return v2Candidate?.let { LegacyCandidate(v2Key, v2IndexKey(lockName)) }
+            ?: legacyCandidate?.let { LegacyCandidate(legacyKey, legacyIndexKey(lockName)) }
+    }
+
+    private fun readLegacySources(
+        lockName: String,
+        nodeId: String,
+        v2Indexed: Boolean,
+        legacyIndexed: Boolean,
+    ): List<LegacyCandidate> = buildList {
+        addLegacySourceIfValid(
+            nodeId,
+            v2CandidateKey(lockName, nodeId),
+            v2IndexKey(lockName),
+            v2Indexed,
+        )?.let(::add)
+        addLegacySourceIfValid(
+            nodeId,
+            legacyCandidateKey(lockName, nodeId),
+            legacyIndexKey(lockName),
+            legacyIndexed,
+        )?.let(::add)
+    }
+
+    private fun addLegacySourceIfValid(
+        nodeId: String,
+        sourceKey: String,
+        sourceIndexKey: String,
+        indexed: Boolean,
+    ): LegacyCandidate? {
+        val candidate = readLegacyCandidate(sourceKey, nodeId)
+        return if (candidate == null) {
+            if (indexed) removeLegacyIndexMembers(sourceIndexKey, listOf(nodeId))
+            null
+        } else {
+            LegacyCandidate(sourceKey, sourceIndexKey)
+        }
+    }
+
     private fun readLegacyCandidate(key: String, expectedNodeId: String): CandidateInfo? {
         val raw = try {
-            sync.get(key)
+            commands.get(key)
         } catch (e: RedisCommandExecutionException) {
             if (!e.isWrongType()) throw e
             null
@@ -194,33 +298,80 @@ internal class LettuceCandidateRegistry(
         return raw?.let(LettuceCandidateInfoCodec::decode)?.takeIf { it.nodeId == expectedNodeId }
     }
 
-    private fun readCurrentCandidate(lockName: String, expectedNodeId: String): CandidateInfo? {
-        val raw = sync.get(candidateKey(lockName, expectedNodeId)) ?: return null
-        return LettuceCandidateInfoCodec.decode(raw).takeIf { it.nodeId == expectedNodeId }
+    private fun migrateLegacyCandidate(lockName: String, nodeId: String, source: LegacyCandidate): Boolean {
+        val sourceRaw = commands.get(source.key)
+        val sourceCandidate = sourceRaw?.let(LettuceCandidateInfoCodec::decode)
+        return if (sourceRaw == null || sourceCandidate?.nodeId != nodeId) {
+            removeSourceIndexMember(source, nodeId)
+            false
+        } else {
+            val observedTtl = commands.pttl(source.key)
+            if (observedTtl == REDIS_KEY_ABSENT_TTL || (observedTtl <= 0L && observedTtl != -1L)) {
+                removeSourceIndexMember(source, nodeId)
+                false
+            } else {
+                val token = UUID.randomUUID().toString()
+                val reply = runWriteScript(
+                    operation = LettuceCandidateWriteScript.MIGRATE,
+                    keys = arrayOf(
+                        candidateKey(lockName, nodeId),
+                        indexKey(lockName),
+                        tombstoneKey(lockName, nodeId),
+                        migrationTokenKey(lockName, nodeId),
+                    ),
+                    args = arrayOf(sourceRaw, observedTtl.toString(), nodeId, token),
+                )
+                when (reply.firstOrNull()?.toString()?.toLongOrNull()) {
+                    LettuceCandidateWriteScript.MIGRATED -> {
+                        cleanupExpiredMigration(lockName, nodeId, source.key, sourceRaw, observedTtl, token)
+                        commands.get(candidateKey(lockName, nodeId)) != null
+                    }
+                    LettuceCandidateWriteScript.EXISTING_REPAIRED -> true
+                    LettuceCandidateWriteScript.MALFORMED -> {
+                        LettuceCandidateInfoCodec.decode(reply.getOrNull(1)?.toString().orEmpty())
+                        false
+                    }
+                    else -> false
+                }
+            }
+        }
     }
 
-    private fun migrateLegacyCandidate(lockName: String, nodeId: String): Boolean {
-        val legacyKey = LettuceCandidateKeyCodec.legacyCandidateKey(keyPrefix, lockName, nodeId)
-        val candidate = readLegacyCandidate(legacyKey, nodeId) ?: return false
-        val raw = LettuceCandidateInfoCodec.encode(candidate)
-        val ttl = sync.pttl(legacyKey)
-        val migrated = when {
-            ttl == -2L -> false
-            ttl == -1L -> sync.setnx(candidateKey(lockName, nodeId), raw)
-            ttl > 0L -> sync.set(candidateKey(lockName, nodeId), raw, SetArgs.Builder.nx().px(ttl)) != null
-            else -> false
-        }
-        if (migrated) {
-            sync.sadd(indexKey(lockName), nodeId)
-            sync.persist(indexKey(lockName))
-        }
-        return migrated
+    private fun cleanupExpiredMigration(
+        lockName: String,
+        nodeId: String,
+        sourceKey: String,
+        sourceRaw: String,
+        observedTtl: Long,
+        token: String,
+    ) {
+        val sourceAfter = commands.get(sourceKey)
+        val sourceTtlAfter = commands.pttl(sourceKey)
+        val expired = sourceAfter == null ||
+            sourceTtlAfter == REDIS_KEY_ABSENT_TTL ||
+            (observedTtl > 0L && sourceTtlAfter == 0L)
+        if (!expired) return
+
+        runWriteScript(
+            operation = LettuceCandidateWriteScript.REMOVE_IF_VALUE,
+            keys = arrayOf(
+                candidateKey(lockName, nodeId),
+                indexKey(lockName),
+                migrationTokenKey(lockName, nodeId),
+            ),
+            args = arrayOf(sourceRaw, token, nodeId),
+        )
     }
 
-    private fun removeMissingCurrentIndexMembers(lockName: String, indexKey: String, nodeIds: List<String>) {
-        val keys = arrayOf(indexKey) + nodeIds.map { candidateKey(lockName, it) }
-        RedisScriptRunner.run<Long>(
-            sync,
+    private fun removeMissingCurrentIndexMembers(lockName: String, currentIndex: String, nodeIds: List<String>) {
+        val keys = buildList {
+            add(currentIndex)
+            nodeIds.forEach { nodeId ->
+                add(candidateKey(lockName, nodeId))
+                add(migrationTokenKey(lockName, nodeId))
+            }
+        }.toTypedArray()
+        commands.runScript<Long>(
             LettuceCandidateIndexCleanupScript.REMOVE_MISSING,
             ScriptOutputType.INTEGER,
             keys,
@@ -228,11 +379,36 @@ internal class LettuceCandidateRegistry(
         )
     }
 
-    private fun removeLegacyIndexMembers(lockName: String, nodeIds: List<String>) {
+    private fun cleanupLegacyCandidate(nodeId: String, candidateKey: String, indexKey: String) {
+        if (readLegacyCandidate(candidateKey, nodeId) != null) commands.del(candidateKey)
+        removeLegacyIndexMembers(indexKey, listOf(nodeId))
+    }
+
+    private fun removeLegacyIndexMembers(indexKey: String, nodeIds: List<String>) {
         try {
-            sync.srem(LettuceCandidateKeyCodec.legacyIndexKey(keyPrefix, lockName), *nodeIds.toTypedArray())
+            commands.srem(indexKey, nodeIds.toTypedArray())
         } catch (e: RedisCommandExecutionException) {
             if (!e.isWrongType()) throw e
         }
     }
+
+    private fun removeSourceIndexMember(source: LegacyCandidate, nodeId: String) {
+        removeLegacyIndexMembers(source.indexKey, listOf(nodeId))
+    }
+
+    private fun candidateTtlMillis(ttl: Duration): Long {
+        require(ttl >= Duration.ZERO) { "Candidate TTL must be non-negative" }
+        val millis = ttl.inWholeMilliseconds
+        require(ttl == Duration.ZERO || millis > 0L) {
+            "Candidate TTL must be zero or at least 1ms"
+        }
+        return millis
+    }
+
+    private data class LegacyCandidate(
+        val key: String,
+        val indexKey: String,
+    )
 }
+
+private const val REDIS_KEY_ABSENT_TTL = -2L

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateResultScript.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateResultScript.kt
@@ -165,6 +165,7 @@ internal object LettuceCandidateResultScript {
         }, '|')
         local written = redis.call('SET', KEYS[1], updated, 'XX', 'KEEPTTL')
         if written then
+          redis.call('DEL', KEYS[2])
           return { $UPDATED }
         end
         return { $ABSENT }

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateWriteScript.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateWriteScript.kt
@@ -1,0 +1,150 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.leader.lettuce.script.RedisScript
+
+/**
+ * v3 후보 value/index/fence 상태를 하나의 hash slot에서 갱신하는 스크립트입니다.
+ *
+ * legacy source key는 migration payload로만 전달하며 `KEYS`에 포함하지 않습니다.
+ * 따라서 migration 이후 source 정리와 v3 destination 원자성의 경계를 분리할 수
+ * 있고, Cluster에서 `CROSSSLOT`을 유발하지 않습니다.
+ */
+internal object LettuceCandidateWriteScript {
+
+    const val REGISTER = "REGISTER"
+    const val MIGRATE = "MIGRATE"
+    const val UNREGISTER = "UNREGISTER"
+    const val REMOVE_IF_VALUE = "REMOVE_IF_VALUE"
+
+    const val ABSENT = 0L
+    const val MALFORMED = -1L
+    const val REGISTERED = 1L
+    const val MIGRATED = 2L
+    const val EXISTING_REPAIRED = 3L
+    const val UNREGISTERED = 4L
+    const val REMOVED = 5L
+    const val TOMBSTONED = 6L
+
+    val WRITE = RedisScript(
+        """
+        local operation = ARGV[1]
+
+        if operation == '$REGISTER' then
+          local ttl = tonumber(ARGV[3])
+          if not ttl or ttl < 0 or ttl % 1 ~= 0 then
+            return redis.error_reply('candidate TTL must be a non-negative integer')
+          end
+
+          redis.call('DEL', KEYS[3], KEYS[4])
+          if ttl > 0 then
+            redis.call('PSETEX', KEYS[1], ttl, ARGV[2])
+          else
+            redis.call('SET', KEYS[1], ARGV[2])
+          end
+          redis.call('SADD', KEYS[2], ARGV[4])
+          redis.call('PERSIST', KEYS[2])
+          return { $REGISTERED }
+        end
+
+        if operation == '$MIGRATE' then
+          if redis.call('EXISTS', KEYS[3]) == 1 then
+            return { $TOMBSTONED }
+          end
+
+          local ttl = tonumber(ARGV[3])
+          if not ttl or ttl == -2 or ttl == 0 or ttl < -2 then
+            return { $ABSENT }
+          end
+
+          if redis.call('EXISTS', KEYS[1]) == 1 then
+            local current = redis.call('GET', KEYS[1])
+            local function validLong(value)
+              return value and string.match(value, '^[+-]?%d+$') ~= nil
+            end
+            local function validOptionalLong(value)
+              return value == '' or validLong(value)
+            end
+            local function validMetadata(value)
+              if value == '' then
+                return true
+              end
+              local start = 1
+              while true do
+                local separator = string.find(value, ',', start, true)
+                local item = separator and string.sub(value, start, separator - 1) or string.sub(value, start)
+                if not string.find(item, '=', 1, true) then
+                  return false
+                end
+                if not separator then
+                  return true
+                end
+                start = separator + 1
+              end
+            end
+
+            local currentNodeId, registeredAt, lastStartTime, lastCompletionTime, successCount, failureCount, metadata =
+              string.match(current, '^([^|]*)|([^|]*)|([^|]*)|([^|]*)|([^|]*)|([^|]*)|(.*)$')
+            local sourceNodeId = string.match(ARGV[2], '^([^|]*)|')
+            if not currentNodeId or not sourceNodeId
+              or not validLong(registeredAt)
+              or not validOptionalLong(lastStartTime)
+              or not validOptionalLong(lastCompletionTime)
+              or not validLong(successCount)
+              or not validLong(failureCount)
+              or not validMetadata(metadata) then
+              return { $MALFORMED, current }
+            end
+
+            if currentNodeId == sourceNodeId then
+              redis.call('SADD', KEYS[2], ARGV[4])
+              redis.call('PERSIST', KEYS[2])
+              return { $EXISTING_REPAIRED }
+            end
+
+            redis.call('DEL', KEYS[1], KEYS[4])
+            redis.call('SREM', KEYS[2], ARGV[4])
+          end
+
+          local written
+          if ttl == -1 then
+            written = redis.call('SET', KEYS[1], ARGV[2], 'NX')
+          elseif ttl > 0 then
+            written = redis.call('SET', KEYS[1], ARGV[2], 'NX', 'PX', ttl)
+          end
+          if written then
+            redis.call('SADD', KEYS[2], ARGV[4])
+            redis.call('PERSIST', KEYS[2])
+            redis.call('SET', KEYS[4], ARGV[5])
+            return { $MIGRATED, ARGV[5] }
+          end
+
+          if redis.call('EXISTS', KEYS[1]) == 1 then
+            redis.call('SADD', KEYS[2], ARGV[4])
+            redis.call('PERSIST', KEYS[2])
+            return { $EXISTING_REPAIRED }
+          end
+          return { $ABSENT }
+        end
+
+        if operation == '$UNREGISTER' then
+          redis.call('SET', KEYS[3], '1')
+          redis.call('DEL', KEYS[1], KEYS[4])
+          redis.call('SREM', KEYS[2], ARGV[2])
+          return { $UNREGISTERED }
+        end
+
+        if operation == '$REMOVE_IF_VALUE' then
+          local current = redis.call('GET', KEYS[1])
+          local currentToken = redis.call('GET', KEYS[3])
+          if current and currentToken and current == ARGV[2] and currentToken == ARGV[3] then
+            redis.call('DEL', KEYS[1], KEYS[3])
+            redis.call('SREM', KEYS[2], ARGV[4])
+            return { $REMOVED }
+          end
+          return { $ABSENT }
+        end
+
+        return redis.error_reply('unsupported candidate write operation: ' .. operation)
+        """.trimIndent()
+    )
+}

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElector.kt
@@ -12,6 +12,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
 import io.bluetape4k.logging.warn
 import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
 import kotlinx.coroutines.CancellationException
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -23,14 +24,24 @@ import kotlin.time.Duration.Companion.seconds
  * 정상 lock contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.
  * @property nodeId Redis Lettuce backend 호출과 상태 계산에 사용하는 속성입니다.
  */
-class LettuceStrategicLeaderElector(
-    connection: StatefulRedisConnection<String, String>,
-    override val nodeId: String = Uuid.V7.nextBase62(),
+class LettuceStrategicLeaderElector private constructor(
+    private val registry: LettuceCandidateRegistry,
+    override val nodeId: String,
 ) : StrategicLeaderElector {
 
-    companion object : KLogging()
+    @JvmOverloads
+    constructor(
+        connection: StatefulRedisConnection<String, String>,
+        nodeId: String = Uuid.V7.nextBase62(),
+    ) : this(LettuceCandidateRegistry(connection), nodeId)
 
-    private val registry = LettuceCandidateRegistry(connection)
+    @JvmOverloads
+    constructor(
+        connection: StatefulRedisClusterConnection<String, String>,
+        nodeId: String = Uuid.V7.nextBase62(),
+    ) : this(LettuceCandidateRegistry(connection), nodeId)
+
+    companion object : KLogging()
 
     override fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
         registry.registerCandidate(lockName, info, ttl)

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderGroupElector.kt
@@ -12,6 +12,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.info
 import io.bluetape4k.logging.warn
 import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
 import kotlinx.coroutines.CancellationException
 import kotlin.time.Duration
 
@@ -21,17 +22,30 @@ import kotlin.time.Duration
  *
  * `maxLeaders`는 관찰한 후보 기준 목록의 선택 수이며 전역 동시 실행 상한이 아닙니다.
  */
-class LettuceStrategicLeaderGroupElector(
-    connection: StatefulRedisConnection<String, String>,
-    override val nodeId: String = Uuid.V7.nextBase62(),
+class LettuceStrategicLeaderGroupElector private constructor(
+    private val registry: LettuceCandidateRegistry,
+    override val nodeId: String,
 ) : StrategicLeaderGroupElector {
 
-    companion object : KLogging()
-
-    private val registry = LettuceCandidateRegistry(
-        connection,
-        LettuceCandidateRegistry.GROUP_KEY_PREFIX,
+    @JvmOverloads
+    constructor(
+        connection: StatefulRedisConnection<String, String>,
+        nodeId: String = Uuid.V7.nextBase62(),
+    ) : this(
+        LettuceCandidateRegistry(connection, LettuceCandidateRegistry.GROUP_KEY_PREFIX),
+        nodeId,
     )
+
+    @JvmOverloads
+    constructor(
+        connection: StatefulRedisClusterConnection<String, String>,
+        nodeId: String = Uuid.V7.nextBase62(),
+    ) : this(
+        LettuceCandidateRegistry(connection, LettuceCandidateRegistry.GROUP_KEY_PREFIX),
+        nodeId,
+    )
+
+    companion object : KLogging()
 
     override fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
         registry.registerCandidate(lockName, info, ttl)

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElector.kt
@@ -15,6 +15,7 @@ import io.bluetape4k.logging.info
 import io.bluetape4k.logging.warn
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
 import kotlinx.coroutines.CancellationException
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -26,14 +27,24 @@ import kotlin.time.Duration.Companion.seconds
  * 정상 lock contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.
  * @property nodeId Redis Lettuce backend 호출과 상태 계산에 사용하는 속성입니다.
  */
-class LettuceStrategicSuspendLeaderElector(
-    connection: StatefulRedisConnection<String, String>,
-    override val nodeId: String = Uuid.V7.nextBase62(),
+class LettuceStrategicSuspendLeaderElector private constructor(
+    private val registry: LettuceSuspendCandidateRegistry,
+    override val nodeId: String,
 ) : StrategicSuspendLeaderElector {
 
-    companion object : KLogging()
+    @JvmOverloads
+    constructor(
+        connection: StatefulRedisConnection<String, String>,
+        nodeId: String = Uuid.V7.nextBase62(),
+    ) : this(LettuceSuspendCandidateRegistry(connection), nodeId)
 
-    private val registry = LettuceSuspendCandidateRegistry(connection)
+    @JvmOverloads
+    constructor(
+        connection: StatefulRedisClusterConnection<String, String>,
+        nodeId: String = Uuid.V7.nextBase62(),
+    ) : this(LettuceSuspendCandidateRegistry(connection), nodeId)
+
+    companion object : KLogging()
 
     override suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
         registry.registerCandidate(lockName, info, ttl)

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElector.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderGroupElector.kt
@@ -15,6 +15,7 @@ import io.bluetape4k.logging.info
 import io.bluetape4k.logging.warn
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
@@ -26,17 +27,30 @@ import kotlin.time.Duration
  *
  * `maxLeaders`는 관찰한 후보 기준 목록의 선택 수이며 전역 동시 실행 상한이 아닙니다.
  */
-class LettuceStrategicSuspendLeaderGroupElector(
-    connection: StatefulRedisConnection<String, String>,
-    override val nodeId: String = Uuid.V7.nextBase62(),
+class LettuceStrategicSuspendLeaderGroupElector private constructor(
+    private val registry: LettuceSuspendCandidateRegistry,
+    override val nodeId: String,
 ) : StrategicSuspendLeaderGroupElector {
 
-    companion object : KLogging()
-
-    private val registry = LettuceSuspendCandidateRegistry(
-        connection,
-        LettuceSuspendCandidateRegistry.GROUP_KEY_PREFIX,
+    @JvmOverloads
+    constructor(
+        connection: StatefulRedisConnection<String, String>,
+        nodeId: String = Uuid.V7.nextBase62(),
+    ) : this(
+        LettuceSuspendCandidateRegistry(connection, LettuceSuspendCandidateRegistry.GROUP_KEY_PREFIX),
+        nodeId,
     )
+
+    @JvmOverloads
+    constructor(
+        connection: StatefulRedisClusterConnection<String, String>,
+        nodeId: String = Uuid.V7.nextBase62(),
+    ) : this(
+        LettuceSuspendCandidateRegistry(connection, LettuceSuspendCandidateRegistry.GROUP_KEY_PREFIX),
+        nodeId,
+    )
+
+    companion object : KLogging()
 
     override suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) =
         registry.registerCandidate(lockName, info, ttl)

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateCommands.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateCommands.kt
@@ -1,0 +1,107 @@
+@file:OptIn(io.lettuce.core.ExperimentalLettuceCoroutinesApi::class)
+@file:Suppress("TooManyFunctions")
+
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.leader.lettuce.script.RedisScript
+import io.lettuce.core.ExperimentalLettuceCoroutinesApi
+import io.lettuce.core.ScriptOutputType
+import io.lettuce.core.SetArgs
+import io.lettuce.core.api.coroutines.RedisCoroutinesCommands
+import io.lettuce.core.api.async.RedisScriptingAsyncCommands
+import io.lettuce.core.cluster.api.coroutines.RedisClusterCoroutinesCommands
+import io.lettuce.core.cluster.api.coroutines
+import kotlinx.coroutines.flow.toList
+
+/** suspend registry가 사용하는 direct command와 script capability입니다. */
+internal interface SuspendCandidateCommands {
+    suspend fun get(key: String): String?
+    suspend fun set(key: String, value: String): String?
+    suspend fun set(key: String, value: String, args: SetArgs): String?
+    suspend fun setnx(key: String, value: String): Boolean
+    suspend fun psetex(key: String, ttlMillis: Long, value: String): String?
+    suspend fun sadd(key: String, nodeId: String): Long
+    suspend fun persist(key: String): Boolean
+    suspend fun smembers(key: String): Set<String>
+    suspend fun srem(key: String, nodeIds: Array<String>): Long
+    suspend fun del(key: String): Long
+    suspend fun pttl(key: String): Long
+
+    suspend fun <T> runScript(
+        script: RedisScript,
+        outputType: ScriptOutputType,
+        keys: Array<String>,
+        vararg args: String,
+    ): T
+}
+
+/** standalone/Cluster coroutine direct command adapter입니다. */
+internal class LettuceSuspendCandidateCommands(
+    private val commands: RedisClusterCoroutinesCommands<String, String>,
+    scriptCommands: () -> RedisScriptingAsyncCommands<String, String>,
+) : SuspendCandidateCommands {
+
+    private val scriptCommands by lazy(scriptCommands)
+
+    override suspend fun get(key: String): String? = commands.get(key)
+
+    override suspend fun set(key: String, value: String): String? = commands.set(key, value)
+
+    override suspend fun set(key: String, value: String, args: SetArgs): String? = commands.set(key, value, args)
+
+    override suspend fun setnx(key: String, value: String): Boolean = commands.setnx(key, value) == true
+
+    override suspend fun psetex(key: String, ttlMillis: Long, value: String): String? =
+        commands.psetex(key, ttlMillis, value)
+
+    override suspend fun sadd(key: String, nodeId: String): Long = commands.sadd(key, nodeId) ?: 0L
+
+    override suspend fun persist(key: String): Boolean = commands.persist(key) == true
+
+    override suspend fun smembers(key: String): Set<String> = commands.smembers(key).toList().toSet()
+
+    override suspend fun srem(key: String, nodeIds: Array<String>): Long = commands.srem(key, *nodeIds) ?: 0L
+
+    override suspend fun del(key: String): Long = commands.del(key) ?: 0L
+
+    override suspend fun pttl(key: String): Long = commands.pttl(key) ?: REDIS_KEY_ABSENT_TTL
+
+    override suspend fun <T> runScript(
+        script: RedisScript,
+        outputType: ScriptOutputType,
+        keys: Array<String>,
+        vararg args: String,
+    ): T = io.bluetape4k.leader.lettuce.script.RedisScriptRunner.runSuspending(
+        scriptCommands,
+        script,
+        outputType,
+        keys,
+        *args,
+    )
+}
+
+internal fun interface SuspendCandidateValueReader {
+    suspend fun read(keys: List<String>): Map<String, String?>
+}
+
+/** standalone에서도 Lettuce coroutine API가 제공하는 MGET으로 후보를 일괄 조회합니다. */
+internal class StandaloneSuspendCandidateValueReader(
+    private val commands: RedisCoroutinesCommands<String, String>,
+) : SuspendCandidateValueReader {
+    override suspend fun read(keys: List<String>): Map<String, String?> =
+        commands.mget(*keys.toTypedArray()).toList().associate { value ->
+            value.key to if (value.hasValue()) value.value else null
+        }
+}
+
+/** Cluster에서는 동일 lock hash-tag를 가진 v3 key를 coroutine MGET으로 읽습니다. */
+internal class ClusterSuspendCandidateValueReader(
+    private val commands: RedisClusterCoroutinesCommands<String, String>,
+) : SuspendCandidateValueReader {
+    override suspend fun read(keys: List<String>): Map<String, String?> =
+        commands.mget(*keys.toTypedArray()).toList().associate { value ->
+            value.key to if (value.hasValue()) value.value else null
+        }
+}
+
+private const val REDIS_KEY_ABSENT_TTL = -2L

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/LettuceSuspendCandidateRegistry.kt
@@ -1,36 +1,59 @@
-@file:OptIn(ExperimentalLettuceCoroutinesApi::class)
+@file:OptIn(io.lettuce.core.ExperimentalLettuceCoroutinesApi::class)
 
 package io.bluetape4k.leader.lettuce
 
+import io.bluetape4k.leader.lettuce.script.RedisScriptRunner
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
-import io.bluetape4k.leader.lettuce.script.RedisScriptRunner
 import io.bluetape4k.leader.validateLockName
 import io.lettuce.core.ExperimentalLettuceCoroutinesApi
 import io.lettuce.core.RedisCommandExecutionException
 import io.lettuce.core.ScriptOutputType
-import io.lettuce.core.SetArgs
 import io.lettuce.core.api.StatefulRedisConnection
 import io.lettuce.core.api.coroutines
 import io.lettuce.core.api.coroutines.RedisCoroutinesCommands
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
+import io.lettuce.core.cluster.api.coroutines
 import kotlinx.coroutines.flow.toList
 import java.time.Instant
+import java.util.UUID
 import kotlin.time.Duration
 
 /**
- * `LettuceSuspendCandidateRegistry`는 Redis Lettuce backend의 leader election, lock lease, ownership 확인을 담당합니다.
- *
- * 정상 lock contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.
+ * `LettuceSuspendCandidateRegistry`는 suspend Lettuce strategic 후보의 lifecycle과
+ * legacy migration을 blocking registry와 동일한 v3 경계로 수행합니다.
  */
 @Suppress("TooManyFunctions")
-internal class LettuceSuspendCandidateRegistry(
-    connection: StatefulRedisConnection<String, String>,
-    private val keyPrefix: String = DEFAULT_KEY_PREFIX,
+internal class LettuceSuspendCandidateRegistry private constructor(
+    private val commands: SuspendCandidateCommands,
+    private val readMany: SuspendCandidateValueReader,
+    private val keyPrefix: String,
 ) {
-    /** 기존 internal JVM constructor descriptor를 보존합니다. */
+
+    /** 기존 standalone internal JVM constructor descriptor를 보존합니다. */
+    internal constructor(
+        connection: StatefulRedisConnection<String, String>,
+        keyPrefix: String = DEFAULT_KEY_PREFIX,
+    ) : this(
+        LettuceSuspendCandidateCommands(connection.coroutines()) { connection.async() },
+        StandaloneSuspendCandidateValueReader(connection.coroutines()),
+        keyPrefix,
+    )
+
+    /** 기존 one-argument internal 호출 surface를 보존합니다. */
     internal constructor(connection: StatefulRedisConnection<String, String>) : this(
         connection,
         DEFAULT_KEY_PREFIX,
+    )
+
+    /** Redis Cluster connection을 위한 additive internal constructor입니다. */
+    internal constructor(
+        connection: StatefulRedisClusterConnection<String, String>,
+        keyPrefix: String = DEFAULT_KEY_PREFIX,
+    ) : this(
+        LettuceSuspendCandidateCommands(connection.coroutines()) { connection.async() },
+        ClusterSuspendCandidateValueReader(connection.coroutines()),
+        keyPrefix,
     )
 
     companion object {
@@ -38,161 +61,241 @@ internal class LettuceSuspendCandidateRegistry(
         internal const val GROUP_KEY_PREFIX = "leader:strategy:group-candidates:lettuce:v1"
     }
 
-    private val cmds: RedisCoroutinesCommands<String, String> = connection.coroutines()
-    private val asyncCommands by lazy { connection.async() }
-
-    private fun indexKey(lockName: String) =
+    private fun indexKey(lockName: String): String =
         LettuceCandidateKeyCodec.indexKey(keyPrefix, lockName)
 
-    private fun candidateKey(lockName: String, nodeId: String) =
+    private fun candidateKey(lockName: String, nodeId: String): String =
         LettuceCandidateKeyCodec.candidateKey(keyPrefix, lockName, nodeId)
 
-    /**
-     * `registerCandidate` 호출은 Redis Lettuce backend leader election 계약의 일부 동작을 수행합니다.
-     *
-     * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
-     */
+    private fun tombstoneKey(lockName: String, nodeId: String): String =
+        LettuceCandidateKeyCodec.tombstoneKey(keyPrefix, lockName, nodeId)
+
+    private fun migrationTokenKey(lockName: String, nodeId: String): String =
+        LettuceCandidateKeyCodec.migrationTokenKey(keyPrefix, lockName, nodeId)
+
+    private fun v2IndexKey(lockName: String): String =
+        LettuceCandidateKeyCodec.v2IndexKey(keyPrefix, lockName)
+
+    private fun v2CandidateKey(lockName: String, nodeId: String): String =
+        LettuceCandidateKeyCodec.v2CandidateKey(keyPrefix, lockName, nodeId)
+
+    private fun legacyIndexKey(lockName: String): String =
+        LettuceCandidateKeyCodec.legacyIndexKey(keyPrefix, lockName)
+
+    private fun legacyCandidateKey(lockName: String, nodeId: String): String =
+        LettuceCandidateKeyCodec.legacyCandidateKey(keyPrefix, lockName, nodeId)
+
     suspend fun registerCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
         validateLockName(lockName)
-        val key = candidateKey(lockName, info.nodeId)
-        val indexKey = indexKey(lockName)
-        val value = LettuceCandidateInfoCodec.encode(info)
-        if (ttl == Duration.ZERO) cmds.set(key, value)
-        else cmds.psetex(key, ttl.inWholeMilliseconds, value)
-        cmds.sadd(indexKey, info.nodeId)
-        // 후보별 TTL은 candidate key에만 적용한다. index set까지 만료시키면
-        // 유한 TTL 후보가 영구 후보를 같은 lockName에서 가릴 수 있다.
-        cmds.persist(indexKey)
+        val ttlMillis = candidateTtlMillis(ttl)
+        val reply = runWriteScript(
+            operation = LettuceCandidateWriteScript.REGISTER,
+            keys = arrayOf(
+                candidateKey(lockName, info.nodeId),
+                indexKey(lockName),
+                tombstoneKey(lockName, info.nodeId),
+                migrationTokenKey(lockName, info.nodeId),
+            ),
+            args = arrayOf(
+                LettuceCandidateInfoCodec.encode(info),
+                ttlMillis.toString(),
+                info.nodeId,
+            ),
+        )
+        requireStatus(reply, LettuceCandidateWriteScript.REGISTERED)
     }
 
-    /** 기존 후보의 heartbeat를 원자적으로 갱신하고 결과 통계는 보존합니다. */
     suspend fun refreshCandidate(lockName: String, info: CandidateInfo, ttl: Duration) {
         validateLockName(lockName)
-        val key = candidateKey(lockName, info.nodeId)
-        if (cmds.get(key) == null) {
-            migrateLegacyCandidate(lockName, info.nodeId)
-        }
-        val reply = RedisScriptRunner.runSuspending<List<Any>>(
-            asyncCommands,
+        val ttlMillis = candidateTtlMillis(ttl)
+        if (commands.get(tombstoneKey(lockName, info.nodeId)) != null) return
+        ensureCurrentCandidate(lockName, info.nodeId)
+        val reply = commands.runScript<List<Any>>(
             LettuceCandidateRefreshScript.REFRESH,
             ScriptOutputType.MULTI,
-            arrayOf(key, indexKey(lockName)),
+            arrayOf(
+                candidateKey(lockName, info.nodeId),
+                indexKey(lockName),
+                migrationTokenKey(lockName, info.nodeId),
+            ),
             LettuceCandidateInfoCodec.encode(info),
-            ttl.inWholeMilliseconds.toString(),
+            ttlMillis.toString(),
         )
         LettuceCandidateRefreshScript.rethrowMalformed(reply)
     }
 
-    /**
-     * `unregisterCandidate` 호출은 Redis Lettuce backend leader election 계약의 일부 동작을 수행합니다.
-     *
-     * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
-     */
     suspend fun unregisterCandidate(lockName: String, nodeId: String) {
         validateLockName(lockName)
-        cmds.del(candidateKey(lockName, nodeId))
-        cmds.srem(indexKey(lockName), nodeId)
-        val legacyKey = LettuceCandidateKeyCodec.legacyCandidateKey(keyPrefix, lockName, nodeId)
-        if (readLegacyCandidate(legacyKey, nodeId) != null) {
-            cmds.del(legacyKey)
-        }
-        removeLegacyIndexMembers(lockName, listOf(nodeId))
+        val reply = runWriteScript(
+            operation = LettuceCandidateWriteScript.UNREGISTER,
+            keys = arrayOf(
+                candidateKey(lockName, nodeId),
+                indexKey(lockName),
+                tombstoneKey(lockName, nodeId),
+                migrationTokenKey(lockName, nodeId),
+            ),
+            args = arrayOf(nodeId),
+        )
+        requireStatus(reply, LettuceCandidateWriteScript.UNREGISTERED)
+
+        cleanupLegacyCandidate(nodeId, v2CandidateKey(lockName, nodeId), v2IndexKey(lockName))
+        cleanupLegacyCandidate(nodeId, legacyCandidateKey(lockName, nodeId), legacyIndexKey(lockName))
     }
 
-    /**
-     * `listCandidates` 호출은 Redis Lettuce backend leader election 계약의 일부 동작을 수행합니다.
-     *
-     * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
-     */
     @Suppress("CyclomaticComplexMethod")
     suspend fun listCandidates(lockName: String): List<CandidateInfo> {
         validateLockName(lockName)
-        val currentIndexKey = indexKey(lockName)
-        val currentNodeIds = cmds.smembers(currentIndexKey).toList()
-        val legacyNodeIds = readLegacyNodeIds(lockName)
-        if (currentNodeIds.isEmpty() && legacyNodeIds.isEmpty()) return emptyList()
-
+        val currentIndex = indexKey(lockName)
+        val currentNodeIds = commands.smembers(currentIndex).toList()
         val candidates = linkedMapOf<String, CandidateInfo>()
         val missingCurrentNodeIds = mutableListOf<String>()
         val mismatchedCurrentNodeIds = mutableListOf<String>()
-        val currentKeys = currentNodeIds.associateBy { nodeId -> candidateKey(lockName, nodeId) }
-        if (currentKeys.isNotEmpty()) {
-            cmds.mget(*currentKeys.keys.toTypedArray()).toList().forEach { kv ->
-                val nodeId = currentKeys[kv.key] ?: return@forEach
-                if (!kv.hasValue()) {
+
+        if (currentNodeIds.isNotEmpty()) {
+            val keys = currentNodeIds.map { candidateKey(lockName, it) }
+            val values = readMany.read(keys)
+            currentNodeIds.forEach { nodeId ->
+                if (commands.get(tombstoneKey(lockName, nodeId)) != null) {
+                    mismatchedCurrentNodeIds += nodeId
+                    return@forEach
+                }
+                val raw = values[candidateKey(lockName, nodeId)]
+                if (raw == null) {
                     missingCurrentNodeIds += nodeId
                     return@forEach
                 }
-                val candidate = LettuceCandidateInfoCodec.decode(kv.getValue())
+                val candidate = LettuceCandidateInfoCodec.decode(raw)
                 if (candidate.nodeId == nodeId) candidates[nodeId] = candidate
                 else mismatchedCurrentNodeIds += nodeId
             }
         }
 
-        val staleLegacyNodeIds = mutableListOf<String>()
-        legacyNodeIds.forEach { nodeId ->
+        val v2Index = v2IndexKey(lockName)
+        val legacyIndex = legacyIndexKey(lockName)
+        val v2NodeIds = readIndexMembers(v2Index)
+        val legacyNodeIds = readIndexMembers(legacyIndex)
+        val sourceNodeIds = (v2NodeIds + legacyNodeIds).distinct()
+        val legacySources = sourceNodeIds.associateWith { nodeId ->
+            readLegacySources(lockName, nodeId, nodeId in v2NodeIds, nodeId in legacyNodeIds)
+        }
+        sourceNodeIds.forEach { nodeId ->
             if (candidates.containsKey(nodeId)) return@forEach
-            val legacyCandidate = readLegacyCandidate(
-                LettuceCandidateKeyCodec.legacyCandidateKey(keyPrefix, lockName, nodeId),
-                nodeId,
-            )
-            if (legacyCandidate == null) {
-                staleLegacyNodeIds += nodeId
-                return@forEach
-            }
-            migrateLegacyCandidate(lockName, nodeId)
-            val currentCandidate = readCurrentCandidate(lockName, nodeId)
-            if (currentCandidate != null) {
-                cmds.sadd(currentIndexKey, nodeId)
-                cmds.persist(currentIndexKey)
-                candidates[nodeId] = currentCandidate
-            } else {
-                candidates[nodeId] = legacyCandidate
-            }
+            if (commands.get(tombstoneKey(lockName, nodeId)) != null) return@forEach
+
+            val source = legacySources[nodeId]?.firstOrNull() ?: return@forEach
+
+            if (!migrateLegacyCandidate(lockName, nodeId, source)) return@forEach
+            mismatchedCurrentNodeIds.remove(nodeId)
+            val currentRaw = commands.get(candidateKey(lockName, nodeId)) ?: return@forEach
+            val currentCandidate = LettuceCandidateInfoCodec.decode(currentRaw)
+            if (currentCandidate.nodeId == nodeId) candidates[nodeId] = currentCandidate
         }
 
         if (mismatchedCurrentNodeIds.isNotEmpty()) {
-            cmds.srem(currentIndexKey, *mismatchedCurrentNodeIds.toTypedArray())
+            commands.srem(currentIndex, mismatchedCurrentNodeIds.toTypedArray())
         }
         if (missingCurrentNodeIds.isNotEmpty()) {
-            removeMissingCurrentIndexMembers(lockName, currentIndexKey, missingCurrentNodeIds)
-        }
-        if (staleLegacyNodeIds.isNotEmpty()) {
-            removeLegacyIndexMembers(lockName, staleLegacyNodeIds)
+            removeMissingCurrentIndexMembers(lockName, currentIndex, missingCurrentNodeIds)
         }
         return candidates.values.toList()
     }
 
-    /**
-     * `updateResult` 호출은 Redis Lettuce backend leader election 계약의 일부 동작을 수행합니다.
-     *
-     * API 이름과 `lock`, `lease`, `watchdog`, `slot`, `schema`, `history` 용어는 기존 계약과 동일하게 유지합니다.
-     */
     suspend fun updateResult(lockName: String, nodeId: String, result: CandidateResult) {
         validateLockName(lockName)
-        val key = candidateKey(lockName, nodeId)
-        if (cmds.get(key) == null) {
-            migrateLegacyCandidate(lockName, nodeId)
-        }
-        val reply = RedisScriptRunner.runSuspending<List<Any>>(
-            asyncCommands,
+        if (commands.get(tombstoneKey(lockName, nodeId)) != null) return
+        ensureCurrentCandidate(lockName, nodeId)
+        val reply = commands.runScript<List<Any>>(
             LettuceCandidateResultScript.UPDATE,
             ScriptOutputType.MULTI,
-            arrayOf(key),
+            arrayOf(candidateKey(lockName, nodeId), migrationTokenKey(lockName, nodeId)),
             *LettuceCandidateResultScript.resultArgs(result, Instant.now().toEpochMilli()),
         )
         LettuceCandidateResultScript.rethrowMalformed(reply)
     }
 
-    private suspend fun readLegacyNodeIds(lockName: String): Set<String> = try {
-        cmds.smembers(LettuceCandidateKeyCodec.legacyIndexKey(keyPrefix, lockName)).toList().toSet()
+    private suspend fun runWriteScript(
+        operation: String,
+        keys: Array<String>,
+        args: Array<String>,
+    ): List<Any> = commands.runScript(
+        LettuceCandidateWriteScript.WRITE,
+        ScriptOutputType.MULTI,
+        keys,
+        operation,
+        *args,
+    )
+
+    private fun requireStatus(reply: List<Any>, expected: Long) {
+        val actual = reply.firstOrNull()?.toString()?.toLongOrNull()
+        require(actual == expected) {
+            "Unexpected candidate write status: expected=$expected actual=$actual"
+        }
+    }
+
+    private suspend fun ensureCurrentCandidate(lockName: String, nodeId: String): Boolean {
+        if (commands.get(candidateKey(lockName, nodeId)) != null) return true
+        val source = readSourceCandidate(lockName, nodeId)
+        return if (source == null) {
+            false
+        } else {
+            migrateLegacyCandidate(lockName, nodeId, source)
+            commands.get(candidateKey(lockName, nodeId)) != null
+        }
+    }
+
+    private suspend fun readIndexMembers(indexKey: String): Set<String> = try {
+        commands.smembers(indexKey)
     } catch (e: RedisCommandExecutionException) {
         if (e.isWrongType()) emptySet() else throw e
     }
 
+    private suspend fun readSourceCandidate(lockName: String, nodeId: String): LegacyCandidate? {
+        val v2Key = v2CandidateKey(lockName, nodeId)
+        val v2Candidate = readLegacyCandidate(v2Key, nodeId)
+        val legacyKey = legacyCandidateKey(lockName, nodeId)
+        val legacyCandidate = readLegacyCandidate(legacyKey, nodeId)
+        return v2Candidate?.let { LegacyCandidate(v2Key, v2IndexKey(lockName)) }
+            ?: legacyCandidate?.let { LegacyCandidate(legacyKey, legacyIndexKey(lockName)) }
+    }
+
+    private suspend fun readLegacySources(
+        lockName: String,
+        nodeId: String,
+        v2Indexed: Boolean,
+        legacyIndexed: Boolean,
+    ): List<LegacyCandidate> = buildList {
+        addLegacySourceIfValid(
+            nodeId,
+            v2CandidateKey(lockName, nodeId),
+            v2IndexKey(lockName),
+            v2Indexed,
+        )?.let(::add)
+        addLegacySourceIfValid(
+            nodeId,
+            legacyCandidateKey(lockName, nodeId),
+            legacyIndexKey(lockName),
+            legacyIndexed,
+        )?.let(::add)
+    }
+
+    private suspend fun addLegacySourceIfValid(
+        nodeId: String,
+        sourceKey: String,
+        sourceIndexKey: String,
+        indexed: Boolean,
+    ): LegacyCandidate? {
+        val candidate = readLegacyCandidate(sourceKey, nodeId)
+        return if (candidate == null) {
+            if (indexed) removeLegacyIndexMembers(sourceIndexKey, listOf(nodeId))
+            null
+        } else {
+            LegacyCandidate(sourceKey, sourceIndexKey)
+        }
+    }
+
     private suspend fun readLegacyCandidate(key: String, expectedNodeId: String): CandidateInfo? {
         val raw = try {
-            cmds.get(key)
+            commands.get(key)
         } catch (e: RedisCommandExecutionException) {
             if (!e.isWrongType()) throw e
             null
@@ -200,37 +303,84 @@ internal class LettuceSuspendCandidateRegistry(
         return raw?.let(LettuceCandidateInfoCodec::decode)?.takeIf { it.nodeId == expectedNodeId }
     }
 
-    private suspend fun readCurrentCandidate(lockName: String, expectedNodeId: String): CandidateInfo? {
-        val raw = cmds.get(candidateKey(lockName, expectedNodeId)) ?: return null
-        return LettuceCandidateInfoCodec.decode(raw).takeIf { it.nodeId == expectedNodeId }
+    private suspend fun migrateLegacyCandidate(lockName: String, nodeId: String, source: LegacyCandidate): Boolean {
+        val sourceRaw = commands.get(source.key)
+        val sourceCandidate = sourceRaw?.let(LettuceCandidateInfoCodec::decode)
+        return if (sourceRaw == null || sourceCandidate?.nodeId != nodeId) {
+            removeSourceIndexMember(source, nodeId)
+            false
+        } else {
+            val observedTtl = commands.pttl(source.key)
+            if (observedTtl == REDIS_KEY_ABSENT_TTL || (observedTtl <= 0L && observedTtl != -1L)) {
+                removeSourceIndexMember(source, nodeId)
+                false
+            } else {
+                val token = UUID.randomUUID().toString()
+                val reply = runWriteScript(
+                    operation = LettuceCandidateWriteScript.MIGRATE,
+                    keys = arrayOf(
+                        candidateKey(lockName, nodeId),
+                        indexKey(lockName),
+                        tombstoneKey(lockName, nodeId),
+                        migrationTokenKey(lockName, nodeId),
+                    ),
+                    args = arrayOf(sourceRaw, observedTtl.toString(), nodeId, token),
+                )
+                when (reply.firstOrNull()?.toString()?.toLongOrNull()) {
+                    LettuceCandidateWriteScript.MIGRATED -> {
+                        cleanupExpiredMigration(lockName, nodeId, source.key, sourceRaw, observedTtl, token)
+                        commands.get(candidateKey(lockName, nodeId)) != null
+                    }
+                    LettuceCandidateWriteScript.EXISTING_REPAIRED -> true
+                    LettuceCandidateWriteScript.MALFORMED -> {
+                        LettuceCandidateInfoCodec.decode(reply.getOrNull(1)?.toString().orEmpty())
+                        false
+                    }
+                    else -> false
+                }
+            }
+        }
     }
 
-    private suspend fun migrateLegacyCandidate(lockName: String, nodeId: String): Boolean {
-        val legacyKey = LettuceCandidateKeyCodec.legacyCandidateKey(keyPrefix, lockName, nodeId)
-        val candidate = readLegacyCandidate(legacyKey, nodeId) ?: return false
-        val raw = LettuceCandidateInfoCodec.encode(candidate)
-        val ttl = cmds.pttl(legacyKey) ?: -2L
-        val migrated = when {
-            ttl == -2L -> false
-            ttl == -1L -> cmds.setnx(candidateKey(lockName, nodeId), raw) == true
-            ttl > 0L -> cmds.set(candidateKey(lockName, nodeId), raw, SetArgs.Builder.nx().px(ttl)) != null
-            else -> false
-        }
-        if (migrated) {
-            cmds.sadd(indexKey(lockName), nodeId)
-            cmds.persist(indexKey(lockName))
-        }
-        return migrated
+    private suspend fun cleanupExpiredMigration(
+        lockName: String,
+        nodeId: String,
+        sourceKey: String,
+        sourceRaw: String,
+        observedTtl: Long,
+        token: String,
+    ) {
+        val sourceAfter = commands.get(sourceKey)
+        val sourceTtlAfter = commands.pttl(sourceKey)
+        val expired = sourceAfter == null ||
+            sourceTtlAfter == REDIS_KEY_ABSENT_TTL ||
+            (observedTtl > 0L && sourceTtlAfter == 0L)
+        if (!expired) return
+
+        runWriteScript(
+            operation = LettuceCandidateWriteScript.REMOVE_IF_VALUE,
+            keys = arrayOf(
+                candidateKey(lockName, nodeId),
+                indexKey(lockName),
+                migrationTokenKey(lockName, nodeId),
+            ),
+            args = arrayOf(sourceRaw, token, nodeId),
+        )
     }
 
     private suspend fun removeMissingCurrentIndexMembers(
         lockName: String,
-        indexKey: String,
+        currentIndex: String,
         nodeIds: List<String>,
     ) {
-        val keys = arrayOf(indexKey) + nodeIds.map { candidateKey(lockName, it) }
-        RedisScriptRunner.runSuspending<Long>(
-            asyncCommands,
+        val keys = buildList {
+            add(currentIndex)
+            nodeIds.forEach { nodeId ->
+                add(candidateKey(lockName, nodeId))
+                add(migrationTokenKey(lockName, nodeId))
+            }
+        }.toTypedArray()
+        commands.runScript<Long>(
             LettuceCandidateIndexCleanupScript.REMOVE_MISSING,
             ScriptOutputType.INTEGER,
             keys,
@@ -238,11 +388,36 @@ internal class LettuceSuspendCandidateRegistry(
         )
     }
 
-    private suspend fun removeLegacyIndexMembers(lockName: String, nodeIds: List<String>) {
+    private suspend fun cleanupLegacyCandidate(nodeId: String, candidateKey: String, indexKey: String) {
+        if (readLegacyCandidate(candidateKey, nodeId) != null) commands.del(candidateKey)
+        removeLegacyIndexMembers(indexKey, listOf(nodeId))
+    }
+
+    private suspend fun removeLegacyIndexMembers(indexKey: String, nodeIds: List<String>) {
         try {
-            cmds.srem(LettuceCandidateKeyCodec.legacyIndexKey(keyPrefix, lockName), *nodeIds.toTypedArray())
+            commands.srem(indexKey, nodeIds.toTypedArray())
         } catch (e: RedisCommandExecutionException) {
             if (!e.isWrongType()) throw e
         }
     }
+
+    private suspend fun removeSourceIndexMember(source: LegacyCandidate, nodeId: String) {
+        removeLegacyIndexMembers(source.indexKey, listOf(nodeId))
+    }
+
+    private fun candidateTtlMillis(ttl: Duration): Long {
+        require(ttl >= Duration.ZERO) { "Candidate TTL must be non-negative" }
+        val millis = ttl.inWholeMilliseconds
+        require(ttl == Duration.ZERO || millis > 0L) {
+            "Candidate TTL must be zero or at least 1ms"
+        }
+        return millis
+    }
+
+    private data class LegacyCandidate(
+        val key: String,
+        val indexKey: String,
+    )
 }
+
+private const val REDIS_KEY_ABSENT_TTL = -2L

--- a/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/script/RedisScript.kt
+++ b/leader-redis-lettuce/src/main/kotlin/io/bluetape4k/leader/lettuce/script/RedisScript.kt
@@ -6,6 +6,10 @@ import io.lettuce.core.RedisNoScriptException
 import io.lettuce.core.ScriptOutputType
 import io.lettuce.core.api.async.RedisAsyncCommands
 import io.lettuce.core.api.sync.RedisCommands
+import io.lettuce.core.cluster.api.async.RedisClusterAsyncCommands
+import io.lettuce.core.cluster.api.sync.RedisClusterCommands
+import io.lettuce.core.api.async.RedisScriptingAsyncCommands
+import io.lettuce.core.api.sync.RedisScriptingCommands
 import kotlinx.coroutines.future.await
 import java.security.MessageDigest
 import java.util.concurrent.CompletableFuture
@@ -42,7 +46,8 @@ class RedisScript(val source: String) {
  *
  * 정상 lock contention은 예외가 아니라 skip/null/result 상태로 표현한다는 core 계약을 보존합니다.
  */
-object RedisScriptRunner: KLogging() {
+@Suppress("TooManyFunctions")
+object RedisScriptRunner : KLogging() {
 
     /**
      * `선언` 호출은 Redis Lettuce backend leader election 계약의 일부 동작을 수행합니다.
@@ -51,6 +56,32 @@ object RedisScriptRunner: KLogging() {
      */
     fun <T> run(
         commands: RedisCommands<String, String>,
+        script: RedisScript,
+        outputType: ScriptOutputType,
+        keys: Array<String>,
+        vararg args: String,
+    ): T = runSync(commands, script, outputType, keys, *args)
+
+    /** Cluster command hierarchy에 대한 additive sync overload입니다. */
+    fun <T> run(
+        commands: RedisClusterCommands<String, String>,
+        script: RedisScript,
+        outputType: ScriptOutputType,
+        keys: Array<String>,
+        vararg args: String,
+    ): T = runSync(commands, script, outputType, keys, *args)
+
+    /** scripting capability만 노출하는 adapter를 위한 additive overload입니다. */
+    fun <T> run(
+        commands: RedisScriptingCommands<String, String>,
+        script: RedisScript,
+        outputType: ScriptOutputType,
+        keys: Array<String>,
+        vararg args: String,
+    ): T = runSync(commands, script, outputType, keys, *args)
+
+    private fun <T> runSync(
+        commands: RedisScriptingCommands<String, String>,
         script: RedisScript,
         outputType: ScriptOutputType,
         keys: Array<String>,
@@ -75,6 +106,32 @@ object RedisScriptRunner: KLogging() {
         outputType: ScriptOutputType,
         keys: Array<String>,
         vararg args: String,
+    ): CompletableFuture<T> = runAsyncInternal(commands, script, outputType, keys, *args)
+
+    /** Cluster command hierarchy에 대한 additive async overload입니다. */
+    fun <T> runAsync(
+        commands: RedisClusterAsyncCommands<String, String>,
+        script: RedisScript,
+        outputType: ScriptOutputType,
+        keys: Array<String>,
+        vararg args: String,
+    ): CompletableFuture<T> = runAsyncInternal(commands, script, outputType, keys, *args)
+
+    /** scripting capability만 노출하는 adapter를 위한 additive overload입니다. */
+    fun <T> runAsync(
+        commands: RedisScriptingAsyncCommands<String, String>,
+        script: RedisScript,
+        outputType: ScriptOutputType,
+        keys: Array<String>,
+        vararg args: String,
+    ): CompletableFuture<T> = runAsyncInternal(commands, script, outputType, keys, *args)
+
+    private fun <T> runAsyncInternal(
+        commands: RedisScriptingAsyncCommands<String, String>,
+        script: RedisScript,
+        outputType: ScriptOutputType,
+        keys: Array<String>,
+        vararg args: String,
     ): CompletableFuture<T> {
         val future = commands.evalsha<T>(script.sha1, outputType, keys, *args).toCompletableFuture()
         return future.exceptionallyCompose { error ->
@@ -95,6 +152,32 @@ object RedisScriptRunner: KLogging() {
      */
     suspend fun <T> runSuspending(
         commands: RedisAsyncCommands<String, String>,
+        script: RedisScript,
+        outputType: ScriptOutputType,
+        keys: Array<String>,
+        vararg args: String,
+    ): T = runSuspendingInternal(commands, script, outputType, keys, *args)
+
+    /** Cluster command hierarchy에 대한 additive suspend overload입니다. */
+    suspend fun <T> runSuspending(
+        commands: RedisClusterAsyncCommands<String, String>,
+        script: RedisScript,
+        outputType: ScriptOutputType,
+        keys: Array<String>,
+        vararg args: String,
+    ): T = runSuspendingInternal(commands, script, outputType, keys, *args)
+
+    /** scripting capability만 노출하는 adapter를 위한 additive overload입니다. */
+    suspend fun <T> runSuspending(
+        commands: RedisScriptingAsyncCommands<String, String>,
+        script: RedisScript,
+        outputType: ScriptOutputType,
+        keys: Array<String>,
+        vararg args: String,
+    ): T = runSuspendingInternal(commands, script, outputType, keys, *args)
+
+    private suspend fun <T> runSuspendingInternal(
+        commands: RedisScriptingAsyncCommands<String, String>,
         script: RedisScript,
         outputType: ScriptOutputType,
         keys: Array<String>,

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateKeyCodecTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateKeyCodecTest.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.leader.validateLockName
+import io.lettuce.core.cluster.SlotHash
+import org.junit.jupiter.api.Test
+
+class LettuceCandidateKeyCodecTest {
+
+    @Test
+    fun `v3 index and candidate keys use the same hash slot`() {
+        val prefix = "leader:strategy:candidates"
+        val lockName = "결정:lock"
+        val nodeId = "node:1"
+
+        val index = LettuceCandidateKeyCodec.indexKey(prefix, lockName)
+        val candidate = LettuceCandidateKeyCodec.candidateKey(prefix, lockName, nodeId)
+
+        index shouldBeEqualTo "leader:strategy:candidates|v3|i|{11:결정:lock}"
+        candidate shouldBeEqualTo "leader:strategy:candidates|v3|c|{11:결정:lock}6:node:1"
+        SlotHash.getSlot(index) shouldBeEqualTo SlotHash.getSlot(candidate)
+    }
+
+    @Test
+    fun `v3 lifecycle keys share the candidate hash slot`() {
+        val prefix = "leader:strategy:candidates"
+        val lockName = "lock"
+        val nodeId = "node"
+        val keys = listOf(
+            LettuceCandidateKeyCodec.indexKey(prefix, lockName),
+            LettuceCandidateKeyCodec.candidateKey(prefix, lockName, nodeId),
+            LettuceCandidateKeyCodec.tombstoneKey(prefix, lockName, nodeId),
+            LettuceCandidateKeyCodec.migrationTokenKey(prefix, lockName, nodeId),
+        )
+
+        keys.map(SlotHash::getSlot).distinct().size shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `legacy source keys retain their original layout`() {
+        val prefix = "leader:strategy:candidates"
+        val lockName = "legacy:lock"
+        val nodeId = "legacy:node"
+
+        LettuceCandidateKeyCodec.legacyIndexKey(prefix, lockName) shouldBeEqualTo
+            "leader:strategy:candidates:legacy:lock"
+        LettuceCandidateKeyCodec.legacyCandidateKey(prefix, lockName, nodeId) shouldBeEqualTo
+            "leader:strategy:candidates:legacy:lock:legacy:node"
+    }
+
+    @Test
+    fun `lock names containing hash tag braces remain invalid`() {
+        assertFailsWith<IllegalArgumentException> { validateLockName("a{b") }
+        assertFailsWith<IllegalArgumentException> { validateLockName("a}b") }
+    }
+}

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateKeyIsolationTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateKeyIsolationTest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.leader.lettuce
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeEqualTo
 import io.bluetape4k.assertions.shouldBeNull
@@ -88,7 +89,7 @@ class LettuceCandidateKeyIsolationTest : AbstractLettuceLeaderTest() {
         val listed = LettuceStrategicLeaderElector(connection, "observer").listCandidates(lockName)
 
         listed.single().nodeId shouldBeEqualTo nodeId
-        connection.sync().get(versionedCandidateKey(lockName, nodeId)).shouldNotBeNull()
+        connection.sync().get(currentCandidateKey(lockName, nodeId)).shouldNotBeNull()
     }
 
     @Test
@@ -108,6 +109,31 @@ class LettuceCandidateKeyIsolationTest : AbstractLettuceLeaderTest() {
         LettuceStrategicLeaderElector(connection, "observer")
             .listCandidates(lockName)
             .shouldBeEmpty()
+    }
+
+    @Test
+    fun `malformed v3 destination is surfaced instead of hiding a valid legacy source`() {
+        val lockName = "issue-854-malformed-v3-${System.nanoTime()}"
+        val nodeId = "hostname:pid"
+        val v3Key = currentCandidateKey(lockName, nodeId)
+        val v2Key = LettuceCandidateKeyCodec.v2CandidateKey(
+            LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+            lockName,
+            nodeId,
+        )
+        val v2Index = LettuceCandidateKeyCodec.v2IndexKey(
+            LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+            lockName,
+        )
+        val raw = LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId, metadata = mapOf("source" to "v2")))
+        connection.sync().set(v3Key, "malformed-v3-payload")
+        connection.sync().set(v2Key, raw)
+        connection.sync().sadd(v2Index, nodeId)
+
+        assertFailsWith<IllegalArgumentException> {
+            LettuceStrategicLeaderElector(connection, "observer").listCandidates(lockName)
+        }
+        connection.sync().get(v3Key) shouldBeEqualTo "malformed-v3-payload"
     }
 
     @Test
@@ -173,11 +199,11 @@ class LettuceCandidateKeyIsolationTest : AbstractLettuceLeaderTest() {
 
         connection.sync().type(legacyIndexKey(lockName)) shouldBeEqualTo "set"
         elector.listCandidates(lockName).single().nodeId shouldBeEqualTo nodeId
-        connection.sync().get(versionedCandidateKey(lockName, nodeId)).shouldNotBeNull()
+        connection.sync().get(currentCandidateKey(lockName, nodeId)).shouldNotBeNull()
     }
 
     @Test
-    fun `blocking list keeps a migrated candidate in the v2 index after stale cleanup`() {
+    fun `blocking list removes a stale v2 index while preserving the migrated colon source`() {
         val lockName = "issue-845-stale-migration-${System.nanoTime()}"
         val nodeId = "hostname:pid"
         seedLegacy(lockName, CandidateInfo(nodeId, metadata = mapOf("source" to "legacy")))
@@ -185,12 +211,12 @@ class LettuceCandidateKeyIsolationTest : AbstractLettuceLeaderTest() {
 
         LettuceStrategicLeaderElector(connection, "observer").listCandidates(lockName)
 
-        connection.sync().smembers(versionedIndexKey(lockName)) shouldBeEqualTo setOf(nodeId)
-        connection.sync().get(versionedCandidateKey(lockName, nodeId)).shouldNotBeNull()
+        connection.sync().smembers(versionedIndexKey(lockName)).shouldBeEmpty()
+        connection.sync().get(currentCandidateKey(lockName, nodeId)).shouldNotBeNull()
     }
 
     @Test
-    fun `suspend list keeps a migrated candidate in the v2 index after stale cleanup`() = runSuspendIO {
+    fun `suspend list removes a stale v2 index while preserving the migrated colon source`() = runSuspendIO {
         val lockName = "issue-845-suspend-stale-migration-${System.nanoTime()}"
         val nodeId = "hostname:pid"
         seedLegacy(lockName, CandidateInfo(nodeId, metadata = mapOf("source" to "legacy")))
@@ -198,40 +224,146 @@ class LettuceCandidateKeyIsolationTest : AbstractLettuceLeaderTest() {
 
         LettuceStrategicSuspendLeaderElector(connection, "observer").listCandidates(lockName)
 
-        connection.sync().smembers(versionedIndexKey(lockName)) shouldBeEqualTo setOf(nodeId)
-        connection.sync().get(versionedCandidateKey(lockName, nodeId)).shouldNotBeNull()
+        connection.sync().smembers(versionedIndexKey(lockName)).shouldBeEmpty()
+        connection.sync().get(currentCandidateKey(lockName, nodeId)).shouldNotBeNull()
     }
 
     @Test
-    fun `blocking list prefers an existing v2 value when legacy migration cannot claim it`() {
+    fun `blocking list prefers an existing v2 value while promoting the v3 index`() {
         val lockName = "issue-845-v2-precedence-${System.nanoTime()}"
         val nodeId = "hostname:pid"
         seedLegacy(lockName, CandidateInfo(nodeId, metadata = mapOf("source" to "legacy")))
         connection.sync().set(
-            versionedCandidateKey(lockName, nodeId),
+            LettuceCandidateKeyCodec.v2CandidateKey(LettuceCandidateRegistry.DEFAULT_KEY_PREFIX, lockName, nodeId),
             LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId, metadata = mapOf("source" to "v2"))),
         )
 
         val listed = LettuceStrategicLeaderElector(connection, "observer").listCandidates(lockName)
 
         listed.single().metadata shouldBeEqualTo mapOf("source" to "v2")
-        connection.sync().smembers(versionedIndexKey(lockName)) shouldBeEqualTo setOf(nodeId)
+        connection.sync().smembers(currentIndexKey(lockName)) shouldBeEqualTo setOf(nodeId)
     }
 
     @Test
-    fun `suspend list prefers an existing v2 value when legacy migration cannot claim it`() = runSuspendIO {
+    fun `suspend list prefers an existing v2 value while promoting the v3 index`() = runSuspendIO {
         val lockName = "issue-845-suspend-v2-precedence-${System.nanoTime()}"
         val nodeId = "hostname:pid"
         seedLegacy(lockName, CandidateInfo(nodeId, metadata = mapOf("source" to "legacy")))
         connection.sync().set(
-            versionedCandidateKey(lockName, nodeId),
+            LettuceCandidateKeyCodec.v2CandidateKey(LettuceCandidateRegistry.DEFAULT_KEY_PREFIX, lockName, nodeId),
             LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId, metadata = mapOf("source" to "v2"))),
         )
 
         val listed = LettuceStrategicSuspendLeaderElector(connection, "observer").listCandidates(lockName)
 
         listed.single().metadata shouldBeEqualTo mapOf("source" to "v2")
+        connection.sync().smembers(currentIndexKey(lockName)) shouldBeEqualTo setOf(nodeId)
+    }
+
+    @Test
+    fun `blocking list removes only the stale legacy version index`() {
+        val lockName = "issue-854-stale-version-${System.nanoTime()}"
+        val nodeId = "hostname:pid"
+        val currentRaw = LettuceCandidateInfoCodec.encode(
+            CandidateInfo(nodeId, metadata = mapOf("source" to "v3")),
+        )
+        val v2Raw = LettuceCandidateInfoCodec.encode(
+            CandidateInfo(nodeId, metadata = mapOf("source" to "v2")),
+        )
+        connection.sync().set(currentCandidateKey(lockName, nodeId), currentRaw)
+        connection.sync().sadd(currentIndexKey(lockName), nodeId)
+        connection.sync().set(
+            LettuceCandidateKeyCodec.v2CandidateKey(
+                LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                lockName,
+                nodeId,
+            ),
+            v2Raw,
+        )
+        connection.sync().sadd(versionedIndexKey(lockName), nodeId)
+        connection.sync().sadd(legacyIndexKey(lockName), nodeId)
+
+        LettuceStrategicLeaderElector(connection, "observer").listCandidates(lockName)
+
         connection.sync().smembers(versionedIndexKey(lockName)) shouldBeEqualTo setOf(nodeId)
+        connection.sync().sismember(legacyIndexKey(lockName), nodeId) shouldBeEqualTo false
+    }
+
+    @Test
+    fun `suspend list removes only the stale legacy version index`() = runSuspendIO {
+        val lockName = "issue-854-suspend-stale-version-${System.nanoTime()}"
+        val nodeId = "hostname:pid"
+        val currentRaw = LettuceCandidateInfoCodec.encode(
+            CandidateInfo(nodeId, metadata = mapOf("source" to "v3")),
+        )
+        val v2Raw = LettuceCandidateInfoCodec.encode(
+            CandidateInfo(nodeId, metadata = mapOf("source" to "v2")),
+        )
+        connection.sync().set(currentCandidateKey(lockName, nodeId), currentRaw)
+        connection.sync().sadd(currentIndexKey(lockName), nodeId)
+        connection.sync().set(
+            LettuceCandidateKeyCodec.v2CandidateKey(
+                LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                lockName,
+                nodeId,
+            ),
+            v2Raw,
+        )
+        connection.sync().sadd(versionedIndexKey(lockName), nodeId)
+        connection.sync().sadd(legacyIndexKey(lockName), nodeId)
+
+        LettuceStrategicSuspendLeaderElector(connection, "observer").listCandidates(lockName)
+
+        connection.sync().smembers(versionedIndexKey(lockName)) shouldBeEqualTo setOf(nodeId)
+        connection.sync().sismember(legacyIndexKey(lockName), nodeId) shouldBeEqualTo false
+    }
+
+    @Test
+    fun `blocking list surfaces malformed legacy source even when v3 is current`() {
+        val lockName = "issue-854-malformed-legacy-current-${System.nanoTime()}"
+        val nodeId = "hostname:pid"
+        connection.sync().set(currentCandidateKey(lockName, nodeId), LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId)))
+        connection.sync().sadd(currentIndexKey(lockName), nodeId)
+        val v2Key = LettuceCandidateKeyCodec.v2CandidateKey(
+            LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+            lockName,
+            nodeId,
+        )
+        connection.sync().set(v2Key, LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId)))
+        connection.sync().sadd(
+            LettuceCandidateKeyCodec.v2IndexKey(LettuceCandidateRegistry.DEFAULT_KEY_PREFIX, lockName),
+            nodeId,
+        )
+        connection.sync().set(legacyCandidateKey(lockName, nodeId), "malformed-legacy-payload")
+        connection.sync().sadd(legacyIndexKey(lockName), nodeId)
+
+        assertFailsWith<IllegalArgumentException> {
+            LettuceStrategicLeaderElector(connection, "observer").listCandidates(lockName)
+        }
+    }
+
+    @Test
+    fun `suspend list surfaces malformed legacy source even when v3 is current`() = runSuspendIO {
+        val lockName = "issue-854-suspend-malformed-legacy-current-${System.nanoTime()}"
+        val nodeId = "hostname:pid"
+        connection.sync().set(currentCandidateKey(lockName, nodeId), LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId)))
+        connection.sync().sadd(currentIndexKey(lockName), nodeId)
+        val v2Key = LettuceCandidateKeyCodec.v2CandidateKey(
+            LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+            lockName,
+            nodeId,
+        )
+        connection.sync().set(v2Key, LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId)))
+        connection.sync().sadd(
+            LettuceCandidateKeyCodec.v2IndexKey(LettuceCandidateRegistry.DEFAULT_KEY_PREFIX, lockName),
+            nodeId,
+        )
+        connection.sync().set(legacyCandidateKey(lockName, nodeId), "malformed-legacy-payload")
+        connection.sync().sadd(legacyIndexKey(lockName), nodeId)
+
+        assertFailsWith<IllegalArgumentException> {
+            LettuceStrategicSuspendLeaderElector(connection, "observer").listCandidates(lockName)
+        }
     }
 
     private fun collisionPair(): CollisionPair {
@@ -260,10 +392,11 @@ class LettuceCandidateKeyIsolationTest : AbstractLettuceLeaderTest() {
         connection.sync().sadd(legacyIndexKey(lockName), candidate.nodeId)
     }
 
-    private fun versionedCandidateKey(lockName: String, nodeId: String): String {
-        fun part(value: String) = "${value.toByteArray(Charsets.UTF_8).size}:$value"
-        return "${LettuceCandidateRegistry.DEFAULT_KEY_PREFIX}|v2|c|${part(lockName)}${part(nodeId)}"
-    }
+    private fun currentCandidateKey(lockName: String, nodeId: String) =
+        LettuceCandidateKeyCodec.candidateKey(LettuceCandidateRegistry.DEFAULT_KEY_PREFIX, lockName, nodeId)
+
+    private fun currentIndexKey(lockName: String) =
+        LettuceCandidateKeyCodec.indexKey(LettuceCandidateRegistry.DEFAULT_KEY_PREFIX, lockName)
 
     private fun versionedIndexKey(lockName: String) =
         "${LettuceCandidateRegistry.DEFAULT_KEY_PREFIX}|v2|i|${lockName.toByteArray(Charsets.UTF_8).size}:$lockName"

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateWriteScriptTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateWriteScriptTest.kt
@@ -1,0 +1,335 @@
+@file:OptIn(io.lettuce.core.ExperimentalLettuceCoroutinesApi::class)
+
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.lettuce.script.RedisScriptRunner
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.lettuce.core.ScriptOutputType
+import io.lettuce.core.api.coroutines
+import org.junit.jupiter.api.Test
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+
+class LettuceCandidateWriteScriptTest : AbstractLettuceLeaderTest() {
+
+    @Test
+    fun `register and unregister fence a candidate in one slot`() {
+        val lockName = "write-script-${System.nanoTime()}"
+        val nodeId = "node-1"
+        val keys = keys(lockName, nodeId)
+        val value = LettuceCandidateInfoCodec.encode(
+            io.bluetape4k.leader.strategy.CandidateInfo(nodeId),
+        )
+
+        val registered = run(keys, LettuceCandidateWriteScript.REGISTER, value, "0", nodeId)
+        registered.status() shouldBeEqualTo LettuceCandidateWriteScript.REGISTERED
+        connection.sync().get(keys.candidate).shouldNotBeNull()
+        connection.sync().sismember(keys.index, nodeId) shouldBeEqualTo true
+
+        val unregistered = run(keys, LettuceCandidateWriteScript.UNREGISTER, nodeId)
+        unregistered.status() shouldBeEqualTo LettuceCandidateWriteScript.UNREGISTERED
+        connection.sync().get(keys.candidate).shouldBeNull()
+        connection.sync().get(keys.token).shouldBeNull()
+        connection.sync().sismember(keys.index, nodeId) shouldBeEqualTo false
+        connection.sync().get(keys.tombstone).shouldNotBeNull()
+    }
+
+    @Test
+    fun `migration claims source payload with a token and matching cleanup removes only its value`() {
+        val lockName = "write-script-migrate-${System.nanoTime()}"
+        val nodeId = "node-1"
+        val keys = keys(lockName, nodeId)
+        val raw = LettuceCandidateInfoCodec.encode(
+            io.bluetape4k.leader.strategy.CandidateInfo(nodeId),
+        )
+        val token = "migration-token-${System.nanoTime()}"
+
+        val migrated = run(
+            keys,
+            LettuceCandidateWriteScript.MIGRATE,
+            raw,
+            "-1",
+            nodeId,
+            token,
+        )
+        migrated.status() shouldBeEqualTo LettuceCandidateWriteScript.MIGRATED
+        connection.sync().get(keys.candidate) shouldBeEqualTo raw
+        connection.sync().get(keys.token) shouldBeEqualTo token
+
+        val removed = run(
+            keys.copyWithoutTombstone(),
+            LettuceCandidateWriteScript.REMOVE_IF_VALUE,
+            raw,
+            token,
+            nodeId,
+        )
+        removed.status() shouldBeEqualTo LettuceCandidateWriteScript.REMOVED
+        connection.sync().get(keys.candidate).shouldBeNull()
+        connection.sync().get(keys.token).shouldBeNull()
+        connection.sync().sismember(keys.index, nodeId) shouldBeEqualTo false
+    }
+
+    @Test
+    fun `regular refresh and result writers clear migration ownership token`() {
+        val lockName = "write-script-token-${System.nanoTime()}"
+        val nodeId = "node-1"
+        val keys = keys(lockName, nodeId)
+        val original = CandidateInfo(nodeId)
+        val raw = LettuceCandidateInfoCodec.encode(original)
+        connection.sync().set(keys.candidate, raw)
+        connection.sync().sadd(keys.index, nodeId)
+        connection.sync().set(keys.token, "stale-token")
+
+        val refreshed = RedisScriptRunner.run<List<Any>>(
+            connection.sync(),
+            LettuceCandidateRefreshScript.REFRESH,
+            ScriptOutputType.MULTI,
+            arrayOf(keys.candidate, keys.index, keys.token),
+            LettuceCandidateInfoCodec.encode(original.copy(metadata = mapOf("phase" to "refresh"))),
+            "0",
+        )
+        refreshed.first().toString().toLong() shouldBeEqualTo LettuceCandidateRefreshScript.UPDATED
+        connection.sync().get(keys.token).shouldBeNull()
+
+        connection.sync().set(keys.token, "stale-token-2")
+        val updated = RedisScriptRunner.run<List<Any>>(
+            connection.sync(),
+            LettuceCandidateResultScript.UPDATE,
+            ScriptOutputType.MULTI,
+            arrayOf(keys.candidate, keys.token),
+            CandidateResult.SUCCESS.name,
+            "123",
+        )
+        updated.first().toString().toLong() shouldBeEqualTo LettuceCandidateResultScript.UPDATED
+        connection.sync().get(keys.token).shouldBeNull()
+        LettuceCandidateInfoCodec.decode(connection.sync().get(keys.candidate)!!).successCount shouldBeEqualTo 1L
+    }
+
+    @Test
+    fun `migration refuses a tombstoned node and does not resurrect source`() {
+        val lockName = "write-script-tombstone-${System.nanoTime()}"
+        val nodeId = "node-1"
+        val keys = keys(lockName, nodeId)
+        val raw = LettuceCandidateInfoCodec.encode(
+            io.bluetape4k.leader.strategy.CandidateInfo(nodeId),
+        )
+        connection.sync().set(keys.tombstone, "1")
+
+        val result = run(
+            keys,
+            LettuceCandidateWriteScript.MIGRATE,
+            raw,
+            "-1",
+            nodeId,
+            "token",
+        )
+        result.status() shouldBeEqualTo LettuceCandidateWriteScript.TOMBSTONED
+        connection.sync().get(keys.candidate).shouldBeNull()
+        connection.sync().get(keys.token).shouldBeNull()
+        connection.sync().sismember(keys.index, nodeId) shouldBeEqualTo false
+    }
+
+    @Test
+    fun `unregister barrier blocks migration until a fresh register clears the tombstone`() {
+        val lockName = "write-script-barrier-${System.nanoTime()}"
+        val nodeId = "node-1"
+        val keys = keys(lockName, nodeId)
+        val raw = LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId))
+
+        run(keys, LettuceCandidateWriteScript.UNREGISTER, nodeId)
+        val blocked = run(
+            keys,
+            LettuceCandidateWriteScript.MIGRATE,
+            raw,
+            "-1",
+            nodeId,
+            "blocked-token",
+        )
+        blocked.status() shouldBeEqualTo LettuceCandidateWriteScript.TOMBSTONED
+        connection.sync().get(keys.candidate).shouldBeNull()
+
+        run(keys, LettuceCandidateWriteScript.REGISTER, raw, "0", nodeId)
+        connection.sync().get(keys.tombstone).shouldBeNull()
+        connection.sync().get(keys.candidate) shouldBeEqualTo raw
+    }
+
+    @Test
+    fun `matching payload with a replaced writer token cannot be cleaned by an old migration`() {
+        val lockName = "write-script-token-owner-${System.nanoTime()}"
+        val nodeId = "node-1"
+        val keys = keys(lockName, nodeId)
+        val raw = LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId))
+
+        run(keys, LettuceCandidateWriteScript.MIGRATE, raw, "-1", nodeId, "old-token")
+        run(keys, LettuceCandidateWriteScript.REGISTER, raw, "0", nodeId)
+
+        val staleCleanup = run(
+            keys,
+            LettuceCandidateWriteScript.REMOVE_IF_VALUE,
+            raw,
+            "old-token",
+            nodeId,
+        )
+        staleCleanup.status() shouldBeEqualTo LettuceCandidateWriteScript.ABSENT
+        connection.sync().get(keys.candidate) shouldBeEqualTo raw
+        connection.sync().sismember(keys.index, nodeId) shouldBeEqualTo true
+    }
+
+    @Test
+    fun `persistent source after a positive migration snapshot is not treated as expired`() {
+        val lockName = "write-script-persistent-source-${System.nanoTime()}"
+        val nodeId = "node-1"
+        val keys = keys(lockName, nodeId)
+        val sourceKey = LettuceCandidateKeyCodec.v2CandidateKey(
+            LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+            lockName,
+            nodeId,
+        )
+        val raw = LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId))
+        val token = "migration-token-${System.nanoTime()}"
+
+        connection.sync().set(keys.candidate, raw)
+        connection.sync().sadd(keys.index, nodeId)
+        connection.sync().set(keys.token, token)
+        connection.sync().set(sourceKey, raw)
+
+        val constructor = LettuceCandidateRegistry::class.java.getDeclaredConstructor(
+            BlockingCandidateCommands::class.java,
+            BlockingCandidateValueReader::class.java,
+            String::class.java,
+        ).apply { isAccessible = true }
+        val registry = constructor.newInstance(
+            LettuceBlockingCandidateCommands(connection.sync()),
+            BlockingCandidateValueReader { emptyMap() },
+            LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+        )
+        LettuceCandidateRegistry::class.java.getDeclaredMethod(
+            "cleanupExpiredMigration",
+            String::class.java,
+            String::class.java,
+            String::class.java,
+            String::class.java,
+            Long::class.javaPrimitiveType,
+            String::class.java,
+        ).apply { isAccessible = true }
+            .invoke(registry, lockName, nodeId, sourceKey, raw, 100L, token)
+
+        connection.sync().get(keys.candidate) shouldBeEqualTo raw
+        connection.sync().get(keys.token) shouldBeEqualTo token
+    }
+
+    @Test
+    fun `suspend persistent source after a positive migration snapshot is not treated as expired`() = runSuspendIO {
+        val lockName = "write-script-suspend-persistent-source-${System.nanoTime()}"
+        val nodeId = "node-1"
+        val keys = keys(lockName, nodeId)
+        val sourceKey = LettuceCandidateKeyCodec.v2CandidateKey(
+            LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+            lockName,
+            nodeId,
+        )
+        val raw = LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId))
+        val token = "suspend-migration-token-${System.nanoTime()}"
+
+        connection.sync().set(keys.candidate, raw)
+        connection.sync().sadd(keys.index, nodeId)
+        connection.sync().set(keys.token, token)
+        connection.sync().set(sourceKey, raw)
+
+        val constructor = LettuceSuspendCandidateRegistry::class.java.getDeclaredConstructor(
+            SuspendCandidateCommands::class.java,
+            SuspendCandidateValueReader::class.java,
+            String::class.java,
+        ).apply { isAccessible = true }
+        val registry = constructor.newInstance(
+            LettuceSuspendCandidateCommands(connection.coroutines()) { connection.async() },
+            SuspendCandidateValueReader { emptyMap() },
+            LettuceSuspendCandidateRegistry.DEFAULT_KEY_PREFIX,
+        )
+
+        invokeSuspendCleanup(registry, lockName, nodeId, sourceKey, raw, 100L, token)
+
+        connection.sync().get(keys.candidate) shouldBeEqualTo raw
+        connection.sync().get(keys.token) shouldBeEqualTo token
+    }
+
+    private fun run(keys: ScriptKeys, operation: String, vararg args: String): List<Any> =
+        RedisScriptRunner.run(
+            connection.sync(),
+            LettuceCandidateWriteScript.WRITE,
+            ScriptOutputType.MULTI,
+            keys.forOperation(operation),
+            operation,
+            *args,
+        )
+
+    private fun List<Any>.status(): Long = first().toString().toLong()
+
+    private suspend fun invokeSuspendCleanup(
+        registry: Any,
+        lockName: String,
+        nodeId: String,
+        sourceKey: String,
+        sourceRaw: String,
+        observedTtl: Long,
+        token: String,
+    ): Any? {
+        val method = LettuceSuspendCandidateRegistry::class.java.getDeclaredMethod(
+            "cleanupExpiredMigration",
+            String::class.java,
+            String::class.java,
+            String::class.java,
+            String::class.java,
+            Long::class.javaPrimitiveType,
+            String::class.java,
+            Continuation::class.java,
+        ).apply { isAccessible = true }
+        return suspendCoroutineUninterceptedOrReturn { continuation ->
+            val result = method.invoke(
+                registry,
+                lockName,
+                nodeId,
+                sourceKey,
+                sourceRaw,
+                observedTtl,
+                token,
+                continuation,
+            )
+            if (result === COROUTINE_SUSPENDED) COROUTINE_SUSPENDED else result
+        }
+    }
+
+    private fun keys(lockName: String, nodeId: String): ScriptKeys =
+        ScriptKeys(
+            LettuceCandidateKeyCodec.candidateKey(LettuceCandidateRegistry.DEFAULT_KEY_PREFIX, lockName, nodeId),
+            LettuceCandidateKeyCodec.indexKey(LettuceCandidateRegistry.DEFAULT_KEY_PREFIX, lockName),
+            LettuceCandidateKeyCodec.tombstoneKey(LettuceCandidateRegistry.DEFAULT_KEY_PREFIX, lockName, nodeId),
+            LettuceCandidateKeyCodec.migrationTokenKey(
+                LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                lockName,
+                nodeId,
+            ),
+        )
+
+    private data class ScriptKeys(
+        val candidate: String,
+        val index: String,
+        val tombstone: String,
+        val token: String,
+    ) {
+        fun forOperation(operation: String): Array<String> =
+            if (operation == LettuceCandidateWriteScript.REMOVE_IF_VALUE) {
+                arrayOf(candidate, index, token)
+            } else {
+                arrayOf(candidate, index, tombstone, token)
+            }
+
+        fun copyWithoutTombstone(): ScriptKeys = this
+    }
+}

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicCandidateLookupFailureTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicCandidateLookupFailureTest.kt
@@ -15,6 +15,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 import java.util.concurrent.atomic.AtomicBoolean
 
 class LettuceStrategicCandidateLookupFailureTest {
@@ -174,6 +175,7 @@ class LettuceStrategicCandidateLookupFailureTest {
         val commands = mockk<RedisCommands<String, String>>()
         every { connection.sync() } returns commands
         every { commands.smembers(any()) } returns setOf("node-1")
+        every { commands.get(any()) } returns null
         every { commands.mget(any<String>()) } returns listOf(
             KeyValue.just(
                 LettuceCandidateKeyCodec.candidateKey(
@@ -200,6 +202,7 @@ class LettuceStrategicCandidateLookupFailureTest {
         val reactive = mockk<RedisReactiveCommands<String, String>>()
         every { connection.reactive() } returns reactive
         every { reactive.smembers(any()) } returns Flux.just("node-1")
+        every { reactive.get(any()) } returns Mono.empty()
         every { reactive.mget(any<String>()) } returns Flux.just(
             KeyValue.just(
                 LettuceCandidateKeyCodec.candidateKey(

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicLeaderElectorTest.kt
@@ -21,6 +21,7 @@ import io.bluetape4k.support.closeSafe
 import io.lettuce.core.codec.StringCodec
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.microseconds
 import kotlin.time.Duration.Companion.seconds
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
@@ -289,6 +290,27 @@ class LettuceStrategicLeaderElectorTest: AbstractLettuceLeaderTest() {
 
         Thread.sleep(100)
         node1.listCandidates(lockName).size shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `candidate TTL은 음수와 1ms 미만 값을 Redis 쓰기 전에 거부`() {
+        val lockName = randomName()
+        val candidate = CandidateInfo("node-1")
+
+        assertFailsWith<IllegalArgumentException> {
+            node1.registerCandidate(lockName, candidate, (-500).microseconds)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            node1.registerCandidate(lockName, candidate, 500.microseconds)
+        }
+
+        node1.registerCandidate(lockName, candidate, Duration.ZERO)
+        assertFailsWith<IllegalArgumentException> {
+            node1.refreshCandidate(lockName, candidate, (-500).microseconds)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            node1.refreshCandidate(lockName, candidate, 500.microseconds)
+        }
     }
 
     @Test

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicRedisClusterTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicRedisClusterTest.kt
@@ -1,0 +1,576 @@
+@file:OptIn(io.lettuce.core.ExperimentalLettuceCoroutinesApi::class)
+
+package io.bluetape4k.leader.lettuce
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeGreaterThan
+import io.bluetape4k.assertions.shouldBeLessOrEqualTo
+import io.bluetape4k.assertions.shouldBeNull
+import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.junit5.coroutines.runSuspendIO
+import io.bluetape4k.leader.lettuce.script.RedisScript
+import io.bluetape4k.leader.strategy.CandidateInfo
+import io.bluetape4k.leader.strategy.CandidateResult
+import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
+import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
+import io.bluetape4k.testcontainers.storage.RedisClusterServer
+import io.lettuce.core.ScriptOutputType
+import io.lettuce.core.cluster.SlotHash
+import io.lettuce.core.cluster.api.coroutines
+import io.lettuce.core.SetArgs
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CancellationException
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+@Tag("redis-cluster")
+class LettuceStrategicRedisClusterTest {
+
+    @Test
+    fun `blocking single elector executes v3 register list refresh result and unregister`() {
+        withCluster { connection ->
+            val lockName = "cluster-single-${System.nanoTime()}"
+            val nodeId = "cluster-node-1"
+            val elector = LettuceStrategicLeaderElector(connection, nodeId)
+
+            elector.registerCandidate(lockName, CandidateInfo(nodeId))
+            elector.listCandidates(lockName).single().nodeId shouldBeEqualTo nodeId
+            elector.refreshCandidate(lockName, CandidateInfo(nodeId, metadata = mapOf("path" to "cluster")))
+            elector.updateResult(lockName, nodeId, CandidateResult.SUCCESS)
+            elector.listCandidates(lockName).single().successCount shouldBeEqualTo 1L
+            elector.runIfLeader(lockName, FifoElectionStrategy) { "done" } shouldBeEqualTo "done"
+
+            elector.unregisterCandidate(lockName, nodeId)
+            elector.listCandidates(lockName).shouldBeEmpty()
+            connection.sync().get(
+                LettuceCandidateKeyCodec.tombstoneKey(
+                    LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                    lockName,
+                    nodeId,
+                ),
+            ).shouldNotBeNull()
+        }
+    }
+
+    @Test
+    fun `blocking group elector uses cluster mget and same-slot scripts`() {
+        withCluster { connection ->
+            val lockName = "cluster-group-${System.nanoTime()}"
+            val electors = listOf("cluster-group-1", "cluster-group-2", "cluster-group-3")
+                .map { LettuceStrategicLeaderGroupElector(connection, it) }
+            electors.forEach { elector ->
+                elector.registerCandidate(lockName, CandidateInfo(elector.nodeId))
+            }
+
+            electors.flatMap { it.listCandidates(lockName) }.map(CandidateInfo::nodeId).distinct().size shouldBeEqualTo 3
+            electors[0].runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) { "winner" }
+                .shouldBeEqualTo("winner")
+            electors[2].runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 2) {
+                error("탈락한 후보의 action은 실행되면 안 됨")
+            }.shouldBeNull()
+        }
+    }
+
+    @Test
+    fun `suspend single elector preserves cancellation and cluster lifecycle`() = runSuspendIO {
+        withClusterSuspend { connection ->
+            val lockName = "cluster-suspend-${System.nanoTime()}"
+            val nodeId = "cluster-suspend-node"
+            val elector = LettuceStrategicSuspendLeaderElector(connection, nodeId)
+            elector.registerCandidate(lockName, CandidateInfo(nodeId))
+
+            elector.listCandidates(lockName).single().nodeId shouldBeEqualTo nodeId
+            elector.refreshCandidate(lockName, CandidateInfo(nodeId, metadata = mapOf("path" to "suspend")))
+            elector.updateResult(lockName, nodeId, CandidateResult.SUCCESS)
+            elector.listCandidates(lockName).single().successCount shouldBeEqualTo 1L
+
+            val cancellation = CancellationException("cluster action cancelled")
+            val thrown = assertFailsWith<CancellationException> {
+                elector.runIfLeader(lockName, FifoElectionStrategy) { throw cancellation }
+            }
+            thrown.message shouldBeEqualTo cancellation.message
+            elector.listCandidates(lockName).single().failureCount shouldBeEqualTo 0L
+        }
+    }
+
+    @Test
+    fun `suspend group elector uses cluster coroutine mget and group script`() = runSuspendIO {
+        withClusterSuspend { connection ->
+            val lockName = "cluster-suspend-group-${System.nanoTime()}"
+            val electors = listOf("cluster-suspend-group-1", "cluster-suspend-group-2")
+                .map { LettuceStrategicSuspendLeaderGroupElector(connection, it) }
+            electors.forEach { elector ->
+                elector.registerCandidate(lockName, CandidateInfo(elector.nodeId))
+            }
+
+            electors.first().listCandidates(lockName).size shouldBeEqualTo 2
+            electors.first().runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 1) { "winner" }
+                .shouldBeEqualTo("winner")
+        }
+    }
+
+    @Test
+    fun `v2 and colon sources migrate through single-key reads and remain preserved`() {
+        withCluster { connection ->
+            val lockName = "cluster-migration-${System.nanoTime()}"
+            val v2NodeId = "cluster-migration-v2"
+            val v2Raw = LettuceCandidateInfoCodec.encode(
+                CandidateInfo(v2NodeId, metadata = mapOf("source" to "v2")),
+            )
+            val v2Key = LettuceCandidateKeyCodec.v2CandidateKey(
+                LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                lockName,
+                v2NodeId,
+            )
+            val v2Index = LettuceCandidateKeyCodec.v2IndexKey(
+                LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                lockName,
+            )
+            val currentIndex = LettuceCandidateKeyCodec.indexKey(
+                LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                lockName,
+            )
+            val currentKey = LettuceCandidateKeyCodec.candidateKey(
+                LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                lockName,
+                v2NodeId,
+            )
+            val mismatchedCurrentRaw = LettuceCandidateInfoCodec.encode(
+                CandidateInfo("cluster-migration-v3-other", metadata = mapOf("source" to "wrong-v3")),
+            )
+            val colonNodeId = "cluster-migration-colon"
+            val colonRaw = LettuceCandidateInfoCodec.encode(
+                CandidateInfo(colonNodeId, metadata = mapOf("source" to "colon")),
+            )
+            val colonIndex = "${LettuceCandidateRegistry.DEFAULT_KEY_PREFIX}:$lockName"
+            val colonKey = "$colonIndex:$colonNodeId"
+            connection.sync().set(currentKey, mismatchedCurrentRaw)
+            connection.sync().sadd(currentIndex, v2NodeId)
+            connection.sync().set(v2Key, v2Raw)
+            connection.sync().sadd(v2Index, v2NodeId)
+            connection.sync().set(colonKey, colonRaw)
+            connection.sync().sadd(colonIndex, colonNodeId)
+
+            val listed = LettuceStrategicLeaderElector(connection, "observer").listCandidates(lockName)
+            listed.map { it.nodeId }.toSet() shouldBeEqualTo setOf(v2NodeId, colonNodeId)
+            listed.first { it.nodeId == v2NodeId }.metadata shouldBeEqualTo mapOf("source" to "v2")
+            listed.first { it.nodeId == colonNodeId }.metadata shouldBeEqualTo mapOf("source" to "colon")
+            connection.sync().get(v2Key) shouldBeEqualTo v2Raw
+            connection.sync().get(colonKey) shouldBeEqualTo colonRaw
+            connection.sync().get(currentKey) shouldBeEqualTo v2Raw
+            connection.sync().sismember(currentIndex, v2NodeId) shouldBeEqualTo true
+            connection.sync().get(
+                LettuceCandidateKeyCodec.candidateKey(
+                    LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                    lockName,
+                    colonNodeId,
+                ),
+            ) shouldBeEqualTo colonRaw
+        }
+    }
+
+    @Test
+    fun `cluster migration preserves positive source TTL on the v3 destination`() {
+        withCluster { connection ->
+            val lockName = "cluster-migration-ttl-${System.nanoTime()}"
+            val nodeId = "cluster-migration-ttl-node"
+            val raw = LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId))
+            val v2Key = LettuceCandidateKeyCodec.v2CandidateKey(
+                LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                lockName,
+                nodeId,
+            )
+            val v2Index = LettuceCandidateKeyCodec.v2IndexKey(
+                LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                lockName,
+            )
+            connection.sync().set(v2Key, raw, SetArgs.Builder.px(3_000))
+            connection.sync().sadd(v2Index, nodeId)
+
+            val sourceTtl = connection.sync().pttl(v2Key)
+            sourceTtl shouldBeGreaterThan 0L
+            LettuceStrategicLeaderElector(connection, "observer")
+                .listCandidates(lockName)
+                .single()
+                .nodeId shouldBeEqualTo nodeId
+
+            val destinationKey = LettuceCandidateKeyCodec.candidateKey(
+                LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                lockName,
+                nodeId,
+            )
+            val destinationTtl = connection.sync().pttl(destinationKey)
+            destinationTtl shouldBeGreaterThan 0L
+            destinationTtl shouldBeLessOrEqualTo sourceTtl
+            connection.sync().get(v2Key) shouldBeEqualTo raw
+        }
+    }
+
+    @Test
+    fun `blocking group elector refreshes result and unregisters in cluster`() {
+        withCluster { connection ->
+            val lockName = "cluster-group-lifecycle-${System.nanoTime()}"
+            val nodeId = "cluster-group-lifecycle-node"
+            val elector = LettuceStrategicLeaderGroupElector(connection, nodeId)
+
+            elector.registerCandidate(lockName, CandidateInfo(nodeId))
+            elector.refreshCandidate(
+                lockName,
+                CandidateInfo(nodeId, metadata = mapOf("phase" to "refreshed")),
+                2.seconds,
+            )
+            elector.updateResult(lockName, nodeId, CandidateResult.SUCCESS)
+
+            val listed = elector.listCandidates(lockName).single()
+            listed.metadata shouldBeEqualTo mapOf("phase" to "refreshed")
+            listed.successCount shouldBeEqualTo 1L
+            elector.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 1) { "winner" }
+                .shouldBeEqualTo("winner")
+
+            elector.unregisterCandidate(lockName, nodeId)
+            elector.listCandidates(lockName).shouldBeEmpty()
+        }
+    }
+
+    @Test
+    fun `blocking group elector migrates a v2 source before refreshing and unregistering`() {
+        withCluster { connection ->
+            val lockName = "cluster-group-migration-${System.nanoTime()}"
+            val nodeId = "cluster-group-migration-node"
+            val raw = LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId))
+            val v2Key = LettuceCandidateKeyCodec.v2CandidateKey(
+                LettuceCandidateRegistry.GROUP_KEY_PREFIX,
+                lockName,
+                nodeId,
+            )
+            val v2Index = LettuceCandidateKeyCodec.v2IndexKey(
+                LettuceCandidateRegistry.GROUP_KEY_PREFIX,
+                lockName,
+            )
+            connection.sync().set(v2Key, raw, SetArgs.Builder.px(3_000))
+            connection.sync().sadd(v2Index, nodeId)
+
+            val elector = LettuceStrategicLeaderGroupElector(connection, nodeId)
+            elector.listCandidates(lockName).single().nodeId shouldBeEqualTo nodeId
+            elector.refreshCandidate(
+                lockName,
+                CandidateInfo(nodeId, metadata = mapOf("source" to "v2-refresh")),
+                2.seconds,
+            )
+            elector.updateResult(lockName, nodeId, CandidateResult.SUCCESS)
+            elector.listCandidates(lockName).single().successCount shouldBeEqualTo 1L
+
+            elector.unregisterCandidate(lockName, nodeId)
+            elector.listCandidates(lockName).shouldBeEmpty()
+            connection.sync().get(v2Key).shouldBeNull()
+        }
+    }
+
+    @Test
+    fun `suspend single elector migrates a v2 source before refreshing and unregistering`() = runSuspendIO {
+        withClusterSuspend { connection ->
+            val lockName = "cluster-suspend-migration-${System.nanoTime()}"
+            val nodeId = "cluster-suspend-migration-node"
+            val raw = LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId))
+            val v2Key = LettuceCandidateKeyCodec.v2CandidateKey(
+                LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                lockName,
+                nodeId,
+            )
+            val v2Index = LettuceCandidateKeyCodec.v2IndexKey(
+                LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                lockName,
+            )
+            connection.sync().set(v2Key, raw, SetArgs.Builder.px(3_000))
+            connection.sync().sadd(v2Index, nodeId)
+
+            val elector = LettuceStrategicSuspendLeaderElector(connection, nodeId)
+            elector.listCandidates(lockName).single().nodeId shouldBeEqualTo nodeId
+            elector.refreshCandidate(
+                lockName,
+                CandidateInfo(nodeId, metadata = mapOf("source" to "v2-refresh")),
+                2.seconds,
+            )
+            elector.updateResult(lockName, nodeId, CandidateResult.SUCCESS)
+            elector.listCandidates(lockName).single().successCount shouldBeEqualTo 1L
+
+            elector.unregisterCandidate(lockName, nodeId)
+            elector.listCandidates(lockName).shouldBeEmpty()
+            connection.sync().get(v2Key).shouldBeNull()
+        }
+    }
+
+    @Test
+    fun `suspend group elector refreshes result and unregisters in cluster`() = runSuspendIO {
+        withClusterSuspend { connection ->
+            val lockName = "cluster-suspend-group-lifecycle-${System.nanoTime()}"
+            val nodeId = "cluster-suspend-group-lifecycle-node"
+            val elector = LettuceStrategicSuspendLeaderGroupElector(connection, nodeId)
+
+            elector.registerCandidate(lockName, CandidateInfo(nodeId))
+            elector.refreshCandidate(
+                lockName,
+                CandidateInfo(nodeId, metadata = mapOf("phase" to "refreshed")),
+                2.seconds,
+            )
+            elector.updateResult(lockName, nodeId, CandidateResult.SUCCESS)
+
+            val listed = elector.listCandidates(lockName).single()
+            listed.metadata shouldBeEqualTo mapOf("phase" to "refreshed")
+            listed.successCount shouldBeEqualTo 1L
+            elector.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 1) { "winner" }
+                .shouldBeEqualTo("winner")
+
+            elector.unregisterCandidate(lockName, nodeId)
+            elector.listCandidates(lockName).shouldBeEmpty()
+        }
+    }
+
+    @Test
+    fun `suspend group elector migrates a colon source before refreshing and unregistering`() = runSuspendIO {
+        withClusterSuspend { connection ->
+            val lockName = "cluster-suspend-group-migration-${System.nanoTime()}"
+            val nodeId = "cluster-suspend-group-migration-node"
+            val raw = LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId))
+            val legacyIndex = "${LettuceCandidateRegistry.GROUP_KEY_PREFIX}:$lockName"
+            val legacyKey = "$legacyIndex:$nodeId"
+            connection.sync().set(legacyKey, raw)
+            connection.sync().sadd(legacyIndex, nodeId)
+
+            val elector = LettuceStrategicSuspendLeaderGroupElector(connection, nodeId)
+            elector.listCandidates(lockName).single().nodeId shouldBeEqualTo nodeId
+            elector.refreshCandidate(
+                lockName,
+                CandidateInfo(nodeId, metadata = mapOf("source" to "colon-refresh")),
+                2.seconds,
+            )
+            elector.updateResult(lockName, nodeId, CandidateResult.SUCCESS)
+            elector.listCandidates(lockName).single().successCount shouldBeEqualTo 1L
+
+            elector.unregisterCandidate(lockName, nodeId)
+            elector.listCandidates(lockName).shouldBeEmpty()
+            connection.sync().get(legacyKey).shouldBeNull()
+        }
+    }
+
+    @Test
+    fun `cluster v3 namespaces use one slot for every elector`() {
+        withCluster { _ ->
+            val lockName = "cluster-slot-${System.nanoTime()}"
+            val nodeId = "cluster-slot-node"
+            val keys = listOf(
+                LettuceCandidateKeyCodec.indexKey(LettuceCandidateRegistry.DEFAULT_KEY_PREFIX, lockName),
+                LettuceCandidateKeyCodec.candidateKey(
+                    LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                    lockName,
+                    nodeId,
+                ),
+                LettuceCandidateKeyCodec.indexKey(LettuceCandidateRegistry.GROUP_KEY_PREFIX, lockName),
+                LettuceCandidateKeyCodec.candidateKey(
+                    LettuceCandidateRegistry.GROUP_KEY_PREFIX,
+                    lockName,
+                    nodeId,
+                ),
+            )
+
+            keys.map(SlotHash::getSlot).distinct().size shouldBeEqualTo 1
+        }
+    }
+
+    @Test
+    fun `blocking group elector preserves positive and persistent TTL boundaries`() {
+        withCluster { connection ->
+            val lockName = "cluster-group-ttl-${System.nanoTime()}"
+            val nodeId = "cluster-group-ttl-node"
+            val elector = LettuceStrategicLeaderGroupElector(connection, nodeId)
+            val candidateKey = LettuceCandidateKeyCodec.candidateKey(
+                LettuceCandidateRegistry.GROUP_KEY_PREFIX,
+                lockName,
+                nodeId,
+            )
+
+            elector.registerCandidate(lockName, CandidateInfo(nodeId), 2.seconds)
+            connection.sync().pttl(candidateKey) shouldBeGreaterThan 0L
+
+            elector.refreshCandidate(lockName, CandidateInfo(nodeId), Duration.ZERO)
+            connection.sync().pttl(candidateKey) shouldBeEqualTo -1L
+            elector.unregisterCandidate(lockName, nodeId)
+        }
+    }
+
+    @Test
+    fun `suspend single elector migrates a v2 source with positive TTL`() = runSuspendIO {
+        withClusterSuspend { connection ->
+            val lockName = "cluster-suspend-migration-ttl-${System.nanoTime()}"
+            val nodeId = "cluster-suspend-migration-ttl-node"
+            val raw = LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId))
+            val v2Key = LettuceCandidateKeyCodec.v2CandidateKey(
+                LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                lockName,
+                nodeId,
+            )
+            val v2Index = LettuceCandidateKeyCodec.v2IndexKey(
+                LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                lockName,
+            )
+            connection.sync().set(v2Key, raw, SetArgs.Builder.px(3_000))
+            connection.sync().sadd(v2Index, nodeId)
+
+            val sourceTtl = connection.sync().pttl(v2Key)
+            sourceTtl shouldBeGreaterThan 0L
+            LettuceStrategicSuspendLeaderElector(connection, nodeId)
+                .listCandidates(lockName)
+                .single()
+                .nodeId shouldBeEqualTo nodeId
+
+            val destinationKey = LettuceCandidateKeyCodec.candidateKey(
+                LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+                lockName,
+                nodeId,
+            )
+            val destinationTtl = connection.sync().pttl(destinationKey)
+            destinationTtl shouldBeGreaterThan 0L
+            destinationTtl shouldBeLessOrEqualTo sourceTtl
+            connection.sync().get(v2Key) shouldBeEqualTo raw
+        }
+    }
+
+    @Test
+    fun `suspend group elector migrates a colon source with positive TTL`() = runSuspendIO {
+        withClusterSuspend { connection ->
+            val lockName = "cluster-suspend-group-migration-ttl-${System.nanoTime()}"
+            val nodeId = "cluster-suspend-group-migration-ttl-node"
+            val raw = LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId))
+            val legacyIndex = "${LettuceCandidateRegistry.GROUP_KEY_PREFIX}:$lockName"
+            val legacyKey = "$legacyIndex:$nodeId"
+            connection.sync().set(legacyKey, raw, SetArgs.Builder.px(3_000))
+            connection.sync().sadd(legacyIndex, nodeId)
+
+            val sourceTtl = connection.sync().pttl(legacyKey)
+            sourceTtl shouldBeGreaterThan 0L
+            LettuceStrategicSuspendLeaderGroupElector(connection, nodeId)
+                .listCandidates(lockName)
+                .single()
+                .nodeId shouldBeEqualTo nodeId
+
+            val destinationKey = LettuceCandidateKeyCodec.candidateKey(
+                LettuceSuspendCandidateRegistry.GROUP_KEY_PREFIX,
+                lockName,
+                nodeId,
+            )
+            val destinationTtl = connection.sync().pttl(destinationKey)
+            destinationTtl shouldBeGreaterThan 0L
+            destinationTtl shouldBeLessOrEqualTo sourceTtl
+            connection.sync().get(legacyKey) shouldBeEqualTo raw
+        }
+    }
+
+    @Test
+    fun `suspend group elector propagates action cancellation without recording failure`() = runSuspendIO {
+        withClusterSuspend { connection ->
+            val lockName = "cluster-suspend-group-cancel-${System.nanoTime()}"
+            val nodeId = "cluster-suspend-group-cancel-node"
+            val elector = LettuceStrategicSuspendLeaderGroupElector(connection, nodeId)
+            elector.registerCandidate(lockName, CandidateInfo(nodeId))
+            val cancellation = CancellationException("cluster group action cancelled")
+
+            val thrown = assertFailsWith<CancellationException> {
+                elector.runIfLeader(lockName, FifoGroupElectionStrategy, maxLeaders = 1) {
+                    throw cancellation
+                }
+            }
+            thrown.message shouldBeEqualTo cancellation.message
+            elector.listCandidates(lockName).single().failureCount shouldBeEqualTo 0L
+        }
+    }
+
+    @Test
+    fun `suspend cluster script cancellation preserves the caller connection`() = runSuspendIO {
+        withClusterSuspend { connection ->
+            val commands = LettuceSuspendCandidateCommands(connection.coroutines()) { connection.async() }
+            val cancelled = Job()
+            val cancellation = CancellationException("cluster script cancelled")
+            cancelled.cancel(cancellation)
+
+            val thrown = assertFailsWith<CancellationException> {
+                withContext(cancelled) {
+                    commands.runScript<String>(
+                        RedisScript("return 'ok'"),
+                        ScriptOutputType.VALUE,
+                        emptyArray(),
+                    )
+                }
+            }
+            thrown.message shouldBeEqualTo cancellation.message
+            connection.sync().ping() shouldBeEqualTo "PONG"
+        }
+    }
+
+    private fun withCluster(block: (StatefulRedisClusterConnection<String, String>) -> Unit) {
+        val server = RedisClusterServer.Launcher.redisCluster
+        RedisClusterServer.Launcher.LettuceLib.getClusterClient(server).use { client ->
+            client.connect().use { connection ->
+                recordClusterRuntime(server, connection)
+                block(connection)
+            }
+        }
+    }
+
+    private suspend fun withClusterSuspend(
+        block: suspend (StatefulRedisClusterConnection<String, String>) -> Unit,
+    ) {
+        val server = RedisClusterServer.Launcher.redisCluster
+        RedisClusterServer.Launcher.LettuceLib.getClusterClient(server).use { client ->
+            client.connect().use { connection ->
+                recordClusterRuntime(server, connection)
+                block(connection)
+            }
+        }
+    }
+
+    private fun recordClusterRuntime(
+        server: RedisClusterServer,
+        connection: StatefulRedisClusterConnection<String, String>,
+    ) {
+        val diagnosticsDirectory = Path.of(
+            System.getProperty(
+                "redis.cluster.diagnostics.dir",
+                "build/redis-cluster-diagnostics",
+            ),
+        )
+        Files.createDirectories(diagnosticsDirectory)
+
+        val imageDigest = server.dockerClient
+            .inspectImageCmd(server.dockerImageName)
+            .exec()
+            .repoDigests
+            .orEmpty()
+            .firstOrNull { "@sha256:" in it }
+            ?: error("Redis Cluster image digest is unavailable for ${server.dockerImageName}")
+        val clusterInfo = connection.sync().clusterInfo()
+        val clusterState = clusterInfo.lineSequence()
+            .firstOrNull { it.startsWith("cluster_state:") }
+            ?.substringAfter(':')
+            ?.trim()
+            ?: "unknown"
+        val endpoints = server.properties()["nodes"].orEmpty()
+        val runtimeProvenance = buildString {
+            appendLine("image=${server.dockerImageName}")
+            appendLine("image_digest=$imageDigest")
+            appendLine("fixture=io.bluetape4k.testcontainers.storage.RedisClusterServer.Launcher.redisCluster")
+            appendLine("cluster_state=$clusterState")
+            appendLine("endpoints=$endpoints")
+            appendLine("mapped_ports=${server.mappedPorts.entries.joinToString(",") { (source, mapped) -> "$source->$mapped" }}")
+        }
+        Files.writeString(diagnosticsDirectory.resolve("cluster-runtime.txt"), runtimeProvenance)
+        Files.writeString(diagnosticsDirectory.resolve("cluster-info.txt"), clusterInfo)
+    }
+}

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElectorTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicSuspendLeaderElectorTest.kt
@@ -28,6 +28,7 @@ import io.bluetape4k.support.closeSafe
 import io.lettuce.core.codec.StringCodec
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.microseconds
 import kotlin.time.Duration.Companion.seconds
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
@@ -186,6 +187,27 @@ class LettuceStrategicSuspendLeaderElectorTest: AbstractLettuceLeaderTest() {
 
         delay(100L.milliseconds)
         node1.listCandidates(lockName).size shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `suspend candidate TTL은 음수와 1ms 미만 값을 Redis 쓰기 전에 거부`() = runSuspendIO {
+        val lockName = randomName()
+        val candidate = CandidateInfo("node-1")
+
+        assertFailsWith<IllegalArgumentException> {
+            node1.registerCandidate(lockName, candidate, (-500).microseconds)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            node1.registerCandidate(lockName, candidate, 500.microseconds)
+        }
+
+        node1.registerCandidate(lockName, candidate, Duration.ZERO)
+        assertFailsWith<IllegalArgumentException> {
+            node1.refreshCandidate(lockName, candidate, (-500).microseconds)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            node1.refreshCandidate(lockName, candidate, 500.microseconds)
+        }
     }
 
     @Test

--- a/leader-redis-lettuce/src/test/resources/redis-cluster-test-matrix.txt
+++ b/leader-redis-lettuce/src/test/resources/redis-cluster-test-matrix.txt
@@ -1,0 +1,17 @@
+blocking single elector executes v3 register list refresh result and unregister
+blocking group elector uses cluster mget and same-slot scripts
+suspend single elector preserves cancellation and cluster lifecycle
+suspend group elector uses cluster coroutine mget and group script
+v2 and colon sources migrate through single-key reads and remain preserved
+cluster migration preserves positive source TTL on the v3 destination
+blocking group elector refreshes result and unregisters in cluster
+blocking group elector migrates a v2 source before refreshing and unregistering
+suspend single elector migrates a v2 source before refreshing and unregistering
+suspend group elector refreshes result and unregisters in cluster
+suspend group elector migrates a colon source before refreshing and unregistering
+cluster v3 namespaces use one slot for every elector
+blocking group elector preserves positive and persistent TTL boundaries
+suspend single elector migrates a v2 source with positive TTL
+suspend group elector migrates a colon source with positive TTL
+suspend group elector propagates action cancellation without recording failure
+suspend cluster script cancellation preserves the caller connection

--- a/scripts/compatibility/check_binary_api.py
+++ b/scripts/compatibility/check_binary_api.py
@@ -94,6 +94,15 @@ KNOWN_SYNTHETIC_ACCESSORS: dict[str, frozenset[str]] = {
             + "java.lang.String)",
             "PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) java.lang.Object "
             + "access$scanKeys(io.bluetape4k.leader.lettuce.LettuceSuspendCandidateRegistry, "
+            + "java.lang.String, kotlin.coroutines.Continuation)",
+            "PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) java.lang.Object "
+            + "access$migrateLegacyCandidate(io.bluetape4k.leader.lettuce.LettuceSuspendCandidateRegistry, "
+            + "java.lang.String, java.lang.String, kotlin.coroutines.Continuation)",
+            "PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) java.lang.Object "
+            + "access$readCurrentCandidate(io.bluetape4k.leader.lettuce.LettuceSuspendCandidateRegistry, "
+            + "java.lang.String, java.lang.String, kotlin.coroutines.Continuation)",
+            "PUBLIC(-) STATIC(-) FINAL(-) SYNTHETIC(-) java.lang.Object "
+            + "access$readLegacyNodeIds(io.bluetape4k.leader.lettuce.LettuceSuspendCandidateRegistry, "
             + "java.lang.String, kotlin.coroutines.Continuation)"
         }
     ),


### PR DESCRIPTION
## Summary

Closes #854

Redis Cluster에서 leader candidate의 다중 키 상태 전이가 동일 hash slot에서 원자적으로 수행되도록 v3 key layout, migration fence, blocking/suspend 경로와 전용 검증 게이트를 추가합니다.

## Background

Milestone `1.1.0`의 Issue #854는 기존 Lettuce 후보 key가 Redis Cluster hash slot을 보장하지 않아 `CROSSSLOT` 위험이 있고, 실제 Cluster에서 lifecycle·legacy migration·TTL 경계가 검증되지 않은 상태를 다룹니다.

## What This Solves

- candidate/index/tombstone/token key를 공통 hash tag로 묶어 Cluster `MGET`과 다중 키 Lua가 같은 slot에서 실행됩니다.
- v2/colon legacy source를 single-key로 안전하게 migrate하고, tombstone·migration token·raw value 비교로 unregister 및 동일 payload writer race를 차단합니다.
- blocking/suspend single/group elector의 register/list/refresh/result/unregister, TTL, migration, cancellation을 실제 Redis Cluster에서 검증합니다.
- regular test와 Cluster test를 분리하고, checked-in manifest exact names·JUnit XML·image digest·cluster state·topology provenance를 CI에서 fail-closed로 검사합니다.

## Work Done

- `LettuceCandidateKeyCodec`, blocking/suspend registry, write/refresh/result/cleanup scripts를 v3 same-slot 계약과 source 보존/forward-fix 경계에 맞게 정리했습니다.
- `RedisScriptRunner`에 standalone/Cluster sync·async·suspend capability overload를 추가하고, 네 strategic elector에 additive Cluster constructors를 제공했습니다.
- `LettuceStrategicRedisClusterTest` 17개와 `redis-cluster-test-matrix.txt` manifest, `clusterTest` Gradle task, Nightly full-scope job/guard를 추가했습니다.
- 양국어 README, spec/plan, 7-Tier review, lesson을 현재 resolved Lettuce `7.6.0.RELEASE`와 rollback/운영 경계에 맞춰 동기화했습니다.

## Validation

- `:bluetape4k-leader-redis-lettuce:test`: PASS (352 tests, failures/skipped/errors 0)
- `:bluetape4k-leader-redis-lettuce:clusterTest`: PASS (manifest 17/17 exact names, failures/skipped/errors 0)
- `koverXmlReport` 및 `detekt`: PASS
- `checkBinaryCompatibility` 및 custom ABI checker: PASS (`artifacts=16 ignored=1 unknown=0`)
- `dependencyInsight`: PASS (`io.lettuce:lettuce-core:7.6.0.RELEASE`)
- CI fan-out/Kover/assertion static validators, YAML parser, `actionlint`, Kotlin/Java consumer fixture: PASS
- Cluster provenance: `tommy351/redis-cluster:6.2@sha256:78eb164a6e3380b733cb3cfb91f7c54f50cba42292bcdc21b969450161af9e89`, `cluster_state=ok`, 6 endpoints
- Nightly full-scope dispatch: [run 33912014082](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33912014082), event `workflow_dispatch`, exact head `7fe13221342f6947fd9927fb62a253b761e4455b`, `29/29` jobs success, cluster matrix `17/17`, `Nightly Status` success

## Review Notes

- P0/P1: 0
- P2/P3: P2 4건(immutable fixture pinning, legacy GET/PTTL bounded race, hosted TTL/failover, MOVED/ASK benchmark)과 P3 1건(test helper `!!`/reflection)을 후속 범위로 기록했습니다.
- Review evidence: [Issue #854 Redis Cluster 7-Tier review](https://github.com/bluetape4k/bluetape4k-leader/blob/develop/docs/review/2026-09-04-issue-854-redis-cluster-review.md)

## Metadata

- Issue: #854, milestone `1.1.0`, assignee `debop`
- PR: #875, head `7fe13221342f6947fd9927fb62a253b761e4455b`, base `develop`
- CI: exact-head PR checks `18 pass / 29 skipped / 0 failure`; full Nightly run [33912014082](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33912014082) `29/29` jobs success; 1인 개발자 예외를 적용해 별도 human review 없이 fresh 사용자 승인을 사용함
- Merge: GitHub rebase merge, merge SHA `7c99875c7d5ec2bdec99e635dae0f88eceb3edcc`, `develop` 동기화 및 기능 worktree/로컬 branch 정리 완료

## DoD Status

Required checks: 55/55; N/A: 3; Blocked: 0

| Check | Action | Status | Evidence | Failure / Next Action |
|------|--------|--------|----------|-----------------------|
| WF-00~WF-06 | guidance, classification, approved Type-A plan, execution receipt | PASS | `20260904T114550Z-57488d5e`, sequence 19, verified receipt | none |
| CG-01~CG-10 | pre-PR implementation, review, lesson, tests, ABI, docs | PASS | exact head `7fe13221342f6947fd9927fb62a253b761e4455b`; P0/P1=0; full validation above | none |
| CG-11 | PR delivery authority | PASS | latest user `승인`; repository/base/head explicitly matched | none |
| CG-12 | publish exact head | PASS | remote `feat/issue-854-redis-cluster` matches `7fe13221342f6947fd9927fb62a253b761e4455b` | none |
| CG-12A | refresh guidance and linked issue before PR | PASS | current user/workspace/repository AGENTS, leaf/common-gates/PR template hashes and live Issue #854 read immediately before creation | none |
| CG-13 | create and live-verify PR | PASS | [PR #875](https://github.com/bluetape4k/bluetape4k-leader/pull/875), base `develop`, head `7fe13221342f6947fd9927fb62a253b761e4455b`, Korean body ending in this section | none |
| CG-13A | full Nightly dispatch | PASS | [run 33912014082](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33912014082), `workflow_dispatch`, `scope=full`, exact head `7fe13221342f6947fd9927fb62a253b761e4455b`, `29/29` jobs success, cluster matrix `17/17`, `Nightly Status` success | none |
| CG-14 | exact-head CI and review | PASS | PR checks `18 pass / 29 skipped / 0 failure`; Nightly run `33912014082` is `29/29` success with cluster matrix `17/17`; local 7-Tier review P0/P1=0 and solo-developer exception explicitly recorded | none |
| CG-15 | merge-ready report | PASS | exact-head PR/Nightly, local review, GNO refresh, and solo-developer exception were re-read before merge | none |
| CG-16~CG-18 | fresh merge approval, merge, sync/cleanup | PASS | latest user approval tied to exact head `7fe13221342f6947fd9927fb62a253b761e4455b`; merge SHA `7c99875c7d5ec2bdec99e635dae0f88eceb3edcc`; local `develop` fast-forward synced and feature worktree/local branch removed | none |
| A-11 | durable knowledge and merge-ready report | PASS | `gno update` reported 5 collections `0 added, 0 updated`; Issue #854 and Redis Cluster docs/review were re-searched; exact-head DoD and merge evidence recorded | none |

Final status: DONE — exact-head CI/Nightly, solo-developer review exception, fresh merge approval, rebase merge, `develop` sync, post-merge tests, and feature worktree/local branch cleanup are complete. P2 4건과 P3 1건은 후속 비차단 항목이다.

Unchecked items: none

