### PR TITLE
test: Redis Cluster fixture 재현성과 migration 회귀 검증 개선

### DIFF
--- a/docs/lessons/2026-09-05-redis-cluster-test-reproducibility.md
+++ b/docs/lessons/2026-09-05-redis-cluster-test-reproducibility.md
@@ -1,0 +1,68 @@
+# Redis Cluster fixture 고정과 migration 회귀 테스트 정리
+
+## 범위와 결정
+
+[PR #875](https://github.com/bluetape4k/bluetape4k-leader/pull/875)의 후속 개선 중
+[#876](https://github.com/bluetape4k/bluetape4k-leader/issues/876)과
+[#878](https://github.com/bluetape4k/bluetape4k-leader/issues/878)을 구현했다.
+기준은 `develop`의 `7c99875c7d5ec2bdec99e635dae0f88eceb3edcc`이며,
+프로덕션 소스와 공개 API는 변경하지 않았다.
+
+- `redis-cluster-image.txt`를 이미지 참조의 단일 원본으로 사용한다.
+  Gradle은 mutable tag를 거부하고, 테스트는 기존 `RedisClusterServer` factory에 digest를 전달한다.
+- 테스트가 서버 시작과 종료를 소유한다. 시작 실패 시에도 정리를 시도하고,
+  정리 실패는 원래 예외의 suppressed exception으로 보존한다.
+- 실행 컨테이너의 image ID를 조회한 뒤 요청 이미지의 ID 및 실제 `RepoDigests`와 대조한다.
+  요청 문자열만 기록하는 것으로 실제 실행 이미지 검증을 대신하지 않는다.
+- migration 회귀 테스트는 private constructor와 cleanup 메서드에 접근하지 않는다.
+  실제 `listCandidates()` 호출 중 첫 양수 `PTTL` 조회 직후 `PERSIST`를 완료하고,
+  cleanup이 관측하는 `-1`이 만료로 처리되지 않는지 검증한다.
+
+## 검증 결과
+
+다음 명령으로 일반 테스트 352개와 Cluster 테스트 17개가 모두 통과했다.
+같은 실행의 detekt도 성공했다. Cluster 실행 기록은 고정 digest 일치,
+`cluster_state=ok`, endpoint 6개를 확인했다.
+
+```bash
+./gradlew :bluetape4k-leader-redis-lettuce:test \
+  :bluetape4k-leader-redis-lettuce:clusterTest \
+  :bluetape4k-leader-redis-lettuce:detekt \
+  --no-daemon --no-configuration-cache --console=plain
+```
+
+- 이미지 참조를 임시로 `tommy351/redis-cluster:6.2`로 변경하자 Gradle이
+  `Redis Cluster fixture requires an immutable SHA-256 image reference`로 거부했다.
+  검증 후 고정 digest로 복원했다.
+- 양쪽 registry의 만료 판정을 임시로 `sourceTtlAfter == 0L`에서 `<= 0L`로 변경하자
+  blocking·suspend 회귀 테스트 두 개가 실패했다. 프로덕션 코드를 복원한 후 위 전체 검증을 통과했다.
+
+## 놓치기 쉬운 점과 재발 방지
+
+첫 테스트 연결은 async 명령을 감쌌지만 suspend 경계가 실행되지 않아 테스트가 실패했다.
+사용 중인 Lettuce `7.6.0.RELEASE` 소스에서 `coroutines()`가 `reactive()`를 감싼다는 것을 확인하고,
+reactive `PTTL`과 `PERSIST`를 순서대로 연결했다. 테스트 대역은 API 이름이 아니라
+실제 호출 경로에 설치하고, source TTL이 정말 `-1`로 변경됐는지도 단언한다.
+
+향후 이미지 갱신 때는 resource의 digest와 실제 실행 image ID를 함께 확인한다.
+회귀 테스트 리팩터링 때는 기존 결함을 재현하는 임시 변이로 검출력을 확인한다.
+
+## PR 직전 재검증
+
+캐시를 비활성화한 fresh 실행에서 기존 `LettuceStrategicGroupToxiproxyCancellationTest`가
+한 번 실패했다. 테스트 본문 진입 전 `ghcr.io/shopify/toxiproxy:2.9.0`의
+`http://localhost:57287/version` 준비 확인이 60초를 초과했다.
+컨테이너 로그에는 `0.0.0.0:8474` 서버 시작이 기록됐고, 같은 실행의 다음 컨테이너는
+0.326초에 시작했다. 해당 테스트와 fixture는 이번 변경에 포함되지 않으며,
+Cluster fixture가 시작되기 전에 발생한 실패다.
+
+코드나 VM 설정을 변경하지 않고 대상 테스트 2개를 재실행해 통과한 뒤,
+일반 352개·Cluster 17개와 detekt를 다시 검증했다. 모두 통과했지만
+호스트 포트 접근이 지연된 근본 원인은 확정하지 않았다. 재발 시 `/version`의
+호스트·컨테이너 양쪽 응답과 Docker 포트 매핑을 수집하며, 재시도 성공만으로 해결됐다고 기록하지 않는다.
+
+## 남은 범위
+
+[#877](https://github.com/bluetape4k/bluetape4k-leader/issues/877)의 추가 migration 경합·TTL 행렬과
+[#879](https://github.com/bluetape4k/bluetape4k-leader/issues/879)의 failover·MOVED/ASK 수렴 측정은
+별도 후속 작업이다. 이번 로컬 검증은 hosted CI나 해당 장애 시나리오의 통과 근거가 아니다.

--- a/docs/review/2026-09-05-issue-876-878-pr-review.md
+++ b/docs/review/2026-09-05-issue-876-878-pr-review.md
@@ -1,0 +1,27 @@
+# Issues #876/#878 PR 직전 검토
+
+## 범위와 기준
+
+- 기준: `develop` `7c99875c7d5ec2bdec99e635dae0f88eceb3edcc`
+- 대상: `leader-redis-lettuce/build.gradle.kts`, `LettuceStrategicRedisClusterTest.kt`,
+  `LettuceCandidateWriteScriptTest.kt`, `redis-cluster-image.txt`, 관련 lesson.
+- 방식: 주 작업 세션의 최종 diff 검토. 별도 `code-reviewer` 세션은 시작 응답이 없어
+  독립 리뷰 결과로 계산하지 않는다. 사람 리뷰는 1인 개발자 저장소이므로 N/A다.
+
+## 관점별 결과
+
+| 관점 | 확인 근거와 판정 |
+|---|---|
+| 구조·호환성 | 프로덕션 소스, dependency 좌표, 공개 API 변경 없음. 기존 `RedisClusterServer` factory 재사용. |
+| 보안 | mutable tag를 거부하고 실제 실행 컨테이너 image ID와 요청 digest를 대조한다. 인증정보 변경 없음. |
+| 성능 | 테스트 전용 변경. Cluster 17개가 단일 fixture를 공유하고 순차 실행된다. |
+| 안정성·운영 | 시작 실패 시 cleanup 시도와 원래 예외 보존. 정상 종료는 `@AfterAll`이 소유한다. |
+| 개발자·API | reflection·수동 continuation·강제 null 해제를 제거했다. registry 진입점과 실제 sync/reactive 명령을 사용한다. |
+| 사용자·호출자 | 배포 API나 README 사용법 변경 없음. 후속 #877/#879 범위를 lesson에 분리했다. |
+| 빌드·테스트 | 일반 352개·Cluster 17개 실패/오류/skip 0. detekt 통과. 잘못된 만료 판정 변이를 두 회귀 테스트가 검출했다. |
+
+## 판정과 제한
+
+현재 diff에서 P0/P1은 발견하지 않았다. IDE 진단 대신 Gradle Kotlin 컴파일·detekt를 사용했다.
+Toxiproxy 준비 확인의 단발 timeout과 재검증 결과는 lesson에 보존했다.
+독립 리뷰와 exact-head hosted CI는 별도 증거가 필요하므로, 이 문서만으로 merge-ready를 선언하지 않는다.

--- a/leader-redis-lettuce/build.gradle.kts
+++ b/leader-redis-lettuce/build.gradle.kts
@@ -33,6 +33,12 @@ tasks.named<Test>("test") {
 }
 
 val clusterTestMatrixFile = layout.projectDirectory.file("src/test/resources/redis-cluster-test-matrix.txt").asFile
+val clusterImageFile = layout.projectDirectory.file("src/test/resources/redis-cluster-image.txt").asFile
+val clusterImage = clusterImageFile.readText().trim().also {
+    require(it.matches(Regex("tommy351/redis-cluster@sha256:[a-f0-9]{64}"))) {
+        "Redis Cluster fixture requires an immutable SHA-256 image reference"
+    }
+}
 val expectedClusterTestNames = clusterTestMatrixFile.readLines()
     .map(String::trim)
     .filter(String::isNotEmpty)
@@ -70,8 +76,8 @@ val clusterTest = tasks.register<Test>("clusterTest") {
         directory.mkdirs()
         directory.resolve("task-provenance.txt").writeText(
             buildString {
-                appendLine("image=tommy351/redis-cluster:6.2")
-                appendLine("fixture=io.bluetape4k.testcontainers.storage.RedisClusterServer.Launcher.redisCluster")
+                appendLine("image=$clusterImage")
+                appendLine("fixture=io.bluetape4k.testcontainers.storage.RedisClusterServer")
                 appendLine("task=clusterTest")
                 appendLine("expectedTests=$expectedClusterTestCount")
                 appendLine("dockerHost=${System.getenv("DOCKER_HOST") ?: "default"}")
@@ -125,7 +131,7 @@ val clusterTest = tasks.register<Test>("clusterTest") {
         val clusterState = provenanceLines.firstOrNull { it.startsWith("cluster_state=") }
         val endpoints = provenanceLines.firstOrNull { it.startsWith("endpoints=") }
         val endpointCount = endpoints?.substringAfter('=')?.split(',')?.count { it.isNotBlank() } ?: 0
-        require(imageDigest?.contains("@sha256:") == true && clusterState == "cluster_state=ok" &&
+        require(imageDigest == "image_digest=$clusterImage" && clusterState == "cluster_state=ok" &&
             endpointCount >= 6) {
             "Redis Cluster runtime provenance is incomplete: $provenanceLines"
         }

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateWriteScriptTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceCandidateWriteScriptTest.kt
@@ -3,6 +3,7 @@
 package io.bluetape4k.leader.lettuce
 
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeGreaterThan
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldNotBeNull
 import io.bluetape4k.junit5.coroutines.runSuspendIO
@@ -10,11 +11,11 @@ import io.bluetape4k.leader.lettuce.script.RedisScriptRunner
 import io.bluetape4k.leader.strategy.CandidateInfo
 import io.bluetape4k.leader.strategy.CandidateResult
 import io.lettuce.core.ScriptOutputType
-import io.lettuce.core.api.coroutines
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.api.reactive.RedisReactiveCommands
+import io.lettuce.core.api.sync.RedisCommands
 import org.junit.jupiter.api.Test
-import kotlin.coroutines.Continuation
-import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
-import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import reactor.core.publisher.Mono
 
 class LettuceCandidateWriteScriptTest : AbstractLettuceLeaderTest() {
 
@@ -108,7 +109,7 @@ class LettuceCandidateWriteScriptTest : AbstractLettuceLeaderTest() {
         )
         updated.first().toString().toLong() shouldBeEqualTo LettuceCandidateResultScript.UPDATED
         connection.sync().get(keys.token).shouldBeNull()
-        LettuceCandidateInfoCodec.decode(connection.sync().get(keys.candidate)!!).successCount shouldBeEqualTo 1L
+        LettuceCandidateInfoCodec.decode(connection.sync().get(keys.candidate).shouldNotBeNull()).successCount shouldBeEqualTo 1L
     }
 
     @Test
@@ -192,36 +193,20 @@ class LettuceCandidateWriteScriptTest : AbstractLettuceLeaderTest() {
             nodeId,
         )
         val raw = LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId))
-        val token = "migration-token-${System.nanoTime()}"
-
-        connection.sync().set(keys.candidate, raw)
-        connection.sync().sadd(keys.index, nodeId)
-        connection.sync().set(keys.token, token)
         connection.sync().set(sourceKey, raw)
-
-        val constructor = LettuceCandidateRegistry::class.java.getDeclaredConstructor(
-            BlockingCandidateCommands::class.java,
-            BlockingCandidateValueReader::class.java,
-            String::class.java,
-        ).apply { isAccessible = true }
-        val registry = constructor.newInstance(
-            LettuceBlockingCandidateCommands(connection.sync()),
-            BlockingCandidateValueReader { emptyMap() },
-            LettuceCandidateRegistry.DEFAULT_KEY_PREFIX,
+        connection.sync().pexpire(sourceKey, 30_000L)
+        connection.sync().sadd(
+            LettuceCandidateKeyCodec.v2IndexKey(LettuceCandidateRegistry.DEFAULT_KEY_PREFIX, lockName),
+            nodeId,
         )
-        LettuceCandidateRegistry::class.java.getDeclaredMethod(
-            "cleanupExpiredMigration",
-            String::class.java,
-            String::class.java,
-            String::class.java,
-            String::class.java,
-            Long::class.javaPrimitiveType,
-            String::class.java,
-        ).apply { isAccessible = true }
-            .invoke(registry, lockName, nodeId, sourceKey, raw, 100L, token)
+        val registry = LettuceCandidateRegistry(persistAfterFirstTtl(sourceKey))
+
+        registry.listCandidates(lockName).single().nodeId shouldBeEqualTo nodeId
 
         connection.sync().get(keys.candidate) shouldBeEqualTo raw
-        connection.sync().get(keys.token) shouldBeEqualTo token
+        connection.sync().get(keys.token).shouldNotBeNull()
+        connection.sync().pttl(sourceKey) shouldBeEqualTo -1L
+        connection.sync().sismember(keys.index, nodeId) shouldBeEqualTo true
     }
 
     @Test
@@ -235,28 +220,20 @@ class LettuceCandidateWriteScriptTest : AbstractLettuceLeaderTest() {
             nodeId,
         )
         val raw = LettuceCandidateInfoCodec.encode(CandidateInfo(nodeId))
-        val token = "suspend-migration-token-${System.nanoTime()}"
-
-        connection.sync().set(keys.candidate, raw)
-        connection.sync().sadd(keys.index, nodeId)
-        connection.sync().set(keys.token, token)
         connection.sync().set(sourceKey, raw)
-
-        val constructor = LettuceSuspendCandidateRegistry::class.java.getDeclaredConstructor(
-            SuspendCandidateCommands::class.java,
-            SuspendCandidateValueReader::class.java,
-            String::class.java,
-        ).apply { isAccessible = true }
-        val registry = constructor.newInstance(
-            LettuceSuspendCandidateCommands(connection.coroutines()) { connection.async() },
-            SuspendCandidateValueReader { emptyMap() },
-            LettuceSuspendCandidateRegistry.DEFAULT_KEY_PREFIX,
+        connection.sync().pexpire(sourceKey, 30_000L)
+        connection.sync().sadd(
+            LettuceCandidateKeyCodec.v2IndexKey(LettuceSuspendCandidateRegistry.DEFAULT_KEY_PREFIX, lockName),
+            nodeId,
         )
+        val registry = LettuceSuspendCandidateRegistry(persistAfterFirstTtl(sourceKey))
 
-        invokeSuspendCleanup(registry, lockName, nodeId, sourceKey, raw, 100L, token)
+        registry.listCandidates(lockName).single().nodeId shouldBeEqualTo nodeId
 
         connection.sync().get(keys.candidate) shouldBeEqualTo raw
-        connection.sync().get(keys.token) shouldBeEqualTo token
+        connection.sync().get(keys.token).shouldNotBeNull()
+        connection.sync().pttl(sourceKey) shouldBeEqualTo -1L
+        connection.sync().sismember(keys.index, nodeId) shouldBeEqualTo true
     }
 
     private fun run(keys: ScriptKeys, operation: String, vararg args: String): List<Any> =
@@ -271,37 +248,38 @@ class LettuceCandidateWriteScriptTest : AbstractLettuceLeaderTest() {
 
     private fun List<Any>.status(): Long = first().toString().toLong()
 
-    private suspend fun invokeSuspendCleanup(
-        registry: Any,
-        lockName: String,
-        nodeId: String,
-        sourceKey: String,
-        sourceRaw: String,
-        observedTtl: Long,
-        token: String,
-    ): Any? {
-        val method = LettuceSuspendCandidateRegistry::class.java.getDeclaredMethod(
-            "cleanupExpiredMigration",
-            String::class.java,
-            String::class.java,
-            String::class.java,
-            String::class.java,
-            Long::class.javaPrimitiveType,
-            String::class.java,
-            Continuation::class.java,
-        ).apply { isAccessible = true }
-        return suspendCoroutineUninterceptedOrReturn { continuation ->
-            val result = method.invoke(
-                registry,
-                lockName,
-                nodeId,
-                sourceKey,
-                sourceRaw,
-                observedTtl,
-                token,
-                continuation,
-            )
-            if (result === COROUTINE_SUSPENDED) COROUTINE_SUSPENDED else result
+    // 실제 PTTL 결과를 반환하되 첫 조회 직후 PERSIST를 완료해서 cleanup의 -1 경계를 재현한다.
+    private fun persistAfterFirstTtl(sourceKey: String): StatefulRedisConnection<String, String> {
+        val sync = connection.sync()
+        val reactive = connection.reactive()
+        var first = true
+        fun persistSource(key: String, ttl: Long) {
+            if (key == sourceKey && first) {
+                ttl shouldBeGreaterThan 0L
+                sync.persist(sourceKey) shouldBeEqualTo true
+                first = false
+            }
+        }
+        val syncCommands = object : RedisCommands<String, String> by sync {
+            override fun pttl(key: String): Long = sync.pttl(key).also { persistSource(key, it) }
+        }
+        val reactiveCommands = object : RedisReactiveCommands<String, String> by reactive {
+            override fun pttl(key: String): Mono<Long> = reactive.pttl(key).flatMap { ttl ->
+                if (key == sourceKey && first) {
+                    ttl shouldBeGreaterThan 0L
+                    first = false
+                    reactive.persist(sourceKey).map { persisted ->
+                        persisted shouldBeEqualTo true
+                        ttl
+                    }
+                } else {
+                    Mono.just(ttl)
+                }
+            }
+        }
+        return object : StatefulRedisConnection<String, String> by connection {
+            override fun sync(): RedisCommands<String, String> = syncCommands
+            override fun reactive(): RedisReactiveCommands<String, String> = reactiveCommands
         }
     }
 

--- a/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicRedisClusterTest.kt
+++ b/leader-redis-lettuce/src/test/kotlin/io/bluetape4k/leader/lettuce/LettuceStrategicRedisClusterTest.kt
@@ -17,14 +17,18 @@ import io.bluetape4k.leader.strategy.strategies.FifoElectionStrategy
 import io.bluetape4k.leader.strategy.strategies.FifoGroupElectionStrategy
 import io.bluetape4k.testcontainers.storage.RedisClusterServer
 import io.lettuce.core.ScriptOutputType
-import io.lettuce.core.cluster.SlotHash
-import io.lettuce.core.cluster.api.coroutines
 import io.lettuce.core.SetArgs
+import io.lettuce.core.cluster.SlotHash
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
+import io.lettuce.core.cluster.api.coroutines
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.testcontainers.utility.DockerImageName
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.CancellationException
@@ -32,7 +36,32 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 @Tag("redis-cluster")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class LettuceStrategicRedisClusterTest {
+
+    private val clusterImage = checkNotNull(javaClass.getResource("/redis-cluster-image.txt"))
+        .readText().trim()
+    // digest를 지정할 수 없는 전역 launcher 대신 기존 서버 factory를 재사용하고 이 테스트가 수명을 소유한다.
+    private val server = RedisClusterServer(DockerImageName.parse(clusterImage))
+
+    @BeforeAll
+    fun startCluster() {
+        try {
+            server.start()
+        } catch (failure: Throwable) {
+            try {
+                server.stop()
+            } catch (cleanupFailure: Throwable) {
+                failure.addSuppressed(cleanupFailure)
+            }
+            throw failure
+        }
+    }
+
+    @AfterAll
+    fun stopCluster() {
+        server.stop()
+    }
 
     @Test
     fun `blocking single elector executes v3 register list refresh result and unregister`() {
@@ -515,7 +544,6 @@ class LettuceStrategicRedisClusterTest {
     }
 
     private fun withCluster(block: (StatefulRedisClusterConnection<String, String>) -> Unit) {
-        val server = RedisClusterServer.Launcher.redisCluster
         RedisClusterServer.Launcher.LettuceLib.getClusterClient(server).use { client ->
             client.connect().use { connection ->
                 recordClusterRuntime(server, connection)
@@ -527,7 +555,6 @@ class LettuceStrategicRedisClusterTest {
     private suspend fun withClusterSuspend(
         block: suspend (StatefulRedisClusterConnection<String, String>) -> Unit,
     ) {
-        val server = RedisClusterServer.Launcher.redisCluster
         RedisClusterServer.Launcher.LettuceLib.getClusterClient(server).use { client ->
             client.connect().use { connection ->
                 recordClusterRuntime(server, connection)
@@ -548,13 +575,16 @@ class LettuceStrategicRedisClusterTest {
         )
         Files.createDirectories(diagnosticsDirectory)
 
-        val imageDigest = server.dockerClient
-            .inspectImageCmd(server.dockerImageName)
+        val actualImageId = server.dockerClient.inspectContainerCmd(server.containerId).exec().imageId
+        val actualImage = server.dockerClient
+            .inspectImageCmd(actualImageId)
             .exec()
-            .repoDigests
+        val requestedImage = server.dockerClient.inspectImageCmd(clusterImage).exec()
+        actualImage.id shouldBeEqualTo requestedImage.id
+        val imageDigest = actualImage.repoDigests
             .orEmpty()
-            .firstOrNull { "@sha256:" in it }
-            ?: error("Redis Cluster image digest is unavailable for ${server.dockerImageName}")
+            .firstOrNull { it == clusterImage }
+            ?: error("Redis Cluster running image does not match pinned digest: $clusterImage")
         val clusterInfo = connection.sync().clusterInfo()
         val clusterState = clusterInfo.lineSequence()
             .firstOrNull { it.startsWith("cluster_state:") }
@@ -565,7 +595,8 @@ class LettuceStrategicRedisClusterTest {
         val runtimeProvenance = buildString {
             appendLine("image=${server.dockerImageName}")
             appendLine("image_digest=$imageDigest")
-            appendLine("fixture=io.bluetape4k.testcontainers.storage.RedisClusterServer.Launcher.redisCluster")
+            appendLine("image_id=$actualImageId")
+            appendLine("fixture=io.bluetape4k.testcontainers.storage.RedisClusterServer")
             appendLine("cluster_state=$clusterState")
             appendLine("endpoints=$endpoints")
             appendLine("mapped_ports=${server.mappedPorts.entries.joinToString(",") { (source, mapped) -> "$source->$mapped" }}")

--- a/leader-redis-lettuce/src/test/resources/redis-cluster-image.txt
+++ b/leader-redis-lettuce/src/test/resources/redis-cluster-image.txt
@@ -1,0 +1,1 @@
+tommy351/redis-cluster@sha256:78eb164a6e3380b733cb3cfb91f7c54f50cba42292bcdc21b969450161af9e89


### PR DESCRIPTION
## 요약

Closes #876
Closes #878

Redis Cluster 테스트가 항상 같은 이미지를 실행하도록 고정하고, migration 회귀 테스트가 실제 registry 경로를 검증하도록 정리합니다.

## 배경

milestone `1.1.0`의 PR #875 후속 개선입니다. mutable image tag는 실행 시점마다 달라질 수 있고, private cleanup 메서드에 대한 reflection 호출은 실제 migration 경로를 검증하지 못했습니다.

## 변경 사항

- 이미지 digest를 `redis-cluster-image.txt`에 고정하고 Gradle에서 mutable tag를 거부합니다.
- 실행 컨테이너 image ID와 요청 digest를 대조하며, 테스트가 기존 `RedisClusterServer`의 수명을 소유합니다.
- 실제 `listCandidates()` 호출 중 sync/reactive `PTTL` 직후 `PERSIST`를 완료해 양수 TTL에서 영속 상태로 바뀌는 경계를 검증합니다.
- reflection·수동 continuation·강제 null 해제를 제거합니다. 프로덕션 API나 dependency 좌표는 변경하지 않습니다.

## 검증

- `./gradlew :bluetape4k-leader-redis-lettuce:test :bluetape4k-leader-redis-lettuce:clusterTest :bluetape4k-leader-redis-lettuce:detekt --no-build-cache --no-daemon --no-configuration-cache --console=plain`: PASS — 일반 352개, Cluster 17개, 실패/오류/skip 0.
- mutable tag 입력 거부 및 실제 실행 digest 일치 확인.
- 만료 판정을 임시로 `<= 0`으로 변경하면 blocking·suspend 회귀 테스트 두 개가 실패함을 확인하고 원본 복원.
- `git diff --check`, staged diff 검사, 한국어 용어 검사: PASS.
- exact-head CI [33917775713](https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33917775713): SUCCESS — 실행 job 17개 성공, 변경 범위 밖 29개 제외. Lettuce·Redisson·Spring Boot 및 영향받는 예제 job 통과. 제외 job을 테스트 통과로 계산하지 않으며 hosted Cluster/Full Nightly 검증을 주장하지 않습니다.
- fresh 실행 중 기존 Toxiproxy 테스트의 `/version` 준비 확인이 한 번 timeout됐습니다. 컨테이너는 내부 HTTP 서버 시작을 기록했고 다음 컨테이너는 정상 시작했습니다. 코드 변경 없이 대상 2개와 전체 369개를 재검증했습니다. 호스트 포트 접근 지연 원인은 미확정이며 해결됐다고 주장하지 않습니다.

## 리뷰와 남은 범위

- inline 최종 검토: P0=0, P1=0.
- 근거: `docs/review/2026-09-05-issue-876-878-pr-review.md`, `docs/lessons/2026-09-05-redis-cluster-test-reproducibility.md`.
- 독립 `code-reviewer` 세션이 시작 응답을 반환하지 않아 독립 리뷰는 PENDING입니다. inline 검토를 독립 리뷰로 계산하지 않습니다.
- #877 migration 경합·TTL 확장과 #879 failover·MOVED/ASK 측정은 후속 범위입니다.

## 메타데이터

- 저장소: `bluetape4k/bluetape4k-leader`
- base: `develop`, head: `test/issue-876-cluster-fixture`
- head SHA: `baf386a5996b517f05e21df2d448bd42f408335c`
- milestone: `1.1.0`, assignee: `debop`
- PR: https://github.com/bluetape4k/bluetape4k-leader/pull/881
- CI: https://github.com/bluetape4k/bluetape4k-leader/actions/runs/33917775713
- 사람 리뷰: N/A — 1인 개발자 저장소이며 별도 human reviewer가 없습니다.

## DoD Status

전달 단계(CG-10~CG-18): PASS: 8/10; 검증 공백을 남긴 사용자 예외 승인: 2/10; 사람 리뷰 N/A: 1.

| Check | Action | Status | Evidence | Failure / Next Action |
|---|---|---|---|---|
| CG-10 | 최종 점검과 commit | PASS | `baf386a5`, 일반352/Cluster17/실패0, detekt | 없음 |
| CG-11 | PR 생성 범위 확인 | PASS | 사용자의 다음 단계 진행 요청, 위 repo/base/head | merge는 별도 승인 |
| CG-12 | 정확한 head push | PASS | local/remote `baf386a5996b517f05e21df2d448bd42f408335c` 일치 | 없음 |
| CG-12A | 지침·템플릿·이슈 재확인 | PASS | 현재 AGENTS 계층, Type B/common gates, PR template, #876/#878 메타데이터 확인 | 변경 시 재검증 |
| CG-13 | PR 생성 및 메타데이터 확인 | PASS | PR #881, head·base·milestone·assignee·labels live readback 일치 | 없음 |
| CG-14 | exact-head CI·리뷰 확인 | EXCEPTION | CI33917775713 성공(17 success/29 범위 밖 제외), 종료 후 reviews/threads 0. 독립 자동 리뷰 미확보를 알린 후 사용자가 머지 지시 | 독립 자동 리뷰 PASS 아님 |
| 사람 리뷰 | 별도 maintainer 검토 | N/A | single-developer lane, 사용자 명시 | 없음 |
| CG-15 | merge-ready 보고 | EXCEPTION | CI 성공 및 독립 리뷰 공백 보고 후 이번 PR의 예외 병합 결정 기록 | 일반 merge-ready 통과로 계산하지 않음 |
| CG-16 | fresh merge 승인 | PASS | 사용자의 명시 지시: “1인개발자야. 머지해”; head baf386a5 재확인 | 없음 |
| CG-17 | merge | PASS | rebase merge de8baf5d69253c19fe2c59242726430824151478, match-head-commit 사용 | 관리자 우회·auto-merge·브랜치 삭제 없음 |
| CG-18 | develop 동기화·정리 | PASS | 로컬 develop=origin/develop=de8baf5d; 병합 전후 tree 동일; #876/#878 CLOSED | 기존 .flow-inputs/와 worktree·branch 보존, 삭제 미실행 |

Final status: DONE — 사용자 지시에 따른 예외 병합과 develop 동기화 완료. 독립 자동 리뷰 미확보는 검증 공백으로 남기며 통과로 간주하지 않습니다. 병합 결정: https://github.com/bluetape4k/bluetape4k-leader/pull/881#issuecomment-5546410226

Unchecked validation: 독립 자동 리뷰 결과, Full Nightly 및 hosted Cluster 검증. 이번 병합은 해당 검증을 완료했다는 주장이 아닙니다.
