### PR TITLE
jetcd 0.8.7 callback 및 async lease 회귀를 검증한다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ env:
   JAVA_VERSION: '25'
   JAVA_DISTRIBUTION: 'temurin'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-  BLUETAPE4K_DEPENDENCIES_CATALOG_REF: '850959d0ea5f76ac7e2c442400f47653d5f95eed'
+  BLUETAPE4K_DEPENDENCIES_CATALOG_REF: '9698c9d66bea6fcba373143ee8fa5bfbd9812d4b'
 
 jobs:
   # ── 0. 시크릿 스캔 ────────────────────────────────────────────────────────

--- a/docs/lessons/2026-09-05-issue-880-jetcd-callback.md
+++ b/docs/lessons/2026-09-05-issue-880-jetcd-callback.md
@@ -1,0 +1,79 @@
+# jetcd watch readiness와 async lease cleanup 교훈
+
+## 문제와 결정
+
+Issue [#880](https://github.com/bluetape4k/bluetape4k-leader/issues/880)은 중앙 catalog의 jetcd `0.8.7` 전환을 callback 동작과 Etcd leader lifecycle의 실행 가능한 계약으로 고정한다. 단순 버전 변경만으로는 callback deadlock, watcher 준비 경합, 반환 future 취소 뒤 lease 잔류를 검출할 수 없었다.
+
+따라서 raw jetcd callback 경계와 library elector 경계를 분리해서 검증했다. raw 테스트는 upstream 행동 차이를, elector 테스트는 Bluetape4k가 소유하는 contention·cancellation·cleanup 의미를 담당한다.
+
+## Watch 준비는 시간 대신 protocol event로 고정한다
+
+watcher 생성 직후 임의 대기한 다음 PUT을 보내면 listener가 준비되기 전 event가 발생할 수 있다. 긴 sleep은 확률만 바꾸며 준비 완료를 증명하지 않는다.
+
+jetcd watch에는 `WatchOption.withCreateNotify(true)`와 created response가 있다. 테스트는 이 response를 `CompletableFuture` readiness barrier로 변환하고, barrier 이후에만 producer를 실행한다. 같은 방식은 event publisher의 collector에도 적용한다. coroutine collector는 `CoroutineStart.UNDISPATCHED`로 구독을 설치하고 positive elected barrier로 경합 순서를 고정한다.
+
+규칙은 다음과 같다.
+
+- protocol이나 framework가 준비 완료 event를 제공하면 그것을 barrier로 사용한다.
+- bounded timeout은 실패 진단 상한이지 readiness 구현이 아니다.
+- 불발을 검증할 때만 짧은 negative timeout을 사용하고, 이후 future/collector를 명시적으로 취소한다.
+- callback thread name이나 executor 개수 같은 dependency 구현 세부사항은 계약으로 고정하지 않는다.
+
+## Dependency-sensitive RED는 실제 경계에서 얻는다
+
+jetcd `0.8.6`의 watch callback 내부에서 같은 client의 blocking KV get을 실행하면 bounded timeout으로 실패했다. 동일 테스트는 `0.8.7`에서 통과했다. 이 RED/GREEN은 compile 실패나 container 준비 실패와 구분해야 한다.
+
+callback 검증은 세 시나리오를 분리한다.
+
+1. callback 내부 blocking KV 호출이 완료된다.
+2. 느린 첫 callback 중 들어온 `PUT(v2)`와 `DELETE`가 `PUT(v1)` 뒤의 순서를 유지한다.
+3. watcher close 뒤 이전 listener에는 전달되지 않고 같은 caller-owned client의 새 watcher는 다시 수신한다.
+
+한 테스트에 모두 섞으면 deadlock, ordering, close race 중 어느 계약이 깨졌는지 알기 어렵다. 독립 시나리오와 한 container invocation을 함께 사용하면 진단력과 실행 비용을 균형 있게 유지할 수 있다.
+
+## 반환 future 취소는 실제 작업과 backend ownership까지 이어져야 한다
+
+`CompletableFuture.handle`과 `thenCompose`가 만든 dependent future는 caller cancellation을 source나 실제 action future로 자동 전달하지 않는다. leader API에서 반환 future만 취소되고 action이나 lease가 남으면 동일 lock의 다음 실행이 막힌다.
+
+Etcd async lifecycle은 다음 세 상태로 정리한다.
+
+- `WAITING`: acquisition 또는 action 제출 전이다. cancellation이 이 상태를 선점하면 cleanup owner가 된다.
+- `STARTED`: action이 실제로 시작됐다. cancellation relay가 action future를 취소하고 action completion handler가 cleanup한다.
+- `CLEANUP`: action을 시작하지 않는다. 늦게 도착한 ownership은 즉시 해제한다.
+
+`WAITING -> STARTED`와 `WAITING -> CLEANUP` 중 하나만 CAS로 성공해야 한다. backend handle 자체도 `markReleased()`를 가져야 unlock/revoke가 중복 completion 경로에서 exactly once가 된다. cancellation test는 call count만 보지 않고 동일 lock/slot 재획득까지 확인해야 cleanup의 기능적 효과를 증명한다.
+
+## 실패 경계마다 소유권을 구분한다
+
+- 첫 executor 제출 거부: acquisition이 시작되지 않았으므로 backend call은 0이어야 한다.
+- acquisition 후 두 번째 제출 거부: 이미 얻은 ownership을 해제하고 원래 `RejectedExecutionException`을 보존해야 한다.
+- action supplier 동기 throw: watchdog을 닫고 ownership을 해제한 뒤 원래 cause를 result에 전달해야 한다.
+- 정상 contention: 예외가 아니라 `null`이며 action supplier는 호출하지 않는다.
+- caller cancellation: returned future뿐 아니라 실제 action future도 취소되고 동일 lock/slot이 재획득 가능해야 한다.
+
+이 경계를 하나의 generic failure handler로 뭉치면 획득 전 불필요한 cleanup이나 획득 후 누락을 만들기 쉽다. acquisition handle의 존재와 lifecycle state를 함께 사용한다.
+
+## Catalog 변경은 원자적이고 되돌릴 수 있어야 한다
+
+local Gradle 설정과 CI가 다른 immutable catalog ref를 사용하면 로컬 GREEN과 hosted 결과가 다른 dependency graph를 검증한다. `settings.gradle.kts`와 `.github/workflows/ci.yml`의 ref를 같은 patch와 commit에서 바꾸고, rollback도 두 파일을 함께 되돌린다.
+
+최종 증거에는 direct dependency 하나만이 아니라 jetcd, gRPC, Netty, Vert.x selected version과 selection reason을 남긴다. TLS/auth, key layout, lease 기본값, caller-owned client lifecycle처럼 변경하지 않은 운영 경계도 명시한다.
+
+## 환경 readiness 실패를 제품 결함이나 성공으로 오인하지 않는다
+
+healthy Colima에서도 container 내부 서비스가 준비됐지만 mapped host endpoint probe가 timeout 또는 reset될 수 있었다. 같은 현상이 Toxiproxy와 etcd에서 관찰되어 [#884](https://github.com/bluetape4k/bluetape4k-leader/issues/884)로 분리했다.
+
+재실행 성공은 최초 실패를 지우지 않는다. container log, mapped endpoint, host listener, Docker/Colima 상태를 보존하고 제품 테스트 본문 진입 전 실패인지 구분한다. timeout 연장이나 healthy VM 재시작은 원인 규명이 아니다.
+
+## 재사용 체크리스트
+
+- listener/collector 준비를 positive event로 증명했는가?
+- dependency-sensitive RED가 정확히 이전 dependency 행동에서 실패했는가?
+- callback blocking, ordering, close/restart를 독립적으로 검증했는가?
+- returned cancellation이 acquisition과 실제 action으로 전달되는가?
+- late ownership, executor rejection, supplier throw가 exactly-once cleanup으로 수렴하는가?
+- 정상 contention이 action 미호출과 `null` 반환을 함께 보존하는가?
+- fake가 cleanup 없이도 재획득되는 거짓 양성을 허용하지 않는가?
+- local/CI catalog ref와 dependency graph가 동일한가?
+- caller-owned client, key layout, lease policy, public ABI가 보존되는가?
+- container readiness 실패를 별도 stability finding으로 추적했는가?

--- a/docs/review/2026-09-05-issue-880-jetcd-callback-review.md
+++ b/docs/review/2026-09-05-issue-880-jetcd-callback-review.md
@@ -1,0 +1,74 @@
+# Issue #880 jetcd callback 및 async lifecycle 7-Tier 코드 리뷰
+
+## DoD 판정
+
+- 기준: `origin/develop` `f9c084c241b5ac87a4b644f64ef47da55d71fbcb`
+- 구현 검토 head: `84b8ac3bcd3c1f11f891418273f3b661fd1b2c3a`
+- 변경 branch/worktree: `test/issue-880-jetcd-callback` / `.worktrees/test/issue-880-jetcd-callback`
+- 이슈: [#880](https://github.com/bluetape4k/bluetape4k-leader/issues/880), milestone `1.1.0`
+- 리뷰 모델: `gpt-5.6-luna`, effort `max`
+- 인라인 판정: **P0=0, P1=0, P2=1, P3=0**
+- 전달 판정: **PENDING** — 로컬 검증은 완료됐고 PR exact-head CI가 남아 있다.
+
+독립 review lane이 유효한 결과를 반환하지 못해 사용자 standing rule에 따라 동일한 7-Tier checklist를 인라인으로 완결했다. 이는 human review를 대체했다는 뜻이 아니다. solo-maintainer의 부재한 human-review subgate만 `N/A`이며, 기술 검증과 exact-head CI는 계속 필수다.
+
+## 7-Tier 결과
+
+| Tier | 판단 및 근거 | 상태 |
+|---|---|---|
+| 1. Kotlin correctness | `EtcdLeaderElector.kt:108-213`과 `EtcdLeaderGroupElector.kt:123-235`는 public signature를 유지하고, 실패 cause를 `CompletionException` 한 겹으로 정규화한다. action supplier의 동기 throw도 failed future로 변환한 뒤 lease를 정리한다. | PASS |
+| 2. Concurrency/cancellation | 두 elector가 `WAITING`/`STARTED`/`CLEANUP` CAS로 action 시작과 cleanup ownership을 직렬화한다. 반환 future 취소는 acquisition source와 실제 action future로 전달되며, 늦게 도착한 ownership도 `EtcdLeaseHandle.markReleased()`로 exactly once 정리된다. `EtcdAsyncLifecycleTest.kt:31-258`의 single/group 취소·late ownership·executor 거부·supplier 실패가 이 경계를 고정한다. | PASS |
+| 3. API/ABI | 새 public type, method, constructor, dependency는 없다. 최종 `checkBinaryCompatibility`는 `artifacts=16`, `ignored=1`, `unknown=0`이었다. README/KDoc/manual은 public 계약 불변이므로 `N/A`다. | PASS |
+| 4. Backend/watch semantics | `JetcdWatchCallbackIntegrationTest.kt:23-177`은 created notification을 readiness barrier로 사용한다. callback 내부 blocking KV get, 느린 callback의 `PUT(v1) -> PUT(v2) -> DELETE`, watcher close 후 전달 중지와 새 watcher 재개를 각각 독립 검증한다. jetcd `0.8.6`에서 blocking callback이 `TimeoutException`으로 RED였고 `0.8.7`에서 3/3 GREEN이었다. | PASS |
+| 5. Tests/flakiness | 고정 `delay` 없이 positive latch/future barrier를 사용한다. fake는 active ownership을 보유해 cleanup 없는 거짓 재획득을 막고, 실제 etcd는 direct async cancellation/contention/AOP scope와 virtual-thread interruption을 검증한다. 다만 healthy Colima에서 container host readiness가 간헐 실패한 현상은 [#884](https://github.com/bluetape4k/bluetape4k-leader/issues/884)로 분리했다. | 기능 PASS; 환경 P2 추적 |
+| 6. Dependency/security/ops | `settings.gradle.kts`와 `.github/workflows/ci.yml`의 catalog ref를 동일한 immutable `9698c9d66bea6fcba373143ee8fa5bfbd9812d4b`로 원자 전환했다. candidate graph는 jetcd `0.8.7`, gRPC `1.82.0`, Netty `4.2.17.Final`, Vert.x `5.1.7`이다. TLS/auth, key layout, TTL/minLease/waitTime, caller-owned `Client` lifecycle은 바꾸지 않았다. | PASS |
+| 7. CI/delivery | 기존 전체 build는 첫 실행에서 unrelated Redisson Toxiproxy host readiness timeout으로 실패했고, 해당 class 3/3 재현 통과 뒤 전체 build가 4분 38초에 성공했다. 최종 working tree의 `build`도 성공했고 JUnit artifact inventory는 4,369 tests, failures/errors/skipped 0이다. 최종 commit의 PR exact-head checks, review threads, mergeability read-back은 아직 실행 전이다. | 로컬 PASS; PR PENDING |
+
+## 주요 findings와 disposition
+
+| Severity | finding | disposition/evidence |
+|---|---|---|
+| P1 -> 해소 | action supplier가 future를 반환하기 전에 throw할 때 원래 cause와 lease cleanup이 직접 고정되지 않았다. | `EtcdAsyncLifecycleTest`에 single/group supplier throw, cause, unlock/revoke 1회, 동일 lock/slot 재획득을 추가했다. commit `84b8ac3b`. |
+| P1 -> 해소 | 정상 async contention이 action을 호출하지 않고 `null`을 반환한다는 core 계약의 실제 etcd 증거가 없었다. | `EtcdAsyncLeaderElectorIntegrationTest`에 single/group contention 테스트를 추가했다. commit `84b8ac3b`. |
+| P2 | healthy Colima에서 Toxiproxy와 etcd container가 내부 readiness를 완료했는데 mapped host endpoint probe가 timeout/reset될 수 있다. | 제품 결함과 분리해 [#884](https://github.com/bluetape4k/bluetape4k-leader/issues/884)에 재현·진단 DoD를 등록했다. timeout 연장이나 healthy VM 재시작으로 감추지 않는다. |
+
+## Performance 및 stability 검토
+
+- callback의 blocking은 raw jetcd 회귀를 검출하기 위한 한 테스트에만 격리했다. publisher 및 lifecycle 테스트는 blocking callback에 의존하지 않는다.
+- readiness는 `WatchOption.withCreateNotify(true)`가 전달하는 created notification으로 고정하며 producer-before-listener race를 timeout 재시도로 숨기지 않는다.
+- slow callback 순서 테스트는 첫 callback 진입을 확인한 후 후속 PUT/DELETE를 발행하고 명시적으로 해제한다. 실패 경로에서도 latch와 watcher를 정리한다.
+- async acquisition과 action은 호출자 executor에서 순차 stage로 실행된다. initial executor rejection에는 backend call이 0이며, post-acquire rejection에는 unlock/revoke가 각각 정확히 한 번이다.
+- returned cancellation, acquisition cancellation, action cancellation이 경합해도 cleanup은 lifecycle CAS와 `markReleased()`의 이중 idempotency 경계를 가진다.
+- 모든 새 executor, watcher, client는 `finally` 또는 `use`로 닫는다. 테스트 synchronization을 위한 `Thread.sleep`/coroutine `delay`는 추가하지 않았다.
+
+## 실행 모델 검증 matrix
+
+| 경로 | single | group | 근거 |
+|---|---|---|---|
+| blocking | PASS | PASS | 기존 실제 etcd acquisition/contention/reacquire tests |
+| `CompletableFuture` async | PASS | PASS | action cancellation, contention `null`, AOP `extendActiveLock`, late cleanup 및 rejection tests |
+| coroutine suspend | PASS | PASS | 기존 cancellation/cleanup integration tests 포함 42-test 회귀 matrix |
+| virtual thread | PASS | executor overload PASS | single interruption/reacquire contract, group executor overload contract |
+| slot-aware async overload | N/A | N/A | Etcd public API에 concrete async `LeaderSlot` overload가 없다. |
+
+## 검증 증거
+
+| Check | 결과 |
+|---|---|
+| old catalog callback sensitivity | jetcd `0.8.6`, 1 test RED, `ExecutionException` cause `TimeoutException`, 3.3초 |
+| candidate callback | 3/3 PASS, JUnit 5.2초, Gradle 18초, retry 없음 |
+| publisher determinism | 4/4 PASS, JUnit 5.3초, 고정 `delay` 0건 |
+| async lifecycle RED -> GREEN | 기존 구현 7개 중 6개 RED -> 수정 후 7/7 PASS |
+| targeted fake/real/virtual | 14/14 PASS |
+| execution-model regression matrix | 42/42 PASS, failures/errors/skipped 0 |
+| review-gap targeted rerun | 15/15 PASS, failures/errors/skipped 0, Gradle 26초 |
+| module full suite | clean `--rerun-tasks` **156/156 PASS**, failures/errors/skipped 0, JUnit 17.303초, Gradle 41초 |
+| detekt | PASS, Gradle 9.6초 |
+| ABI | PASS, `artifacts=16`, `ignored=1`, `unknown=0`, Gradle 6.8초 |
+| repository full build | 첫 광역 실행 container readiness 1건 실패, 원인 class 3/3 PASS, 두 번째 광역 실행 4분 38초 PASS. 최종 working tree build PASS, JUnit artifact inventory 4,369/0/0/0 |
+| final dependency graph | jetcd `0.8.7`, gRPC `1.82.0`, Netty `4.2.17.Final`, Vert.x `5.1.7`; 네 insight 모두 exit 0 |
+| PR exact-head CI | PENDING |
+
+## 최종 판정
+
+구현 diff의 P0/P1은 0이다. public API와 운영 정책은 변하지 않았고, callback upgrade의 검출력과 async cleanup 계약은 RED/GREEN 및 실제 etcd로 증명됐다. 최종 로컬 gate는 통과했으며 PR exact-head CI만 남아 있으므로 현재 상태는 **PENDING (delivery)** 이다.

--- a/docs/superpowers/plans/2026-09-05-issue-880-jetcd-callback-plan.md
+++ b/docs/superpowers/plans/2026-09-05-issue-880-jetcd-callback-plan.md
@@ -12,8 +12,8 @@
 
 ## 실행 상태 체크박스
 
-- [ ] Task 1 — 기준 graph와 jetcd callback RED 고정
-- [ ] Task 2 — catalog pin 원자 전환과 callback GREEN
+- [x] Task 1 — 기준 graph와 jetcd callback RED 고정
+- [x] Task 2 — catalog pin 원자 전환과 callback GREEN
 - [ ] Task 3 — publisher watch 준비·경합 테스트 결정성 개선
 - [ ] Task 4 — Etcd 단일/group async lifecycle RED
 - [ ] Task 5 — 취소 전파·exactly-once cleanup GREEN
@@ -70,7 +70,7 @@
 
 **Files:** 신규 `JetcdWatchCallbackIntegrationTest.kt`, `.flow-inputs/checklist.md`.
 
-1. `[ ]` 현재 ref에서 기준 graph를 보존한다. 각 명령의 selected version과 selection reason을 checklist에 기록한다.
+1. `[x]` 현재 ref에서 기준 graph를 보존한다. 각 명령의 selected version과 selection reason을 checklist에 기록한다.
 
    ```bash
    ./gradlew :bluetape4k-leader-etcd:dependencyInsight --dependency io.etcd:jetcd-core --configuration testRuntimeClasspath --no-daemon --console=plain
@@ -81,15 +81,15 @@
 
    old ref에서 `io.etcd:jetcd-core:0.8.6`이 선택되어야 한다. 출력은 secret이 없음을 확인한 뒤 증거 경로에 보존한다.
 
-2. `[ ]` raw jetcd fixture를 먼저 추가한다. watcher는 `WatchOption.newBuilder().withCreateNotify(true).build()`를 사용하고 첫 empty `WatchResponse`의 `isCreated`를 `CompletableFuture<Unit>` 또는 `CountDownLatch` readiness로 변환한다. readiness가 10초 안에 오지 않으면 테스트를 실패시키며 임의 delay로 대체하지 않는다.
+2. `[x]` raw jetcd fixture를 먼저 추가한다. watcher는 `WatchOption.newBuilder().withCreateNotify(true).build()`를 사용하고 첫 empty `WatchResponse`의 `isCreated`를 `CompletableFuture<Unit>` 또는 `CountDownLatch` readiness로 변환한다. readiness가 10초 안에 오지 않으면 테스트를 실패시키며 임의 delay로 대체하지 않는다.
 
-3. `[ ]` blocking callback 테스트를 추가한다. created barrier 이후 PUT을 발생시키고 event callback 안에서 같은 `Client.kvClient.get(key).get(10, TimeUnit.SECONDS)`를 호출해 방금 저장한 값을 읽는다. callback 결과 future가 10초 안에 완료되고 예외가 없음을 검증한다.
+3. `[x]` blocking callback 테스트를 추가한다. created barrier 이후 PUT을 발생시키고 event callback 안에서 같은 `Client.kvClient.get(key).get(10, TimeUnit.SECONDS)`를 호출해 방금 저장한 값을 읽는다. callback 결과 future가 10초 안에 완료되고 예외가 없음을 검증한다.
 
-4. `[ ]` ordered delivery 테스트를 별도로 추가한다. 첫 PUT callback은 latch에서 대기시키되 callback 진입을 main test에 알린다. 첫 callback이 대기 중인 동안 두 번째 PUT과 DELETE를 발행하고 latch를 해제한다. 관측 목록이 revision 증가 순서의 `PUT(v1)`, `PUT(v2)`, `DELETE`와 일치해야 한다. 병렬 callback 개수나 thread 이름은 assertion하지 않는다.
+4. `[x]` ordered delivery 테스트를 별도로 추가한다. 첫 PUT callback은 latch에서 대기시키되 callback 진입을 main test에 알린다. 첫 callback이 대기 중인 동안 두 번째 PUT과 DELETE를 발행하고 latch를 해제한다. 관측 목록이 revision 증가 순서의 `PUT(v1)`, `PUT(v2)`, `DELETE`와 일치해야 한다. 병렬 callback 개수나 thread 이름은 assertion하지 않는다.
 
-5. `[ ]` close/restart 테스트를 별도로 추가한다. created barrier를 지난 첫 watcher를 close한 뒤 event count snapshot을 잡고 PUT을 수행한다. 첫 listener count가 변하지 않음을 bounded negative window로 확인하고, 같은 client에서 만든 두 번째 watcher의 created barrier와 다음 PUT 수신을 확인한다. negative window는 `poll`/future timeout으로 표현하고 고정 sleep을 사용하지 않는다.
+5. `[x]` close/restart 테스트를 별도로 추가한다. created barrier를 지난 첫 watcher를 close한 뒤 event count snapshot을 잡고 PUT을 수행한다. 첫 listener count가 변하지 않음을 bounded negative window로 확인하고, 같은 client에서 만든 두 번째 watcher의 created barrier와 다음 PUT 수신을 확인한다. negative window는 `poll`/future timeout으로 표현하고 고정 sleep을 사용하지 않는다.
 
-6. `[ ]` RED 검증은 old catalog ref에서 blocking test만 실행한다.
+6. `[x]` RED 검증은 old catalog ref에서 blocking test만 실행한다.
 
    ```bash
    ./gradlew :bluetape4k-leader-etcd:test --tests '*JetcdWatchCallbackIntegrationTest.callback can perform blocking kv get*' --no-daemon --no-configuration-cache --no-build-cache --rerun-tasks --console=plain
@@ -97,15 +97,15 @@
 
    jetcd `0.8.6`에서 callback 내부 blocking call이 bounded timeout으로 실패해야 Issue #880의 dependency-driven RED가 성립한다. compile 오류, Docker 오류, fixture readiness 실패는 유효한 RED가 아니며 먼저 fixture를 수정한다. 예상과 달리 old ref가 GREEN이면 upstream diff와 test sensitivity를 재검토하고 dependency upgrade를 정당화하는 별도 행동 차이가 확인되기 전까지 Task 2로 진행하지 않는다.
 
-7. `[ ]` watcher/client는 `use`/`try-finally`로 닫고 key는 test마다 고유 prefix를 사용한다. timeout 시 outstanding future와 watcher를 정리해 다음 테스트로 누출하지 않는다.
+7. `[x]` watcher/client는 `use`/`try-finally`로 닫고 key는 test마다 고유 prefix를 사용한다. timeout 시 outstanding future와 watcher를 정리해 다음 테스트로 누출하지 않는다.
 
 ## 4. Task 2 — catalog pin 원자 전환과 callback GREEN
 
 **Files:** `settings.gradle.kts`, `.github/workflows/ci.yml`, `JetcdWatchCallbackIntegrationTest.kt`.
 
-1. `[ ]` `settings.gradle.kts`와 `.github/workflows/ci.yml`의 기존 `850959d0ea5f76ac7e2c442400f47653d5f95eed`를 `9698c9d66bea6fcba373143ee8fa5bfbd9812d4b`로 한 patch에서 바꾼다.
+1. `[x]` `settings.gradle.kts`와 `.github/workflows/ci.yml`의 기존 `850959d0ea5f76ac7e2c442400f47653d5f95eed`를 `9698c9d66bea6fcba373143ee8fa5bfbd9812d4b`로 한 patch에서 바꾼다.
 
-2. `[ ]` 두 ref가 정확히 하나이고 동일한지 검증한다.
+2. `[x]` 두 ref가 정확히 하나이고 동일한지 검증한다.
 
    ```bash
    rg -n '850959d0ea5f76ac7e2c442400f47653d5f95eed|9698c9d66bea6fcba373143ee8fa5bfbd9812d4b' settings.gradle.kts .github/workflows/ci.yml
@@ -113,9 +113,9 @@
 
    old ref는 0건, new ref는 두 파일에서 각 1건이어야 한다.
 
-3. `[ ]` Task 1의 네 `dependencyInsight`를 다시 실행한다. `jetcd-core:0.8.7`, gRPC/Netty/Vert.x selected version과 `selected by rule`/catalog constraint 근거를 review artifact에 기록한다. 중앙 catalog의 광역 변경 때문에 예상하지 못한 downgrade/conflict가 있으면 구현을 중지하고 두 pin을 함께 rollback한다.
+3. `[x]` Task 1의 네 `dependencyInsight`를 다시 실행한다. `jetcd-core:0.8.7`, gRPC/Netty/Vert.x selected version과 `selected by rule`/catalog constraint 근거를 review artifact에 기록한다. 중앙 catalog의 광역 변경 때문에 예상하지 못한 downgrade/conflict가 있으면 구현을 중지하고 두 pin을 함께 rollback한다.
 
-4. `[ ]` 세 callback 테스트를 한 invocation으로 실행한다.
+4. `[x]` 세 callback 테스트를 한 invocation으로 실행한다.
 
    ```bash
    ./gradlew :bluetape4k-leader-etcd:test --tests '*JetcdWatchCallbackIntegrationTest*' --no-daemon --no-configuration-cache --no-build-cache --rerun-tasks --console=plain
@@ -123,7 +123,7 @@
 
    첫 실행에서 모두 GREEN이어야 한다. retry로만 통과하면 PASS가 아니라 stability finding으로 기록하고 원인을 고친다.
 
-5. `[ ]` commit은 catalog 두 pin, raw callback tests, RED/GREEN 증거를 하나의 의도 단위로 묶고 Korean Lore 형식을 사용한다. rollback은 해당 commit revert로 두 pin과 tests를 함께 되돌릴 수 있어야 한다.
+5. `[x]` commit은 catalog 두 pin, raw callback tests, RED/GREEN 증거를 하나의 의도 단위로 묶고 Korean Lore 형식을 사용한다. rollback은 해당 commit revert로 두 pin과 tests를 함께 되돌릴 수 있어야 한다.
 
 ## 5. Task 3 — publisher watch 준비·경합 테스트 결정성 개선
 

--- a/docs/superpowers/plans/2026-09-05-issue-880-jetcd-callback-plan.md
+++ b/docs/superpowers/plans/2026-09-05-issue-880-jetcd-callback-plan.md
@@ -14,7 +14,7 @@
 
 - [x] Task 1 — 기준 graph와 jetcd callback RED 고정
 - [x] Task 2 — catalog pin 원자 전환과 callback GREEN
-- [ ] Task 3 — publisher watch 준비·경합 테스트 결정성 개선
+- [x] Task 3 — publisher watch 준비·경합 테스트 결정성 개선
 - [ ] Task 4 — Etcd 단일/group async lifecycle RED
 - [ ] Task 5 — 취소 전파·exactly-once cleanup GREEN
 - [ ] Task 6 — module·전체 저장소·ABI 검증
@@ -129,13 +129,13 @@
 
 **Files:** `EtcdLeaderElectionEventPublisherIntegrationTest.kt`.
 
-1. `[ ]` collector가 producer보다 먼저 구독하도록 모든 `async { publisher.events... }`를 `async(start = CoroutineStart.UNDISPATCHED) { ... }`로 바꾸고 collector 준비용 `delay(250)`를 삭제한다.
+1. `[x]` collector가 producer보다 먼저 구독하도록 모든 `async { publisher.events... }`를 `async(start = CoroutineStart.UNDISPATCHED) { ... }`로 바꾸고 collector 준비용 `delay(250)`를 삭제한다.
 
-2. `[ ]` queued contender 테스트의 `delay(500)`를 제거한다. holder 진입 latch 이후 contender가 실제 acquisition을 시작했음을 executor-side latch로 알리고, publisher가 holder `Elected`를 전달한 것을 positive barrier로 확인한 뒤 holder를 해제한다. assertion은 최종 event sequence가 `elected`, `revoked`, `elected`, `revoked`이고 queued 상태에서 추가 `Elected`가 발생하지 않았다는 기존 의미를 유지한다.
+2. `[x]` queued contender 테스트의 `delay(500)`를 제거한다. holder 진입 latch 이후 contender가 실제 acquisition을 시작했음을 executor-side latch로 알리고, publisher가 holder `Elected`를 전달한 것을 positive barrier로 확인한 뒤 holder를 해제한다. assertion은 최종 event sequence가 `elected`, `revoked`, `elected`, `revoked`이고 queued 상태에서 추가 `Elected`가 발생하지 않았다는 기존 의미를 유지한다.
 
-3. `[ ]` close 테스트를 확장한다. publisher를 close한 뒤 동일 prefix에 실제 ownership 변화를 만들고 closed publisher의 `first()` collector가 완료되지 않음을 `future.get(500, TimeUnit.MILLISECONDS)`의 `TimeoutException`으로 확인한 뒤 collector를 취소한다. 이어 같은 caller-owned client로 새 publisher/elector가 정상 event를 전달함을 확인한다. client usability만 확인하는 기존 assertion도 유지한다.
+3. `[x]` close 테스트를 확장한다. publisher를 close한 뒤 동일 prefix에 실제 ownership 변화를 만들고 closed publisher의 `first()` collector가 완료되지 않음을 `future.get(500, TimeUnit.MILLISECONDS)`의 `TimeoutException`으로 확인한 뒤 collector를 취소한다. 이어 같은 caller-owned client로 새 publisher/elector가 정상 event를 전달함을 확인한다. client usability만 확인하는 기존 assertion도 유지한다.
 
-4. `[ ]` RED/GREEN 검증은 수정할 테스트 class만 매번 실행한다.
+4. `[x]` RED/GREEN 검증은 수정할 테스트 class만 매번 실행한다.
 
    ```bash
    ./gradlew :bluetape4k-leader-etcd:test --tests '*EtcdLeaderElectionEventPublisherIntegrationTest*' --no-daemon --no-configuration-cache --no-build-cache --rerun-tasks --console=plain

--- a/docs/superpowers/plans/2026-09-05-issue-880-jetcd-callback-plan.md
+++ b/docs/superpowers/plans/2026-09-05-issue-880-jetcd-callback-plan.md
@@ -15,7 +15,7 @@
 - [x] Task 1 — 기준 graph와 jetcd callback RED 고정
 - [x] Task 2 — catalog pin 원자 전환과 callback GREEN
 - [x] Task 3 — publisher watch 준비·경합 테스트 결정성 개선
-- [ ] Task 4 — Etcd 단일/group async lifecycle RED
+- [x] Task 4 — Etcd 단일/group async lifecycle RED
 - [ ] Task 5 — 취소 전파·exactly-once cleanup GREEN
 - [ ] Task 6 — module·전체 저장소·ABI 검증
 - [ ] Task 7 — 7-Tier 리뷰·lesson·PR·exact-head CI
@@ -147,17 +147,17 @@
 
 **Files:** 신규 `EtcdAsyncLifecycleTest.kt`.
 
-1. `[ ]` `EtcdLockClient` fake는 granted lease, pending/complete lock future, ownership key, unlock/revoke call count를 thread-safe하게 기록한다. active lease/ownership을 상태로 보유하고 unlock/revoke 전의 두 번째 acquisition은 완료시키지 않아 후속 재획득 assertion이 실제 cleanup을 검증하도록 한다. action은 직접 제어하는 `CompletableFuture<T>`를 반환한다. 새 예외 assertion은 반드시 `io.bluetape4k.assertions.assertFailsWith`를 사용한다.
+1. `[x]` `EtcdLockClient` fake는 granted lease, pending/complete lock future, ownership key, unlock/revoke call count를 thread-safe하게 기록한다. active lease/ownership을 상태로 보유하고 unlock/revoke 전의 두 번째 acquisition은 완료시키지 않아 후속 재획득 assertion이 실제 cleanup을 검증하도록 한다. action은 직접 제어하는 `CompletableFuture<T>`를 반환한다. 새 예외 assertion은 반드시 `io.bluetape4k.assertions.assertFailsWith`를 사용한다.
 
-2. `[ ]` 단일 elector RED를 추가한다. action 진입을 barrier로 확인하고 반환 future를 `cancel(true)`한다. 실제 action future가 `isCancelled == true`, unlock/revoke가 각각 정확히 한 번, 후속 동일 lock 실행이 성공함을 확인한다.
+2. `[x]` 단일 elector RED를 추가한다. action 진입을 barrier로 확인하고 반환 future를 `cancel(true)`한다. 실제 action future가 `isCancelled == true`, unlock/revoke가 각각 정확히 한 번, 후속 동일 lock 실행이 성공함을 확인한다.
 
-3. `[ ]` group elector RED를 `maxLeaders=1`로 추가한다. 반환 future 취소 후 실제 action 취소, 동일 slot cleanup, 후속 같은 group lock 재획득을 확인한다.
+3. `[x]` group elector RED를 `maxLeaders=1`로 추가한다. 반환 future 취소 후 실제 action 취소, 동일 slot cleanup, 후속 같은 group lock 재획득을 확인한다.
 
-4. `[ ]` acquisition 대기 중 취소 시 action이 호출되지 않고, 늦게 완료된 ownership key가 unlock/revoke되는 single/group case를 추가한다. returned future의 cancel과 lock future 완료 경합을 barrier로 고정한다.
+4. `[x]` acquisition 대기 중 취소 시 action이 호출되지 않고, 늦게 완료된 ownership key가 unlock/revoke되는 single/group case를 추가한다. returned future의 cancel과 lock future 완료 경합을 barrier로 고정한다.
 
-5. `[ ]` lease 획득과 action 제출 사이 executor 거부를 재현하는 scripted executor를 추가한다. 첫 `execute`는 acquisition task를 실행하고 두 번째 `execute`는 `RejectedExecutionException("rejected-after-acquire")`을 던져야 한다. 결과 cause가 원래 예외이고 unlock/revoke가 정확히 한 번이며 후속 재획득이 성공해야 한다. 별도 always-reject executor는 acquisition 전 거부가 backend 호출 0건임을 확인할 때만 사용한다.
+5. `[x]` lease 획득과 action 제출 사이 executor 거부를 재현하는 scripted executor를 추가한다. 첫 `execute`는 acquisition task를 실행하고 두 번째 `execute`는 `RejectedExecutionException("rejected-after-acquire")`을 던져야 한다. 결과 cause가 원래 예외이고 unlock/revoke가 정확히 한 번이며 후속 재획득이 성공해야 한다. 별도 always-reject executor는 acquisition 전 거부가 backend 호출 0건임을 확인할 때만 사용한다.
 
-6. `[ ]` 현재 구현에서 targeted class를 실행해 유효한 RED를 얻는다.
+6. `[x]` 현재 구현에서 targeted class를 실행해 유효한 RED를 얻는다.
 
    ```bash
    ./gradlew :bluetape4k-leader-etcd:test --tests '*EtcdAsyncLifecycleTest*' --no-daemon --no-configuration-cache --no-build-cache --rerun-tasks --console=plain

--- a/docs/superpowers/plans/2026-09-05-issue-880-jetcd-callback-plan.md
+++ b/docs/superpowers/plans/2026-09-05-issue-880-jetcd-callback-plan.md
@@ -17,7 +17,7 @@
 - [x] Task 3 — publisher watch 준비·경합 테스트 결정성 개선
 - [x] Task 4 — Etcd 단일/group async lifecycle RED
 - [x] Task 5 — 취소 전파·exactly-once cleanup GREEN
-- [ ] Task 6 — module·전체 저장소·ABI 검증
+- [x] Task 6 — module·전체 저장소·ABI 검증
 - [ ] Task 7 — 7-Tier 리뷰·lesson·PR·exact-head CI
 
 ## 0. 고정 전제와 실행 경계
@@ -203,7 +203,7 @@
 
 **Files:** 모든 변경 파일, Gradle/JUnit 결과, `.flow-inputs/checklist.md`.
 
-1. `[ ]` source hygiene와 결정성 정적 검사를 한다.
+1. `[x]` source hygiene와 결정성 정적 검사를 한다.
 
    ```bash
    git diff --check
@@ -213,7 +213,7 @@
 
    첫 명령은 exit 0, 두 번째와 세 번째는 0건이어야 한다.
 
-2. `[ ]` `leader-etcd` 전체 테스트를 retry 없이 clean first-run으로 실행한다. CI의 5회 retry wrapper를 로컬 성공 증거로 사용하지 않는다.
+2. `[x]` `leader-etcd` 전체 테스트를 retry 없이 clean first-run으로 실행한다. CI의 5회 retry wrapper를 로컬 성공 증거로 사용하지 않는다.
 
    ```bash
    ./gradlew :bluetape4k-leader-etcd:cleanTest :bluetape4k-leader-etcd:test --no-daemon --no-configuration-cache --no-build-cache --rerun-tasks --console=plain
@@ -221,7 +221,7 @@
 
    JUnit XML의 tests/failures/errors/skipped 합계와 elapsed time을 checklist/review에 기록한다. unexplained retry나 skipped integration test는 PASS가 아니다.
 
-3. `[ ]` central catalog 광역 영향과 public ABI를 검증한다.
+3. `[x]` central catalog 광역 영향과 public ABI를 검증한다.
 
    ```bash
    ./gradlew detekt --no-daemon --console=plain
@@ -231,21 +231,21 @@
 
    모두 exit 0이어야 한다. 환경상 전체 build를 실행할 수 없다면 정확한 실패와 대체 범위를 `PENDING`으로 남기고 PR merge-ready를 주장하지 않는다.
 
-4. `[ ]` sync/async/suspend/virtual-thread와 single/group 결과를 verification matrix에 명시한다. 테스트가 존재하지 않는 조합은 임의 PASS가 아니라 `N/A` 또는 `PENDING`으로 분류하고 근거를 쓴다.
+4. `[x]` sync/async/suspend/virtual-thread와 single/group 결과를 verification matrix에 명시한다. 테스트가 존재하지 않는 조합은 임의 PASS가 아니라 `N/A` 또는 `PENDING`으로 분류하고 근거를 쓴다.
 
-5. `[ ]` 두 catalog pin equality, `jetcd 0.8.7`, gRPC/Netty/Vert.x graph, 변경된 public API 0건, README/KDoc `N/A`를 최종 증거에 다시 기록한다.
+5. `[x]` 두 catalog pin equality, `jetcd 0.8.7`, gRPC/Netty/Vert.x graph, 변경된 public API 0건, README/KDoc `N/A`를 최종 증거에 다시 기록한다.
 
 ## 9. Task 7 — 7-Tier 리뷰·lesson·PR·exact-head CI
 
 **Files:** 신규 review/lesson 문서, 전체 diff, GitHub PR.
 
-1. `[ ]` `$bluetape-kotlin-patterns`의 7-Tier 순서로 exact diff를 검토한다: Kotlin correctness, concurrency/cancellation, API/ABI, backend/watch semantics, tests/flakiness, dependency/security/ops, CI/delivery. 발견은 파일/line·재현·severity·처리 상태를 `docs/review/2026-09-05-issue-880-jetcd-callback-review.md`에 기록한다.
+1. `[x]` `$bluetape-kotlin-patterns`의 7-Tier 순서로 exact diff를 검토한다: Kotlin correctness, concurrency/cancellation, API/ABI, backend/watch semantics, tests/flakiness, dependency/security/ops, CI/delivery. 발견은 파일/line·재현·severity·처리 상태를 `docs/review/2026-09-05-issue-880-jetcd-callback-review.md`에 기록한다.
 
-2. `[ ]` performance/stability scan을 별도로 수행한다. callback backpressure, bounded waits, thread/executor leak, watcher close race, CAS ownership, cleanup count, full-suite runtime을 확인한다. P0/P1은 PR 전 모두 고치고 다시 검증한다.
+2. `[x]` performance/stability scan을 별도로 수행한다. callback backpressure, bounded waits, thread/executor leak, watcher close race, CAS ownership, cleanup count, full-suite runtime을 확인한다. P0/P1은 PR 전 모두 고치고 다시 검증한다.
 
-3. `[ ]` 독립 review lane을 한 번 실행한다. lane이 90초 안에 유효 결과를 내지 못하거나 unavailable이면 중단하고 사용자 standing rule에 따라 같은 checklist를 inline으로 완결한다. human reviewer는 solo-maintainer lane에서만 `N/A`; 기술 검토는 생략하지 않는다.
+3. `[x]` 독립 review lane을 한 번 실행한다. lane이 90초 안에 유효 결과를 내지 못하거나 unavailable이면 중단하고 사용자 standing rule에 따라 같은 checklist를 inline으로 완결한다. human reviewer는 solo-maintainer lane에서만 `N/A`; 기술 검토는 생략하지 않는다.
 
-4. `[ ]` `docs/lessons/2026-09-05-issue-880-jetcd-callback.md`에 created notification readiness, dependency-sensitive RED, blocking callback/backpressure, action cancellation relay, exactly-once cleanup, atomic catalog rollback을 재사용 가능한 규칙으로 기록한다.
+4. `[x]` `docs/lessons/2026-09-05-issue-880-jetcd-callback.md`에 created notification readiness, dependency-sensitive RED, blocking callback/backpressure, action cancellation relay, exactly-once cleanup, atomic catalog rollback을 재사용 가능한 규칙으로 기록한다.
 
 5. `[ ]` 변경을 작은 Lore commit으로 정리한다. 각 commit은 한국어 intent line, `Constraint`, `Rejected`, `Confidence`, `Scope-risk`, `Directive`, `Tested`, `Not-tested` 중 필요한 trailer를 포함한다. commit 전마다 `git diff --check`와 관련 targeted test를 다시 읽는다.
 

--- a/docs/superpowers/plans/2026-09-05-issue-880-jetcd-callback-plan.md
+++ b/docs/superpowers/plans/2026-09-05-issue-880-jetcd-callback-plan.md
@@ -247,7 +247,7 @@
 
 4. `[x]` `docs/lessons/2026-09-05-issue-880-jetcd-callback.md`에 created notification readiness, dependency-sensitive RED, blocking callback/backpressure, action cancellation relay, exactly-once cleanup, atomic catalog rollback을 재사용 가능한 규칙으로 기록한다.
 
-5. `[ ]` 변경을 작은 Lore commit으로 정리한다. 각 commit은 한국어 intent line, `Constraint`, `Rejected`, `Confidence`, `Scope-risk`, `Directive`, `Tested`, `Not-tested` 중 필요한 trailer를 포함한다. commit 전마다 `git diff --check`와 관련 targeted test를 다시 읽는다.
+5. `[x]` 변경을 작은 Lore commit으로 정리한다. 각 commit은 한국어 intent line, `Constraint`, `Rejected`, `Confidence`, `Scope-risk`, `Directive`, `Tested`, `Not-tested` 중 필요한 trailer를 포함한다. commit 전마다 `git diff --check`와 관련 targeted test를 다시 읽는다.
 
 6. `[ ]` PR 생성 직전 live `gh`로 Issue #880, milestone `1.1.0`, labels, assignee, 기존 open PR/duplicate를 다시 확인한다. head `test/issue-880-jetcd-callback`, base `develop`을 명시하고 한국어 PR body 마지막을 `## DoD Status`로 끝낸다. PR 생성은 승인됐지만 merge는 승인되지 않았다.
 

--- a/docs/superpowers/plans/2026-09-05-issue-880-jetcd-callback-plan.md
+++ b/docs/superpowers/plans/2026-09-05-issue-880-jetcd-callback-plan.md
@@ -1,0 +1,302 @@
+# Issue #880 jetcd callback·watch·lease 회귀 검증 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 중앙 catalog의 jetcd `0.8.7` 전환을 원자적으로 적용하고, callback 내부 blocking 호출·ordered watch delivery·watch close/restart·publisher event·단일/group async 취소 정리 계약을 결정적 테스트와 최소 내부 수정으로 보장한다.
+
+**Architecture:** raw jetcd watch 테스트는 `WatchOption.withCreateNotify(true)`의 created response를 준비 완료 barrier로 사용하고 blocking callback, ordered delivery, close/restart를 독립 시나리오로 분리한다. publisher 테스트는 `CoroutineStart.UNDISPATCHED`와 latch/future barrier로 collector 및 경합 시작을 고정한다. Etcd 단일/group async adapter는 기존 `LeaderFutureBridge`와 `WAITING`/`STARTED`/`CLEANUP` 원자 lifecycle 패턴을 재사용해 반환 future 취소를 실제 action과 lease cleanup에 전달한다. public API, key layout, client ownership, lease 정책은 바꾸지 않는다.
+
+**Tech Stack:** Kotlin/JVM, jetcd `0.8.7`, JUnit 5, kotlinx-coroutines, bluetape assertions, Testcontainers etcd, Gradle dependency locking/version catalog, detekt, binary API checker, GitHub Actions.
+
+---
+
+## 실행 상태 체크박스
+
+- [ ] Task 1 — 기준 graph와 jetcd callback RED 고정
+- [ ] Task 2 — catalog pin 원자 전환과 callback GREEN
+- [ ] Task 3 — publisher watch 준비·경합 테스트 결정성 개선
+- [ ] Task 4 — Etcd 단일/group async lifecycle RED
+- [ ] Task 5 — 취소 전파·exactly-once cleanup GREEN
+- [ ] Task 6 — module·전체 저장소·ABI 검증
+- [ ] Task 7 — 7-Tier 리뷰·lesson·PR·exact-head CI
+
+## 0. 고정 전제와 실행 경계
+
+- 기준은 `develop`의 `f9c084c241b5ac87a4b644f64ef47da55d71fbcb`이며 작업 branch/worktree는 `test/issue-880-jetcd-callback` / `.worktrees/test/issue-880-jetcd-callback`다.
+- 승인된 설계는 `docs/superpowers/specs/2026-09-05-issue-880-jetcd-callback-design.md`이며 Issue [#880](https://github.com/bluetape4k/bluetape4k-leader/issues/880)과 jetcd [PR #1559](https://github.com/etcd-io/jetcd/pull/1559)의 callback 실행 변경을 근거로 한다.
+- 중앙 catalog immutable ref `9698c9d66bea6fcba373143ee8fa5bfbd9812d4b`를 `settings.gradle.kts`와 `.github/workflows/ci.yml`에 함께 적용한다. 둘의 ref가 다른 중간 상태는 commit하지 않는다.
+- raw watch 테스트는 callback executor의 구현 세부사항이나 thread name을 계약으로 고정하지 않는다. 검증 대상은 callback 내부 blocking KV 호출의 완료, 동일 watcher의 응답 순서, close 이후 전달 중지, 새 watcher 재개다.
+- `EtcdLeaderElector`와 `EtcdLeaderGroupElector`의 public signature, etcd key layout, TTL/minLease/waitTime 기본값, 호출자 소유 `Client` lifecycle은 유지한다.
+- async 수정은 기존 저장소의 `LeaderFutureBridge`와 원자 lifecycle 패턴을 재사용한다. 새 public abstraction이나 의존성을 추가하지 않는다.
+- 고정 `Thread.sleep`/`delay`는 테스트 동기화 수단으로 추가하지 않는다. bounded timeout은 실패 진단 상한으로만 사용한다.
+- README/KDoc/manual 변경은 public 계약이 달라지지 않으므로 `N/A`다. 구현 중 public 동작이 달라지는 사실이 발견되면 즉시 설계 게이트로 되돌아간다.
+- push와 PR 생성은 이 계획에 포함되지만 merge, tag, release, publish, branch/worktree 삭제는 별도 권한 경계다. PR exact-head가 merge-ready여도 merge 전 fresh 승인을 받는다.
+
+## 1. 파일 소유와 변경 지도
+
+| 경로 | 작업 | 책임 |
+|---|---|---|
+| `settings.gradle.kts` | 수정 | 기본 중앙 catalog ref를 `9698c9d...`로 전환 |
+| `.github/workflows/ci.yml` | 수정 | CI catalog ref를 기본 ref와 동일하게 전환 |
+| `leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/internal/JetcdWatchCallbackIntegrationTest.kt` | 신규 | blocking callback, ordered delivery, close/restart raw jetcd 검증 |
+| `leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdLeaderElectionEventPublisherIntegrationTest.kt` | 수정 | collector 준비와 contender 경합에서 고정 delay 제거, close 계약 강화 |
+| `leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdAsyncLifecycleTest.kt` | 신규 | 단일/group action 취소, cleanup, 재획득, executor 거부 회귀 |
+| `leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdAsyncLeaderElectorIntegrationTest.kt` | 신규 | 실제 etcd에서 단일/group async 취소와 재획득 검증 |
+| `leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/contract/EtcdVirtualThreadLeaderElectorContractTest.kt` | 수정 | virtual-thread 취소 뒤 실제 etcd 재획득 검증 |
+| `leader-etcd/src/main/kotlin/io/bluetape4k/leader/etcd/EtcdLeaderElector.kt` | 수정 | 단일 async cancellation relay와 원자 cleanup |
+| `leader-etcd/src/main/kotlin/io/bluetape4k/leader/etcd/EtcdLeaderGroupElector.kt` | 수정 | group async cancellation relay와 원자 cleanup |
+| `docs/review/2026-09-05-issue-880-jetcd-callback-review.md` | 신규 | 7-Tier exact-diff 검토와 P0/P1 수렴 증거 |
+| `docs/lessons/2026-09-05-issue-880-jetcd-callback.md` | 신규 | jetcd watch readiness와 async lease cleanup 재사용 교훈 |
+| `.flow-inputs/checklist.md` | 로컬 갱신 | Type A gate 명령·count·SHA 증거, commit 제외 |
+
+모든 production/test 파일은 inline main lane이 소유한다. 독립 검토 lane은 read-only이며, lane이 실패하거나 결과를 내지 못하면 사용자 지침대로 즉시 inline 검토로 대체한다.
+
+## 2. Acceptance traceability
+
+| Issue/설계 acceptance | 구현 작업 | 완료 증거 |
+|---|---|---|
+| `jetcd-core:0.8.7`과 중앙 gRPC/Netty/Vert.x graph | Task 1, 2 | 전·후 `dependencyInsight`, pin equality |
+| callback 내부 blocking KV 호출이 deadlock 없이 완료 | Task 1, 2 | old ref RED, new ref GREEN인 targeted integration test |
+| 느린 첫 callback 뒤 PUT/DELETE 순서 보존 | Task 1, 2 | ordered callback list와 bounded completion |
+| watcher close 뒤 전달 중지, 새 watcher 재개 | Task 1, 2 | closed listener count 고정 + restarted listener event |
+| publisher의 elected/revoked 의미와 queued contender 억제 | Task 3 | sleep 없는 publisher integration suite |
+| sync/suspend/virtual-thread 및 단일/group lease 회귀 없음 | Task 5, 6 | 기존 contract/integration tests와 module full suite |
+| 반환 future 취소가 실제 action으로 전파되고 lease 정리 | Task 4, 5 | single/group action `isCancelled`, unlock/revoke, 동일 lock/slot 재획득 |
+| executor 거부 시 원래 예외 보존과 lease 정리 | Task 4, 5 | `RejectedExecutionException`, unlock/revoke, 재획득 |
+| 첫 실행 안정성과 광역 catalog 호환성 | Task 6 | retry 없는 module test, full build, detekt, ABI |
+| P0/P1 0 및 exact-head CI | Task 7 | 7-Tier artifact, PR checks/threads/mergeability read-back |
+
+## 3. Task 1 — 기준 graph와 jetcd callback RED 고정
+
+**Files:** 신규 `JetcdWatchCallbackIntegrationTest.kt`, `.flow-inputs/checklist.md`.
+
+1. `[ ]` 현재 ref에서 기준 graph를 보존한다. 각 명령의 selected version과 selection reason을 checklist에 기록한다.
+
+   ```bash
+   ./gradlew :bluetape4k-leader-etcd:dependencyInsight --dependency io.etcd:jetcd-core --configuration testRuntimeClasspath --no-daemon --console=plain
+   ./gradlew :bluetape4k-leader-etcd:dependencyInsight --dependency io.grpc --configuration testRuntimeClasspath --no-daemon --console=plain
+   ./gradlew :bluetape4k-leader-etcd:dependencyInsight --dependency io.netty --configuration testRuntimeClasspath --no-daemon --console=plain
+   ./gradlew :bluetape4k-leader-etcd:dependencyInsight --dependency io.vertx --configuration testRuntimeClasspath --no-daemon --console=plain
+   ```
+
+   old ref에서 `io.etcd:jetcd-core:0.8.6`이 선택되어야 한다. 출력은 secret이 없음을 확인한 뒤 증거 경로에 보존한다.
+
+2. `[ ]` raw jetcd fixture를 먼저 추가한다. watcher는 `WatchOption.newBuilder().withCreateNotify(true).build()`를 사용하고 첫 empty `WatchResponse`의 `isCreated`를 `CompletableFuture<Unit>` 또는 `CountDownLatch` readiness로 변환한다. readiness가 10초 안에 오지 않으면 테스트를 실패시키며 임의 delay로 대체하지 않는다.
+
+3. `[ ]` blocking callback 테스트를 추가한다. created barrier 이후 PUT을 발생시키고 event callback 안에서 같은 `Client.kvClient.get(key).get(10, TimeUnit.SECONDS)`를 호출해 방금 저장한 값을 읽는다. callback 결과 future가 10초 안에 완료되고 예외가 없음을 검증한다.
+
+4. `[ ]` ordered delivery 테스트를 별도로 추가한다. 첫 PUT callback은 latch에서 대기시키되 callback 진입을 main test에 알린다. 첫 callback이 대기 중인 동안 두 번째 PUT과 DELETE를 발행하고 latch를 해제한다. 관측 목록이 revision 증가 순서의 `PUT(v1)`, `PUT(v2)`, `DELETE`와 일치해야 한다. 병렬 callback 개수나 thread 이름은 assertion하지 않는다.
+
+5. `[ ]` close/restart 테스트를 별도로 추가한다. created barrier를 지난 첫 watcher를 close한 뒤 event count snapshot을 잡고 PUT을 수행한다. 첫 listener count가 변하지 않음을 bounded negative window로 확인하고, 같은 client에서 만든 두 번째 watcher의 created barrier와 다음 PUT 수신을 확인한다. negative window는 `poll`/future timeout으로 표현하고 고정 sleep을 사용하지 않는다.
+
+6. `[ ]` RED 검증은 old catalog ref에서 blocking test만 실행한다.
+
+   ```bash
+   ./gradlew :bluetape4k-leader-etcd:test --tests '*JetcdWatchCallbackIntegrationTest.callback can perform blocking kv get*' --no-daemon --no-configuration-cache --no-build-cache --rerun-tasks --console=plain
+   ```
+
+   jetcd `0.8.6`에서 callback 내부 blocking call이 bounded timeout으로 실패해야 Issue #880의 dependency-driven RED가 성립한다. compile 오류, Docker 오류, fixture readiness 실패는 유효한 RED가 아니며 먼저 fixture를 수정한다. 예상과 달리 old ref가 GREEN이면 upstream diff와 test sensitivity를 재검토하고 dependency upgrade를 정당화하는 별도 행동 차이가 확인되기 전까지 Task 2로 진행하지 않는다.
+
+7. `[ ]` watcher/client는 `use`/`try-finally`로 닫고 key는 test마다 고유 prefix를 사용한다. timeout 시 outstanding future와 watcher를 정리해 다음 테스트로 누출하지 않는다.
+
+## 4. Task 2 — catalog pin 원자 전환과 callback GREEN
+
+**Files:** `settings.gradle.kts`, `.github/workflows/ci.yml`, `JetcdWatchCallbackIntegrationTest.kt`.
+
+1. `[ ]` `settings.gradle.kts`와 `.github/workflows/ci.yml`의 기존 `850959d0ea5f76ac7e2c442400f47653d5f95eed`를 `9698c9d66bea6fcba373143ee8fa5bfbd9812d4b`로 한 patch에서 바꾼다.
+
+2. `[ ]` 두 ref가 정확히 하나이고 동일한지 검증한다.
+
+   ```bash
+   rg -n '850959d0ea5f76ac7e2c442400f47653d5f95eed|9698c9d66bea6fcba373143ee8fa5bfbd9812d4b' settings.gradle.kts .github/workflows/ci.yml
+   ```
+
+   old ref는 0건, new ref는 두 파일에서 각 1건이어야 한다.
+
+3. `[ ]` Task 1의 네 `dependencyInsight`를 다시 실행한다. `jetcd-core:0.8.7`, gRPC/Netty/Vert.x selected version과 `selected by rule`/catalog constraint 근거를 review artifact에 기록한다. 중앙 catalog의 광역 변경 때문에 예상하지 못한 downgrade/conflict가 있으면 구현을 중지하고 두 pin을 함께 rollback한다.
+
+4. `[ ]` 세 callback 테스트를 한 invocation으로 실행한다.
+
+   ```bash
+   ./gradlew :bluetape4k-leader-etcd:test --tests '*JetcdWatchCallbackIntegrationTest*' --no-daemon --no-configuration-cache --no-build-cache --rerun-tasks --console=plain
+   ```
+
+   첫 실행에서 모두 GREEN이어야 한다. retry로만 통과하면 PASS가 아니라 stability finding으로 기록하고 원인을 고친다.
+
+5. `[ ]` commit은 catalog 두 pin, raw callback tests, RED/GREEN 증거를 하나의 의도 단위로 묶고 Korean Lore 형식을 사용한다. rollback은 해당 commit revert로 두 pin과 tests를 함께 되돌릴 수 있어야 한다.
+
+## 5. Task 3 — publisher watch 준비·경합 테스트 결정성 개선
+
+**Files:** `EtcdLeaderElectionEventPublisherIntegrationTest.kt`.
+
+1. `[ ]` collector가 producer보다 먼저 구독하도록 모든 `async { publisher.events... }`를 `async(start = CoroutineStart.UNDISPATCHED) { ... }`로 바꾸고 collector 준비용 `delay(250)`를 삭제한다.
+
+2. `[ ]` queued contender 테스트의 `delay(500)`를 제거한다. holder 진입 latch 이후 contender가 실제 acquisition을 시작했음을 executor-side latch로 알리고, publisher가 holder `Elected`를 전달한 것을 positive barrier로 확인한 뒤 holder를 해제한다. assertion은 최종 event sequence가 `elected`, `revoked`, `elected`, `revoked`이고 queued 상태에서 추가 `Elected`가 발생하지 않았다는 기존 의미를 유지한다.
+
+3. `[ ]` close 테스트를 확장한다. publisher를 close한 뒤 동일 prefix에 실제 ownership 변화를 만들고 closed publisher의 `first()` collector가 완료되지 않음을 `future.get(500, TimeUnit.MILLISECONDS)`의 `TimeoutException`으로 확인한 뒤 collector를 취소한다. 이어 같은 caller-owned client로 새 publisher/elector가 정상 event를 전달함을 확인한다. client usability만 확인하는 기존 assertion도 유지한다.
+
+4. `[ ]` RED/GREEN 검증은 수정할 테스트 class만 매번 실행한다.
+
+   ```bash
+   ./gradlew :bluetape4k-leader-etcd:test --tests '*EtcdLeaderElectionEventPublisherIntegrationTest*' --no-daemon --no-configuration-cache --no-build-cache --rerun-tasks --console=plain
+   ```
+
+   테스트 source의 `delay(`가 0건이어야 한다. negative assertion timeout은 완료 조건이 아니라 불발 검증 상한임을 주석 없이 코드 구조로 드러낸다.
+
+## 6. Task 4 — Etcd 단일/group async lifecycle RED
+
+**Files:** 신규 `EtcdAsyncLifecycleTest.kt`.
+
+1. `[ ]` `EtcdLockClient` fake는 granted lease, pending/complete lock future, ownership key, unlock/revoke call count를 thread-safe하게 기록한다. active lease/ownership을 상태로 보유하고 unlock/revoke 전의 두 번째 acquisition은 완료시키지 않아 후속 재획득 assertion이 실제 cleanup을 검증하도록 한다. action은 직접 제어하는 `CompletableFuture<T>`를 반환한다. 새 예외 assertion은 반드시 `io.bluetape4k.assertions.assertFailsWith`를 사용한다.
+
+2. `[ ]` 단일 elector RED를 추가한다. action 진입을 barrier로 확인하고 반환 future를 `cancel(true)`한다. 실제 action future가 `isCancelled == true`, unlock/revoke가 각각 정확히 한 번, 후속 동일 lock 실행이 성공함을 확인한다.
+
+3. `[ ]` group elector RED를 `maxLeaders=1`로 추가한다. 반환 future 취소 후 실제 action 취소, 동일 slot cleanup, 후속 같은 group lock 재획득을 확인한다.
+
+4. `[ ]` acquisition 대기 중 취소 시 action이 호출되지 않고, 늦게 완료된 ownership key가 unlock/revoke되는 single/group case를 추가한다. returned future의 cancel과 lock future 완료 경합을 barrier로 고정한다.
+
+5. `[ ]` lease 획득과 action 제출 사이 executor 거부를 재현하는 scripted executor를 추가한다. 첫 `execute`는 acquisition task를 실행하고 두 번째 `execute`는 `RejectedExecutionException("rejected-after-acquire")`을 던져야 한다. 결과 cause가 원래 예외이고 unlock/revoke가 정확히 한 번이며 후속 재획득이 성공해야 한다. 별도 always-reject executor는 acquisition 전 거부가 backend 호출 0건임을 확인할 때만 사용한다.
+
+6. `[ ]` 현재 구현에서 targeted class를 실행해 유효한 RED를 얻는다.
+
+   ```bash
+   ./gradlew :bluetape4k-leader-etcd:test --tests '*EtcdAsyncLifecycleTest*' --no-daemon --no-configuration-cache --no-build-cache --rerun-tasks --console=plain
+   ```
+
+   예상 RED는 실제 action future 미취소 또는 lease cleanup 지연/누락이다. fake compile 오류나 timeout-only failure는 유효한 RED로 인정하지 않는다.
+
+## 7. Task 5 — 취소 전파·exactly-once cleanup GREEN
+
+**Files:** `EtcdLeaderElector.kt`, `EtcdLeaderGroupElector.kt`, `EtcdAsyncLifecycleTest.kt`, 신규 `EtcdAsyncLeaderElectorIntegrationTest.kt`, `contract/EtcdVirtualThreadLeaderElectorContractTest.kt`.
+
+1. `[ ]` 두 elector에 private `AsyncLifecycle { WAITING, STARTED, CLEANUP }`을 두고 `AtomicReference` CAS로 action 시작과 cleanup 소유권을 직렬화한다. 취소와 action 시작 중 하나만 `WAITING`을 선점하며 cleanup은 lease handle의 `markReleased()`와 함께 exactly once다.
+
+2. `[ ]` acquisition은 caller executor에서 수행하되 source/returned future를 `LeaderFutureBridge`로 연결한다. 반환 future 취소는 acquisition source, 실제 action future, watchdog/cleanup에 전파한다. action supplier가 throw하면 failed future와 동일한 cleanup path로 수렴한다.
+
+3. `[ ]` action은 lease 획득 뒤에만 호출한다. `LeaderFutureBridge.cancellationRelay()`를 action future에 설치하고 result mapping에서 `CompletionException` wrapper를 불필요하게 노출하지 않는다. 정상 contention은 기존처럼 `null`을 반환한다.
+
+4. `[ ]` `LeaderLockHandle`의 single/group identity, group `slotId`/`auditLeaderId`, AOP scope capture, autoExtend 설정, `minLeaseTime`, unlock→revoke 순서와 caller-owned client 계약을 보존한다. group은 기존과 같이 watchdog disabled 의미를 유지한다.
+
+5. `[ ]` executor가 initial acquisition 또는 post-acquire action 실행을 거부할 때 원래 `RejectedExecutionException`을 result에 보존한다. lease가 이미 획득된 경우 cleanup을 먼저 설치한 뒤 제출하며, 획득 전 거부에는 backend 호출이 없어야 한다.
+
+6. `[ ]` Task 4 targeted class를 GREEN으로 만들고 다음 기존 회귀 tests도 실행한다.
+
+   ```bash
+   ./gradlew :bluetape4k-leader-etcd:test \
+     --tests '*EtcdAsyncLifecycleTest*' \
+     --tests '*EtcdLeaderCleanupTimeoutTest*' \
+     --tests '*EtcdLeaderElectorIntegrationTest*' \
+     --tests '*EtcdLeaderGroupElectorIntegrationTest*' \
+     --tests '*EtcdSuspendLeaderElectorIntegrationTest*' \
+     --tests '*EtcdSuspendLeaderGroupElectorIntegrationTest*' \
+     --tests '*EtcdVirtualThreadLeaderElectorContractTest*' \
+     --no-daemon --no-configuration-cache --no-build-cache --rerun-tasks --console=plain
+   ```
+
+7. `[ ]` 실제 etcd integration test에서 단일/group `runAsyncIfLeader`의 action future를 취소하고 returned future의 취소 상태, 같은 lock/slot 재획득을 확인한다. virtual-thread contract에는 action 진입 후 returned `VirtualFuture` 취소와 같은 lock 재획득을 추가한다. 기존 sync sequential reacquire, sync contention, suspend single/group cancellation tests와 함께 execution-model matrix를 완성한다.
+
+8. `[ ]` async action supplier가 `extendActiveLock()`을 호출하는 기존 scope 의미와 auto-extend cleanup을 fake 또는 integration test로 고정한다. 구현이 기존 scope 의미를 보존할 수 없거나 의미가 불명확하면 무단으로 축소하지 않고 설계 게이트로 되돌아간다.
+
+9. `[ ]` duplicated single/group lifecycle code는 먼저 기존 두 클래스의 대칭성을 유지한다. 검증된 반복이 private internal helper로 명확히 줄어들지 않는 한 새 abstraction을 만들지 않는다.
+
+## 8. Task 6 — module·전체 저장소·ABI 검증
+
+**Files:** 모든 변경 파일, Gradle/JUnit 결과, `.flow-inputs/checklist.md`.
+
+1. `[ ]` source hygiene와 결정성 정적 검사를 한다.
+
+   ```bash
+   git diff --check
+   rg -n 'delay\(|Thread\.sleep\(' leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/internal/JetcdWatchCallbackIntegrationTest.kt leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdLeaderElectionEventPublisherIntegrationTest.kt leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdAsyncLifecycleTest.kt leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdAsyncLeaderElectorIntegrationTest.kt
+   rg -n 'assertThrows|kotlin\.test\.assertFailsWith|shouldThrow' leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd
+   ```
+
+   첫 명령은 exit 0, 두 번째와 세 번째는 0건이어야 한다.
+
+2. `[ ]` `leader-etcd` 전체 테스트를 retry 없이 clean first-run으로 실행한다. CI의 5회 retry wrapper를 로컬 성공 증거로 사용하지 않는다.
+
+   ```bash
+   ./gradlew :bluetape4k-leader-etcd:cleanTest :bluetape4k-leader-etcd:test --no-daemon --no-configuration-cache --no-build-cache --rerun-tasks --console=plain
+   ```
+
+   JUnit XML의 tests/failures/errors/skipped 합계와 elapsed time을 checklist/review에 기록한다. unexplained retry나 skipped integration test는 PASS가 아니다.
+
+3. `[ ]` central catalog 광역 영향과 public ABI를 검증한다.
+
+   ```bash
+   ./gradlew detekt --no-daemon --console=plain
+   ./gradlew checkBinaryCompatibility --no-daemon --console=plain
+   ./gradlew build --no-daemon --console=plain
+   ```
+
+   모두 exit 0이어야 한다. 환경상 전체 build를 실행할 수 없다면 정확한 실패와 대체 범위를 `PENDING`으로 남기고 PR merge-ready를 주장하지 않는다.
+
+4. `[ ]` sync/async/suspend/virtual-thread와 single/group 결과를 verification matrix에 명시한다. 테스트가 존재하지 않는 조합은 임의 PASS가 아니라 `N/A` 또는 `PENDING`으로 분류하고 근거를 쓴다.
+
+5. `[ ]` 두 catalog pin equality, `jetcd 0.8.7`, gRPC/Netty/Vert.x graph, 변경된 public API 0건, README/KDoc `N/A`를 최종 증거에 다시 기록한다.
+
+## 9. Task 7 — 7-Tier 리뷰·lesson·PR·exact-head CI
+
+**Files:** 신규 review/lesson 문서, 전체 diff, GitHub PR.
+
+1. `[ ]` `$bluetape-kotlin-patterns`의 7-Tier 순서로 exact diff를 검토한다: Kotlin correctness, concurrency/cancellation, API/ABI, backend/watch semantics, tests/flakiness, dependency/security/ops, CI/delivery. 발견은 파일/line·재현·severity·처리 상태를 `docs/review/2026-09-05-issue-880-jetcd-callback-review.md`에 기록한다.
+
+2. `[ ]` performance/stability scan을 별도로 수행한다. callback backpressure, bounded waits, thread/executor leak, watcher close race, CAS ownership, cleanup count, full-suite runtime을 확인한다. P0/P1은 PR 전 모두 고치고 다시 검증한다.
+
+3. `[ ]` 독립 review lane을 한 번 실행한다. lane이 90초 안에 유효 결과를 내지 못하거나 unavailable이면 중단하고 사용자 standing rule에 따라 같은 checklist를 inline으로 완결한다. human reviewer는 solo-maintainer lane에서만 `N/A`; 기술 검토는 생략하지 않는다.
+
+4. `[ ]` `docs/lessons/2026-09-05-issue-880-jetcd-callback.md`에 created notification readiness, dependency-sensitive RED, blocking callback/backpressure, action cancellation relay, exactly-once cleanup, atomic catalog rollback을 재사용 가능한 규칙으로 기록한다.
+
+5. `[ ]` 변경을 작은 Lore commit으로 정리한다. 각 commit은 한국어 intent line, `Constraint`, `Rejected`, `Confidence`, `Scope-risk`, `Directive`, `Tested`, `Not-tested` 중 필요한 trailer를 포함한다. commit 전마다 `git diff --check`와 관련 targeted test를 다시 읽는다.
+
+6. `[ ]` PR 생성 직전 live `gh`로 Issue #880, milestone `1.1.0`, labels, assignee, 기존 open PR/duplicate를 다시 확인한다. head `test/issue-880-jetcd-callback`, base `develop`을 명시하고 한국어 PR body 마지막을 `## DoD Status`로 끝낸다. PR 생성은 승인됐지만 merge는 승인되지 않았다.
+
+7. `[ ]` exact-head SHA를 pin하고 terminal CI를 확인한다. required checks, test count, skipped/failed jobs, review/thread read-back, mergeability를 기록한다. path-filtered skip, old SHA green, retry-only green은 exact-head PASS가 아니다.
+
+8. `[ ]` 최종 상태는 다음이 모두 충족되면 `PENDING (merge approval)`이다: 로컬/CI exact-head 성공, P0=0/P1=0, open review thread 0, mergeable, 변경된 public API 0, rollback 경계 명확. fresh merge 승인 전에는 merge·branch 삭제·worktree 삭제를 수행하지 않는다.
+
+## 10. Rollback과 중단 조건
+
+- catalog 회귀가 원인이면 `settings.gradle.kts`와 `.github/workflows/ci.yml`의 ref를 같은 patch/commit에서 이전 `850959d0ea5f76ac7e2c442400f47653d5f95eed`로 되돌린다. 한 파일만 rollback한 상태는 허용하지 않는다.
+- callback test가 old ref에서도 GREEN이면 test sensitivity를 먼저 수정한다. jetcd `0.8.7`의 행동 차이를 증명하지 못하면 dependency upgrade를 진행하지 않는다.
+- async fix가 public API/ABI, key layout, lease policy를 바꿔야 한다면 현재 설계를 넘어선 것이므로 구현을 중지하고 Type A 설계 승인을 새로 받는다.
+- Testcontainers/Docker가 unavailable이면 fake test만으로 backend callback PASS를 선언하지 않는다. 환경을 진단하고 integration 항목을 `PENDING`으로 둔다.
+- central catalog 때문에 비-etcd module build가 실패하면 실패 module과 dependency edge를 기록하고 local force/override로 감추지 않는다.
+
+## 11. 계획 검토 결과
+
+독립 test-engineering lane은 90초 bounded wait 안에 결과를 반환하지 않아 중단했다. 사용자 standing rule에 따라 같은 범위를 inline으로 검토했고, 설계 검토에서 사용한 여섯 관점과 test-engineering·spec traceability를 함께 적용했다.
+
+| 우선순위 | 관점 | 발견 | 계획 반영 |
+|---|---|---|---|
+| P1 | Stability/Test | 단순 call-count fake에서는 cleanup 없이도 후속 acquisition이 성공해 재획득 assertion이 무효가 될 수 있음 | fake가 active ownership을 유지하고 unlock/revoke 전 재획득을 막도록 Task 4를 보강 |
+| P1 | Test/Operator | always-reject executor는 lease 획득 뒤 제출 거부를 재현하지 못함 | 첫 acquisition task는 받고 두 번째 제출만 거부하는 scripted executor를 명시 |
+| P1 | Developer/API | fake만으로 direct async와 virtual-thread 실제 etcd 재획득을 증명할 수 없음 | `EtcdAsyncLeaderElectorIntegrationTest`와 virtual cancellation contract를 파일 지도·Task 5에 추가 |
+| P1 | Developer/API | 다른 backend의 async pattern을 그대로 복사하면 Etcd의 기존 AOP scope/auto-extend 의미가 축소될 수 있음 | `extendActiveLock()` supplier 의미와 watchdog cleanup을 먼저 테스트하고 불명확하면 설계로 복귀 |
+| P2 | Stability | close 이후 불발 검증이 추상적인 polling이면 구현마다 다른 wait가 생김 | `first()` future의 bounded `TimeoutException`과 명시적 collector cancel로 고정 |
+| P2 | Performance | callback block을 순서 테스트와 섞으면 원인과 suite 시간이 불명확함 | blocking, ordered delivery, close/restart를 독립 test로 유지하고 한 container invocation에서 실행 |
+| P2 | Security | jetcd channel 전환과 중앙 catalog 광역 변경이 TLS/auth 또는 transitive downgrade를 숨길 수 있음 | client 설정 불변, 네 graph의 before/after selection reason, full build를 요구 |
+| P2 | Operator/Ops | local/CI pin 불일치와 retry-only green이 rollout 결함을 숨길 수 있음 | 두 pin 원자 변경·rollback, retry 없는 local first-run, exact-head CI read-back을 요구 |
+| P3 | User/caller | public 계약 불변인데 README/manual을 바꾸면 검증 범위를 사용자 기능처럼 보이게 함 | README/KDoc/manual은 근거를 적어 `N/A` 유지 |
+
+통합 뒤 남은 계획 finding은 `P0=0`, `P1=0`이다. P2는 Task 1–7의 실행 검증 항목으로 추적한다.
+
+### 계획 검토 체크리스트
+
+- [x] Performance: callback backpressure와 bounded wait가 suite/runtime·thread leak을 만들지 않는다.
+- [x] Stability: created barrier, close/restart, action-start/cancel CAS, late acquisition cleanup이 race를 결정적으로 재현한다.
+- [x] Security: Netty/TLS/auth client 설정을 바꾸지 않으며 dependency graph의 예상치 못한 downgrade/conflict가 없다.
+- [x] Operator/Ops: local/CI pin이 동일하고 rollback이 원자적이며 첫 실패 로그가 보존된다.
+- [x] Developer/API: public descriptor와 contention `null`, exception cause, client ownership 계약이 유지된다.
+- [x] User/caller: README/KDoc/manual 변경 `N/A`의 근거가 public 계약 불변과 일치한다.
+- [x] Test engineering: RED가 의도한 결함으로 실패하고 GREEN이 retry/sleep/환경 우연에 의존하지 않는다.
+- [x] Spec traceability: Issue acceptance 각각에 task와 fresh command evidence가 있다.
+- [x] Delivery: PR exact-head와 CI, review threads, mergeability를 merge 승인 직전에 다시 읽는다.
+
+## 12. 계획 DoD
+
+- [x] 승인된 설계의 acceptance 10개가 Task 1–7과 검증 명령에 연결됐다.
+- [x] 변경 파일, ownership, RED/GREEN, rollback, public API/N/A 경계가 명시됐다.
+- [x] 6개 관점과 test-engineering 검토에서 P0=0, P1=0이다.
+- [x] 계획 승인 전 production/test 구현을 시작하지 않았다.
+- [ ] 계획 commit SHA와 workflow Type A receipt가 기록됐다.

--- a/docs/superpowers/plans/2026-09-05-issue-880-jetcd-callback-plan.md
+++ b/docs/superpowers/plans/2026-09-05-issue-880-jetcd-callback-plan.md
@@ -16,7 +16,7 @@
 - [x] Task 2 — catalog pin 원자 전환과 callback GREEN
 - [x] Task 3 — publisher watch 준비·경합 테스트 결정성 개선
 - [x] Task 4 — Etcd 단일/group async lifecycle RED
-- [ ] Task 5 — 취소 전파·exactly-once cleanup GREEN
+- [x] Task 5 — 취소 전파·exactly-once cleanup GREEN
 - [ ] Task 6 — module·전체 저장소·ABI 검증
 - [ ] Task 7 — 7-Tier 리뷰·lesson·PR·exact-head CI
 
@@ -169,17 +169,17 @@
 
 **Files:** `EtcdLeaderElector.kt`, `EtcdLeaderGroupElector.kt`, `EtcdAsyncLifecycleTest.kt`, 신규 `EtcdAsyncLeaderElectorIntegrationTest.kt`, `contract/EtcdVirtualThreadLeaderElectorContractTest.kt`.
 
-1. `[ ]` 두 elector에 private `AsyncLifecycle { WAITING, STARTED, CLEANUP }`을 두고 `AtomicReference` CAS로 action 시작과 cleanup 소유권을 직렬화한다. 취소와 action 시작 중 하나만 `WAITING`을 선점하며 cleanup은 lease handle의 `markReleased()`와 함께 exactly once다.
+1. `[x]` 두 elector에 private `AsyncLifecycle { WAITING, STARTED, CLEANUP }`을 두고 `AtomicReference` CAS로 action 시작과 cleanup 소유권을 직렬화한다. 취소와 action 시작 중 하나만 `WAITING`을 선점하며 cleanup은 lease handle의 `markReleased()`와 함께 exactly once다.
 
-2. `[ ]` acquisition은 caller executor에서 수행하되 source/returned future를 `LeaderFutureBridge`로 연결한다. 반환 future 취소는 acquisition source, 실제 action future, watchdog/cleanup에 전파한다. action supplier가 throw하면 failed future와 동일한 cleanup path로 수렴한다.
+2. `[x]` acquisition은 caller executor에서 수행하되 source/returned future를 `LeaderFutureBridge`로 연결한다. 반환 future 취소는 acquisition source, 실제 action future, watchdog/cleanup에 전파한다. action supplier가 throw하면 failed future와 동일한 cleanup path로 수렴한다.
 
-3. `[ ]` action은 lease 획득 뒤에만 호출한다. `LeaderFutureBridge.cancellationRelay()`를 action future에 설치하고 result mapping에서 `CompletionException` wrapper를 불필요하게 노출하지 않는다. 정상 contention은 기존처럼 `null`을 반환한다.
+3. `[x]` action은 lease 획득 뒤에만 호출한다. `LeaderFutureBridge.cancellationRelay()`를 action future에 설치하고 result mapping에서 `CompletionException` wrapper를 불필요하게 노출하지 않는다. 정상 contention은 기존처럼 `null`을 반환한다.
 
-4. `[ ]` `LeaderLockHandle`의 single/group identity, group `slotId`/`auditLeaderId`, AOP scope capture, autoExtend 설정, `minLeaseTime`, unlock→revoke 순서와 caller-owned client 계약을 보존한다. group은 기존과 같이 watchdog disabled 의미를 유지한다.
+4. `[x]` `LeaderLockHandle`의 single/group identity, group `slotId`/`auditLeaderId`, AOP scope capture, autoExtend 설정, `minLeaseTime`, unlock→revoke 순서와 caller-owned client 계약을 보존한다. group은 기존과 같이 watchdog disabled 의미를 유지한다.
 
-5. `[ ]` executor가 initial acquisition 또는 post-acquire action 실행을 거부할 때 원래 `RejectedExecutionException`을 result에 보존한다. lease가 이미 획득된 경우 cleanup을 먼저 설치한 뒤 제출하며, 획득 전 거부에는 backend 호출이 없어야 한다.
+5. `[x]` executor가 initial acquisition 또는 post-acquire action 실행을 거부할 때 원래 `RejectedExecutionException`을 result에 보존한다. lease가 이미 획득된 경우 cleanup을 먼저 설치한 뒤 제출하며, 획득 전 거부에는 backend 호출이 없어야 한다.
 
-6. `[ ]` Task 4 targeted class를 GREEN으로 만들고 다음 기존 회귀 tests도 실행한다.
+6. `[x]` Task 4 targeted class를 GREEN으로 만들고 다음 기존 회귀 tests도 실행한다.
 
    ```bash
    ./gradlew :bluetape4k-leader-etcd:test \
@@ -193,11 +193,11 @@
      --no-daemon --no-configuration-cache --no-build-cache --rerun-tasks --console=plain
    ```
 
-7. `[ ]` 실제 etcd integration test에서 단일/group `runAsyncIfLeader`의 action future를 취소하고 returned future의 취소 상태, 같은 lock/slot 재획득을 확인한다. virtual-thread contract에는 action 진입 후 returned `VirtualFuture` 취소와 같은 lock 재획득을 추가한다. 기존 sync sequential reacquire, sync contention, suspend single/group cancellation tests와 함께 execution-model matrix를 완성한다.
+7. `[x]` 실제 etcd integration test에서 단일/group `runAsyncIfLeader`의 action future를 취소하고 returned future의 취소 상태, 같은 lock/slot 재획득을 확인한다. virtual-thread contract에는 action 진입 후 returned `VirtualFuture` 취소와 같은 lock 재획득을 추가한다. 기존 sync sequential reacquire, sync contention, suspend single/group cancellation tests와 함께 execution-model matrix를 완성한다.
 
-8. `[ ]` async action supplier가 `extendActiveLock()`을 호출하는 기존 scope 의미와 auto-extend cleanup을 fake 또는 integration test로 고정한다. 구현이 기존 scope 의미를 보존할 수 없거나 의미가 불명확하면 무단으로 축소하지 않고 설계 게이트로 되돌아간다.
+8. `[x]` async action supplier가 `extendActiveLock()`을 호출하는 기존 scope 의미와 auto-extend cleanup을 fake 또는 integration test로 고정한다. 구현이 기존 scope 의미를 보존할 수 없거나 의미가 불명확하면 무단으로 축소하지 않고 설계 게이트로 되돌아간다.
 
-9. `[ ]` duplicated single/group lifecycle code는 먼저 기존 두 클래스의 대칭성을 유지한다. 검증된 반복이 private internal helper로 명확히 줄어들지 않는 한 새 abstraction을 만들지 않는다.
+9. `[x]` duplicated single/group lifecycle code는 먼저 기존 두 클래스의 대칭성을 유지한다. 검증된 반복이 private internal helper로 명확히 줄어들지 않는 한 새 abstraction을 만들지 않는다.
 
 ## 8. Task 6 — module·전체 저장소·ABI 검증
 

--- a/docs/superpowers/specs/2026-09-05-issue-880-jetcd-callback-design.md
+++ b/docs/superpowers/specs/2026-09-05-issue-880-jetcd-callback-design.md
@@ -1,0 +1,167 @@
+# Issue #880 jetcd callback·watch·lease 회귀 검증 설계
+
+## 문서 상태
+
+- 상태: 사용자 승인 방향과 6개 관점 inline 검토를 반영한 설계
+- 작성일: 2026-09-05
+- 대상 저장소: `bluetape4k/bluetape4k-leader`
+- 대상 모듈: `leader-etcd`
+- 이슈: [#880](https://github.com/bluetape4k/bluetape4k-leader/issues/880)
+- 기준 커밋: `f9c084c241b5ac87a4b644f64ef47da55d71fbcb` (`develop`)
+- 작업 branch: `test/issue-880-jetcd-callback`
+- 승인 범위: 중앙 catalog `9698c9d66bea6fcba373143ee8fa5bfbd9812d4b` 채택과 jetcd `0.8.7` callback·watch·lease 회귀 검증
+- 제외 범위: public API 변경, etcd 운영 정책 변경, publish/release/tag, merge
+
+## SPW-01 — 독자·목적·근거 고정
+
+이 문서는 `leader-etcd` 구현자와 리뷰어가 의존성 전환과 회귀 테스트의 경계를 확인하도록 작성한다. 다음 근거를 기준으로 삼는다.
+
+| 근거 | 확인한 계약 |
+|---|---|
+| [Issue #880](https://github.com/bluetape4k/bluetape4k-leader/issues/880) | jetcd `0.8.7`, callback 순서, watch lifecycle, sync/async/suspend lease 검증 요구 |
+| [jetcd PR #1559](https://github.com/etcd-io/jetcd/pull/1559) | 기본 channel을 `VertxChannelBuilder`에서 `NettyChannelBuilder`로 바꾸어 callback 안의 blocking call과 ordered callback 실행을 지원 |
+| 중앙 catalog `9698c9d66bea6fcba373143ee8fa5bfbd9812d4b` | `jetcd-core 0.8.7`, gRPC `1.84.0`, Vert.x `5.1.7`을 포함한 다음 dependency train |
+| `EtcdLeaderElectionEventPublisher.kt` | jetcd callback에서 event 목록을 만든 뒤 별도 coroutine으로 owner를 재검증 |
+| `AsyncLeaderElector.kt` | 반환 future 취소를 acquisition, action, lease cleanup으로 전달하는 공통 계약 |
+| `EtcdLeaderElector.kt`, `EtcdLeaderGroupElector.kt` | 현재 `CompletableFuture.supplyAsync { action().join() }` 구현은 반환 future 취소를 action future로 전달하지 않음 |
+| 기존 `leader-etcd` 테스트 | 기본 catalog와 후보 catalog에서 각각 137 tests 통과 |
+
+확인되지 않은 주장은 설계에 포함하지 않는다. 특히 jetcd callback의 순서 보장은 `scope.launch` 이후 coroutine 처리 순서까지 보장하지 않으며, 현재 Leader의 deadlock이나 event loss가 재현되었다고 가정하지 않는다.
+
+## SPW-02 — 문제와 선택
+
+현재 `settings.gradle.kts`와 `.github/workflows/ci.yml`은 catalog commit `850959d0ea5f76ac7e2c442400f47653d5f95eed`를 고정하므로 기본 graph에서 `jetcd-core 0.8.6`이 선택된다. 로컬에서 catalog path만 주입하면 `0.8.7` 테스트는 가능하지만 hosted CI와 실제 기본 build는 계속 `0.8.6`을 사용한다.
+
+### 대안 A — 중앙 catalog pin을 갱신하고 실제 etcd 회귀 테스트를 추가한다 (선택)
+
+두 catalog 진입점을 `9698c9d66bea6fcba373143ee8fa5bfbd9812d4b`로 맞춘다. 실제 etcd watch callback에서 blocking KV 호출, callback 직렬화, close/restart를 검증하고 기존 elector 테스트로 lease lifecycle을 다시 확인한다.
+
+- 장점: 로컬 기본 build와 hosted CI가 같은 `0.8.7` graph를 검증한다.
+- 단점: jetcd 외 Spring Boot, Exposed, gRPC 등 중앙 train 전체가 바뀌므로 저장소 전체 회귀 검증이 필요하다.
+
+### 대안 B — 테스트 명령에만 catalog path를 주입한다
+
+- 장점: 기본 dependency graph를 바꾸지 않는다.
+- 단점: PR이 merge되어도 Leader의 기본 artifact는 `0.8.6`을 사용하므로 Issue #880 완료 조건을 충족하지 못한다.
+- 판정: 거부.
+
+### 대안 C — callback 이후 처리를 production serial queue로 바꾼다
+
+- 장점: `scope.launch` 이후 처리 순서를 별도로 고정할 수 있다.
+- 단점: 현재 event loss나 잘못된 event 의미가 재현되지 않았고, 불필요한 hot-path와 lifecycle 변경을 만든다.
+- 판정: 거부. 결정론적 RED가 Leader 자체 결함을 증명할 때만 최소 수정안을 다시 검토한다.
+
+## 설계
+
+### 1. Dependency graph
+
+`settings.gradle.kts`의 기본 catalog ref와 `.github/workflows/ci.yml`의 `BLUETAPE4K_DEPENDENCIES_CATALOG_REF`를 같은 immutable SHA로 변경한다. 다음 두 graph를 증거로 남긴다.
+
+1. `jetcd-core 0.8.7` 직접 선택
+2. 함께 선택된 gRPC/Netty/Vert.x 버전과 dependency conflict 결과
+
+catalog commit에는 여러 모듈이 사용하는 버전 변경이 포함되므로 `leader-etcd` 테스트만으로 채택을 확정하지 않는다. 전체 build와 CI summary가 함께 통과해야 한다.
+
+### 2. jetcd callback fixture
+
+새 실제 etcd integration fixture는 raw `Watch.Listener` 경계를 검증한다.
+
+watch 생성 자체는 server-side subscription 완료를 뜻하지 않는다. 모든 fixture는 `WatchOption.withCreateNotify(true)`의 created response를 readiness barrier로 사용한 뒤 PUT을 시작한다. blocking call, ordered delivery, close/restart는 서로 다른 테스트로 분리한다.
+
+1. blocking-call 테스트는 callback 안에서 같은 `Client`의 `KV.get(...).get(timeout)`을 실행하고 응답값을 확인한다.
+2. ordered-delivery 테스트는 첫 callback을 `CountDownLatch`로 붙잡은 뒤 두 번째 PUT을 보내고, 두 번째 callback이 먼저 진입하지 않음을 확인한다. 첫 callback을 해제한 뒤 callback 관찰 순서가 PUT 순서와 같은지 확인한다.
+3. close/restart 테스트는 callback과 `Watcher.close()`를 경합시킨 뒤 close 이후 PUT이 기존 listener로 전달되지 않는지 확인한다. 새 watcher는 별도 created barrier를 통과한 뒤 후속 PUT을 받아야 한다.
+
+고정 `Thread.sleep`이나 coroutine `delay`는 동기화 수단으로 사용하지 않는다. bounded `await`와 future timeout은 실패를 무한 대기로 바꾸지 않기 위한 상한으로만 사용한다.
+
+### 3. Leader event 의미
+
+`EtcdLeaderElectionEventPublisherIntegrationTest`의 collector는 `CoroutineStart.UNDISPATCHED`로 즉시 구독한다. 기존 `delay(250)`를 제거하고 다음 의미를 검증한다.
+
+- 실제 owner 생성은 `Elected(lockName)` 한 건으로 관찰된다.
+- owner 삭제는 같은 lock의 `Revoked(lockName)`으로 관찰된다.
+- queued contender의 중간 key event는 별도 leader election으로 노출되지 않는다.
+- publisher close 이후 event가 방출되지 않고 caller-owned `Client`는 계속 사용할 수 있다.
+
+raw callback 순서와 Leader event 의미는 별도 테스트로 유지한다. upstream callback 직렬화를 Leader event 순서의 유일한 근거로 사용하지 않는다.
+
+### 4. Lease lifecycle 검증
+
+기존 실제 etcd 및 fake-client 테스트를 acceptance matrix로 묶고 부족한 async 경로만 보강한다.
+
+| 진입점 | 검증 내용 |
+|---|---|
+| sync | lease grant, lock, keep-alive, unlock, revoke, contention timeout 뒤 재획득 |
+| async | 단일/group action 완료·실패 뒤 재획득, 반환 future 취소가 실제 action future로 전달되고 cleanup 뒤 재획득 가능 |
+| suspend | keep-alive, cancellation/timeout 뒤 unlock·revoke와 재획득 |
+| virtual thread | blocking delegate 완료 뒤 재획득 |
+
+`EtcdLeaderElector`와 `EtcdLeaderGroupElector`의 현재 async wrapper는 `CompletableFuture.supplyAsync` 안에서 action future를 `join()`한다. 반환 future의 `cancel()`은 이 source task나 실제 action future를 자동으로 취소하지 않으므로 `AsyncLeaderElector` KDoc 계약과 맞지 않는다. 결정론적 RED로 확인한 뒤 기존 `LeaderFutureBridge`와 backend별 async lifecycle 패턴을 재사용해 다음 상태를 보장한다.
+
+- 취소 전 action이 정해졌으면 실제 action future를 취소한다.
+- acquisition이나 action 대기 중인 worker가 있으면 협력적 중단을 전달한다.
+- action 시작, 취소, executor 거부가 경합해도 lease cleanup은 한 경로만 소유한다.
+- cleanup 뒤 같은 lock 또는 group slot을 다시 획득할 수 있다.
+- 원래 `CancellationException`과 `RejectedExecutionException`을 다른 실패로 바꾸지 않는다.
+
+public API와 callback 실행 모델은 바꾸지 않는다. 이 lifecycle 보정이 별도 public contract나 공통 core 변경을 요구하면 구현을 중단하고 설계를 다시 승인받는다.
+
+## 실패 모드와 대응
+
+1. **callback 안의 blocking KV 호출이 timeout된다.** `0.8.6`에서 RED를 확인하고 catalog 전환 뒤 같은 테스트가 GREEN인지 비교한다. `0.8.7`에서도 실패하면 graph와 channel builder를 먼저 확인한다.
+2. **callback 순서 테스트가 하나의 WatchResponse batch만 검증한다.** 첫 callback 진입을 확인한 다음 두 번째 PUT을 보내서 서로 다른 delivery 시점을 만든다.
+3. **close 이후 negative assertion이 서버 지연 때문에 우연히 통과한다.** close된 watcher와 새 watcher를 동시에 비교하고, 새 watcher가 후속 PUT을 받는 positive assertion을 함께 둔다.
+4. **event collector가 늦게 구독해 첫 event를 놓친다.** `CoroutineStart.UNDISPATCHED`로 collector 등록을 완료한 뒤 lock 작업을 시작한다.
+5. **전역 catalog 변경이 다른 모듈을 깨뜨린다.** targeted test 다음 전체 build를 실행하고, 실패하면 catalog pin 두 곳을 이전 SHA로 되돌린 뒤 원인을 별도 분리한다.
+6. **원인 미확인 재시도에서만 통과한다.** 첫 실패 로그를 보존하고 원인을 설명하기 전에는 PASS로 기록하지 않는다.
+7. **async 취소와 action 시작이 경합해 lease가 남는다.** action 시작과 cleanup 소유권을 하나의 원자 상태로 관리하고, 취소된 action과 동일 lock/slot 재획득을 함께 검증한다.
+8. **executor가 lease 획득 뒤 작업 제출을 거부한다.** 제출 지점을 cleanup 소유권 안에 두고 원래 `RejectedExecutionException`과 재획득을 검증한다.
+
+## 호환성·운영·rollback
+
+- public Kotlin/JVM API, KDoc, README, examples에는 변경이 없다.
+- etcd key layout, lease TTL, timeout 기본값, client ownership은 유지한다.
+- 중앙 catalog 전환은 compile/runtime graph를 넓게 바꾸므로 ABI dump뿐 아니라 전체 build와 CI matrix를 확인한다.
+- rollback은 두 catalog pin을 함께 `850959d0ea5f76ac7e2c442400f47653d5f95eed`로 되돌리는 것이다. 둘 중 하나만 되돌리는 상태는 허용하지 않는다.
+- publish, release, tag, workflow dispatch, merge는 별도 승인 경계다.
+
+## Acceptance criteria
+
+- [ ] 기본 `dependencyInsight`에서 `io.etcd:jetcd-core:0.8.7`을 확인한다.
+- [ ] gRPC/Netty/Vert.x 조합과 선택 사유를 기록한다.
+- [ ] callback 내부 blocking KV 호출이 bounded timeout 안에 완료된다.
+- [ ] 느린 첫 callback과 연속 PUT에서도 callback 순서가 보존된다.
+- [ ] close 뒤 기존 listener는 event를 받지 않고 새 watcher는 event를 받는다.
+- [ ] publisher의 PUT/DELETE event 의미와 queued contender 억제가 고정 sleep 없이 통과한다.
+- [ ] sync/async/suspend/virtual-thread 단일 및 해당 group lease lifecycle이 timeout·취소·실패 뒤 재획득을 보장한다.
+- [ ] async 반환 future 취소가 실제 action future로 전달되고 cleanup 뒤 동일 lock/slot을 재획득한다.
+- [ ] executor 거부가 원래 예외를 보존하고 획득한 lease를 남기지 않는다.
+- [ ] `leader-etcd` 전체 테스트가 첫 실행에서 통과한다.
+- [ ] 전체 build, detekt, ABI/API, `git diff --check`가 통과한다.
+- [ ] 7-Tier 리뷰에서 P0=0, P1=0이고 exact-head PR CI가 통과한다.
+
+## DoD
+
+설계·계획 추적성, RED/GREEN 증거, dependency graph, 테스트 수와 실패 수, 전체 build·정적 검사·ABI 결과, review finding 처리, PR head와 CI 결론을 모두 기록한다. merge는 fresh exact-head 승인 전까지 `PENDING`으로 남긴다.
+
+## SPW-03..SPW-05 — 문체·추적성·읽기 검토
+
+- `SPW-03`: 한국어 기술 문서 register와 `KO-01..KO-07`을 적용하고 identifier, SHA, command, URL을 그대로 유지한다.
+- `SPW-04`: Issue #880, jetcd PR #1559, 중앙 catalog diff, 현재 source/test 경계와 acceptance criteria를 대조한다.
+- `SPW-05`: Markdown 구조, 표, 목록, link, scope/rollback/DoD를 다시 읽고 placeholder와 상충 문장을 허용하지 않는다.
+
+## 설계 검토 결과
+
+독립 native lane 세 개는 3분 bounded wait와 종료 요청에도 결과를 반환하지 않아 중단했다. 사용자 지침에 따라 여섯 관점을 inline으로 다시 검토했다.
+
+| 우선순위 | 관점 | 근거 | 반영 |
+|---|---|---|---|
+| P1 | stability | `watch()` 반환만으로 server-side create 완료를 알 수 없음 | `withCreateNotify(true)` created barrier를 모든 watch fixture에 추가 |
+| P1 | stability | blocking call과 첫 callback 지연을 한 테스트에 섞으면 timeout 원인을 구분할 수 없음 | blocking, ordered delivery, close/restart를 세 테스트로 분리 |
+| P1 | developer/API | `AsyncLeaderElector`는 반환 future 취소 전파를 요구하지만 Etcd 단일/group은 `supplyAsync` source와 action을 연결하지 않음 | 단일/group cancellation relay, exactly-once cleanup, executor 거부 테스트를 설계에 포함 |
+| P2 | performance | ordered callback 테스트가 긴 timeout을 반복하면 module suite 시간을 늘림 | latch timeout은 진단 상한으로만 사용하고 실제 Testcontainers invocation은 한 번에 실행 |
+| P2 | security | Netty 기본 channel 전환은 TLS/auth 설정 경계를 바꿀 수 있음 | public client 설정을 바꾸지 않고 resolved graph와 기존 client integration suite로 호환성 확인 |
+| P2 | operator/Ops | catalog rollback 두 pin 중 하나만 복구하면 local/CI graph가 달라짐 | 두 pin의 원자적 rollback과 일치 검사를 명시 |
+| P3 | user/caller | public 동작과 설정 변경이 없으므로 README 변경은 오히려 범위를 흐림 | README/KDoc 변경을 N/A로 유지하고 PR에 검증 범위만 기록 |
+
+최종 통합 판정은 `P0=0`, `P1=0`이다. P1 세 건은 위 설계에 반영했고 P2/P3는 계획의 검증·N/A 근거로 추적한다.

--- a/leader-etcd/src/main/kotlin/io/bluetape4k/leader/etcd/EtcdLeaderElector.kt
+++ b/leader-etcd/src/main/kotlin/io/bluetape4k/leader/etcd/EtcdLeaderElector.kt
@@ -17,6 +17,7 @@ import io.bluetape4k.leader.etcd.internal.JetcdEtcdLockClient
 import io.bluetape4k.leader.etcd.internal.etcdCleanupTimeout
 import io.bluetape4k.leader.etcd.internal.getWithinEtcdCleanupTimeout
 import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import io.bluetape4k.leader.remainingMinLeaseTime
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
@@ -25,9 +26,11 @@ import io.etcd.jetcd.ByteSequence
 import io.etcd.jetcd.Client
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 
 /**
@@ -68,6 +71,12 @@ class EtcdLeaderElector private constructor(
             EtcdLeaderElector(lockClient, options)
     }
 
+    private enum class AsyncLifecycle {
+        WAITING,
+        STARTED,
+        CLEANUP,
+    }
+
     override fun <T> runIfLeader(lockName: String, action: () -> T): T? {
         val leaseHandle = acquire(lockName) ?: return null
         val delegate = EtcdLockExtendDelegate(lockClient, leaseHandle)
@@ -100,11 +109,108 @@ class EtcdLeaderElector private constructor(
         lockName: String,
         executor: Executor,
         action: () -> CompletableFuture<T>,
-    ): CompletableFuture<T?> =
-        CompletableFuture.supplyAsync(
-            { runIfLeader(lockName) { action().join() } },
-            executor,
+    ): CompletableFuture<T?> {
+        val acquiredRef = AtomicReference<EtcdLeaseHandle?>()
+        val lifecycle = AtomicReference(AsyncLifecycle.WAITING)
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
+        val beginCleanup: () -> Unit = {
+            if (lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.CLEANUP)) {
+                acquiredRef.get()?.let(::releaseAfterMinLease)
+            }
+        }
+        val acquisitionFuture = CompletableFuture.supplyAsync({
+            acquire(lockName).also { handle ->
+                if (handle != null) {
+                    acquiredRef.set(handle)
+                    if (lifecycle.get() == AsyncLifecycle.CLEANUP) {
+                        releaseAfterMinLease(handle)
+                    }
+                }
+            }
+        }, executor)
+        val pipelineFuture = acquisitionFuture.thenComposeAsync({ handle ->
+            when {
+                handle == null -> CompletableFuture.completedFuture(null)
+                !lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.STARTED) ->
+                    CompletableFuture.failedFuture(
+                        CancellationException("leader result future was cancelled before action"),
+                    )
+                else -> runAcquiredAsync(handle, cancellationRelay, action)
+            }
+        }, executor)
+        pipelineFuture.whenComplete { _, failure ->
+            if (pipelineFuture.isCancelled) {
+                acquisitionFuture.cancel(true)
+            }
+            if (failure != null) {
+                beginCleanup()
+            }
+        }
+        acquisitionFuture.whenComplete { handle, _ ->
+            if (handle != null && pipelineFuture.isCancelled) {
+                beginCleanup()
+            }
+        }
+        return LeaderFutureBridge.map(pipelineFuture, cancellationRelay) { value, failure ->
+            val cause = failure?.unwrapCompletionException()
+            if (cause != null) {
+                throw CompletionException(cause)
+            }
+            value
+        }
+    }
+
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
+    private fun <T> runAcquiredAsync(
+        leaseHandle: EtcdLeaseHandle,
+        cancellationRelay: LeaderFutureBridge.CancellationRelay,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> {
+        val delegate = EtcdLockExtendDelegate(lockClient, leaseHandle)
+        val handle = LeaderLockHandle.real(
+            identity = LockIdentity(
+                lockName = leaseHandle.lockName,
+                kind = LockIdentity.AnnotationKind.SINGLE,
+                factoryBeanName = ETCD_FACTORY_BEAN_NAME,
+            ),
+            token = leaseHandle.token,
+            acquiredAtNanos = leaseHandle.acquiredAtNanos,
+            extendDelegate = delegate,
         )
+        val watchdog = try {
+            LeaderLeaseAutoExtender.start(
+                enabled = options.leaderOptions.autoExtend,
+                leaseTime = options.leaderOptions.leaseTime,
+                delegate = delegate,
+                classifier = ERROR_CLASSIFIER,
+            )
+        } catch (e: Throwable) {
+            releaseAfterMinLease(leaseHandle)
+            return CompletableFuture.failedFuture(e)
+        }
+        val actionFuture = try {
+            AopScopeAccess.withPushedSync(handle) {
+                cancellationRelay.invoke(action)
+            }
+        } catch (e: Throwable) {
+            watchdog.close()
+            releaseAfterMinLease(leaseHandle)
+            return CompletableFuture.failedFuture(e)
+        }
+
+        return actionFuture.handle { value, failure ->
+            watchdog.close()
+            releaseAfterMinLease(leaseHandle)
+            val cause = failure?.unwrapCompletionException()
+            if (cause != null) {
+                throw CompletionException(cause)
+            }
+            value
+        }
+    }
+
+    private fun Throwable.unwrapCompletionException(): Throwable =
+        (this as? CompletionException)?.cause ?: this
 
     // Lease grant and lock acquisition have separate timeout, cancellation, interruption,
     // and backend-error branches; keeping them explicit preserves cleanup semantics.

--- a/leader-etcd/src/main/kotlin/io/bluetape4k/leader/etcd/EtcdLeaderGroupElector.kt
+++ b/leader-etcd/src/main/kotlin/io/bluetape4k/leader/etcd/EtcdLeaderGroupElector.kt
@@ -21,6 +21,7 @@ import io.bluetape4k.leader.etcd.internal.JetcdEtcdLockClient
 import io.bluetape4k.leader.etcd.internal.etcdCleanupTimeout
 import io.bluetape4k.leader.etcd.internal.getWithinEtcdCleanupTimeout
 import io.bluetape4k.leader.internal.CompositeBackendErrorClassifier
+import io.bluetape4k.leader.internal.LeaderFutureBridge
 import io.bluetape4k.leader.remainingMinLeaseTime
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
@@ -29,10 +30,12 @@ import io.etcd.jetcd.ByteSequence
 import io.etcd.jetcd.Client
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
 import java.util.concurrent.Executor
 import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -69,6 +72,12 @@ class EtcdLeaderGroupElector private constructor(
             options: EtcdLeaderGroupElectionOptions = EtcdLeaderGroupElectionOptions.Default,
         ): EtcdLeaderGroupElector =
             EtcdLeaderGroupElector(lockClient, options)
+    }
+
+    private enum class AsyncLifecycle {
+        WAITING,
+        STARTED,
+        CLEANUP,
     }
 
     override val maxLeaders: Int = options.maxLeaders
@@ -115,11 +124,115 @@ class EtcdLeaderGroupElector private constructor(
         lockName: String,
         executor: Executor,
         action: () -> CompletableFuture<T>,
-    ): CompletableFuture<T?> =
-        CompletableFuture.supplyAsync(
-            { runIfLeader(lockName) { action().join() } },
-            executor,
+    ): CompletableFuture<T?> {
+        val acquiredRef = AtomicReference<EtcdLeaseHandle?>()
+        val lifecycle = AtomicReference(AsyncLifecycle.WAITING)
+        val cancellationRelay = LeaderFutureBridge.cancellationRelay()
+        val beginCleanup: () -> Unit = {
+            if (lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.CLEANUP)) {
+                acquiredRef.get()?.let(::releaseAfterMinLease)
+            }
+        }
+        val acquisitionFuture = CompletableFuture.supplyAsync({
+            acquire(lockName).also { handle ->
+                if (handle != null) {
+                    acquiredRef.set(handle)
+                    if (lifecycle.get() == AsyncLifecycle.CLEANUP) {
+                        releaseAfterMinLease(handle)
+                    }
+                }
+            }
+        }, executor)
+        val pipelineFuture = acquisitionFuture.thenComposeAsync({ handle ->
+            when {
+                handle == null -> CompletableFuture.completedFuture(null)
+                !lifecycle.compareAndSet(AsyncLifecycle.WAITING, AsyncLifecycle.STARTED) ->
+                    CompletableFuture.failedFuture(
+                        CancellationException("leader result future was cancelled before action"),
+                    )
+                else -> runAcquiredAsync(handle, cancellationRelay, action)
+            }
+        }, executor)
+        pipelineFuture.whenComplete { _, failure ->
+            if (pipelineFuture.isCancelled) {
+                acquisitionFuture.cancel(true)
+            }
+            if (failure != null) {
+                beginCleanup()
+            }
+        }
+        acquisitionFuture.whenComplete { handle, _ ->
+            if (handle != null && pipelineFuture.isCancelled) {
+                beginCleanup()
+            }
+        }
+        return LeaderFutureBridge.map(pipelineFuture, cancellationRelay) { value, failure ->
+            val cause = failure?.unwrapCompletionException()
+            if (cause != null) {
+                throw CompletionException(cause)
+            }
+            value
+        }
+    }
+
+    @Suppress("ReturnCount", "TooGenericExceptionCaught")
+    private fun <T> runAcquiredAsync(
+        leaseHandle: EtcdLeaseHandle,
+        cancellationRelay: LeaderFutureBridge.CancellationRelay,
+        action: () -> CompletableFuture<T>,
+    ): CompletableFuture<T?> {
+        val delegate = EtcdLockExtendDelegate(lockClient, leaseHandle)
+        val handle = LeaderLockHandle.real(
+            identity = LockIdentity(
+                lockName = leaseHandle.lockName,
+                kind = LockIdentity.AnnotationKind.GROUP,
+                factoryBeanName = ETCD_GROUP_FACTORY_BEAN_NAME,
+                groupParams = LockIdentity.GroupParams(maxLeaders),
+            ),
+            token = leaseHandle.token,
+            acquiredAtNanos = leaseHandle.acquiredAtNanos,
+            slotId = leaseHandle.slotId,
+            extendDelegate = delegate,
         )
+        val watchdog = try {
+            LeaderLeaseAutoExtender.start(
+                enabled = false,
+                leaseTime = options.leaderGroupOptions.leaseTime,
+                delegate = delegate,
+                classifier = ERROR_CLASSIFIER,
+            )
+        } catch (e: Throwable) {
+            releaseAfterMinLease(leaseHandle)
+            return CompletableFuture.failedFuture(e)
+        }
+        val actionFuture = try {
+            AopScopeAccess.withPushedSync(handle) {
+                AopScopeAccess.setCapture(handle)
+                try {
+                    cancellationRelay.invoke(action)
+                } finally {
+                    AopScopeAccess.clearCapture()
+                }
+            }
+        } catch (e: Throwable) {
+            watchdog.close()
+            releaseAfterMinLease(leaseHandle)
+            return CompletableFuture.failedFuture(e)
+        }
+
+        return actionFuture.handle { value, failure ->
+            watchdog.close()
+            releaseAfterMinLease(leaseHandle)
+            val cause = failure?.unwrapCompletionException()
+            if (cause != null) {
+                throw CompletionException(cause)
+            }
+            value
+        }
+    }
+
+    private fun Throwable.unwrapCompletionException(): Throwable =
+        (this as? CompletionException)?.cause ?: this
 
     private fun <T> runImpl(lockName: String, auditLeaderId: String?, action: () -> T): T? {
         val leaseHandle = acquire(lockName) ?: return null

--- a/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdAsyncLeaderElectorIntegrationTest.kt
+++ b/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdAsyncLeaderElectorIntegrationTest.kt
@@ -10,6 +10,8 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class EtcdAsyncLeaderElectorIntegrationTest: AbstractEtcdLeaderTest() {
@@ -83,6 +85,106 @@ class EtcdAsyncLeaderElectorIntegrationTest: AbstractEtcdLeaderTest() {
                 elector.runIfLeader(lockName) { "reacquired" } shouldBeEqualTo "reacquired"
             } finally {
                 actionFuture.cancel(true)
+                executor.shutdownNow()
+            }
+        }
+    }
+
+    @Test
+    fun `single async contention returns null without invoking action`() {
+        newClient().use { client ->
+            val executor = Executors.newFixedThreadPool(2)
+            val keyPrefix = "/bluetape4k/leader/test/${randomName()}"
+            val holder = EtcdLeaderElector(
+                client,
+                EtcdLeaderElectionOptions(
+                    leaderOptions = LeaderElectionOptions(waitTime = 2.seconds, leaseTime = 10.seconds),
+                    keyPrefix = keyPrefix,
+                ),
+            )
+            val contender = EtcdLeaderElector(
+                client,
+                EtcdLeaderElectionOptions(
+                    leaderOptions = LeaderElectionOptions(waitTime = 200.milliseconds, leaseTime = 10.seconds),
+                    keyPrefix = keyPrefix,
+                ),
+            )
+            val lockName = randomName()
+            val holderStarted = CountDownLatch(1)
+            val holderAction = CompletableFuture<String>()
+            val contenderInvoked = AtomicBoolean()
+
+            try {
+                val holderResult = holder.runAsyncIfLeader(lockName, executor) {
+                    holderStarted.countDown()
+                    holderAction
+                }
+                holderStarted.await(10, TimeUnit.SECONDS).shouldBeTrue()
+
+                contender.runAsyncIfLeader(lockName, executor) {
+                    contenderInvoked.set(true)
+                    CompletableFuture.completedFuture("should-not-run")
+                }.get(10, TimeUnit.SECONDS) shouldBeEqualTo null
+                contenderInvoked.get() shouldBeEqualTo false
+
+                holderAction.complete("holder")
+                holderResult.get(10, TimeUnit.SECONDS) shouldBeEqualTo "holder"
+            } finally {
+                holderAction.cancel(true)
+                executor.shutdownNow()
+            }
+        }
+    }
+
+    @Test
+    fun `group async contention returns null without invoking action`() {
+        newClient().use { client ->
+            val executor = Executors.newFixedThreadPool(2)
+            val keyPrefix = "/bluetape4k/leader/test/${randomName()}"
+            val holder = EtcdLeaderGroupElector(
+                client,
+                EtcdLeaderGroupElectionOptions(
+                    leaderGroupOptions = LeaderGroupElectionOptions(
+                        maxLeaders = 1,
+                        waitTime = 2.seconds,
+                        leaseTime = 10.seconds,
+                    ),
+                    keyPrefix = keyPrefix,
+                ),
+            )
+            val contender = EtcdLeaderGroupElector(
+                client,
+                EtcdLeaderGroupElectionOptions(
+                    leaderGroupOptions = LeaderGroupElectionOptions(
+                        maxLeaders = 1,
+                        waitTime = 200.milliseconds,
+                        leaseTime = 10.seconds,
+                    ),
+                    keyPrefix = keyPrefix,
+                ),
+            )
+            val lockName = randomName()
+            val holderStarted = CountDownLatch(1)
+            val holderAction = CompletableFuture<String>()
+            val contenderInvoked = AtomicBoolean()
+
+            try {
+                val holderResult = holder.runAsyncIfLeader(lockName, executor) {
+                    holderStarted.countDown()
+                    holderAction
+                }
+                holderStarted.await(10, TimeUnit.SECONDS).shouldBeTrue()
+
+                contender.runAsyncIfLeader(lockName, executor) {
+                    contenderInvoked.set(true)
+                    CompletableFuture.completedFuture("should-not-run")
+                }.get(10, TimeUnit.SECONDS) shouldBeEqualTo null
+                contenderInvoked.get() shouldBeEqualTo false
+
+                holderAction.complete("holder")
+                holderResult.get(10, TimeUnit.SECONDS) shouldBeEqualTo "holder"
+            } finally {
+                holderAction.cancel(true)
                 executor.shutdownNow()
             }
         }

--- a/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdAsyncLeaderElectorIntegrationTest.kt
+++ b/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdAsyncLeaderElectorIntegrationTest.kt
@@ -1,0 +1,138 @@
+package io.bluetape4k.leader.etcd
+
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.LockExtender
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
+
+class EtcdAsyncLeaderElectorIntegrationTest: AbstractEtcdLeaderTest() {
+
+    @Test
+    fun `single cancellation reaches action and same lock can be reacquired`() {
+        newClient().use { client ->
+            val executor = Executors.newSingleThreadExecutor()
+            val actionStarted = CountDownLatch(1)
+            val actionFuture = CompletableFuture<String>()
+            val elector = EtcdLeaderElector(
+                client,
+                EtcdLeaderElectionOptions(
+                    leaderOptions = LeaderElectionOptions(
+                        waitTime = 2.seconds,
+                        leaseTime = 10.seconds,
+                        autoExtend = true,
+                    ),
+                    keyPrefix = "/bluetape4k/leader/test/${randomName()}",
+                ),
+            )
+            val lockName = randomName()
+
+            try {
+                val result = elector.runAsyncIfLeader(lockName, executor) {
+                    actionStarted.countDown()
+                    actionFuture
+                }
+
+                actionStarted.await(10, TimeUnit.SECONDS).shouldBeTrue()
+                result.cancel(true).shouldBeTrue()
+                result.isCancelled.shouldBeTrue()
+                actionFuture.isCancelled.shouldBeTrue()
+                elector.runIfLeader(lockName) { "reacquired" } shouldBeEqualTo "reacquired"
+            } finally {
+                actionFuture.cancel(true)
+                executor.shutdownNow()
+            }
+        }
+    }
+
+    @Test
+    fun `group cancellation reaches action and same slot can be reacquired`() {
+        newClient().use { client ->
+            val executor = Executors.newSingleThreadExecutor()
+            val actionStarted = CountDownLatch(1)
+            val actionFuture = CompletableFuture<String>()
+            val elector = EtcdLeaderGroupElector(
+                client,
+                EtcdLeaderGroupElectionOptions(
+                    leaderGroupOptions = LeaderGroupElectionOptions(
+                        maxLeaders = 1,
+                        waitTime = 2.seconds,
+                        leaseTime = 10.seconds,
+                    ),
+                    keyPrefix = "/bluetape4k/leader/test/${randomName()}",
+                ),
+            )
+            val lockName = randomName()
+
+            try {
+                val result = elector.runAsyncIfLeader(lockName, executor) {
+                    actionStarted.countDown()
+                    actionFuture
+                }
+
+                actionStarted.await(10, TimeUnit.SECONDS).shouldBeTrue()
+                result.cancel(true).shouldBeTrue()
+                result.isCancelled.shouldBeTrue()
+                actionFuture.isCancelled.shouldBeTrue()
+                elector.runIfLeader(lockName) { "reacquired" } shouldBeEqualTo "reacquired"
+            } finally {
+                actionFuture.cancel(true)
+                executor.shutdownNow()
+            }
+        }
+    }
+
+    @Test
+    fun `single async action supplier can extend active lock`() {
+        newClient().use { client ->
+            val executor = Executors.newSingleThreadExecutor()
+            val elector = EtcdLeaderElector(
+                client,
+                EtcdLeaderElectionOptions(
+                    leaderOptions = LeaderElectionOptions(waitTime = 2.seconds, leaseTime = 10.seconds),
+                    keyPrefix = "/bluetape4k/leader/test/${randomName()}",
+                ),
+            )
+
+            try {
+                elector.runAsyncIfLeader(randomName(), executor) {
+                    CompletableFuture.completedFuture(LockExtender.extendActiveLock(10.seconds))
+                }.get(10, TimeUnit.SECONDS) shouldBeEqualTo true
+            } finally {
+                executor.shutdownNow()
+            }
+        }
+    }
+
+    @Test
+    fun `group async action supplier can extend active lock`() {
+        newClient().use { client ->
+            val executor = Executors.newSingleThreadExecutor()
+            val elector = EtcdLeaderGroupElector(
+                client,
+                EtcdLeaderGroupElectionOptions(
+                    leaderGroupOptions = LeaderGroupElectionOptions(
+                        maxLeaders = 1,
+                        waitTime = 2.seconds,
+                        leaseTime = 10.seconds,
+                    ),
+                    keyPrefix = "/bluetape4k/leader/test/${randomName()}",
+                ),
+            )
+
+            try {
+                elector.runAsyncIfLeader(randomName(), executor) {
+                    CompletableFuture.completedFuture(LockExtender.extendActiveLock(10.seconds))
+                }.get(10, TimeUnit.SECONDS) shouldBeEqualTo true
+            } finally {
+                executor.shutdownNow()
+            }
+        }
+    }
+}

--- a/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdAsyncLifecycleTest.kt
+++ b/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdAsyncLifecycleTest.kt
@@ -1,0 +1,321 @@
+package io.bluetape4k.leader.etcd
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeInstanceOf
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.leader.LeaderElectionOptions
+import io.bluetape4k.leader.LeaderGroupElectionOptions
+import io.bluetape4k.leader.etcd.internal.EtcdLockClient
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.lease.LeaseKeepAliveResponse
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.seconds
+
+class EtcdAsyncLifecycleTest {
+
+    @Test
+    fun `single caller cancellation cancels action and releases lease`() {
+        val client = StatefulEtcdLockClient()
+        val elector = EtcdLeaderElector.create(client, singleOptions())
+        val executor = Executors.newSingleThreadExecutor()
+        val action = CancellationRecordingFuture<String>()
+
+        try {
+            val result = elector.runAsyncIfLeader("lock-a", executor) { action }
+
+            client.acquired.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            result.cancel(true).shouldBeTrue()
+
+            action.cancelled.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            client.cleaned.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            client.unlockCalls.get() shouldBeEqualTo 1
+            client.revokeCalls.get() shouldBeEqualTo 1
+            elector.runIfLeader("lock-a") { "reacquired" } shouldBeEqualTo "reacquired"
+        } finally {
+            action.complete("cleanup")
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `group caller cancellation cancels action and releases slot`() {
+        val client = StatefulEtcdLockClient()
+        val elector = EtcdLeaderGroupElector.create(client, groupOptions())
+        val executor = Executors.newSingleThreadExecutor()
+        val action = CancellationRecordingFuture<String>()
+
+        try {
+            val result = elector.runAsyncIfLeader("lock-a", executor) { action }
+
+            client.acquired.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            result.cancel(true).shouldBeTrue()
+
+            action.cancelled.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            client.cleaned.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            client.unlockCalls.get() shouldBeEqualTo 1
+            client.revokeCalls.get() shouldBeEqualTo 1
+            elector.runIfLeader("lock-a") { "reacquired" } shouldBeEqualTo "reacquired"
+        } finally {
+            action.complete("cleanup")
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `single cancellation before acquisition releases late ownership without invoking action`() {
+        val client = StatefulEtcdLockClient(pendFirstLock = true)
+        val elector = EtcdLeaderElector.create(client, singleOptions())
+        val executor = Executors.newSingleThreadExecutor()
+        val actionInvoked = AtomicBoolean()
+
+        try {
+            val result = elector.runAsyncIfLeader("lock-a", executor) {
+                actionInvoked.set(true)
+                CompletableFuture.completedFuture("should-not-run")
+            }
+
+            client.pendingAcquisition.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            result.cancel(true).shouldBeTrue()
+            client.completePendingOwnership()
+
+            client.cleaned.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            actionInvoked.get().shouldBeFalse()
+            client.unlockCalls.get() shouldBeEqualTo 1
+            client.revokeCalls.get() shouldBeEqualTo 1
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `group cancellation before acquisition releases late ownership without invoking action`() {
+        val client = StatefulEtcdLockClient(pendFirstLock = true)
+        val elector = EtcdLeaderGroupElector.create(client, groupOptions())
+        val executor = Executors.newSingleThreadExecutor()
+        val actionInvoked = AtomicBoolean()
+
+        try {
+            val result = elector.runAsyncIfLeader("lock-a", executor) {
+                actionInvoked.set(true)
+                CompletableFuture.completedFuture("should-not-run")
+            }
+
+            client.pendingAcquisition.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            result.cancel(true).shouldBeTrue()
+            client.completePendingOwnership()
+
+            client.cleaned.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            actionInvoked.get().shouldBeFalse()
+            client.unlockCalls.get() shouldBeEqualTo 1
+            client.revokeCalls.get() shouldBeEqualTo 1
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `single second executor rejection releases acquired lease`() {
+        val client = StatefulEtcdLockClient()
+        val elector = EtcdLeaderElector.create(client, singleOptions())
+        val worker = Executors.newSingleThreadExecutor()
+        val actionInvoked = AtomicBoolean()
+        val executor = rejectAfterFirstSubmission(worker)
+
+        try {
+            val result = elector.runAsyncIfLeader("lock-a", executor) {
+                actionInvoked.set(true)
+                CompletableFuture.completedFuture("should-not-run")
+            }
+
+            val failure = assertFailsWith<CompletionException> { result.join() }
+            failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            failure.cause?.message shouldBeEqualTo "rejected-after-acquire"
+            client.cleaned.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            actionInvoked.get().shouldBeFalse()
+            elector.runIfLeader("lock-a") { "reacquired" } shouldBeEqualTo "reacquired"
+        } finally {
+            worker.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `group second executor rejection releases acquired slot`() {
+        val client = StatefulEtcdLockClient()
+        val elector = EtcdLeaderGroupElector.create(client, groupOptions())
+        val worker = Executors.newSingleThreadExecutor()
+        val actionInvoked = AtomicBoolean()
+        val executor = rejectAfterFirstSubmission(worker)
+
+        try {
+            val result = elector.runAsyncIfLeader("lock-a", executor) {
+                actionInvoked.set(true)
+                CompletableFuture.completedFuture("should-not-run")
+            }
+
+            val failure = assertFailsWith<CompletionException> { result.join() }
+            failure.cause.shouldBeInstanceOf<RejectedExecutionException>()
+            failure.cause?.message shouldBeEqualTo "rejected-after-acquire"
+            client.cleaned.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            actionInvoked.get().shouldBeFalse()
+            elector.runIfLeader("lock-a") { "reacquired" } shouldBeEqualTo "reacquired"
+        } finally {
+            worker.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `first executor rejection performs no backend call`() {
+        val singleClient = StatefulEtcdLockClient()
+        val groupClient = StatefulEtcdLockClient()
+        val rejectingExecutor = Executor { throw RejectedExecutionException("rejected-before-acquire") }
+
+        assertFailsWith<RejectedExecutionException> {
+            EtcdLeaderElector.create(singleClient, singleOptions())
+                .runAsyncIfLeader("lock-a", rejectingExecutor) { CompletableFuture.completedFuture("unused") }
+        }
+        assertFailsWith<RejectedExecutionException> {
+            EtcdLeaderGroupElector.create(groupClient, groupOptions())
+                .runAsyncIfLeader("lock-a", rejectingExecutor) { CompletableFuture.completedFuture("unused") }
+        }
+
+        singleClient.backendCalls() shouldBeEqualTo 0
+        groupClient.backendCalls() shouldBeEqualTo 0
+    }
+
+    private fun singleOptions(): EtcdLeaderElectionOptions =
+        EtcdLeaderElectionOptions(
+            leaderOptions = LeaderElectionOptions(waitTime = 2.seconds, leaseTime = 10.seconds),
+        )
+
+    private fun groupOptions(): EtcdLeaderGroupElectionOptions =
+        EtcdLeaderGroupElectionOptions(
+            leaderGroupOptions = LeaderGroupElectionOptions(
+                maxLeaders = 1,
+                waitTime = 2.seconds,
+                leaseTime = 10.seconds,
+            ),
+        )
+
+    private fun rejectAfterFirstSubmission(worker: Executor): Executor {
+        val submissions = AtomicInteger()
+        return Executor { command ->
+            if (submissions.incrementAndGet() == 1) {
+                worker.execute(command)
+            } else {
+                throw RejectedExecutionException("rejected-after-acquire")
+            }
+        }
+    }
+
+    private class CancellationRecordingFuture<T>: CompletableFuture<T>() {
+        val cancelled = CountDownLatch(1)
+
+        override fun cancel(mayInterruptIfRunning: Boolean): Boolean =
+            super.cancel(mayInterruptIfRunning).also { cancelled ->
+                if (cancelled) this.cancelled.countDown()
+            }
+    }
+
+    private class StatefulEtcdLockClient(
+        private val pendFirstLock: Boolean = false,
+    ): EtcdLockClient {
+        val acquired = CountDownLatch(1)
+        val pendingAcquisition = CountDownLatch(1)
+        val cleaned = CountDownLatch(1)
+        val grantCalls = AtomicInteger()
+        val lockCalls = AtomicInteger()
+        val unlockCalls = AtomicInteger()
+        val revokeCalls = AtomicInteger()
+
+        private val nextLeaseId = AtomicLong(10L)
+        private val activeLockKeys = ConcurrentHashMap.newKeySet<ByteSequence>()
+        private val ownershipToLockKey = ConcurrentHashMap<ByteSequence, ByteSequence>()
+        private val leaseToLockKey = ConcurrentHashMap<Long, ByteSequence>()
+        private val pending = AtomicReference<PendingLock?>()
+
+        override fun singleLockKey(lockName: String): ByteSequence =
+            bytes("/bluetape4k/leader/single/$lockName")
+
+        override fun groupSlotLockKey(lockName: String, zeroBasedSlot: Int): ByteSequence =
+            bytes("/bluetape4k/leader/group/$lockName/slot-$zeroBasedSlot")
+
+        override fun grantLease(ttlSeconds: Long): CompletableFuture<Long> {
+            grantCalls.incrementAndGet()
+            return CompletableFuture.completedFuture(nextLeaseId.incrementAndGet())
+        }
+
+        override fun lock(lockKey: ByteSequence, leaseId: Long): CompletableFuture<ByteSequence> {
+            val call = lockCalls.incrementAndGet()
+            val ownershipKey = bytes("${lockKey.toString(StandardCharsets.UTF_8)}/owner-$leaseId")
+            if (pendFirstLock && call == 1) {
+                val future = CompletableFuture<ByteSequence>()
+                pending.set(PendingLock(lockKey, leaseId, ownershipKey, future))
+                pendingAcquisition.countDown()
+                return future
+            }
+            if (!activeLockKeys.add(lockKey)) {
+                return CompletableFuture()
+            }
+            ownershipToLockKey[ownershipKey] = lockKey
+            leaseToLockKey[leaseId] = lockKey
+            acquired.countDown()
+            return CompletableFuture.completedFuture(ownershipKey)
+        }
+
+        override fun unlock(ownershipKey: ByteSequence): CompletableFuture<Unit> {
+            unlockCalls.incrementAndGet()
+            ownershipToLockKey.remove(ownershipKey)?.let(activeLockKeys::remove)
+            return CompletableFuture.completedFuture(Unit)
+        }
+
+        override fun revokeLease(leaseId: Long): CompletableFuture<Unit> {
+            revokeCalls.incrementAndGet()
+            leaseToLockKey.remove(leaseId)?.let(activeLockKeys::remove)
+            cleaned.countDown()
+            return CompletableFuture.completedFuture(Unit)
+        }
+
+        override fun keepAliveOnce(leaseId: Long): CompletableFuture<LeaseKeepAliveResponse> =
+            CompletableFuture.failedFuture(UnsupportedOperationException("keepAliveOnce is not used"))
+
+        override fun ownershipKeys(lockKey: ByteSequence): CompletableFuture<List<ByteSequence>> =
+            CompletableFuture.completedFuture(emptyList())
+
+        fun completePendingOwnership() {
+            val request = checkNotNull(pending.getAndSet(null)) { "pending ownership does not exist" }
+            activeLockKeys.add(request.lockKey)
+            ownershipToLockKey[request.ownershipKey] = request.lockKey
+            leaseToLockKey[request.leaseId] = request.lockKey
+            acquired.countDown()
+            request.future.complete(request.ownershipKey)
+        }
+
+        fun backendCalls(): Int =
+            grantCalls.get() + lockCalls.get() + unlockCalls.get() + revokeCalls.get()
+
+        private fun bytes(value: String): ByteSequence =
+            ByteSequence.from(value, StandardCharsets.UTF_8)
+
+        private data class PendingLock(
+            val lockKey: ByteSequence,
+            val leaseId: Long,
+            val ownershipKey: ByteSequence,
+            val future: CompletableFuture<ByteSequence>,
+        )
+    }
+}

--- a/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdAsyncLifecycleTest.kt
+++ b/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdAsyncLifecycleTest.kt
@@ -34,11 +34,15 @@ class EtcdAsyncLifecycleTest {
         val elector = EtcdLeaderElector.create(client, singleOptions())
         val executor = Executors.newSingleThreadExecutor()
         val action = CancellationRecordingFuture<String>()
+        val actionStarted = CountDownLatch(1)
 
         try {
-            val result = elector.runAsyncIfLeader("lock-a", executor) { action }
+            val result = elector.runAsyncIfLeader("lock-a", executor) {
+                actionStarted.countDown()
+                action
+            }
 
-            client.acquired.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            actionStarted.await(2, TimeUnit.SECONDS).shouldBeTrue()
             result.cancel(true).shouldBeTrue()
 
             action.cancelled.await(2, TimeUnit.SECONDS).shouldBeTrue()
@@ -58,11 +62,15 @@ class EtcdAsyncLifecycleTest {
         val elector = EtcdLeaderGroupElector.create(client, groupOptions())
         val executor = Executors.newSingleThreadExecutor()
         val action = CancellationRecordingFuture<String>()
+        val actionStarted = CountDownLatch(1)
 
         try {
-            val result = elector.runAsyncIfLeader("lock-a", executor) { action }
+            val result = elector.runAsyncIfLeader("lock-a", executor) {
+                actionStarted.countDown()
+                action
+            }
 
-            client.acquired.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            actionStarted.await(2, TimeUnit.SECONDS).shouldBeTrue()
             result.cancel(true).shouldBeTrue()
 
             action.cancelled.await(2, TimeUnit.SECONDS).shouldBeTrue()
@@ -147,6 +155,8 @@ class EtcdAsyncLifecycleTest {
             failure.cause?.message shouldBeEqualTo "rejected-after-acquire"
             client.cleaned.await(2, TimeUnit.SECONDS).shouldBeTrue()
             actionInvoked.get().shouldBeFalse()
+            client.unlockCalls.get() shouldBeEqualTo 1
+            client.revokeCalls.get() shouldBeEqualTo 1
             elector.runIfLeader("lock-a") { "reacquired" } shouldBeEqualTo "reacquired"
         } finally {
             worker.shutdownNow()
@@ -172,6 +182,8 @@ class EtcdAsyncLifecycleTest {
             failure.cause?.message shouldBeEqualTo "rejected-after-acquire"
             client.cleaned.await(2, TimeUnit.SECONDS).shouldBeTrue()
             actionInvoked.get().shouldBeFalse()
+            client.unlockCalls.get() shouldBeEqualTo 1
+            client.revokeCalls.get() shouldBeEqualTo 1
             elector.runIfLeader("lock-a") { "reacquired" } shouldBeEqualTo "reacquired"
         } finally {
             worker.shutdownNow()
@@ -234,7 +246,6 @@ class EtcdAsyncLifecycleTest {
     private class StatefulEtcdLockClient(
         private val pendFirstLock: Boolean = false,
     ): EtcdLockClient {
-        val acquired = CountDownLatch(1)
         val pendingAcquisition = CountDownLatch(1)
         val cleaned = CountDownLatch(1)
         val grantCalls = AtomicInteger()
@@ -273,7 +284,6 @@ class EtcdAsyncLifecycleTest {
             }
             ownershipToLockKey[ownershipKey] = lockKey
             leaseToLockKey[leaseId] = lockKey
-            acquired.countDown()
             return CompletableFuture.completedFuture(ownershipKey)
         }
 
@@ -301,7 +311,6 @@ class EtcdAsyncLifecycleTest {
             activeLockKeys.add(request.lockKey)
             ownershipToLockKey[request.ownershipKey] = request.lockKey
             leaseToLockKey[request.leaseId] = request.lockKey
-            acquired.countDown()
             request.future.complete(request.ownershipKey)
         }
 

--- a/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdAsyncLifecycleTest.kt
+++ b/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdAsyncLifecycleTest.kt
@@ -191,6 +191,54 @@ class EtcdAsyncLifecycleTest {
     }
 
     @Test
+    fun `single action supplier failure preserves cause and releases lease`() {
+        val client = StatefulEtcdLockClient()
+        val elector = EtcdLeaderElector.create(client, singleOptions())
+        val executor = Executors.newSingleThreadExecutor()
+
+        try {
+            val failure = assertFailsWith<CompletionException> {
+                elector.runAsyncIfLeader<String>("lock-a", executor) {
+                    throw IllegalStateException("action-supplier-failed")
+                }.join()
+            }
+
+            failure.cause.shouldBeInstanceOf<IllegalStateException>()
+            failure.cause?.message shouldBeEqualTo "action-supplier-failed"
+            client.cleaned.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            client.unlockCalls.get() shouldBeEqualTo 1
+            client.revokeCalls.get() shouldBeEqualTo 1
+            elector.runIfLeader("lock-a") { "reacquired" } shouldBeEqualTo "reacquired"
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `group action supplier failure preserves cause and releases slot`() {
+        val client = StatefulEtcdLockClient()
+        val elector = EtcdLeaderGroupElector.create(client, groupOptions())
+        val executor = Executors.newSingleThreadExecutor()
+
+        try {
+            val failure = assertFailsWith<CompletionException> {
+                elector.runAsyncIfLeader<String>("lock-a", executor) {
+                    throw IllegalStateException("action-supplier-failed")
+                }.join()
+            }
+
+            failure.cause.shouldBeInstanceOf<IllegalStateException>()
+            failure.cause?.message shouldBeEqualTo "action-supplier-failed"
+            client.cleaned.await(2, TimeUnit.SECONDS).shouldBeTrue()
+            client.unlockCalls.get() shouldBeEqualTo 1
+            client.revokeCalls.get() shouldBeEqualTo 1
+            elector.runIfLeader("lock-a") { "reacquired" } shouldBeEqualTo "reacquired"
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
     fun `first executor rejection performs no backend call`() {
         val singleClient = StatefulEtcdLockClient()
         val groupClient = StatefulEtcdLockClient()

--- a/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdLeaderElectionEventPublisherIntegrationTest.kt
+++ b/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/EtcdLeaderElectionEventPublisherIntegrationTest.kt
@@ -1,18 +1,26 @@
 package io.bluetape4k.leader.etcd
 
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.junit5.coroutines.runSuspendIO
 import io.bluetape4k.leader.LeaderElectionEvent
 import io.bluetape4k.leader.LeaderGroupElectionOptions
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import kotlin.time.Duration.Companion.seconds
 
 class EtcdLeaderElectionEventPublisherIntegrationTest: AbstractEtcdLeaderTest() {
@@ -27,14 +35,20 @@ class EtcdLeaderElectionEventPublisherIntegrationTest: AbstractEtcdLeaderTest() 
                 EtcdLeaderElectionOptions(keyPrefix = keyPrefix),
             )
             val lockName = randomName()
+            val elected = CountDownLatch(1)
 
             publisher.use {
-                val events = async {
-                    publisher.events.take(2).toList()
+                val events = async(start = CoroutineStart.UNDISPATCHED) {
+                    publisher.events
+                        .onEach { event ->
+                            if (event == LeaderElectionEvent.Elected(lockName)) elected.countDown()
+                        }
+                        .take(2)
+                        .toList()
                 }
-                delay(250)
 
                 elector.runIfLeader(lockName) {
+                    elected.await(10, TimeUnit.SECONDS).shouldBeTrue()
                     "done"
                 } shouldBeEqualTo "done"
 
@@ -61,14 +75,20 @@ class EtcdLeaderElectionEventPublisherIntegrationTest: AbstractEtcdLeaderTest() 
                 ),
             )
             val lockName = randomName()
+            val elected = CountDownLatch(1)
 
             publisher.use {
-                val events = async {
-                    publisher.events.take(2).toList()
+                val events = async(start = CoroutineStart.UNDISPATCHED) {
+                    publisher.events
+                        .onEach { event ->
+                            if (event == LeaderElectionEvent.Elected(lockName)) elected.countDown()
+                        }
+                        .take(2)
+                        .toList()
                 }
-                delay(250)
 
                 elector.runIfLeader(lockName) {
+                    elected.await(10, TimeUnit.SECONDS).shouldBeTrue()
                     "done"
                 } shouldBeEqualTo "done"
 
@@ -93,15 +113,21 @@ class EtcdLeaderElectionEventPublisherIntegrationTest: AbstractEtcdLeaderTest() 
             )
             val lockName = randomName()
             val started = CountDownLatch(1)
+            val holderElected = CountDownLatch(1)
+            val contenderStarted = CountDownLatch(1)
             val release = CountDownLatch(1)
             val executor = Executors.newFixedThreadPool(2)
 
             try {
                 publisher.use {
-                    val events = async {
-                        publisher.events.take(4).toList()
+                    val events = async(start = CoroutineStart.UNDISPATCHED) {
+                        publisher.events
+                            .onEach { event ->
+                                if (event == LeaderElectionEvent.Elected(lockName)) holderElected.countDown()
+                            }
+                            .take(4)
+                            .toList()
                     }
-                    delay(250)
 
                     val holder = executor.submit<String?> {
                         elector.runIfLeader(lockName) {
@@ -111,13 +137,15 @@ class EtcdLeaderElectionEventPublisherIntegrationTest: AbstractEtcdLeaderTest() 
                         }
                     }
 
-                    started.await(10, TimeUnit.SECONDS) shouldBeEqualTo true
+                    started.await(10, TimeUnit.SECONDS).shouldBeTrue()
+                    holderElected.await(10, TimeUnit.SECONDS).shouldBeTrue()
                     val contender = executor.submit<String?> {
+                        contenderStarted.countDown()
                         elector.runIfLeader(lockName) {
                             "contender"
                         }
                     }
-                    delay(500)
+                    contenderStarted.await(10, TimeUnit.SECONDS).shouldBeTrue()
 
                     release.countDown()
                     holder.get(10, TimeUnit.SECONDS) shouldBeEqualTo "holder"
@@ -138,16 +166,52 @@ class EtcdLeaderElectionEventPublisherIntegrationTest: AbstractEtcdLeaderTest() 
     fun `closing publisher does not close caller owned client`() = runSuspendIO {
         newClient().use { client ->
             val keyPrefix = "/bluetape4k/leader/test/${randomName()}"
-            EtcdLeaderElectionEventPublisher(client, keyPrefix).close()
-
             val elector = EtcdLeaderElector(
                 client,
                 EtcdLeaderElectionOptions(keyPrefix = keyPrefix),
             )
+            val closedPublisher = EtcdLeaderElectionEventPublisher(client, keyPrefix)
+            val unexpectedEvent = CompletableFuture<LeaderElectionEvent>()
+            val closedCollector = launch(start = CoroutineStart.UNDISPATCHED) {
+                closedPublisher.events.collect { event -> unexpectedEvent.complete(event) }
+            }
+
+            closedPublisher.close()
 
             elector.runIfLeader(randomName()) {
                 "still-open"
             } shouldBeEqualTo "still-open"
+
+            assertFailsWith<TimeoutException> {
+                unexpectedEvent.get(500, TimeUnit.MILLISECONDS)
+            }
+            closedCollector.cancelAndJoin()
+
+            val lockName = randomName()
+            val restartedPublisher = EtcdLeaderElectionEventPublisher(client, keyPrefix)
+            val elected = CountDownLatch(1)
+            restartedPublisher.use {
+                val events = async(start = CoroutineStart.UNDISPATCHED) {
+                    restartedPublisher.events
+                        .onEach { event ->
+                            if (event == LeaderElectionEvent.Elected(lockName)) elected.countDown()
+                        }
+                        .take(2)
+                        .toList()
+                }
+
+                elector.runIfLeader(lockName) {
+                    elected.await(10, TimeUnit.SECONDS).shouldBeTrue()
+                    "restarted"
+                } shouldBeEqualTo "restarted"
+
+                withTimeout(10.seconds) {
+                    events.await()
+                } shouldBeEqualTo listOf(
+                    LeaderElectionEvent.Elected(lockName),
+                    LeaderElectionEvent.Revoked(lockName),
+                )
+            }
         }
     }
 

--- a/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/contract/EtcdVirtualThreadLeaderElectorContractTest.kt
+++ b/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/contract/EtcdVirtualThreadLeaderElectorContractTest.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.leader.etcd.contract
 
 import io.bluetape4k.concurrent.virtualthread.VirtualThreadExecutor
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.leader.LeaderElectionOptions
 import io.bluetape4k.leader.LeaderGroupElectionOptions
 import io.bluetape4k.leader.etcd.EtcdLeaderElector
@@ -12,6 +13,8 @@ import io.bluetape4k.leader.etcd.EtcdVirtualThreadLeaderElector
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * Direct etcd virtual-thread and group executor overload coverage.
@@ -38,6 +41,41 @@ class EtcdVirtualThreadLeaderElectorContractTest {
         elector.runAsyncIfLeader(lockName) { "virtual-reacquired" }
             .toCompletableFuture()
             .join() shouldBeEqualTo "virtual-reacquired"
+    }
+
+    @Test
+    fun virtualWrapperCancellationInterruptsActionAndReleasesLock() {
+        val elector = EtcdVirtualThreadLeaderElector(
+            EtcdLeaderElector(
+                EtcdContractSupport.client,
+                EtcdLeaderElectionOptions(keyPrefix = EtcdContractSupport.keyPrefix()),
+            ),
+        )
+        val lockName = "etcd-virtual-cancellation-contract"
+        val actionStarted = CountDownLatch(1)
+        val actionInterrupted = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val result = elector.runAsyncIfLeader(lockName) {
+            actionStarted.countDown()
+            try {
+                release.await()
+                "should-not-complete"
+            } catch (e: InterruptedException) {
+                actionInterrupted.countDown()
+                throw e
+            }
+        }
+
+        try {
+            actionStarted.await(10, TimeUnit.SECONDS).shouldBeTrue()
+            result.cancel(true).shouldBeTrue()
+            actionInterrupted.await(10, TimeUnit.SECONDS).shouldBeTrue()
+            elector.runAsyncIfLeader(lockName) { "virtual-reacquired" }
+                .toCompletableFuture()
+                .get(10, TimeUnit.SECONDS) shouldBeEqualTo "virtual-reacquired"
+        } finally {
+            release.countDown()
+        }
     }
 
     @Test

--- a/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/internal/JetcdWatchCallbackIntegrationTest.kt
+++ b/leader-etcd/src/test/kotlin/io/bluetape4k/leader/etcd/internal/JetcdWatchCallbackIntegrationTest.kt
@@ -1,0 +1,178 @@
+package io.bluetape4k.leader.etcd.internal
+
+import io.bluetape4k.assertions.assertFailsWith
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.leader.etcd.AbstractEtcdLeaderTest
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.Watch
+import io.etcd.jetcd.options.WatchOption
+import io.etcd.jetcd.watch.WatchEvent
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+class JetcdWatchCallbackIntegrationTest: AbstractEtcdLeaderTest() {
+
+    @Test
+    fun `callback can perform blocking kv get`() {
+        newClient().use { client ->
+            val key = byteSequence("/bluetape4k/leader/test/${randomName()}/callback")
+            val expected = "callback-value"
+            val callbackValue = CompletableFuture<String>()
+            val watcher = client.readyWatcher(
+                key = key,
+                onEvent = { event ->
+                    if (event.eventType == WatchEvent.EventType.PUT) {
+                        val response = client.kvClient.get(key).get(3, TimeUnit.SECONDS)
+                        callbackValue.complete(response.kvs.single().value.asString())
+                    }
+                },
+                onFailure = callbackValue::completeExceptionally,
+            )
+
+            watcher.use {
+                watcher.awaitReady()
+                client.kvClient.put(key, byteSequence(expected)).get(10, TimeUnit.SECONDS)
+
+                callbackValue.get(10, TimeUnit.SECONDS) shouldBeEqualTo expected
+            }
+        }
+    }
+
+    @Test
+    fun `slow first callback preserves put and delete order`() {
+        newClient().use { client ->
+            val key = byteSequence("/bluetape4k/leader/test/${randomName()}/ordered")
+            val firstEntered = CountDownLatch(1)
+            val releaseFirst = CountDownLatch(1)
+            val allEvents = CountDownLatch(3)
+            val observed = CopyOnWriteArrayList<String>()
+            val failure = CompletableFuture<Unit>()
+            val watcher = client.readyWatcher(
+                key = key,
+                onEvent = { event ->
+                    if (event.eventType == WatchEvent.EventType.PUT && observed.isEmpty()) {
+                        firstEntered.countDown()
+                        releaseFirst.await(5, TimeUnit.SECONDS).shouldBeTrue()
+                    }
+                    observed += event.label()
+                    allEvents.countDown()
+                },
+                onFailure = failure::completeExceptionally,
+            )
+
+            try {
+                watcher.awaitReady()
+                client.kvClient.put(key, byteSequence("v1")).get(10, TimeUnit.SECONDS)
+                firstEntered.await(10, TimeUnit.SECONDS).shouldBeTrue()
+                client.kvClient.put(key, byteSequence("v2")).get(10, TimeUnit.SECONDS)
+                client.kvClient.delete(key).get(10, TimeUnit.SECONDS)
+                releaseFirst.countDown()
+
+                allEvents.await(10, TimeUnit.SECONDS).shouldBeTrue()
+                failure.isDone.shouldBeFalse()
+                observed shouldBeEqualTo listOf("PUT:v1", "PUT:v2", "DELETE")
+            } finally {
+                releaseFirst.countDown()
+                watcher.close()
+            }
+        }
+    }
+
+    @Test
+    fun `closed watcher stops delivery and a new watcher resumes`() {
+        newClient().use { client ->
+            val key = byteSequence("/bluetape4k/leader/test/${randomName()}/restart")
+            val closedWatcherEvent = CompletableFuture<String>()
+            val firstWatcher = client.readyWatcher(
+                key = key,
+                onEvent = { event -> closedWatcherEvent.complete(event.label()) },
+                onFailure = closedWatcherEvent::completeExceptionally,
+            )
+
+            firstWatcher.awaitReady()
+            firstWatcher.close()
+            client.kvClient.put(key, byteSequence("after-close")).get(10, TimeUnit.SECONDS)
+
+            assertFailsWith<TimeoutException> {
+                closedWatcherEvent.get(500, TimeUnit.MILLISECONDS)
+            }
+
+            val restartedWatcherEvent = CompletableFuture<String>()
+            val restartedWatcher = client.readyWatcher(
+                key = key,
+                onEvent = { event -> restartedWatcherEvent.complete(event.label()) },
+                onFailure = restartedWatcherEvent::completeExceptionally,
+            )
+            restartedWatcher.use {
+                restartedWatcher.awaitReady()
+                client.kvClient.put(key, byteSequence("after-restart")).get(10, TimeUnit.SECONDS)
+
+                restartedWatcherEvent.get(10, TimeUnit.SECONDS) shouldBeEqualTo "PUT:after-restart"
+            }
+        }
+    }
+
+    private fun Client.readyWatcher(
+        key: ByteSequence,
+        onEvent: (WatchEvent) -> Unit,
+        onFailure: (Throwable) -> Unit,
+    ): ReadyWatcher {
+        val ready = CompletableFuture<Unit>()
+        val option = WatchOption.builder()
+            .withCreateNotify(true)
+            .build()
+        val watcher = watchClient.watch(
+            key,
+            option,
+            Watch.listener(
+                { response ->
+                    if (response.isCreatedNotify) {
+                        ready.complete(Unit)
+                    } else {
+                        runCatching { response.events.forEach(onEvent) }
+                            .onFailure(onFailure)
+                    }
+                },
+                { error ->
+                    ready.completeExceptionally(error)
+                    onFailure(error)
+                },
+            ),
+        )
+        return ReadyWatcher(watcher, ready)
+    }
+
+    private fun WatchEvent.label(): String =
+        when (eventType) {
+            WatchEvent.EventType.PUT -> "PUT:${keyValue.value.asString()}"
+            WatchEvent.EventType.DELETE -> "DELETE"
+            WatchEvent.EventType.UNRECOGNIZED -> "UNRECOGNIZED"
+        }
+
+    private fun byteSequence(value: String): ByteSequence =
+        ByteSequence.from(value, StandardCharsets.UTF_8)
+
+    private fun ByteSequence.asString(): String = toString(StandardCharsets.UTF_8)
+
+    private class ReadyWatcher(
+        private val delegate: Watch.Watcher,
+        private val ready: CompletableFuture<Unit>,
+    ): AutoCloseable {
+
+        fun awaitReady() {
+            ready.get(10, TimeUnit.SECONDS)
+        }
+
+        override fun close() {
+            delegate.close()
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
 
 val bluetape4kDependenciesCatalogRef = providers.gradleProperty("bluetape4kDependenciesCatalogRef")
     .orElse(providers.environmentVariable("BLUETAPE4K_DEPENDENCIES_CATALOG_REF"))
-        .orElse("850959d0ea5f76ac7e2c442400f47653d5f95eed")
+        .orElse("9698c9d66bea6fcba373143ee8fa5bfbd9812d4b")
     .get()
 require(bluetape4kDependenciesCatalogRef.matches(Regex("[0-9a-f]{40}|[0-9a-f]{64}"))) {
     "bluetape4k-dependencies catalog ref must be an immutable Git commit SHA: " +


### PR DESCRIPTION
## 요약

- 중앙 catalog ref를 `9698c9d66bea6fcba373143ee8fa5bfbd9812d4b`로 원자 전환해 jetcd `0.8.7`을 적용합니다.
- raw jetcd watch에서 callback 내부 blocking KV 호출, ordered delivery, close/restart 계약을 created-notification barrier로 검증합니다.
- Etcd single/group async elector가 반환 future 취소를 실제 action과 lease cleanup에 전달하도록 lifecycle CAS와 `LeaderFutureBridge`를 적용합니다.
- publisher 및 lifecycle 테스트의 시간 추측을 제거하고 contention `null`, supplier throw, executor rejection, virtual-thread cancellation을 회귀 테스트로 고정합니다.

Closes #880

## 공개 및 운영 경계

- public API/ABI, etcd key layout, TTL/minLease/waitTime 기본값은 변경하지 않습니다.
- caller-owned `Client`를 elector 또는 publisher가 닫지 않습니다.
- README/KDoc/manual은 public 계약 불변이므로 변경하지 않았습니다.
- Colima/Testcontainers host readiness의 별도 간헐 실패는 #884에서 추적합니다.

## 검증

- old jetcd `0.8.6` callback: 1 test RED, `TimeoutException`
- jetcd `0.8.7` callback: 3/3 PASS
- publisher determinism: 4/4 PASS
- async fake/real/virtual targeted 및 회귀 matrix: 14/14, 42/42 PASS
- review-gap targeted: 15/15 PASS
- `leader-etcd` clean `--rerun-tasks`: 156/156 PASS, failures/errors/skipped 0
- `detekt`: PASS
- `checkBinaryCompatibility`: PASS, artifacts 16 / ignored 1 / unknown 0
- `build`: PASS, JUnit artifact inventory 4,369 tests / failures 0 / errors 0 / skipped 0
- dependency graph: jetcd `0.8.7`, gRPC `1.82.0`, Netty `4.2.17.Final`, Vert.x `5.1.7`

## 리뷰 결과

- `gpt-5.6-luna`, effort `max` 인라인 7-Tier 검토
- P0=0, P1=0, P2=1(#884), P3=0
- solo maintainer human-review subgate만 `N/A`; exact-head CI, thread read-back, mergeability 확인은 유지합니다.

## DoD Status

- [x] Issue #880 acceptance 및 RED/GREEN 증거
- [x] callback/watch와 single/group async lifecycle 회귀 테스트
- [x] clean module suite, detekt, ABI, repository build
- [x] 7-Tier review 및 lesson 기록
- [x] PR exact-head CI terminal success
- [x] review thread 0 및 mergeability 재확인
- [ ] fresh merge 승인 후 merge
